### PR TITLE
Canonicalize OK status on construction

### DIFF
--- a/iree/base/internal/status.cc
+++ b/iree/base/internal/status.cc
@@ -89,9 +89,11 @@ std::string StatusCodeToString(StatusCode code) {
 Status::Status() {}
 
 Status::Status(StatusCode code, absl::string_view message) {
-  state_ = absl::make_unique<State>();
-  state_->code = code;
-  state_->message = std::string(message);
+  if (code != StatusCode::kOk) {
+    state_ = absl::make_unique<State>();
+    state_->code = code;
+    state_->message = std::string(message);
+  }
 }
 
 Status::Status(const Status& x) {

--- a/iree/base/internal/status.h
+++ b/iree/base/internal/status.h
@@ -70,6 +70,7 @@ class Status final {
   Status();
 
   // Creates a status with the specified code and error message.
+  // If |code| is kOk, |message| is ignored.
   Status(StatusCode code, absl::string_view message);
 
   Status(const Status&);

--- a/iree/base/internal/status.h
+++ b/iree/base/internal/status.h
@@ -70,7 +70,7 @@ class Status final {
   Status();
 
   // Creates a status with the specified code and error message.
-  // If |code| is kOk, |message| is ignored.
+  // If `code` is kOk, `message` is ignored.
   Status(StatusCode code, absl::string_view message);
 
   Status(const Status&);


### PR DESCRIPTION
This should fix failing lit tests introduced in 5f24fb57990bc4f9da85bbb050ef509654ed501d.

Currently the ok() method just checks if state is nullptr, but some dynamic construction is creating Ok statuses from the version that accepts arguments, which is causing test failures in OSS.

Tested: Kokoro presubmits