### PR TITLE
Specify backend for interpreter e2e tests

### DIFF
--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -330,7 +330,8 @@ Status RunFile(std::string mlir_filename) {
                                llvm::Twine(split_line));
     auto sub_failure = EvaluateFile(std::move(sub_buffer));
     if (!sub_failure.ok()) {
-      LOG(ERROR) << sub_failure;
+      LOG(ERROR) << "Failure for split at line #" << split_line << ": "
+                 << sub_failure;
       if (any_failure.ok()) {
         any_failure = std::move(sub_failure);
       }

--- a/test/e2e/scalars.mlir
+++ b/test/e2e/scalars.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-run-mlir %s | IreeFileCheck %s
+// RUN: iree-run-mlir --target_backends=interpreter-bytecode %s | IreeFileCheck %s
 
 // CHECK-LABEL: EXEC @scalars
 func @scalars() -> tensor<f32> {

--- a/test/e2e/xla/gemm.mlir
+++ b/test/e2e/xla/gemm.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-run-mlir2 %s -input-value="5x3xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" -input-value="3x5xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
+// RUN: iree-run-mlir2 %s -iree-hal-target-backends=interpreter-bytecode -input-value="5x3xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" -input-value="3x5xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir2 -iree-hal-target-backends=vulkan-spirv %s -input-value="5x3xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" -input-value="3x5xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @main


### PR DESCRIPTION
These didn't previously have the backend specified, which means it ran for all backends and the vulkan backend might fail (depending on the environment). The tests were still passing, however, because the interpreter backend would succeed and run, outputting the correct results.

https://github.com/google/iree/commit/4388043a930c54ddc5b0052906b77078577b6a51 set pipefail, which revealed this silent failure.