### PR TITLE
CMake fixes

### DIFF
--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -14,6 +14,39 @@
 
 iree_cc_library(
   NAME
+    Common
+  HDRS
+    "CommonDialect.h"
+    "CommonOps.h"
+    "CommonOps.h.inc"
+  SRCS
+    "CommonDialect.cpp"
+    "CommonOps.cpp"
+    "CommonOps.cpp.inc"
+  DEPS
+    iree::compiler::Translation::Interpreter::IR::CommonOpsGen
+    iree::compiler::IR
+    iree::compiler::IR::OpsGen
+    LLVMSupport
+    MLIRIR
+    MLIRStandardOps
+    MLIRSupport
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    CommonOpsGen
+  SRCS
+    CommonOps.td
+  OUTS
+    -gen-op-decls CommonOps.h.inc
+    -gen-op-defs CommonOps.cpp.inc
+)
+
+iree_cc_library(
+  NAME
     IR
   HDRS
     "HLDialect.h"

--- a/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
@@ -29,10 +29,13 @@ iree_cc_library(
     "VMModuleBuilder.cpp"
   DEPS
     iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::Interpreter::IR
+    iree::compiler::Translation::Interpreter::Utils
     iree::schemas::interpreter_module_def_cc_fbs
     iree::schemas::bytecode::interpreter_bytecode_v0
+    flatbuffers
     LLVMSupport
     MLIRIR
+    MLIRStandardOps
+    MLIRSupport
   PUBLIC
 )

--- a/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
@@ -37,12 +37,20 @@ iree_cc_library(
   DEPS
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Translation::Interpreter::IR
+    iree::compiler::Translation::Interpreter::IR::Common
+    iree::compiler::Translation::Interpreter::Serialization
     iree::compiler::Translation::Interpreter::Utils
     iree::compiler::Utils
-    tensorflow::mlir_xla
+    iree::schemas::bytecode::interpreter_bytecode_v0
     LLVMSupport
+    MLIRAnalysis
     MLIRIR
     MLIRPass
+    MLIRStandardOps
+    MLIRSupport
     MLIRTransformUtils
+    MLIRTransforms
+    tensorflow::mlir_xla
+  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
@@ -24,8 +24,14 @@ iree_cc_library(
     "OpCreationUtils.cpp"
   DEPS
     iree::compiler::Dialect::IREE::IR
-    tensorflow::mlir_xla
+    iree::compiler::Translation::Interpreter::IR::Common
     LLVMSupport
     MLIRIR
+    MLIRPass
+    MLIRStandardOps
+    MLIRSupport
+    MLIRTransformUtils
+    MLIRTransforms
+    tensorflow::mlir_xla
   PUBLIC
 )

--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -11,6 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-add_subdirectory(hal)
-add_subdirectory(rt)

--- a/iree/schemas/CMakeLists.txt
+++ b/iree/schemas/CMakeLists.txt
@@ -32,9 +32,9 @@ flatbuffer_cc_library(
 
 flatbuffer_cc_library(
   NAME
-    module_def_cc_fbs
+    interpreter_module_def_cc_fbs
   SRCS
-    "module_def.fbs"
+    "interpreter_module_def.fbs"
   PUBLIC
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -33,6 +33,9 @@ if(${IREE_BUILD_COMPILER})
     MLIRTranslation
     MLIRSupport
     MLIRVectorOps
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::VM::IR
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Translation::Interpreter::IR
     tensorflow::mlir_xla
@@ -102,7 +105,7 @@ if(${IREE_BUILD_COMPILER})
       "translate_main.cc"
     DEPS
       ${_ALWAYSLINK_LIBS}
-      iree::compiler::Translation::Interpreter
+      iree::compiler::Dialect::VM::Target::Bytecode
       iree::compiler::Translation::SPIRV
       MLIRTranslateClParser
   )

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -51,33 +51,34 @@ if(${IREE_BUILD_COMPILER})
     endif()
   endforeach(LIB)
 
-  iree_cc_binary(
-    NAME
-      iree-run-mlir
-    SRCS
-      "run_mlir_main.cc"
-    DEPS
-      absl::flags
-      absl::strings
-      # TODO(marbre): Fix problems with property "ALWAYSLINK".
-      #iree::base::source_location
-      iree::rt
-      LLVMSupport
-      MLIRIR
-      MLIRParser
-      MLIRSupport
-      iree::base::init
-      iree::base::status
-      iree::compiler::Translation::Interpreter
-      iree::compiler::Translation::SPIRV
-      iree::compiler::Translation::IREEVM
-      iree::hal::buffer_view_string_util
-      iree::hal::driver_registry
-      # TODO(marbre)_ Add deps
-      # PLATFORM_VULKAN_DEPS
-      iree::hal::interpreter::interpreter_driver_module
-      iree::hal::vulkan::vulkan_driver_module
-    )
+# TODO(mabre): Get this working
+#  iree_cc_binary(
+#    NAME
+#      iree-run-mlir
+#    SRCS
+#      "run_mlir_main.cc"
+#    DEPS
+#      absl::flags
+#      absl::strings
+#      # TODO(marbre): Fix problems with property "ALWAYSLINK".
+#      #iree::base::source_location
+#      iree::rt
+#      LLVMSupport
+#      MLIRIR
+#      MLIRParser
+#      MLIRSupport
+#      iree::base::init
+#      iree::base::status
+#      iree::compiler::Translation::Interpreter
+#      iree::compiler::Translation::SPIRV
+#      iree::compiler::Translation::IREEVM
+#      iree::hal::buffer_view_string_util
+#      iree::hal::driver_registry
+#      # TODO(marbre)_ Add deps
+#      # PLATFORM_VULKAN_DEPS
+#      iree::hal::interpreter::interpreter_driver_module
+#      iree::hal::vulkan::vulkan_driver_module
+#    )
 
   iree_cc_binary(
     NAME


### PR DESCRIPTION
These changes get us closer to a working CMake build again. Unfortunately, `iree-translate` currently fails:

```
[100%] Linking CXX executable iree-translate
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lFlowEnumsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lFlowOpInterfaceGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lFlowOpsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lHALEnumsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lHALOpInterfaceGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lHALOpsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lVMEnumsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lVMOpEncoderGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lVMOpInterfaceGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lVMOpsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lIREEOpsGen
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lMLIRStandardDialect
```

These should be included in `iree::compiler::Dialect::{Flow,HAL,VM;IREE}::IR` and `MLIRStandardOps`, which are included in the `_ALWAYSLINK_LIBS` libraries.

Since the OSS build is failing at the moment, it might be acceptable to go ahead with a merge anyway.
