### PR TITLE
Enable testing via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ endif()
 
 if(${IREE_BUILD_TESTS})
   add_subdirectory(third_party/benchmark EXCLUDE_FROM_ALL)
+  enable_testing(iree)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -77,13 +77,13 @@ endif()
 # Third party: benchmark
 #-------------------------------------------------------------------------------
 
-set(BENCHMARK_ENABLE_TESTING OFF)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 
 #-------------------------------------------------------------------------------
 # Third party: flatbuffers
 #-------------------------------------------------------------------------------
 
-set(FLATBUFFERS_BUILD_TESTS OFF)
+set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_INSTALL OFF)
 set(FLATBUFFERS_BUILD_FLATC ON)
 set(FLATBUFFERS_BUILD_FLATHASH OFF)
@@ -103,7 +103,7 @@ list(APPEND IREE_DEFAULT_COPTS ${FLATBUFFERS_COPTS})
 # Third party: glslang
 #-------------------------------------------------------------------------------
 
-set(ENABLE_CTEST OFF)
+set(ENABLE_CTEST OFF CACHE BOOL "" FORCE)
 
 #-------------------------------------------------------------------------------
 # Third party: gtest


### PR DESCRIPTION
This forces to disable testing for the submodules

* benchmark
* flatbuffers
* glslang

Testing for the iree subdirectory is enabled in the main CMake configuration.