### PR TITLE
Update CMake min to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 cmake_policy(SET CMP0077 NEW)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/iree/base/api_util.h
+++ b/iree/base/api_util.h
@@ -25,7 +25,7 @@
 namespace iree {
 
 inline iree_status_t ToApiStatus(Status status) {
-  DLOG(ERROR) << status;
+  LOG(ERROR) << status;
   return static_cast<iree_status_t>(status.code());
 }
 


### PR DESCRIPTION
STRING JOIN was introduced in 3.12

TEST=builds with cmake 3.12 fails with 3.10.2 (stock in ubuntu)

Latest Ubuntu PPAs are here: https://apt.kitware.com/