### PR TITLE
Remove nocopts attribute that is incompatible with Bazel 1.0.

### DIFF
--- a/build_tools/third_party/glslang/BUILD.overlay
+++ b/build_tools/third_party/glslang/BUILD.overlay
@@ -53,8 +53,6 @@ cc_library(
         "NV_EXTENSIONS",
     ],
     linkstatic = 1,
-    # glslang is not clean under signed-integer-overflow or null sanitizers
-    nocopts = "-fsanitize=.*",
 )
 
 cc_library(
@@ -87,8 +85,6 @@ cc_library(
         "SPIRV/spvIR.h",
     ],
     linkstatic = 1,
-    # glslang is not clean under signed-integer-overflow or null sanitizers
-    nocopts = "-fsanitize=.*",
     deps = [
         ":SPIRV_headers",
         ":glslang",


### PR DESCRIPTION
Closes google/iree#20
