### PR TITLE
Increase magic submodule depth to 10000

### DIFF
--- a/git_scripts/submodule_versions.py
+++ b/git_scripts/submodule_versions.py
@@ -122,8 +122,8 @@ def init_submodules(repo_dir):
 def parallel_shallow_update_submodules(repo_dir):
   print("*** Making shallow clone of submodules")
   # TODO(gcmn) Figure out a way to quickly fetch submodules without relying on
-  # target SHA being within 1000 commits of HEAD.
-  magic_depth = 1000
+  # target SHA being within 10000 commits of HEAD.
+  magic_depth = 10000
   utils.execute([
       "git", "submodule", "update", "--jobs", "8", "--depth",
       str(magic_depth)


### PR DESCRIPTION
We're more than 1000 commits behind LLVM HEAD, which is causing automation to fail. This is still a horrible hack that I hate, but I tried out fetching full submodule history in https://github.com/google/iree/pull/564 and it really does slow down the presubmits by a ton. It seems very unlikely we'll get 10000 commits behind HEAD until we can figure out how to get this to work robustly and it imposes only a minimal slowdown (order of 10s).