### PR TITLE
Cleanup how lit tests get run.

### DIFF
--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -20,6 +20,15 @@ set -e
 
 set -x
 
+# CI-friendly defaults that control availability of certain platform tests.
+if ! [[ -v IREE_VULKAN_DISABLE ]]; then
+  IREE_VULKAN_DISABLE=1
+fi
+test_env_args=(
+  --test_env=IREE_VULKAN_DISABLE=$IREE_VULKAN_DISABLE
+)
+echo "Running with test env args: ${test_env_args[@]}"
+
 # Build and test everything not explicitly marked as excluded from CI (using the
 # tag "notap", "Test Automation Platform").
 # Note that somewhat contrary to its name `bazel test` will also build
@@ -28,4 +37,5 @@ set -x
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "notap".
-bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --keep_going --test_output=errors
+bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | \
+    xargs bazel test ${test_env_args[@]} --keep_going --test_output=errors

--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -53,3 +53,20 @@ cc_library(
     ],
     alwayslink = 1,
 )
+
+cc_binary(
+    name = "iree-tf-opt",
+    deps = [
+        ":tensorflow",
+        "//iree/tools:iree_opt_library",
+        "@local_config_mlir//:MlirOptMain",
+    ],
+)
+
+cc_binary(
+    name = "iree-tf-translate",
+    deps = [
+        ":tensorflow",
+        "//iree/tools:iree_translate_library",
+    ],
+)

--- a/integrations/tensorflow/compiler/test/BUILD
+++ b/integrations/tensorflow/compiler/test/BUILD
@@ -27,7 +27,7 @@ package(
 
 iree_setup_lit_package(
     data = [
-        "//iree/tools:iree-opt",
+        "//integrations/tensorflow/compiler:iree-tf-opt",
     ],
 )
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -35,7 +35,6 @@ TARGET_COMPILER_BACKENDS = [
 cc_library(
     name = "iree_opt_library",
     deps = [
-        "//integrations/tensorflow/compiler:tensorflow",
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/Flow/Analysis",
         "//iree/compiler/Dialect/Flow/IR",

--- a/test/e2e/xla/concatenate.mlir
+++ b/test/e2e/xla/concatenate.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode --input_values="2x2xf32= 1 2 3 4\n2x3xf32= 5 6 7 8 9 10\n2x2xf32= 11 12 13 14" %s | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv --input_values="2x2xf32= 1 2 3 4\n2x3xf32= 5 6 7 8 9 10\n2x2xf32= 11 12 13 14" %s | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv --input_values="2x2xf32= 1 2 3 4\n2x3xf32= 5 6 7 8 9 10\n2x2xf32= 11 12 13 14" %s | IreeFileCheck %s)
 
 // -----
 

--- a/test/e2e/xla/constant_f32.mlir
+++ b/test/e2e/xla/constant_f32.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s | IreeFileCheck %s)
 
 // -----
 

--- a/test/e2e/xla/constant_i32.mlir
+++ b/test/e2e/xla/constant_i32.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode --output_types=i,i %s | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv --output_types=i,i %s | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv --output_types=i,i %s | IreeFileCheck %s)
 
 // -----
 

--- a/test/e2e/xla/fullyconnected.mlir
+++ b/test/e2e/xla/fullyconnected.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir %s --target_backends=interpreter-bytecode --input_values="1x5xf32=1,-2,-3,4,-5\n1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
-// RUN: iree-run-mlir %s --target_backends=vulkan-spirv --input_values="1x5xf32=1,-2,-3,4,-5\n1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir %s --target_backends=vulkan-spirv --input_values="1x5xf32=1,-2,-3,4,-5\n1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @main
 func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x3x1xf32>) -> tuple<tensor<5x1x5xf32>>

--- a/test/e2e/xla/gather.mlir
+++ b/test/e2e/xla/gather.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="5x1x5xi32=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25]\ni64=2" --output_types=i | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="5x1x5xi32=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25]\ni64=2" --output_types=i | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="5x1x5xi32=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25]\ni64=2" --output_types=i | IreeFileCheck %s)
 
 module {
   // CHECK-LABEL: EXEC @foo

--- a/test/e2e/xla/gather_concat.mlir
+++ b/test/e2e/xla/gather_concat.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode --input_values="1x2xf32= 1 2\n2x1x4xf32= 5 6 7 8 9 10 11 12\ni64= 0" --output_types=f %s | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv --input_values="1x2xf32= 1 2\n2x1x4xf32= 5 6 7 8 9 10 11 12\ni64= 0" --output_types=f %s | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv --input_values="1x2xf32= 1 2\n2x1x4xf32= 5 6 7 8 9 10 11 12\ni64= 0" --output_types=f %s | IreeFileCheck %s)
 
 module {
   func @gather_concat(%arg0: tensor<1x2xf32>, %arg1: tensor<2x1x4xf32>, %arg2: tensor<i64>) -> tensor<1x6xf32> {

--- a/test/e2e/xla/mnist.mlir
+++ b/test/e2e/xla/mnist.mlir
@@ -1,7 +1,7 @@
 // MNIST model with placeholder weights, for translation testing.
 
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="1x28x28x1xf32" | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="1x28x28x1xf32" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="1x28x28x1xf32" | IreeFileCheck %s)
 
 module {
   // CHECK-LABEL: EXEC @main

--- a/test/e2e/xla/reduce_float.mlir
+++ b/test/e2e/xla/reduce_float.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-run-mlir %s --target_backends=interpreter-bytecode --output_types="f" | IreeFileCheck %s
 // TODO(b/142903911): figure out swiftshader+asan crash:
-// RUN: iree-run-mlir %s --target_backends=vulkan-spirv --output_types="f" --norun
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir %s --target_backends=vulkan-spirv --output_types="f" --norun)
 
 // Float sum values from [1.0, 10.0]
 // CHECK-LABEL: EXEC @reduce_sum_1x10xf32

--- a/test/e2e/xla/reshape.mlir
+++ b/test/e2e/xla/reshape.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="12xf32=[1 2 3 4 5 6 7 8 9 10 11 12]" | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="12xf32=[1 2 3 4 5 6 7 8 9 10 11 12]" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="12xf32=[1 2 3 4 5 6 7 8 9 10 11 12]" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @reshape_1D_2D
 func @reshape_1D_2D(%arg : tensor<12xf32>) -> tensor<3x4xf32> {

--- a/test/e2e/xla/reshape_adddims.mlir
+++ b/test/e2e/xla/reshape_adddims.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="2x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="2x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="2x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @reshape_3D_2D
 func @reshape_3D_2D(%arg : tensor<2x6xf32>) -> tensor<2x1x6xf32> {

--- a/test/e2e/xla/reshape_dropdims.mlir
+++ b/test/e2e/xla/reshape_dropdims.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="2x1x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="2x1x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="2x1x6xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @reshape_3D_1D
 func @reshape_3D_1D(%arg : tensor<2x1x6xf32>) -> tensor<2x6xf32> {

--- a/test/e2e/xla/reverse.mlir
+++ b/test/e2e/xla/reverse.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s | IreeFileCheck %s)
 
 // -----
 

--- a/test/e2e/xla/slice.mlir
+++ b/test/e2e/xla/slice.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-run-mlir --target_backends=interpreter-bytecode %s --input_values="3x4xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
-// RUN: iree-run-mlir --target_backends=vulkan-spirv %s --input_values="3x4xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --target_backends=vulkan-spirv %s --input_values="3x4xf32= 1 2 3 4 5 6 7 8 9 10 11 12" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @slice_whole_buffer
 func @slice_whole_buffer(%arg : tensor<3x4xf32>) -> tensor<3x4xf32> {


### PR DESCRIPTION
* Now that we can have custom 'opt' binaries easily, removes the
tensorflow passes from the main iree-opt in favor of creating a
iree-tf-opt just in the integrations/tensorflow directory.
* Verified that the main CI bazel_build.sh no longer builds tensorflow
deps, which should dramatically reduce build time.
* The CI is failing now because I fixed the bug which was causing only
the first RUN line to execute (for OSS). All of our Vulkan tests
(requiring a real driver) were on second RUN lines. I plumbed through a
IREE_VULKAN_DISABLE environment variable and defaulted it to 1 for CI
builds.
* Verified that all tests pass on my laptop (with Intel graphics) with
both IREE_VULKAN_DISABLE=1 and 0 (and inspected output to make sure
tests are actually running).