### PR TITLE
Some cleanup to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -5,5 +5,4 @@ iree/tools/web
 
 # Ignore third_party directories which contain BUILD files so that recursive
 # from root works.
-third_party/abseil-cpp
-third_party/googletest
+third_party

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,7 +1,6 @@
 # TODO(scotttodd): enable when Dawn HAL implementation is functional
 iree/hal/dawn
 iree/tools/web
-#iree/bindings/python
 
 # Ignore third_party directories which contain BUILD files so that recursive
 # from root works.


### PR DESCRIPTION
Ignore all directories under third_party. Doesn't seem like there's a lot of reason to list each one that may contain BUILD files.

Remove commented out line (we can put it back if it needs to be enabled).