### PR TITLE
Add link to last passing commit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ libraries that make use of modern hardware acceleration APIs and techniques (see
 ![ci-status](https://github.com/google/iree/workflows/Continuous%20Integration/badge.svg)
 
 To find the last passing commit, choose the latest passing run
-[here](https://github.com/google/iree/actions?query=branch%3Amaster+event%3Apush+is%3Asuccess)
+[here](https://github.com/google/iree/actions?query=branch%3Amaster+event%3Apush+is%3Asuccess).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ libraries that make use of modern hardware acceleration APIs and techniques (see
 
 ![ci-status](https://github.com/google/iree/workflows/Continuous%20Integration/badge.svg)
 
+To find the last passing commit, choose the latest passing run
+[here](https://github.com/google/iree/actions?query=branch%3Amaster+event%3Apush+is%3Asuccess)
+
 ## Table of Contents
 
 -   [Quickstart](#quickstart)


### PR DESCRIPTION
The CI status badge is almost always grey, which isn't super useful. There's got to be a better way to do this, but this seems useful in the meantime