### PR TITLE
Exclude python binding tests from Kokoro CI

### DIFF
--- a/bindings/python/pyiree/common/BUILD
+++ b/bindings/python/pyiree/common/BUILD
@@ -31,6 +31,7 @@ pybind_cc_library(
         "binding.h",
         "status_utils.h",
     ],
+    tags = ["nokokoro"],
     deps = [
         "//iree/base:api",
         "//iree/base:status",

--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -48,6 +48,7 @@ py_library(
         "conditional_tensorflow.py",
     ],
     srcs_version = "PY3",
+    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -62,6 +63,7 @@ iree_py_extension(
     copts = PYBIND_COPTS + PYBIND_EXTENSION_COPTS,
     features = PYBIND_FEATURES,
     linkstatic = 1,
+    tags = ["nokokoro"],
     win_def_file = "export.def",
     deps = [
         ":compiler_library",
@@ -78,6 +80,7 @@ pybind_cc_library(
     hdrs = [
         "compiler.h",
     ],
+    tags = ["nokokoro"],
     deps = COMPILER_DEPS + [
         "//bindings/python/pyiree/common",
         "@llvm-project//llvm:support",
@@ -91,6 +94,7 @@ py_test(
     name = "compiler_test",
     srcs = ["compiler_test.py"],
     python_version = "PY3",
+    tags = ["nokokoro"],
     deps = NUMPY_DEPS + [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",

--- a/bindings/python/pyiree/rt/BUILD
+++ b/bindings/python/pyiree/rt/BUILD
@@ -40,6 +40,7 @@ py_library(
         "system_api.py",
     ],
     srcs_version = "PY3",
+    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -80,6 +81,7 @@ pybind_cc_library(
         "host_types.h",
         "vm.h",
     ],
+    tags = ["nokokoro"],
     deps = [
         "//bindings/python/pyiree/common",
         "//iree/base:api",

--- a/bindings/python/pyiree/tf/support/BUILD
+++ b/bindings/python/pyiree/tf/support/BUILD
@@ -28,6 +28,7 @@ py_library(
         "tf_test_driver.py",
         "tf_test_utils.py",
     ],
+    tags = ["nokokoro"],
     deps = INTREE_TENSORFLOW_PY_DEPS + [
         "//bindings/python/pyiree/compiler",
         "//bindings/python/pyiree/rt",


### PR DESCRIPTION
When these got moved around, some of these exclusions were dropped. These tests don't build on Kokoro+RBE yet.

Since we have big directory exclusions, we could move back to a hybrid path/tag exclusion mechanism. This is a bit cumbersome for excluding every target in a directory. It's nice for fine-grained control if we start to support some of these though.