### PR TITLE
Refactor CMake configuration for iree::tools and ALWAYSLINK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,3 +182,6 @@ add_subdirectory(iree/tools)
 if(${IREE_BUILD_SAMPLES})
   add_subdirectory(iree/samples)
 endif()
+
+# Set ALWAYSLINK property after all targets have been created
+include(iree_alwayslink)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Additional libraries containing statically registered functions/flags, which
+# should always be linked in to binaries.
+
+set(_ALWAYSLINK_LIBS
+  MLIRAffineOps
+  MLIRAnalysis
+  MLIREDSC
+  MLIRParser
+  MLIRPass
+  MLIRSPIRV
+  MLIRSPIRVSerialization
+  MLIRSPIRVTransforms
+  MLIRStandardOps
+  MLIRTransforms
+  MLIRTranslation
+  MLIRSupport
+  MLIRVectorOps
+  MLIRLinalgOps
+  MLIROptMain
+  tensorflow::mlir_xla
+)
+
+foreach(LIB ${_ALWAYSLINK_LIBS})
+# Aliased targets are always in-project, so we control them and can set
+# ALWAYSLINK on them directly.
+get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
+if(NOT _ALIASED_TARGET)
+  set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
+endif()
+endforeach(LIB)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -35,12 +35,7 @@ set(_ALWAYSLINK_LIBS
 )
 
 foreach(LIB ${_ALWAYSLINK_LIBS})
-# Aliased targets are always in-project, so we control them and can set
-# ALWAYSLINK on them directly.
-if(TARGET LIB)
-  get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
-  if(NOT _ALIASED_TARGET)
+  if(TARGET LIB)
     set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
   endif()
-endif()
 endforeach(LIB)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -19,6 +19,7 @@ set(_ALWAYSLINK_LIBS
   MLIRAffineOps
   MLIRAnalysis
   MLIREDSC
+  MLIRIR
   MLIRParser
   MLIRPass
   MLIRSPIRV

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -37,8 +37,10 @@ set(_ALWAYSLINK_LIBS
 foreach(LIB ${_ALWAYSLINK_LIBS})
 # Aliased targets are always in-project, so we control them and can set
 # ALWAYSLINK on them directly.
-get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
-if(NOT _ALIASED_TARGET)
-  set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
+if(TARGET LIB)
+  get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
+  if(NOT _ALIASED_TARGET)
+    set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
+  endif()
 endif()
 endforeach(LIB)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -30,7 +30,6 @@ set(_ALWAYSLINK_LIBS
   MLIRSupport
   MLIRVectorOps
   MLIRLinalgOps
-  MLIROptMain
   tensorflow::mlir_xla
 )
 

--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(marbre): Add once custom-translate runs without errors
-#add_subdirectory(custom_mdules)
-
+# TODO(marbre): Add once iree-translate and custom-translate run without errors
+#add_subdirectory(custom_modules)
 #add_subdirectory(simple_embedding)

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_test(
     iree::samples::custom_modules::native_module
     iree::base::api
     iree::base::logging
+    iree::modules::hal
     iree::testing::gtest_main
     iree::vm
     iree::vm::bytecode_module

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -66,6 +66,8 @@ iree_cc_embed_data(
 iree_cc_binary(
   NAME
     custom-opt
+  OUT
+    custom-opt
   DEPS
     iree::samples::custom_modules::dialect
     iree::tools::iree_opt_library

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -152,11 +152,11 @@ if(${IREE_BUILD_COMPILER})
       MLIRSPIRV
       MLIRSPIRVSerialization
       MLIRSPIRVTransforms
+      MLIRSupport
       MLIRStandardOps
       MLIRTransforms
       MLIRTranslateClParser
       MLIRTranslation
-      MLIRSupport
       MLIRVectorOps
       tensorflow::mlir_xla
     ALWAYSLINK

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -100,35 +100,50 @@ if(${IREE_BUILD_COMPILER})
   )
   add_executable(iree-opt ALIAS iree_tools_iree-opt)
 
-# TODO(mabre): Get this working
-#  iree_cc_binary(
-#    NAME
-#      iree-run-mlir
-#    SRCS
-#      "run_mlir_main.cc"
-#    DEPS
-#      absl::flags
-#      absl::strings
-#      # TODO(marbre): Fix problems with property "ALWAYSLINK".
-#      #iree::base::source_location
-#      iree::rt
-#      LLVMSupport
-#      MLIRIR
-#      MLIRParser
-#      MLIRSupport
-#      iree::base::init
-#      iree::base::status
-#      iree::compiler::Translation::Interpreter
-#      iree::compiler::Translation::SPIRV::LinalgToSPIRV
-#      iree::compiler::Translation::SPIRV::XLAToSPIRV
-#      iree::compiler::Translation::IREEVM
-#      iree::hal::buffer_view_string_util
-#      iree::hal::driver_registry
-#      # TODO(marbre)_ Add deps
-#      # PLATFORM_VULKAN_DEPS
-#      iree::hal::interpreter::interpreter_driver_module
-#      iree::hal::vulkan::vulkan_driver_module
-#    )
+  iree_cc_binary(
+    NAME
+      iree-run-mlir
+    SRCS
+      "run_mlir_main.cc"
+    DEPS
+      absl::flags
+      absl::strings
+      iree::base::api
+      iree::base::api_util
+      iree::base::shaped_buffer
+      iree::base::shaped_buffer_string_util
+      iree::base::signature_mangle
+      iree::base::source_location
+      iree::compiler::Dialect::Flow::Conversion
+      iree::compiler::Dialect::Flow::Transforms
+      iree::compiler::Dialect::HAL::Conversion
+      iree::compiler::Dialect::HAL::Transforms
+      iree::compiler::Dialect::IREE::Transforms
+      iree::compiler::Dialect::VM::Target::Bytecode
+      iree::compiler::Dialect::VM::Transforms
+      iree::hal::api
+      iree::modules::hal
+      iree::vm
+      iree::vm::bytecode_module
+      LLVMSupport
+      MLIRIR
+      MLIRParser
+      MLIRPass
+      MLIRSPIRV
+      MLIRSPIRVSerialization
+      MLIRSPIRVTransforms
+      MLIRSupport
+      iree::base::init
+      iree::base::status
+      iree::compiler::Translation::IREEVM
+      iree::hal::buffer_view_string_util
+      iree::hal::driver_registry
+      # TODO(marbre): Add PLATFORM_VULKAN_DEPS
+      # TODO(marbre): Move the HAL::Target deps to TARGET_COMPILER_BACKENDS
+      iree::compiler::Dialect::HAL::Target::LegacyInterpreter
+      iree::compiler::Dialect::HAL::Target::VulkanSPIRV
+      iree::hal::vulkan::vulkan_driver_module
+    )
 
   iree_cc_library(
     NAME

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -49,54 +49,12 @@ endif()
 
 if(${IREE_BUILD_COMPILER})
 
-  # Additional libraries containing statically registered functions/flags, which
-  # should always be linked in to binaries.
-  set(_ALWAYSLINK_LIBS_IREE_TRANSLATE
-    MLIRAffineOps
-    MLIRAnalysis
-    MLIREDSC
-    MLIRParser
-    MLIRPass
-    MLIRSPIRV
-    MLIRSPIRVSerialization
-    MLIRSPIRVTransforms
-    MLIRStandardOps
-    MLIRTransforms
-    MLIRTranslation
-    MLIRSupport
-    MLIRVectorOps
-    tensorflow::mlir_xla
-  )
-
-  set(_ALWAYSLINK_LIBS_IREE_OPT
-    MLIRAffineOps
-    MLIRLinalgOps
-    MLIRStandardOps
-    MLIRSPIRV
-    MLIRSPIRVSerialization
-    MLIRSPIRVTransforms
-    MLIRTranslation
-    MLIROptMain
-    tensorflow::mlir_xla
-  )
-
-  foreach(LIB IN LISTS _ALWAYSLINK_LIBS_IREE_TRANSLATE _ALWAYSLINK_LIBS_IREE_OPT)
-    # Aliased targets are always in-project, so we control them and can set
-    # ALWAYSLINK on them directly.
-    # TODO(scotttodd): add the ALWAYSLINK property to MLIR libraries elsewhere
-    get_target_property(_ALIASED_TARGET ${LIB} ALIASED_TARGET)
-    if(NOT _ALIASED_TARGET)
-      set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
-    endif()
-  endforeach(LIB)
-
   iree_cc_library(
     NAME
       iree_opt_library
     SRCS
       "${IREE_ROOT_DIR}/third_party/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp"
     DEPS
-      ${_ALWAYSLINK_LIBS_IREE_OPT}
       iree::compiler::Dialect::IREE::IR
       iree::compiler::Dialect::IREE::Transforms
       iree::compiler::Dialect::Flow::Analysis
@@ -118,6 +76,15 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Translation::SPIRV::XLAToSPIRV
       iree::compiler::Translation::SPIRV::LinalgToSPIRV
       LLVMSupport
+      MLIRAffineOps
+      MLIRLinalgOps
+      MLIRStandardOps
+      MLIRSPIRV
+      MLIRSPIRVSerialization
+      MLIRSPIRVTransforms
+      MLIRTranslation
+      MLIROptMain
+      tensorflow::mlir_xla
     ALWAYSLINK
   )
 
@@ -169,7 +136,6 @@ if(${IREE_BUILD_COMPILER})
     SRCS
       "translate_main.cc"
     DEPS
-      ${_ALWAYSLINK_LIBS_IREE_TRANSLATE}
       iree::compiler::Dialect::Flow::Conversion
       iree::compiler::Dialect::HAL::Conversion
       iree::compiler::Dialect::HAL::Target::LegacyInterpreter
@@ -178,7 +144,21 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Translation::IREEVM
       iree::compiler::Translation::SPIRV::XLAToSPIRV
       LLVMSupport
+      MLIRAffineOps
+      MLIRAnalysis
+      MLIREDSC
+      MLIRParser
+      MLIRPass
+      MLIRSPIRV
+      MLIRSPIRVSerialization
+      MLIRSPIRVTransforms
+      MLIRStandardOps
+      MLIRTransforms
       MLIRTranslateClParser
+      MLIRTranslation
+      MLIRSupport
+      MLIRVectorOps
+      tensorflow::mlir_xla
     ALWAYSLINK
   )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -164,6 +164,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRAnalysis
       MLIREDSC
       MLIRParser
+      MLIRIR
       MLIRPass
       MLIRSPIRV
       MLIRSPIRVSerialization

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -83,7 +83,6 @@ if(${IREE_BUILD_COMPILER})
       MLIRSPIRVSerialization
       MLIRSPIRVTransforms
       MLIRTranslation
-      MLIROptMain
       tensorflow::mlir_xla
     ALWAYSLINK
   )
@@ -95,6 +94,7 @@ if(${IREE_BUILD_COMPILER})
       iree-opt
     DEPS
       iree::tools::iree_opt_library
+      MLIROptMain
     LINKOPTS
       "-lpthread"
   )

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -103,6 +103,8 @@ if(${IREE_BUILD_COMPILER})
   iree_cc_binary(
     NAME
       iree-run-mlir
+    OUT
+      iree-run-mlir
     SRCS
       "run_mlir_main.cc"
     DEPS
@@ -143,7 +145,8 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Dialect::HAL::Target::LegacyInterpreter
       iree::compiler::Dialect::HAL::Target::VulkanSPIRV
       iree::hal::vulkan::vulkan_driver_module
-    )
+  )
+  add_executable(iree-run-mlir ALIAS iree_tools_iree-run-mlir)
 
   iree_cc_library(
     NAME

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -95,8 +95,6 @@ if(${IREE_BUILD_COMPILER})
     DEPS
       iree::tools::iree_opt_library
       MLIROptMain
-    LINKOPTS
-      "-lpthread"
   )
   add_executable(iree-opt ALIAS iree_tools_iree-opt)
 


### PR DESCRIPTION
* Moves ALWAYSLINK libraries to separate file
* Fixes some deps of the iree::tools targets
* Reenables the CMake configuration for iree::tools::iree-run-mlir

Resolves #393