### PR TITLE
Add optional dependency on TF.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,6 +46,31 @@ build:windows --copt=-DNOGDI --host_copt=-DNOGDI
 # system settings.
 build:windows --experimental_enable_runfiles
 
+###############################################################################
+# Flags to make tensorflow build.
+# Some of these are also of general use and fine to enable globally for windows.
+build:windows --copt=/arch:AVX
+# Host and target are the same in windows so don't waste time building both.
+build:windows --distinct_host_configuration=false
+# Avoids incompatible versions of winsock and other badness.
+build:windows --copt=/DWIN32_LEAN_AND_MEAN --host_copt=/DWIN32_LEAN_AND_MEAN
+# That is one way to have less warnings :(
+build:windows --per_file_copt=tensorflow@-w
+# This is used a lot and shouldn't be an error.
+build:windows --per_file_copt=tensorflow@-Wno-microsoft-unqualified-friend
+# Why are min/max macros? No one knows.
+build:windows --copt=/DNOMINMAX --host_copt=/DNOMINMAX
+# Yay for security warnings. Boo for non-standard.
+build:windows --copt=/D_CRT_SECURE_NO_WARNINGS --host_copt=/D_CRT_SECURE_NO_WARNINGS
+# TensorFlow requires the "monolithic" build mode for now on Windows.
+build:windows --define framework_shared_object=false
+# TODO(laurenzo): Clang uses runtime functions for 128bit math that require the
+# rt library and there is not a convenient way to link it. Figure out how to
+# do the following:
+# See: http://clang-developers.42468.n3.nabble.com/Issue-with-Clang-on-Windows-and-compiler-rt-builtins-td4059230.html
+build:windows --linkopt=/DEFAULTLIB:clang_rt.builtins-x86_64.lib
+###############################################################################
+
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.
 try-import %workspace%/user.bazelrc

--- a/bindings/python/pyiree/BUILD
+++ b/bindings/python/pyiree/BUILD
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//iree:build_defs.bzl", "NUMPY_DEPS", "iree_py_extension")
+load("//iree:build_defs.bzl", "NUMPY_DEPS", "PYTHON_HEADERS_DEPS",
+                              "iree_py_extension")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -52,11 +53,27 @@ py_library(
     ],
 )
 
+cc_library(
+    name = "base",
+    hdrs = [
+        "binding.h",
+        "status_utils.h",
+    ],
+    srcs = [
+        "status_utils.cc",
+    ],
+    deps = [
+        "@com_google_absl//absl/types:optional",
+        "@iree_pybind11//:pybind11",
+        "//iree/base:api",
+        "//iree/base:status",
+    ] + PYTHON_HEADERS_DEPS,
+)
+
 iree_py_extension(
     name = "binding",
     srcs = [
-        "binding.cc",
-        "binding.h",
+        "initialize_module.cc",
         "compiler.cc",
         "compiler.h",
         "hal.cc",
@@ -65,22 +82,23 @@ iree_py_extension(
         "initialize.h",
         "rt.cc",
         "rt.h",
-        "status_utils.cc",
-        "status_utils.h",
         "vm.cc",
         "vm.h",
     ],
+    linkstatic = 1,
     copts = [
         "-fexceptions",
     ],
     features = ["-use_header_modules"],
+    win_def_file = "export.def",
     deps = [
+        ":base",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
+        "//bindings/python/pyiree/tensorflow",
         "//iree/base:api",
         "//iree/base:init",
-        "//iree/base:status",
         "//iree/hal:api",
         "//iree/rt:api",
         "//iree/schemas",
@@ -89,7 +107,7 @@ iree_py_extension(
         "@local_config_mlir//:IR",
         "@local_config_mlir//:Parser",
         "@iree_pybind11//:pybind11",
-    ] + COMPILER_DEPS + DRIVER_DEPS,
+    ] + COMPILER_DEPS + DRIVER_DEPS + PYTHON_HEADERS_DEPS,
 )
 
 py_test(

--- a/bindings/python/pyiree/export.def
+++ b/bindings/python/pyiree/export.def
@@ -1,0 +1,3 @@
+LIBRARY BINDING
+EXPORTS
+  PyInit_binding @1

--- a/bindings/python/pyiree/initialize_module.cc
+++ b/bindings/python/pyiree/initialize_module.cc
@@ -19,6 +19,7 @@
 #include "bindings/python/pyiree/initialize.h"
 #include "bindings/python/pyiree/rt.h"
 #include "bindings/python/pyiree/status_utils.h"
+#include "bindings/python/pyiree/tensorflow/register_tensorflow.h"
 #include "bindings/python/pyiree/vm.h"
 
 namespace iree {
@@ -40,6 +41,12 @@ PYBIND11_MODULE(binding, m) {
 
   auto vm_m = m.def_submodule("vm", "IREE VM api");
   SetupVmBindings(vm_m);
+
+// TensorFlow.
+#if defined(IREE_TENSORFLOW_ENABLED)
+  auto tf_m = m.def_submodule("tf_interop", "IREE TensorFlow interop");
+  SetupTensorFlowBindings(tf_m);
+#endif
 }
 
 }  // namespace python

--- a/bindings/python/pyiree/tensorflow/BUILD
+++ b/bindings/python/pyiree/tensorflow/BUILD
@@ -1,0 +1,99 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+config_setting(
+    name = "enable",
+    define_values = {
+        "iree_tensorflow": "true",
+    },
+)
+
+cc_library(
+    name = "tensorflow",
+    hdrs = [
+      "register_tensorflow.h",
+    ],
+    defines = select({
+      ":enable": [
+        "IREE_TENSORFLOW_ENABLED",
+      ],
+      "//conditions:default": [],
+    }),
+    deps = select({
+      ":enable": [
+        ":tensorflow_impl",
+      ],
+      "//conditions:default": [
+        ":tensorflow_disabled",
+      ],
+    }) + [
+      "//bindings/python/pyiree:base",
+    ],
+)
+
+# Runtime deps needed to compile the tensorflow compiler.
+SAVED_MODEL_TF_RUNTIME_DEPS = [
+    "@org_tensorflow//tensorflow/core:core_cpu",
+    "@org_tensorflow//tensorflow/core:direct_session",
+    "@org_tensorflow//tensorflow/core:ops",
+]
+
+# Kernels that the current version of the GraphDef/SavedModel importer
+# needs. This has been manually curated and may need tweaking. As-is,
+# this adds about 7MB to the binary (on win64) vs >300MB if all kernels
+# are pulled in. As such, curating is a big enough savings to be worth the
+# trouble in this case. Also, there is discussion about severing the
+# importer from needing these things.
+SAVED_MODEL_REQUIRED_KERNEL_DEPS = [
+    "@org_tensorflow//tensorflow/core/kernels:constant_op",
+    "@org_tensorflow//tensorflow/core/kernels:io",
+    "@org_tensorflow//tensorflow/core/kernels:partitioned_function_ops",
+    "@org_tensorflow//tensorflow/core/kernels:identity_op",
+    "@org_tensorflow//tensorflow/core/kernels:identity_n_op",
+]
+
+cc_library(
+    name ="tensorflow_impl",
+    hdrs = [
+      "register_tensorflow.h",
+    ],
+    srcs = [
+      "register_tensorflow.cc",
+    ],
+    deps = [
+      "@llvm//:support",
+      "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
+      "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:translate_lib",
+      "//bindings/python/pyiree:base",
+    ] + SAVED_MODEL_TF_RUNTIME_DEPS + SAVED_MODEL_REQUIRED_KERNEL_DEPS,
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "tensorflow_disabled",
+    hdrs = [
+      "register_tensorflow.h",
+    ],
+    srcs = [
+      "register_tensorflow_noop.cc",
+    ],
+    deps = [
+      "//bindings/python/pyiree:base",
+    ],
+)

--- a/bindings/python/pyiree/tensorflow/register_tensorflow.cc
+++ b/bindings/python/pyiree/tensorflow/register_tensorflow.cc
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/python/pyiree/tensorflow/register_tensorflow.h"
+
+#include <string>
+#include <vector>
+
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Module.h"
+#include "tensorflow/compiler/mlir/tensorflow/translate/tf_mlir_translate.h"
+
+using namespace mlir;
+
+namespace iree {
+namespace python {
+
+namespace {
+
+std::string ImportSavedModelToMlirAsm(const std::string& saved_model_dir,
+                                      std::vector<std::string> exported_names,
+                                      std::vector<std::string> tags) {
+  std::unordered_set<std::string> tags_set;
+  for (const auto& tag : tags) {
+    tags_set.insert(tag);
+  }
+
+  MLIRContext context;
+  auto module = tensorflow::SavedModelToMlirImport(
+      saved_model_dir, tags_set, absl::MakeSpan(exported_names), &context);
+
+  // Print to asm.
+  std::string asm_output;
+  llvm::raw_string_ostream sout(asm_output);
+  OpPrintingFlags print_flags;
+  module->print(sout, print_flags);
+  return sout.str();
+}
+
+}  // namespace
+
+void SetupTensorFlowBindings(pybind11::module m) {
+  m.def("import_saved_model_to_mlir_asm", &ImportSavedModelToMlirAsm,
+        py::arg("saved_model_dir"),
+        py::arg("exported_names") = std::vector<std::string>(),
+        py::arg("tags") = std::vector<std::string>({std::string("serve")}));
+}
+
+}  // namespace python
+}  // namespace iree

--- a/bindings/python/pyiree/tensorflow/register_tensorflow.h
+++ b/bindings/python/pyiree/tensorflow/register_tensorflow.h
@@ -1,0 +1,30 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_PYTHON_PYIREE_TENSORFLOW_REGISTER_TENSORFLOW_H_
+#define IREE_BINDINGS_PYTHON_PYIREE_TENSORFLOW_REGISTER_TENSORFLOW_H_
+
+#include <string>
+
+#include "bindings/python/pyiree/binding.h"
+
+namespace iree {
+namespace python {
+
+void SetupTensorFlowBindings(pybind11::module m);
+
+}  // namespace python
+}  // namespace iree
+
+#endif  // IREE_BINDINGS_PYTHON_PYIREE_TENSORFLOW_REGISTER_TENSORFLOW_H_

--- a/bindings/python/pyiree/tensorflow/register_tensorflow_noop.cc
+++ b/bindings/python/pyiree/tensorflow/register_tensorflow_noop.cc
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/python/pyiree/tensorflow/register_tensorflow.h"
+
+namespace iree {
+namespace python {
+
+void SetupTensorFlowBindings(pybind11::module m) {}
+
+}  // namespace python
+}  // namespace iree

--- a/build_tools/python/build_defs.bzl
+++ b/build_tools/python/build_defs.bzl
@@ -9,9 +9,11 @@ def py_extension(
         data = [],
         copts = [],
         linkopts = [],
+        linkstatic = 0,
         deps = [],
         features = [],
-        visibility = []):
+        visibility = [],
+        win_def_file = None):
     """Builds a platform specific native python extension shared library.
 
     Note that you typically need to add some dependency on the python headers,
@@ -31,6 +33,7 @@ def py_extension(
     pyd_file = name + ".pyd"
     so_file = name + ".so"
     for platform_so_name in [dll_file, so_file]:
+        actual_def_file = win_def_file if platform_so_name == dll_file else None
         cc_binary(
             name = platform_so_name,
             srcs = srcs,
@@ -39,8 +42,10 @@ def py_extension(
             linkopts = linkopts,
             deps = deps,
             linkshared = True,
+            linkstatic = linkstatic,
             features = features,
             visibility = visibility,
+            win_def_file = actual_def_file,
         )
 
     # TODO(laurenzo): Bug the bazel team about letting a cc_binary output

--- a/iree/build_defs.bzl
+++ b/iree/build_defs.bzl
@@ -6,6 +6,7 @@ load("@iree_core//build_tools/third_party/glslang:build_defs.bzl", "glsl_vulkan"
 load("@rules_python//python:defs.bzl", "py_library")
 
 NUMPY_DEPS = []
+PYTHON_HEADERS_DEPS = ["@iree_native_python//:python_headers"]
 
 def platform_trampoline_deps(basename, path = "base"):
     """Produce a list of deps for the given `basename` platform target.
@@ -54,12 +55,9 @@ def iree_py_library(**kwargs):
     #   imports
     py_library(**kwargs)
 
-def iree_py_extension(deps = [], **kwargs):
+def iree_py_extension(**kwargs):
     """Delegates to the real py_extension."""
-    py_extension(
-        deps = ["@iree_native_python//:python_headers"] + deps,
-        **kwargs
-    )
+    py_extension(**kwargs)
 
 def iree_build_test(name, targets):
     """Dummy rule to ensure that targets build.


### PR DESCRIPTION
+ Sufficient for importing a savedmodel/graphdef
+ Careful to not pull in the whole TF runtime (>300M vs ~20M when
enabled via this PR).