### PR TITLE
Fix building iree::compiler::Dialect with CMake

### DIFF
--- a/iree/compiler/Dialect/CMakeLists.txt
+++ b/iree/compiler/Dialect/CMakeLists.txt
@@ -22,6 +22,8 @@ add_subdirectory(Flow/Utils)
 add_subdirectory(HAL)
 
 add_subdirectory(VM/Analysis)
+add_subdirectory(VM/Conversion)
+add_subdirectory(VM/Conversion/StandardToVM)
 add_subdirectory(VM/IR)
 add_subdirectory(VM/Target/Bytecode)
 add_subdirectory(VM/Tools)

--- a/iree/compiler/Dialect/CMakeLists.txt
+++ b/iree/compiler/Dialect/CMakeLists.txt
@@ -19,12 +19,7 @@ add_subdirectory(Flow/IR)
 add_subdirectory(Flow/Transforms)
 add_subdirectory(Flow/Utils)
 
-add_subdirectory(HAL/Conversion/FlowToHAL)
-add_subdirectory(HAL/Conversion/HALToVM)
-add_subdirectory(HAL/IR)
-add_subdirectory(HAL/Target)
-add_subdirectory(HAL/Transforms)
-add_subdirectory(HAL/Utils)
+add_subdirectory(HAL)
 
 add_subdirectory(VM/Analysis)
 add_subdirectory(VM/IR)

--- a/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_cc_library(
+  NAME
+    Conversion
+  HDRS
+    "TypeConverter.h"
+  SRCS
+    "TypeConverter.cpp"
+  DEPS
+    iree::compiler::Dialect
+    MLIRIR
+    MLIRParser
+    MLIRTransforms
+  ALWAYSLINK
+  PUBLIC
+)

--- a/iree/compiler/Dialect/HAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(Conversion/FlowToHAL)
+add_subdirectory(Conversion/HALToVM)
+add_subdirectory(IR)
+add_subdirectory(Target)
+add_subdirectory(Transforms)
+add_subdirectory(Utils)
+
+add_custom_command(
+  PRE_BUILD
+  OUTPUT hal.imports.h hal.imports.cc
+  COMMAND generate_cc_embed_data "${CMAKE_CURRENT_SOURCE_DIR}/hal.imports.mlir"
+          --output_header=hal.imports.h
+          --output_impl=hal.imports.cc
+          --identifier=hal_imports
+          --cpp_namespace=mlir::iree_compiler
+          --flatten
+  DEPENDS generate_cc_embed_data
+)
+
+add_custom_target(iree_compiler_Dialect_HAL_hal_imports DEPENDS hal.imports.h)

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -14,16 +14,30 @@
 
 iree_cc_library(
   NAME
-    HALtoVM
+    HALToVM
   HDRS
     "ConvertHALToVM.h"
   SRCS
+    "ConvertAllocatorOps.cpp"
+    "ConvertBufferOps.cpp"
+    "ConvertCommandBufferOps.cpp"
+    "ConvertDeviceOps.cpp"
+    "ConvertExecutableOps.cpp"
+    "ConvertExperimentalOps.cpp"
     "ConvertHALToVM.cpp"
-    "ConvertHALToVMPass.cpp"
+    "ConvertVariableOps.cpp"
   DEPS
     iree::compiler::Dialect
-    iree::compiler::Dialect::HAL::IR
+    iree_compiler_Dialect_HAL_hal_imports
+    iree::compiler::Dialect::HAL::IR::IR
+    iree::compiler::Dialect::HAL::IR::HALEnumsGen
+    iree::compiler::Dialect::HAL::IR::HALOpInterfaceGen
+    iree::compiler::Dialect::HAL::IR::HALOpsGen
+    iree::compiler::Dialect::HAL::Utils
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::Conversion::StandardToVM
     iree::compiler::Dialect::VM::IR
+    LLVMSupport
     MLIRIR
     MLIRPass
     MLIRStandardOps

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -16,20 +16,17 @@ iree_cc_library(
   NAME
     IR
   HDRS
-    "HALDialect.h"
+    "HALEnums.cpp.inc"
+    "HALOpFolders.cpp"
+    "HALOpInterface.cpp.inc"
+    "HALOps.cpp"
+    "HALTypes.cpp"
+  SRCS
     "HALEnums.h.inc"
     "HALOpInterface.h.inc"
     "HALOps.h"
     "HALOps.h.inc"
     "HALTypes.h"
-  SRCS
-    "HALDialect.cpp"
-    "HALEnums.cpp.inc"
-    "HALOpFolders.cpp"
-    "HALOpInterface.cpp.inc"
-    "HALOps.cpp"
-    "HALOps.cpp.inc"
-    "HALTypes.cpp"
   DEPS
     HALEnumsGen
     HALOpInterfaceGen
@@ -37,6 +34,30 @@ iree_cc_library(
     iree::compiler::Dialect
     LLVMSupport
     MLIRIR
+    MLIRParser
+    MLIRStandardOps
+    MLIRSupport
+    MLIRTransformUtils
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    HALDialect
+  HDRS
+    "HALDialect.cpp"
+  SRCS
+    "HALDialect.h"
+  DEPS
+    IR
+    iree::compiler::Dialect
+    iree_compiler_Dialect_HAL_hal_imports
+    iree::compiler::Dialect::HAL::Conversion::HALToVM
+    iree::compiler::Dialect::VM::Conversion
+    LLVMSupport
+    MLIRIR
+    MLIRParser
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -16,17 +16,17 @@ iree_cc_library(
   NAME
     IR
   HDRS
-    "HALEnums.cpp.inc"
-    "HALOpFolders.cpp"
-    "HALOpInterface.cpp.inc"
-    "HALOps.cpp"
-    "HALTypes.cpp"
-  SRCS
     "HALEnums.h.inc"
     "HALOpInterface.h.inc"
     "HALOps.h"
     "HALOps.h.inc"
     "HALTypes.h"
+  SRCS
+    "HALEnums.cpp.inc"
+    "HALOpFolders.cpp"
+    "HALOpInterface.cpp.inc"
+    "HALOps.cpp"
+    "HALTypes.cpp"
   DEPS
     HALEnumsGen
     HALOpInterfaceGen

--- a/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
@@ -14,18 +14,22 @@
 
 iree_cc_library(
   NAME
-    ImportUtils
+    Conversion
   HDRS
+    "ConversionDialectInterface.h"
+    "ConversionTarget.h"
     "ImportUtils.h"
+    "TypeConverter.h"
   SRCS
+    "ConversionTarget.cpp"
     "ImportUtils.cpp"
+    "TypeConverter.cpp"
   DEPS
     iree::compiler::Dialect
-    iree::compiler::Dialect::VM:IR
+    iree::compiler::Dialect::VM::IR
     MLIRIR
     MLIRParser
     MLIRSupport
     MLIRTransforms
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
@@ -22,7 +22,7 @@ iree_cc_library(
     "ConvertStandardToVMPass.cpp"
   DEPS
     iree::compiler::Dialect
-    iree::compiler::Dialect::VM:IR
+    iree::compiler::Dialect::VM::IR
     LLVMSupport
     MLIRIR
     MLIRPass

--- a/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
@@ -17,12 +17,14 @@ iree_cc_library(
     Bytecode
   HDRS
     "BytecodeModuleTarget.h"
+    "TranslationFlags.h"
   SRCS
     "BytecodeEncoder.cpp"
     "BytecodeEncoder.h"
     "BytecodeModuleTarget.cpp"
     "ConstantEncoder.cpp"
     "ConstantEncoder.h"
+    "TranslationFlags.cpp"
     "TranslationRegistration.cpp"
   DEPS
     iree::compiler::Dialect


### PR DESCRIPTION
After several changes in the source structure, I ported the necessary modifications from the Bazel BUILD files to CMake and further fixed some minor issues/typos.