### PR TITLE
Add a separate tag for excluding tests from GitHub actions

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI
-          # (using the tag "notap", "Test Automation Platform").
+          # (using the tags "notap"="Test Automation Platform" and
+          # "noga"="GitHub Actions").
           # Note that somewhat contrary to its name `bazel test` will also build
           # any non-test targets specified.
           # We use `bazel query //...` piped to `bazel test` rather than the
@@ -65,4 +66,4 @@ jobs:
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "notap".
           # TODO(gcmn) Enable all tests except notap once we can run them on the CI
-          bazel query '//... except attr("tags", "notap", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors
+          bazel query '//... except attr("tags", "notap", //...) except attr("tags", "noga", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors


### PR DESCRIPTION
Due to different infrastructure, the set of tests we want to exclude from OSS CI is not the same as the ones we want to exclude from internal CI.

I'll remove the exclusion for the notap tag when all tests are also tagged noga