### PR TITLE
Exclude vm2 from CMake build for now.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ add_subdirectory(iree/hal)
 add_subdirectory(iree/rt)
 add_subdirectory(iree/schemas)
 add_subdirectory(iree/vm)
-add_subdirectory(iree/vm2)
 
 if(${IREE_BUILD_COMPILER})
   add_subdirectory(third_party/glslang EXCLUDE_FROM_ALL)


### PR DESCRIPTION
It doesn't build. We can add it back when it does.