### PR TITLE
Remove vulkan sdk from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,6 @@ jobs:
         run: |
           sudo apt install clang libsdl2-dev python3 python3-pip
           sudo pip install numpy
-      - name: Downloading the Vulkan SDK
-        # https://vulkan.lunarg.com/doc/sdk/1.1.126.0/linux/getting_started.html
-        run: |
-          mkdir ~/vulkan
-          wget -qO- https://sdk.lunarg.com/sdk/download/1.1.126.0/linux/vulkan-sdk.tar.gz | tar xzf - -C ~/vulkan/
       - name: Checking out latest version and all submodules
         run: |
           git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
@@ -51,7 +46,6 @@ jobs:
           git submodule update --init --depth 1000 --jobs 8
       - name: Building and testing with bazel
         run: |
-          source ~/vulkan/1.1.126.0/setup-env.sh
           # Build and test everything not explicitly marked as excluded from CI
           # (using the tag "notap", "Test Automation Platform").
           # Note that somewhat contrary to its name `bazel test` will also build


### PR DESCRIPTION
These tests are currently marked notap so they get excluded anyway. Having the vulkan env variables set causes HAL tests to fail.