### PR TITLE
Fixes for SPIR-V kernel generation via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ add_subdirectory(iree/schemas)
 add_subdirectory(iree/vm)
 
 if(${IREE_BUILD_COMPILER})
+  add_subdirectory(third_party/glslang EXCLUDE_FROM_ALL)
   add_subdirectory(iree/compiler)
 endif()
 

--- a/iree/compiler/Translation/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/CMakeLists.txt
@@ -49,8 +49,9 @@ iree_cc_library(
     iree::compiler::Serialization
     iree::compiler::Transforms
     iree::compiler::Transforms::Sequencer
-    # TODO(benvanik): generate filetoc for kernels.
+    # TODO(marbre): Use instead of Kernels target, as soon as build with iree_glsl_cc_library
     #iree::compiler::Translation::SPIRV::Kernels
+    Kernels
     iree::compiler::Utils
     iree::schemas
     iree::schemas::spirv_executable_def_cc_fbs

--- a/iree/compiler/Translation/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/CMakeLists.txt
@@ -51,7 +51,7 @@ iree_cc_library(
     iree::compiler::Transforms::Sequencer
     # TODO(marbre): Use instead of Kernels target, as soon as build with iree_glsl_cc_library
     #iree::compiler::Translation::SPIRV::Kernels
-    Kernels
+    iree_compiler_Translation_SPIRV_Kernels
     iree::compiler::Utils
     iree::schemas
     iree::schemas::spirv_executable_def_cc_fbs

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -23,3 +23,30 @@
 #    "reduce_untiled.comp"
 #   PUBLIC
 # )
+
+add_custom_command(
+  OUTPUT matmul.spv
+  COMMAND glslangValidator -V "${CMAKE_CURRENT_SOURCE_DIR}/matmul.comp" -o matmul.spv
+  DEPENDS glslangValidator
+)
+
+add_custom_command(
+  OUTPUT reduce_untiled.spv
+  COMMAND glslangValidator -V "${CMAKE_CURRENT_SOURCE_DIR}/reduce_untiled.comp" -o reduce_untiled.spv
+  DEPENDS glslangValidator
+)
+
+add_custom_command(
+  OUTPUT Kernels.h Kernels.cc
+  COMMAND generate_cc_embed_data matmul.spv reduce_untiled.spv
+          --output_header=Kernels.h
+          --output_impl=Kernels.cc
+          --identifier=Kernels
+          --cpp_namespace=mlir::iree_compiler::spirv_kernels
+          --flatten
+  DEPENDS generate_cc_embed_data
+          matmul.spv
+          reduce_untiled.spv
+)
+
+add_library(Kernels STATIC Kernels.cc)

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -49,4 +49,4 @@ add_custom_command(
           reduce_untiled.spv
 )
 
-add_library(Kernels STATIC Kernels.cc)
+add_library(iree_compiler_Translation_SPIRV_Kernels STATIC Kernels.cc)

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -45,8 +45,7 @@ if(${IREE_BUILD_COMPILER})
       ${_ALWAYSLINK_LIBS}
       iree::compiler::Translation::Interpreter
       iree::compiler::Translation::Sequencer
-      # TODO(benvanik): get the SPIR-V translation working.
-      #iree::compiler::Translation::SPIRV
+      iree::compiler::Translation::SPIRV
       MLIRTranslateClParser
   )
 


### PR DESCRIPTION
This PR depends on #160, which implements building `generate_cc_embed_data`. The PR does not implement `iree_glsl_cc_library`, but I think that can be refactored after getting the complete compiler or samples target working.