### PR TITLE
Update CMake deps for iree::samples

### DIFF
--- a/iree/samples/hal/CMakeLists.txt
+++ b/iree/samples/hal/CMakeLists.txt
@@ -17,8 +17,7 @@ add_custom_command(
   COMMAND iree-translate
           --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_compute_test.mlir"
           -o simple_compute_test_module.emod
-  # TODO(marbre): Get iree_translate target working.
-  #DEPENDS iree_translate
+  DEPENDS iree::tools::iree_translate
 )
 
 add_custom_command(
@@ -29,8 +28,7 @@ add_custom_command(
           --identifier=simple_compute_test_module
           --cpp_namespace=iree::hal::samples
   DEPENDS generate_cc_embed_data
-          # TODO(marbre): Enable dep as soon as target is working.
-          #simple_compute_test_module.emod
+          simple_compute_test_module.emod
 )
 
 add_library(

--- a/iree/samples/rt/CMakeLists.txt
+++ b/iree/samples/rt/CMakeLists.txt
@@ -19,8 +19,7 @@ add_custom_command(
   COMMAND iree-translate
           --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_module_test.mlir"
           -o simple_module_test_bytecode_module.emod
-  # TODO(marbre): Get iree_translate target working.
-  #DEPENDS iree_translate
+  DEPENDS iree::tools::iree_translate
 )
 
 add_custom_command(
@@ -31,8 +30,7 @@ add_custom_command(
           --identifier=simple_module_test_bytecode_module
           --cpp_namespace=iree::rt::samples
   DEPENDS generate_cc_embed_data
-          # TODO(marbre): Enable dep as soon as target is working.
-          #simple_module_test_bytecode_module.emod
+          simple_module_test_bytecode_module.emod
 )
 
 add_library(

--- a/iree/samples/rt/vulkan/CMakeLists.txt
+++ b/iree/samples/rt/vulkan/CMakeLists.txt
@@ -17,8 +17,7 @@ add_custom_command(
   COMMAND iree-translate
           --mlir-to-iree-module "${CMAKE_CURRENT_SOURCE_DIR}/simple_mul.mlir"
           -o simple_mul_bytecode_module.emod
-  # TODO(marbre): Get iree_translate target working.
-  #DEPENDS iree_translate
+  DEPENDS iree::tools::iree_translate
 )
 
 add_custom_command(
@@ -29,8 +28,7 @@ add_custom_command(
           --identifier=simple_mul_bytecode_module
           --cpp_namespace=iree::rt::samples
   DEPENDS generate_cc_embed_data
-          # TODO(marbre): Enable dep as soon as target is working.
-          #simple_mul_bytecode_module.emod
+          simple_mul_bytecode_module.emod
 )
 
 add_library(


### PR DESCRIPTION
With #184, #185, #186 and #187 merged, this enables the build toolchain to compile the examples. Together with the other PRs this nearly enables the compilation of the examples :)