### PR TITLE
Move static constexpr to namespace scope

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -58,13 +58,13 @@ class ModuleOpConversion : public OpConversionPattern<ModuleOp> {
   }
 };
 
+// Whitelist of function attributes to retain when converting to vm.func.
+constexpr std::array<const char *, 1> kRetainedAttributes = {
+    "iree.reflection",
+};
+
 class FuncOpConversion : public OpConversionPattern<FuncOp> {
   using OpConversionPattern::OpConversionPattern;
-
-  // Whitelist of function attributes to retain when converting to vm.func.
-  static constexpr std::array<const char *, 1> kRetainedAttributes = {
-      "iree.reflection",
-  };
 
   PatternMatchResult matchAndRewrite(
       FuncOp srcOp, ArrayRef<Value> operands,


### PR DESCRIPTION
A definition at namespace scope is required before C++17. Internally we're building with C++17 and in OSS we're building with opt, which means this gets inlined. We could keep the static declaration inside the class, but it seems not super useful if we have to redeclare it at namespace scope anyway.

See https://en.cppreference.com/w/cpp/language/static

Closes #475

Tested:
```
bazel query '//... except attr("tags", "nokokoro", //...)' | \
  xargs bazel test --test_env=IREE_VULKAN_DISABLE=$IREE_VULKAN_DISABLE\
   --compilation_mode=fastbuild \
    --define=iree_tensorflow=true \
    --config=rbe --config=rs \
    --keep_going --test_output=errors
```
https://source.cloud.google.com/results/invocations/f62f3bac-9ec4-427a-8834-b414d8b5c642