### PR TITLE
CMake configuration for HAL Targets LegacyInterpreter and VulkanSPIRV

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(LegacyInterpreter)
+add_subdirectory(VulkanSPIRV)
+
 iree_cc_library(
   NAME
     ExecutableTarget

--- a/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_cc_library(
+  NAME
+    LegacyInterpreter
+  HDRS
+    "LegacyInterpreterTarget.h"
+  SRCS
+    "LegacyInterpreterTarget.cpp"
+  DEPS
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::Target::ExecutableTarget
+    iree::compiler:.Dialect::HAL::Transforms
+    iree::compiler::IR
+    iree::compiler::IR::Interpreter
+    iree::compiler::Serialization
+    iree::compiler::Transforms
+    iree::compiler::Transforms::Interpreter
+    iree::compiler::Utils
+    flatbuffers
+    LLVMSupport
+    MLIRIR
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+  ALWAYSLINK
+  PUBLIC
+)

--- a/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
@@ -23,7 +23,7 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
-    iree::compiler:.Dialect::HAL::Transforms
+    iree::compiler::Dialect::HAL::Transforms
     iree::compiler::IR
     iree::compiler::IR::Interpreter
     iree::compiler::Serialization

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_cc_library(
     "VulkanSPIRVTarget.cpp"
   DEPS
     iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::HAL:Target::ExecutableTarget
+    iree::compiler::Dialect::HAL::Target::ExecutableTarget
     iree::compiler::IR
     iree::compiler::Translation::SPIRV
     iree::schemas

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     MLIRIR
     MLIRPass
     MLIRSPIRVDialect
+    MLIRSPIRVLowering
     MLIRSPIRVSerialization
     MLIRSupport
     tensorflow::mlir_xla


### PR DESCRIPTION
These are required by `iree-run-mlir`.