### PR TITLE
Add kokoro build configuration for cmake

### DIFF
--- a/kokoro/gcp_ubuntu/continuous_cmake.cfg
+++ b/kokoro/gcp_ubuntu/continuous_cmake.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for Kokoro build that runs cmake on pushes to master.
+
+build_file: "iree/kokoro/gcp_ubuntu/cmake_build.sh"


### PR DESCRIPTION
Later, I'll rename the bazel configs so they include that in the name.