### PR TITLE
Make it easier to switch cmake binaries in build script

### DIFF
--- a/build_tools/scripts/cmake_build.sh
+++ b/build_tools/scripts/cmake_build.sh
@@ -19,11 +19,13 @@ set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-cmake --version
+CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+
+"$CMAKE_BIN" --version
 
 cd ${ROOT_DIR?}
 rm -rf build/
 mkdir build && cd build
-cmake -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
-cmake --build .
+"$CMAKE_BIN" -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
+"$CMAKE_BIN" --build .
 rm -rf build/


### PR DESCRIPTION
There are a lot of things that work differently depending on the cmake version. This makes it easier to swap out the binary for testing locally.