### PR TITLE
Don't run actions on pushes to ci-test

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - master
-      - ci-test # A branch specifically for testing CI
 
 jobs:
   linux:

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - master
-      - ci-test # A branch specifically for testing CI
   pull_request:
     types: [opened, ready_for_review, synchronize]
 


### PR DESCRIPTION
To work around a [bug in GitHub actions](https://github.community/t5/GitHub-Actions/Actions-Reporting-Wrong-Branch-on-Merges/td-p/36966), https://github.com/google/iree/pull/395 makes our CI status look at all push events. We don't want pushes to ci-test to get mixed up with pushes to master. To get the bazel build to run on unsubmitted code, people will have to edit the workflow definition as part of a PR (I don't see any other way around it :-/).

Tested:
The bazel build action doesn't run on this PR and the cmake one only runs with the event label pull_request.