### PR TITLE
CMake: Support transitive ALWAYSLINK deps, update iree-translate rule.

### DIFF
--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -32,7 +32,6 @@ include(CMakeParseArguments)
 # INCLUDES: Include directories to add to dependencies
 # LINKOPTS: List of link options
 # ALWAYSLINK: Always link the library into any binary with a direct dep.
-#   TODO(scotttodd): Make transitive deps also respect ALWAYSLINK
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
 # Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC will be
 # in ${PACKAGE}/internal.

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -95,14 +95,13 @@ function(iree_cc_binary)
       ${_RULE_COPTS}
   )
 
-  # Split DEPS into two lists - one for whole archive (alwayslink) and one for
+  # List all dependencies, including transitive dependencies, then split the
+  # dependency list into one for whole archive (ALWAYSLINK) and one for
   # standard linking (which only links in symbols that are directly used).
-  #
-  # TODO(scotttodd): traverse transitive dependencies also (all direct
-  #                  dependencies of ALWAYSLINK libraries should be linked in)
+  _iree_transitive_dependencies("${_RULE_DEPS}" _TRANSITIVE_DEPS)
   set(_ALWAYS_LINK_DEPS "")
   set(_STANDARD_DEPS "")
-  foreach(_DEP ${_RULE_DEPS})
+  foreach(_DEP ${_TRANSITIVE_DEPS})
     # Check if _DEP is a library with the ALWAYSLINK property set.
     get_target_property(_DEP_TYPE ${_DEP} TYPE)
     if(${_DEP_TYPE} STREQUAL "INTERFACE_LIBRARY")
@@ -161,4 +160,61 @@ function(iree_cc_binary)
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
+endfunction()
+
+# Lists all transitive dependencies of DIRECT_DEPS in TRANSITIVE_DEPS.
+function(_iree_transitive_dependencies DIRECT_DEPS TRANSITIVE_DEPS)
+  set(_TRANSITIVE "")
+
+  foreach(_DEP ${DIRECT_DEPS})
+    _iree_transitive_dependencies_helper(${_DEP} _TRANSITIVE)
+  endforeach(_DEP)
+
+  set(${TRANSITIVE_DEPS} "${_TRANSITIVE}" PARENT_SCOPE)
+endfunction()
+
+# Recursive helper function for _iree_transitive_dependencies.
+# Performs a depth-first search through the dependency graph, appending all
+# dependencies of TARGET to the TRANSITIVE_DEPS list.
+function(_iree_transitive_dependencies_helper TARGET TRANSITIVE_DEPS)
+  if (NOT TARGET ${TARGET})
+    # Excluded from the project, or invalid name? Just ignore.
+    return()
+  endif()
+
+  # Resolve aliases, canonicalize name formatting.
+  get_target_property(_ALIASED_TARGET ${TARGET} ALIASED_TARGET)
+  if(_ALIASED_TARGET)
+    set(_TARGET_NAME ${_ALIASED_TARGET})
+  else()
+    string(REPLACE "::" "_" _TARGET_NAME ${TARGET})
+  endif()
+
+  set(_RESULT "${${TRANSITIVE_DEPS}}")
+  if (${_TARGET_NAME} IN_LIST _RESULT)
+    # Already visited, ignore.
+    return()
+  endif()
+
+  # Append this target to the list. Dependencies of this target will be added
+  # (if valid and not already visited) in recursive function calls.
+  list(APPEND _RESULT ${_TARGET_NAME})
+
+  # Get the list of direct dependencies for this target.
+  get_target_property(_TARGET_TYPE ${_TARGET_NAME} TYPE)
+  if(NOT ${_TARGET_TYPE} STREQUAL "INTERFACE_LIBRARY")
+    get_target_property(_TARGET_DEPS ${_TARGET_NAME} LINK_LIBRARIES)
+  else()
+    get_target_property(_TARGET_DEPS ${_TARGET_NAME} INTERFACE_LINK_LIBRARIES)
+  endif()
+
+  if(_TARGET_DEPS)
+    # Recurse on each dependency.
+    foreach(_TARGET_DEP ${_TARGET_DEPS})
+      _iree_transitive_dependencies_helper(${_TARGET_DEP} _RESULT)
+    endforeach(_TARGET_DEP)
+  endif()
+
+  # Propagate the augmented list up to the parent scope.
+  set(${TRANSITIVE_DEPS} "${_RESULT}" PARENT_SCOPE)
 endfunction()

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -28,7 +28,6 @@ include(CMakeParseArguments)
 # INCLUDES: Include directories to add to dependencies
 # LINKOPTS: List of link options
 # ALWAYSLINK: Always link the library into any binary with a direct dep.
-#   TODO(scotttodd): Make transitive deps also respect ALWAYSLINK
 # PUBLIC: Add this so that this library will be exported under iree::
 # Also in IDE, target will appear in IREE folder while non PUBLIC will be in IREE/internal.
 # TESTONLY: When added, this target will only be built if user passes -DIREE_BUILD_TESTS=ON to CMake.

--- a/iree/compiler/Dialect/Flow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/CMakeLists.txt
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 add_subdirectory(Analysis)
-add_subdirectory(Conversion/HLOToFlow)
-add_subdirectory(Conversion/StandardToFlow)
+add_subdirectory(Conversion)
 add_subdirectory(IR)
 add_subdirectory(Transforms)
 add_subdirectory(Utils)

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -36,7 +36,6 @@ iree_cc_library(
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
-  ALWAYSLINK
   PUBLIC
 )
 
@@ -48,7 +47,7 @@ iree_cc_library(
   SRCS
     "HALDialect.h"
   DEPS
-    IR
+    iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::hal_imports
     iree::compiler::Dialect::HAL::Conversion::HALToVM
     iree::compiler::Dialect::VM::Conversion

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -35,7 +35,7 @@ iree_cc_library(
     LLVMSupport
     MLIRIR
     MLIRPass
-    MLIRStandardDialectRegistration
+    MLIRStandardOps
     MLIRSupport
     MLIRTranslation
     tensorflow::mlir_xla

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -35,4 +35,5 @@ iree_cc_library(
     MLIRStandardToSPIRVTransforms
     MLIRSupport
     MLIRTransforms
+  ALWAYSLINK
 )

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -52,8 +52,7 @@ if(${IREE_BUILD_COMPILER})
   # Additional libraries containing statically registered functions/flags, which
   # should always be linked in to binaries.
   #
-  # TODO(scotttodd): Make the ALWAYSLINK property apply transitively and force
-  #                  MLIR libs to generally be ALWAYSLINK wherever used in IREE.
+  # TODO(scotttodd): Set MLIR libs to generally be ALWAYSLINK in IREE?
   set(_ALWAYSLINK_LIBS
     MLIRAffineOps
     MLIRAnalysis

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -51,8 +51,6 @@ if(${IREE_BUILD_COMPILER})
 
   # Additional libraries containing statically registered functions/flags, which
   # should always be linked in to binaries.
-  #
-  # TODO(scotttodd): Set MLIR libs to generally be ALWAYSLINK in IREE?
   set(_ALWAYSLINK_LIBS
     MLIRAffineOps
     MLIRAnalysis
@@ -67,11 +65,6 @@ if(${IREE_BUILD_COMPILER})
     MLIRTranslation
     MLIRSupport
     MLIRVectorOps
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::VM::IR
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::Interpreter::IR
     tensorflow::mlir_xla
   )
 
@@ -115,19 +108,32 @@ if(${IREE_BUILD_COMPILER})
 #      iree::hal::vulkan::vulkan_driver_module
 #    )
 
+  iree_cc_library(
+    NAME
+      iree_translate_library
+    SRCS
+      "translate_main.cc"
+    DEPS
+      ${_ALWAYSLINK_LIBS}
+      iree::compiler::Dialect::Flow::Conversion
+      iree::compiler::Dialect::HAL::Conversion
+      iree::compiler::Dialect::HAL::Target::LegacyInterpreter
+      iree::compiler::Dialect::HAL::Target::VulkanSPIRV
+      iree::compiler::Dialect::VM::Target::Bytecode
+      iree::compiler::Translation::IREEVM
+      iree::compiler::Translation::SPIRV::XLAToSPIRV
+      LLVMSupport
+      MLIRTranslateClParser
+    ALWAYSLINK
+  )
+
   iree_cc_binary(
     NAME
       iree-translate
     OUT
       iree-translate
-    SRCS
-      "translate_main.cc"
     DEPS
-      ${_ALWAYSLINK_LIBS}
-      iree::compiler::Dialect::VM::Target::Bytecode
-      iree::compiler::Translation::SPIRV::LinalgToSPIRV
-      iree::compiler::Translation::SPIRV::XLAToSPIRV
-      MLIRTranslateClParser
+      iree::tools::iree_translate_library
   )
   add_executable(iree-translate ALIAS iree_tools_iree-translate)
 


### PR DESCRIPTION
`iree_cc_binary` now walks the dependency graph to enumerate all direct and indirect/transitive dependencies, then splits that full list into ALWAYSLINK and default link lists.

I also split `iree-translate` into `iree_translate_library` and `iree-translate`, matching Bazel. The options on `iree-translate` when built with Bazel and with CMake are _almost_ identical now - the SPIR-V flags are slightly different. I wanted to make the `iree-translate` changes separately, but linker issues prompted me to fold them into this PR.

Fixes #190 
Fixes #443
Progress on #393