### PR TITLE
Add "alwayslink" support to CMake builds, update CMake dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 
+# Require python3
+find_package(PythonInterp 3 REQUIRED)
+find_package(PythonLibs 3 REQUIRED)
+
 #-------------------------------------------------------------------------------
 # IREE-specific CMake configuration
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,6 @@ option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 
-# Require python3
-find_package(PythonInterp 3 REQUIRED)
-find_package(PythonLibs 3 REQUIRED)
-
 #-------------------------------------------------------------------------------
 # IREE-specific CMake configuration
 #-------------------------------------------------------------------------------
@@ -59,6 +55,13 @@ string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 #-------------------------------------------------------------------------------
 # Third-party dependencies
 #-------------------------------------------------------------------------------
+
+if(${IREE_BUILD_COMPILER})
+  # Compiler dependencies require Python.
+  # Find version 3+ first, so CMake doesn't find a lower version like 2.7 first.
+  find_package(PythonInterp 3 REQUIRED)
+  find_package(PythonLibs 3 REQUIRED)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/third_party/flatbuffers/CMake/

--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -31,6 +31,8 @@ include(CMakeParseArguments)
 # DEFINES: List of public defines
 # INCLUDES: Include directories to add to dependencies
 # LINKOPTS: List of link options
+# ALWAYSLINK: Always link the library into any binary with a direct dep.
+#   TODO(scotttodd): Make transitive deps also respect ALWAYSLINK
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
 # Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC will be
 # in ${PACKAGE}/internal.
@@ -75,11 +77,9 @@ include(CMakeParseArguments)
 #   DEPS
 #     some_external_thing::fantastic_lib
 # )
-#
-# TODO: Implement "ALWAYSLINK"
 function(external_cc_library)
   cmake_parse_arguments(_RULE
-    "PUBLIC;TESTONLY"
+    "PUBLIC;ALWAYSLINK;TESTONLY"
     "PACKAGE;NAME;ROOT"
     "HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS;INCLUDES"
     ${ARGN}
@@ -138,6 +138,10 @@ function(external_cc_library)
         PUBLIC
           ${_RULE_DEFINES}
       )
+
+      if(DEFINED _RULE_ALWAYSLINK)
+        set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
+      endif()
 
       # Add all external targets to a a folder in the IDE for organization.
       if(_RULE_PUBLIC)

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -27,7 +27,8 @@ include(CMakeParseArguments)
 # DEFINES: List of public defines
 # INCLUDES: Include directories to add to dependencies
 # LINKOPTS: List of link options
-# ALWAYSLINK: Always link the library into any binary with a transitive dep.
+# ALWAYSLINK: Always link the library into any binary with a direct dep.
+#   TODO(scotttodd): Make transitive deps also respect ALWAYSLINK
 # PUBLIC: Add this so that this library will be exported under iree::
 # Also in IDE, target will appear in IREE folder while non PUBLIC will be in IREE/internal.
 # TESTONLY: When added, this target will only be built if user passes -DIREE_BUILD_TESTS=ON to CMake.
@@ -109,6 +110,7 @@ function(iree_cc_library)
           ${_RULE_COPTS}
           ${IREE_DEFAULT_COPTS}
       )
+
       target_link_libraries(${_NAME}
         PUBLIC
           ${_RULE_DEPS}
@@ -120,6 +122,10 @@ function(iree_cc_library)
         PUBLIC
           ${_RULE_DEFINES}
       )
+
+      if(DEFINED _RULE_ALWAYSLINK)
+        set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
+      endif()
 
       # Add all IREE targets to a a folder in the IDE for organization.
       if(_RULE_PUBLIC)

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
@@ -33,14 +33,18 @@ external_cc_library(
   ROOT
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
+    "convert_op_folder.cc"
     "ir/dialect_registration.cc"
     "ir/hlo_ops.cc"
+    "ir/hlo_utils.cc"
     "ir/lhlo_ops.cc"
     "transforms/legalize_control_flow.cc"
     "transforms/legalize_to_standard.cc"
     "transforms/lower_general_dot.cc"
   HDRS
+    "convert_op_folder.h"
     "ir/hlo_ops.h"
+    "ir/hlo_utils.h"
     "ir/lhlo_ops.h"
     "transforms/passes.h"
     "transforms/rewriters.h"
@@ -61,6 +65,7 @@ external_cc_library(
     MLIRIR
     MLIRPass
     MLIRTransformUtils
+  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -64,7 +64,7 @@ if(${IREE_BUILD_COMPILER})
     OUT
       iree-translate
     SRCS
-      "${IREE_ROOT_DIR}/third_party/mlir/tools/mlir-translate/mlir-translate.cpp"
+      "iree_translate_main.cc"
     DEPS
       ${_ALWAYSLINK_LIBS}
       iree::compiler::Translation::Interpreter

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -56,18 +56,11 @@ if(${IREE_BUILD_COMPILER})
       iree-tblgen
     SRCS
       "${IREE_ROOT_DIR}/third_party/mlir/tools/mlir-tblgen/mlir-tblgen.cpp"
-      "${IREE_ROOT_DIR}/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp"
-      "${IREE_ROOT_DIR}/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp"
     DEPS
+      iree::compiler::Dialect::VM::Tools
       LLVMMLIRTableGen
       MLIRSupport
       LLVMTableGen
-      LLVMMC
-      LLVMDebugInfoCodeView
-      LLVMBinaryFormat
-      LLVMDebugInfoMSF
-      LLVMSupport
-      LLVMDemangle
     LINKOPTS
       "-lpthread"
   )

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -14,7 +14,11 @@
 
 if(${IREE_BUILD_COMPILER})
 
-  # TODO(benvanik): fix the ALWAYSLINK property and force MLIR libs.
+  # Additional libraries containing statically registered functions/flags, which
+  # should always be linked in to binaries.
+  #
+  # TODO(scotttodd): Make the ALWAYSLINK property apply transitively and force
+  #                  MLIR libs to generally be ALWAYSLINK wherever used in IREE.
   set(_ALWAYSLINK_LIBS
     MLIRAffineOps
     MLIRAnalysis
@@ -23,6 +27,7 @@ if(${IREE_BUILD_COMPILER})
     MLIRPass
     MLIRSPIRV
     MLIRSPIRVSerialization
+    MLIRSPIRVTransforms
     MLIRStandardOps
     MLIRTransforms
     MLIRTranslation
@@ -33,6 +38,16 @@ if(${IREE_BUILD_COMPILER})
     iree::compiler::IR::Interpreter
     tensorflow::mlir_xla
   )
+
+  foreach(LIB ${_ALWAYSLINK_LIBS})
+    # Aliased targets are always in-project, so we control them and can set
+    # ALWAYSLINK on them directly.
+    # TODO(scotttodd): add the ALWAYSLINK property to MLIR libraries elsewhere
+    get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
+    if(NOT _ALIASED_TARGET)
+      set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
+    endif()
+  endforeach(LIB)
 
   iree_cc_binary(
     NAME


### PR DESCRIPTION
Progress on #190. iree-translate now includes options such as `-mlir-to-iree-module`, which is needed for building the samples with CMake.

Transitive alwayslink dependencies are not supported yet.

Tested on Linux and Windows. I haven't tested gcc yet, which may need a branch, see https://github.com/PixarAnimationStudios/USD/blob/4b1162957b2ad219e1635c81de8343be490e41fc/cmake/macros/Private.cmake#L809-L870