### PR TITLE
Remove reference to undefined CMake target.

### DIFF
--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -49,7 +49,6 @@ iree_cc_library(
     "HALDialect.h"
   DEPS
     IR
-    iree::compiler::Dialect
     iree::compiler::Dialect::HAL::hal_imports
     iree::compiler::Dialect::HAL::Conversion::HALToVM
     iree::compiler::Dialect::VM::Conversion


### PR DESCRIPTION
Hoping this fixes the CMake build break introduced around https://github.com/google/iree/commit/e6fc67c37d53aee7bd5b00a14563fcf919e45446 (see https://github.com/google/iree/runs/391619176)