### PR TITLE
Initial support to build pybind libraries with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(IREE_BUILD_COMPILER "Builds the IREE compiler." ON)
 option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
+option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 
 if(${IREE_BUILD_SAMPLES})
   set(IREE_BUILD_COMPILER ON CACHE BOOL "Build the IREE compiler for sample projects." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
+  ${CMAKE_CURRENT_LIST_DIR}/bindings/python/build_tools/cmake/
   ${CMAKE_CURRENT_LIST_DIR}/third_party/abseil-cpp/absl/copts/
 )
 
@@ -63,6 +64,7 @@ include(iree_bytecode_module)
 include(iree_glslang)
 include(iree_glsl_vulkan)
 include(iree_spirv_kernel_cc_library)
+include(iree_pybind_cc_library)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,10 @@ if(${IREE_BUILD_TESTS})
   enable_testing(iree)
 endif()
 
+if(${IREE_BUILD_PYTHON_BINDINGS})
+  add_subdirectory(third_party/pybind11 EXCLUDE_FROM_ALL)
+endif()
+
 #-------------------------------------------------------------------------------
 # IREE top-level libraries
 #-------------------------------------------------------------------------------
@@ -167,6 +171,10 @@ elseif(${IREE_ENABLE_LLVM})
   # If not building the compiler, tablegen is still needed
   # to generate vm ops so deep include it only.
   add_subdirectory(iree/compiler/Dialect/VM/Tools)
+endif()
+
+if(${IREE_BUILD_PYTHON_BINDINGS})
+  add_subdirectory(bindings/python)
 endif()
 
 add_subdirectory(iree/tools)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(NUMPY_DEPS "")
+
+# TODO(marbre): Set PYTHON_HEADERS_DEPS to something useful
+set(PYTHON_HEADERS_DEPS "")
+set(PYBIND_COPTS "-fexceptions")
+set(PYBIND_EXTENSION_COPTS "-fvisibility=hidden")
+
+add_subdirectory(pyiree)

--- a/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
@@ -27,7 +27,7 @@ include(CMakeParseArguments)
 # DEFINES: List of public defines
 # INCLUDES: Include directories to add to dependencies
 # LINKOPTS: List of link options
-# TYPE: Type of library to be crated: either "MODULE" or "SHARED" (default).
+# TYPE: Type of library to be crated: either "MODULE", "SHARED" or "STATIC" (default).
 # TESTONLY: When added, this target will only be built if user passes -DIREE_BUILD_TESTS=ON to CMake.
 
 function(iree_pybind_cc_library)
@@ -46,11 +46,11 @@ function(iree_pybind_cc_library)
     set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
     if(NOT _RULE_TYPE)
-      set(_RULE_TYPE "SHARED")
+      set(_RULE_TYPE "STATIC")
     endif()
 
     string(TOUPPER "${_RULE_TYPE}" _uppercase_RULE_TYPE)
-    if(NOT _uppercase_RULE_TYPE MATCHES "^(SHARED|MODULE)")
+    if(NOT _uppercase_RULE_TYPE MATCHES "^(STATIC|SHARED|MODULE)")
       message(FATAL_ERROR "Unsported library TYPE for iree_pybind_cc_library: ${_RULE_TYPE}")
     endif()
 
@@ -103,9 +103,10 @@ function(iree_pybind_cc_library)
     set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
     set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
-    set_property(TARGET ${_NAME} PROPERTY PREFIX "${PYTHON_MODULE_PREFIX}")
-    set_property(TARGET ${_NAME} PROPERTY SUFFIX "${PYTHON_MODULE_EXTENSION}")
-
+    if(NOT _uppercase_RULE_TYPE MATCHES "STATIC")
+      set_property(TARGET ${_NAME} PROPERTY PREFIX "${PYTHON_MODULE_PREFIX}")
+      set_property(TARGET ${_NAME} PROPERTY SUFFIX "${PYTHON_MODULE_EXTENSION}")
+    endif()
 
     # Alias the iree_package_name library to iree::package::name.
     # This lets us more clearly map to Bazel and makes it possible to

--- a/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
@@ -65,6 +65,7 @@ function(iree_pybind_cc_library)
         "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
         "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
       PRIVATE
+        # TODO(marbre): Check if both pybind includes are necessary
         ${PYBIND11_INCLUDE_DIR}
         ${pybind11_INCLUDE_DIR} 
         ${PYTHON_INCLUDE_DIRS}

--- a/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
@@ -1,0 +1,122 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeParseArguments)
+
+# iree_pybind_cc_library()
+#
+# CMake function to imitate Bazel's pybind_cc_library rule.
+#
+# Parameters:
+# NAME: name of target
+# HDRS: List of public header files for the library
+# SRCS: List of source files for the library
+# DEPS: List of other libraries to be linked in to the binary targets
+# COPTS: List of private compile options
+# DEFINES: List of public defines
+# INCLUDES: Include directories to add to dependencies
+# LINKOPTS: List of link options
+# TYPE: Type of library to be crated: either "MODULE" or "SHARED" (default).
+# TESTONLY: When added, this target will only be built if user passes -DIREE_BUILD_TESTS=ON to CMake.
+
+function(iree_pybind_cc_library)
+
+  cmake_parse_arguments(
+    _RULE
+    "TESTONLY"
+    "NAME"
+    "HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS;INCLUDES;TYPE"
+    ${ARGN}
+  )
+
+  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
+    # Prefix the library with the package name, so we get: iree_package_name.
+    iree_package_name(_PACKAGE_NAME)
+    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+    if(NOT _RULE_TYPE)
+      set(_RULE_TYPE "SHARED")
+    endif()
+
+    string(TOUPPER "${_RULE_TYPE}" _uppercase_RULE_TYPE)
+    if(NOT _uppercase_RULE_TYPE MATCHES "^(SHARED|MODULE)")
+      message(FATAL_ERROR "Unsported library TYPE for iree_pybind_cc_library: ${_RULE_TYPE}")
+    endif()
+
+    add_library(${_NAME} ${_uppercase_RULE_TYPE} "")
+    target_sources(${_NAME}
+      PRIVATE
+        ${_RULE_SRCS}
+        ${_RULE_HDRS}
+    )
+    target_include_directories(${_NAME}
+      PUBLIC
+        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+        "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+      PRIVATE
+        ${PYBIND11_INCLUDE_DIR}
+        ${pybind11_INCLUDE_DIR} 
+        ${PYTHON_INCLUDE_DIRS}
+    )
+    target_compile_options(${_NAME}
+      PRIVATE
+        ${_RULE_COPTS}
+        ${PYBIND_COPTS}
+        ${IREE_DEFAULT_COPTS}
+    )
+
+    target_link_libraries(${_NAME}
+      PUBLIC
+        ${_RULE_DEPS}
+      PRIVATE
+        pybind11
+        # TODO(marbre): Add PYTHON_HEADERS_DEPS
+        ${_RULE_LINKOPTS}
+        ${IREE_DEFAULT_LINKOPTS}
+    )
+    target_compile_definitions(${_NAME}
+      PUBLIC
+        ${_RULE_DEFINES}
+    )
+
+    # Add all IREE targets to a folder in the IDE for organization.
+    if(_RULE_PUBLIC)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER})
+    elseif(_RULE_TESTONLY)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
+    else()
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/internal)
+    endif()
+
+    # INTERFACE libraries can't have the CXX_STANDARD property set.
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+
+    set_property(TARGET ${_NAME} PROPERTY PREFIX "${PYTHON_MODULE_PREFIX}")
+    set_property(TARGET ${_NAME} PROPERTY SUFFIX "${PYTHON_MODULE_EXTENSION}")
+
+
+    # Alias the iree_package_name library to iree::package::name.
+    # This lets us more clearly map to Bazel and makes it possible to
+    # disambiguate the underscores in paths vs. the separators.
+    iree_package_ns(_PACKAGE_NS)
+    add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
+    iree_package_dir(_PACKAGE_DIR)
+    if(${_RULE_NAME} STREQUAL ${_PACKAGE_DIR})
+      # If the library name matches the package then treat it as a default.
+      # For example, foo/bar/ library 'bar' would end up as 'foo::bar'.
+      add_library(${_PACKAGE_NS} ALIAS ${_NAME})
+    endif()
+  endif()
+endfunction()

--- a/bindings/python/pyiree/CMakeLists.txt
+++ b/bindings/python/pyiree/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(common)
+add_subdirectory(rt)
+
+# TODO(marbre): The base pyiree-compiler supporting build-in dialects should be
+#               buildable with CMake after TensorFlow components are moved to
+#               pyiree-tf-compiler
+#if(${IREE_BUILD_COMPILER})
+#  add_subdirectory(compiler)
+#endif()

--- a/bindings/python/pyiree/common/CMakeLists.txt
+++ b/bindings/python/pyiree/common/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_pybind_cc_library(
+  NAME
+    common
+  HDRS
+    "binding.h"
+    "status_utils.h"
+  SRCS
+    "status_utils.cc"
+  DEPS
+    iree::base::api
+    iree::base::status
+    absl::strings
+    absl::optional
+)

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_pybind_cc_library(
+  NAME
+    rt_library
+  HDRS
+    "function_abi.h"
+    "hal.h"
+    "host_types.h"
+    "vm.h"
+  SRCS
+    "function_abi.cc"
+    "hal.cc"
+    "host_types.cc"
+    "vm.cc"
+  DEPS
+    bindings::python::pyiree::common
+    iree::base::api
+    iree::base::signature_mangle
+    iree::hal::api
+    iree::modules::hal
+    iree::vm
+    iree::vm::bytecode_module
+    iree::vm::invocation
+    iree::vm::ref
+    iree::vm::variant_list
+    absl::inlined_vector
+    absl::memory
+    absl::strings
+    absl::optional
+    absl::span
+  TYPE
+    MODULE
+)


### PR DESCRIPTION
* Creates the targets as expected
* Not yet fully functional (e.g. some compiler flags might be missing)
* Intended to allow a first review and to avoid one super large PR (which would include all the other functions required to build the python bindings)