### PR TITLE
Use checkout action in workflows

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -47,12 +47,10 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
-      - name: Checking out latest version and all submodules
-        run: |
-          git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
-          git clone https://github.com/${GITHUB_REPOSITORY?} ${GITHUB_WORKSPACE?} --no-checkout --no-tags
-          git checkout ${GITHUB_SHA?}
-          git submodule update --init --depth 1000 --jobs 8
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Updating submodules
+        run: git submodule update --init --depth 1000 --jobs 8
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -33,12 +33,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install clang libsdl2-dev python3 python3-pip
           sudo pip install numpy
-      - name: Checking out latest version and all submodules
-        run: |
-          git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
-          git clone https://github.com/${GITHUB_REPOSITORY?} ${GITHUB_WORKSPACE?} --no-checkout --no-tags
-          git checkout ${GITHUB_SHA?}
-          git submodule update --init --depth 1000 --jobs 8
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Updating submodules
+        run: git submodule update --init --depth 1000 --jobs 8
       - name: Building with cmake
         run: |
           mkdir build && cd build

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,11 +33,11 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
         wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
         chmod +x /tmp/git-clang-format
-    - name: Checking out latest version and all submodules
-      run: |
-        git config --global remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
-        git clone https://github.com/$GITHUB_REPOSITORY $GITHUB_WORKSPACE --no-checkout --no-tags
-        git checkout $GITHUB_SHA
+    - name: Checking out repository
+      uses: actions/checkout@v2
+      # We have to explicitly fetch master as well
+    - name: Fetching master
+      run: git fetch --no-tags --prune --depth=1 origin master
     - name: Running clang-format on changed source files
       # TODO(benvanik): actually filter to changed files.
       run: |


### PR DESCRIPTION
This should simplify things a bit and will hopefully be more robust so we get fewer errors during checkout.

Tested: presubmit (clang-format) and cmake actions still pass. Bazel action is suuuuper slow, so I'm not going to wait for it, but it at least gets to the point of starting the build.