### PR TITLE
Misc fixes for Bazel/Linux build.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,3 +153,7 @@ maybe(new_local_repository,
     path = "third_party/pybind11",
     build_file = "build_tools/third_party/pybind11/BUILD.overlay",
 )
+
+maybe(local_repository,
+    name = "com_google_benchmark",
+    path = "third_party/benchmark")

--- a/bindings/python/pyiree/BUILD
+++ b/bindings/python/pyiree/BUILD
@@ -76,7 +76,7 @@ py_test(
     python_version = "PY3",
     deps = [
         ":binding",
-        "//bindings/python:pathsetup",
+        "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",
     ],
 )
@@ -87,7 +87,7 @@ py_test(
     python_version = "PY3",
     deps = [
         ":binding",
-        "//bindings/python:pathsetup",
+        "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",
     ],
 )
@@ -98,6 +98,7 @@ py_test(
     python_version = "PY3",
     deps = NUMPY_DEPS + [
         ":binding",
+        "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",
     ],
 )

--- a/bindings/python/pyiree/hal.cc
+++ b/bindings/python/pyiree/hal.cc
@@ -14,6 +14,7 @@
 
 #include "bindings/python/pyiree/hal.h"
 
+#include "absl/container/inlined_vector.h"
 #include "iree/hal/api.h"
 
 namespace iree {
@@ -52,18 +53,16 @@ class HalMappedMemory {
   }
 
   py::buffer_info ToBufferInfo() {
-    iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(bv_);
     iree_shape_t shape;
     CheckApiStatus(iree_hal_buffer_view_shape(bv_, &shape),
                    "Error getting buffer view shape");
     int8_t element_size = iree_hal_buffer_view_element_size(bv_);
-    iree_device_size_t byte_length = iree_hal_buffer_byte_length(buffer);
-    absl::InlinedVector<ssize_t, IREE_SHAPE_MAX_RANK> dims;
+    absl::InlinedVector<py::ssize_t, IREE_SHAPE_MAX_RANK> dims;
     dims.resize(shape.rank);
     for (int i = 0; i < shape.rank; ++i) {
       dims[i] = shape.dims[i];
     }
-    absl::InlinedVector<ssize_t, IREE_SHAPE_MAX_RANK> strides;
+    absl::InlinedVector<py::ssize_t, IREE_SHAPE_MAX_RANK> strides;
     strides.resize(shape.rank);
     for (int i = 1; i < shape.rank; ++i) {
       strides[i - 1] = shape.dims[i] * element_size;

--- a/bindings/python/pyiree/initialize.h
+++ b/bindings/python/pyiree/initialize.h
@@ -15,6 +15,7 @@
 #ifndef IREE_BINDINGS_PYTHON_PYIREE_INITIALIZE_H_
 #define IREE_BINDINGS_PYTHON_PYIREE_INITIALIZE_H_
 
+#include <string>
 #include <vector>
 
 namespace iree {

--- a/bindings/python/pyiree/rt.cc
+++ b/bindings/python/pyiree/rt.cc
@@ -139,9 +139,9 @@ void SetupRtBindings(pybind11::module m) {
   // RtInvocation.
   py::class_<RtInvocation>(m, "Invocation")
       .def("query_status", &RtInvocation::QueryStatus)
-      .def("await", &RtInvocation::Await,
+      .def("await_ready", &RtInvocation::Await,
            py::arg("deadline") = IREE_TIME_INFINITE_FUTURE)
-      .def("await_optional", &RtInvocation::AwaitOptional,
+      .def("await_ready_optional", &RtInvocation::AwaitOptional,
            py::arg("deadline") = IREE_TIME_INFINITE_FUTURE)
       .def_property_readonly("results", &RtInvocation::ConsumeResults);
 }

--- a/bindings/python/pyiree/runtime_test.py
+++ b/bindings/python/pyiree/runtime_test.py
@@ -109,7 +109,7 @@ class RuntimeTest(absltest.TestCase):
 
     inv = context.invoke(f, policy, [arg0, arg1])
     print("Status:", inv.query_status())
-    inv.await()
+    inv.await_ready()
     results = inv.results
     print("Results:", results)
     result = results[0].map()
@@ -124,5 +124,5 @@ class RuntimeTest(absltest.TestCase):
 
 if __name__ == "__main__":
   # Uncomment to initialize the extension with custom flags.
-  binding.initialize_extension(["--logtostderr"])
+  # binding.initialize_extension(["--logtostderr"])
   absltest.main()

--- a/bindings/python/pyiree/status_utils.h
+++ b/bindings/python/pyiree/status_utils.h
@@ -48,14 +48,14 @@ T&& PyConsumeStatusOr(iree::StatusOr<T>&& sor) {
 pybind11::error_already_set ApiStatusToPyExc(iree_status_t status,
                                              const char* message);
 
-static void CheckApiStatus(iree_status_t status, const char* message) {
+inline void CheckApiStatus(iree_status_t status, const char* message) {
   if (status == IREE_STATUS_OK) {
     return;
   }
   throw ApiStatusToPyExc(status, message);
 }
 
-static void CheckApiNotNull(const void* p, const char* message) {
+inline void CheckApiNotNull(const void* p, const char* message) {
   if (!p) {
     throw RaiseValueError(message);
   }

--- a/build_tools/third_party/pybind11/BUILD.overlay
+++ b/build_tools/third_party/pybind11/BUILD.overlay
@@ -18,6 +18,6 @@ package(
 
 cc_library(
     name = "pybind11",
-    hdrs = glob(["include/pybind11/*.h"]),
+    hdrs = glob(["include/pybind11/**/*.h"]),
     includes = ["include"],
 )


### PR DESCRIPTION
- Type/header/include fixes for different platform.
- Explicit include for all pybind headers
- Remove some unused-* warning causes
- Add benchmark workspace repo
- Rename await() method to await_ready() for compatibility with python 3.7 (reserved word?)

Closes #92