### PR TITLE
Upload CI results to result store UI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,10 +38,24 @@ build --experimental_guard_against_concurrent_changes
 
 ###############################################################################
 
+# Options for connecting to the IREE GCP remote build project.
+
+# Enable authentication. This will pick up application default credentials by
+# default. You can use --google_credentials=some_file.json to use a service
+# account credential instead.
+build:gcp --google_default_credentials=true
+# Point to the remote instance constructed in the iree-oss project
+build:gcp --remote_instance_name=projects/iree-oss/instances/default_instance
+
+###############################################################################
+
 # Configuration for building remotely using Remote Build Execution (RBE)
 # https://cloud.google.com/remote-build-execution/
 # Based on https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-1.0.0.bazelrc
 # Currently in development only usable by CI.
+
+# Set up connections to GCP project.
+build:rbe --config=gcp
 
 # Depending on how many machines are in the remote execution instance, setting
 # this higher can make builds faster by allowing more jobs to run in parallel.
@@ -80,16 +94,19 @@ build:rbe --incompatible_strict_action_env=true
 # Set a higher timeout value, just in case.
 build:rbe --remote_timeout=3600
 
-# Enable authentication. This will pick up application default credentials by
-# default. You can use --google_credentials=some_file.json to use a service
-# account credential instead.
-build:rbe --google_default_credentials=true
-
 # Local disk cache is incompatible with remote execution (for obvious reasons).
 build:rbe --disk_cache=""
 
-# Point to the remote instance constructed in the iree-oss project
-build:rbe --remote_instance_name=projects/iree-oss/instances/default_instance
+###############################################################################
+
+# Configuration for uploading build results to Result Store UI
+# https://cloud.google.com/remote-build-execution/docs/results-ui/getting-started-results-ui
+# Can be used either with or without --config=rbe.
+
+build:rs --config=gcp
+build:rs --bes_backend="buildeventservice.googleapis.com"
+build:rs --bes_results_url="https://source.cloud.google.com/results/invocations/"
+build:rs --project_id=iree-oss
 
 ###############################################################################
 

--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -38,4 +38,4 @@ echo "Running with test env args: ${test_env_args[@]}"
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "notap".
 bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | \
-    xargs bazel test ${test_env_args[@]} --config=rbe --keep_going --test_output=errors
+    xargs bazel test ${test_env_args[@]} --config=rbe --config=rs --keep_going --test_output=errors


### PR DESCRIPTION
This will make them externally visible and nicely parsed.

Tested:
Made sure that the build worked with and without each of these configs and with both together.
Manually ran a kokoro build against this branch: https://source.cloud.google.com/results/invocations/2bd99c6b-a114-452d-b68e-8ac2b3d960e6/targets (soon these will post externally-accessible links)