### PR TITLE
Changes to make iree build with cmake with vm2 and llvm mono-repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(IREE_ENABLE_DEBUG "Enables debugging of the VM." ON)
+option(IREE_ENABLE_LLVM "Enables LLVM dependencies." ON)
 option(IREE_ENABLE_TRACING "Enables WTF tracing." OFF)
 
 option(IREE_BUILD_COMPILER "Builds the IREE compiler." ON)
@@ -36,6 +37,10 @@ option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 
 if(${IREE_BUILD_SAMPLES})
   set(IREE_BUILD_COMPILER ON CACHE BOOL "Build the IREE compiler for sample projects." FORCE)
+endif()
+
+if(${IREE_BUILD_COMPILER})
+  set(IREE_ENABLE_LLVM ON CACHE BOOL "Enable LLVM dependencies if the IREE compiler is build." FORCE)
 endif()
 
 #-------------------------------------------------------------------------------
@@ -83,9 +88,12 @@ add_subdirectory(third_party/abseil-cpp EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
 
-if(${IREE_BUILD_COMPILER})
+if(${IREE_ENABLE_LLVM})
   add_subdirectory(third_party/llvm-project/llvm EXCLUDE_FROM_ALL)
   include(external_tablegen_library)
+endif()
+
+if(${IREE_BUILD_COMPILER})
   add_subdirectory(build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla EXCLUDE_FROM_ALL)
 endif()
 
@@ -108,11 +116,19 @@ add_subdirectory(iree/base)
 add_subdirectory(iree/hal)
 add_subdirectory(iree/schemas)
 add_subdirectory(iree/testing)
-add_subdirectory(iree/vm)
+
+if(${IREE_ENABLE_LLVM})
+  # The VM requires LLVM to build its op definitions.
+  add_subdirectory(iree/vm)
+endif()
 
 if(${IREE_BUILD_COMPILER})
   add_subdirectory(third_party/glslang EXCLUDE_FROM_ALL)
   add_subdirectory(iree/compiler)
+elseif(${IREE_ENABLE_LLVM})
+  # If not building the compiler, tablegen is still needed
+  # to generate vm ops so deep include it only.
+  add_subdirectory(iree/compiler/Dialect/VM/Tools)
 endif()
 
 add_subdirectory(iree/tools)

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -145,7 +145,7 @@ function(iree_cc_binary)
     )
   endif()
 
-  # Add all IREE targets to a a folder in the IDE for organization.
+  # Add all IREE targets to a folder in the IDE for organization.
   set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/binaries)
 
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -127,7 +127,7 @@ function(iree_cc_library)
         set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
       endif()
 
-      # Add all IREE targets to a a folder in the IDE for organization.
+      # Add all IREE targets to a folder in the IDE for organization.
       if(_RULE_PUBLIC)
         set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER})
       elseif(_RULE_TESTONLY)

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -93,7 +93,7 @@ function(iree_cc_test)
     PRIVATE
       ${_RULE_LINKOPTS}
   )
-  # Add all IREE targets to a a folder in the IDE for organization.
+  # Add all IREE targets to a folder in the IDE for organization.
   set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
 
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -108,32 +108,26 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # Third party: llvm/mlir
 #-------------------------------------------------------------------------------
 
-set(LLVM_INCLUDE_EXAMPLES OFF)
-set(LLVM_INCLUDE_TESTS OFF)
-set(LLVM_INCLUDE_BENCHMARKS OFF)
-set(LLVM_APPEND_VC_REV OFF)
-set(LLVM_ENABLE_IDE ON)
-set(LLVM_ENABLE_RTTI ON)
+set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
+set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(LLVM_APPEND_VC_REV OFF CACHE BOOL "" FORCE)
+set(LLVM_ENABLE_IDE ON CACHE BOOL "" FORCE)
+set(LLVM_ENABLE_RTTI ON CACHE BOOL "" FORCE)
 
-set(LLVM_TARGETS_TO_BUILD "WebAssembly")
+set(LLVM_TARGETS_TO_BUILD "WebAssembly" CACHE STRING "" FORCE)
 
-set(LLVM_ENABLE_PROJECTS "")
-set(LLVM_EXTERNAL_PROJECTS "MLIR")
-set(LLVM_EXTERNAL_MLIR_SOURCE_DIR "${IREE_ROOT_DIR}/third_party/mlir/")
-set(LLVM_ENABLE_BINDINGS OFF)
+set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "" FORCE)
+set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "" FORCE)
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/llvm/include
   ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/mlir/include
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/tools/MLIR/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/mlir/include
+  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include
 )
 
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
-set(MLIR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/mlir/include)
-set(MLIR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/mlir)
-set(MLIR_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/tools/MLIR)
-
 set(IREE_TABLEGEN_EXE iree-tblgen)
 
 #-------------------------------------------------------------------------------

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -31,9 +31,6 @@ iree_cc_library(
     "FlowOps.cpp.inc"
     "FlowTypes.cpp"
   DEPS
-    FlowEnumsGen
-    FlowOpInterfaceGen
-    FlowOpsGen
     iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -26,11 +26,9 @@ iree_cc_library(
     "HALOpFolders.cpp"
     "HALOpInterface.cpp.inc"
     "HALOps.cpp"
+    "HALOps.cpp.inc"
     "HALTypes.cpp"
   DEPS
-    HALEnumsGen
-    HALOpInterfaceGen
-    HALOpsGen
     iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -26,7 +26,6 @@ iree_cc_library(
     "IREEOps.cpp"
     "IREEOps.cpp.inc"
   DEPS
-    IREEOpsGen
     LLVMSupport
     MLIRIR
     MLIRParser

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -34,10 +34,6 @@ iree_cc_library(
     "VMOps.cpp.inc"
     "VMTypes.cpp"
   DEPS
-    VMEnumsGen
-    VMOpEncoderGen
-    VMOpInterfaceGen
-    VMOpsGen
     iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR

--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -25,8 +25,7 @@ iree_cc_library(
     "CommonOps.cpp.inc"
   DEPS
     iree::compiler::Translation::Interpreter::IR::CommonOpsGen
-    iree::compiler::IR
-    iree::compiler::IR::OpsGen
+    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps

--- a/iree/hal/interpreter/CMakeLists.txt
+++ b/iree/hal/interpreter/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_cc_library(
     iree::hal::executable_spec
     iree::hal::interpreter::bytecode_kernels
     iree::hal::heap_buffer
+    iree::schemas::interpreter_module_def_cc_fbs
     iree::schemas::bytecode::interpreter_bytecode_v0
   PUBLIC
 )

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -12,6 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (${IREE_ENABLE_LLVM})
+  iree_cc_binary(
+    NAME
+      iree_tblgen
+    OUT
+      iree-tblgen
+    SRCS
+      "${IREE_ROOT_DIR}/third_party/llvm-project/mlir/tools/mlir-tblgen/mlir-tblgen.cpp"
+    DEPS
+      iree::compiler::Dialect::VM::Tools
+      LLVMMLIRTableGen
+      MLIRSupport
+      LLVMTableGen
+    LINKOPTS
+      "-lpthread"
+  )
+  add_executable(iree-tblgen ALIAS iree_tools_iree_tblgen)
+endif()
+
 if(${IREE_BUILD_COMPILER})
 
   # Additional libraries containing statically registered functions/flags, which
@@ -79,23 +98,6 @@ if(${IREE_BUILD_COMPILER})
 #      iree::hal::interpreter::interpreter_driver_module
 #      iree::hal::vulkan::vulkan_driver_module
 #    )
-
-  iree_cc_binary(
-    NAME
-      iree_tblgen
-    OUT
-      iree-tblgen
-    SRCS
-      "${IREE_ROOT_DIR}/third_party/mlir/tools/mlir-tblgen/mlir-tblgen.cpp"
-    DEPS
-      iree::compiler::Dialect::VM::Tools
-      LLVMMLIRTableGen
-      MLIRSupport
-      LLVMTableGen
-    LINKOPTS
-      "-lpthread"
-  )
-  add_executable(iree-tblgen ALIAS iree_tools_iree_tblgen)
 
   iree_cc_binary(
     NAME


### PR DESCRIPTION
* WIP.
* Adds a new flag for IREE_ENABLE_LLVM (default on) which bootstraps enough things to use tablegen for the VM.
* I expect a number more changes are needed to get the compiler working.
* Not completely right yet but can iterate more. Specifically, for some reason, cmake fails to generate its config on the first exec then succeeds on the second.
* With these changes I am able to do a clean build of VM2 and the LLVM mono-repo.