### PR TITLE
Get SDL2, ImGui, and graphics sample building on Windows with Bazel.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,9 +50,8 @@ build:x86opt --copt=-mavx2
 build:windows --copt=-Wno-builtin-macro-redefined --host_copt=-Wno-builtin-macro-redefined
 build:windows --copt=-Wno-unknown-argument --host_copt=-Wno-unknown-argument
 
-# Disables windows headers from pulling in GDI, which does a lot of terrible
-# things (such as defining the ERROR macro, which breaks the world).
-build:windows --copt=-DNOGDI --host_copt=-DNOGDI
+# Avoid warnings for WIN32_LEAN_AND_MEAN being defined multiple times.
+build:windows --copt=-Wno-macro-redefined
 
 # Enables unix-style runfiles link trees (requires symlink permission).
 # See: https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/

--- a/build_tools/third_party/dear_imgui/BUILD.overlay
+++ b/build_tools/third_party/dear_imgui/BUILD.overlay
@@ -73,3 +73,15 @@ cc_library(
         "@sdl2//:SDL2",
     ],
 )
+
+cc_binary(
+    name = "example_sdl_vulkan",
+    srcs = [
+        "examples/example_sdl_vulkan/main.cpp",
+    ],
+    deps = [
+        ":dear_imgui_srcs",
+        ":imgui_sdl_vulkan_srcs",
+    ],
+    includes = ["examples/"],
+)

--- a/build_tools/third_party/sdl2/BUILD.overlay
+++ b/build_tools/third_party/sdl2/BUILD.overlay
@@ -143,7 +143,6 @@ sdl_linkopts = select({
         "-DEFAULTLIB:advapi32",
         "-DEFAULTLIB:hid",
         "-DEFAULTLIB:setupapi",
-        "-DEFAULTLIB:opengl32",
     ],
     "//conditions:default": [
         "-ldl",

--- a/build_tools/third_party/sdl2/BUILD.overlay
+++ b/build_tools/third_party/sdl2/BUILD.overlay
@@ -37,11 +37,15 @@ sdl_sources = select({
             "src/**/*.h",
         ],
         exclude = [
+            # Ignore test files
             "src/test/*.c",
-            "src/video/qnx/**",
+            # Ignore Linux/Unix
             "src/core/linux/**",
-            "src/thread/**",
             "src/core/unix/**",
+            # Ignore thread (exclude for thread/windows)
+            "src/thread/**",
+            # Remove support for QNX
+            "src/video/qnx/**",
         ],
     ) + glob([
         "src/thread/*",
@@ -117,6 +121,7 @@ sdl_headers = [
 ]
 
 sdl_copts = select({
+    "@bazel_tools//src/conditions:windows": [],
     "//conditions:default": [
         "-Wno-string-conversion",
         "-pthread",
@@ -126,16 +131,19 @@ sdl_copts = select({
 
 sdl_linkopts = select({
     "@bazel_tools//src/conditions:windows": [
-        "-Wl,advapi32.lib",
-        "-Wl,gdi32.lib",
-        "-Wl,imm32.lib",
-        "-Wl,ole32.lib",
-        "-Wl,oleaut32.lib",
-        "-Wl,opengl32.lib",
-        "-Wl,shell32.lib",
-        "-Wl,user32.lib",
-        "-Wl,version.lib",
-        "-Wl,winmm.lib",
+        "-DEFAULTLIB:user32",
+        "-DEFAULTLIB:gdi32",
+        "-DEFAULTLIB:winmm",
+        "-DEFAULTLIB:imm32",
+        "-DEFAULTLIB:ole32",
+        "-DEFAULTLIB:oleaut32",
+        "-DEFAULTLIB:version",
+        "-DEFAULTLIB:uuid",
+        "-DEFAULTLIB:shell32",
+        "-DEFAULTLIB:advapi32",
+        "-DEFAULTLIB:hid",
+        "-DEFAULTLIB:setupapi",
+        "-DEFAULTLIB:opengl32",
     ],
     "//conditions:default": [
         "-ldl",

--- a/build_tools/third_party/sdl2/SDL_config_linux.h
+++ b/build_tools/third_party/sdl2/SDL_config_linux.h
@@ -1,5 +1,6 @@
-#ifndef _SDL_config_linux_h
-#define _SDL_config_linux_h
+#ifndef SDL_config_linux_h
+#define SDL_config_linux_h
+#define SDL_config_h_
 
 /**
  *  \file SDL_config_linux.h
@@ -401,4 +402,4 @@
 /* Enable dynamic libsamplerate support */
 /* #undef SDL_LIBSAMPLERATE_DYNAMIC */
 
-#endif /* _SDL_config_linux_h */
+#endif /* SDL_config_linux_h */

--- a/build_tools/third_party/sdl2/SDL_config_windows.h
+++ b/build_tools/third_party/sdl2/SDL_config_windows.h
@@ -187,35 +187,35 @@ typedef unsigned int uintptr_t;
 /* Enable various timer systems */
 #define SDL_TIMER_WINDOWS 1
 
-/* Enable various video drivers */
+/* Enable/disable various video drivers */
 #define SDL_VIDEO_DRIVER_DUMMY 1
 #define SDL_VIDEO_DRIVER_WINDOWS 1
 
 #ifndef SDL_VIDEO_RENDER_D3D
-#define SDL_VIDEO_RENDER_D3D 1
+#define SDL_VIDEO_RENDER_D3D 0
 #endif
 #ifndef SDL_VIDEO_RENDER_D3D11
 #define SDL_VIDEO_RENDER_D3D11 0
 #endif
 
-/* Enable OpenGL support */
+/* Disable OpenGL support, just use Vulkan */
 #ifndef SDL_VIDEO_OPENGL
-#define SDL_VIDEO_OPENGL 1
+#define SDL_VIDEO_OPENGL 0
 #endif
 #ifndef SDL_VIDEO_OPENGL_WGL
-#define SDL_VIDEO_OPENGL_WGL 1
+#define SDL_VIDEO_OPENGL_WGL 0
 #endif
 #ifndef SDL_VIDEO_RENDER_OGL
-#define SDL_VIDEO_RENDER_OGL 1
+#define SDL_VIDEO_RENDER_OGL 0
 #endif
 #ifndef SDL_VIDEO_RENDER_OGL_ES2
-#define SDL_VIDEO_RENDER_OGL_ES2 1
+#define SDL_VIDEO_RENDER_OGL_ES2 0
 #endif
 #ifndef SDL_VIDEO_OPENGL_ES2
-#define SDL_VIDEO_OPENGL_ES2 1
+#define SDL_VIDEO_OPENGL_ES2 0
 #endif
 #ifndef SDL_VIDEO_OPENGL_EGL
-#define SDL_VIDEO_OPENGL_EGL 1
+#define SDL_VIDEO_OPENGL_EGL 0
 #endif
 
 /* Enable Vulkan support */

--- a/build_tools/third_party/sdl2/SDL_config_windows.h
+++ b/build_tools/third_party/sdl2/SDL_config_windows.h
@@ -4,6 +4,12 @@
 
 #include "SDL_platform.h"
 
+// Explicitly include headers for SSE intrinsics.
+// SDL itself conditionally chooses to not include these on Windows, but they
+// appear to be needed on some systems anyway.
+#include <intrin.h>
+#include <xmmintrin.h>
+
 /* This is a set of defines to configure the SDL features */
 
 #if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
@@ -64,6 +70,7 @@ typedef unsigned int uintptr_t;
 
 /* This is disabled by default to avoid C runtime dependencies and manifest
  * requirements */
+#define HAVE_LIBC 1  // Enable it anyway :D
 #ifdef HAVE_LIBC
 /* Useful headers */
 #define STDC_HEADERS 1

--- a/build_tools/third_party/vulkan_sdk/repo.bzl
+++ b/build_tools/third_party/vulkan_sdk/repo.bzl
@@ -30,7 +30,7 @@ cc_library(
     name = "sdk",
     srcs = select({
         "@bazel_tools//src/conditions:windows": [
-            "Lib/vulkan-1.lib"
+            "vulkan-sdk/Lib/vulkan-1.lib"
         ],
         "//conditions:default": [
             "vulkan-sdk/lib/libvulkan.so.1",


### PR DESCRIPTION
* Fix Vulkan SDK lib path on Windows.
* Workaround SDL omitting includes for intrinsics.
* Adjust .bazelrc to be less restrictive (Windows GDI, Graphics Device Interace, is needed now).

Tested that `bazel build //...` and ` bazel run //iree/samples/rt/vulkan:vk_graphics_integration` both work on my Windows machine.

Relates to #19