### PR TITLE
Don't delete build directory on cmake build completion

### DIFF
--- a/build_tools/scripts/cmake_build.sh
+++ b/build_tools/scripts/cmake_build.sh
@@ -29,4 +29,3 @@ rm -rf build/
 mkdir build && cd build
 "$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
 "$CMAKE_BIN" --build .
-rm -rf build/

--- a/git_scripts/submodule_versions.py
+++ b/git_scripts/submodule_versions.py
@@ -122,8 +122,8 @@ def init_submodules(repo_dir):
 def parallel_shallow_update_submodules(repo_dir):
   print("*** Making shallow clone of submodules")
   # TODO(gcmn) Figure out a way to quickly fetch submodules without relying on
-  # target SHA being within 1000 commits of HEAD.
-  magic_depth = 1000
+  # target SHA being within 10000 commits of HEAD.
+  magic_depth = 10000
   utils.execute([
       "git", "submodule", "update", "--jobs", "8", "--depth",
       str(magic_depth)


### PR DESCRIPTION
This makes it harder to use the script locally, as you frequently want to examine the build outputs. It also isn't super useful, since in the CI the VM will get torn down anyway. And it's not reliable, because if the build fails it won't be executed.

Depends on https://github.com/google/iree/pull/565