### PR TITLE
Update CMake configuration to reflect latest changes

### DIFF
--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
   SRCS
     "api.cc"
   DEPS
+    iree::base::api_hdrs
     iree::base::api_util
     iree::base::file_mapping
     iree::base::init
@@ -29,11 +30,22 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    api_hdrs
+  HDRS
+    "api.h"
+  PUBLIC
+)
+
+
+iree_cc_library(
+  NAME
     api_util
   HDRS
     "api.h"
     "api_util.h"
   DEPS
+    absl::base
+    absl::container
     absl::time
     iree::base::logging
     iree::base::shape
@@ -49,6 +61,7 @@ iree_cc_library(
   SRCS
     "arena.cc"
   DEPS
+    absl::base
     absl::span
     iree::base::logging
   PUBLIC
@@ -71,7 +84,6 @@ iree_cc_library(
     "bitfield.h"
   DEPS
     absl::span
-    iree::base::bitfield
   PUBLIC
 )
 
@@ -95,6 +107,7 @@ iree_cc_library(
     "buffer_string_util.h"
   DEPS
     absl::strings
+    absl::optional
     absl::span
     iree::base::memory
     iree::base::shape
@@ -113,12 +126,14 @@ iree_cc_test(
     iree::base::memory
     iree::base::status
     iree::base::status_matchers
+    absl::optional
     absl::strings
 )
 
+#TODO(marbre) build within internal
 iree_cc_library(
   NAME
-    file_handle
+    file_handle_win32
   SRCS
     "internal/file_handle_win32.cc"
   HDRS
@@ -137,7 +152,9 @@ iree_cc_library(
   NAME
     file_io
   SRCS
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("file_io") in the Bazel world
     "internal/file_io_posix.cc"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("file_io") in the Bazel world
     "internal/file_io_win32.cc"
   HDRS
     "file_io.h"
@@ -145,7 +162,7 @@ iree_cc_library(
     absl::memory
     absl::strings
     absl::span
-    iree::base::file_handle
+    iree::base::file_handle_win32
     iree::base::platform_headers
     iree::base::ref_ptr
     iree::base::status
@@ -155,9 +172,20 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    file_io_hdrs
+  HDRS
+    "file_io.h"
+  DEPS
+    iree::base::status
+)
+
+iree_cc_library(
+  NAME
     file_mapping
   SRCS
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("file_mapping") in the Bazel world
     "internal/file_mapping_posix.cc"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("file_io") in the Bazel world
     "internal/file_mapping_win32.cc"
   HDRS
     "file_mapping.h"
@@ -165,13 +193,26 @@ iree_cc_library(
     absl::memory
     absl::strings
     absl::span
-    iree::base::file_handle
-    iree::base::platform_headers
     iree::base::ref_ptr
     iree::base::status
-    iree::base::tracing
+    #(marbre): Following deps pulled in by platform_trampoline_deps("file_io") in the Bazel world
+    iree::base::file_mapping_hdrs
+    iree::base::platform_headers
     iree::base::target_platform
+    iree::base::tracing
+
   PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    file_mapping_hdrs
+  HDRS
+    "file_mapping.h"
+  DEPS
+    absl::span
+    iree::base::ref_ptr
+    iree::base::status
 )
 
 iree_cc_library(
@@ -184,6 +225,16 @@ iree_cc_library(
   DEPS
     absl::strings
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    file_path_test
+  SRCS
+    "file_path_test.cc"
+  DEPS
+    iree::base::file_path
+    gtest_main
 )
 
 iree_cc_library(
@@ -202,6 +253,7 @@ iree_cc_library(
     iree::base::file_mapping
     iree::base::memory
     iree::base::ref_ptr
+    iree::base::source_location
     iree::base::status
     iree::base::tracing
   PUBLIC
@@ -212,10 +264,13 @@ iree_cc_library(
     init
   HDRS
     "init.h"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("init") in the Bazel world
     "internal/init_internal.h"
   SRCS
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("init") in the Bazel world
     "internal/init_internal.cc"
   DEPS
+    #(marbre): Following deps pulled in by platform_trampoline_deps("init") in the Bazel world
     absl::flags
     absl::flags_parse
     iree::base::initializer
@@ -252,8 +307,11 @@ iree_cc_test(
   NAME
     intrusive_list_test
   SRCS
+    "intrusive_list_ref_ptr_test.cc"
     "intrusive_list_test.cc"
+    "intrusive_list_unique_ptr_test.cc"
   DEPS
+    absl::memory
     gtest_main
     iree::base::intrusive_list
 )
@@ -263,10 +321,13 @@ iree_cc_library(
     logging
   HDRS
     "logging.h"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("logging") in the Bazel world
     "internal/logging.h"
   SRCS
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("logging") in the Bazel world
     "internal/logging.cc"
   DEPS
+    #(marbre): Following deps pulled in by platform_trampoline_deps("logging") in the Bazel world
     absl::base
     absl::flags
     iree::base::platform_headers
@@ -332,13 +393,74 @@ iree_cc_library(
   SRCS
     "shape.cc"
   DEPS
-    absl::base
     absl::span
     absl::strings
     absl::type_traits
     iree::base::logging
+    iree::base::source_location
     iree::base::status
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    shape_test
+  SRCS
+    "shape_test.cc"
+  DEPS
+    iree::base::shape
+    iree::base::status
+    iree::base::status_matchers
+    gtest_main
+)
+
+iree_cc_library(
+  NAME
+    shaped_buffer
+  HDRS
+    "shaped_buffer.h"
+  DEPS
+    absl::fixed_array
+    absl::span
+    iree::base::logging
+    iree::base::memory
+    iree::base::shape
+)
+
+iree_cc_library(
+  NAME
+    shaped_buffer_string_util
+  SRCS
+    "shaped_buffer_string_util.cc"
+  HDRS
+    "shaped_buffer_string_util.h"
+  DEPS
+    absl::fixed_array
+    absl::strings
+    absl::optional
+    absl::span
+    iree::base::buffer_string_util
+    iree::base::memory
+    iree::base::shape
+    iree::base::shaped_buffer
+    iree::base::source_location
+    iree::base::status
+)
+
+iree_cc_test(
+  NAME
+    shaped_buffer_string_util_test
+  SRCS
+    "shaped_buffer_string_util_test.cc"
+  DEPS
+    absl::strings
+    iree::base::buffer_string_util
+    iree::base::memory
+    iree::base::shaped_buffer
+    iree::base::shaped_buffer_string_util
+    iree::base::status
+    iree::base::status_matchers
+    gtest_main
 )
 
 iree_cc_library(
@@ -354,6 +476,7 @@ iree_cc_library(
     absl::optional
     absl::span
     absl::strings
+    iree::base::status
   PUBLIC
 )
 
@@ -364,23 +487,7 @@ iree_cc_test(
     "signature_mangle_test.cc"
   DEPS
     gtest_main
-    iree::base::logging
     iree::base::signature_mangle
-)
-
-iree_cc_test(
-  NAME
-    shape_test
-  SRCS
-    "shape_test.cc"
-  DEPS
-    absl::span
-    absl::strings
-    gtest_main
-    iree::base::logging
-    iree::base::shape
-    iree::base::status
-    iree::base::status_matchers
 )
 
 iree_cc_library(
@@ -388,6 +495,7 @@ iree_cc_library(
     source_location
   HDRS
     "source_location.h"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("source_location") in the Bazel world
     "internal/source_location.h"
   PUBLIC
 )
@@ -397,6 +505,7 @@ iree_cc_library(
     status
   HDRS
     "status.h"
+    #(marbre): Following deps pulled in by platform_trampoline_deps("status") in the Bazel world
     "internal/status.h"
     "internal/status_builder.h"
     "internal/status_errno.h"
@@ -405,6 +514,7 @@ iree_cc_library(
     "internal/status_win32_errors.h"
     "internal/statusor.h"
   SRCS
+    #(marbre): Following deps pulled in by platform_trampoline_deps("status") in the Bazel world
     "internal/status.cc"
     "internal/status_builder.cc"
     "internal/status_errno.cc"
@@ -412,6 +522,8 @@ iree_cc_library(
     "internal/status_win32_errors.cc"
     "internal/statusor.cc"
   DEPS
+    iree::base::source_location
+    #(marbre): Following deps pulled in by platform_trampoline_deps("status") in the Bazel world
     absl::base
     absl::debugging
     absl::flags
@@ -419,7 +531,7 @@ iree_cc_library(
     absl::strings
     iree::base::logging
     iree::base::platform_headers
-    iree::base::source_location
+    iree::base::target_platform
   PUBLIC
 )
 
@@ -428,11 +540,13 @@ iree_cc_library(
     status_matchers
   HDRS
     "status_matchers.h"
+    #(marbre): Pulled in as dep defined by platform_trampoline_deps("status_matchers") in the Bazel world
     "internal/status_matchers.h"
   DEPS
+    #(marbre): Following deps pulled in by platform_trampoline_deps("status_matchers") in the Bazel world
     absl::strings
     absl::optional
-    gmock
+    gtest_main
     iree::base::status
   TESTONLY
   PUBLIC
@@ -462,18 +576,13 @@ if(${IREE_ENABLE_TRACING})
       tracing
     HDRS
       "tracing.h"
-    SRCS
-      "tracing.cc"
     DEPS
-      absl::core_headers
-      absl::flags
       absl::strings
-      absl::synchronization
+      absl::optional
       absl::time
-      iree::base::file_io
-      iree::base::inititializer
-      iree::base::logging
-      iree::base::status
+      #TODO(marbre): Add dependencies
+      # "@com_google_tracing_framework_cpp//:tracing_framework_bindings_cpp"
+      # "@com_google_tracing_framework_cpp//:wtf_enable": [":tracing_enabled"]
     PUBLIC
   )
 else()
@@ -482,13 +591,58 @@ else()
       tracing
     HDRS
       "tracing.h"
-    SRCS
-      "tracing_disabled.cc"
     DEPS
       absl::flags
     PUBLIC
   )
 endif()
+
+iree_cc_library(
+  NAME
+    tracing_disabled
+  HDRS
+    "tracing.h"
+  SRCS
+    "tracing_disabled.cc"
+  DEPS
+    absl::flags
+    absl::strings
+    absl::time
+    absl::optional
+      #TODO(marbre): Add dependencies
+      # "@com_google_tracing_framework_cpp//:tracing_framework_bindings_cpp"
+  ALWAYSLINK
+)
+
+if(${IREE_ENABLE_TRACING})
+
+iree_cc_library(
+  NAME
+    tracing_enabled
+  HDRS
+    "tracing.h"
+  SRCS
+    "tracing_enabled.cc"
+  DEPS
+    absl::core_headers
+    absl::flags
+    absl::strings
+    absl::synchronization
+    absl::time
+    absl::optional
+    iree::base::file_io
+    iree::base::file_path
+    iree::base::initializer
+    iree::base::logging
+    iree::base::status
+      #TODO(marbre): Add dependencies
+      # "@com_google_tracing_framework_cpp//:tracing_framework_bindings_cpp"
+  ALWAYSLINK
+)
+
+endif()
+
+
 
 # TODO(benvanik): get wait_handle ported to win32.
 # iree_cc_library(

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -25,12 +25,16 @@ iree_cc_library(
     "FormStreams.cpp"
     "IdentifyDispatchRegions.cpp"
     "IdentifyReductionRegions.cpp"
+    "LegalizeInputTypes.cpp"
+    "MaterializeExportedReflection.cpp"
+    "MergeExportedReflection.cpp"
     "OutlineDispatchRegions.cpp"
     "OutlineReductionRegions.cpp"
     "Passes.cpp"
     "PrePostPartitioningConversion.cpp"
     "RematerializeDispatchConstants.cpp"
   DEPS
+    iree::base::signature_mangle
     iree::compiler::Dialect::Flow::Analysis
     iree::compiler::Dialect::Flow::Conversion::HLOToFlow
     iree::compiler::Dialect::Flow::Conversion::StandardToFlow

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -25,15 +25,12 @@ iree_cc_library(
   SRCS
     "allocator.cc"
   DEPS
-    absl::base
-    absl::fixed_array
     absl::span
-    absl::strings
-    absl::time
-    iree::base::logging
     iree::base::ref_ptr
+    iree::base::source_location
     iree::base::status
-    iree::base::time
+    iree::base::tracing
+    iree::hal::buffer
   PUBLIC
 )
 
@@ -42,20 +39,35 @@ iree_cc_library(
     api
   HDRS
     "api.h"
+    "api_detail.h"
   SRCS
     "api.cc"
   DEPS
+    absl::span
     iree::base::api
     iree::base::api_util
     iree::base::shape
     iree::base::tracing
+    iree::hal::api_hdrs
     iree::hal::buffer
     iree::hal::buffer_view
+    iree::hal::command_buffer
     iree::hal::device
     iree::hal::driver
+    iree::hal::driver_registry
     iree::hal::fence
     iree::hal::heap_buffer
     iree::hal::semaphore
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    api_hdrs
+  HDRS
+    "api.h"
+  DEPS
+    iree::base::api_hdrs
   PUBLIC
 )
 
@@ -73,6 +85,7 @@ iree_cc_library(
     absl::variant
     iree::base::bitfield
     iree::base::logging
+    iree::base::source_location
     iree::base::status
     iree::hal::resource
   PUBLIC
@@ -82,9 +95,9 @@ iree_cc_test(
   NAME
     buffer_test
   SRCS
+    "buffer_mapping_test.cc"
     "buffer_test.cc"
   DEPS
-    absl::base
     absl::span
     gtest_main
     iree::base::status
@@ -104,6 +117,7 @@ iree_cc_library(
     absl::inlined_vector
     absl::strings
     iree::base::shape
+    iree::base::source_location
     iree::base::status
     iree::hal::buffer_view
   PUBLIC
@@ -132,7 +146,9 @@ iree_cc_library(
     "buffer_view_string_util.cc"
   DEPS
     absl::strings
+    absl::optional
     iree::base::buffer_string_util
+    iree::base::source_location
     iree::base::status
     iree::hal::allocator
     iree::hal::buffer_view
@@ -273,6 +289,8 @@ iree_cc_library(
   DEPS
     absl::span
     absl::synchronization
+    absl::time
+    iree::base::source_location
     iree::base::status
     iree::base::time
     iree::base::tracing
@@ -319,6 +337,7 @@ iree_cc_library(
     absl::base
     absl::synchronization
     iree::base::initializer
+    iree::base::ref_ptr
     iree::base::status
     iree::hal::driver
   PUBLIC
@@ -402,6 +421,7 @@ iree_cc_library(
     "heap_buffer.cc"
   DEPS
     absl::base
+    iree::base::source_location
     iree::base::status
     iree::base::tracing
     iree::hal::allocator


### PR DESCRIPTION
Adopts the most recent changes to CMake. As a follow up, the iree::base components will get split into iree::base and iree::base::internal.