### PR TITLE
Add SDL2 submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,3 +48,6 @@
 [submodule "third_party/benchmark"]
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "third_party/sdl2"]
+	path = third_party/sdl2
+	url = https://github.com/SDL-mirror/SDL.git


### PR DESCRIPTION
See https://github.com/SDL-mirror/SDL. This is used by the (currently disabled) debugger at https://github.com/google/iree/tree/master/iree/tools/debugger and we may also use it for Vulkan samples.