### PR TITLE
Generate CMake lit_test_suite rules

### DIFF
--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -225,11 +225,12 @@ class BuildFileFunctions(object):
     #    package1::target1
     #    package1::target2
     #    package2::target
-    deps = kwargs.get("data")
-    deps_list = [self._convert_target(dep) for dep in deps]
-    deps_list = sorted(list(set(deps_list)))  # Remove duplicates and sort.
-    deps_list = "\n".join(["    %s" % (dep,) for dep in deps_list])
-    return "  DATA\n%s\n" % (deps_list,)
+    data = kwargs.get("data")
+    data_list = [self._convert_target(dep) for dep in data]
+    # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
+    data_list = list(filter(None, OrderedDict(zip(data_list, repeat(None)))))
+    data_list = "\n".join(["    %s" % (data,) for data in data_list])
+    return "  DATA\n%s\n" % (data_list,)
 
   def _convert_deps_block(self, **kwargs):
     if not kwargs.get("deps"):

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -280,14 +280,14 @@ class BuildFileFunctions(object):
   def exports_files(self, *args, **kwargs):
     pass
 
-  def glob(self, include, exclude = [], exclude_directories=1):
+  def glob(self, include, exclude=[], exclude_directories=1):
     if exclude_directories != 1:
       raise ValueError("Non-default exclude_directories not supported")
 
     filepaths = []
     for pattern in include:
       if "**" in pattern:
-        # glob has some specific restrictions about crossing package boundaries.
+        # bazel's glob has some specific restrictions about crossing package boundaries.
         # We have no uses of recursive globs. Rather than try to emulate them or
         # silently give different behavior, just error out.
         # See https://docs.bazel.build/versions/master/be/functions.html#glob
@@ -300,9 +300,14 @@ class BuildFileFunctions(object):
       if "**" in pattern:
         # See comment above
         raise ValueError("Recursive globs not supported")
-      exclude_filepaths.update(glob.glob(self.converter.directory_path + "/" + pattern))
+      exclude_filepaths.update(
+          glob.glob(self.converter.directory_path + "/" + pattern))
 
-    basenames = sorted([os.path.basename(path) for path in filepaths if path not in exclude_filepaths])
+    basenames = sorted([
+        os.path.basename(path)
+        for path in filepaths
+        if path not in exclude_filepaths
+    ])
     return basenames
 
   def config_setting(self, **kwargs):
@@ -423,15 +428,15 @@ class BuildFileFunctions(object):
     srcs_block = self._convert_srcs_block(**kwargs)
     data_block = self._convert_data_block(**kwargs)
 
-    self.converter.body += (
-        "iree_lit_test_suite(\n"
-        "%(name_block)s"
-        "%(srcs_block)s"
-        "%(data_block)s)\n\n" % {
-            "name_block": name_block,
-            "srcs_block": srcs_block,
-            "data_block": data_block,
-        })
+    self.converter.body += ("iree_lit_test_suite(\n"
+                            "%(name_block)s"
+                            "%(srcs_block)s"
+                            "%(data_block)s)\n\n" % {
+                                "name_block": name_block,
+                                "srcs_block": srcs_block,
+                                "data_block": data_block,
+                            })
+
 
 class Converter(object):
   """Conversion state tracking and full file template substitution."""

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -281,6 +281,10 @@ class BuildFileFunctions(object):
     pass
 
   def glob(self, include, exclude=[], exclude_directories=1):
+    # Rather than converting bazel globs into CMake globs, we evaluate the glob at
+    # conversion time. This avoids issues with different glob semantics and dire
+    # warnings about not knowing when to reevaluate the glob.
+    # See https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
     if exclude_directories != 1:
       raise ValueError("Non-default exclude_directories not supported")
 

--- a/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "dispatchability.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -12,4 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "dispatch_ops.mlir"
+    "dispatch_regions.mlir"
+    "executable_ops.mlir"
+    "reduction_regions.mlir"
+    "stream_ops.mlir"
+    "tensor_folding.mlir"
+    "tensor_ops.mlir"
+    "variable_folding.mlir"
+    "variable_ops.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -12,4 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "assign_executable_workloads.mlir"
+    "fold_compatible_dispatch_regions.mlir"
+    "form_streams.mlir"
+    "identify_dispatch_regions.mlir"
+    "identify_reduction_regions.mlir"
+    "legalize_input_types.mlir"
+    "materialize_and_merge_exported_reflection.mlir"
+    "materialize_exported_reflection.mlir"
+    "merge_exported_reflection.mlir"
+    "rematerialize_dispatch_constants.mlir"
+    "transformation.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
@@ -12,4 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "stream_ops.mlir"
+    "structural_ops.mlir"
+    "tensor_ops.mlir"
+    "variable_ops.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
@@ -12,4 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "allocator_ops.mlir"
+    "buffer_ops.mlir"
+    "command_buffer_ops.mlir"
+    "device_ops.mlir"
+    "executable_ops.mlir"
+    "variable_ops.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -16,9 +16,11 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "allocator_folding.mlir"
     "allocator_ops.mlir"
+    "buffer_folding.mlir"
     "buffer_ops.mlir"
+    "buffer_view_folding.mlir"
+    "buffer_view_ops.mlir"
     "command_buffer_ops.mlir"
     "descriptor_set_ops.mlir"
     "device_ops.mlir"

--- a/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -12,4 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "allocator_folding.mlir"
+    "allocator_ops.mlir"
+    "buffer_ops.mlir"
+    "command_buffer_ops.mlir"
+    "descriptor_set_ops.mlir"
+    "device_ops.mlir"
+    "executable_ops.mlir"
+    "experimental_ops.mlir"
+    "variable_folding.mlir"
+    "variable_ops.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "smoketest.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "transformation.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
@@ -12,4 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "bindings.mlir"
+    "do_not_optimize.mlir"
+    "parse_print.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "drop_compiler_hints.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
@@ -12,4 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "register_allocation.mlir"
+    "value_liveness.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
@@ -12,4 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "arithmetic_ops.mlir"
+    "assignment_ops.mlir"
+    "comparison_ops.mlir"
+    "const_ops.mlir"
+    "control_flow_ops.mlir"
+    "func_attrs.mlir"
+    "structural_ops.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
@@ -12,15 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(gcmn): should we generate the glob at bazel->cmake time instead?
-file(GLOB _TEST_FILES CONFIGURE_DEPENDS *.mlir)
-
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "${_TEST_FILES}"
+    "arithmetic_folding.mlir"
+    "arithmetic_ops.mlir"
+    "assignment_folding.mlir"
+    "assignment_ops.mlir"
+    "comparison_folding.mlir"
+    "comparison_ops.mlir"
+    "const_folding.mlir"
+    "const_ops.mlir"
+    "control_flow_folding.mlir"
+    "control_flow_ops.mlir"
+    "conversion_folding.mlir"
+    "conversion_ops.mlir"
+    "debug_folding.mlir"
+    "debug_ops.mlir"
+    "global_folding.mlir"
+    "global_ops.mlir"
+    "structural_ops.mlir"
   DATA
-    iree_tools_iree-opt
-    IreeFileCheck
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
 )

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
@@ -12,4 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "module_encoding_smoke.mlir"
+    "reflection_attrs.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-translate
+)

--- a/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "global_initialization.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
@@ -12,4 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "concat.mlir"
+    "constant.mlir"
+    "invalid_types_hl.mlir"
+    "invalid_types_ll.mlir"
+    "scalar_memref.mlir"
+    "tensor_memref.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
@@ -12,4 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+add_subdirectory(xla)
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "clone.mlir"
+    "make_executable_abi.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
@@ -16,17 +16,10 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "concatenate.mlir"
-    "copy.mlir"
-    "extract_element.mlir"
+    "concat.mlir"
+    "dynamic_update_slice.mlir"
     "gather.mlir"
-    "pad.mlir"
-    "reverse.mlir"
     "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/test/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "single_pw_op.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Translation/SPIRV/ReductionCodegen/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/ReductionCodegen/test/CMakeLists.txt
@@ -12,4 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "ops.mlir"
+    "simple.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
@@ -12,4 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_glob_lit_tests()
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "adjust_integer_width.mlir"
+    "arithmetic_ops.mlir"
+    "broadcast.mlir"
+    "broadcast_in_dim.mlir"
+    "concatenate.mlir"
+    "constant.mlir"
+    "convert.mlir"
+    "copy.mlir"
+    "exp_test.mlir"
+    "extract_element.mlir"
+    "gather.mlir"
+    "max.mlir"
+    "pad.mlir"
+    "reshape.mlir"
+    "reshape_dropdims.mlir"
+    "reverse.mlir"
+    "select.mlir"
+    "slice.mlir"
+    "store_reduce.mlir"
+    "transpose_add.mlir"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
+)


### PR DESCRIPTION
I went with evaluating the glob as part of the cmake file generation.

Depends on https://github.com/google/iree/pull/559

Tested:
56 tests pass before and after this change.