### PR TITLE
Only set CMP0077 if it exists, allowing cmake 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.13)
-cmake_policy(SET CMP0077 NEW)
+cmake_minimum_required(VERSION 3.12)
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
cmake 3.12 is what's on the github runners and getting them to use something different is proving to a PITA. Unfortunately, this version does not appear to support the "-B" flag for setting the build directory, based on my local testing.

The pattern of only setting this policy if it exists appears to be common. It avoids warnings in newer versions of cmake that complain if it's not specified and errors in older versions that don't recognize it. I guess it means people building with 3.12 will get slightly different esoteric options behavior, but seems not too bad.