### PR TITLE
CMake configuration for iree::tools::iree-run-mlir

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -51,6 +51,39 @@ if(${IREE_BUILD_COMPILER})
 
   iree_cc_binary(
     NAME
+      iree-run-mlir
+    SRCS
+      "run_mlir_main.cc"
+    DEPS
+      absl::flags
+      absl::strings
+      # TODO(marbre): Fix problems with property "ALWAYSLINK".
+      #iree::base::source_location
+      iree::rt
+      iree::vm::sequencer_module
+      LLVMSupport
+      MLIRIR
+      MLIRParser
+      MLIRSupport
+      iree::base::init
+      iree::base::status
+      iree::compiler::Translation::Sequencer
+      iree::compiler::Translation::Interpreter
+      iree::compiler::Translation::SPIRV
+      iree::compiler::Translation::IREEVM
+      iree::hal::buffer_view_string_util
+      iree::hal::driver_registry
+      # TODO(marbre): Fix problems with property "ALWAYSLINK".
+      #iree::schemas
+      iree::rt::debug::debug_server_flags
+      # TODO(marbre)_ Add deps
+      # PLATFORM_VULKAN_DEPS
+      iree::hal::interpreter::interpreter_driver_module
+      iree::hal::vulkan::vulkan_driver_module
+    )
+
+  iree_cc_binary(
+    NAME
       iree_tblgen
     OUT
       iree-tblgen


### PR DESCRIPTION
I tried to add a CMake configuration for the executable `iree-run-mlir`, but adding the dependencies `iree::base::source_location` and `iree::schemas` let CMake fail:

```
CMake Error at build_tools/cmake/iree_cc_binary.cmake:106 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "ALWAYSLINK" is not allowed.
Call Stack (most recent call first):
  iree/tools/CMakeLists.txt:52 (iree_cc_binary)
```

@ScottTodd Since you worked on the `ALWAYSLINK` issue, maybe you might have an idea?