### PR TITLE
Remove unnecessary setup from kokoro build

### DIFF
--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -20,17 +20,10 @@ set -e
 
 set -x
 
-# bazel is currently installed in the user bin.
-export PATH="${HOME}/bin:${PATH}"
-
 # Check these exist and print the versions for later debugging
 bazel --version
-clang++-6.0 --version
 python3 -V
 
-echo "Preparing environment variables"
-export CXX=clang++-6.0
-export CC=clang-6.0
 export PYTHON_BIN="$(which python3)"
 
 # Kokoro checks out the repository here.


### PR DESCRIPTION
I've moved the bazel installation to a place on the default path (now that we control the VMs). The clang on the host machine isn't used, since we're building with RBE.