### PR TITLE
Disable simple_embedding_test in Kokoro CI

### DIFF
--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -37,5 +37,5 @@ echo "Running with test env args: ${test_env_args[@]}"
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "notap".
-bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | \
+bazel query '//... except attr("tags", "notap", //...) except //bindings/... except //integrations/... except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | \
     xargs bazel test ${test_env_args[@]} --config=rbe --config=rs --keep_going --test_output=errors


### PR DESCRIPTION
It's failing for mysterious reasons here but passing upstream. Disable it for now till we can find the issue

Tested: https://source.cloud.google.com/results/invocations/e8cf58f1-9337-4af2-85ba-54fa62f87f6d/targets