### PR TITLE
Add CMake iree_lit_test[_suite] mirroring bazel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ include(iree_glsl_vulkan)
 include(iree_spirv_kernel_cc_library)
 include(iree_pybind_cc_library)
 include(iree_glob_lit_tests)
+include(iree_lit_test)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -1,0 +1,94 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeParseArguments)
+
+# iree_lit_test()
+#
+# Creates a lit test for the specified source file.
+#
+# Mirrors the bzl rule of the same name.
+#
+# Parameters:
+# NAME: Name of the target
+# TEST_FILE: Test file to run with the lit runner.
+# DATA: Additional data dependencies invoked by the test (e.g. binaries
+#   called in the RUN line)
+#
+# TODO(gcmn): allow using alternative driver
+# A driver other than the default iree/tools/run_lit.sh is not currently supported.
+function(iree_lit_test)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;TEST_FILE"
+    "DATA"
+    ${ARGN}
+  )
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  get_filename_component(_TEST_FILE_PATH ${_RULE_TEST_FILE} ABSOLUTE)
+  
+  add_test(
+    NAME ${_NAME}
+    COMMAND ${CMAKE_SOURCE_DIR}/iree/tools/run_lit.sh "${_TEST_FILE_PATH}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}" # Make sure the lit runner can find all the binaries
+  )
+  set_tests_properties(${_NAME} PROPERTIES DEPENDS _RULE_DATA)
+endfunction()
+
+
+# iree_lit_test_suite()
+#
+# Creates a suite of lit tests for a list of source files.
+#
+# Mirrors the bzl rule of the same name.
+#
+# Parameters:
+# NAME: Name of the target
+# SRCS: List of test files to run with the lit runner. Creates one test per source.
+# DATA: Additional data dependencies invoked by the test (e.g. binaries
+#   called in the RUN line)
+#
+# TODO(gcmn): allow using alternative driver
+# A driver other than the default iree/tools/run_lit.sh is not currently supported.
+function(iree_lit_test_suite)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DATA"
+    ${ARGN}
+  )
+  IF(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
+  foreach(_TEST_FILE ${_RULE_SRCS})
+    get_filename_component(_TEST_BASENAME ${_TEST_FILE} NAME)
+    iree_lit_test(
+      NAME
+        "${_RULE_NAME}_${_TEST_BASENAME}_test"
+      TEST_FILE
+        "${_TEST_FILE}"
+      DATA
+        "${_RULE_DATA}"
+    )
+  endforeach()
+endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -50,7 +50,7 @@ function(iree_lit_test)
     COMMAND ${CMAKE_SOURCE_DIR}/iree/tools/run_lit.sh "${_TEST_FILE_PATH}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}" # Make sure the lit runner can find all the binaries
   )
-  set_tests_properties(${_NAME} PROPERTIES DEPENDS _RULE_DATA)
+  # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
 endfunction()
 
 

--- a/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
@@ -12,4 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+# TODO(gcmn): should we generate the glob at bazel->cmake time instead?
+file(GLOB _TEST_FILES CONFIGURE_DEPENDS *.mlir)
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "${_TEST_FILES}"
+  DATA
+    iree_tools_iree-opt
+    IreeFileCheck
+)


### PR DESCRIPTION
Creates CMake rules mirroring those recently added in b6deef9903c13f2efcc1eefd68781bc2f316754e.

It also includes a single usage of the rules to verify correctness. I will try out a bazel-to-cmake update to get the rest.

Depends on https://github.com/google/iree/pull/561

Tested:
All tests under iree/compiler/Dialect/VM/IR/test/ still pass.