### PR TITLE
Add missing Bazel deps on XLA targets.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -57,6 +57,7 @@ cc_library(
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_control_flow",
+        "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_lower",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_materialize_broadcasts",
     ],
     alwayslink = 1,

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/BUILD
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
+        "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_to_standard",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_unfuse_batch_norm",
     ],
     alwayslink = 1,


### PR DESCRIPTION
Without these, iree-translate fails to link if compiled without `//iree/compiler/Dialect/HAL/Target/LegacyInterpreter` in `TARGET_COMPILER_BACKENDS`:
https://github.com/google/iree/blob/8c4e44efab955e24ad9d43b411b55e66f86837d7/iree/tools/BUILD#L30-L33

I'm trying to translate just to vulkan-spirv, which can be achieved either by removing the compile-time dep or by using `-iree-hal-target-backends=vulkan-spirv`.

No CMake changes because all files are globbed into `tensorflow::mlir_xla`.