### PR TITLE
Add bazel build machinery for depending on LLVM/MLIR as a submodule.

### DIFF
--- a/build_tools/bazel/third_party_import/llvm-project/BUILD.bazel
+++ b/build_tools/bazel/third_party_import/llvm-project/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intentionally empty.

--- a/build_tools/bazel/third_party_import/llvm-project/configure.bzl
+++ b/build_tools/bazel/third_party_import/llvm-project/configure.bzl
@@ -1,0 +1,92 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configures an LLVM overlay project."""
+
+_OVERLAY_PARENT_PATHS = [
+    "llvm",
+    "mlir",
+    "mlir/test",
+]
+
+def _is_absolute(path):
+    """Returns `True` if `path` is an absolute path.
+    Args:
+      path: A path (which is a string).
+    Returns:
+      `True` if `path` is an absolute path.
+    """
+    return path.startswith("/") or (len(path) > 2 and path[1] == ":")
+
+def _join_path(a, b):
+    return str(a) + "/" + str(b)
+
+def _symlink_src_dir(repository_ctx, from_path, to_path):
+    children = repository_ctx.path(from_path).readdir()
+    for from_child_path in children:
+      if to_path:
+        to_child_path = _join_path(to_path, from_child_path.basename)
+      else: # Root
+        to_child_path = from_child_path.basename
+      # Skip paths that are already in the overlay list.
+      # They will have this function called on them to populate.
+      if to_child_path in _OVERLAY_PARENT_PATHS: continue
+      repository_ctx.symlink(from_child_path, to_child_path)
+
+def _llvm_configure_impl(repository_ctx):
+    # Compute path that sources are symlinked from.
+    src_workspace_path = repository_ctx.path(
+          repository_ctx.attr.workspace).dirname
+    src_path = repository_ctx.attr.path
+    if not _is_absolute(src_path):
+      src_path = _join_path(src_workspace_path, src_path)
+
+    # Compute path (relative to here) where overlay files
+    # are symlinked from.
+    this_workspace_path = repository_ctx.path(
+        repository_ctx.attr.workspace).dirname
+    overlay_path = _join_path(
+        this_workspace_path, 
+        "build_tools/bazel/third_party_import/llvm-project/overlay")
+    
+    # Each parent path of an overlay file must have its children manually
+    # symlinked. This is because the directory itself must be in the cahche
+    # (so that we can modify it without modifying the underlying source
+    # path). An alternative to this would be to perform a deep symlink of
+    # the entire tree (which would be wasteful).
+    for overlay_parent_path in _OVERLAY_PARENT_PATHS:
+      src_child_path = _join_path(src_path, overlay_parent_path)
+      overlay_child_path = _join_path(overlay_path, overlay_parent_path)
+      # Symlink from external src path
+      _symlink_src_dir(repository_ctx, src_child_path, overlay_parent_path)
+      # Symlink from the overlay path.
+      _symlink_src_dir(repository_ctx, overlay_child_path, overlay_parent_path)
+
+    # Then symlink any top-level entries not previously handled.
+    # Doing it here means that if we got it wrong, it will fail with a
+    # "File Exists" error vs doing the wrong thing.
+    _symlink_src_dir(repository_ctx, src_path, "")
+
+    # Build files and overlays.
+    repository_ctx.file("BUILD")  # Root build is empty.
+
+llvm_configure = repository_rule(
+    implementation = _llvm_configure_impl,
+    local = True,
+    attrs = {
+        "_this_workspace": attr.label(default = Label("//:WORKSPACE")),
+        "workspace": attr.label(default = Label("//:WORKSPACE")),
+        "path": attr.string(mandatory = True),
+    },
+)

--- a/build_tools/bazel/third_party_import/llvm-project/overlay/llvm/BUILD.bazel
+++ b/build_tools/bazel/third_party_import/llvm-project/overlay/llvm/BUILD.bazel
@@ -1,0 +1,4461 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bazel BUILD file for LLVM.
+#
+# This BUILD file is auto-generated; do not edit!
+
+licenses(["notice"])
+
+exports_files(["LICENSE.TXT"])
+
+load(
+    "@org_tensorflow//third_party/llvm:llvm.bzl",
+    "cmake_var_string",
+    "expand_cmake_vars",
+    "gentbl",
+    "llvm_all_cmake_vars",
+    "llvm_copts",
+    "llvm_defines",
+    "llvm_linkopts",
+    "llvm_support_platform_specific_srcs_glob",
+)
+load(
+    "@org_tensorflow//third_party:common.bzl",
+    "template_rule",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+llvm_host_triple = "x86_64-unknown-linux_gnu"
+
+llvm_targets = [
+    "AArch64",
+    "AMDGPU",
+    "ARM",
+    "NVPTX",
+    "PowerPC",
+    "X86",
+]
+
+llvm_target_asm_parsers = llvm_targets
+
+llvm_target_asm_printers = llvm_targets
+
+llvm_target_disassemblers = llvm_targets
+
+# Performs CMake variable substitutions on configuration header files.
+expand_cmake_vars(
+    name = "config_gen",
+    src = "include/llvm/Config/config.h.cmake",
+    cmake_vars = llvm_all_cmake_vars,
+    dst = "include/llvm/Config/config.h",
+)
+
+expand_cmake_vars(
+    name = "llvm_config_gen",
+    src = "include/llvm/Config/llvm-config.h.cmake",
+    cmake_vars = llvm_all_cmake_vars,
+    dst = "include/llvm/Config/llvm-config.h",
+)
+
+expand_cmake_vars(
+    name = "abi_breaking_gen",
+    src = "include/llvm/Config/abi-breaking.h.cmake",
+    cmake_vars = llvm_all_cmake_vars,
+    dst = "include/llvm/Config/abi-breaking.h",
+)
+
+# Performs macro expansions on .def.in files
+template_rule(
+    name = "targets_def_gen",
+    src = "include/llvm/Config/Targets.def.in",
+    out = "include/llvm/Config/Targets.def",
+    substitutions = {
+        "@LLVM_ENUM_TARGETS@": "\n".join(
+            ["LLVM_TARGET({})".format(t) for t in llvm_targets],
+        ),
+    },
+)
+
+template_rule(
+    name = "asm_parsers_def_gen",
+    src = "include/llvm/Config/AsmParsers.def.in",
+    out = "include/llvm/Config/AsmParsers.def",
+    substitutions = {
+        "@LLVM_ENUM_ASM_PARSERS@": "\n".join(
+            ["LLVM_ASM_PARSER({})".format(t) for t in llvm_target_asm_parsers],
+        ),
+    },
+)
+
+template_rule(
+    name = "asm_printers_def_gen",
+    src = "include/llvm/Config/AsmPrinters.def.in",
+    out = "include/llvm/Config/AsmPrinters.def",
+    substitutions = {
+        "@LLVM_ENUM_ASM_PRINTERS@": "\n".join(
+            ["LLVM_ASM_PRINTER({})".format(t) for t in llvm_target_asm_printers],
+        ),
+    },
+)
+
+template_rule(
+    name = "disassemblers_def_gen",
+    src = "include/llvm/Config/Disassemblers.def.in",
+    out = "include/llvm/Config/Disassemblers.def",
+    substitutions = {
+        "@LLVM_ENUM_DISASSEMBLERS@": "\n".join(
+            ["LLVM_DISASSEMBLER({})".format(t) for t in llvm_target_disassemblers],
+        ),
+    },
+)
+
+# A common library that all LLVM targets depend on.
+# TODO(b/113996071): We need to glob all potentially #included files and stage
+# them here because LLVM's build files are not strict headers clean, and remote
+# build execution requires all inputs to be depended upon.
+cc_library(
+    name = "config",
+    hdrs = glob([
+        "**/*.h",
+        "**/*.def",
+        "**/*.inc.cpp",
+    ]) + [
+        "include/llvm/Config/AsmParsers.def",
+        "include/llvm/Config/AsmPrinters.def",
+        "include/llvm/Config/Disassemblers.def",
+        "include/llvm/Config/Targets.def",
+        "include/llvm/Config/config.h",
+        "include/llvm/Config/llvm-config.h",
+        "include/llvm/Config/abi-breaking.h",
+    ],
+    defines = llvm_defines,
+    includes = ["include"],
+)
+
+# A creator of an empty file include/llvm/Support/VCSRevision.h.
+# This is usually populated by the upstream build infrastructure, but in this
+# case we leave it blank. See upstream revision r300160.
+genrule(
+    name = "vcs_revision_gen",
+    srcs = [],
+    outs = ["include/llvm/Support/VCSRevision.h"],
+    cmd = "echo '' > \"$@\"",
+)
+
+# Rules that apply the LLVM tblgen tool.
+gentbl(
+    name = "attributes_gen",
+    tbl_outs = [("-gen-attrs", "include/llvm/IR/Attributes.inc")],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Attributes.td",
+    td_srcs = ["include/llvm/IR/Attributes.td"],
+)
+
+gentbl(
+    name = "attributes_compat_gen",
+    tbl_outs = [("-gen-attrs", "lib/IR/AttributesCompatFunc.inc")],
+    tblgen = ":llvm-tblgen",
+    td_file = "lib/IR/AttributesCompatFunc.td",
+    td_srcs = [
+        "lib/IR/AttributesCompatFunc.td",
+        "include/llvm/IR/Attributes.td",
+    ],
+)
+
+gentbl(
+    name = "instcombine_transforms_gen",
+    tbl_outs = [(
+        "-gen-searchable-tables",
+        "lib/Transforms/InstCombine/InstCombineTables.inc",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "lib/Transforms/InstCombine/InstCombineTables.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]) + ["include/llvm/TableGen/SearchableTable.td"],
+)
+
+gentbl(
+    name = "intrinsic_enums_gen",
+    tbl_outs = [("-gen-intrinsic-enums", "include/llvm/IR/IntrinsicEnums.inc")],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "aarch64_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=aarch64",
+        "include/llvm/IR/IntrinsicsAArch64.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "amdgcn_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=amdgcn",
+        "include/llvm/IR/IntrinsicsAMDGPU.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "arm_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=arm",
+        "include/llvm/IR/IntrinsicsARM.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "bpf_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=bpf",
+        "include/llvm/IR/IntrinsicsBPF.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "hexagon_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=hexagon",
+        "include/llvm/IR/IntrinsicsHexagon.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "mips_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=mips",
+        "include/llvm/IR/IntrinsicsMips.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "nvvm_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=nvvm",
+        "include/llvm/IR/IntrinsicsNVPTX.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "ppc_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=ppc",
+        "include/llvm/IR/IntrinsicsPowerPC.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "r600_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=r600",
+        "include/llvm/IR/IntrinsicsR600.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "riscv_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=riscv",
+        "include/llvm/IR/IntrinsicsRISCV.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "s390_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=s390",
+        "include/llvm/IR/IntrinsicsS390.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "wasm_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=wasm",
+        "include/llvm/IR/IntrinsicsWebAssembly.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "x86_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=x86",
+        "include/llvm/IR/IntrinsicsX86.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "xcore_enums_gen",
+    tbl_outs = [(
+        "-gen-intrinsic-enums -intrinsic-prefix=xcore",
+        "include/llvm/IR/IntrinsicsXCore.h",
+    )],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+gentbl(
+    name = "intrinsics_impl_gen",
+    tbl_outs = [("-gen-intrinsic-impl", "include/llvm/IR/IntrinsicImpl.inc")],
+    tblgen = ":llvm-tblgen",
+    td_file = "include/llvm/IR/Intrinsics.td",
+    td_srcs = glob([
+        "include/llvm/CodeGen/*.td",
+        "include/llvm/IR/Intrinsics*.td",
+    ]),
+)
+
+cc_library(
+    name = "utils_tablegen",
+    srcs = glob([
+        "utils/TableGen/GlobalISel/*.cpp",
+    ]),
+    hdrs = glob([
+        "utils/TableGen/GlobalISel/*.h",
+    ]),
+    deps = [
+        ":tablegen",
+    ],
+)
+
+# Binary targets used by Tensorflow.
+cc_binary(
+    name = "llvm-tblgen",
+    srcs = glob([
+        "utils/TableGen/*.cpp",
+        "utils/TableGen/*.h",
+    ]),
+    copts = llvm_copts,
+    linkopts = llvm_linkopts,
+    stamp = 0,
+    deps = [
+        ":config",
+        ":support",
+        ":tablegen",
+        ":utils_tablegen",
+    ],
+)
+
+cc_binary(
+    name = "FileCheck",
+    testonly = 1,
+    srcs = glob([
+        "utils/FileCheck/*.cpp",
+        "utils/FileCheck/*.h",
+    ]),
+    copts = llvm_copts,
+    linkopts = llvm_linkopts,
+    stamp = 0,
+    deps = [":support"],
+)
+
+llvm_target_list = [
+    {
+        "name": "AArch64",
+        "lower_name": "aarch64",
+        "short_name": "AArch64",
+        "tbl_outs": [
+            ("-gen-register-bank", "lib/Target/AArch64/AArch64GenRegisterBank.inc"),
+            ("-gen-register-info", "lib/Target/AArch64/AArch64GenRegisterInfo.inc"),
+            ("-gen-instr-info", "lib/Target/AArch64/AArch64GenInstrInfo.inc"),
+            ("-gen-emitter", "lib/Target/AArch64/AArch64GenMCCodeEmitter.inc"),
+            ("-gen-pseudo-lowering", "lib/Target/AArch64/AArch64GenMCPseudoLowering.inc"),
+            ("-gen-asm-writer", "lib/Target/AArch64/AArch64GenAsmWriter.inc"),
+            ("-gen-asm-writer -asmwriternum=1", "lib/Target/AArch64/AArch64GenAsmWriter1.inc"),
+            ("-gen-asm-matcher", "lib/Target/AArch64/AArch64GenAsmMatcher.inc"),
+            ("-gen-dag-isel", "lib/Target/AArch64/AArch64GenDAGISel.inc"),
+            ("-gen-fast-isel", "lib/Target/AArch64/AArch64GenFastISel.inc"),
+            ("-gen-global-isel", "lib/Target/AArch64/AArch64GenGlobalISel.inc"),
+            ("-gen-global-isel-combiner -combiners=AArch64PreLegalizerCombinerHelper", "lib/Target/AArch64/AArch64GenGICombiner.inc"),
+            ("-gen-callingconv", "lib/Target/AArch64/AArch64GenCallingConv.inc"),
+            ("-gen-subtarget", "lib/Target/AArch64/AArch64GenSubtargetInfo.inc"),
+            ("-gen-disassembler", "lib/Target/AArch64/AArch64GenDisassemblerTables.inc"),
+            ("-gen-searchable-tables", "lib/Target/AArch64/AArch64GenSystemOperands.inc"),
+        ],
+    },
+    {
+        "name": "AMDGPU",
+        "lower_name": "amdgpu",
+        "short_name": "AMDGPU",
+        "tbl_outs": [
+            ("-gen-register-bank", "lib/Target/AMDGPU/AMDGPUGenRegisterBank.inc"),
+            ("-gen-register-info", "lib/Target/AMDGPU/AMDGPUGenRegisterInfo.inc"),
+            ("-gen-instr-info", "lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc"),
+            ("-gen-dag-isel", "lib/Target/AMDGPU/AMDGPUGenDAGISel.inc"),
+            ("-gen-callingconv", "lib/Target/AMDGPU/AMDGPUGenCallingConv.inc"),
+            ("-gen-subtarget", "lib/Target/AMDGPU/AMDGPUGenSubtargetInfo.inc"),
+            ("-gen-emitter", "lib/Target/AMDGPU/AMDGPUGenMCCodeEmitter.inc"),
+            ("-gen-dfa-packetizer", "lib/Target/AMDGPU/AMDGPUGenDFAPacketizer.inc"),
+            ("-gen-asm-writer", "lib/Target/AMDGPU/AMDGPUGenAsmWriter.inc"),
+            ("-gen-asm-matcher", "lib/Target/AMDGPU/AMDGPUGenAsmMatcher.inc"),
+            ("-gen-disassembler", "lib/Target/AMDGPU/AMDGPUGenDisassemblerTables.inc"),
+            ("-gen-pseudo-lowering", "lib/Target/AMDGPU/AMDGPUGenMCPseudoLowering.inc"),
+            ("-gen-searchable-tables", "lib/Target/AMDGPU/AMDGPUGenSearchableTables.inc"),
+            ("-gen-global-isel", "lib/Target/AMDGPU/AMDGPUGenGlobalISel.inc"),
+        ],
+    },
+    {
+        "name": "AMDGPU",
+        "lower_name": "amdgpu_r600",
+        "short_name": "R600",
+        "tbl_outs": [
+            ("-gen-asm-writer", "lib/Target/AMDGPU/R600GenAsmWriter.inc"),
+            ("-gen-callingconv", "lib/Target/AMDGPU/R600GenCallingConv.inc"),
+            ("-gen-dag-isel", "lib/Target/AMDGPU/R600GenDAGISel.inc"),
+            ("-gen-dfa-packetizer", "lib/Target/AMDGPU/R600GenDFAPacketizer.inc"),
+            ("-gen-instr-info", "lib/Target/AMDGPU/R600GenInstrInfo.inc"),
+            ("-gen-emitter", "lib/Target/AMDGPU/R600GenMCCodeEmitter.inc"),
+            ("-gen-register-info", "lib/Target/AMDGPU/R600GenRegisterInfo.inc"),
+            ("-gen-subtarget", "lib/Target/AMDGPU/R600GenSubtargetInfo.inc"),
+        ],
+    },
+    {
+        "name": "ARM",
+        "lower_name": "arm",
+        "short_name": "ARM",
+        "tbl_outs": [
+            ("-gen-register-bank", "lib/Target/ARM/ARMGenRegisterBank.inc"),
+            ("-gen-register-info", "lib/Target/ARM/ARMGenRegisterInfo.inc"),
+            ("-gen-searchable-tables", "lib/Target/ARM/ARMGenSystemRegister.inc"),
+            ("-gen-instr-info", "lib/Target/ARM/ARMGenInstrInfo.inc"),
+            ("-gen-emitter", "lib/Target/ARM/ARMGenMCCodeEmitter.inc"),
+            ("-gen-pseudo-lowering", "lib/Target/ARM/ARMGenMCPseudoLowering.inc"),
+            ("-gen-asm-writer", "lib/Target/ARM/ARMGenAsmWriter.inc"),
+            ("-gen-asm-matcher", "lib/Target/ARM/ARMGenAsmMatcher.inc"),
+            ("-gen-dag-isel", "lib/Target/ARM/ARMGenDAGISel.inc"),
+            ("-gen-fast-isel", "lib/Target/ARM/ARMGenFastISel.inc"),
+            ("-gen-global-isel", "lib/Target/ARM/ARMGenGlobalISel.inc"),
+            ("-gen-callingconv", "lib/Target/ARM/ARMGenCallingConv.inc"),
+            ("-gen-subtarget", "lib/Target/ARM/ARMGenSubtargetInfo.inc"),
+            ("-gen-disassembler", "lib/Target/ARM/ARMGenDisassemblerTables.inc"),
+        ],
+    },
+    {
+        "name": "NVPTX",
+        "lower_name": "nvptx",
+        "short_name": "NVPTX",
+        "tbl_outs": [
+            ("-gen-register-info", "lib/Target/NVPTX/NVPTXGenRegisterInfo.inc"),
+            ("-gen-instr-info", "lib/Target/NVPTX/NVPTXGenInstrInfo.inc"),
+            ("-gen-asm-writer", "lib/Target/NVPTX/NVPTXGenAsmWriter.inc"),
+            ("-gen-dag-isel", "lib/Target/NVPTX/NVPTXGenDAGISel.inc"),
+            ("-gen-subtarget", "lib/Target/NVPTX/NVPTXGenSubtargetInfo.inc"),
+        ],
+    },
+    {
+        "name": "PowerPC",
+        "lower_name": "powerpc",
+        "short_name": "PPC",
+        "tbl_outs": [
+            ("-gen-asm-writer", "lib/Target/PowerPC/PPCGenAsmWriter.inc"),
+            ("-gen-asm-matcher", "lib/Target/PowerPC/PPCGenAsmMatcher.inc"),
+            ("-gen-emitter", "lib/Target/PowerPC/PPCGenMCCodeEmitter.inc"),
+            ("-gen-register-info", "lib/Target/PowerPC/PPCGenRegisterInfo.inc"),
+            ("-gen-instr-info", "lib/Target/PowerPC/PPCGenInstrInfo.inc"),
+            ("-gen-dag-isel", "lib/Target/PowerPC/PPCGenDAGISel.inc"),
+            ("-gen-fast-isel", "lib/Target/PowerPC/PPCGenFastISel.inc"),
+            ("-gen-callingconv", "lib/Target/PowerPC/PPCGenCallingConv.inc"),
+            ("-gen-subtarget", "lib/Target/PowerPC/PPCGenSubtargetInfo.inc"),
+            ("-gen-disassembler", "lib/Target/PowerPC/PPCGenDisassemblerTables.inc"),
+        ],
+    },
+    {
+        "name": "X86",
+        "lower_name": "x86",
+        "short_name": "X86",
+        "tbl_outs": [
+            ("-gen-register-bank", "lib/Target/X86/X86GenRegisterBank.inc"),
+            ("-gen-register-info", "lib/Target/X86/X86GenRegisterInfo.inc"),
+            ("-gen-disassembler", "lib/Target/X86/X86GenDisassemblerTables.inc"),
+            ("-gen-instr-info", "lib/Target/X86/X86GenInstrInfo.inc"),
+            ("-gen-asm-writer", "lib/Target/X86/X86GenAsmWriter.inc"),
+            ("-gen-asm-writer -asmwriternum=1", "lib/Target/X86/X86GenAsmWriter1.inc"),
+            ("-gen-asm-matcher", "lib/Target/X86/X86GenAsmMatcher.inc"),
+            ("-gen-dag-isel", "lib/Target/X86/X86GenDAGISel.inc"),
+            ("-gen-fast-isel", "lib/Target/X86/X86GenFastISel.inc"),
+            ("-gen-global-isel", "lib/Target/X86/X86GenGlobalISel.inc"),
+            ("-gen-callingconv", "lib/Target/X86/X86GenCallingConv.inc"),
+            ("-gen-subtarget", "lib/Target/X86/X86GenSubtargetInfo.inc"),
+            ("-gen-x86-EVEX2VEX-tables", "lib/Target/X86/X86GenEVEX2VEXTables.inc"),
+        ],
+    },
+]
+
+[
+    gentbl(
+        name = target["lower_name"] + "_target_gen",
+        tbl_outs = target["tbl_outs"],
+        tblgen = ":llvm-tblgen",
+        td_file = ("lib/Target/" + target["name"] + "/" + target["short_name"] +
+                   ".td"),
+        td_srcs = glob([
+            "lib/Target/" + target["name"] + "/*.td",
+            "include/llvm/CodeGen/*.td",
+            "include/llvm/IR/Intrinsics*.td",
+            "include/llvm/TableGen/*.td",
+            "include/llvm/Target/*.td",
+            "include/llvm/Target/GlobalISel/*.td",
+        ]),
+    )
+    for target in llvm_target_list
+]
+
+# This target is used to provide *.def files to x86_code_gen.
+# Files with '.def' extension are not allowed in 'srcs' of 'cc_library' rule.
+cc_library(
+    name = "x86_defs",
+    hdrs = glob([
+        "lib/Target/X86/*.def",
+    ]),
+    visibility = ["//visibility:private"],
+)
+
+# This filegroup provides the docker build script in LLVM repo
+filegroup(
+    name = "docker",
+    srcs = glob([
+        "utils/docker/build_docker_image.sh",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "lit",
+    srcs = ["utils/lit/lit.py"] + glob(["utils/lit/lit/**/*.py"]),
+)
+
+cc_binary(
+    name = "count",
+    srcs = ["utils/count/count.c"],
+)
+
+cc_binary(
+    name = "not",
+    srcs = ["utils/not/not.cpp"],
+    copts = llvm_copts,
+    linkopts = llvm_linkopts,
+    deps = [
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "aarch64_asm_parser",
+    srcs = glob([
+        "lib/Target/AArch64/AsmParser/*.c",
+        "lib/Target/AArch64/AsmParser/*.cpp",
+        "lib/Target/AArch64/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/AsmParser/*.h",
+        "include/llvm/Target/AArch64/AsmParser/*.def",
+        "include/llvm/Target/AArch64/AsmParser/*.inc",
+        "lib/Target/AArch64/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":aarch64_desc",
+        ":aarch64_info",
+        ":aarch64_utils",
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "aarch64_code_gen",
+    srcs = glob([
+        "lib/Target/AArch64/*.c",
+        "lib/Target/AArch64/*.cpp",
+        "lib/Target/AArch64/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/*.h",
+        "include/llvm/Target/AArch64/*.def",
+        "include/llvm/Target/AArch64/*.inc",
+        "lib/Target/AArch64/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":aarch64_desc",
+        ":aarch64_info",
+        ":aarch64_utils",
+        ":analysis",
+        ":asm_printer",
+        ":cf_guard",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":mc",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "aarch64_desc",
+    srcs = glob([
+        "lib/Target/AArch64/MCTargetDesc/*.c",
+        "lib/Target/AArch64/MCTargetDesc/*.cpp",
+        "lib/Target/AArch64/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/MCTargetDesc/*.h",
+        "include/llvm/Target/AArch64/MCTargetDesc/*.def",
+        "include/llvm/Target/AArch64/MCTargetDesc/*.inc",
+        "lib/Target/AArch64/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":aarch64_info",
+        ":aarch64_target_gen",
+        ":aarch64_utils",
+        ":attributes_gen",
+        ":config",
+        ":intrinsic_enums_gen",
+        ":intrinsics_impl_gen",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "aarch64_disassembler",
+    srcs = glob([
+        "lib/Target/AArch64/Disassembler/*.c",
+        "lib/Target/AArch64/Disassembler/*.cpp",
+        "lib/Target/AArch64/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/Disassembler/*.h",
+        "include/llvm/Target/AArch64/Disassembler/*.def",
+        "include/llvm/Target/AArch64/Disassembler/*.inc",
+        "lib/Target/AArch64/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":aarch64_desc",
+        ":aarch64_info",
+        ":aarch64_utils",
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "aarch64_info",
+    srcs = glob([
+        "lib/Target/AArch64/TargetInfo/*.c",
+        "lib/Target/AArch64/TargetInfo/*.cpp",
+        "lib/Target/AArch64/TargetInfo/*.inc",
+        "lib/Target/AArch64/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/TargetInfo/*.h",
+        "include/llvm/Target/AArch64/TargetInfo/*.def",
+        "include/llvm/Target/AArch64/TargetInfo/*.inc",
+        "lib/Target/AArch64/*.def",
+        "lib/Target/AArch64/AArch64*.h",
+        "lib/Target/AArch64/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":code_gen",
+        ":config",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "aarch64_utils",
+    srcs = glob([
+        "lib/Target/AArch64/Utils/*.c",
+        "lib/Target/AArch64/Utils/*.cpp",
+        "lib/Target/AArch64/Utils/*.inc",
+        "lib/Target/AArch64/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AArch64/Utils/*.h",
+        "include/llvm/Target/AArch64/Utils/*.def",
+        "include/llvm/Target/AArch64/Utils/*.inc",
+        "lib/Target/AArch64/Utils/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AArch64"],
+    deps = [
+        ":aarch64_target_gen",
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_asm_parser",
+    srcs = glob([
+        "lib/Target/AMDGPU/AsmParser/*.c",
+        "lib/Target/AMDGPU/AsmParser/*.cpp",
+        "lib/Target/AMDGPU/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/AsmParser/*.h",
+        "include/llvm/Target/AMDGPU/AsmParser/*.def",
+        "include/llvm/Target/AMDGPU/AsmParser/*.inc",
+        "lib/Target/AMDGPU/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_desc",
+        ":amdgpu_info",
+        ":amdgpu_utils",
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_code_gen",
+    srcs = glob([
+        "lib/Target/AMDGPU/*.c",
+        "lib/Target/AMDGPU/*.cpp",
+        "lib/Target/AMDGPU/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/*.h",
+        "include/llvm/Target/AMDGPU/*.def",
+        "include/llvm/Target/AMDGPU/*.inc",
+        "lib/Target/AMDGPU/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_desc",
+        ":amdgpu_info",
+        ":amdgpu_utils",
+        ":analysis",
+        ":asm_printer",
+        ":binary_format",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":ipo",
+        ":mc",
+        ":mir_parser",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+        ":vectorize",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_desc",
+    srcs = glob([
+        "lib/Target/AMDGPU/MCTargetDesc/*.c",
+        "lib/Target/AMDGPU/MCTargetDesc/*.cpp",
+        "lib/Target/AMDGPU/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/MCTargetDesc/*.h",
+        "include/llvm/Target/AMDGPU/MCTargetDesc/*.def",
+        "include/llvm/Target/AMDGPU/MCTargetDesc/*.inc",
+        "lib/Target/AMDGPU/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_info",
+        ":amdgpu_utils",
+        ":binary_format",
+        ":config",
+        ":core",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_disassembler",
+    srcs = glob([
+        "lib/Target/AMDGPU/Disassembler/*.c",
+        "lib/Target/AMDGPU/Disassembler/*.cpp",
+        "lib/Target/AMDGPU/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/Disassembler/*.h",
+        "include/llvm/Target/AMDGPU/Disassembler/*.def",
+        "include/llvm/Target/AMDGPU/Disassembler/*.inc",
+        "lib/Target/AMDGPU/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_desc",
+        ":amdgpu_info",
+        ":amdgpu_utils",
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_info",
+    srcs = glob([
+        "lib/Target/AMDGPU/TargetInfo/*.c",
+        "lib/Target/AMDGPU/TargetInfo/*.cpp",
+        "lib/Target/AMDGPU/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/TargetInfo/*.h",
+        "include/llvm/Target/AMDGPU/TargetInfo/*.def",
+        "include/llvm/Target/AMDGPU/TargetInfo/*.inc",
+        "lib/Target/AMDGPU/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_r600_target_gen",
+        ":amdgpu_target_gen",
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "amdgpu_utils",
+    srcs = glob([
+        "lib/Target/AMDGPU/Utils/*.c",
+        "lib/Target/AMDGPU/Utils/*.cpp",
+        "lib/Target/AMDGPU/Utils/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AMDGPU/Utils/*.h",
+        "include/llvm/Target/AMDGPU/Utils/*.def",
+        "include/llvm/Target/AMDGPU/Utils/*.inc",
+        "lib/Target/AMDGPU/Utils/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AMDGPU"],
+    deps = [
+        ":amdgpu_r600_target_gen",
+        ":amdgpu_target_gen",
+        ":binary_format",
+        ":config",
+        ":core",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arc_code_gen",
+    srcs = glob([
+        "lib/Target/ARC/*.c",
+        "lib/Target/ARC/*.cpp",
+        "lib/Target/ARC/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARC/*.h",
+        "include/llvm/Target/ARC/*.def",
+        "include/llvm/Target/ARC/*.inc",
+        "lib/Target/ARC/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARC"],
+    deps = [
+        ":analysis",
+        ":arc_desc",
+        ":arc_info",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "arc_desc",
+    srcs = glob([
+        "lib/Target/ARC/MCTargetDesc/*.c",
+        "lib/Target/ARC/MCTargetDesc/*.cpp",
+        "lib/Target/ARC/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARC/MCTargetDesc/*.h",
+        "include/llvm/Target/ARC/MCTargetDesc/*.def",
+        "include/llvm/Target/ARC/MCTargetDesc/*.inc",
+        "lib/Target/ARC/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARC"],
+    deps = [
+        ":arc_info",
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arc_disassembler",
+    srcs = glob([
+        "lib/Target/ARC/Disassembler/*.c",
+        "lib/Target/ARC/Disassembler/*.cpp",
+        "lib/Target/ARC/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARC/Disassembler/*.h",
+        "include/llvm/Target/ARC/Disassembler/*.def",
+        "include/llvm/Target/ARC/Disassembler/*.inc",
+        "lib/Target/ARC/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARC"],
+    deps = [
+        ":arc_info",
+        ":config",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arc_info",
+    srcs = glob([
+        "lib/Target/ARC/TargetInfo/*.c",
+        "lib/Target/ARC/TargetInfo/*.cpp",
+        "lib/Target/ARC/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARC/TargetInfo/*.h",
+        "include/llvm/Target/ARC/TargetInfo/*.def",
+        "include/llvm/Target/ARC/TargetInfo/*.inc",
+        "lib/Target/ARC/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARC"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arm_asm_parser",
+    srcs = glob([
+        "lib/Target/ARM/AsmParser/*.c",
+        "lib/Target/ARM/AsmParser/*.cpp",
+        "lib/Target/ARM/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/AsmParser/*.h",
+        "include/llvm/Target/ARM/AsmParser/*.def",
+        "include/llvm/Target/ARM/AsmParser/*.inc",
+        "lib/Target/ARM/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":arm_desc",
+        ":arm_info",
+        ":arm_utils",
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arm_code_gen",
+    srcs = glob([
+        "lib/Target/ARM/*.c",
+        "lib/Target/ARM/*.cpp",
+        "lib/Target/ARM/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/*.h",
+        "include/llvm/Target/ARM/*.def",
+        "include/llvm/Target/ARM/*.inc",
+        "lib/Target/ARM/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":analysis",
+        ":arm_desc",
+        ":arm_info",
+        ":arm_utils",
+        ":asm_printer",
+        ":cf_guard",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":mc",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "arm_desc",
+    srcs = glob([
+        "lib/Target/ARM/MCTargetDesc/*.c",
+        "lib/Target/ARM/MCTargetDesc/*.cpp",
+        "lib/Target/ARM/MCTargetDesc/*.inc",
+        "lib/Target/ARM/*.h",
+        "include/llvm/CodeGen/GlobalISel/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/MCTargetDesc/*.h",
+        "include/llvm/Target/ARM/MCTargetDesc/*.def",
+        "include/llvm/Target/ARM/MCTargetDesc/*.inc",
+        "lib/Target/ARM/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":arm_info",
+        ":arm_target_gen",
+        ":arm_utils",
+        ":attributes_gen",
+        ":config",
+        ":intrinsic_enums_gen",
+        ":intrinsics_impl_gen",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arm_disassembler",
+    srcs = glob([
+        "lib/Target/ARM/Disassembler/*.c",
+        "lib/Target/ARM/Disassembler/*.cpp",
+        "lib/Target/ARM/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/Disassembler/*.h",
+        "include/llvm/Target/ARM/Disassembler/*.def",
+        "include/llvm/Target/ARM/Disassembler/*.inc",
+        "lib/Target/ARM/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":arm_desc",
+        ":arm_info",
+        ":arm_utils",
+        ":config",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "arm_info",
+    srcs = glob([
+        "lib/Target/ARM/TargetInfo/*.c",
+        "lib/Target/ARM/TargetInfo/*.cpp",
+        "lib/Target/ARM/TargetInfo/*.inc",
+        "lib/Target/ARM/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/TargetInfo/*.h",
+        "include/llvm/Target/ARM/TargetInfo/*.def",
+        "include/llvm/Target/ARM/TargetInfo/*.inc",
+        "lib/Target/ARM/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":arm_target_gen",
+        ":config",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "arm_utils",
+    srcs = glob([
+        "lib/Target/ARM/Utils/*.c",
+        "lib/Target/ARM/Utils/*.cpp",
+        "lib/Target/ARM/Utils/*.inc",
+        "lib/Target/ARM/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/ARM/Utils/*.h",
+        "include/llvm/Target/ARM/Utils/*.def",
+        "include/llvm/Target/ARM/Utils/*.inc",
+        "lib/Target/ARM/Utils/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/ARM"],
+    deps = [
+        ":arm_target_gen",
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "avr_asm_parser",
+    srcs = glob([
+        "lib/Target/AVR/AsmParser/*.c",
+        "lib/Target/AVR/AsmParser/*.cpp",
+        "lib/Target/AVR/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AVR/AsmParser/*.h",
+        "include/llvm/Target/AVR/AsmParser/*.def",
+        "include/llvm/Target/AVR/AsmParser/*.inc",
+        "lib/Target/AVR/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AVR"],
+    deps = [
+        ":avr_desc",
+        ":avr_info",
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "avr_code_gen",
+    srcs = glob([
+        "lib/Target/AVR/*.c",
+        "lib/Target/AVR/*.cpp",
+        "lib/Target/AVR/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AVR/*.h",
+        "include/llvm/Target/AVR/*.def",
+        "include/llvm/Target/AVR/*.inc",
+        "lib/Target/AVR/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AVR"],
+    deps = [
+        ":asm_printer",
+        ":avr_desc",
+        ":avr_info",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "avr_desc",
+    srcs = glob([
+        "lib/Target/AVR/MCTargetDesc/*.c",
+        "lib/Target/AVR/MCTargetDesc/*.cpp",
+        "lib/Target/AVR/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AVR/MCTargetDesc/*.h",
+        "include/llvm/Target/AVR/MCTargetDesc/*.def",
+        "include/llvm/Target/AVR/MCTargetDesc/*.inc",
+        "lib/Target/AVR/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AVR"],
+    deps = [
+        ":avr_info",
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "avr_disassembler",
+    srcs = glob([
+        "lib/Target/AVR/Disassembler/*.c",
+        "lib/Target/AVR/Disassembler/*.cpp",
+        "lib/Target/AVR/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AVR/Disassembler/*.h",
+        "include/llvm/Target/AVR/Disassembler/*.def",
+        "include/llvm/Target/AVR/Disassembler/*.inc",
+        "lib/Target/AVR/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AVR"],
+    deps = [
+        ":avr_info",
+        ":config",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "avr_info",
+    srcs = glob([
+        "lib/Target/AVR/TargetInfo/*.c",
+        "lib/Target/AVR/TargetInfo/*.cpp",
+        "lib/Target/AVR/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/AVR/TargetInfo/*.h",
+        "include/llvm/Target/AVR/TargetInfo/*.def",
+        "include/llvm/Target/AVR/TargetInfo/*.inc",
+        "lib/Target/AVR/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/AVR"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "aggressive_inst_combine",
+    srcs = glob([
+        "lib/Transforms/AggressiveInstCombine/*.c",
+        "lib/Transforms/AggressiveInstCombine/*.cpp",
+        "lib/Transforms/AggressiveInstCombine/*.inc",
+        "lib/Transforms/AggressiveInstCombine/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/AggressiveInstCombine/*.h",
+        "include/llvm/Transforms/AggressiveInstCombine/*.def",
+        "include/llvm/Transforms/AggressiveInstCombine/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "analysis",
+    srcs = glob([
+        "lib/Analysis/*.c",
+        "lib/Analysis/*.cpp",
+        "lib/Analysis/*.inc",
+        "include/llvm/Transforms/Utils/Local.h",
+        "include/llvm/Transforms/Scalar.h",
+        "lib/Analysis/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Analysis/*.h",
+        "include/llvm/Analysis/*.def",
+        "include/llvm/Analysis/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":core",
+        ":object",
+        ":profile_data",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "asm_parser",
+    srcs = glob([
+        "lib/AsmParser/*.c",
+        "lib/AsmParser/*.cpp",
+        "lib/AsmParser/*.inc",
+        "lib/AsmParser/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/AsmParser/*.h",
+        "include/llvm/AsmParser/*.def",
+        "include/llvm/AsmParser/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "asm_printer",
+    srcs = glob([
+        "lib/CodeGen/AsmPrinter/*.c",
+        "lib/CodeGen/AsmPrinter/*.cpp",
+        "lib/CodeGen/AsmPrinter/*.inc",
+        "lib/CodeGen/AsmPrinter/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/CodeGen/AsmPrinter/*.h",
+        "include/llvm/CodeGen/AsmPrinter/*.def",
+        "include/llvm/CodeGen/AsmPrinter/*.inc",
+        "lib/CodeGen/AsmPrinter/*.def",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":binary_format",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":debug_info_code_view",
+        ":debug_info_dwarf",
+        ":debug_info_msf",
+        ":mc",
+        ":mc_parser",
+        ":remarks",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "bpf_asm_parser",
+    srcs = glob([
+        "lib/Target/BPF/AsmParser/*.c",
+        "lib/Target/BPF/AsmParser/*.cpp",
+        "lib/Target/BPF/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/BPF/AsmParser/*.h",
+        "include/llvm/Target/BPF/AsmParser/*.def",
+        "include/llvm/Target/BPF/AsmParser/*.inc",
+        "lib/Target/BPF/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/BPF"],
+    deps = [
+        ":bpf_desc",
+        ":bpf_info",
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bpf_code_gen",
+    srcs = glob([
+        "lib/Target/BPF/*.c",
+        "lib/Target/BPF/*.cpp",
+        "lib/Target/BPF/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/BPF/*.h",
+        "include/llvm/Target/BPF/*.def",
+        "include/llvm/Target/BPF/*.inc",
+        "lib/Target/BPF/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/BPF"],
+    deps = [
+        ":asm_printer",
+        ":bpf_desc",
+        ":bpf_info",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "bpf_desc",
+    srcs = glob([
+        "lib/Target/BPF/MCTargetDesc/*.c",
+        "lib/Target/BPF/MCTargetDesc/*.cpp",
+        "lib/Target/BPF/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/BPF/MCTargetDesc/*.h",
+        "include/llvm/Target/BPF/MCTargetDesc/*.def",
+        "include/llvm/Target/BPF/MCTargetDesc/*.inc",
+        "lib/Target/BPF/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/BPF"],
+    deps = [
+        ":bpf_info",
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bpf_disassembler",
+    srcs = glob([
+        "lib/Target/BPF/Disassembler/*.c",
+        "lib/Target/BPF/Disassembler/*.cpp",
+        "lib/Target/BPF/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/BPF/Disassembler/*.h",
+        "include/llvm/Target/BPF/Disassembler/*.def",
+        "include/llvm/Target/BPF/Disassembler/*.inc",
+        "lib/Target/BPF/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/BPF"],
+    deps = [
+        ":bpf_info",
+        ":config",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bpf_info",
+    srcs = glob([
+        "lib/Target/BPF/TargetInfo/*.c",
+        "lib/Target/BPF/TargetInfo/*.cpp",
+        "lib/Target/BPF/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/BPF/TargetInfo/*.h",
+        "include/llvm/Target/BPF/TargetInfo/*.def",
+        "include/llvm/Target/BPF/TargetInfo/*.inc",
+        "lib/Target/BPF/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/BPF"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "binary_format",
+    srcs = glob([
+        "lib/BinaryFormat/*.c",
+        "lib/BinaryFormat/*.cpp",
+        "lib/BinaryFormat/*.inc",
+        "lib/BinaryFormat/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/BinaryFormat/*.h",
+        "include/llvm/BinaryFormat/*.def",
+        "include/llvm/BinaryFormat/*.inc",
+        "include/llvm/BinaryFormat/ELFRelocs/*.def",
+        "include/llvm/BinaryFormat/WasmRelocs/*.def",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bit_reader",
+    srcs = glob([
+        "lib/Bitcode/Reader/*.c",
+        "lib/Bitcode/Reader/*.cpp",
+        "lib/Bitcode/Reader/*.inc",
+        "lib/Bitcode/Reader/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Bitcode/Reader/*.h",
+        "include/llvm/Bitcode/Reader/*.def",
+        "include/llvm/Bitcode/Reader/*.inc",
+        "include/llvm/Bitcode/BitstreamReader.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":bitstream_reader",
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bit_writer",
+    srcs = glob([
+        "lib/Bitcode/Writer/*.c",
+        "lib/Bitcode/Writer/*.cpp",
+        "lib/Bitcode/Writer/*.inc",
+        "lib/Bitcode/Writer/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Bitcode/Writer/*.h",
+        "include/llvm/Bitcode/Writer/*.def",
+        "include/llvm/Bitcode/Writer/*.inc",
+        "include/llvm/Bitcode/BitcodeWriter.h",
+        "include/llvm/Bitcode/BitcodeWriterPass.h",
+        "include/llvm/Bitcode/BitstreamWriter.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":mc",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "bitstream_reader",
+    srcs = glob([
+        "lib/Bitstream/Reader/*.c",
+        "lib/Bitstream/Reader/*.cpp",
+        "lib/Bitstream/Reader/*.inc",
+        "lib/Bitstream/Reader/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Bitstream/Reader/*.h",
+        "include/llvm/Bitstream/Reader/*.def",
+        "include/llvm/Bitstream/Reader/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "cf_guard",
+    srcs = glob([
+        "lib/Transforms/CFGuard/*.c",
+        "lib/Transforms/CFGuard/*.cpp",
+        "lib/Transforms/CFGuard/*.inc",
+        "lib/Transforms/CFGuard/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/CFGuard/*.h",
+        "include/llvm/Transforms/CFGuard/*.def",
+        "include/llvm/Transforms/CFGuard/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "code_gen",
+    srcs = glob([
+        "lib/CodeGen/*.c",
+        "lib/CodeGen/*.cpp",
+        "lib/CodeGen/*.inc",
+        "lib/CodeGen/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/CodeGen/*.h",
+        "include/llvm/CodeGen/*.def",
+        "include/llvm/CodeGen/*.inc",
+        "include/llvm/CodeGen/**/*.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":bit_reader",
+        ":bit_writer",
+        ":config",
+        ":core",
+        ":instrumentation",
+        ":mc",
+        ":profile_data",
+        ":scalar",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "core",
+    srcs = glob([
+        "lib/IR/*.c",
+        "lib/IR/*.cpp",
+        "lib/IR/*.inc",
+        "include/llvm/Analysis/*.h",
+        "include/llvm/Bitcode/BitcodeReader.h",
+        "include/llvm/Bitcode/BitCodes.h",
+        "include/llvm/Bitcode/LLVMBitCodes.h",
+        "include/llvm/CodeGen/MachineValueType.h",
+        "include/llvm/CodeGen/ValueTypes.h",
+        "lib/IR/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/IR/*.h",
+        "include/llvm/IR/*.def",
+        "include/llvm/IR/*.inc",
+        "include/llvm/*.h",
+        "include/llvm/Analysis/*.def",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":aarch64_enums_gen",
+        ":amdgcn_enums_gen",
+        ":arm_enums_gen",
+        ":attributes_compat_gen",
+        ":attributes_gen",
+        ":binary_format",
+        ":bpf_enums_gen",
+        ":config",
+        ":hexagon_enums_gen",
+        ":intrinsic_enums_gen",
+        ":intrinsics_impl_gen",
+        ":mips_enums_gen",
+        ":nvvm_enums_gen",
+        ":ppc_enums_gen",
+        ":r600_enums_gen",
+        ":remarks",
+        ":riscv_enums_gen",
+        ":s390_enums_gen",
+        ":support",
+        ":wasm_enums_gen",
+        ":x86_enums_gen",
+        ":xcore_enums_gen",
+    ],
+)
+
+cc_library(
+    name = "coroutines",
+    srcs = glob([
+        "lib/Transforms/Coroutines/*.c",
+        "lib/Transforms/Coroutines/*.cpp",
+        "lib/Transforms/Coroutines/*.inc",
+        "lib/Transforms/Coroutines/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/Coroutines/*.h",
+        "include/llvm/Transforms/Coroutines/*.def",
+        "include/llvm/Transforms/Coroutines/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":ipo",
+        ":scalar",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "coverage",
+    srcs = glob([
+        "lib/ProfileData/Coverage/*.c",
+        "lib/ProfileData/Coverage/*.cpp",
+        "lib/ProfileData/Coverage/*.inc",
+        "lib/ProfileData/Coverage/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ProfileData/Coverage/*.h",
+        "include/llvm/ProfileData/Coverage/*.def",
+        "include/llvm/ProfileData/Coverage/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":object",
+        ":profile_data",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "debug_info_code_view",
+    srcs = glob([
+        "lib/DebugInfo/CodeView/*.c",
+        "lib/DebugInfo/CodeView/*.cpp",
+        "lib/DebugInfo/CodeView/*.inc",
+        "lib/DebugInfo/CodeView/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/CodeView/*.h",
+        "include/llvm/DebugInfo/CodeView/*.def",
+        "include/llvm/DebugInfo/CodeView/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":debug_info_msf",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "debug_info_dwarf",
+    srcs = glob([
+        "lib/DebugInfo/DWARF/*.c",
+        "lib/DebugInfo/DWARF/*.cpp",
+        "lib/DebugInfo/DWARF/*.inc",
+        "lib/DebugInfo/DWARF/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/DWARF/*.h",
+        "include/llvm/DebugInfo/DWARF/*.def",
+        "include/llvm/DebugInfo/DWARF/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":mc",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "debug_info_gsym",
+    srcs = glob([
+        "lib/DebugInfo/GSYM/*.c",
+        "lib/DebugInfo/GSYM/*.cpp",
+        "lib/DebugInfo/GSYM/*.inc",
+        "lib/DebugInfo/GSYM/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/GSYM/*.h",
+        "include/llvm/DebugInfo/GSYM/*.def",
+        "include/llvm/DebugInfo/GSYM/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "debug_info_msf",
+    srcs = glob([
+        "lib/DebugInfo/MSF/*.c",
+        "lib/DebugInfo/MSF/*.cpp",
+        "lib/DebugInfo/MSF/*.inc",
+        "lib/DebugInfo/MSF/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/MSF/*.h",
+        "include/llvm/DebugInfo/MSF/*.def",
+        "include/llvm/DebugInfo/MSF/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "debug_info_pdb",
+    srcs = glob([
+        "lib/DebugInfo/PDB/*.c",
+        "lib/DebugInfo/PDB/*.cpp",
+        "lib/DebugInfo/PDB/*.inc",
+        "lib/DebugInfo/PDB/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/PDB/*.h",
+        "include/llvm/DebugInfo/PDB/*.def",
+        "include/llvm/DebugInfo/PDB/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":debug_info_code_view",
+        ":debug_info_msf",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "demangle",
+    srcs = glob([
+        "lib/Demangle/*.c",
+        "lib/Demangle/*.cpp",
+        "lib/Demangle/*.inc",
+        "lib/Demangle/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Demangle/*.h",
+        "include/llvm/Demangle/*.def",
+        "include/llvm/Demangle/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [":config"],
+)
+
+cc_library(
+    name = "dlltool_driver",
+    srcs = glob([
+        "lib/ToolDrivers/llvm-dlltool/*.c",
+        "lib/ToolDrivers/llvm-dlltool/*.cpp",
+        "lib/ToolDrivers/llvm-dlltool/*.inc",
+        "lib/ToolDrivers/llvm-dlltool/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ToolDrivers/llvm-dlltool/*.h",
+        "include/llvm/ToolDrivers/llvm-dlltool/*.def",
+        "include/llvm/ToolDrivers/llvm-dlltool/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":object",
+        ":option",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "execution_engine",
+    srcs = glob([
+        "lib/ExecutionEngine/*.c",
+        "lib/ExecutionEngine/*.cpp",
+        "lib/ExecutionEngine/*.inc",
+        "lib/ExecutionEngine/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/*.h",
+        "include/llvm/ExecutionEngine/*.def",
+        "include/llvm/ExecutionEngine/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":mc",
+        ":object",
+        ":runtime_dyld",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "frontend_open_mp",
+    srcs = glob([
+        "lib/Frontend/OpenMP/*.c",
+        "lib/Frontend/OpenMP/*.cpp",
+        "lib/Frontend/OpenMP/*.inc",
+        "lib/Frontend/OpenMP/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Frontend/OpenMP/*.h",
+        "include/llvm/Frontend/OpenMP/*.def",
+        "include/llvm/Frontend/OpenMP/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "fuzz_mutate",
+    srcs = glob([
+        "lib/FuzzMutate/*.c",
+        "lib/FuzzMutate/*.cpp",
+        "lib/FuzzMutate/*.inc",
+        "lib/FuzzMutate/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/FuzzMutate/*.h",
+        "include/llvm/FuzzMutate/*.def",
+        "include/llvm/FuzzMutate/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":bit_reader",
+        ":bit_writer",
+        ":config",
+        ":core",
+        ":scalar",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "global_i_sel",
+    srcs = glob([
+        "lib/CodeGen/GlobalISel/*.c",
+        "lib/CodeGen/GlobalISel/*.cpp",
+        "lib/CodeGen/GlobalISel/*.inc",
+        "lib/CodeGen/GlobalISel/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/CodeGen/GlobalISel/*.h",
+        "include/llvm/CodeGen/GlobalISel/*.def",
+        "include/llvm/CodeGen/GlobalISel/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "hexagon_asm_parser",
+    srcs = glob([
+        "lib/Target/Hexagon/AsmParser/*.c",
+        "lib/Target/Hexagon/AsmParser/*.cpp",
+        "lib/Target/Hexagon/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Hexagon/AsmParser/*.h",
+        "include/llvm/Target/Hexagon/AsmParser/*.def",
+        "include/llvm/Target/Hexagon/AsmParser/*.inc",
+        "lib/Target/Hexagon/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Hexagon"],
+    deps = [
+        ":config",
+        ":hexagon_desc",
+        ":hexagon_info",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "hexagon_code_gen",
+    srcs = glob([
+        "lib/Target/Hexagon/*.c",
+        "lib/Target/Hexagon/*.cpp",
+        "lib/Target/Hexagon/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Hexagon/*.h",
+        "include/llvm/Target/Hexagon/*.def",
+        "include/llvm/Target/Hexagon/*.inc",
+        "lib/Target/Hexagon/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Hexagon"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":hexagon_asm_parser",
+        ":hexagon_desc",
+        ":hexagon_info",
+        ":ipo",
+        ":mc",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "hexagon_desc",
+    srcs = glob([
+        "lib/Target/Hexagon/MCTargetDesc/*.c",
+        "lib/Target/Hexagon/MCTargetDesc/*.cpp",
+        "lib/Target/Hexagon/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Hexagon/MCTargetDesc/*.h",
+        "include/llvm/Target/Hexagon/MCTargetDesc/*.def",
+        "include/llvm/Target/Hexagon/MCTargetDesc/*.inc",
+        "lib/Target/Hexagon/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Hexagon"],
+    deps = [
+        ":config",
+        ":hexagon_info",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "hexagon_disassembler",
+    srcs = glob([
+        "lib/Target/Hexagon/Disassembler/*.c",
+        "lib/Target/Hexagon/Disassembler/*.cpp",
+        "lib/Target/Hexagon/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Hexagon/Disassembler/*.h",
+        "include/llvm/Target/Hexagon/Disassembler/*.def",
+        "include/llvm/Target/Hexagon/Disassembler/*.inc",
+        "lib/Target/Hexagon/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Hexagon"],
+    deps = [
+        ":config",
+        ":hexagon_desc",
+        ":hexagon_info",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "hexagon_info",
+    srcs = glob([
+        "lib/Target/Hexagon/TargetInfo/*.c",
+        "lib/Target/Hexagon/TargetInfo/*.cpp",
+        "lib/Target/Hexagon/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Hexagon/TargetInfo/*.h",
+        "include/llvm/Target/Hexagon/TargetInfo/*.def",
+        "include/llvm/Target/Hexagon/TargetInfo/*.inc",
+        "lib/Target/Hexagon/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Hexagon"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "ipo",
+    srcs = glob([
+        "lib/Transforms/IPO/*.c",
+        "lib/Transforms/IPO/*.cpp",
+        "lib/Transforms/IPO/*.inc",
+        "include/llvm/Transforms/SampleProfile.h",
+        "include/llvm-c/Transforms/IPO.h",
+        "include/llvm-c/Transforms/PassManagerBuilder.h",
+        "lib/Transforms/IPO/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/IPO/*.h",
+        "include/llvm/Transforms/IPO/*.def",
+        "include/llvm/Transforms/IPO/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":aggressive_inst_combine",
+        ":analysis",
+        ":bit_reader",
+        ":bit_writer",
+        ":config",
+        ":core",
+        ":inst_combine",
+        ":instrumentation",
+        ":ir_reader",
+        ":linker",
+        ":object",
+        ":profile_data",
+        ":scalar",
+        ":support",
+        ":transform_utils",
+        ":vectorize",
+    ],
+)
+
+cc_library(
+    name = "ir_reader",
+    srcs = glob([
+        "lib/IRReader/*.c",
+        "lib/IRReader/*.cpp",
+        "lib/IRReader/*.inc",
+        "lib/IRReader/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/IRReader/*.h",
+        "include/llvm/IRReader/*.def",
+        "include/llvm/IRReader/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":asm_parser",
+        ":bit_reader",
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "inst_combine",
+    srcs = glob([
+        "lib/Transforms/InstCombine/*.c",
+        "lib/Transforms/InstCombine/*.cpp",
+        "lib/Transforms/InstCombine/*.inc",
+        "lib/Transforms/InstCombine/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/InstCombine/*.h",
+        "include/llvm/Transforms/InstCombine/*.def",
+        "include/llvm/Transforms/InstCombine/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":instcombine_transforms_gen",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "instrumentation",
+    srcs = glob([
+        "lib/Transforms/Instrumentation/*.c",
+        "lib/Transforms/Instrumentation/*.cpp",
+        "lib/Transforms/Instrumentation/*.inc",
+        "lib/Transforms/Instrumentation/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/Instrumentation/*.h",
+        "include/llvm/Transforms/Instrumentation/*.def",
+        "include/llvm/Transforms/Instrumentation/*.inc",
+        "include/llvm/Transforms/GCOVProfiler.h",
+        "include/llvm/Transforms/Instrumentation.h",
+        "include/llvm/Transforms/InstrProfiling.h",
+        "include/llvm/Transforms/PGOInstrumentation.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":mc",
+        ":profile_data",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "interpreter",
+    srcs = glob([
+        "lib/ExecutionEngine/Interpreter/*.c",
+        "lib/ExecutionEngine/Interpreter/*.cpp",
+        "lib/ExecutionEngine/Interpreter/*.inc",
+        "lib/ExecutionEngine/Interpreter/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/Interpreter/*.h",
+        "include/llvm/ExecutionEngine/Interpreter/*.def",
+        "include/llvm/ExecutionEngine/Interpreter/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":code_gen",
+        ":config",
+        ":core",
+        ":execution_engine",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "jit_link",
+    srcs = glob([
+        "lib/ExecutionEngine/JITLink/*.c",
+        "lib/ExecutionEngine/JITLink/*.cpp",
+        "lib/ExecutionEngine/JITLink/*.inc",
+        "lib/ExecutionEngine/JITLink/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/JITLink/*.h",
+        "include/llvm/ExecutionEngine/JITLink/*.def",
+        "include/llvm/ExecutionEngine/JITLink/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "lto",
+    srcs = glob([
+        "lib/LTO/*.c",
+        "lib/LTO/*.cpp",
+        "lib/LTO/*.inc",
+        "lib/LTO/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/LTO/*.h",
+        "include/llvm/LTO/*.def",
+        "include/llvm/LTO/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":aggressive_inst_combine",
+        ":analysis",
+        ":bit_reader",
+        ":bit_writer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":inst_combine",
+        ":ipo",
+        ":linker",
+        ":mc",
+        ":objc_arc",
+        ":object",
+        ":passes",
+        ":remarks",
+        ":scalar",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "lanai_asm_parser",
+    srcs = glob([
+        "lib/Target/Lanai/AsmParser/*.c",
+        "lib/Target/Lanai/AsmParser/*.cpp",
+        "lib/Target/Lanai/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Lanai/AsmParser/*.h",
+        "include/llvm/Target/Lanai/AsmParser/*.def",
+        "include/llvm/Target/Lanai/AsmParser/*.inc",
+        "lib/Target/Lanai/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Lanai"],
+    deps = [
+        ":config",
+        ":lanai_desc",
+        ":lanai_info",
+        ":mc",
+        ":mc_parser",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "lanai_code_gen",
+    srcs = glob([
+        "lib/Target/Lanai/*.c",
+        "lib/Target/Lanai/*.cpp",
+        "lib/Target/Lanai/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Lanai/*.h",
+        "include/llvm/Target/Lanai/*.def",
+        "include/llvm/Target/Lanai/*.inc",
+        "lib/Target/Lanai/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Lanai"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":lanai_asm_parser",
+        ":lanai_desc",
+        ":lanai_info",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "lanai_desc",
+    srcs = glob([
+        "lib/Target/Lanai/MCTargetDesc/*.c",
+        "lib/Target/Lanai/MCTargetDesc/*.cpp",
+        "lib/Target/Lanai/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Lanai/MCTargetDesc/*.h",
+        "include/llvm/Target/Lanai/MCTargetDesc/*.def",
+        "include/llvm/Target/Lanai/MCTargetDesc/*.inc",
+        "lib/Target/Lanai/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Lanai"],
+    deps = [
+        ":config",
+        ":lanai_info",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "lanai_disassembler",
+    srcs = glob([
+        "lib/Target/Lanai/Disassembler/*.c",
+        "lib/Target/Lanai/Disassembler/*.cpp",
+        "lib/Target/Lanai/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Lanai/Disassembler/*.h",
+        "include/llvm/Target/Lanai/Disassembler/*.def",
+        "include/llvm/Target/Lanai/Disassembler/*.inc",
+        "lib/Target/Lanai/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Lanai"],
+    deps = [
+        ":config",
+        ":lanai_desc",
+        ":lanai_info",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "lanai_info",
+    srcs = glob([
+        "lib/Target/Lanai/TargetInfo/*.c",
+        "lib/Target/Lanai/TargetInfo/*.cpp",
+        "lib/Target/Lanai/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Lanai/TargetInfo/*.h",
+        "include/llvm/Target/Lanai/TargetInfo/*.def",
+        "include/llvm/Target/Lanai/TargetInfo/*.inc",
+        "lib/Target/Lanai/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Lanai"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "lib_driver",
+    srcs = glob([
+        "lib/ToolDrivers/llvm-lib/*.c",
+        "lib/ToolDrivers/llvm-lib/*.cpp",
+        "lib/ToolDrivers/llvm-lib/*.inc",
+        "lib/ToolDrivers/llvm-lib/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ToolDrivers/llvm-lib/*.h",
+        "include/llvm/ToolDrivers/llvm-lib/*.def",
+        "include/llvm/ToolDrivers/llvm-lib/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":bit_reader",
+        ":config",
+        ":object",
+        ":option",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "line_editor",
+    srcs = glob([
+        "lib/LineEditor/*.c",
+        "lib/LineEditor/*.cpp",
+        "lib/LineEditor/*.inc",
+        "lib/LineEditor/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/LineEditor/*.h",
+        "include/llvm/LineEditor/*.def",
+        "include/llvm/LineEditor/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "linker",
+    srcs = glob([
+        "lib/Linker/*.c",
+        "lib/Linker/*.cpp",
+        "lib/Linker/*.inc",
+        "lib/Linker/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Linker/*.h",
+        "include/llvm/Linker/*.def",
+        "include/llvm/Linker/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "mc",
+    srcs = glob([
+        "lib/MC/*.c",
+        "lib/MC/*.cpp",
+        "lib/MC/*.inc",
+        "lib/MC/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/MC/*.h",
+        "include/llvm/MC/*.def",
+        "include/llvm/MC/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":debug_info_code_view",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mca",
+    srcs = glob([
+        "lib/MCA/*.c",
+        "lib/MCA/*.cpp",
+        "lib/MCA/*.inc",
+        "lib/MCA/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/MCA/*.h",
+        "include/llvm/MCA/*.def",
+        "include/llvm/MCA/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mc_disassembler",
+    srcs = glob([
+        "lib/MC/MCDisassembler/*.c",
+        "lib/MC/MCDisassembler/*.cpp",
+        "lib/MC/MCDisassembler/*.inc",
+        "lib/MC/MCDisassembler/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/MC/MCDisassembler/*.h",
+        "include/llvm/MC/MCDisassembler/*.def",
+        "include/llvm/MC/MCDisassembler/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mcjit",
+    srcs = glob([
+        "lib/ExecutionEngine/MCJIT/*.c",
+        "lib/ExecutionEngine/MCJIT/*.cpp",
+        "lib/ExecutionEngine/MCJIT/*.inc",
+        "lib/ExecutionEngine/MCJIT/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/MCJIT/*.h",
+        "include/llvm/ExecutionEngine/MCJIT/*.def",
+        "include/llvm/ExecutionEngine/MCJIT/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":execution_engine",
+        ":object",
+        ":runtime_dyld",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "mc_parser",
+    srcs = glob([
+        "lib/MC/MCParser/*.c",
+        "lib/MC/MCParser/*.cpp",
+        "lib/MC/MCParser/*.inc",
+        "lib/MC/MCParser/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/MC/MCParser/*.h",
+        "include/llvm/MC/MCParser/*.def",
+        "include/llvm/MC/MCParser/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mir_parser",
+    srcs = glob([
+        "lib/CodeGen/MIRParser/*.c",
+        "lib/CodeGen/MIRParser/*.cpp",
+        "lib/CodeGen/MIRParser/*.inc",
+        "lib/CodeGen/MIRParser/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/CodeGen/MIRParser/*.h",
+        "include/llvm/CodeGen/MIRParser/*.def",
+        "include/llvm/CodeGen/MIRParser/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":asm_parser",
+        ":binary_format",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "msp430_asm_parser",
+    srcs = glob([
+        "lib/Target/MSP430/AsmParser/*.c",
+        "lib/Target/MSP430/AsmParser/*.cpp",
+        "lib/Target/MSP430/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/MSP430/AsmParser/*.h",
+        "include/llvm/Target/MSP430/AsmParser/*.def",
+        "include/llvm/Target/MSP430/AsmParser/*.inc",
+        "lib/Target/MSP430/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/MSP430"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":msp430_desc",
+        ":msp430_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "msp430_code_gen",
+    srcs = glob([
+        "lib/Target/MSP430/*.c",
+        "lib/Target/MSP430/*.cpp",
+        "lib/Target/MSP430/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/MSP430/*.h",
+        "include/llvm/Target/MSP430/*.def",
+        "include/llvm/Target/MSP430/*.inc",
+        "lib/Target/MSP430/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/MSP430"],
+    deps = [
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":msp430_desc",
+        ":msp430_info",
+        ":selection_dag",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "msp430_desc",
+    srcs = glob([
+        "lib/Target/MSP430/MCTargetDesc/*.c",
+        "lib/Target/MSP430/MCTargetDesc/*.cpp",
+        "lib/Target/MSP430/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/MSP430/MCTargetDesc/*.h",
+        "include/llvm/Target/MSP430/MCTargetDesc/*.def",
+        "include/llvm/Target/MSP430/MCTargetDesc/*.inc",
+        "lib/Target/MSP430/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/MSP430"],
+    deps = [
+        ":config",
+        ":mc",
+        ":msp430_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "msp430_disassembler",
+    srcs = glob([
+        "lib/Target/MSP430/Disassembler/*.c",
+        "lib/Target/MSP430/Disassembler/*.cpp",
+        "lib/Target/MSP430/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/MSP430/Disassembler/*.h",
+        "include/llvm/Target/MSP430/Disassembler/*.def",
+        "include/llvm/Target/MSP430/Disassembler/*.inc",
+        "lib/Target/MSP430/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/MSP430"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":msp430_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "msp430_info",
+    srcs = glob([
+        "lib/Target/MSP430/TargetInfo/*.c",
+        "lib/Target/MSP430/TargetInfo/*.cpp",
+        "lib/Target/MSP430/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/MSP430/TargetInfo/*.h",
+        "include/llvm/Target/MSP430/TargetInfo/*.def",
+        "include/llvm/Target/MSP430/TargetInfo/*.inc",
+        "lib/Target/MSP430/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/MSP430"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mips_asm_parser",
+    srcs = glob([
+        "lib/Target/Mips/AsmParser/*.c",
+        "lib/Target/Mips/AsmParser/*.cpp",
+        "lib/Target/Mips/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Mips/AsmParser/*.h",
+        "include/llvm/Target/Mips/AsmParser/*.def",
+        "include/llvm/Target/Mips/AsmParser/*.inc",
+        "lib/Target/Mips/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Mips"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":mips_desc",
+        ":mips_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mips_code_gen",
+    srcs = glob([
+        "lib/Target/Mips/*.c",
+        "lib/Target/Mips/*.cpp",
+        "lib/Target/Mips/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Mips/*.h",
+        "include/llvm/Target/Mips/*.def",
+        "include/llvm/Target/Mips/*.inc",
+        "lib/Target/Mips/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Mips"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":mc",
+        ":mips_desc",
+        ":mips_info",
+        ":selection_dag",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "mips_desc",
+    srcs = glob([
+        "lib/Target/Mips/MCTargetDesc/*.c",
+        "lib/Target/Mips/MCTargetDesc/*.cpp",
+        "lib/Target/Mips/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Mips/MCTargetDesc/*.h",
+        "include/llvm/Target/Mips/MCTargetDesc/*.def",
+        "include/llvm/Target/Mips/MCTargetDesc/*.inc",
+        "lib/Target/Mips/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Mips"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mips_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mips_disassembler",
+    srcs = glob([
+        "lib/Target/Mips/Disassembler/*.c",
+        "lib/Target/Mips/Disassembler/*.cpp",
+        "lib/Target/Mips/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Mips/Disassembler/*.h",
+        "include/llvm/Target/Mips/Disassembler/*.def",
+        "include/llvm/Target/Mips/Disassembler/*.inc",
+        "lib/Target/Mips/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Mips"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":mips_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "mips_info",
+    srcs = glob([
+        "lib/Target/Mips/TargetInfo/*.c",
+        "lib/Target/Mips/TargetInfo/*.cpp",
+        "lib/Target/Mips/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Mips/TargetInfo/*.h",
+        "include/llvm/Target/Mips/TargetInfo/*.def",
+        "include/llvm/Target/Mips/TargetInfo/*.inc",
+        "lib/Target/Mips/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Mips"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "nvptx_code_gen",
+    srcs = glob([
+        "lib/Target/NVPTX/*.c",
+        "lib/Target/NVPTX/*.cpp",
+        "lib/Target/NVPTX/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/NVPTX/*.h",
+        "include/llvm/Target/NVPTX/*.def",
+        "include/llvm/Target/NVPTX/*.inc",
+        "lib/Target/NVPTX/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/NVPTX"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":ipo",
+        ":mc",
+        ":nvptx_desc",
+        ":nvptx_info",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+        ":vectorize",
+    ],
+)
+
+cc_library(
+    name = "nvptx_desc",
+    srcs = glob([
+        "lib/Target/NVPTX/MCTargetDesc/*.c",
+        "lib/Target/NVPTX/MCTargetDesc/*.cpp",
+        "lib/Target/NVPTX/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/NVPTX/MCTargetDesc/*.h",
+        "include/llvm/Target/NVPTX/MCTargetDesc/*.def",
+        "include/llvm/Target/NVPTX/MCTargetDesc/*.inc",
+        "lib/Target/NVPTX/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/NVPTX"],
+    deps = [
+        "nvptx_target_gen",
+        ":config",
+        ":mc",
+        ":nvptx_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "nvptx_info",
+    srcs = glob([
+        "lib/Target/NVPTX/TargetInfo/*.c",
+        "lib/Target/NVPTX/TargetInfo/*.cpp",
+        "lib/Target/NVPTX/TargetInfo/*.inc",
+        "lib/Target/NVPTX/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/NVPTX/TargetInfo/*.h",
+        "include/llvm/Target/NVPTX/TargetInfo/*.def",
+        "include/llvm/Target/NVPTX/TargetInfo/*.inc",
+        "lib/Target/NVPTX/NVPTX.h",
+        "lib/Target/NVPTX/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/NVPTX"],
+    deps = [
+        "nvptx_target_gen",
+        ":attributes_gen",
+        ":config",
+        ":core",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "objc_arc",
+    srcs = glob([
+        "lib/Transforms/ObjCARC/*.c",
+        "lib/Transforms/ObjCARC/*.cpp",
+        "lib/Transforms/ObjCARC/*.inc",
+        "include/llvm/Transforms/ObjCARC.h",
+        "lib/Transforms/ObjCARC/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/ObjCARC/*.h",
+        "include/llvm/Transforms/ObjCARC/*.def",
+        "include/llvm/Transforms/ObjCARC/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "object",
+    srcs = glob([
+        "lib/Object/*.c",
+        "lib/Object/*.cpp",
+        "lib/Object/*.inc",
+        "lib/Object/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Object/*.h",
+        "include/llvm/Object/*.def",
+        "include/llvm/Object/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":bit_reader",
+        ":config",
+        ":core",
+        ":mc",
+        ":mc_parser",
+        ":support",
+        ":text_api",
+    ],
+)
+
+cc_library(
+    name = "object_yaml",
+    srcs = glob([
+        "lib/ObjectYAML/*.c",
+        "lib/ObjectYAML/*.cpp",
+        "lib/ObjectYAML/*.inc",
+        "lib/ObjectYAML/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ObjectYAML/*.h",
+        "include/llvm/ObjectYAML/*.def",
+        "include/llvm/ObjectYAML/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":debug_info_code_view",
+        ":mc",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "option",
+    srcs = glob([
+        "lib/Option/*.c",
+        "lib/Option/*.cpp",
+        "lib/Option/*.inc",
+        "lib/Option/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Option/*.h",
+        "include/llvm/Option/*.def",
+        "include/llvm/Option/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "orc_error",
+    srcs = glob([
+        "lib/ExecutionEngine/OrcError/*.c",
+        "lib/ExecutionEngine/OrcError/*.cpp",
+        "lib/ExecutionEngine/OrcError/*.inc",
+        "lib/ExecutionEngine/OrcError/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/OrcError/*.h",
+        "include/llvm/ExecutionEngine/OrcError/*.def",
+        "include/llvm/ExecutionEngine/OrcError/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "orc_jit",
+    srcs = glob([
+        "lib/ExecutionEngine/Orc/*.c",
+        "lib/ExecutionEngine/Orc/*.cpp",
+        "lib/ExecutionEngine/Orc/*.inc",
+        "lib/ExecutionEngine/Orc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/Orc/*.h",
+        "include/llvm/ExecutionEngine/Orc/*.def",
+        "include/llvm/ExecutionEngine/Orc/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":execution_engine",
+        ":jit_link",
+        ":mc",
+        ":object",
+        ":orc_error",
+        ":passes",
+        ":runtime_dyld",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "passes",
+    srcs = glob([
+        "lib/Passes/*.c",
+        "lib/Passes/*.cpp",
+        "lib/Passes/*.inc",
+        "lib/Passes/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Passes/*.h",
+        "include/llvm/Passes/*.def",
+        "include/llvm/Passes/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":aggressive_inst_combine",
+        ":analysis",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":inst_combine",
+        ":instrumentation",
+        ":ipo",
+        ":scalar",
+        ":support",
+        ":target",
+        ":transform_utils",
+        ":vectorize",
+    ],
+)
+
+cc_library(
+    name = "powerpc_asm_parser",
+    srcs = glob([
+        "lib/Target/PowerPC/AsmParser/*.c",
+        "lib/Target/PowerPC/AsmParser/*.cpp",
+        "lib/Target/PowerPC/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/PowerPC/AsmParser/*.h",
+        "include/llvm/Target/PowerPC/AsmParser/*.def",
+        "include/llvm/Target/PowerPC/AsmParser/*.inc",
+        "lib/Target/PowerPC/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/PowerPC"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":powerpc_desc",
+        ":powerpc_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "powerpc_code_gen",
+    srcs = glob([
+        "lib/Target/PowerPC/*.c",
+        "lib/Target/PowerPC/*.cpp",
+        "lib/Target/PowerPC/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/PowerPC/*.h",
+        "include/llvm/Target/PowerPC/*.def",
+        "include/llvm/Target/PowerPC/*.inc",
+        "lib/Target/PowerPC/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/PowerPC"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":powerpc_desc",
+        ":powerpc_info",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "powerpc_desc",
+    srcs = glob([
+        "lib/Target/PowerPC/MCTargetDesc/*.c",
+        "lib/Target/PowerPC/MCTargetDesc/*.cpp",
+        "lib/Target/PowerPC/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/PowerPC/MCTargetDesc/*.h",
+        "include/llvm/Target/PowerPC/MCTargetDesc/*.def",
+        "include/llvm/Target/PowerPC/MCTargetDesc/*.inc",
+        "lib/Target/PowerPC/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/PowerPC"],
+    deps = [
+        ":attributes_gen",
+        ":config",
+        ":intrinsic_enums_gen",
+        ":intrinsics_impl_gen",
+        ":mc",
+        ":powerpc_info",
+        ":powerpc_target_gen",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "powerpc_disassembler",
+    srcs = glob([
+        "lib/Target/PowerPC/Disassembler/*.c",
+        "lib/Target/PowerPC/Disassembler/*.cpp",
+        "lib/Target/PowerPC/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/PowerPC/Disassembler/*.h",
+        "include/llvm/Target/PowerPC/Disassembler/*.def",
+        "include/llvm/Target/PowerPC/Disassembler/*.inc",
+        "lib/Target/PowerPC/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/PowerPC"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":powerpc_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "powerpc_info",
+    srcs = glob([
+        "lib/Target/PowerPC/TargetInfo/*.c",
+        "lib/Target/PowerPC/TargetInfo/*.cpp",
+        "lib/Target/PowerPC/TargetInfo/*.inc",
+        "lib/Target/PowerPC/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/PowerPC/TargetInfo/*.h",
+        "include/llvm/Target/PowerPC/TargetInfo/*.def",
+        "include/llvm/Target/PowerPC/TargetInfo/*.inc",
+        "lib/Target/PowerPC/PPC*.h",
+        "lib/Target/PowerPC/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/PowerPC"],
+    deps = [
+        ":attributes_gen",
+        ":config",
+        ":core",
+        ":powerpc_target_gen",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "profile_data",
+    srcs = glob([
+        "lib/ProfileData/*.c",
+        "lib/ProfileData/*.cpp",
+        "lib/ProfileData/*.inc",
+        "lib/ProfileData/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ProfileData/*.h",
+        "include/llvm/ProfileData/*.def",
+        "include/llvm/ProfileData/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "riscv_asm_parser",
+    srcs = glob([
+        "lib/Target/RISCV/AsmParser/*.c",
+        "lib/Target/RISCV/AsmParser/*.cpp",
+        "lib/Target/RISCV/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/AsmParser/*.h",
+        "include/llvm/Target/RISCV/AsmParser/*.def",
+        "include/llvm/Target/RISCV/AsmParser/*.inc",
+        "lib/Target/RISCV/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":riscv_desc",
+        ":riscv_info",
+        ":riscv_utils",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "riscv_code_gen",
+    srcs = glob([
+        "lib/Target/RISCV/*.c",
+        "lib/Target/RISCV/*.cpp",
+        "lib/Target/RISCV/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/*.h",
+        "include/llvm/Target/RISCV/*.def",
+        "include/llvm/Target/RISCV/*.inc",
+        "lib/Target/RISCV/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":mc",
+        ":riscv_desc",
+        ":riscv_info",
+        ":riscv_utils",
+        ":selection_dag",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "riscv_desc",
+    srcs = glob([
+        "lib/Target/RISCV/MCTargetDesc/*.c",
+        "lib/Target/RISCV/MCTargetDesc/*.cpp",
+        "lib/Target/RISCV/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/MCTargetDesc/*.h",
+        "include/llvm/Target/RISCV/MCTargetDesc/*.def",
+        "include/llvm/Target/RISCV/MCTargetDesc/*.inc",
+        "lib/Target/RISCV/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":config",
+        ":mc",
+        ":riscv_info",
+        ":riscv_utils",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "riscv_disassembler",
+    srcs = glob([
+        "lib/Target/RISCV/Disassembler/*.c",
+        "lib/Target/RISCV/Disassembler/*.cpp",
+        "lib/Target/RISCV/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/Disassembler/*.h",
+        "include/llvm/Target/RISCV/Disassembler/*.def",
+        "include/llvm/Target/RISCV/Disassembler/*.inc",
+        "lib/Target/RISCV/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":riscv_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "riscv_info",
+    srcs = glob([
+        "lib/Target/RISCV/TargetInfo/*.c",
+        "lib/Target/RISCV/TargetInfo/*.cpp",
+        "lib/Target/RISCV/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/TargetInfo/*.h",
+        "include/llvm/Target/RISCV/TargetInfo/*.def",
+        "include/llvm/Target/RISCV/TargetInfo/*.inc",
+        "lib/Target/RISCV/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "riscv_utils",
+    srcs = glob([
+        "lib/Target/RISCV/Utils/*.c",
+        "lib/Target/RISCV/Utils/*.cpp",
+        "lib/Target/RISCV/Utils/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/RISCV/Utils/*.h",
+        "include/llvm/Target/RISCV/Utils/*.def",
+        "include/llvm/Target/RISCV/Utils/*.inc",
+        "lib/Target/RISCV/Utils/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/RISCV"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "remarks",
+    srcs = glob([
+        "lib/Remarks/*.c",
+        "lib/Remarks/*.cpp",
+        "lib/Remarks/*.inc",
+        "lib/Remarks/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Remarks/*.h",
+        "include/llvm/Remarks/*.def",
+        "include/llvm/Remarks/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":bitstream_reader",
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "runtime_dyld",
+    srcs = glob([
+        "lib/ExecutionEngine/RuntimeDyld/*.c",
+        "lib/ExecutionEngine/RuntimeDyld/*.cpp",
+        "lib/ExecutionEngine/RuntimeDyld/*.inc",
+        "include/llvm/ExecutionEngine/JITSymbol.h",
+        "include/llvm/ExecutionEngine/RTDyldMemoryManager.h",
+        "lib/ExecutionEngine/RuntimeDyld/*.h",
+        "lib/ExecutionEngine/RuntimeDyld/Targets/*.h",
+        "lib/ExecutionEngine/RuntimeDyld/Targets/*.cpp",
+        "lib/ExecutionEngine/RuntimeDyld/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/ExecutionEngine/RuntimeDyld/*.h",
+        "include/llvm/ExecutionEngine/RuntimeDyld/*.def",
+        "include/llvm/ExecutionEngine/RuntimeDyld/*.inc",
+        "include/llvm/DebugInfo/DIContext.h",
+        "include/llvm/ExecutionEngine/RTDyldMemoryManager.h",
+        "include/llvm/ExecutionEngine/RuntimeDyld*.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "scalar",
+    srcs = glob([
+        "lib/Transforms/Scalar/*.c",
+        "lib/Transforms/Scalar/*.cpp",
+        "lib/Transforms/Scalar/*.inc",
+        "include/llvm-c/Transforms/Scalar.h",
+        "include/llvm/Transforms/Scalar.h",
+        "include/llvm/Target/TargetMachine.h",
+        "lib/Transforms/Scalar/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/Scalar/*.h",
+        "include/llvm/Transforms/Scalar/*.def",
+        "include/llvm/Transforms/Scalar/*.inc",
+        "include/llvm/Transforms/IPO.h",
+        "include/llvm/Transforms/IPO/SCCP.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":aggressive_inst_combine",
+        ":analysis",
+        ":config",
+        ":core",
+        ":inst_combine",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "selection_dag",
+    srcs = glob([
+        "lib/CodeGen/SelectionDAG/*.c",
+        "lib/CodeGen/SelectionDAG/*.cpp",
+        "lib/CodeGen/SelectionDAG/*.inc",
+        "lib/CodeGen/SelectionDAG/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/CodeGen/SelectionDAG/*.h",
+        "include/llvm/CodeGen/SelectionDAG/*.def",
+        "include/llvm/CodeGen/SelectionDAG/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":support",
+        ":target",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "sparc_asm_parser",
+    srcs = glob([
+        "lib/Target/Sparc/AsmParser/*.c",
+        "lib/Target/Sparc/AsmParser/*.cpp",
+        "lib/Target/Sparc/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Sparc/AsmParser/*.h",
+        "include/llvm/Target/Sparc/AsmParser/*.def",
+        "include/llvm/Target/Sparc/AsmParser/*.inc",
+        "lib/Target/Sparc/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Sparc"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":sparc_desc",
+        ":sparc_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "sparc_code_gen",
+    srcs = glob([
+        "lib/Target/Sparc/*.c",
+        "lib/Target/Sparc/*.cpp",
+        "lib/Target/Sparc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Sparc/*.h",
+        "include/llvm/Target/Sparc/*.def",
+        "include/llvm/Target/Sparc/*.inc",
+        "lib/Target/Sparc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Sparc"],
+    deps = [
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":sparc_desc",
+        ":sparc_info",
+        ":support",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "sparc_desc",
+    srcs = glob([
+        "lib/Target/Sparc/MCTargetDesc/*.c",
+        "lib/Target/Sparc/MCTargetDesc/*.cpp",
+        "lib/Target/Sparc/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Sparc/MCTargetDesc/*.h",
+        "include/llvm/Target/Sparc/MCTargetDesc/*.def",
+        "include/llvm/Target/Sparc/MCTargetDesc/*.inc",
+        "lib/Target/Sparc/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Sparc"],
+    deps = [
+        ":config",
+        ":mc",
+        ":sparc_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "sparc_disassembler",
+    srcs = glob([
+        "lib/Target/Sparc/Disassembler/*.c",
+        "lib/Target/Sparc/Disassembler/*.cpp",
+        "lib/Target/Sparc/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Sparc/Disassembler/*.h",
+        "include/llvm/Target/Sparc/Disassembler/*.def",
+        "include/llvm/Target/Sparc/Disassembler/*.inc",
+        "lib/Target/Sparc/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Sparc"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":sparc_info",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "sparc_info",
+    srcs = glob([
+        "lib/Target/Sparc/TargetInfo/*.c",
+        "lib/Target/Sparc/TargetInfo/*.cpp",
+        "lib/Target/Sparc/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/Sparc/TargetInfo/*.h",
+        "include/llvm/Target/Sparc/TargetInfo/*.def",
+        "include/llvm/Target/Sparc/TargetInfo/*.inc",
+        "lib/Target/Sparc/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/Sparc"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "support",
+    srcs = glob([
+        "lib/Support/*.c",
+        "lib/Support/*.cpp",
+        "lib/Support/*.inc",
+        "include/llvm-c/*.h",
+        "include/llvm/CodeGen/MachineValueType.h",
+        "include/llvm/BinaryFormat/COFF.h",
+        "include/llvm/BinaryFormat/MachO.h",
+        "lib/Support/*.h",
+    ]) + llvm_support_platform_specific_srcs_glob(),
+    hdrs = glob([
+        "include/llvm/Support/*.h",
+        "include/llvm/Support/*.def",
+        "include/llvm/Support/*.inc",
+        "include/llvm/ADT/*.h",
+        "include/llvm/Support/ELFRelocs/*.def",
+        "include/llvm/Support/WasmRelocs/*.def",
+    ]) + [
+        "include/llvm/BinaryFormat/MachO.def",
+        "include/llvm/Support/VCSRevision.h",
+    ],
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":demangle",
+        "@zlib_archive//:zlib",
+    ],
+)
+
+cc_library(
+    name = "symbolize",
+    srcs = glob([
+        "lib/DebugInfo/Symbolize/*.c",
+        "lib/DebugInfo/Symbolize/*.cpp",
+        "lib/DebugInfo/Symbolize/*.inc",
+        "lib/DebugInfo/Symbolize/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/DebugInfo/Symbolize/*.h",
+        "include/llvm/DebugInfo/Symbolize/*.def",
+        "include/llvm/DebugInfo/Symbolize/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":debug_info_dwarf",
+        ":debug_info_pdb",
+        ":demangle",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "system_z_asm_parser",
+    srcs = glob([
+        "lib/Target/SystemZ/AsmParser/*.c",
+        "lib/Target/SystemZ/AsmParser/*.cpp",
+        "lib/Target/SystemZ/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/SystemZ/AsmParser/*.h",
+        "include/llvm/Target/SystemZ/AsmParser/*.def",
+        "include/llvm/Target/SystemZ/AsmParser/*.inc",
+        "lib/Target/SystemZ/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/SystemZ"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+        ":system_z_desc",
+        ":system_z_info",
+    ],
+)
+
+cc_library(
+    name = "system_z_code_gen",
+    srcs = glob([
+        "lib/Target/SystemZ/*.c",
+        "lib/Target/SystemZ/*.cpp",
+        "lib/Target/SystemZ/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/SystemZ/*.h",
+        "include/llvm/Target/SystemZ/*.def",
+        "include/llvm/Target/SystemZ/*.inc",
+        "lib/Target/SystemZ/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/SystemZ"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":system_z_desc",
+        ":system_z_info",
+        ":target",
+    ],
+)
+
+cc_library(
+    name = "system_z_desc",
+    srcs = glob([
+        "lib/Target/SystemZ/MCTargetDesc/*.c",
+        "lib/Target/SystemZ/MCTargetDesc/*.cpp",
+        "lib/Target/SystemZ/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/SystemZ/MCTargetDesc/*.h",
+        "include/llvm/Target/SystemZ/MCTargetDesc/*.def",
+        "include/llvm/Target/SystemZ/MCTargetDesc/*.inc",
+        "lib/Target/SystemZ/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/SystemZ"],
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+        ":system_z_info",
+    ],
+)
+
+cc_library(
+    name = "system_z_disassembler",
+    srcs = glob([
+        "lib/Target/SystemZ/Disassembler/*.c",
+        "lib/Target/SystemZ/Disassembler/*.cpp",
+        "lib/Target/SystemZ/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/SystemZ/Disassembler/*.h",
+        "include/llvm/Target/SystemZ/Disassembler/*.def",
+        "include/llvm/Target/SystemZ/Disassembler/*.inc",
+        "lib/Target/SystemZ/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/SystemZ"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+        ":system_z_desc",
+        ":system_z_info",
+    ],
+)
+
+cc_library(
+    name = "system_z_info",
+    srcs = glob([
+        "lib/Target/SystemZ/TargetInfo/*.c",
+        "lib/Target/SystemZ/TargetInfo/*.cpp",
+        "lib/Target/SystemZ/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/SystemZ/TargetInfo/*.h",
+        "include/llvm/Target/SystemZ/TargetInfo/*.def",
+        "include/llvm/Target/SystemZ/TargetInfo/*.inc",
+        "lib/Target/SystemZ/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/SystemZ"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "tablegen",
+    srcs = glob([
+        "lib/TableGen/*.c",
+        "lib/TableGen/*.cpp",
+        "lib/TableGen/*.inc",
+        "include/llvm/CodeGen/*.h",
+        "lib/TableGen/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/TableGen/*.h",
+        "include/llvm/TableGen/*.def",
+        "include/llvm/TableGen/*.inc",
+        "include/llvm/Target/*.def",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "target",
+    srcs = glob([
+        "lib/Target/*.c",
+        "lib/Target/*.cpp",
+        "lib/Target/*.inc",
+        "include/llvm/CodeGen/*.h",
+        "include/llvm-c/Initialization.h",
+        "include/llvm-c/Target.h",
+        "lib/Target/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/*.h",
+        "include/llvm/Target/*.def",
+        "include/llvm/Target/*.inc",
+        "include/llvm/CodeGen/*.def",
+        "include/llvm/CodeGen/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":mc",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "testing_support",
+    srcs = glob([
+        "lib/Testing/Support/*.c",
+        "lib/Testing/Support/*.cpp",
+        "lib/Testing/Support/*.inc",
+        "lib/Testing/Support/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Testing/Support/*.h",
+        "include/llvm/Testing/Support/*.def",
+        "include/llvm/Testing/Support/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "text_api",
+    srcs = glob([
+        "lib/TextAPI/*.c",
+        "lib/TextAPI/*.cpp",
+        "lib/TextAPI/*.inc",
+        "lib/TextAPI/ELF/*.cpp",
+        "lib/TextAPI/MachO/*.cpp",
+        "lib/TextAPI/MachO/*.h",
+        "lib/TextAPI/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/TextAPI/*.h",
+        "include/llvm/TextAPI/*.def",
+        "include/llvm/TextAPI/*.inc",
+    ]) + [
+        "include/llvm/TextAPI/ELF/TBEHandler.h",
+        "include/llvm/TextAPI/ELF/ELFStub.h",
+        "include/llvm/TextAPI/MachO/Architecture.def",
+        "include/llvm/TextAPI/MachO/PackedVersion.h",
+        "include/llvm/TextAPI/MachO/InterfaceFile.h",
+        "include/llvm/TextAPI/MachO/Symbol.h",
+        "include/llvm/TextAPI/MachO/ArchitectureSet.h",
+        "include/llvm/TextAPI/MachO/TextAPIWriter.h",
+        "include/llvm/TextAPI/MachO/TextAPIReader.h",
+        "include/llvm/TextAPI/MachO/Architecture.h",
+    ],
+    copts = llvm_copts,
+    deps = [
+        ":binary_format",
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "transform_utils",
+    srcs = glob([
+        "lib/Transforms/Utils/*.c",
+        "lib/Transforms/Utils/*.cpp",
+        "lib/Transforms/Utils/*.inc",
+        "include/llvm/Transforms/IPO.h",
+        "include/llvm/Transforms/Scalar.h",
+        "lib/Transforms/Utils/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/Utils/*.h",
+        "include/llvm/Transforms/Utils/*.def",
+        "include/llvm/Transforms/Utils/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "vectorize",
+    srcs = glob([
+        "lib/Transforms/Vectorize/*.c",
+        "lib/Transforms/Vectorize/*.cpp",
+        "lib/Transforms/Vectorize/*.inc",
+        "include/llvm-c/Transforms/Vectorize.h",
+        "lib/Transforms/Vectorize/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Transforms/Vectorize/*.h",
+        "include/llvm/Transforms/Vectorize/*.def",
+        "include/llvm/Transforms/Vectorize/*.inc",
+        "include/llvm/Transforms/Vectorize.h",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":analysis",
+        ":config",
+        ":core",
+        ":scalar",
+        ":support",
+        ":transform_utils",
+    ],
+)
+
+cc_library(
+    name = "web_assembly_asm_parser",
+    srcs = glob([
+        "lib/Target/WebAssembly/AsmParser/*.c",
+        "lib/Target/WebAssembly/AsmParser/*.cpp",
+        "lib/Target/WebAssembly/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/WebAssembly/AsmParser/*.h",
+        "include/llvm/Target/WebAssembly/AsmParser/*.def",
+        "include/llvm/Target/WebAssembly/AsmParser/*.inc",
+        "lib/Target/WebAssembly/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/WebAssembly"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+        ":web_assembly_info",
+    ],
+)
+
+cc_library(
+    name = "web_assembly_code_gen",
+    srcs = glob([
+        "lib/Target/WebAssembly/*.c",
+        "lib/Target/WebAssembly/*.cpp",
+        "lib/Target/WebAssembly/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/WebAssembly/*.h",
+        "include/llvm/Target/WebAssembly/*.def",
+        "include/llvm/Target/WebAssembly/*.inc",
+        "lib/Target/WebAssembly/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/WebAssembly"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":binary_format",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":scalar",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+        ":web_assembly_desc",
+        ":web_assembly_info",
+    ],
+)
+
+cc_library(
+    name = "web_assembly_desc",
+    srcs = glob([
+        "lib/Target/WebAssembly/MCTargetDesc/*.c",
+        "lib/Target/WebAssembly/MCTargetDesc/*.cpp",
+        "lib/Target/WebAssembly/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/WebAssembly/MCTargetDesc/*.h",
+        "include/llvm/Target/WebAssembly/MCTargetDesc/*.def",
+        "include/llvm/Target/WebAssembly/MCTargetDesc/*.inc",
+        "lib/Target/WebAssembly/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/WebAssembly"],
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+        ":web_assembly_info",
+    ],
+)
+
+cc_library(
+    name = "web_assembly_disassembler",
+    srcs = glob([
+        "lib/Target/WebAssembly/Disassembler/*.c",
+        "lib/Target/WebAssembly/Disassembler/*.cpp",
+        "lib/Target/WebAssembly/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/WebAssembly/Disassembler/*.h",
+        "include/llvm/Target/WebAssembly/Disassembler/*.def",
+        "include/llvm/Target/WebAssembly/Disassembler/*.inc",
+        "lib/Target/WebAssembly/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/WebAssembly"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":support",
+        ":web_assembly_desc",
+        ":web_assembly_info",
+    ],
+)
+
+cc_library(
+    name = "web_assembly_info",
+    srcs = glob([
+        "lib/Target/WebAssembly/TargetInfo/*.c",
+        "lib/Target/WebAssembly/TargetInfo/*.cpp",
+        "lib/Target/WebAssembly/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/WebAssembly/TargetInfo/*.h",
+        "include/llvm/Target/WebAssembly/TargetInfo/*.def",
+        "include/llvm/Target/WebAssembly/TargetInfo/*.inc",
+        "lib/Target/WebAssembly/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/WebAssembly"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "windows_manifest",
+    srcs = glob([
+        "lib/WindowsManifest/*.c",
+        "lib/WindowsManifest/*.cpp",
+        "lib/WindowsManifest/*.inc",
+        "lib/WindowsManifest/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/WindowsManifest/*.h",
+        "include/llvm/WindowsManifest/*.def",
+        "include/llvm/WindowsManifest/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "x86_asm_parser",
+    srcs = glob([
+        "lib/Target/X86/AsmParser/*.c",
+        "lib/Target/X86/AsmParser/*.cpp",
+        "lib/Target/X86/AsmParser/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/AsmParser/*.h",
+        "include/llvm/Target/X86/AsmParser/*.def",
+        "include/llvm/Target/X86/AsmParser/*.inc",
+        "lib/Target/X86/AsmParser/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_parser",
+        ":support",
+        ":x86_desc",
+        ":x86_info",
+    ],
+)
+
+cc_library(
+    name = "x86_code_gen",
+    srcs = glob([
+        "lib/Target/X86/*.c",
+        "lib/Target/X86/*.cpp",
+        "lib/Target/X86/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/*.h",
+        "include/llvm/Target/X86/*.def",
+        "include/llvm/Target/X86/*.inc",
+        "lib/Target/X86/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":cf_guard",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":global_i_sel",
+        ":mc",
+        ":profile_data",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":x86_defs",
+        ":x86_desc",
+        ":x86_info",
+        ":x86_utils",
+    ],
+)
+
+cc_library(
+    name = "x86_desc",
+    srcs = glob([
+        "lib/Target/X86/MCTargetDesc/*.c",
+        "lib/Target/X86/MCTargetDesc/*.cpp",
+        "lib/Target/X86/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/MCTargetDesc/*.h",
+        "include/llvm/Target/X86/MCTargetDesc/*.def",
+        "include/llvm/Target/X86/MCTargetDesc/*.inc",
+        "lib/Target/X86/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":config",
+        ":mc",
+        ":mc_disassembler",
+        ":object",
+        ":support",
+        ":x86_info",
+        ":x86_utils",
+    ],
+)
+
+cc_library(
+    name = "x86_disassembler",
+    srcs = glob([
+        "lib/Target/X86/Disassembler/*.c",
+        "lib/Target/X86/Disassembler/*.cpp",
+        "lib/Target/X86/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/Disassembler/*.h",
+        "include/llvm/Target/X86/Disassembler/*.def",
+        "include/llvm/Target/X86/Disassembler/*.inc",
+        "lib/Target/X86/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":support",
+        ":x86_info",
+    ],
+)
+
+cc_library(
+    name = "x86_info",
+    srcs = glob([
+        "lib/Target/X86/TargetInfo/*.c",
+        "lib/Target/X86/TargetInfo/*.cpp",
+        "lib/Target/X86/TargetInfo/*.inc",
+        "lib/Target/X86/MCTargetDesc/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/TargetInfo/*.h",
+        "include/llvm/Target/X86/TargetInfo/*.def",
+        "include/llvm/Target/X86/TargetInfo/*.inc",
+        "lib/Target/X86/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+        ":x86_target_gen",
+    ],
+)
+
+cc_library(
+    name = "x86_utils",
+    srcs = glob([
+        "lib/Target/X86/Utils/*.c",
+        "lib/Target/X86/Utils/*.cpp",
+        "lib/Target/X86/Utils/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/X86/Utils/*.h",
+        "include/llvm/Target/X86/Utils/*.def",
+        "include/llvm/Target/X86/Utils/*.inc",
+        "lib/Target/X86/Utils/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/X86"],
+    deps = [
+        ":code_gen",
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "x_core_code_gen",
+    srcs = glob([
+        "lib/Target/XCore/*.c",
+        "lib/Target/XCore/*.cpp",
+        "lib/Target/XCore/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/XCore/*.h",
+        "include/llvm/Target/XCore/*.def",
+        "include/llvm/Target/XCore/*.inc",
+        "lib/Target/XCore/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/XCore"],
+    deps = [
+        ":analysis",
+        ":asm_printer",
+        ":code_gen",
+        ":config",
+        ":core",
+        ":mc",
+        ":selection_dag",
+        ":support",
+        ":target",
+        ":transform_utils",
+        ":x_core_desc",
+        ":x_core_info",
+    ],
+)
+
+cc_library(
+    name = "x_core_desc",
+    srcs = glob([
+        "lib/Target/XCore/MCTargetDesc/*.c",
+        "lib/Target/XCore/MCTargetDesc/*.cpp",
+        "lib/Target/XCore/MCTargetDesc/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/XCore/MCTargetDesc/*.h",
+        "include/llvm/Target/XCore/MCTargetDesc/*.def",
+        "include/llvm/Target/XCore/MCTargetDesc/*.inc",
+        "lib/Target/XCore/MCTargetDesc/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/XCore"],
+    deps = [
+        ":config",
+        ":mc",
+        ":support",
+        ":x_core_info",
+    ],
+)
+
+cc_library(
+    name = "x_core_disassembler",
+    srcs = glob([
+        "lib/Target/XCore/Disassembler/*.c",
+        "lib/Target/XCore/Disassembler/*.cpp",
+        "lib/Target/XCore/Disassembler/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/XCore/Disassembler/*.h",
+        "include/llvm/Target/XCore/Disassembler/*.def",
+        "include/llvm/Target/XCore/Disassembler/*.inc",
+        "lib/Target/XCore/Disassembler/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/XCore"],
+    deps = [
+        ":config",
+        ":mc_disassembler",
+        ":support",
+        ":x_core_info",
+    ],
+)
+
+cc_library(
+    name = "x_core_info",
+    srcs = glob([
+        "lib/Target/XCore/TargetInfo/*.c",
+        "lib/Target/XCore/TargetInfo/*.cpp",
+        "lib/Target/XCore/TargetInfo/*.inc",
+    ]),
+    hdrs = glob([
+        "include/llvm/Target/XCore/TargetInfo/*.h",
+        "include/llvm/Target/XCore/TargetInfo/*.def",
+        "include/llvm/Target/XCore/TargetInfo/*.inc",
+        "lib/Target/XCore/TargetInfo/*.h",
+    ]),
+    copts = llvm_copts + ["-Iexternal/llvm/lib/Target/XCore"],
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "x_ray",
+    srcs = glob([
+        "lib/XRay/*.c",
+        "lib/XRay/*.cpp",
+        "lib/XRay/*.inc",
+        "lib/XRay/*.h",
+    ]),
+    hdrs = glob([
+        "include/llvm/XRay/*.h",
+        "include/llvm/XRay/*.def",
+        "include/llvm/XRay/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":object",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "gtest",
+    srcs = glob([
+        "utils/unittest/*.c",
+        "utils/unittest/*.cpp",
+        "utils/unittest/*.inc",
+        "utils/unittest/*.h",
+    ]),
+    hdrs = glob([
+        "utils/unittest/*.h",
+        "utils/unittest/*.def",
+        "utils/unittest/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":support",
+    ],
+)
+
+cc_library(
+    name = "gtest_main",
+    srcs = glob([
+        "utils/unittest/*.c",
+        "utils/unittest/*.cpp",
+        "utils/unittest/*.inc",
+        "utils/unittest/*.h",
+    ]),
+    hdrs = glob([
+        "utils/unittest/*.h",
+        "utils/unittest/*.def",
+        "utils/unittest/*.inc",
+    ]),
+    copts = llvm_copts,
+    deps = [
+        ":config",
+        ":gtest",
+    ],
+)

--- a/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel
+++ b/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel
@@ -1,0 +1,2555 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Description:
+#   The MLIR "Multi-Level Intermediate Representation" Compiler Infrastructure
+
+load("@org_tensorflow//third_party/mlir:tblgen.bzl", "gentbl")
+
+licenses(["notice"])
+
+package(default_visibility = [":friends"])
+
+package_group(
+    name = "subpackages",
+    packages = ["//third_party/llvm/llvm/projects/google_mlir/..."],
+)
+
+# In particular the OWNERS file of the dependent project should be updated.
+# TODO(b/140669524): Use proper MLIR tests instead of end-to-end tests for
+# tf_runtime and tf_runtime_google.
+package_group(
+    name = "friends",
+    includes = ["@org_tensorflow//tensorflow/compiler/mlir:subpackages"],
+    packages = ["//..."],
+)
+
+exports_files([
+    "run_lit.sh",
+    "LICENSE.TXT",
+])
+
+cc_library(
+    name = "DialectSymbolRegistry",
+    # strip_include_prefix does not apply to textual_hdrs.
+    hdrs = ["include/mlir/IR/DialectSymbolRegistry.def"],
+    strip_include_prefix = "include/mlir/IR",
+    textual_hdrs = ["include/mlir/IR/DialectSymbolRegistry.def"],
+)
+
+gentbl(
+    name = "OpAsmInterfacesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "include/mlir/IR/OpAsmInterface.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "include/mlir/IR/OpAsmInterface.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/IR/OpAsmInterface.td",
+    td_srcs = [
+        ":OpBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "IR",
+    srcs = [
+        "lib/IR/AffineExpr.cpp",
+        "lib/IR/AffineExprDetail.h",
+        "lib/IR/AffineMap.cpp",
+        "lib/IR/AffineMapDetail.h",
+        "lib/IR/AsmPrinter.cpp",
+        "lib/IR/AttributeDetail.h",
+        "lib/IR/Attributes.cpp",
+        "lib/IR/Block.cpp",
+        "lib/IR/Builders.cpp",
+        "lib/IR/Diagnostics.cpp",
+        "lib/IR/Dialect.cpp",
+        "lib/IR/Function.cpp",
+        "lib/IR/FunctionImplementation.cpp",
+        "lib/IR/IntegerSet.cpp",
+        "lib/IR/IntegerSetDetail.h",
+        "lib/IR/Location.cpp",
+        "lib/IR/LocationDetail.h",
+        "lib/IR/MLIRContext.cpp",
+        "lib/IR/Module.cpp",
+        "lib/IR/Operation.cpp",
+        "lib/IR/OperationSupport.cpp",
+        "lib/IR/PatternMatch.cpp",
+        "lib/IR/Region.cpp",
+        "lib/IR/StandardTypes.cpp",
+        "lib/IR/SymbolTable.cpp",
+        "lib/IR/TypeDetail.h",
+        "lib/IR/TypeUtilities.cpp",
+        "lib/IR/Types.cpp",
+        "lib/IR/Value.cpp",
+        "lib/IR/Visitors.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Analysis/CallInterfaces.h",
+        "include/mlir/IR/AffineExpr.h",
+        "include/mlir/IR/AffineExprVisitor.h",
+        "include/mlir/IR/AffineMap.h",
+        "include/mlir/IR/AttributeSupport.h",
+        "include/mlir/IR/Attributes.h",
+        "include/mlir/IR/Block.h",
+        "include/mlir/IR/BlockAndValueMapping.h",
+        "include/mlir/IR/BlockSupport.h",
+        "include/mlir/IR/Builders.h",
+        "include/mlir/IR/Diagnostics.h",
+        "include/mlir/IR/Dialect.h",
+        "include/mlir/IR/DialectHooks.h",
+        "include/mlir/IR/DialectImplementation.h",
+        "include/mlir/IR/DialectInterface.h",
+        "include/mlir/IR/Function.h",
+        "include/mlir/IR/FunctionImplementation.h",
+        "include/mlir/IR/FunctionSupport.h",
+        "include/mlir/IR/Identifier.h",
+        "include/mlir/IR/IntegerSet.h",
+        "include/mlir/IR/Location.h",
+        "include/mlir/IR/MLIRContext.h",
+        "include/mlir/IR/Matchers.h",
+        "include/mlir/IR/Module.h",
+        "include/mlir/IR/OpDefinition.h",
+        "include/mlir/IR/OpImplementation.h",
+        "include/mlir/IR/Operation.h",
+        "include/mlir/IR/OperationSupport.h",
+        "include/mlir/IR/PatternMatch.h",
+        "include/mlir/IR/Region.h",
+        "include/mlir/IR/RegionGraphTraits.h",
+        "include/mlir/IR/StandardTypes.h",
+        "include/mlir/IR/StorageUniquerSupport.h",
+        "include/mlir/IR/SymbolTable.h",
+        "include/mlir/IR/TypeSupport.h",
+        "include/mlir/IR/TypeUtilities.h",
+        "include/mlir/IR/Types.h",
+        "include/mlir/IR/UseDefLists.h",
+        "include/mlir/IR/Value.h",
+        "include/mlir/IR/Visitors.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CallOpInterfacesIncGen",
+        ":DialectSymbolRegistry",
+        ":InferTypeOpInterfaceIncGen",
+        ":OpAsmInterfacesIncGen",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "Pass",
+    srcs = [
+        "lib/Pass/IRPrinting.cpp",
+        "lib/Pass/Pass.cpp",
+        "lib/Pass/PassDetail.h",
+        "lib/Pass/PassManagerOptions.cpp",
+        "lib/Pass/PassRegistry.cpp",
+        "lib/Pass/PassStatistics.cpp",
+        "lib/Pass/PassTiming.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Analysis/Verifier.h",
+        "include/mlir/Pass/AnalysisManager.h",
+        "include/mlir/Pass/Pass.h",
+        "include/mlir/Pass/PassInstrumentation.h",
+        "include/mlir/Pass/PassManager.h",
+        "include/mlir/Pass/PassOptions.h",
+        "include/mlir/Pass/PassRegistry.h",
+    ],
+    includes = ["include"],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    deps = [
+        ":IR",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "EDSC",
+    srcs = [
+        "lib/EDSC/Builders.cpp",
+        "lib/EDSC/Helpers.cpp",
+        "lib/EDSC/Intrinsics.cpp",
+    ],
+    hdrs = [
+        "include/mlir-c/Core.h",
+        "include/mlir/EDSC/Builders.h",
+        "include/mlir/EDSC/Helpers.h",
+        "include/mlir/EDSC/Intrinsics.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":IR",
+        ":LoopOps",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "EDSCInterface",
+    srcs = [
+        "lib/EDSC/CoreAPIs.cpp",
+    ],
+    hdrs = [
+        "include/mlir-c/Core.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Parser",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+filegroup(
+    name = "OpBaseTdFiles",
+    srcs = [
+        "include/mlir/IR/OpBase.td",
+    ],
+)
+
+filegroup(
+    name = "AffineOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/AffineOps/AffineOps.td",
+        "include/mlir/Dialect/AffineOps/AffineOpsBase.td",
+        "include/mlir/Transforms/LoopLikeInterface.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "AffineOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/AffineOps/AffineOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/AffineOps/AffineOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/AffineOps/AffineOps.td",
+    td_srcs = [
+        ":AffineOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "LoopOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/LoopOps/LoopOps.td",
+        "include/mlir/Transforms/LoopLikeInterface.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LoopOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/LoopOps/LoopOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/LoopOps/LoopOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LoopOps/LoopOps.td",
+    td_srcs = [
+        ":LoopOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "StdOpsTdFiles",
+    srcs = [
+        "include/mlir/Analysis/CallInterfaces.td",
+        "include/mlir/Dialect/StandardOps/Ops.td",
+        "include/mlir/IR/OpAsmInterface.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "StandardOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/StandardOps/Ops.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/StandardOps/Ops.cpp.inc",
+        ),
+        (
+            "-gen-enum-decls",
+            "include/mlir/Dialect/StandardOps/OpsEnums.h.inc",
+        ),
+        (
+            "-gen-enum-defs",
+            "include/mlir/Dialect/StandardOps/OpsEnums.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/StandardOps/Ops.td",
+    td_srcs = [
+        ":StdOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "lib/Dialect/Traits.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/Traits.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "DialectUtils",
+    srcs = [
+    ],
+    hdrs = [
+        "include/mlir/Dialect/Utils/StructuredOpsUtils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "AffineOps",
+    srcs = [
+        "include/mlir/Transforms/InliningUtils.h",
+        "include/mlir/Transforms/LoopLikeInterface.h",
+        "lib/Dialect/AffineOps/AffineOps.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/AffineOps/AffineOps.h",
+        "include/mlir/Transforms/SideEffectsInterface.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOpsIncGen",
+        ":IR",
+        ":LoopLikeOpInterfaceIncGen",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+# Library with affine dialect static initialization.
+cc_library(
+    name = "AffineDialectRegistration",
+    srcs = ["lib/Dialect/AffineOps/DialectRegistration.cpp"],
+    deps = [":AffineOps"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "AffineToStandardTransforms",
+    srcs = ["lib/Conversion/AffineToStandard/AffineToStandard.cpp"],
+    hdrs = ["include/mlir/Conversion/AffineToStandard/AffineToStandard.h"],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":IR",
+        ":LoopOps",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":Transforms",
+    ],
+    alwayslink = 1,  # contains pass registration
+)
+
+# SDBM dialect only contains attribute components that can be constructed given
+# a dialect object, so whenever it is used it must also be registered. Therefore
+# we don't split out the registration library for it.
+cc_library(
+    name = "SDBM",
+    srcs = [
+        "lib/Dialect/SDBM/SDBM.cpp",
+        "lib/Dialect/SDBM/SDBMDialect.cpp",
+        "lib/Dialect/SDBM/SDBMExpr.cpp",
+        "lib/Dialect/SDBM/SDBMExprDetail.h",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/SDBM/SDBM.h",
+        "include/mlir/Dialect/SDBM/SDBMDialect.h",
+        "include/mlir/Dialect/SDBM/SDBMExpr.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "LoopOps",
+    srcs = [
+        "lib/Dialect/LoopOps/LoopOps.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/LoopOps/LoopOps.h",
+        "include/mlir/Transforms/LoopLikeInterface.h",
+        "include/mlir/Transforms/SideEffectsInterface.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LoopLikeOpInterfaceIncGen",
+        ":LoopOpsIncGen",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "LoopDialectRegistration",
+    srcs = ["lib/Dialect/LoopOps/DialectRegistration.cpp"],
+    deps = [":LoopOps"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "StandardOps",
+    srcs = [
+        "lib/Dialect/StandardOps/Ops.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Analysis/CallInterfaces.h",
+        "include/mlir/Dialect/StandardOps/Ops.h",
+        "include/mlir/Transforms/InliningUtils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CallOpInterfacesIncGen",
+        ":CommonFolders",
+        ":IR",
+        ":StandardOpsIncGen",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+# Library with standard dialect static initialization.
+cc_library(
+    name = "StandardDialectRegistration",
+    srcs = ["lib/Dialect/StandardOps/DialectRegistration.cpp"],
+    deps = [":StandardOps"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "VectorOps",
+    srcs = [
+        "lib/Dialect/VectorOps/VectorOps.cpp",
+        "lib/Dialect/VectorOps/VectorTransforms.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/VectorOps/Utils.h",
+        "include/mlir/Dialect/VectorOps/VectorOps.h",
+        "include/mlir/Dialect/VectorOps/VectorTransforms.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":DialectUtils",
+        ":EDSC",
+        ":IR",
+        ":StandardOps",
+        ":Support",
+        ":VectorOpsIncGen",
+        ":VectorTransformPatternsIncGen",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "VectorDialectRegistration",
+    srcs = ["lib/Dialect/VectorOps/DialectRegistration.cpp"],
+    deps = [":VectorOps"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "Support",
+    srcs = [
+        "lib/Support/FileUtilities.cpp",
+        "lib/Support/StorageUniquer.cpp",
+        "lib/Support/ToolUtilities.cpp",
+    ],
+    hdrs = [
+        "include/mlir/ADT/TypeSwitch.h",
+        "include/mlir/Support/DebugStringHelper.h",
+        "include/mlir/Support/FileUtilities.h",
+        "include/mlir/Support/Functional.h",
+        "include/mlir/Support/LLVM.h",
+        "include/mlir/Support/LogicalResult.h",
+        "include/mlir/Support/MathExtras.h",
+        "include/mlir/Support/STLExtras.h",
+        "include/mlir/Support/StorageUniquer.h",
+        "include/mlir/Support/StringExtras.h",
+        "include/mlir/Support/ToolUtilities.h",
+    ],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "ParserTokenKinds",
+    # strip_include_prefix does not apply to textual_hdrs.
+    hdrs = ["lib/Parser/TokenKinds.def"],
+    strip_include_prefix = "lib/Parser",
+    textual_hdrs = ["lib/Parser/TokenKinds.def"],
+)
+
+cc_library(
+    name = "Parser",
+    srcs = [
+        "lib/Parser/Lexer.cpp",
+        "lib/Parser/Lexer.h",
+        "lib/Parser/Parser.cpp",
+        "lib/Parser/Token.cpp",
+        "lib/Parser/Token.h",
+    ],
+    hdrs = [
+        "include/mlir/Parser.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":IR",
+        ":ParserTokenKinds",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "LLVMDialect",
+    srcs = [
+        "lib/Dialect/LLVMIR/IR/LLVMDialect.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/LLVMIR/LLVMDialect.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMOpsIncGen",
+        ":Support",
+        "@llvm-project//llvm:asm_parser",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "GPUOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/GPU/GPUOps.td",
+        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "GPUOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/GPU/GPUOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/GPU/GPUOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/GPU/GPUOps.td",
+    td_srcs = [
+        ":GPUOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "GPUDialect",
+    srcs = ["lib/Dialect/GPU/IR/GPUDialect.cpp"],
+    hdrs = [
+        "include/mlir/Dialect/GPU/GPUDialect.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUOpsIncGen",
+        ":IR",
+        ":LLVMDialect",
+        ":StandardOps",
+    ],
+)
+
+cc_library(
+    name = "GPUDialectRegistration",
+    srcs = ["lib/Dialect/GPU/IR/DialectRegistration.cpp"],
+    deps = [
+        ":GPUDialect",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "GPUTransforms",
+    srcs = ["lib/Dialect/GPU/Transforms/KernelOutlining.cpp"],
+    hdrs = ["include/mlir/Dialect/GPU/Passes.h"],
+    includes = ["include"],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":Pass",
+        ":StandardOps",
+        ":Transforms",
+    ],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "LLVMOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
+        "include/mlir/Dialect/LLVMIR/LLVMOps.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "GPUCommonTransforms",
+    hdrs = [
+        "lib/Conversion/GPUCommon/IndexIntrinsicsOpLowering.h",
+        "lib/Conversion/GPUCommon/OpToFuncCallLowering.h",
+    ],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":StandardOps",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+gentbl(
+    name = "GPUToNVVMGen",
+    strip_include_prefix = "lib/Conversion/GPUToNVVM",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "lib/Conversion/GPUToNVVM/GPUToNVVM.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "lib/Conversion/GPUToNVVM/GPUToNVVM.td",
+    td_srcs = [
+        ":GPUOpsTdFiles",
+        ":NVVMOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "GPUToNVVMTransforms",
+    srcs = ["lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp"],
+    hdrs = [
+        "include/mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUCommonTransforms",
+        ":GPUDialect",
+        ":GPUToNVVMGen",
+        ":IR",
+        ":LLVMTransforms",
+        ":NVVMDialect",
+        ":Pass",
+        ":Transforms",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "GPUToROCDLTransforms",
+    srcs = ["lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp"],
+    hdrs = [
+        "include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUCommonTransforms",
+        ":GPUDialect",
+        ":LLVMTransforms",
+        ":Pass",
+        ":ROCDLDialect",
+        ":Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "GPUToCUDATransforms",
+    srcs = [
+        "lib/Conversion/GPUToCUDA/ConvertKernelFuncToCubin.cpp",
+        "lib/Conversion/GPUToCUDA/ConvertLaunchFuncToCudaCalls.cpp",
+    ],
+    hdrs = ["include/mlir/Conversion/GPUToCUDA/GPUToCUDAPass.h"],
+    includes = ["include"],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":LLVMDialect",
+        ":Pass",
+        ":Support",
+        ":TargetNVVMIR",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:nvptx_target",  # buildcleaner: keep
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:target",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "GPUToSPIRVTransforms",
+    srcs = [
+        "lib/Conversion/GPUToSPIRV/ConvertGPUToSPIRV.cpp",
+        "lib/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRV.h",
+        "include/mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":LoopOps",
+        ":Pass",
+        ":SPIRVDialect",
+        ":SPIRVLowering",
+        ":StandardToSPIRVConversions",
+        ":Support",
+        ":Transforms",
+    ],
+    alwayslink = 1,
+)
+
+gentbl(
+    name = "LLVMOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/LLVMIR/LLVMOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/LLVMIR/LLVMOps.cpp.inc",
+        ),
+        (
+            "-gen-enum-decls",
+            "include/mlir/Dialect/LLVMIR/LLVMOpsEnums.h.inc",
+        ),
+        (
+            "-gen-enum-defs",
+            "include/mlir/Dialect/LLVMIR/LLVMOpsEnums.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/LLVMOps.td",
+    td_srcs = [
+        ":LLVMOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LLVMConversionIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-llvmir-conversions",
+            "include/mlir/Dialect/LLVMIR/LLVMConversions.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/LLVMOps.td",
+    td_srcs = [
+        ":LLVMOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "NVVMDialect",
+    srcs = [
+        "lib/Dialect/LLVMIR/IR/NVVMDialect.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/LLVMIR/NVVMDialect.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMDialect",
+        ":NVVMOpsIncGen",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:asm_parser",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "NVVMOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
+        "include/mlir/Dialect/LLVMIR/NVVMOps.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "NVVMOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/LLVMIR/NVVMOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/LLVMIR/NVVMOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/NVVMOps.td",
+    td_srcs = [
+        ":NVVMOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "NVVMConversionIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-llvmir-conversions",
+            "include/mlir/Dialect/LLVMIR/NVVMConversions.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/NVVMOps.td",
+    td_srcs = [
+        ":NVVMOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "ROCDLDialect",
+    srcs = [
+        "lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/LLVMIR/ROCDLDialect.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMDialect",
+        ":ROCDLOpsIncGen",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:asm_parser",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "ROCDLOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/LLVMIR/LLVMOpBase.td",
+        "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "ROCDLOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/LLVMIR/ROCDLOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/LLVMIR/ROCDLOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
+    td_srcs = [
+        ":ROCDLOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "ROCDLConversionIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-llvmir-conversions",
+            "include/mlir/Dialect/LLVMIR/ROCDLConversions.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/LLVMIR/ROCDLOps.td",
+    td_srcs = [
+        ":ROCDLOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "SPIRVOpsTdFiles",
+    srcs = [
+        "include/mlir/Analysis/CallInterfaces.td",
+        "include/mlir/Dialect/SPIRV/SPIRVArithmeticOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVAtomicOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVBase.td",
+        "include/mlir/Dialect/SPIRV/SPIRVBitOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVCastOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVCompositeOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVControlFlowOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVGLSLOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVGroupOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVLogicalOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVNonUniformOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVOps.td",
+        "include/mlir/Dialect/SPIRV/SPIRVStructureOps.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "SPIRVOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/SPIRV/SPIRVOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/SPIRV/SPIRVOps.cpp.inc",
+        ),
+        (
+            "-gen-op-doc",
+            "g3doc/Dialects/SPIRV/SPIRVOps.md",
+        ),
+        (
+            "-gen-enum-decls",
+            "include/mlir/Dialect/SPIRV/SPIRVEnums.h.inc",
+        ),
+        (
+            "-gen-enum-defs",
+            "include/mlir/Dialect/SPIRV/SPIRVEnums.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/SPIRV/SPIRVOps.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "SPIRVCanonicalizationIncGen",
+    strip_include_prefix = "lib/Dialect/SPIRV",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "lib/Dialect/SPIRV/SPIRVCanonicalization.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "lib/Dialect/SPIRV/SPIRVCanonicalization.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+        "lib/Dialect/SPIRV/SPIRVCanonicalization.td",
+    ],
+)
+
+gentbl(
+    name = "StandardToSPIRVGen",
+    strip_include_prefix = "lib/Conversion/StandardToSPIRV",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "lib/Conversion/StandardToSPIRV/StandardToSPIRV.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "lib/Conversion/StandardToSPIRV/StandardToSPIRV.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+        ":StdOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "SPIRVLoweringStructGen",
+    tbl_outs = [
+        (
+            "-gen-struct-attr-decls",
+            "include/mlir/Dialect/SPIRV/SPIRVLowering.h.inc",
+        ),
+        (
+            "-gen-struct-attr-defs",
+            "include/mlir/Dialect/SPIRV/SPIRVLowering.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/SPIRV/SPIRVLowering.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+        ":StdOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "SPIRVOpUtilsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-spirv-op-utils",
+            "include/mlir/Dialect/SPIRV/SPIRVOpUtils.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/SPIRV/SPIRVBase.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "SPIRVSerializationGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-spirv-serialization",
+            "include/mlir/Dialect/SPIRV/SPIRVSerialization.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/SPIRV/SPIRVOps.td",
+    td_srcs = [
+        ":SPIRVOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "SPIRVDialect",
+    srcs = [
+        "include/mlir/Transforms/InliningUtils.h",
+        "lib/Dialect/SPIRV/LayoutUtils.cpp",
+        "lib/Dialect/SPIRV/SPIRVDialect.cpp",
+        "lib/Dialect/SPIRV/SPIRVOps.cpp",
+        "lib/Dialect/SPIRV/SPIRVTypes.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/SPIRV/LayoutUtils.h",
+        "include/mlir/Dialect/SPIRV/SPIRVDialect.h",
+        "include/mlir/Dialect/SPIRV/SPIRVOps.h",
+        "include/mlir/Dialect/SPIRV/SPIRVTypes.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CommonFolders",
+        ":IR",
+        ":Parser",
+        ":SPIRVCanonicalizationIncGen",
+        ":SPIRVOpUtilsIncGen",
+        ":SPIRVOpsIncGen",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "SPIRVLowering",
+    srcs = [
+        "lib/Dialect/SPIRV/SPIRVLowering.cpp",
+        "lib/Dialect/SPIRV/Transforms/DecorateSPIRVCompositeTypeLayoutPass.cpp",
+        "lib/Dialect/SPIRV/Transforms/LowerABIAttributesPass.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/SPIRV/Passes.h",
+        "include/mlir/Dialect/SPIRV/SPIRVLowering.h",
+    ],
+    includes = [
+        "include",
+    ],
+    deps = [
+        ":IR",
+        ":Pass",
+        ":SPIRVDialect",
+        ":SPIRVLoweringStructGen",
+        ":StandardOps",
+        ":Support",
+        ":Transforms",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "StandardToSPIRVConversions",
+    srcs = [
+        "lib/Conversion/StandardToSPIRV/ConvertStandardToSPIRV.cpp",
+        "lib/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.cpp",
+        "lib/Conversion/StandardToSPIRV/LegalizeStandardForSPIRV.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRV.h",
+        "include/mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h",
+    ],
+    includes = [
+        "include",
+        "lib/Conversion/StandardToSPIRV",
+    ],
+    deps = [
+        ":IR",
+        ":Pass",
+        ":SPIRVDialect",
+        ":SPIRVLowering",
+        ":StandardOps",
+        ":StandardToSPIRVGen",
+        ":Support",
+        ":Transforms",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "SPIRVSerialization",
+    srcs = [
+        "lib/Dialect/SPIRV/Serialization/Deserializer.cpp",
+        "lib/Dialect/SPIRV/Serialization/SPIRVBinaryUtils.cpp",
+        "lib/Dialect/SPIRV/Serialization/Serializer.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/SPIRV/SPIRVBinaryUtils.h",
+        "include/mlir/Dialect/SPIRV/Serialization.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":SPIRVDialect",
+        ":SPIRVSerializationGen",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "SPIRVTranslateRegistration",
+    srcs = [
+        "lib/Dialect/SPIRV/Serialization/TranslateRegistration.cpp",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Parser",
+        ":SPIRVDialect",
+        ":SPIRVSerialization",
+        ":Support",
+        ":Translation",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "SPIRVDialectRegistration",
+    srcs = ["lib/Dialect/SPIRV/DialectRegistration.cpp"],
+    deps = [
+        ":SPIRVDialect",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TransformUtils",
+    srcs = [
+        "lib/Transforms/Utils/FoldUtils.cpp",
+        "lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp",
+        "lib/Transforms/Utils/InliningUtils.cpp",
+        "lib/Transforms/Utils/LoopFusionUtils.cpp",
+        "lib/Transforms/Utils/LoopUtils.cpp",
+        "lib/Transforms/Utils/RegionUtils.cpp",
+        "lib/Transforms/Utils/Utils.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Transforms/FoldUtils.h",
+        "include/mlir/Transforms/InliningUtils.h",
+        "include/mlir/Transforms/LoopFusionUtils.h",
+        "include/mlir/Transforms/LoopUtils.h",
+        "include/mlir/Transforms/RegionUtils.h",
+        "include/mlir/Transforms/Utils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":Analysis",
+        ":IR",
+        ":LoopDialectRegistration",
+        ":LoopOps",
+        ":StandardDialectRegistration",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+gentbl(
+    name = "LoopLikeOpInterfaceIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "include/mlir/Transforms/LoopLikeInterface.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "include/mlir/Transforms/LoopLikeInterface.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Transforms/LoopLikeInterface.td",
+    td_srcs = [
+        ":OpBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "Transforms",
+    srcs = [
+        "lib/Transforms/AffineDataCopyGeneration.cpp",
+        "lib/Transforms/AffineLoopInvariantCodeMotion.cpp",
+        "lib/Transforms/CSE.cpp",
+        "lib/Transforms/Canonicalizer.cpp",
+        "lib/Transforms/DialectConversion.cpp",
+        "lib/Transforms/Inliner.cpp",
+        "lib/Transforms/LoopCoalescing.cpp",
+        "lib/Transforms/LoopFusion.cpp",
+        "lib/Transforms/LoopInvariantCodeMotion.cpp",
+        "lib/Transforms/LoopTiling.cpp",
+        "lib/Transforms/LoopUnroll.cpp",
+        "lib/Transforms/LoopUnrollAndJam.cpp",
+        "lib/Transforms/MemRefDataFlowOpt.cpp",
+        "lib/Transforms/PipelineDataTransfer.cpp",
+        "lib/Transforms/SimplifyAffineStructures.cpp",
+        "lib/Transforms/StripDebugInfo.cpp",
+        "lib/Transforms/Vectorize.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Transforms/DialectConversion.h",
+        "include/mlir/Transforms/Passes.h",
+        "include/mlir/Transforms/SideEffectsInterface.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":Analysis",
+        ":EDSC",
+        ":IR",
+        ":LoopLikeOpInterfaceIncGen",
+        ":LoopOps",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        ":VectorAnalysis",
+        ":VectorOps",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "CommonFolders",
+    srcs = [
+    ],
+    hdrs = [
+        "include/mlir/Dialect/CommonFolders.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "LoopsToGPU",
+    srcs = [
+        "lib/Conversion/LoopsToGPU/LoopsToGPU.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/LoopsToGPU/LoopsToGPU.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":AffineToStandardTransforms",
+        ":GPUDialect",
+        ":IR",
+        ":Linalg",
+        ":LoopOps",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        ":Transforms",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "LoopsToGPUPass",
+    srcs = [
+        "lib/Conversion/LoopsToGPU/LoopsToGPUPass.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/LoopsToGPU/LoopsToGPUPass.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":LoopOps",
+        ":LoopsToGPU",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "CFGTransforms",
+    srcs = [
+        "lib/Conversion/LoopToStandard/ConvertLoopToStandard.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/LoopToStandard/ConvertLoopToStandard.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMDialect",
+        ":LoopOps",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        ":Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "LLVMTransforms",
+    srcs = [
+        "lib/Conversion/StandardToLLVM/ConvertStandardToLLVM.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h",
+        "include/mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":CFGTransforms",
+        ":IR",
+        ":LLVMDialect",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        ":Transforms",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+gentbl(
+    name = "CallOpInterfacesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "include/mlir/Analysis/CallInterfaces.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "include/mlir/Analysis/CallInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Analysis/CallInterfaces.td",
+    td_srcs = [
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "InferTypeOpInterfaceIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "include/mlir/Analysis/InferTypeOpInterface.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "include/mlir/Analysis/InferTypeOpInterface.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Analysis/InferTypeOpInterface.td",
+    td_srcs = [
+        ":OpBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "Analysis",
+    srcs = [
+        "lib/Analysis/AffineAnalysis.cpp",
+        "lib/Analysis/AffineStructures.cpp",
+        "lib/Analysis/CallGraph.cpp",
+        "lib/Analysis/Dominance.cpp",
+        "lib/Analysis/InferTypeOpInterface.cpp",
+        "lib/Analysis/Liveness.cpp",
+        "lib/Analysis/LoopAnalysis.cpp",
+        "lib/Analysis/MemRefBoundCheck.cpp",
+        "lib/Analysis/NestedMatcher.cpp",
+        "lib/Analysis/OpStats.cpp",
+        "lib/Analysis/SliceAnalysis.cpp",
+        "lib/Analysis/TestMemRefDependenceCheck.cpp",
+        "lib/Analysis/TestParallelismDetection.cpp",
+        "lib/Analysis/Utils.cpp",
+        "lib/Analysis/Verifier.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Analysis/AffineAnalysis.h",
+        "include/mlir/Analysis/AffineStructures.h",
+        "include/mlir/Analysis/CallGraph.h",
+        "include/mlir/Analysis/CallInterfaces.h",
+        "include/mlir/Analysis/Dominance.h",
+        "include/mlir/Analysis/InferTypeOpInterface.h",
+        "include/mlir/Analysis/Liveness.h",
+        "include/mlir/Analysis/LoopAnalysis.h",
+        "include/mlir/Analysis/NestedMatcher.h",
+        "include/mlir/Analysis/Passes.h",
+        "include/mlir/Analysis/SliceAnalysis.h",
+        "include/mlir/Analysis/Utils.h",
+        "include/mlir/Analysis/Verifier.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":CallOpInterfacesIncGen",
+        ":IR",
+        ":InferTypeOpInterfaceIncGen",
+        ":LoopOps",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "VectorAnalysis",
+    srcs = [
+        "lib/Analysis/VectorAnalysis.cpp",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":Analysis",
+        ":IR",
+        ":StandardOps",
+        ":Support",
+        ":VectorOps",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "Translation",
+    srcs = ["lib/Translation/Translation.cpp"],
+    hdrs = ["include/mlir/Translation.h"],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Parser",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "LLVMIRModuleTranslation",
+    srcs = [
+        "lib/Target/LLVMIR/ModuleTranslation.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Target/LLVMIR/ModuleTranslation.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMConversionIncGen",
+        ":LLVMDialect",
+        ":Support",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:transform_utils",
+    ],
+)
+
+cc_library(
+    name = "TargetLLVMIR",
+    srcs = [
+        "lib/Target/LLVMIR/ConvertFromLLVMIR.cpp",
+        "lib/Target/LLVMIR/ConvertToLLVMIR.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Target/LLVMIR.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMIRModuleTranslation",
+        ":Support",
+        ":Translation",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:ir_reader",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TargetNVVMIR",
+    srcs = [
+        "lib/Target/LLVMIR/ConvertToNVVMIR.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Target/NVVMIR.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMIRModuleTranslation",
+        ":NVVMConversionIncGen",
+        ":NVVMDialect",
+        ":Support",
+        ":Translation",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TargetROCDLIR",
+    srcs = [
+        "lib/Target/LLVMIR/ConvertToROCDLIR.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Target/ROCDLIR.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":GPUDialect",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMIRModuleTranslation",
+        ":ROCDLConversionIncGen",
+        ":ROCDLDialect",
+        ":Support",
+        ":Translation",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "ExecutionEngine",
+    srcs = [
+        "lib/ExecutionEngine/ExecutionEngine.cpp",
+    ],
+    hdrs = [
+        "include/mlir/ExecutionEngine/ExecutionEngine.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMDialect",
+        ":Support",
+        ":TargetLLVMIR",
+        ":Translation",
+        "@llvm-project//llvm:bit_reader",
+        "@llvm-project//llvm:bit_writer",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:execution_engine",
+        "@llvm-project//llvm:mc",
+        "@llvm-project//llvm:orc_jit",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:target",  # fixdeps: keep
+        "@llvm-project//llvm:transform_utils",
+        "@llvm-project//llvm:x86_code_gen",  # fixdeps: keep
+        "@llvm-project//llvm:x86_disassembler",  # fixdeps: keep
+    ],
+)
+
+cc_library(
+    name = "ExecutionEngineUtils",
+    srcs = [
+        "lib/ExecutionEngine/OptUtils.cpp",
+    ],
+    hdrs = [
+        "include/mlir/ExecutionEngine/OptUtils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//llvm:analysis",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:ipo",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:target",
+    ],
+)
+
+cc_library(
+    name = "MlirOptLib",
+    srcs = [
+        "lib/Support/MlirOptMain.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Support/MlirOptMain.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":GPUToNVVMTransforms",
+        ":GPUToROCDLTransforms",
+        ":GPUToSPIRVTransforms",
+        ":GPUTransforms",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":LinalgToLLVM",
+        ":NVVMDialect",
+        ":Parser",
+        ":Pass",
+        ":QuantizerTransforms",
+        ":SPIRVDialectRegistration",
+        ":StandardToSPIRVConversions",
+        ":Support",
+        ":Transforms",
+        ":VectorToLLVM",
+        ":VectorToLoops",
+        ":ViewOpGraph",
+        ":ViewRegionGraph",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "ViewOpGraph",
+    srcs = ["lib/Transforms/ViewOpGraph.cpp"],
+    hdrs = ["include/mlir/Transforms/ViewOpGraph.h"],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":IR",
+        ":Pass",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "ViewRegionGraph",
+    srcs = ["lib/Transforms/ViewRegionGraph.cpp"],
+    hdrs = ["include/mlir/Transforms/ViewRegionGraph.h"],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":IR",
+        ":Pass",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TranslateClParser",
+    srcs = ["lib/Support/TranslateClParser.cpp"],
+    hdrs = ["include/mlir/Support/TranslateClParser.h"],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":IR",
+        ":Parser",
+        ":Support",
+        ":Translation",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "MlirTranslateMain",
+    srcs = ["tools/mlir-translate/mlir-translate.cpp"],
+    deps = [
+        ":IR",
+        ":Parser",
+        ":Support",
+        ":TranslateClParser",
+        ":Translation",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_binary(
+    name = "mlir-translate",
+    deps = [
+        ":LoopDialectRegistration",
+        ":MlirTranslateMain",
+        ":SPIRVDialectRegistration",
+        ":SPIRVTranslateRegistration",
+        ":StandardDialectRegistration",
+        ":TargetLLVMIR",
+        ":TargetNVVMIR",
+        ":TargetROCDLIR",
+        ":VectorDialectRegistration",
+    ],
+)
+
+# TODO(jpienaar): This library should be removed.
+cc_library(
+    name = "MlirOptMain",
+    srcs = [
+        "tools/mlir-opt/mlir-opt.cpp",
+    ],
+    deps = [
+        ":Analysis",
+        ":MlirOptLib",
+        ":Pass",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_binary(
+    name = "mlir-opt",
+    deps = [
+        ":AffineDialectRegistration",
+        ":Analysis",
+        ":FxpMathOps",
+        ":FxpMathOpsDialectRegistration",
+        ":GPUDialectRegistration",
+        ":IR",
+        ":LinalgDialectRegistration",
+        ":LoopDialectRegistration",
+        ":LoopsToGPUPass",
+        ":MlirOptLib",
+        ":MlirOptMain",
+        ":QuantOps",
+        ":QuantOpsDialectRegistration",
+        ":ROCDLDialect",
+        ":StandardDialectRegistration",
+        ":Transforms",
+        ":VectorDialectRegistration",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir/test:TestDialect",
+        "@llvm-project//mlir/test:TestIR",
+        "@llvm-project//mlir/test:TestPass",
+        "@llvm-project//mlir/test:TestTransforms",
+    ],
+)
+
+cc_library(
+    name = "MlirJitRunner",
+    srcs = ["lib/Support/JitRunner.cpp"],
+    hdrs = ["include/mlir/Support/JitRunner.h"],
+    includes = ["include"],
+    deps = [
+        ":AffineDialectRegistration",
+        ":CFGTransforms",
+        ":ExecutionEngine",
+        ":ExecutionEngineUtils",
+        ":IR",
+        ":LLVMDialect",
+        ":Parser",
+        ":Pass",
+        ":Support",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:orc_jit",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_binary(
+    name = "mlir-cpu-runner",
+    srcs = ["tools/mlir-cpu-runner/mlir-cpu-runner.cpp"],
+    linkopts = ["-ldl"],
+    deps = [":MlirJitRunner"],
+)
+
+cc_binary(
+    name = "tools/libcuda-runtime-wrappers.so",
+    srcs = ["tools/mlir-cuda-runner/cuda-runtime-wrappers.cpp"],
+    linkshared = True,
+    deps = [
+        "//third_party/gpus/cuda:cuda_headers",
+        "//third_party/gpus/cuda:cuda_runtime",
+        "//third_party/gpus/cuda:libcuda",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_binary(
+    name = "mlir-cuda-runner",
+    srcs = ["tools/mlir-cuda-runner/mlir-cuda-runner.cpp"],
+    data = [
+        ":tools/libcuda-runtime-wrappers.so",
+        "@llvm-project//mlir/test/mlir-cpu-runner:libmlir_runner_utils.so",
+    ],
+    deps = [
+        ":GPUDialect",
+        ":GPUDialectRegistration",
+        ":GPUToNVVMTransforms",
+        ":GPUToROCDLTransforms",
+        ":GPUTransforms",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":MlirJitRunner",
+        ":NVVMDialect",
+        ":Pass",
+        ":Transforms",
+        "//devtools/build/runtime:get_runfiles_dir",
+        "//third_party/gpus/cuda:cuda_headers",
+        "//third_party/gpus/cuda:cuda_runtime",
+        "//third_party/gpus/cuda:libcuda",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "TableGen",
+    srcs = [
+        "lib/TableGen/Argument.cpp",
+        "lib/TableGen/Attribute.cpp",
+        "lib/TableGen/Constraint.cpp",
+        "lib/TableGen/Dialect.cpp",
+        "lib/TableGen/Format.cpp",
+        "lib/TableGen/OpInterfaces.cpp",
+        "lib/TableGen/OpTrait.cpp",
+        "lib/TableGen/Operator.cpp",
+        "lib/TableGen/Pattern.cpp",
+        "lib/TableGen/Predicate.cpp",
+        "lib/TableGen/Type.cpp",
+    ],
+    hdrs = [
+        "include/mlir/TableGen/Argument.h",
+        "include/mlir/TableGen/Attribute.h",
+        "include/mlir/TableGen/Constraint.h",
+        "include/mlir/TableGen/Dialect.h",
+        "include/mlir/TableGen/Format.h",
+        "include/mlir/TableGen/GenInfo.h",
+        "include/mlir/TableGen/GenNameParser.h",
+        "include/mlir/TableGen/OpInterfaces.h",
+        "include/mlir/TableGen/OpTrait.h",
+        "include/mlir/TableGen/Operator.h",
+        "include/mlir/TableGen/Pattern.h",
+        "include/mlir/TableGen/Predicate.h",
+        "include/mlir/TableGen/Region.h",
+        "include/mlir/TableGen/Type.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Support",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:tablegen",
+    ],
+)
+
+cc_library(
+    name = "MlirTableGenMain",
+    srcs = [
+        "tools/mlir-tblgen/mlir-tblgen.cpp",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Support",
+        ":TableGen",
+        "@llvm-project//llvm:config",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:tablegen",
+    ],
+)
+
+cc_binary(
+    name = "mlir-tblgen",
+    srcs = [
+        "tools/mlir-tblgen/DocGenUtilities.h",
+        "tools/mlir-tblgen/EnumsGen.cpp",
+        "tools/mlir-tblgen/LLVMIRConversionGen.cpp",
+        "tools/mlir-tblgen/OpDefinitionsGen.cpp",
+        "tools/mlir-tblgen/OpDocGen.cpp",
+        "tools/mlir-tblgen/OpInterfacesGen.cpp",
+        "tools/mlir-tblgen/ReferenceImplGen.cpp",
+        "tools/mlir-tblgen/RewriterGen.cpp",
+        "tools/mlir-tblgen/SPIRVUtilsGen.cpp",
+        "tools/mlir-tblgen/StructsGen.cpp",
+    ],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    deps = [
+        ":MlirTableGenMain",
+        ":Support",
+        ":TableGen",
+        "@llvm-project//llvm:config",
+        "@llvm-project//llvm:support",
+        "@llvm-project//llvm:tablegen",
+    ],
+)
+
+filegroup(
+    name = "QuantizationOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/QuantOps/QuantOps.td",
+        "include/mlir/Dialect/QuantOps/QuantPredicates.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+## QuantOps dialect
+gentbl(
+    name = "QuantOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/QuantOps/QuantOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/QuantOps/QuantOps.cpp.inc",
+        ),
+        (
+            "-gen-op-doc",
+            "g3doc/Dialects/QuantOps/QuantOps.md",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/QuantOps/QuantOps.td",
+    td_srcs = [
+        ":QuantizationOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "QuantOps",
+    srcs = [
+        "lib/Dialect/QuantOps/IR/QuantOps.cpp",
+        "lib/Dialect/QuantOps/IR/QuantTypes.cpp",
+        "lib/Dialect/QuantOps/IR/TypeDetail.h",
+        "lib/Dialect/QuantOps/IR/TypeParser.cpp",
+        "lib/Dialect/QuantOps/Transforms/ConvertConst.cpp",
+        "lib/Dialect/QuantOps/Transforms/ConvertSimQuant.cpp",
+        "lib/Dialect/QuantOps/Utils/FakeQuantSupport.cpp",
+        "lib/Dialect/QuantOps/Utils/QuantizeUtils.cpp",
+        "lib/Dialect/QuantOps/Utils/UniformSupport.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/QuantOps/FakeQuantSupport.h",
+        "include/mlir/Dialect/QuantOps/Passes.h",
+        "include/mlir/Dialect/QuantOps/QuantOps.h",
+        "include/mlir/Dialect/QuantOps/QuantTypes.h",
+        "include/mlir/Dialect/QuantOps/QuantizeUtils.h",
+        "include/mlir/Dialect/QuantOps/UniformSupport.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":IR",
+        ":Pass",
+        ":QuantOpsIncGen",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "QuantOpsDialectRegistration",
+    srcs = ["lib/Dialect/QuantOps/IR/DialectRegistration.cpp"],
+    deps = [":QuantOps"],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "FxpMathOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/FxpMathOps/FxpMathOps.td",
+        "include/mlir/Dialect/QuantOps/QuantPredicates.td",
+        ":OpBaseTdFiles",
+    ],
+)
+
+## FxpMathOps dialect
+gentbl(
+    name = "FxpMathOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/FxpMathOps/FxpMathOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/FxpMathOps/FxpMathOps.cpp.inc",
+        ),
+        (
+            "-gen-op-doc",
+            "g3doc/Dialects/FxpMathOps/FxpMathOps.md",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/FxpMathOps/FxpMathOps.td",
+    td_srcs = [
+        ":FxpMathOpsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "FxpMathOps",
+    srcs = [
+        "lib/Dialect/FxpMathOps/IR/FxpMathOps.cpp",
+        "lib/Dialect/FxpMathOps/Transforms/LowerUniformRealMath.cpp",
+        "lib/Dialect/FxpMathOps/Transforms/UniformKernelUtils.h",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/FxpMathOps/FxpMathOps.h",
+        "include/mlir/Dialect/FxpMathOps/Passes.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":Analysis",
+        ":FxpMathOpsIncGen",
+        ":IR",
+        ":Pass",
+        ":QuantOps",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "FxpMathOpsDialectRegistration",
+    srcs = ["lib/Dialect/FxpMathOps/IR/DialectRegistration.cpp"],
+    deps = [":FxpMathOps"],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "LinalgOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/Linalg/IR/LinalgBase.td",
+        "include/mlir/Dialect/Linalg/IR/LinalgOps.td",
+        "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td",
+        ":AffineOpsTdFiles",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LinalgOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/Linalg/IR/LinalgOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/Linalg/IR/LinalgOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/Linalg/IR/LinalgOps.td",
+    td_srcs = [
+        ":LinalgOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "LinalgStructuredOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/Linalg/IR/LinalgBase.td",
+        "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td",
+        ":AffineOpsTdFiles",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LinalgStructuredOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc",
+        ),
+        (
+            "-gen-op-interface-decls",
+            "include/mlir/Dialect/Linalg/IR/LinalgStructuredOpsInterfaces.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "include/mlir/Dialect/Linalg/IR/LinalgStructuredOpsInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td",
+    td_srcs = [
+        ":LinalgStructuredOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "LinalgDocTdFiles",
+    srcs = [
+        "include/mlir/Dialect/Linalg/IR/LinalgDoc.td",
+        ":LinalgOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LinalgDocIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-doc",
+            "g3doc/Dialects/Linalg/LinalgOps.md",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/Linalg/IR/LinalgDoc.td",
+    td_srcs = [
+        ":LinalgDocTdFiles",
+    ],
+)
+
+filegroup(
+    name = "LinalgTransformPatternsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/Linalg/Transforms/LinalgTransformPatterns.td",
+        ":AffineOpsTdFiles",
+        ":LinalgOpsTdFiles",
+        ":LinalgStructuredOpsTdFiles",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "LinalgTransformPatternsIncGen",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "include/mlir/Dialect/Linalg/Transforms/LinalgTransformPatterns.h.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/Linalg/Transforms/LinalgTransformPatterns.td",
+    td_srcs = [
+        ":LinalgTransformPatternsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "LinalgToLLVM",
+    srcs = [
+        "lib/Conversion/LinalgToLLVM/LinalgToLLVM.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineToStandardTransforms",
+        ":Analysis",
+        ":CFGTransforms",
+        ":EDSC",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":Linalg",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":Transforms",
+        ":VectorToLLVM",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "Linalg",
+    srcs = [
+        "lib/Dialect/Linalg/Analysis/DependenceAnalysis.cpp",
+        "lib/Dialect/Linalg/EDSC/Builders.cpp",
+        "lib/Dialect/Linalg/IR/LinalgOps.cpp",
+        "lib/Dialect/Linalg/IR/LinalgTypes.cpp",
+        "lib/Dialect/Linalg/Transforms/Fusion.cpp",
+        "lib/Dialect/Linalg/Transforms/LinalgToLoops.cpp",
+        "lib/Dialect/Linalg/Transforms/LinalgTransforms.cpp",
+        "lib/Dialect/Linalg/Transforms/Promotion.cpp",
+        "lib/Dialect/Linalg/Transforms/Tiling.cpp",
+        "lib/Dialect/Linalg/Utils/Utils.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h",
+        "include/mlir/Dialect/Linalg/EDSC/Builders.h",
+        "include/mlir/Dialect/Linalg/EDSC/Intrinsics.h",
+        "include/mlir/Dialect/Linalg/IR/LinalgOps.h",
+        "include/mlir/Dialect/Linalg/IR/LinalgTraits.h",
+        "include/mlir/Dialect/Linalg/IR/LinalgTypes.h",
+        "include/mlir/Dialect/Linalg/Passes.h",
+        "include/mlir/Dialect/Linalg/Transforms/LinalgTransforms.h",
+        "include/mlir/Dialect/Linalg/Utils/Intrinsics.h",
+        "include/mlir/Dialect/Linalg/Utils/Utils.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":AffineOps",
+        ":AffineToStandardTransforms",
+        ":Analysis",
+        ":CFGTransforms",
+        ":DialectUtils",
+        ":EDSC",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":LinalgOpsIncGen",
+        ":LinalgStructuredOpsIncGen",
+        ":LinalgTransformPatternsIncGen",
+        ":LoopOps",
+        ":Parser",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":TransformUtils",
+        ":Transforms",
+        ":VectorOps",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "LinalgDialectRegistration",
+    srcs = ["lib/Dialect/Linalg/LinalgRegistration.cpp"],
+    deps = [":Linalg"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "QuantizerSupportLib",
+    srcs = [
+        "lib/Quantizer/Configurations/FxpMathConfig.cpp",
+        "lib/Quantizer/Support/Configuration.cpp",
+        "lib/Quantizer/Support/ConstraintAnalysisGraph.cpp",
+        "lib/Quantizer/Support/Metadata.cpp",
+        "lib/Quantizer/Support/Statistics.cpp",
+        "lib/Quantizer/Support/TypeUtils.cpp",
+        "lib/Quantizer/Support/UniformConstraints.cpp",
+        "lib/Quantizer/Support/UniformSolvers.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Quantizer/Configurations/FxpMathConfig.h",
+        "include/mlir/Quantizer/Support/Configuration.h",
+        "include/mlir/Quantizer/Support/ConstraintAnalysisGraph.h",
+        "include/mlir/Quantizer/Support/ConstraintAnalysisGraphTraits.h",
+        "include/mlir/Quantizer/Support/Metadata.h",
+        "include/mlir/Quantizer/Support/Rules.h",
+        "include/mlir/Quantizer/Support/Statistics.h",
+        "include/mlir/Quantizer/Support/TypeUtils.h",
+        "include/mlir/Quantizer/Support/UniformConstraints.h",
+        "include/mlir/Quantizer/Support/UniformSolvers.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":FxpMathOps",
+        ":IR",
+        ":QuantOps",
+        ":StandardOps",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+)
+
+cc_library(
+    name = "QuantizerTransforms",
+    srcs = [
+        "lib/Quantizer/Transforms/AddDefaultStatsTestPass.cpp",
+        "lib/Quantizer/Transforms/InferQuantizedTypesPass.cpp",
+        "lib/Quantizer/Transforms/RemoveInstrumentationPass.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Quantizer/Transforms/Passes.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":Pass",
+        ":QuantOps",
+        ":QuantizerSupportLib",
+        ":Support",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+filegroup(
+    name = "VectorOpsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/VectorOps/VectorOps.td",
+        ":AffineOpsTdFiles",
+        ":OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "VectorOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "include/mlir/Dialect/VectorOps/VectorOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "include/mlir/Dialect/VectorOps/VectorOps.cpp.inc",
+        ),
+        (
+            "-gen-op-doc",
+            "g3doc/Dialects/Vector/VectorOps.md",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/VectorOps/VectorOps.td",
+    td_srcs = [
+        ":VectorOpsTdFiles",
+    ],
+)
+
+filegroup(
+    name = "VectorTransformPatternsTdFiles",
+    srcs = [
+        "include/mlir/Dialect/VectorOps/VectorTransformPatterns.td",
+        ":AffineOpsTdFiles",
+        ":LinalgOpsTdFiles",
+        ":LinalgStructuredOpsTdFiles",
+        ":OpBaseTdFiles",
+        ":StdOpsTdFiles",
+        ":VectorOpsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "VectorTransformPatternsIncGen",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "include/mlir/Dialect/VectorOps/VectorTransformPatterns.h.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/VectorOps/VectorTransformPatterns.td",
+    td_srcs = [
+        ":VectorTransformPatternsTdFiles",
+    ],
+)
+
+cc_library(
+    name = "VectorToLLVM",
+    srcs = [
+        "lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":EDSC",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":Transforms",
+        ":VectorOps",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "VectorToLoops",
+    srcs = [
+        "lib/Conversion/VectorToLoops/ConvertVectorToLoops.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Conversion/VectorToLoops/ConvertVectorToLoops.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":EDSC",
+        ":IR",
+        ":LLVMDialect",
+        ":LLVMTransforms",
+        ":Pass",
+        ":StandardOps",
+        ":Support",
+        ":Transforms",
+        ":VectorOps",
+        "@llvm-project//llvm:core",
+        "@llvm-project//llvm:support",
+    ],
+    alwayslink = 1,
+)
+
+# To reference all tablegen files here when checking for updates to them.
+filegroup(
+    name = "TdFiles",
+    srcs = glob(["**/*.td"]),
+)
+
+exports_files(
+    [
+        "include/mlir/Dialect/StandardOps/Ops.td",
+        "include/mlir/Analysis/CallInterfaces.td",
+        "include/mlir/Transforms/InliningUtils.h",
+        "include/mlir/IR/OpBase.td",
+        "include/mlir/IR/OpAsmInterface.td",
+        "include/mlir/Analysis/CallInterfaces.h",
+    ],
+    visibility = ["@llvm-project//mlir:friends"],
+)
+
+exports_files(
+    ["include/mlir/Analysis/InferTypeOpInterface.td"],
+    visibility = ["@llvm-project//mlir:friends"],
+)

--- a/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/test/BUILD.bazel
+++ b/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/test/BUILD.bazel
@@ -1,0 +1,197 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@org_tensorflow//third_party/mlir:tblgen.bzl", "gentbl")
+
+licenses(["notice"])
+
+package(default_visibility = [":test_friends"])
+
+# Please only depend on this from MLIR tests.
+package_group(
+    name = "test_friends",
+    includes = ["@org_tensorflow//tensorflow/compiler/mlir:subpackages"],
+    packages = ["//..."],
+)
+
+cc_library(
+    name = "IRProducingAPITest",
+    hdrs = ["APITest.h"],
+    includes = ["."],
+)
+
+gentbl(
+    name = "TestLinalgTransformPatternsIncGen",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "lib/DeclarativeTransforms/TestLinalgTransformPatterns.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "lib/DeclarativeTransforms/TestLinalgTransformPatterns.td",
+    td_srcs = [
+        "@llvm-project//mlir:LinalgTransformPatternsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "TestVectorTransformPatternsIncGen",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "lib/DeclarativeTransforms/TestVectorTransformPatterns.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "lib/DeclarativeTransforms/TestVectorTransformPatterns.td",
+    td_srcs = [
+        "@llvm-project//mlir:VectorTransformPatternsTdFiles",
+    ],
+)
+
+gentbl(
+    name = "TestOpsIncGen",
+    strip_include_prefix = "lib/TestDialect",
+    tbl_outs = [
+        (
+            "-gen-op-decls",
+            "lib/TestDialect/TestOps.h.inc",
+        ),
+        (
+            "-gen-op-defs",
+            "lib/TestDialect/TestOps.cpp.inc",
+        ),
+        (
+            "-gen-enum-decls",
+            "lib/TestDialect/TestOpEnums.h.inc",
+        ),
+        (
+            "-gen-enum-defs",
+            "lib/TestDialect/TestOpEnums.cpp.inc",
+        ),
+        (
+            "-gen-rewriters",
+            "lib/TestDialect/TestPatterns.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "lib/TestDialect/TestOps.td",
+    td_srcs = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:include/mlir/IR/OpAsmInterface.td",
+        "@llvm-project//mlir:include/mlir/Analysis/CallInterfaces.td",
+        "@llvm-project//mlir:include/mlir/Analysis/InferTypeOpInterface.td",
+    ],
+    test = True,
+)
+
+cc_library(
+    name = "TestDialect",
+    srcs = [
+        "lib/TestDialect/TestDialect.cpp",
+        "lib/TestDialect/TestPatterns.cpp",
+    ],
+    hdrs = [
+        "lib/TestDialect/TestDialect.h",
+    ],
+    includes = [
+        "lib/DeclarativeTransforms",
+        "lib/TestDialect",
+    ],
+    deps = [
+        ":TestOpsIncGen",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TestIR",
+    srcs = [
+        "lib/IR/TestFunc.cpp",
+        "lib/IR/TestMatchers.cpp",
+        "lib/IR/TestSymbolUses.cpp",
+    ],
+    deps = [
+        ":TestDialect",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TestPass",
+    srcs = [
+        "lib/Pass/TestPassManager.cpp",
+    ],
+    deps = [
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "TestTransforms",
+    srcs = [
+        "lib/Transforms/TestCallGraph.cpp",
+        "lib/Transforms/TestConstantFold.cpp",
+        "lib/Transforms/TestInlining.cpp",
+        "lib/Transforms/TestLinalgTransforms.cpp",
+        "lib/Transforms/TestLiveness.cpp",
+        "lib/Transforms/TestLoopFusion.cpp",
+        "lib/Transforms/TestLoopMapping.cpp",
+        "lib/Transforms/TestLoopParametricTiling.cpp",
+        "lib/Transforms/TestMemRefStrideCalculation.cpp",
+        "lib/Transforms/TestOpaqueLoc.cpp",
+        "lib/Transforms/TestVectorToLoopsConversion.cpp",
+        "lib/Transforms/TestVectorTransforms.cpp",
+        "lib/Transforms/TestVectorizationUtils.cpp",
+    ],
+    includes = ["lib/TestDialect"],
+    deps = [
+        ":TestDialect",
+        ":TestLinalgTransformPatternsIncGen",
+        ":TestVectorTransformPatternsIncGen",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:AffineOps",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:EDSC",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Linalg",
+        "@llvm-project//mlir:LoopOps",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:VectorOps",
+        "@llvm-project//mlir:VectorToLLVM",
+        "@llvm-project//mlir:VectorToLoops",
+    ],
+    alwayslink = 1,
+)


### PR DESCRIPTION
* This isn't used yet but confirmed it works with some WORKSPACE changes.
* The build files themselves come from TensorFlow.
* I'll add a script to read TensorFlow's LLVM commit hash and syncing the submodule.
* This will allow joint development in both IREE/LLVM/MLIR from the same repo.
* Makes progress on #77 