### PR TITLE
Use SmallVector instead of std::vector

### DIFF
--- a/iree/compiler/Transforms/Sequencer/LowerSequencerDialect.cpp
+++ b/iree/compiler/Transforms/Sequencer/LowerSequencerDialect.cpp
@@ -285,7 +285,7 @@ class LowerSequencerDialectPass : public ModulePass<LowerSequencerDialectPass> {
     // executable if we just call it on the top-level module. This can't be a
     // function pass because type conversion replaces the original functions.
     auto funcsIt = getModule().getOps<FuncOp>();
-    std::vector<Operation *> funcs(funcsIt.begin(), funcsIt.end());
+    SmallVector<Operation *, 4> funcs(funcsIt.begin(), funcsIt.end());
 
     if (failed(applyFullConversion(funcs, target, patterns, &typeConverter))) {
       return signalPassFailure();

--- a/iree/compiler/Transforms/Sequencer/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Transforms/Sequencer/OutlineDispatchRegions.cpp
@@ -201,8 +201,8 @@ class OutlineDispatchRegionsPass
     auto module = getModule();
 
     ModuleManager moduleManager(module);
-    std::vector<FuncOp> funcOps(module.getOps<FuncOp>().begin(),
-                                module.getOps<FuncOp>().end());
+    auto funcs = module.getOps<FuncOp>();
+    SmallVector<FuncOp, 4> funcOps(funcs.begin(), funcs.end());
     for (auto func : funcOps) {
       // Perform marshaling of the dispatcher and dispatchee I/O.
       // This inserts the required stores and loads to make everything memrefs
@@ -218,7 +218,7 @@ class OutlineDispatchRegionsPass
       }
 
       // Outline all of the iree.dispatch_region ops in this function.
-      std::vector<IREE::DispatchRegionOp> dispatchRegionOps;
+      SmallVector<IREE::DispatchRegionOp, 8> dispatchRegionOps;
       func.walk(
           [&](IREE::DispatchRegionOp op) { dispatchRegionOps.push_back(op); });
       for (int i = 0; i < dispatchRegionOps.size(); ++i) {

--- a/iree/compiler/Transforms/Sequencer/OutlineReductionRegions.cpp
+++ b/iree/compiler/Transforms/Sequencer/OutlineReductionRegions.cpp
@@ -278,8 +278,8 @@ class OutlineReductionRegionsPass
     auto module = getModule();
 
     ModuleManager moduleManager(module);
-    std::vector<FuncOp> funcOps(module.getOps<FuncOp>().begin(),
-                                module.getOps<FuncOp>().end());
+    auto funcs = module.getOps<FuncOp>();
+    SmallVector<FuncOp, 4> funcOps(funcs.begin(), funcs.end());
     for (auto func : funcOps) {
       // Outline all of the iree.reduction_region ops in this function.
       std::vector<IREE::ReductionRegionOp> reductionRegionOps;


### PR DESCRIPTION
We can avoid allocation to some extent and this also resolves the
compilation error on Windows:

  error: indirection requires pointer operand