### PR TITLE
Only run submodule synchronize push if there's a diff

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -29,17 +29,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Initializing submodules
         run: ./git_scripts/submodule_versions.py init
-      - name: Committing updates
+      - name: Checking submodule state
         run: |
-          # Only commit if there's a diff.
-          if ! git diff --cached --exit-code; then
-            git config --local user.email "noreply+action@github.com"
-            git config --local user.name "Submodule Synchronize Action"
-            git commit -am "Synchronize submodules"
-          else
-            echo "Submodules already up to date"
-          fi
+          echo "::set-env name=has_diff::false"
+          git diff --cached --exit-code || echo "::set-env name=has_diff::true"
+      - name: Committing updates
+        if: env.has_diff == 'true'
+        run: |
+          git config --local user.email "noreply+action@github.com"
+          git config --local user.name "Submodule Synchronize Action"
+          git commit -am "Synchronize submodules"
       - name: Pushing changes
+        if: env.has_diff == 'true'
         # Will push regardless, but exit successfully if already up to date with master
         uses: ad-m/github-push-action@v0.5.0
         with:


### PR DESCRIPTION
This avoids push failures in the case where another commit has been added to master in the meantime. Just keeps the status posted to commits a bit cleaner. It will avoid spurious failures like https://github.com/google/iree/runs/394391825

Tested:
Merged this into my fork and confirmed that it aborts early with no submodule changes (https://github.com/GMNGeoffrey/iree/runs/396023603). Pushed a submodule change and confirmed it does synchronization correctly (https://github.com/GMNGeoffrey/iree/runs/396027641 -> https://github.com/GMNGeoffrey/iree/commit/20542cc3a16445819050f31d98fe25cb3fcb1cdd).