### PR TITLE
Add GitHub workflow that labels copybara app PRs to trigger kokoro

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Label everything with the "kokoro:run" label.
+# See details in .github/workflows/kokoro_labeler.yml
+
+kokoro:run:
+  - '**'      # Normal files in the repository, e.g. "README.md", "iree/BUILD.bazel"
+  - '.*'      # Dot files at the root level, e.g. ".bazelrc", ".gitignore"
+  - '.*/**'   # Files in dotted directories, e.g. .github/labeler.yml

--- a/.github/workflows/kokoro_labeler.yml
+++ b/.github/workflows/kokoro_labeler.yml
@@ -12,18 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This action is a temporary test to see how the copybara-service app author
-# gets printed in github actions. I suspect it may be different for apps.
+# Trigger Kokoro runs on PRs coming from upstream changes.
+#
+# This is achieved by labeling them with "kokoro:run".
+#
+# For security, Kokoro does not run automatically on all PRs (since that
+# would grant RCE), but it does run automatically on PRs from collaborators
+# and Google organization members. Unfortunately, GitHub apps appear to be
+# impossible to register as either.
+#
+# The labeler action requires a GITHUB_TOKEN with write access to the
+# repository. PRs from forks run within the fork and only receive a token
+# with read access (for security reasons). Thus the label step would fail.
+# The entire job is conditioned on the PR author being the copybara app, so
+# it simply shouldn't run on these other PRs.
 
-name: Author Printer
+name: Kokoro Labeler
 
 on: [pull_request]
 
 jobs:
-  print_author:
+  label_pr:
+    if: github.actor == 'copybara-service[bot]'
     runs-on: ubuntu-18.04
-    env:
-      AUTHOR: ${{ github.actor }}
     steps:
-      - name: Printing author
-        run: echo "$AUTHOR"
+      - name: Adding label
+        uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Per the giant comment in the workflow file, this does not present a security risk because it will only run on PRs coming from the main repo.

For security, Kokoro does not run automatically on all PRs (since that would grant RCE), but it does run automatically on PRs from collaborators and Google organization members. Unfortunately, GitHub apps appear to be impossible to register as either.

The labeler action requires a GITHUB_TOKEN with write access to the repository. PRs from forks run within the fork and only receive a token with read access (for security reasons). Thus the label step would fail. The entire job is conditioned on the PR author being the copybara app, so it simply shouldn't run on these other PRs.