### PR TITLE
Make actions import from SUBMODULE_VERSIONS

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -48,8 +48,8 @@ jobs:
           sudo python3 -m pip install numpy tf-nightly
       - name: Checking out repository
         uses: actions/checkout@v2
-      - name: Updating submodules
-        run: git submodule update --init --depth 1000 --jobs 8
+      - name: Initializing submodules
+        run: ./git_scripts/submodule_versions.py init
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -36,7 +36,7 @@ jobs:
           sudo pip install numpy
       - name: Checking out repository
         uses: actions/checkout@v2
-      - name: Updating submodules
-        run: git submodule update --init --depth 1000 --jobs 8
+      - name: Initializing submodules
+        run: ./git_scripts/submodule_versions.py init
       - name: Building with cmake
         run: ./build_tools/scripts/cmake_build.sh

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -27,10 +27,8 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
-      - name: Updating submodules
-        run: git submodule update --init --depth 1000 --jobs 8
-      - name: Synchronizing submodules
-        run: ./git_scripts/submodule_versions.py import
+      - name: Initializing submodules
+        run: ./git_scripts/submodule_versions.py init
       - name: Committing updates
         run: |
           # Only commit if there's a diff.


### PR DESCRIPTION
This allows originating submodule changes from upstream. The submodule version check will fail on such a PR, but we can test what it will look like after the submodule sync action has made things consistent. Note that this may mean that if someone sends a PR that only updates submodules in the git state they'll get failing presubmits on build. The submodule check presubmit should mitigate the confusion there.

Depends on #471 