### PR TITLE
Add action to automatically update submodules

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sets submodule state to the one specified in SUBMODULE_VERSIONS
+
+name: Synchronize Submodules
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Updating submodules
+        run: git submodule update --init --depth 1000 --jobs 8
+      - name: Synchronizing submodules
+        run: ./git_scripts/submodule_versions.py import
+      - name: Committing updates
+        run: |
+          # Only commit if there's a diff.
+          if ! git diff --cached --exit-code; then
+            git config --local user.email "noreply+action@github.com"
+            git config --local user.name "Submodule Synchronize Action"
+            git commit -am "Synchronize submodules"
+          else
+            echo "Submodules already up to date"
+          fi
+      - name: Pushing changes
+        # Will push regardless, but exit successfully if already up to date with master
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
This will run after every push to master and synchronize the submodule state, using SUBMODULE_VERSIONS as the source of truth.

Due to constraints with the synchronization tooling from upstream, we cannot push a submodule update from upstream atomically. This will follow fast behind and synchronize the submodules.

There is the risk of races here with other things committing:
1. If this action doesn't finish pushing before another push occurs from elsewhere, it may fail (it will not force push). Since it will try again on the next push, this seems not too bad, and the price we must pay for using eventual consistency instead of atomic updates.
2. If this action completes a push and other automation is trying to push based on the previous HEAD, that automation may fail because the push would not be a fastfoward. In that case, we would also have to rely on the automation eventually retrying.

Let's try to avoid using this where possible (just update submodules as normal), but it does make upstream submodule updates possible, which seems nice.

Tested:
I tried this out in my fork using changes that did and did not update the SUBMODULE_VERSIONS file. You can see the history in this branch: https://github.com/GMNGeoffrey/iree/commits/submodule-autoupdate-demo (I actually did all this on master, but pulled it into a branch to preserve it). I'll leave the branch around for a while.