### PR TITLE
Specify supported test backends in CI

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -64,4 +64,4 @@ jobs:
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "notap".
           # TODO(gcmn) Enable all tests except notap once we can run them on the CI
-          bazel query '//... except attr("tags", "notap", //...) except attr("tags", "noga", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --define=iree_tensorflow=true --test_output=errors
+          bazel query '//... except attr("tags", "notap", //...) except attr("tags", "noga", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_TEST_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors


### PR DESCRIPTION
Vulkan is the default otherwise and it's not supported in the OSS CI

Tested:
I tried this out on my laptop, which doesn't have vulkan support and now I can run //integrations/tensorflow/e2e:exported_names_test