### PR TITLE
Fix build failure from using flatbuffer string_view and missing include

### DIFF
--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -224,10 +224,9 @@ static Offset<iree::vm::FunctionSignatureDef> makeFunctionSignatureDef(
       auto key = reflectionAttr.first.strref();
       auto value = reflectionAttr.second.dyn_cast<StringAttr>();
       if (!value || key.empty()) continue;
-      auto keyOffset =
-          fbb.CreateString(flatbuffers::string_view(key.data(), key.size()));
-      auto valueOffset = fbb.CreateString(flatbuffers::string_view(
-          value.getValue().data(), value.getValue().size()));
+      auto keyOffset = fbb.CreateString(key.data(), key.size());
+      auto valueOffset =
+          fbb.CreateString(value.getValue().data(), value.getValue().size());
       iree::vm::ReflectionAttrDefBuilder rattr(fbb);
       rattr.add_key(keyOffset);
       rattr.add_value(valueOffset);

--- a/iree/samples/simple_embedding/simple_embedding_test.cc
+++ b/iree/samples/simple_embedding/simple_embedding_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "absl/base/macros.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "iree/base/api.h"
 #include "iree/base/api_util.h"


### PR DESCRIPTION
Flatbuffer string_view is only defined when using C++17 or using experimental flatbuffer string views. Upstream we're building with C++17, but our OSS CI is still on C++14.

Fortunately, CreateString can just take data and size directly. There's no need to create a view.

Also fixed a missing include so this makes the build green