### PR TITLE
Disable simple_embedding_test in GitHub action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "notap".
           # TODO(gcmn) Enable all tests except notap once we can run them on the CI
-          bazel query '//... except attr("tags", "notap", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors
+          bazel query '//... except attr("tags", "notap", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors
 
   cmake:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
It's failing for mysterious reasons here but passing upstream. Disable it for now till we can find the issue.