### PR TITLE
A GitHub action that prints out the author of a PR

### DIFF
--- a/.github/workflows/kokoro_labeler.yml
+++ b/.github/workflows/kokoro_labeler.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/kokoro_labeler.yml
+++ b/.github/workflows/kokoro_labeler.yml
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This action is a temporary test to see how the copybara-service app author
+# gets printed in github actions. I suspect it may be different for apps.
+
+name: Author Printer
+
+on: [pull_request]
+
+jobs:
+  print_author:
+    runs-on: ubuntu-18.04
+    env:
+      AUTHOR: ${{ github.actor }}
+    steps:
+      - name: Printing author
+        run: echo "$AUTHOR"


### PR DESCRIPTION
I'm writing an action to auto-label PRs from the copybara app with "kokoro:run" so we don't have to keep doing it manually. I need to be able to filter for just the service because otherwise the action would try to label all PRs. For PRs coming from the main repo, this would just be redundant (everyone else with write access is a collaborator, so kokoro will run automatically) and may make kokoro confused. For PRs coming from forks it would just fail because they don't have the token to apply labels (GitHub's actions work terribly with forks).

So yeah testing in prod. I don't have any way to get the copybara app to send PRs to my fork. I could just write the action and hope, but I have this suspicion that I'll get it wrong. This action is pretty harmless.