### PR TITLE
CMake module related fixes

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -53,7 +53,7 @@ function(iree_bytecode_module)
     if(DEFINED _RULE_TRANSLATION_TOOL)
       set(_TRANSLATION_TOOL ${_RULE_TRANSLATION_TOOL})
     else()
-      set(_TRANSLATION_TOOL "iree_tools_iree_translate")
+      set(_TRANSLATION_TOOL "iree_tools_iree-translate")
     endif()
 
     # Resolve the executable binary path from the target name.

--- a/build_tools/cmake/iree_cc_embed_data.cmake
+++ b/build_tools/cmake/iree_cc_embed_data.cmake
@@ -79,7 +79,7 @@ function(iree_cc_embed_data)
     add_custom_command(
       OUTPUT "${_RULE_H_FILE_OUTPUT}" "${_RULE_CC_FILE_OUTPUT}"
       COMMAND generate_cc_embed_data ${_ARGS}
-      DEPENDS generate_cc_embed_data ${_RULE_SRCS}
+      DEPENDS generate_cc_embed_data ${_RULE_SRCS} ${_RULE_GENERATED_SRCS}
     )
 
     iree_cc_library(

--- a/build_tools/cmake/iree_cc_embed_data.cmake
+++ b/build_tools/cmake/iree_cc_embed_data.cmake
@@ -72,7 +72,7 @@ function(iree_cc_embed_data)
     foreach(SRC ${_RULE_SRCS})
       list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${SRC}")
     endforeach(SRC)
-    foreach(SRC ${_GENERATED_SRCS})
+    foreach(SRC ${_RULE_GENERATED_SRCS})
       list(APPEND _ARGS "${SRC}")
     endforeach(SRC)
 

--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(simple_embedding)
+#add_subdirectory(simple_embedding)

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -88,7 +88,7 @@ iree_bytecode_module(
   NAME
     bytecode_module_benchmark_module
   SRC
-    "bytecode_module_benchmark_module.mlir"
+    "bytecode_module_benchmark.mlir"
   CC_NAMESPACE
     "iree::vm"
   TRANSLATION


### PR DESCRIPTION
Due to a bug in `iree_cc_embed_data`, the files `{conv2d_nhwc,matmul,reduce_untiled}.spv` files were not generated from `iree/compiler/Translation/SPIRV/EmbeddedKernels/Kernels/{conv2d_nhwc,matmul,reduce_untiled}.comp`. This is now fixed and revealed some other issues, now also fixed.

Unfortunately, also the `simple_embedding` is broken and building it is therefore disabled. This will be reported in a separate issue.