### PR TITLE
Fix bug in internal Status that was causing explicit construction wit…

### DIFF
--- a/iree/base/internal/status.cc
+++ b/iree/base/internal/status.cc
@@ -89,6 +89,7 @@ std::string StatusCodeToString(StatusCode code) {
 Status::Status() {}
 
 Status::Status(StatusCode code, absl::string_view message) {
+  if (code == StatusCode::kOk) return;
   state_ = absl::make_unique<State>();
   state_->code = code;
   state_->message = std::string(message);


### PR DESCRIPTION
…h a kOk code to allocate a state, violating invariants.