### PR TITLE
Do not add subdirectory Interpreter

### DIFF
--- a/iree/compiler/Dialect/CMakeLists.txt
+++ b/iree/compiler/Dialect/CMakeLists.txt
@@ -15,5 +15,5 @@
 add_subdirectory(Flow)
 add_subdirectory(HAL)
 add_subdirectory(IREE)
-add_subdirectory(Interpreter)
+#add_subdirectory(Interpreter)
 add_subdirectory(VM)


### PR DESCRIPTION
Closes #194. Should be re-enabled as soon as that files land in the GitHub repo.