### PR TITLE
Fixes to build samples with CMake

### DIFF
--- a/iree/samples/hal/CMakeLists.txt
+++ b/iree/samples/hal/CMakeLists.txt
@@ -12,6 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_custom_command(
+  OUTPUT simple_compute_test_module.emod
+  COMMAND iree-translate
+          --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_compute_test.mlir"
+          -o simple_compute_test_module.emod
+  # TODO(marbre): Get iree_translate target working.
+  #DEPENDS iree_translate
+)
+
+add_custom_command(
+  OUTPUT simple_compute_test_module.h simple_compute_test_module.cc
+  COMMAND generate_cc_embed_data simple_compute_test_module.emod
+          --output_header=simple_compute_test_module.h
+          --output_impl=simple_compute_test_module.cc
+          --identifier=simple_compute_test_module
+          --cpp_namespace=iree::hal::samples
+  DEPENDS generate_cc_embed_data
+          # TODO(marbre): Enable dep as soon as target is working.
+          #simple_compute_test_module.emod
+)
+
+add_library(
+  simple_compute_test_module STATIC
+  simple_compute_test_module.cc
+)
+
 iree_cc_test(
   NAME
     simple_compute_test
@@ -32,4 +58,5 @@ iree_cc_test(
     # Enabled drivers:
     iree::hal::interpreter::interpreter_driver_module
     iree::hal::vulkan::vulkan_driver_module
+    simple_compute_test_module
 )

--- a/iree/samples/rt/CMakeLists.txt
+++ b/iree/samples/rt/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_test(
     iree::schemas
     iree::rt
     iree::vm::bytecode_module
+    iree::vm::sequencer_module
     # Enabled drivers:
     iree::hal::interpreter::interpreter_driver_module
     iree::hal::vulkan::vulkan_driver_module

--- a/iree/samples/rt/CMakeLists.txt
+++ b/iree/samples/rt/CMakeLists.txt
@@ -14,6 +14,32 @@
 
 add_subdirectory(vulkan)
 
+add_custom_command(
+  OUTPUT simple_module_test_bytecode_module.emod
+  COMMAND iree-translate
+          --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_module_test.mlir"
+          -o simple_module_test_bytecode_module.emod
+  # TODO(marbre): Get iree_translate target working.
+  #DEPENDS iree_translate
+)
+
+add_custom_command(
+  OUTPUT simple_module_test_bytecode_module.h simple_module_test_bytecode_module.cc
+  COMMAND generate_cc_embed_data simple_module_test_bytecode_module.emod
+          --output_header=simple_module_test_bytecode_module.h
+          --output_impl=simple_module_test_bytecode_module.cc
+          --identifier=simple_module_test_bytecode_module
+          --cpp_namespace=iree::rt::samples
+  DEPENDS generate_cc_embed_data
+          # TODO(marbre): Enable dep as soon as target is working.
+          #simple_module_test_bytecode_module.emod
+)
+
+add_library(
+  simple_module_test_bytecode_module STATIC
+  simple_module_test_bytecode_module.cc
+)
+
 iree_cc_test(
   NAME
     bytecode_module_test
@@ -34,4 +60,5 @@ iree_cc_test(
     # Enabled drivers:
     iree::hal::interpreter::interpreter_driver_module
     iree::hal::vulkan::vulkan_driver_module
+    simple_module_test_bytecode_module
 )

--- a/iree/samples/rt/vulkan/CMakeLists.txt
+++ b/iree/samples/rt/vulkan/CMakeLists.txt
@@ -12,6 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_custom_command(
+  OUTPUT simple_mul_bytecode_module.emod
+  COMMAND iree-translate
+          --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_mul.mlir"
+          -o simple_mul_bytecode_module.emod
+  # TODO(marbre): Get iree_translate target working.
+  #DEPENDS iree_translate
+)
+
+add_custom_command(
+  OUTPUT simple_mul_bytecode_module.h simple_mul_bytecode_module.cc
+  COMMAND generate_cc_embed_data simple_mul_bytecode_module.emod
+          --output_header=simple_mul_bytecode_module.h
+          --output_impl=simple_mul_bytecode_module.cc
+          --identifier=simple_mul_bytecode_module
+          --cpp_namespace=iree::rt::samples
+  DEPENDS generate_cc_embed_data
+          # TODO(marbre): Enable dep as soon as target is working.
+          #simple_mul_bytecode_module.emod
+)
+
+add_library(
+  simple_mul_bytecode_module STATIC
+  simple_mul_bytecode_module.cc
+)
+
 iree_cc_binary(
     NAME
       vk_graphics_integration
@@ -29,4 +55,6 @@ iree_cc_binary(
       iree::rt::api
       iree::vm::api
       SDL2-static
+      simple_mul_bytecode_module
+      # TODO(marbre): Add Vulkan dependencies
 )


### PR DESCRIPTION
This PR complements #160. I implemented the generation of *emod*, *h* and *cc* files, by using `add_custom_command` to call `iree-translate` and `generate_cc_embed_data`.

At the moment, the `iree_translate` target to build the `iree-translate` executable still fails. For testing puposes, I added `#file(COPY "${CMAKE_SOURCE_DIR}/iree/tools/iree-translate" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")` to `iree/tools/CMakeLists.txt` and replaced `COMMAND iree-translate` by `COMMAND "${CMAKE_BINARY_DIR}/iree/tools/iree-translate"`. This allowed me to verify that the additions to the CMakeLists.txt work as expected, using the `iree-translate` executable build with Bazel.

Prior to (maybe) merging this, I would like to discuss if a *raw* `add_custom_command` is the way to go or, taking comment https://github.com/google/iree/pull/160#discussion_r350910157 into account, if wrapping, e.g. in a CMake function, would be preferable.