### PR TITLE
Make kokoro import from SUBMODULE_VERSIONS

### DIFF
--- a/kokoro/gcp_ubuntu/bazel_build.sh
+++ b/kokoro/gcp_ubuntu/bazel_build.sh
@@ -30,8 +30,8 @@ export PYTHON_BIN="$(which python3)"
 
 # Kokoro checks out the repository here.
 cd ${KOKORO_ARTIFACTS_DIR?}/github/iree
-echo "Checking out submodules"
-git submodule update --init --depth 1000 --jobs 8
+echo "Initializing submodules"
+./git_scripts/submodule_versions.py init
 
 echo "Building and testing with bazel"
 ./build_tools/scripts/bazel_build.sh


### PR DESCRIPTION
This allows originating submodule changes from upstream. The submodule version check will fail on such a PR, but we can test what it will look like after the submodule sync action has made things consistent. Note that this may mean that if someone sends a PR that only updates submodules in the git state they'll get failing presubmits on build. The submodule check presubmit should mitigate the confusion there.

Depends on #471 