### PR TITLE
Exclude wait_handle.cc from build.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -327,32 +327,35 @@ cc_library(
     alwayslink = 1,
 )
 
-cc_library(
-    name = "wait_handle",
-    srcs = ["wait_handle.cc"],
-    hdrs = ["wait_handle.h"],
-    deps = [
-        ":logging",
-        ":ref_ptr",
-        ":source_location",
-        ":status",
-        ":time",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:fixed_array",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/time",
-        "@com_google_absl//absl/types:span",
-    ],
-)
+# Dependent code has been removed and wait_handle is currently incompatible
+# with Windows, so excluding entirely.
+# See google/iree/65
+# cc_library(
+#     name = "wait_handle",
+#     srcs = ["wait_handle.cc"],
+#     hdrs = ["wait_handle.h"],
+#     deps = [
+#         ":logging",
+#         ":ref_ptr",
+#         ":source_location",
+#         ":status",
+#         ":time",
+#         "@com_google_absl//absl/base:core_headers",
+#         "@com_google_absl//absl/container:fixed_array",
+#         "@com_google_absl//absl/strings",
+#         "@com_google_absl//absl/time",
+#         "@com_google_absl//absl/types:span",
+#     ],
+# )
 
-cc_test(
-    name = "wait_handle_test",
-    srcs = ["wait_handle_test.cc"],
-    deps = [
-        ":status",
-        ":status_matchers",
-        ":wait_handle",
-        "@com_google_absl//absl/time",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+# cc_test(
+#     name = "wait_handle_test",
+#     srcs = ["wait_handle_test.cc"],
+#     deps = [
+#         ":status",
+#         ":status_matchers",
+#         ":wait_handle",
+#         "@com_google_absl//absl/time",
+#         "@com_google_googletest//:gtest_main",
+#     ],
+# )


### PR DESCRIPTION
It is presently unused and incompatible with Windows.

google/iree/65