### PR TITLE
Adjust CMake configuration to reflect changes introduced with PR #383

### DIFF
--- a/iree/modules/hal/CMakeLists.txt
+++ b/iree/modules/hal/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     iree::hal::command_queue
     iree::hal::device
     iree::vm
+    iree::vm::module_abi_cc
     absl::core_headers
     absl::memory
     absl::strings

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -182,6 +182,7 @@ iree_cc_library(
     iree::vm::module
     iree::vm::ref
     iree::vm::stack
+    iree::vm::types
     iree::base::api
     iree::base::api_util
     iree::base::ref_ptr


### PR DESCRIPTION
Switching the HAL module to the new C++ ABI binding introduces new deps. This can also be safley merged prior to PR #383.