### PR TITLE
Update CMake generation of iree_compiler_Translation_SPIRV_Kernels

### DIFF
--- a/iree/compiler/Translation/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/CMakeLists.txt
@@ -52,9 +52,7 @@ iree_cc_library(
     iree::compiler::Serialization
     iree::compiler::Transforms
     iree::compiler::Transforms::Sequencer
-    # TODO(marbre): Use instead of Kernels target, as soon as build with iree_glsl_cc_library
-    #iree::compiler::Translation::SPIRV::Kernels
-    iree_compiler_Translation_SPIRV_Kernels
+    iree::compiler::Translation::SPIRV::Kernels
     iree::compiler::Utils
     iree::schemas
     iree::schemas::spirv_executable_def_cc_fbs

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -51,6 +51,7 @@ add_custom_command(
           --cpp_namespace=mlir::iree_compiler::spirv_kernels
           --flatten
   DEPENDS generate_cc_embed_data
+          conv2d_nhwc.spv
           matmul.spv
           reduce_untiled.spv
 )

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -54,6 +54,6 @@ iree_cc_embed_data(
   H_FILE_OUTPUT
     "Kernels.h"
   CPP_NAMESPACE
-    mlir::iree_compiler::spirv_kernels
+    "mlir::iree_compiler::spirv_kernels"
   FLATTEN
 )

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -42,18 +42,18 @@ add_custom_command(
   DEPENDS glslangValidator
 )
 
-add_custom_command(
-  OUTPUT Kernels.h Kernels.cc
-  COMMAND generate_cc_embed_data conv2d_nhwc.spv matmul.spv reduce_untiled.spv
-          --output_header=Kernels.h
-          --output_impl=Kernels.cc
-          --identifier=Kernels
-          --cpp_namespace=mlir::iree_compiler::spirv_kernels
-          --flatten
-  DEPENDS generate_cc_embed_data
-          conv2d_nhwc.spv
-          matmul.spv
-          reduce_untiled.spv
+iree_cc_embed_data(
+  NAME
+    Kernels
+  GENERATED_SRCS
+    "conv2d_nhwc.spv"
+    "matmul.spv"
+    "reduce_untiled.spv"
+  CC_FILE_OUTPUT
+    "Kernels.cc"
+  H_FILE_OUTPUT
+    "Kernels.h"
+  CPP_NAMESPACE
+    mlir::iree_compiler::spirv_kernels
+  FLATTEN
 )
-
-add_library(iree_compiler_Translation_SPIRV_Kernels STATIC Kernels.cc)

--- a/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Kernels/CMakeLists.txt
@@ -25,6 +25,12 @@
 # )
 
 add_custom_command(
+  OUTPUT conv2d_nhwc.spv
+  COMMAND glslangValidator -V "${CMAKE_CURRENT_SOURCE_DIR}/conv2d_nhwc.comp" -o conv2d_nhwc.spv
+  DEPENDS glslangValidator
+)
+
+add_custom_command(
   OUTPUT matmul.spv
   COMMAND glslangValidator -V "${CMAKE_CURRENT_SOURCE_DIR}/matmul.comp" -o matmul.spv
   DEPENDS glslangValidator
@@ -38,7 +44,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT Kernels.h Kernels.cc
-  COMMAND generate_cc_embed_data matmul.spv reduce_untiled.spv
+  COMMAND generate_cc_embed_data conv2d_nhwc.spv matmul.spv reduce_untiled.spv
           --output_header=Kernels.h
           --output_impl=Kernels.cc
           --identifier=Kernels


### PR DESCRIPTION
Fixes the current CMake build configuration, prior to go with #213.