### PR TITLE
Set up build configuration for Kokoro

### DIFF
--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the IREE project with bazel. Designed for CI, but can be run manually.
+
+set -e
+
+set -x
+
+# Build and test everything not explicitly marked as excluded from CI (using the
+# tag "notap", "Test Automation Platform").
+# Note that somewhat contrary to its name `bazel test` will also build
+# any non-test targets specified.
+# We use `bazel query //...` piped to `bazel test` rather than the simpler
+# `bazel test //...` because the latter excludes targets tagged "manual". The
+# "manual" tag allows targets to be excluded from human wildcard builds, but we
+# want them built by CI unless they are excluded with "notap".
+bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --test_output=errors

--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -28,4 +28,4 @@ set -x
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "notap".
-bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --test_output=errors
+bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --keep_going --test_output=errors

--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -23,4 +23,8 @@ set -e
 
 set -x
 
+# Relative to the root of the repository. Kokoro will make sure we're in the
+# ${KOKORO_ARTIFACTS_DIR}/github/iree directory (which is equivalent) before
+# invoking this
+
 ./build_tools/bazel_build.sh

--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the project with bazel using Kokoro.
+
+# Having separate build scripts with this indirection is recommended by the
+# Kokoro setup instructions. 
+
+set -e
+
+set -x
+
+./build_tools/bazel_build.sh

--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -25,6 +25,6 @@ set -x
 
 # Relative to the root of the repository. Kokoro will make sure we're in the
 # ${KOKORO_ARTIFACTS_DIR}/github/iree directory (which is equivalent) before
-# invoking this
+# invoking this.
 
 ./build_tools/bazel_build.sh

--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -17,7 +17,7 @@
 # Build the project with bazel using Kokoro.
 
 # Having separate build scripts with this indirection is recommended by the
-# Kokoro setup instructions. 
+# Kokoro setup instructions.
 
 set -e
 

--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "iree/kokoro/gcp_ubuntu/bazel_build.sh"


### PR DESCRIPTION
This includes
1. A bazel build script that can be shared between CI and human invocations
2. A Kokoro-specific build script
3. A Kokoro CI build configuration