### PR TITLE
Add initial CMake configuration custom_modules sample

### DIFF
--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(marbre): Add once custom-translate runs without errors
+#add_subdirectory(custom_mdules)
+
 #add_subdirectory(simple_embedding)

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(dialect)
+
+iree_bytecode_module(
+  NAME
+    custom_modules_test_module
+  SRC
+    "custom_modules_test.mlir"
+  CC_NAMESPACE
+    "iree::samples::custom_modules"
+  TRANSLATION_TOOL
+    iree::samples::custom_modules::dialect::custom-translate
+  TRANSLATION
+    "-iree-mlir-to-vm-bytecode-module"
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    custom_modules_test
+  SRCS
+    "custom_modules_test.cc"
+  DEPS
+    iree::samples::custom_modules::custom_modules_test_module_cc
+    iree::samples::custom_modules::native_module
+    iree::base::api
+    iree::base::logging
+    iree::testing::gtest_main
+    iree::vm
+    iree::vm::bytecode_module
+    iree::vm::ref
+    absl::core_headers
+    absl::strings
+)
+
+iree_cc_library(
+  NAME
+    native_module
+  HDRS
+    "native_module.h"
+  SRCS
+    "native_module.cc"
+  DEPS
+    iree::base::api
+    iree::base::api_util
+    iree::base::buffer_string_util
+    iree::hal::api
+    iree::modules::hal
+    iree::vm
+    iree::vm::module_abi_cc
+  PUBLIC
+)

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -22,7 +22,7 @@ iree_bytecode_module(
   CC_NAMESPACE
     "iree::samples::custom_modules"
   TRANSLATION_TOOL
-    iree::samples::custom_modules::dialect::custom-translate
+    iree_samples_custom_modules_dialect_custom-translate
   TRANSLATION
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_cc_library(
+  NAME
+    dialect
+  HDRS
+    "conversion_patterns.h"
+    "custom_dialect.h"
+    "custom_ops.h.inc"
+  SRCS
+    "conversion_patterns.cc"
+    "custom_dialect.cc"
+    "custom_ops.cc.inc"
+  DEPS
+    iree::samples::custom_modules::dialect::custom_imports
+    iree::compiler::Dialect::HAL::Conversion
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
+    LLVMSupport
+    MLIRIR
+    MLIRParser
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    custom_ops_gen
+  SRCS
+    custom_ops.td
+  OUTS
+    -gen-op-decls custom_ops.h.inc
+    -gen-op-defs custom_ops.cc.inc
+)
+
+iree_cc_embed_data(
+  NAME
+    custom_imports
+  SRCS
+    "custom.imports.mlir"
+  CC_FILE_OUTPUT
+    "custom.imports.cc"
+  H_FILE_OUTPUT
+    "custom.imports.h"
+  CPP_NAMESPACE
+    "mlir::iree_compiler::IREE::Custom"
+  FLATTEN
+)
+
+iree_cc_binary(
+  NAME
+    custom-opt
+  DEPS
+    iree::samples::custom_modules::dialect
+    iree::tools::iree_opt_library
+    MLIROptMain
+)
+
+iree_cc_binary(
+  NAME
+    custom-translate
+  DEPS
+    iree::samples::custom_modules::dialect
+    iree::tools::iree_translate_library
+)

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -75,6 +75,8 @@ iree_cc_binary(
 iree_cc_binary(
   NAME
     custom-translate
+  OUT
+    custom-translate
   DEPS
     iree::samples::custom_modules::dialect
     iree::tools::iree_translate_library


### PR DESCRIPTION
* Adds an initial CMake configuration for `iree::samples::custom_modules`
* Intended as a work-basis
* Subdirectory is not yet included in upper level CMakeLists, because the execution of `custom-translate` currently fails