### PR TITLE
Fix submodule versions import and check

### DIFF
--- a/git_scripts/submodule_versions.py
+++ b/git_scripts/submodule_versions.py
@@ -112,21 +112,17 @@ def import_versions(repo_dir):
     command = ["git", "update-index", "--cacheinfo", "160000", written, path]
     print("Updating", path, "to", written)
     utils.execute(command, cwd=repo_dir)
-    # It should not be technically necessary to also do an add here. However
-    # it seemed that this kept a subsequent submodule update from overwriting
-    # the change.
-    # TODO(laurenzo): Triage this further with actual updates.
-    utils.execute(["git", "add", path], cwd=repo_dir)
 
 
 def check_submodule_versions(repo_dir):
   diff_versions = get_diff_versions(repo_dir)
   if diff_versions:
-    print("Submodule versions need to be exported. Run (and commit):")
-    print("  ./build_tools/scripts/submodule_util write export")
+    print("Submodule state differs from SUBMODULE_VERSIONS file. Run (and commit) one of:")
+    print("  ./git_scripts/submodule_versions.py import # Use version in SUBMODULE_VERSIONS")
+    print("  ./git_scripts/submodule_versions.py export # Use version in git state")
     for k, (current, written) in diff_versions.items():
       print("%s : actual=%s written=%s" % (k, current, written))
-      return False
+    return False
   return True
 
 


### PR DESCRIPTION
A few little bugs here:
1. The `git add` after `git update-index` actually seems to revert the submodule changes. Removed it.
2. The error message for `check` pointed to the old script location and only suggested export.
3. `check` returned before all diffs had been printed because the return was indented too far (thanks Python).
4. `check` printed diffs in a non-deterministic order because dictionaries. Not a huge deal, but figured determinism was nice.

Tested:
Demo that this works now
https://pastebin.com/zrt4PxzX