### PR TITLE
Log information about check failures.

### DIFF
--- a/iree/base/internal/logging.cc
+++ b/iree/base/internal/logging.cc
@@ -100,5 +100,54 @@ LogMessageFatal::~LogMessageFatal() {
   abort();
 }
 
+template <>
+void MakeCheckOpValueString(std::ostream* os, const char& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "char value " << static_cast<int16_t>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const int8_t& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "signed char value " << static_cast<int16_t>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const uint8_t& v) {
+  if (v >= 32 && v <= 126) {
+    (*os) << "'" << v << "'";
+  } else {
+    (*os) << "unsigned char value " << static_cast<uint16_t>(v);
+  }
+}
+
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& p) {
+  (*os) << "nullptr";
+}
+
+CheckOpMessageBuilder::CheckOpMessageBuilder(const char* exprtext)
+    : stream_(new std::ostringstream) {
+  *stream_ << "Check failed: " << exprtext << " (";
+}
+
+CheckOpMessageBuilder::~CheckOpMessageBuilder() { delete stream_; }
+
+std::ostream* CheckOpMessageBuilder::ForVar2() {
+  *stream_ << " vs. ";
+  return stream_;
+}
+
+std::string* CheckOpMessageBuilder::NewString() {
+  *stream_ << ")";
+  return new std::string(stream_->str());
+}
+
 }  // namespace internal
 }  // namespace iree

--- a/iree/base/internal/logging.h
+++ b/iree/base/internal/logging.h
@@ -16,6 +16,7 @@
 #define IREE_BASE_INTERNAL_LOGGING_H_
 
 #include <cstdint>
+#include <limits>
 #include <sstream>
 
 #include "absl/base/attributes.h"
@@ -130,10 +131,140 @@ inline NullStream& operator<<(NullStream& str,
   if (ABSL_PREDICT_FALSE(!(condition))) \
   LOG(FATAL) << "Check failed: " #condition " "
 
-// TODO(scotttodd): Log information about the check failure
-#define CHECK_OP_LOG(name, op, val1, val2)   \
-  if (ABSL_PREDICT_FALSE(!((val1)op(val2)))) \
-  LOG(FATAL) << "Check " #name " failed: " #val1 " " #op " " #val2
+// Function is overloaded for integral types to allow static const
+// integrals declared in classes and not defined to be used as arguments to
+// CHECK* macros. It's not encouraged though.
+template <typename T>
+inline const T& GetReferenceableValue(const T& t) {
+  return t;
+}
+inline char GetReferenceableValue(char t) { return t; }
+inline int8_t GetReferenceableValue(int8_t t) { return t; }
+inline uint8_t GetReferenceableValue(uint8_t t) { return t; }
+inline int16_t GetReferenceableValue(int16_t t) { return t; }
+inline uint16_t GetReferenceableValue(uint16_t t) { return t; }
+inline int32_t GetReferenceableValue(int32_t t) { return t; }
+inline uint32_t GetReferenceableValue(uint32_t t) { return t; }
+inline int64_t GetReferenceableValue(int64_t t) { return t; }
+inline uint64_t GetReferenceableValue(uint64_t t) { return t; }
+
+// This formats a value for a failing CHECK_XX statement.  Ordinarily,
+// it uses the definition for operator<<, with a few special cases below.
+template <typename T>
+inline void MakeCheckOpValueString(std::ostream* os, const T& v) {
+  (*os) << v;
+}
+
+// Overrides for char types provide readable values for unprintable
+// characters.
+template <>
+void MakeCheckOpValueString(std::ostream* os, const char& v);
+template <>
+void MakeCheckOpValueString(std::ostream* os, const int8_t& v);
+template <>
+void MakeCheckOpValueString(std::ostream* os, const uint8_t& v);
+// We need an explicit specialization for std::nullptr_t.
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& p);
+
+// A container for a string pointer which can be evaluated to a bool -
+// true iff the pointer is non-NULL.
+struct CheckOpString {
+  CheckOpString(std::string* str) : str_(str) {}  // NOLINT
+  // No destructor: if str_ is non-NULL, we're about to LOG(FATAL),
+  // so there's no point in cleaning up str_.
+  operator bool() const { return ABSL_PREDICT_FALSE(str_ != NULL); }
+  std::string* str_;
+};
+
+// Build the error message string. Specify no inlining for code size.
+template <typename T1, typename T2>
+std::string* MakeCheckOpString(const T1& v1, const T2& v2,
+                               const char* exprtext) ABSL_ATTRIBUTE_NOINLINE;
+
+// A helper class for formatting "expr (V1 vs. V2)" in a CHECK_XX
+// statement. See MakeCheckOpString for sample usage.
+class CheckOpMessageBuilder {
+ public:
+  // Inserts "exprtext" and " (" to the stream.
+  explicit CheckOpMessageBuilder(const char* exprtext);
+  // Deletes "stream_".
+  ~CheckOpMessageBuilder();
+  // For inserting the first variable.
+  std::ostream* ForVar1() { return stream_; }
+  // For inserting the second variable (adds an intermediate " vs. ").
+  std::ostream* ForVar2();
+  // Get the result (inserts the closing ")").
+  std::string* NewString();
+
+ private:
+  std::ostringstream* stream_;
+};
+
+template <typename T1, typename T2>
+std::string* MakeCheckOpString(const T1& v1, const T2& v2,
+                               const char* exprtext) {
+  CheckOpMessageBuilder comb(exprtext);
+  MakeCheckOpValueString(comb.ForVar1(), v1);
+  MakeCheckOpValueString(comb.ForVar2(), v2);
+  return comb.NewString();
+}
+
+// Helper functions for CHECK_OP macro.
+// The (int, int) specialization works around the issue that the compiler
+// will not instantiate the template version of the function on values of
+// unnamed enum type - see comment below.
+// The (size_t, int) and (int, size_t) specialization are to handle unsigned
+// comparison errors while still being thorough with the comparison.
+#define _IREE_DEFINE_CHECK_OP_IMPL(name, op)                             \
+  template <typename T1, typename T2>                                    \
+  inline std::string* name##Impl(const T1& v1, const T2& v2,             \
+                                 const char* exprtext) {                 \
+    if (ABSL_PREDICT_TRUE(v1 op v2))                                     \
+      return NULL;                                                       \
+    else                                                                 \
+      return ::iree::internal::MakeCheckOpString(v1, v2, exprtext);      \
+  }                                                                      \
+  inline std::string* name##Impl(int v1, int v2, const char* exprtext) { \
+    return name##Impl<int, int>(v1, v2, exprtext);                       \
+  }                                                                      \
+  inline std::string* name##Impl(const size_t v1, const int v2,          \
+                                 const char* exprtext) {                 \
+    if (ABSL_PREDICT_FALSE(v2 < 0)) {                                    \
+      return ::iree::internal::MakeCheckOpString(v1, v2, exprtext);      \
+    }                                                                    \
+    const size_t uval = (size_t)((unsigned)v1);                          \
+    return name##Impl<size_t, size_t>(uval, v2, exprtext);               \
+  }                                                                      \
+  inline std::string* name##Impl(const int v1, const size_t v2,          \
+                                 const char* exprtext) {                 \
+    if (ABSL_PREDICT_FALSE(v2 >= std::numeric_limits<int>::max())) {     \
+      return ::iree::internal::MakeCheckOpString(v1, v2, exprtext);      \
+    }                                                                    \
+    const size_t uval = (size_t)((unsigned)v2);                          \
+    return name##Impl<size_t, size_t>(v1, uval, exprtext);               \
+  }
+
+// We use the full name Check_EQ, Check_NE, etc. in case the file including
+// base/logging.h provides its own #defines for the simpler names EQ, NE, etc.
+_IREE_DEFINE_CHECK_OP_IMPL(Check_EQ,
+                           ==)  // Compilation error with CHECK_EQ(NULL, x)?
+_IREE_DEFINE_CHECK_OP_IMPL(Check_NE, !=)  // Use CHECK(x == NULL) instead.
+_IREE_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
+_IREE_DEFINE_CHECK_OP_IMPL(Check_LT, <)
+_IREE_DEFINE_CHECK_OP_IMPL(Check_GE, >=)
+_IREE_DEFINE_CHECK_OP_IMPL(Check_GT, >)
+#undef _IREE_DEFINE_CHECK_OP_IMPL
+
+// In optimized mode, use CheckOpString to hint to compiler that
+// the while condition is unlikely.
+#define CHECK_OP_LOG(name, op, val1, val2)                      \
+  while (::iree::internal::CheckOpString _result =              \
+             ::iree::internal::name##Impl(                      \
+                 ::iree::internal::GetReferenceableValue(val1), \
+                 ::iree::internal::GetReferenceableValue(val2), \
+                 #val1 " " #op " " #val2))                      \
+  ::iree::internal::LogMessageFatal(__FILE__, __LINE__) << *(_result.str_)
 
 #define CHECK_OP(name, op, val1, val2) CHECK_OP_LOG(name, op, val1, val2)
 


### PR DESCRIPTION
Lifted from
https://github.com/google/xrtl/blob/master/xrtl/port/common/base/logging_macros.h
https://github.com/google/xrtl/blob/master/xrtl/port/common/base/logging_macros.cc

(which roughly came from TensorFlow)