### PR TITLE
Let CMake build position independent code by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ include(iree_bytecode_module)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
 #-------------------------------------------------------------------------------
 # Third-party dependencies
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Configure CMake to compile static libraries with position independent code, as discussed in #451.

Closes #451.