### PR TITLE
Basic support for building on windows (reapply after revert).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,3 +19,32 @@ build --nocheck_visibility
 
 # Enable some default cpu flags for x86 optimization.
 build:x86opt --copt=-mavx2
+
+# Experimental config for building on Windows via clang-cl.
+# As an aspiration, it may eventually not be required to manually
+# activate this config, but for now, it is a place to store the
+# set of flags and tweaks needed to get the Windows build working.
+# Note that this is intended to work with clang-cl, not the Visual
+# Studio compiler. The following must be performed prior to invoking
+# Bazel:
+#   * Install Visual Studio Build Tools
+#   * export USE_CLANG_CL=1
+#   * export BAZEL_LLVM=C:/Users/$USER/scoop/apps/llvm/current
+#     (or actual LLVM install location)
+# Then one can build with:
+#   bazel build --config=windows {targets...}
+
+# Works around __TIME__ __DATE__, etc redefinitions and -std=c++14
+# warnings.
+build:windows --copt=-Wno-builtin-macro-redefined --copt=-Wno-unknown-argument
+
+# Disables windows headers from pulling in GDI, which does a lot of terrible
+# things (such as defining the ERROR macro, which breaks the world).
+build:windows --copt=-DNOGDI
+
+# Enables unix-style runfiles link trees (requires symlink permission).
+# See: https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+# Generally: Enable Developer Mode in the Developer Settings page of the
+# system settings.
+build:windows --experimental_enable_runfiles
+

--- a/build_tools/third_party/glslang/BUILD.overlay
+++ b/build_tools/third_party/glslang/BUILD.overlay
@@ -14,6 +14,31 @@
 
 package(default_visibility = ["//visibility:public"])
 
+OS_SRCS = select({
+    "@bazel_tools//src/conditions:windows": [
+        "glslang/OSDependent/Windows/ossource.cpp",
+    ],
+    "//conditions:default": [
+        "glslang/OSDependent/Unix/ossource.cpp",
+    ],
+})
+
+OS_DEFINES = select({
+    "@bazel_tools//src/conditions:windows": [
+    ],
+    "//conditions:default": [
+        "GLSLANG_OSINCLUDE_UNIX",
+    ],
+})
+
+OS_LINKOPTS = select({
+    "@bazel_tools//src/conditions:windows": [
+    ],
+    "//conditions:default": [
+        "-lpthread",
+    ],
+})
+
 cc_library(
     name = "glslang",
     srcs = glob(
@@ -31,8 +56,7 @@ cc_library(
         ],
     ) + [
         "OGLCompilersDLL/InitializeDll.cpp",
-        "glslang/OSDependent/Unix/ossource.cpp",
-    ],
+    ] + OS_SRCS,
     hdrs = glob([
         "glslang/Include/*.h",
         "glslang/MachineIndependent/*.h",
@@ -49,9 +73,8 @@ cc_library(
         "AMD_EXTENSIONS",
         "ENABLE_HLSL",
         "ENABLE_OPT=1",
-        "GLSLANG_OSINCLUDE_UNIX",
         "NV_EXTENSIONS",
-    ],
+    ] + OS_DEFINES,
     linkstatic = 1,
 )
 
@@ -110,6 +133,5 @@ cc_binary(
         ":glslang",
         ":glslang-default-resource-limits",
     ],
-    # TODO(laurenzo): Windows?
-    linkopts = ["-pthread"],
+    linkopts = OS_LINKOPTS,
 )

--- a/iree/base/internal/init_internal.cc
+++ b/iree/base/internal/init_internal.cc
@@ -14,6 +14,8 @@
 
 #include "iree/base/internal/init_internal.h"
 
+#include <string.h>
+
 #include <set>
 
 #include "absl/flags/parse.h"
@@ -92,7 +94,15 @@ void Initializer::RunInitializer(InitializerData* initializer_data) {
 }
 
 void InitializeEnvironment(int* argc, char*** argv) {
-  absl::ParseCommandLine(*argc, *argv);
+  auto positional_args = absl::ParseCommandLine(*argc, *argv);
+  if (positional_args.size() < *argc) {
+    // Edit the passed argument refs to only include positional args.
+    *argc = positional_args.size();
+    for (int i = 0; i < *argc; ++i) {
+      (*argv)[i] = positional_args[i];
+    }
+    (*argv)[*argc + 1] = nullptr;
+  }
 
   IREE_RUN_MODULE_INITIALIZERS();
 }

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -344,7 +344,11 @@ extern "C" int main(int argc, char** argv) {
     LOG(ERROR) << "Must supply an input .mlir file.";
     return 1;
   }
-  QCHECK_OK(RunFile(argv[1]));
+  auto status = RunFile(argv[1]);
+  if (!status.ok()) {
+    std::cerr << "ERROR running file (" << argv[1] << "): " << status << "\n";
+  }
+  QCHECK_OK(status);
   return 0;
 }
 


### PR DESCRIPTION
* Requires clang-cl
* Spews a bunch of warning about benign redefinitions and unknown
command line arguments (needs triage).
* Allows building of iree/tools/run_module and iree/tools/iree-run-mlir,
which together, account for building most of the non-test assets.

google/iree#19

Fix path issue in lit test runner so it works on Windows under msys2.

With this, all of the iree/compiler/... tests build/pass.

google/iree#19

Filter for the lit RUN line (not just first line).

This allows the e2e tests that include comments first to function.

I really need to get lit working properly but this gets us to the point
where all of the compiler and e2e tests work (on Windows too).

Make the lit RUN line matching more robust.

Fix argument command line parsing to trim options.

This has the side effect of getting most compiler and e2e tests running
on Windows, although some are failing (for unknown reasons).

Closes google/iree#23
google/iree#19

Edit positional command arguments in place.