### PR TITLE
 Add submodule for Google benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,6 @@
 [submodule "third_party/swiftshader"]
 	path = third_party/swiftshader
 	url = https://github.com/google/swiftshader.git
+[submodule "third_party/benchmark"]
+	path = third_party/benchmark
+	url = https://github.com/google/benchmark.git


### PR DESCRIPTION
We will use this for writing benchmarks of IREE. The dependency should be limited to the benchmarking code.