### PR TITLE
Build TF dependencies in Kokoro CI

### DIFF
--- a/bindings/python/BUILD
+++ b/bindings/python/BUILD
@@ -22,6 +22,4 @@ package(
 iree_py_library(
     name = "pathsetup",
     imports = ["."],
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
 )

--- a/build_tools/bazel_build.sh
+++ b/build_tools/bazel_build.sh
@@ -38,4 +38,6 @@ echo "Running with test env args: ${test_env_args[@]}"
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
 bazel query '//... except attr("tags", "nokokoro", //...)' | \
-    xargs bazel test ${test_env_args[@]} --config=rbe --config=rs --keep_going --test_output=errors
+  xargs bazel test ${test_env_args[@]} --define=iree_tensorflow=true \
+    --config=rbe --config=rs \
+    --keep_going --test_output=errors

--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -36,8 +36,6 @@ cc_library(
         "//conditions:default": [
         ],
     }),
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = select({
         "//iree:enable_tensorflow": [
             "@llvm//:support",
@@ -59,8 +57,6 @@ cc_library(
 
 cc_binary(
     name = "iree-tf-opt",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = [
         ":tensorflow",
         "//iree/tools:iree_opt_library",
@@ -70,8 +66,6 @@ cc_binary(
 
 cc_binary(
     name = "iree-tf-translate",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = [
         ":tensorflow",
         "//iree/tools:iree_translate_library",

--- a/integrations/tensorflow/compiler/test/BUILD
+++ b/integrations/tensorflow/compiler/test/BUILD
@@ -29,7 +29,6 @@ iree_setup_lit_package(
     data = [
         "//integrations/tensorflow/compiler:iree-tf-opt",
     ],
-    tags = ["nokokoro"],
 )
 
 iree_glob_lit_tests(tags = ["nokokoro"])


### PR DESCRIPTION
Everything still builds without these tags. Let's see how well RBE handles building tensorflow