### PR TITLE
Fetch full submodule history

### DIFF
--- a/git_scripts/submodule_versions.py
+++ b/git_scripts/submodule_versions.py
@@ -120,15 +120,10 @@ def init_submodules(repo_dir):
 
 
 def parallel_shallow_update_submodules(repo_dir):
-  print("*** Making shallow clone of submodules")
+  print("*** Cloning submodules")
   # TODO(gcmn) Figure out a way to quickly fetch submodules without relying on
-  # target SHA being within 1000 commits of HEAD.
-  magic_depth = 1000
-  utils.execute([
-      "git", "submodule", "update", "--jobs", "8", "--depth",
-      str(magic_depth)
-  ],
-                cwd=repo_dir)
+  # target SHA being within some fixed number of commits from HEAD.
+  utils.execute(["git", "submodule", "update", "--jobs", "8"], cwd=repo_dir)
 
 
 def check_submodule_versions(repo_dir):


### PR DESCRIPTION
Presubmits have started failing, I think because we're more than 1000 commits behind LLVM HEAD. This isn't very reliable and enforces a weird arbitrary limit on the submodule SHAs which results in difficult to debug errors. This may slow down runs as they fetch the submodules.