### PR TITLE
Disable Vulkan lit tests on GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "notap".
           # TODO(gcmn) Enable all tests except notap once we can run them on the CI
-          bazel query '//... except attr("tags", "notap", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --define=iree_tensorflow=true --test_output=errors
+          bazel query '//... except attr("tags", "notap", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors
 
   cmake:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
3374b659a260ac59a23b03c9a3dc40651c64e185 fixed the OSS lit test runner so it runs all run lines, not just the first one. This means vulkan tests are actually getting run now and failing because they're not supported in the CI environment