### PR TITLE
Avoid using uninitialized "driver" variable in driver creation error path

### DIFF
--- a/bindings/python/pyiree/system_api.py
+++ b/bindings/python/pyiree/system_api.py
@@ -71,8 +71,9 @@ def _create_default_iree_driver(
           "Could not create default driver %s: %r" % (driver_name, ex),
           file=sys.stderr)
       driver_exceptions[driver_name] = ex
-    print("Created IREE driver %s: %r" % (driver_name, driver), file=sys.stderr)
-    return driver
+    else:
+      print("Created IREE driver %s: %r" % (driver_name, driver), file=sys.stderr)
+      return driver
 
   # All failed.
   raise RuntimeError("Could not create any requested driver "

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -36,13 +36,26 @@ package(
     )
     for name in [
         "control_flow_test",
-        "exported_names_test",
         "keras_lstm_test",
         "simple_stateful_test",
         "mandelbrot_test",
         "simple_arithmetic_test",
     ]
 ]
+
+py_test(
+    name = "exported_names_test",
+    srcs = ["exported_names_test.py"],
+    python_version = "PY3",
+    # TODO(b/145815906) Get this running in OSS CI.
+    tags = [
+        "noga",
+        "nokokoro",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//bindings/python/pyiree",
+    ],
+)
 
 py_test(
     name = "vulkan_conv_test",

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -36,26 +36,13 @@ package(
     )
     for name in [
         "control_flow_test",
+        "exported_names_test",
         "keras_lstm_test",
         "simple_stateful_test",
         "mandelbrot_test",
         "simple_arithmetic_test",
     ]
 ]
-
-py_test(
-    name = "exported_names_test",
-    srcs = ["exported_names_test.py"],
-    python_version = "PY3",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
-    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
-        "//bindings/python/pyiree",
-    ],
-)
 
 py_test(
     name = "vulkan_conv_test",


### PR DESCRIPTION
Right now, driver creation tries to use the driver variable even if it failed to create it.