### PR TITLE
Run a computation with IREE's Vulkan HAL in vk_graphics_integration.

### DIFF
--- a/iree/samples/rt/vulkan/BUILD
+++ b/iree/samples/rt/vulkan/BUILD
@@ -14,9 +14,17 @@
 
 # Samples demonstrating use of the RT API with Vulkan.
 
+load("//iree/tools:compilation.bzl", "iree_bytecode_module")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
+)
+
+iree_bytecode_module(
+    name = "simple_mul_bytecode_module",
+    srcs = ["simple_mul.mlir"],
+    cc_namespace = "iree::rt::samples",
 )
 
 cc_binary(
@@ -28,6 +36,7 @@ cc_binary(
         "notap",
     ],
     deps = [
+        ":simple_mul_bytecode_module_cc",
         "//iree/base:api",
         "//iree/base:logging",
         "//iree/hal:api",

--- a/iree/samples/rt/vulkan/simple_mul.mlir
+++ b/iree/samples/rt/vulkan/simple_mul.mlir
@@ -1,0 +1,19 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
+    attributes { iree.module.export } {
+  %0 = "xla_hlo.mul"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}


### PR DESCRIPTION
* Forked IREE C API usage code from `bytecode_module_api_test.cc`
* Added ImGui UI for providing input data values and displaying the results

Some possible next steps for this sample:

* Share a ``VkDevice`` between the application code and IREE
* Use a more complex computation, such as one that uses GPU resources
* Show synchronization options (poll w/o blocking or chain calls together)

I only expect this to work on Linux with Bazel for now (CMake needs
``cc_embed_data``/``iree_bytecode_module`` and Windows needs SDL and Dear ImGui
dependencies to build).

![iree_vk_integration_simple_mul](https://user-images.githubusercontent.com/4010439/68981263-b678c880-07b7-11ea-8acc-6e416325475e.png)
