### PR TITLE
Properly set test tool dependencies for lit tests

### DIFF
--- a/build_tools/cmake/iree_glob_lit_tests.cmake
+++ b/build_tools/cmake/iree_glob_lit_tests.cmake
@@ -25,6 +25,7 @@ function(iree_glob_lit_tests)
 
   iree_package_name(_PACKAGE_NAME)
   file(GLOB_RECURSE _TEST_FILES *.mlir)
+  set(_TOOL_DEPS iree_tool_iree-opt IreeFileCheck)
 
   foreach(_TEST_FILE ${_TEST_FILES})
     get_filename_component(_TEST_FILE_LOCATION ${_TEST_FILE} DIRECTORY)
@@ -32,6 +33,6 @@ function(iree_glob_lit_tests)
     set(_NAME "${_PACKAGE_NAME}_${_TEST_NAME}")
 
     add_test(NAME ${_NAME} COMMAND ${CMAKE_SOURCE_DIR}/iree/tools/run_lit.sh ${_TEST_FILE} ${CMAKE_SOURCE_DIR}/iree/tools/IreeFileCheck.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/iree/tools)
-    set_tests_properties(${_NAME} PROPERTIES DEPENDS iree_tools_iree-opt IreeFileCheck)
+    set_tests_properties(${_NAME} PROPERTIES DEPENDS _TOOL_DEPS)
   endforeach()
 endfunction()


### PR DESCRIPTION
The syntax for `set_tests_properties` is `set_tests_properties(test1 [test2...] PROPERTIES prop1 value1 prop2 value2)`, so the DEPENDS properties has to be a list here.

This was missed in https://github.com/google/iree/pull/530 because I forgot to rerun the kokoro presubmit after the final commit. It turns out the original had a bug though and CMake was just treating LLVMFileCheck as a test property which it set to IreeFileCheck... That would've been a fun race condition to diagnose later.