### PR TITLE
Remove broken GitHub action status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ to join/post/read messages on the
 
 CI System      | Build System | Platform | Status
 -------------- | ------------ | -------- | ------
-GitHub Actions | CMake        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22CMake+Build%22)*
-GitHub Actions | Bazel        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22Bazel+Build%22)*
+GitHub Actions | CMake        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22CMake+Build%22)
+GitHub Actions | Bazel        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22Bazel+Build%22)
 Kokoro         | Bazel        | Linux    | [![kokoro-status-bazel-linux](https://storage.googleapis.com/iree-oss-build-badges/bazel/build_status_linux.svg)](https://storage.googleapis.com/iree-oss-build-badges/bazel/build_result_linux.html)
-
-\* Due to a [bug in GitHub actions](https://github.community/t5/GitHub-Actions/Actions-Reporting-Wrong-Branch-on-Merges/td-p/36966) runs will frequently be tagged with the branch that was pushed from instead of the master branch. This also breaks the status badge.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ to join/post/read messages on the
 
 CI System      | Build System | Platform | Status
 -------------- | ------------ | -------- | ------
-GitHub Actions | CMake        | Linux    | [![github-cmake-linux-status](https://github.com/google/iree/workflows/CMake%20Build/badge.svg)](https://github.com/google/iree/actions?query=branch%3Amaster+event%3Apush+workflow%3A%22CMake+Build%22)
-GitHub Actions | Bazel        | Linux    | [![github-bazel-linux-status](https://github.com/google/iree/workflows/Bazel%20Build/badge.svg)](https://github.com/google/iree/actions?query=branch%3Amaster+event%3Apush+workflow%3A%22Bazel+Build%22)
+GitHub Actions | CMake        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22CMake+Build%22)*
+GitHub Actions | Bazel        | Linux    | [Workflow History](https://github.com/google/iree/actions?query=event%3Apush+workflow%3A%22Bazel+Build%22)*
 Kokoro         | Bazel        | Linux    | [![kokoro-status-bazel-linux](https://storage.googleapis.com/iree-oss-build-badges/bazel/build_status_linux.svg)](https://storage.googleapis.com/iree-oss-build-badges/bazel/build_result_linux.html)
+
+\* Due to a [bug in GitHub actions](https://github.community/t5/GitHub-Actions/Actions-Reporting-Wrong-Branch-on-Merges/td-p/36966) runs will frequently be tagged with the branch that was pushed from instead of the master branch. This also breaks the status badge.
 
 ## Quickstart
 


### PR DESCRIPTION
GitHub actions have a [bug](https://github.community/t5/GitHub-Actions/Actions-Reporting-Wrong-Branch-on-Merges/td-p/36966) where workflow runs are tagged with the branch that a merge came from. This breaks the status badge and makes it unusable because it can only be for a single branch. I also changed the link to point at all runs with the "push" event, since it breaks that search as well. Right now, this contains pushes to the ci-test branch, but we can remove this trigger. CMake already runs on all PRs and we can make Bazel run on PRs from ci-test.