### PR TITLE
Add action to check submodule state on PRs

### DIFF
--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -1,0 +1,30 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Checks that the submodule state in SUBMODULE_VERSIONS matches `git submodule status`
+
+name: Check Submodules
+
+on: [pull_request]
+
+jobs:
+  submodules:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Updating submodules
+        run: git submodule update --init --depth 1000 --jobs 8
+      - name: Checking submodules
+        run: ./git_scripts/submodule_versions.py check


### PR DESCRIPTION
This will confirm that submodule state between `git submodule status` and SUBMODULE_VERSIONS matches.