### PR TITLE
Start Vulkan HAL API, share VkInstance between app and VulkanDriver.

### DIFF
--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -254,6 +254,11 @@ iree_api_version_check(iree_api_version_t expected_version,
 
 // Initializes IREE for use within a binary.
 //
+// Specifically, this parses any command line flags and performs module
+// initialization (such as for tracing and dynamic driver registration). If
+// your application is certain it does not need this functionality, this call
+// may be skipped.
+//
 // |argc| and |argv| should contain any command line flags to parse.
 // If there are no flags to parse, nullptr may be passed, but this should still
 // be called so other initialization happens.

--- a/iree/hal/BUILD
+++ b/iree/hal/BUILD
@@ -47,6 +47,8 @@ cc_library(
         ":api_hdrs",
         ":buffer",
         ":buffer_view",
+        ":device",
+        ":driver",
         ":fence",
         ":heap_buffer",
         ":semaphore",

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -51,6 +51,8 @@ iree_cc_library(
     iree::base::tracing
     iree::hal::buffer
     iree::hal::buffer_view
+    iree::hal::device
+    iree::hal::driver
     iree::hal::fence
     iree::hal::heap_buffer
     iree::hal::semaphore

--- a/iree/hal/api.cc
+++ b/iree/hal/api.cc
@@ -21,6 +21,8 @@
 #include "iree/hal/api_detail.h"
 #include "iree/hal/buffer.h"
 #include "iree/hal/buffer_view.h"
+#include "iree/hal/device.h"
+#include "iree/hal/driver.h"
 #include "iree/hal/fence.h"
 #include "iree/hal/heap_buffer.h"
 #include "iree/hal/semaphore.h"
@@ -428,6 +430,58 @@ IREE_API_EXPORT iree_status_t iree_hal_fence_retain(iree_hal_fence_t* fence) {
 IREE_API_EXPORT iree_status_t iree_hal_fence_release(iree_hal_fence_t* fence) {
   IREE_TRACE_SCOPE0("iree_hal_fence_release");
   auto* handle = reinterpret_cast<Fence*>(fence);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  handle->ReleaseReference();
+  return IREE_STATUS_OK;
+}
+
+//===----------------------------------------------------------------------===//
+// iree::hal::Device
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t
+iree_hal_device_retain(iree_hal_device_t* device) {
+  IREE_TRACE_SCOPE0("iree_hal_device_retain");
+  auto* handle = reinterpret_cast<Device*>(device);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  handle->AddReference();
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_device_release(iree_hal_device_t* device) {
+  IREE_TRACE_SCOPE0("iree_hal_device_release");
+  auto* handle = reinterpret_cast<Device*>(device);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  handle->ReleaseReference();
+  return IREE_STATUS_OK;
+}
+
+//===----------------------------------------------------------------------===//
+// iree::hal::Driver
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_driver_retain(iree_hal_driver_t* driver) {
+  IREE_TRACE_SCOPE0("iree_hal_driver_retain");
+  auto* handle = reinterpret_cast<Driver*>(driver);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  handle->AddReference();
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_driver_release(iree_hal_driver_t* driver) {
+  IREE_TRACE_SCOPE0("iree_hal_driver_release");
+  auto* handle = reinterpret_cast<Driver*>(driver);
   if (!handle) {
     return IREE_STATUS_INVALID_ARGUMENT;
   }

--- a/iree/hal/api.h
+++ b/iree/hal/api.h
@@ -33,6 +33,8 @@ typedef struct iree_hal_buffer iree_hal_buffer_t;
 typedef struct iree_hal_buffer_view iree_hal_buffer_view_t;
 typedef struct iree_hal_semaphore iree_hal_semaphore_t;
 typedef struct iree_hal_fence iree_hal_fence_t;
+typedef struct iree_hal_device iree_hal_device_t;
+typedef struct iree_hal_driver iree_hal_driver_t;
 
 // Reference to a buffer's mapped memory.
 typedef struct {
@@ -356,6 +358,43 @@ iree_hal_fence_retain(iree_hal_fence_t* fence);
 // Releases the given |fence| from the caller.
 IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_hal_fence_release(iree_hal_fence_t* fence);
+
+#endif  // IREE_API_NO_PROTOTYPES
+
+//===----------------------------------------------------------------------===//
+// iree::hal::Device
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_API_NO_PROTOTYPES
+
+// HAL devices are created via HAL drivers.
+
+// Retains the given |device| for the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_retain(iree_hal_device_t* device);
+
+// Releases the given |device| from the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_release(iree_hal_device_t* device);
+
+#endif  // IREE_API_NO_PROTOTYPES
+
+//===----------------------------------------------------------------------===//
+// iree::hal::Driver
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_API_NO_PROTOTYPES
+
+// HAL drivers are created for concrete implementations (e.g. Vulkan with
+// iree_hal_vulkan_driver_create).
+
+// Retains the given |driver| for the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_driver_retain(iree_hal_driver_t* driver);
+
+// Releases the given |driver| from the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_driver_release(iree_hal_driver_t* driver);
 
 #endif  // IREE_API_NO_PROTOTYPES
 

--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -38,6 +38,23 @@ config_setting(
 )
 
 cc_library(
+    name = "api",
+    srcs = ["api.cc"],
+    hdrs = ["api.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":dynamic_symbols",
+        ":vulkan_device",
+        ":vulkan_driver",
+        "//iree/base:api",
+        "//iree/base:api_util",
+        "//iree/base:tracing",
+        "//iree/hal:api",
+        "@vulkan_headers//:vulkan_headers_no_prototypes",
+    ],
+)
+
+cc_library(
     name = "debug_reporter",
     srcs = ["debug_reporter.cc"],
     hdrs = ["debug_reporter.h"],

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -18,6 +18,27 @@ set(VMA_SRC_ROOT
 
 iree_cc_library(
   NAME
+    api
+  HDRS
+    "api.h"
+  SRCS
+    "api.cc"
+  COPTS
+    "-DVK_NO_PROTOTYPES"
+  DEPS
+    iree::base::api
+    iree::base::api_util
+    iree::base::tracing
+    iree::hal::api
+    iree::hal::vulkan::dynamic_symbols
+    iree::hal::vulkan::vulkan_device
+    iree::hal::vulkan::vulkan_driver
+    Vulkan::Headers
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     debug_reporter
   HDRS
     "debug_reporter.h"

--- a/iree/hal/vulkan/api.cc
+++ b/iree/hal/vulkan/api.cc
@@ -1,0 +1,202 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/vulkan/api.h"
+
+#include "iree/base/api.h"
+#include "iree/base/api_util.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/vulkan/dynamic_symbols.h"
+#include "iree/hal/vulkan/vulkan_device.h"
+#include "iree/hal/vulkan/vulkan_driver.h"
+
+namespace iree {
+namespace hal {
+namespace vulkan {
+
+//===----------------------------------------------------------------------===//
+// iree::hal::vulkan::DynamicSymbols
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_vulkan_syms_create(
+    void* vkGetInstanceProcAddr_fn, iree_hal_vulkan_syms_t** out_syms) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_syms_create");
+  if (!out_syms) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  *out_syms = nullptr;
+
+  IREE_API_ASSIGN_OR_RETURN(
+      auto syms, DynamicSymbols::Create([&vkGetInstanceProcAddr_fn](
+                                            const char* function_name) {
+        // Only resolve vkGetInstanceProcAddr, rely on syms->LoadFromInstance()
+        // and/or syms->LoadFromDevice() for further loading.
+        std::string fn = "vkGetInstanceProcAddr";
+        if (strncmp(function_name, fn.data(), fn.size()) == 0) {
+          return reinterpret_cast<PFN_vkVoidFunction>(vkGetInstanceProcAddr_fn);
+        }
+        return reinterpret_cast<PFN_vkVoidFunction>(NULL);
+      }));
+
+  *out_syms = reinterpret_cast<iree_hal_vulkan_syms_t*>(syms.release());
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_syms_create_from_system_loader(
+    iree_hal_vulkan_syms_t** out_syms) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_syms_create_from_system_loader");
+  if (!out_syms) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  *out_syms = nullptr;
+
+  IREE_API_ASSIGN_OR_RETURN(auto syms,
+                            DynamicSymbols::CreateFromSystemLoader());
+  *out_syms = reinterpret_cast<iree_hal_vulkan_syms_t*>(syms.release());
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_vulkan_syms_release(iree_hal_vulkan_syms_t* syms) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_syms_release");
+  auto* handle = reinterpret_cast<DynamicSymbols*>(syms);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  handle->ReleaseReference();
+  return IREE_STATUS_OK;
+}
+
+//===----------------------------------------------------------------------===//
+// iree::hal::vulkan::VulkanDriver
+//===----------------------------------------------------------------------===//
+
+VulkanDriver::Options ConvertDriverOptions(
+    iree_hal_vulkan_driver_options_t options) {
+  VulkanDriver::Options driver_options;
+  driver_options.api_version = options.api_version;
+
+  // TODO: validation layers have bugs when using VK_EXT_debug_report, so if the
+  // user requested that we force them off with a warning. Prefer using
+  // VK_EXT_debug_utils when available.
+  if ((options.extensibility_options & IREE_HAL_VULKAN_ENABLE_DEBUG_REPORT) &&
+      (options.extensibility_options &
+       IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS)) {
+    LOG(WARNING) << "VK_EXT_debug_report has issues with modern validation "
+                    "layers; disabling validation";
+    options.extensibility_options =
+        static_cast<iree_hal_vulkan_extensibility_options_t>(
+            options.extensibility_options &
+            ~IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS);
+  }
+
+  // REQUIRED: these are required extensions that must be present for IREE to
+  // work (such as those relied upon by SPIR-V kernels, etc).
+  driver_options.device_extensibility.required_extensions.push_back(
+      VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
+
+  if (options.extensibility_options &
+      IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS) {
+    driver_options.instance_extensibility.optional_layers.push_back(
+        "VK_LAYER_LUNARG_standard_validation");
+  }
+
+  if (options.extensibility_options & IREE_HAL_VULKAN_ENABLE_DEBUG_REPORT) {
+    driver_options.instance_extensibility.optional_extensions.push_back(
+        VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+  }
+  if (options.extensibility_options & IREE_HAL_VULKAN_ENABLE_DEBUG_UTILS) {
+    driver_options.instance_extensibility.optional_extensions.push_back(
+        VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  }
+
+  if (options.extensibility_options & IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS) {
+    driver_options.instance_extensibility.optional_extensions.push_back(
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    driver_options.device_extensibility.optional_extensions.push_back(
+        VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
+  }
+
+  return driver_options;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_vulkan_driver_create(
+    iree_hal_vulkan_driver_options_t options, iree_hal_vulkan_syms_t* syms,
+    iree_hal_driver_t** out_driver) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_driver_create");
+  if (!out_driver) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  *out_driver = nullptr;
+
+  IREE_API_ASSIGN_OR_RETURN(
+      auto driver,
+      VulkanDriver::Create(ConvertDriverOptions(options),
+                           add_ref(reinterpret_cast<DynamicSymbols*>(syms))));
+  *out_driver = reinterpret_cast<iree_hal_driver_t*>(driver.release());
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_driver_create_using_instance(
+    iree_hal_vulkan_driver_options_t options, iree_hal_vulkan_syms_t* syms,
+    VkInstance instance, iree_hal_driver_t** out_driver) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_driver_create_using_instance");
+  if (!out_driver) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  *out_driver = nullptr;
+
+  IREE_API_ASSIGN_OR_RETURN(
+      auto driver,
+      VulkanDriver::CreateUsingInstance(
+          ConvertDriverOptions(options),
+          add_ref(reinterpret_cast<DynamicSymbols*>(syms)), instance));
+  *out_driver = reinterpret_cast<iree_hal_driver_t*>(driver.release());
+  return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_driver_create_default_device(iree_hal_driver_t* driver,
+                                             iree_hal_device_t** out_device) {
+  IREE_TRACE_SCOPE0("iree_hal_vulkan_driver_create_default_device");
+  if (!out_device) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  *out_device = nullptr;
+
+  auto* handle = reinterpret_cast<VulkanDriver*>(driver);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+
+  LOG(INFO) << "Enumerating available Vulkan devices...";
+  IREE_API_ASSIGN_OR_RETURN(auto available_devices,
+                            handle->EnumerateAvailableDevices());
+  for (const auto& device_info : available_devices) {
+    LOG(INFO) << "  Device: " << device_info.name();
+  }
+  LOG(INFO) << "Creating default device...";
+  IREE_API_ASSIGN_OR_RETURN(auto device, handle->CreateDefaultDevice());
+  LOG(INFO) << "Successfully created device '" << device->info().name() << "'";
+
+  *out_device = reinterpret_cast<iree_hal_device_t*>(device.release());
+
+  return IREE_STATUS_OK;
+}
+
+}  // namespace vulkan
+}  // namespace hal
+}  // namespace iree

--- a/iree/hal/vulkan/api.h
+++ b/iree/hal/vulkan/api.h
@@ -1,0 +1,131 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// See iree/base/api.h for documentation on the API conventions used.
+
+#ifndef IREE_HAL_VULKAN_API_H_
+#define IREE_HAL_VULKAN_API_H_
+
+#include <vulkan/vulkan.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Types and Enums
+//===----------------------------------------------------------------------===//
+
+// Bitfield that defines Vulkan extensibility options to enable.
+typedef enum {
+  // Enables standard Vulkan validation layers.
+  IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS = 0,
+
+  // Enables VK_EXT_debug_utils, records markers, and logs errors.
+  IREE_HAL_VULKAN_ENABLE_DEBUG_UTILS = 1 << 0,
+
+  // Enables VK_EXT_debug_report and logs errors.
+  IREE_HAL_VULKAN_ENABLE_DEBUG_REPORT = 1 << 1,
+
+  // Enables use of vkCmdPushDescriptorSetKHR, if available.
+  IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS = 1 << 2,
+} iree_hal_vulkan_extensibility_options_t;
+
+// Vulkan driver creation options.
+typedef struct {
+  // Vulkan version that will be requested.
+  // Driver creation will fail if the required version is not available.
+  uint32_t api_version = VK_API_VERSION_1_0;
+
+  // Vulkan options to request.
+  iree_hal_vulkan_extensibility_options_t extensibility_options;
+} iree_hal_vulkan_driver_options_t;
+
+typedef struct iree_hal_vulkan_syms iree_hal_vulkan_syms_t;
+
+//===----------------------------------------------------------------------===//
+// iree::hal::vulkan::DynamicSymbols
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_API_NO_PROTOTYPES
+
+// Loads Vulkan functions by invoking |vkGetInstanceProcAddr|.
+//
+// |vkGetInstanceProcAddr| can be obtained in whatever way suites the calling
+// application, such as via `dlsym` or `GetProcAddress` when dynamically
+// loading Vulkan, or `reinterpret_cast<void*>(&vkGetInstanceProcAddr)` when
+// statically linking Vulkan.
+//
+// |out_syms| must be released by the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_vulkan_syms_create(
+    void* vkGetInstanceProcAddr_fn, iree_hal_vulkan_syms_t** out_syms);
+
+// Loads Vulkan functions from the Vulkan loader.
+// This will look for a Vulkan loader on the system (like libvulkan.so) and
+// dlsym the functions from that.
+//
+// |out_syms| must be released by the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_syms_create_from_system_loader(
+    iree_hal_vulkan_syms_t** out_syms);
+
+// Releases the given |syms| from the caller.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_syms_release(iree_hal_vulkan_syms_t* syms);
+
+#endif  // IREE_API_NO_PROTOTYPES
+
+//===----------------------------------------------------------------------===//
+// iree::hal::vulkan::VulkanDriver
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_API_NO_PROTOTYPES
+
+// Creates a Vulkan HAL driver that manages its own VkInstance.
+//
+// |out_driver| must be released by the caller (see |iree_hal_driver_release|).
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_vulkan_driver_create(
+    iree_hal_vulkan_driver_options_t options, iree_hal_vulkan_syms_t* syms,
+    iree_hal_driver_t** out_driver);
+
+// Creates a Vulkan HAL driver that shares an existing VkInstance.
+//
+// An IREE_STATUS_INVALID_ARGUMENT error will be returned if the requested
+// |options| are not compatible with the existing |instance|.
+//
+// |instance| must remain valid for the life of |out_driver| and |out_driver|
+// itself must be released by the caller (see |iree_hal_driver_release|).
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_driver_create_using_instance(
+    iree_hal_vulkan_driver_options_t options, iree_hal_vulkan_syms_t* syms,
+    VkInstance instance, iree_hal_driver_t** out_driver);
+
+// Creates the default Vulkan HAL device using |driver| that manages its own
+// VkPhysicalDevice/VkDevice.
+//
+// |out_device| must be released by the caller (see |iree_hal_device_release|).
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_vulkan_driver_create_default_device(iree_hal_driver_t* driver,
+                                             iree_hal_device_t** out_device);
+
+#endif  // IREE_API_NO_PROTOTYPES
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_VULKAN_API_H_

--- a/iree/hal/vulkan/vulkan_driver.h
+++ b/iree/hal/vulkan/vulkan_driver.h
@@ -42,10 +42,20 @@ class VulkanDriver final : public Driver {
     ExtensibilitySpec device_extensibility;
   };
 
+  // Creates a VulkanDriver that manages its own VkInstance.
   static StatusOr<ref_ptr<VulkanDriver>> Create(Options options,
                                                 ref_ptr<DynamicSymbols> syms);
 
-  // TODO(benvanik): method to wrap an existing instance/device (interop).
+  // Creates a VulkanDriver that shares an externally managed VkInstance.
+  //
+  // |options| are checked for compatibility.
+  //
+  // |syms| must at least have |vkGetInstanceProcAddr| set. Other symbols will
+  // be loaded as needed from |instance|.
+  //
+  // |instance| must remain valid for the life of the returned VulkanDriver.
+  static StatusOr<ref_ptr<VulkanDriver>> CreateUsingInstance(
+      Options options, ref_ptr<DynamicSymbols> syms, VkInstance instance);
 
   ~VulkanDriver() override;
 
@@ -62,11 +72,13 @@ class VulkanDriver final : public Driver {
 
  private:
   VulkanDriver(ref_ptr<DynamicSymbols> syms, VkInstance instance,
+               bool owns_instance,
                std::unique_ptr<DebugReporter> debug_reporter,
                ExtensibilitySpec device_extensibility_spec);
 
   ref_ptr<DynamicSymbols> syms_;
   VkInstance instance_;
+  bool owns_instance_;
   std::unique_ptr<DebugReporter> debug_reporter_;
   ExtensibilitySpec device_extensibility_spec_;
 };

--- a/iree/rt/api.cc
+++ b/iree/rt/api.cc
@@ -99,6 +99,20 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_rt_instance_register_driver_ex(
   return IREE_STATUS_OK;
 }
 
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_rt_instance_register_device(
+    iree_rt_instance_t* instance, iree_hal_device_t* device) {
+  IREE_TRACE_SCOPE0("iree_rt_instance_register_device");
+  auto* handle = reinterpret_cast<Instance*>(instance);
+  if (!handle) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+
+  IREE_API_RETURN_IF_ERROR(handle->device_manager()->RegisterDevice(
+      add_ref(reinterpret_cast<hal::Device*>(device))));
+
+  return IREE_STATUS_OK;
+}
+
 //===----------------------------------------------------------------------===//
 // iree::rt::Module
 //===----------------------------------------------------------------------===//

--- a/iree/rt/api.h
+++ b/iree/rt/api.h
@@ -151,6 +151,10 @@ iree_rt_instance_release(iree_rt_instance_t* instance);
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_rt_instance_register_driver_ex(
     iree_rt_instance_t* instance, iree_string_view_t driver_name);
 
+// Registers a HAL device with the runtime instance.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_rt_instance_register_device(
+    iree_rt_instance_t* instance, iree_hal_device_t* device);
+
 #endif  // IREE_API_NO_PROTOTYPES
 
 //===----------------------------------------------------------------------===//

--- a/iree/samples/rt/vulkan/BUILD
+++ b/iree/samples/rt/vulkan/BUILD
@@ -40,7 +40,7 @@ cc_binary(
         "//iree/base:api",
         "//iree/base:logging",
         "//iree/hal:api",
-        "//iree/hal/vulkan:vulkan_driver_module",  # build-cleaner: keep
+        "//iree/hal/vulkan:api",
         "//iree/rt:api",
         "//iree/vm:api",
         "@com_google_absl//absl/base:core_headers",

--- a/iree/samples/rt/vulkan/CMakeLists.txt
+++ b/iree/samples/rt/vulkan/CMakeLists.txt
@@ -25,7 +25,7 @@ iree_cc_binary(
       iree::base::api
       iree::base::logging
       iree::hal::api
-      iree::hal::vulkan::vulkan_driver_module
+      iree::hal::vulkan::api
       iree::rt::api
       iree::vm::api
       SDL2-static


### PR DESCRIPTION
For an application to integrate closely with IREE's Vulkan HAL, it will need to
use the same `VkInstance`, `VkPhysicalDevice`, and `VkDevice`. We will also
later want to add API integration points for objects like `VkSemaphore`,
`VkBuffer`, and `VkImage`.

This change makes progress in that direction:

* Add `Device` and `Driver` to iree/hal/api.[h,cc]
* Add iree/hal/vulkan/api.[h,cc] with basic `Driver` and `Device` management
* Support loading Vulkan symbols (`iree::hal::vulkan::DynamicSymbols`) from a
  statically linked `vkGetInstanceProcAddr` for `vk_graphics_integration.cc`
  sample
* Update `vk_graphics_integration.cc` sample to use the new API methods instead
  of dynamic driver lookup (`iree_rt_instance_register_vulkan_driver_ex`)
* Allow `VulkanDriver` to use an existing `VkInstance` instead of creating its
  own

A following change will allow `VulkanDevice` to use an existing `VkDevice` and
set of `VkQueue`s.