### PR TITLE
CMake: Switch status matchers gtest dependency to use iree shim

### DIFF
--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -130,8 +130,8 @@ iree_cc_library(
     "status_matchers.h"
   DEPS
     iree::base::status
+    iree::testing::gtest
     absl::strings
     absl::optional
-    gtest
   TESTONLY
 )


### PR DESCRIPTION
Adopt changes introduced with 0255a39 to Bazel for CMake. Apologies for not having mentioned that in #409.