### PR TITLE
Move C++ deps to the native library.

### DIFF
--- a/bindings/python/pyiree/BUILD
+++ b/bindings/python/pyiree/BUILD
@@ -15,6 +15,7 @@
 load(
     "//iree:build_defs.bzl",
     "NUMPY_DEPS",
+    "PLATFORM_VULKAN_DEPS",
     "PYTHON_HEADERS_DEPS",
     "iree_py_extension",
 )
@@ -38,7 +39,7 @@ COMPILER_DEPS = [
     "//iree/compiler/Translation/SPIRV",
 ]
 
-DRIVER_DEPS = [
+DRIVER_DEPS = PLATFORM_VULKAN_DEPS + [
     "//iree/hal/interpreter:interpreter_driver_module",
     "//iree/hal/vulkan:vulkan_driver_module",
 ]

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -16,7 +16,6 @@ load(
     "//iree:build_defs.bzl",
     "INTREE_TENSORFLOW_PY_DEPS",
     "NUMPY_DEPS",
-    "PLATFORM_VULKAN_DEPS",
 )
 
 package(
@@ -28,8 +27,7 @@ py_test(
     name = "simple_arithmetic_test",
     srcs = ["simple_arithmetic_test.py"],
     python_version = "PY3",
-    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + PLATFORM_VULKAN_DEPS + [
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//bindings/python/pyiree",
-        "//iree/hal/vulkan:vulkan_driver_module",
     ],
 )


### PR DESCRIPTION
The upstream build system is more flexible about this and the forbidden
deps snuck through.

Closes #127