### PR TITLE
Make Kokoro build use RBE

### DIFF
--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -38,4 +38,4 @@ echo "Running with test env args: ${test_env_args[@]}"
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "notap".
 bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | \
-    xargs bazel test ${test_env_args[@]} --keep_going --test_output=errors
+    xargs bazel test ${test_env_args[@]} --config=rbe --keep_going --test_output=errors


### PR DESCRIPTION
Now that all the auth stuff is sorted, this should work.

Tested:
Connected to a GCP VM instantiated by Kokoro (therefore creds match) and ran this script (with modification to use RBE).
Kicked off a manual Kokoro run for this branch: https://source.cloud.google.com/results/invocations/0bf1b481-dd36-470e-9706-4d1b730f8c52/targets