### PR TITLE
Build everything not tagged with noga in GitHub action CI

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -54,14 +54,12 @@ jobs:
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI
-          # (using the tags "notap"="Test Automation Platform" and
-          # "noga"="GitHub Actions").
+          # (using the tag "noga"=No GitHub Actions").
           # Note that somewhat contrary to its name `bazel test` will also build
           # any non-test targets specified.
           # We use `bazel query //...` piped to `bazel test` rather than the
           # simpler `bazel test //...` because the latter excludes targets
           # tagged "manual". The "manual" tag allows targets to be excluded from
           # human wildcard builds, but we want them built by CI unless they are
-          # excluded with "notap".
-          # TODO(gcmn) Enable all tests except notap once we can run them on the CI
-          bazel query '//... except attr("tags", "notap", //...) except attr("tags", "noga", //...) except //integrations/tensorflow/e2e:vulkan_conv_test except //iree/hal/vulkan:dynamic_symbols_test except //iree/samples/rt:bytecode_module_api_test except //iree/samples/simple_embedding:simple_embedding_test' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_TEST_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors
+          # excluded with "noga".
+          bazel query '//... except attr("tags", "noga", //...)' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_TEST_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors --keep_going

--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI
-          # (using the tag "noga"=No GitHub Actions").
+          # (using the tag "noga"="No GitHub Actions").
           # Note that somewhat contrary to its name `bazel test` will also build
           # any non-test targets specified.
           # We use `bazel query //...` piped to `bazel test` rather than the


### PR DESCRIPTION
The samples/rt directory was deleted in https://github.com/google/iree/commit/9ea36a0987167464afa088e94b0dd8d3064813c3. Everything not tagged should build fine.

I also added the --keep_going flag while I was here, so it will be clearer what's failing.

Tested:
bazel query '//... except attr("tags", "noga", //...)' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_TEST_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors