### PR TITLE
Bazel to cmake strict mode

### DIFF
--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -53,6 +53,11 @@ def parse_arguments():
       help="Prints results instead of writing files",
       action="store_true",
       default=False)
+  parser.add_argument(
+      "--strict",
+      help="Does not try to generate files where it cannot convert completely",
+      action="store_true",
+      default=False)
 
   # Specify only one of these (defaults to --root_dir=iree).
   group = parser.add_mutually_exclusive_group()
@@ -252,10 +257,10 @@ class BuildFileFunctions(object):
 
   def _convert_unimplemented_function(self, rule, *args, **kwargs):
     name = kwargs.get("name", "unnamed")
-    self.converter.body += "# Unimplemented %(rule)s %(name)s\n" % {
-        "rule": rule,
-        "name": name
-    }
+    message = "Unimplemented %(rule)s %(name)s\n" % {"rule": rule, "name": name}
+    if not self.converter.first_error:
+      self.converter.first_error = NotImplementedError(message)
+    self.converter.body += "# %s" % (message,)
 
   # ------------------------------------------------------------------------- #
   # Function handlers that convert BUILD definitions to CMake definitions.    #
@@ -290,8 +295,9 @@ class BuildFileFunctions(object):
     # conversion time. This avoids issues with different glob semantics and dire
     # warnings about not knowing when to reevaluate the glob.
     # See https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
+
     if exclude_directories != 1:
-      raise ValueError("Non-default exclude_directories not supported")
+      raise NotImplementedError("Non-default exclude_directories not supported")
 
     filepaths = []
     for pattern in include:
@@ -300,7 +306,7 @@ class BuildFileFunctions(object):
         # We have no uses of recursive globs. Rather than try to emulate them or
         # silently give different behavior, just error out.
         # See https://docs.bazel.build/versions/master/be/functions.html#glob
-        raise ValueError("Recursive globs not supported")
+        raise NotImplementedError("Recursive globs not supported")
 
       filepaths += glob.glob(self.converter.directory_path + "/" + pattern)
 
@@ -308,7 +314,7 @@ class BuildFileFunctions(object):
     for pattern in exclude:
       if "**" in pattern:
         # See comment above
-        raise ValueError("Recursive globs not supported")
+        raise NotImplementedError("Recursive globs not supported")
       exclude_filepaths.update(
           glob.glob(self.converter.directory_path + "/" + pattern))
 
@@ -462,6 +468,7 @@ class Converter(object):
     self.body = ""
     self.directory_path = directory_path
     self.rel_build_file_path = rel_build_file_path
+    self.first_error = None
 
   def convert(self, copyright_line):
     # One `add_subdirectory(name)` per subdirectory.
@@ -514,15 +521,15 @@ def GetDict(obj):
   return ret
 
 
-def convert_directory_tree(root_directory_path, write_files):
+def convert_directory_tree(root_directory_path, write_files, strict):
   print("convert_directory_tree: %s" % (root_directory_path,))
   # Process directories starting at leaves so we can skip add_directory on
   # subdirs without a CMakeLists file.
   for root, dirs, file_names in os.walk(root_directory_path, topdown=False):
-    convert_directory(root, write_files)
+    convert_directory(root, write_files, strict)
 
 
-def convert_directory(directory_path, write_files):
+def convert_directory(directory_path, write_files, strict):
   if not os.path.isdir(directory_path):
     raise FileNotFoundError("Cannot find directory '%s'" % (directory_path,))
 
@@ -571,12 +578,14 @@ def convert_directory(directory_path, write_files):
     try:
       exec(build_file_code, GetDict(BuildFileFunctions(converter)))
       converted_text = converter.convert(copyright_line)
+      if strict and converter.first_error:
+        raise converter.first_error
       if write_allowed:
         with open(cmakelists_file_path, "wt") as cmakelists_file:
           cmakelists_file.write(converted_text)
       else:
         print(converted_text)
-    except NameError as e:
+    except (NameError, NotImplementedError) as e:
       print(
           "Failed to convert %s. Missing a rule handler in bazel_to_cmake.py?" %
           (rel_build_file_path))
@@ -595,9 +604,11 @@ def main(args):
   write_files = not args.preview
 
   if args.root_dir:
-    convert_directory_tree(os.path.join(repo_root, args.root_dir), write_files)
+    convert_directory_tree(
+        os.path.join(repo_root, args.root_dir), write_files, args.strict)
   elif args.dir:
-    convert_directory(os.path.join(repo_root, args.dir), write_files)
+    convert_directory(
+        os.path.join(repo_root, args.dir), write_files, args.strict)
 
 
 if __name__ == "__main__":

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -34,8 +34,13 @@ import textwrap
 from collections import OrderedDict
 from itertools import repeat
 import glob
+import re
 
 repo_root = None
+
+EDIT_BLOCKING_PATTERN = re.compile(
+    "bazel[\s_]*to[\s_]*cmake[\s_]*:?[\s_]*do[\s_]*not[\s_]*edit",
+    flags=re.IGNORECASE)
 
 
 def parse_arguments():
@@ -458,18 +463,19 @@ class Converter(object):
     self.directory_path = directory_path
     self.rel_build_file_path = rel_build_file_path
 
-  def convert(self):
+  def convert(self, copyright_line):
     # One `add_subdirectory(name)` per subdirectory.
-    add_subdirectories = ""
+    add_subdir_commands = []
     for root, dirs, file_names in os.walk(self.directory_path):
-      add_subdirectories = "\n".join(
-          ["add_subdirectory(%s)" % (dir,) for dir in dirs])
+      for dir in sorted(dirs):
+        if os.path.isfile(os.path.join(root, dir, "CMakeLists.txt")):
+          add_subdir_commands.append("add_subdirectory(%s)" % (dir,))
       # Stop walk, only add direct subdirectories.
       break
 
     converted_file = self.template % {
-        "date_year": datetime.date.today().year,
-        "add_subdirectories": add_subdirectories,
+        "copyright_line": copyright_line,
+        "add_subdirectories": "\n".join(add_subdir_commands),
         "body": self.body,
     }
 
@@ -481,7 +487,7 @@ class Converter(object):
     return converted_file
 
   template = textwrap.dedent("""\
-    # Copyright %(date_year)s Google LLC
+    %(copyright_line)s
     #
     # Licensed under the Apache License, Version 2.0 (the "License");
     # you may not use this file except in compliance with the License.
@@ -510,7 +516,9 @@ def GetDict(obj):
 
 def convert_directory_tree(root_directory_path, write_files):
   print("convert_directory_tree: %s" % (root_directory_path,))
-  for root, dirs, file_names in os.walk(root_directory_path):
+  # Process directories starting at leaves so we can skip add_directory on
+  # subdirs without a CMakeLists file.
+  for root, dirs, file_names in os.walk(root_directory_path, topdown=False):
     convert_directory(root, write_files)
 
 
@@ -530,11 +538,29 @@ def convert_directory(directory_path, write_files):
   rel_cmakelists_file_path = os.path.relpath(cmakelists_file_path, repo_root)
   print("Converting %s to %s" % (rel_build_file_path, rel_cmakelists_file_path))
 
-  if write_files:
+  cmake_file_exists = os.path.isfile(cmakelists_file_path)
+  copyright_line = "# Copyright %s Google LLC" % (datetime.date.today().year,)
+  write_allowed = write_files
+  if cmake_file_exists:
+    with open(cmakelists_file_path) as f:
+      for i, line in enumerate(f):
+        if line.startswith("# Copyright"):
+          copyright_line = line.rstrip()
+        if EDIT_BLOCKING_PATTERN.search(line):
+          print(
+              "  %(path)s already exists, and line %(index)d: '%(line)s' prevents edits. Falling back to preview"
+              % {
+                  "path": rel_cmakelists_file_path,
+                  "index": i + 1,
+                  "line": line.strip()
+              })
+          write_allowed = False
+
+  if write_allowed:
     # TODO(scotttodd): Attempt to merge instead of overwrite?
     #   Existing CMakeLists.txt may have special logic that should be preserved
-    if os.path.isfile(cmakelists_file_path):
-      print("  %s already exists, overwritting" % (rel_cmakelists_file_path,))
+    if cmake_file_exists:
+      print("  %s already exists, overwriting" % (rel_cmakelists_file_path,))
     else:
       print("  %s does not exist yet, creating" % (rel_cmakelists_file_path,))
   print("")
@@ -544,9 +570,8 @@ def convert_directory(directory_path, write_files):
     converter = Converter(directory_path, rel_build_file_path)
     try:
       exec(build_file_code, GetDict(BuildFileFunctions(converter)))
-      converted_text = converter.convert()
-
-      if write_files:
+      converted_text = converter.convert(copyright_line)
+      if write_allowed:
         with open(cmakelists_file_path, "wt") as cmakelists_file:
           cmakelists_file.write(converted_text)
       else:

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -93,33 +93,36 @@ class BuildFileFunctions(object):
   # between similar rule conversions (e.g. cc_library and cc_binary).         #
   # ------------------------------------------------------------------------- #
 
-  def _convert_name_block(self, **kwargs):
+  def _convert_name_block(self, name):
     #  NAME
     #    rule_name
-    return "  NAME\n    %s\n" % (kwargs["name"])
+    return "  NAME\n    %s\n" % (name)
 
-  def _convert_cc_namespace_block(self, **kwargs):
+  def _convert_cc_namespace_block(self, cc_namespace):
     #  CC_NAMESPACE
     #    "cc_namespace"
-    return "  CC_NAMESPACE\n    \"%s\"\n" % (kwargs["cc_namespace"])
+    if not cc_namespace:
+      return ""
+    return "  CC_NAMESPACE\n    \"%s\"\n" % (cc_namespace)
 
-  def _convert_cpp_namespace_block(self, **kwargs):
+  def _convert_cpp_namespace_block(self, cpp_namespace):
+    if not cpp_namespace:
+      return ""
     #  CPP_NAMESPACE
     #    "cpp_namespace"
-    return "  CPP_NAMESPACE\n    \"%s\"\n" % (kwargs["cpp_namespace"])
+    return "  CPP_NAMESPACE\n    \"%s\"\n" % (cpp_namespace)
 
-  def _convert_translation_block(self, **kwargs):
-    return "  TRANSLATION\n    \"%s\"\n" % (kwargs["translation"])
+  def _convert_translation_block(self, translation):
+    return "  TRANSLATION\n    \"%s\"\n" % (translation)
 
-  def _convert_translate_tool_block(self, **kwargs):
-    translate_tool = kwargs.get("translate_tool")
+  def _convert_translate_tool_block(self, translate_tool):
     if translate_tool:
       # Bazel `//iree/base`     -> CMake `iree::base`
       # Bazel `//iree/base:api` -> CMake `iree::base::api`
       translate_tool = translate_tool.replace("//", "")  # iree/base:api
       translate_tool = translate_tool.replace(":", "_")  # iree/base::api
       translate_tool = translate_tool.replace("/", "_")  # iree::base::api
-      return "  TRANSLATION_TOOL\n    %s\n" % (translate_tool)
+      return "  TRANSLATE_TOOL\n    %s\n" % (translate_tool)
     else:
       return ""
 
@@ -131,14 +134,14 @@ class BuildFileFunctions(object):
     else:
       return ""
 
-  def _convert_alwayslink_block(self, **kwargs):
-    return self._convert_option_block("ALWAYSLINK", kwargs.get("alwayslink"))
+  def _convert_alwayslink_block(self, alwayslink):
+    return self._convert_option_block("ALWAYSLINK", alwayslink)
 
-  def _convert_testonly_block(self, **kwargs):
-    return self._convert_option_block("TESTONLY", kwargs.get("testonly"))
+  def _convert_testonly_block(self, testonly):
+    return self._convert_option_block("TESTONLY", testonly)
 
-  def _convert_flatten_block(self, **kwargs):
-    return self._convert_option_block("FLATTEN", kwargs.get("flatten"))
+  def _convert_flatten_block(self, flatten):
+    return self._convert_option_block("FLATTEN", flatten)
 
   def _convert_filelist_block(self, list_name, files):
     if not files:
@@ -151,23 +154,22 @@ class BuildFileFunctions(object):
     files_list = "\n".join(["    \"%s\"" % (file) for file in files])
     return "  %s\n%s\n" % (list_name, files_list)
 
-  def _convert_hdrs_block(self, **kwargs):
-    return self._convert_filelist_block("HDRS", kwargs.get("hdrs"))
+  def _convert_hdrs_block(self, hdrs):
+    return self._convert_filelist_block("HDRS", hdrs)
 
-  def _convert_srcs_block(self, **kwargs):
-    return self._convert_filelist_block("SRCS", kwargs.get("srcs"))
+  def _convert_srcs_block(self, srcs):
+    return self._convert_filelist_block("SRCS", srcs)
 
-  def _convert_src_block(self, **kwargs):
-    return "  SRC\n    \"%s\"\n" % kwargs.get("src")
+  def _convert_src_block(self, src):
+    return "  SRC\n    \"%s\"\n" % src
 
-  def _convert_cc_file_output_block(self, **kwargs):
-    return "  CC_FILE_OUTPUT\n    \"%s\"\n" % kwargs.get("cc_file_output")
+  def _convert_cc_file_output_block(self, cc_file_output):
+    return "  CC_FILE_OUTPUT\n    \"%s\"\n" % (cc_file_output)
 
-  def _convert_h_file_output_block(self, **kwargs):
-    return "  H_FILE_OUTPUT\n    \"%s\"\n" % kwargs.get("h_file_output")
+  def _convert_h_file_output_block(self, h_file_output):
+    return "  H_FILE_OUTPUT\n    \"%s\"\n" % (h_file_output)
 
-  def _convert_td_file_block(self, **kwargs):
-    td_file = kwargs.get("td_file")
+  def _convert_td_file_block(self, td_file):
     if td_file.startswith("//iree"):
       # Bazel `//iree/dir/td_file.td`
       # -> CMake `${IREE_ROOT_DIR}/iree/dir/td_file.td
@@ -177,13 +179,11 @@ class BuildFileFunctions(object):
       td_file = td_file.replace(":", "/")
     return "  SRCS\n    \"%s\"\n" % (td_file)
 
-  def _convert_tbl_outs_block(self, **kwargs):
-    tbl_outs = kwargs.get("tbl_outs")
+  def _convert_tbl_outs_block(self, tbl_outs):
     outs_list = "\n".join(["    %s %s" % tbl_out for tbl_out in tbl_outs])
     return "  OUTS\n%s\n" % (outs_list)
 
-  def _convert_tblgen_block(self, **kwargs):
-    tblgen = kwargs.get("tblgen")
+  def _convert_tblgen_block(self, tblgen):
     if tblgen.endswith("iree-tblgen"):
       return "  TBLGEN\n    IREE\n"
     else:
@@ -217,30 +217,28 @@ class BuildFileFunctions(object):
       target = target.replace("/", "::")  # iree::base::api
     return target
 
-  def _convert_data_block(self, **kwargs):
-    if not kwargs.get("data"):
+  def _convert_data_block(self, data):
+    if not data:
       return ""
 
     #  DATA
     #    package1::target1
     #    package1::target2
     #    package2::target
-    data = kwargs.get("data")
     data_list = [self._convert_target(dep) for dep in data]
     # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
     data_list = list(filter(None, OrderedDict(zip(data_list, repeat(None)))))
     data_list = "\n".join(["    %s" % (data,) for data in data_list])
     return "  DATA\n%s\n" % (data_list,)
 
-  def _convert_deps_block(self, **kwargs):
-    if not kwargs.get("deps"):
+  def _convert_deps_block(self, deps):
+    if not deps:
       return ""
 
     #  DEPS
     #    package1::target1
     #    package1::target2
     #    package2::target
-    deps = kwargs.get("deps")
     deps_list = [self._convert_target(dep) for dep in deps]
     # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
     deps_list = list(filter(None, OrderedDict(zip(deps_list, repeat(None)))))
@@ -262,6 +260,7 @@ class BuildFileFunctions(object):
   # ------------------------------------------------------------------------- #
 
   def load(self, *args):
+    # No mapping to CMake, ignore.
     pass
 
   def package(self, **kwargs):
@@ -278,6 +277,7 @@ class BuildFileFunctions(object):
     self._convert_unimplemented_function("filegroup", **kwargs)
 
   def exports_files(self, *args, **kwargs):
+    # No mapping to CMake, ignore.
     pass
 
   def glob(self, include, exclude=[], exclude_directories=1):
@@ -318,13 +318,20 @@ class BuildFileFunctions(object):
     # No mapping to CMake, ignore.
     pass
 
-  def cc_library(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    hdrs_block = self._convert_hdrs_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
-    deps_block = self._convert_deps_block(**kwargs)
-    alwayslink_block = self._convert_alwayslink_block(**kwargs)
-    testonly_block = self._convert_testonly_block(**kwargs)
+  def cc_library(self,
+                 name,
+                 hdrs=[],
+                 srcs=[],
+                 deps=[],
+                 alwayslink=False,
+                 testonly=False,
+                 **kwargs):
+    name_block = self._convert_name_block(name)
+    hdrs_block = self._convert_hdrs_block(hdrs)
+    srcs_block = self._convert_srcs_block(srcs)
+    deps_block = self._convert_deps_block(deps)
+    alwayslink_block = self._convert_alwayslink_block(alwayslink)
+    testonly_block = self._convert_testonly_block(testonly)
 
     self.converter.body += """iree_cc_library(
 %(name_block)s%(hdrs_block)s%(srcs_block)s%(deps_block)s%(alwayslink_block)s%(testonly_block)s  PUBLIC
@@ -337,11 +344,11 @@ class BuildFileFunctions(object):
     "testonly_block": testonly_block,
     }
 
-  def cc_test(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    hdrs_block = self._convert_hdrs_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
-    deps_block = self._convert_deps_block(**kwargs)
+  def cc_test(self, name, hdrs=[], srcs=[], deps=[], **kwargs):
+    name_block = self._convert_name_block(name)
+    hdrs_block = self._convert_hdrs_block(hdrs)
+    srcs_block = self._convert_srcs_block(srcs)
+    deps_block = self._convert_deps_block(deps)
 
     self.converter.body += """iree_cc_test(
 %(name_block)s%(hdrs_block)s%(srcs_block)s%(deps_block)s)\n\n""" % {
@@ -351,10 +358,10 @@ class BuildFileFunctions(object):
     "deps_block": deps_block,
     }
 
-  def cc_binary(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
-    deps_block = self._convert_deps_block(**kwargs)
+  def cc_binary(self, name, srcs=[], deps=[], **kwargs):
+    name_block = self._convert_name_block(name)
+    srcs_block = self._convert_srcs_block(srcs)
+    deps_block = self._convert_deps_block(deps)
 
     self.converter.body += """iree_cc_binary(
 %(name_block)s%(srcs_block)s%(deps_block)s)\n\n""" % {
@@ -363,13 +370,15 @@ class BuildFileFunctions(object):
     "deps_block": deps_block,
     }
 
-  def cc_embed_data(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
-    cc_file_output_block = self._convert_cc_file_output_block(**kwargs)
-    h_file_output_block = self._convert_h_file_output_block(**kwargs)
-    namespace_block = self._convert_cpp_namespace_block(**kwargs)
-    flatten_block = self._convert_flatten_block(**kwargs)
+  def cc_embed_data(self, name, srcs, cc_file_output, h_file_output, cpp_namespace = None, strip_prefix = None, flatten = False, identifier = None, **kwargs):
+    if identifier:
+      self._convert_unimplemented_function("cc_embed_data", name=name)
+    name_block = self._convert_name_block(name)
+    srcs_block = self._convert_srcs_block(srcs)
+    cc_file_output_block = self._convert_cc_file_output_block(cc_file_output)
+    h_file_output_block = self._convert_h_file_output_block(h_file_output)
+    namespace_block = self._convert_cpp_namespace_block(cpp_namespace)
+    flatten_block = self._convert_flatten_block(flatten)
 
     self.converter.body += """iree_cc_embed_data(
 %(name_block)s%(srcs_block)s%(cc_file_output_block)s%(h_file_output_block)s%(namespace_block)s%(flatten_block)s  PUBLIC\n)\n\n""" % {
@@ -381,9 +390,9 @@ class BuildFileFunctions(object):
     "flatten_block": flatten_block,
     }
 
-  def spirv_kernel_cc_library(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
+  def spirv_kernel_cc_library(self, name, srcs):
+    name_block = self._convert_name_block(name)
+    srcs_block = self._convert_srcs_block(srcs)
 
     self.converter.body += """iree_spirv_kernel_cc_library(
 %(name_block)s%(srcs_block)s)\n\n""" % {
@@ -391,12 +400,17 @@ class BuildFileFunctions(object):
     "srcs_block": srcs_block,
     }
 
-  def iree_bytecode_module(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    src_block = self._convert_src_block(**kwargs)
-    namespace_block = self._convert_cc_namespace_block(**kwargs)
-    translate_tool_block = self._convert_translate_tool_block(**kwargs)
-    translation_block = self._convert_translation_block(**kwargs)
+  def iree_bytecode_module(self,
+                           name,
+                           src,
+                           translation="-iree-mlir-to-vm-bytecode-module",
+                           translate_tool="//iree/tools:iree-translate",
+                           cc_namespace=None):
+    name_block = self._convert_name_block(name)
+    src_block = self._convert_src_block(src)
+    namespace_block = self._convert_cc_namespace_block(cc_namespace)
+    translate_tool_block = self._convert_translate_tool_block(translate_tool)
+    translation_block = self._convert_translation_block(translation)
 
     self.converter.body += """iree_bytecode_module(
 %(name_block)s%(src_block)s%(namespace_block)s%(translate_tool_block)s%(translation_block)s  PUBLIC\n)\n\n""" % {
@@ -407,30 +421,24 @@ class BuildFileFunctions(object):
     "translation_block": translation_block,
     }
 
-  def gentbl(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_td_file_block(**kwargs)
-    outs_block = self._convert_tbl_outs_block(**kwargs)
-    tblgen_block = self._convert_tblgen_block(**kwargs)
+  def gentbl(self, name, tblgen, td_file, tbl_outs, td_srcs = [], td_includes = [], strip_include_prefix = None, test = False):
+    name_block = self._convert_name_block(name)
+    tblgen_block = self._convert_tblgen_block(tblgen)
+    td_file_block = self._convert_td_file_block(td_file)
+    outs_block = self._convert_tbl_outs_block(tbl_outs)
 
     self.converter.body += """iree_tablegen_library(
-%(name_block)s%(srcs_block)s%(outs_block)s%(tblgen_block)s)\n\n""" % {
+%(name_block)s%(td_file_block)s%(outs_block)s%(tblgen_block)s)\n\n""" % {
     "name_block": name_block,
-    "srcs_block": srcs_block,
+    "td_file_block": td_file_block,
     "outs_block": outs_block,
     "tblgen_block": tblgen_block,
     }
 
-  def iree_setup_lit_package(self, **kwargs):
-    self._convert_unimplemented_function("iree_setup_lit_package", **kwargs)
-
-  def iree_glob_lit_tests(self, **kwargs):
-    self._convert_unimplemented_function("iree_glob_lit_tests", **kwargs)
-
-  def iree_lit_test_suite(self, **kwargs):
-    name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_srcs_block(**kwargs)
-    data_block = self._convert_data_block(**kwargs)
+  def iree_lit_test_suite(self, name, srcs, data, **kwargs):
+    name_block = self._convert_name_block(name)
+    srcs_block = self._convert_srcs_block(srcs)
+    data_block = self._convert_data_block(data)
 
     self.converter.body += ("iree_lit_test_suite(\n"
                             "%(name_block)s"

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     iree::base::target_platform
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -41,6 +42,7 @@ iree_cc_library(
     iree::base::target_platform
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -57,6 +59,7 @@ iree_cc_library(
     iree::base::tracing
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -70,6 +73,7 @@ iree_cc_library(
     iree::base::initializer
     iree::base::target_platform
     absl::flags_parse
+  PUBLIC
 )
 
 iree_cc_library(
@@ -83,6 +87,7 @@ iree_cc_library(
     iree::base::platform_headers
     absl::core_headers
     absl::flags
+  PUBLIC
 )
 
 iree_cc_library(
@@ -90,6 +95,7 @@ iree_cc_library(
     source_location_internal
   HDRS
     "source_location.h"
+  PUBLIC
 )
 
 iree_cc_library(
@@ -120,6 +126,7 @@ iree_cc_library(
     absl::flags
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -133,4 +140,5 @@ iree_cc_library(
     absl::strings
     absl::optional
   TESTONLY
+  PUBLIC
 )

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     HLOToFlow

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
@@ -15,28 +15,6 @@
 iree_lit_test_suite(
   NAME
     lit
-  SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     StandardToFlow

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
@@ -15,28 +15,6 @@
 iree_lit_test_suite(
   NAME
     lit
-  SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/CMakeLists.txt
@@ -30,4 +30,5 @@ iree_cc_embed_data(
   CPP_NAMESPACE
     "mlir::iree_compiler"
   FLATTEN
+  PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
@@ -28,9 +28,9 @@ iree_cc_library(
   DEPS
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
+    iree::compiler::Dialect::HAL::Utils
     iree::compiler::Dialect::IREE::IR
     MLIRIR
-    MLIRParser
     MLIRStandardOps
     MLIRTransforms
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
 add_subdirectory(LegacyInterpreter)
-add_subdirectory(VulkanSPIRV)
 add_subdirectory(VMLA)
+add_subdirectory(VulkanSPIRV)
+add_subdirectory(test)
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "TypeUtils.cpp"
   DEPS
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRStandardOps
     MLIRTransforms

--- a/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
@@ -16,27 +16,10 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "canonicalize.mlir"
+    "op_verification.mlir"
+    "parse_print.mlir"
+    "ranked_shape_type.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     Transforms
@@ -21,11 +23,8 @@ iree_cc_library(
     "ExpandFunctionDynamicDims.cpp"
   DEPS
     iree::compiler::Dialect::Shape::IR
-    LLVMSupport
     MLIRIR
     MLIRPass
-    MLIRSupport
-    MLIRTransformUtils
     MLIRTransforms
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
@@ -16,27 +16,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "expand_function_dynamic_dims.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(Interpreter)
 add_subdirectory(SPIRV)
 add_subdirectory(XLAToLinalg)
+add_subdirectory(test)
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     MLIRIR
     MLIRLinalgOps
     MLIRLinalgTransforms
+    # bazel_to_cmake: DO NOT EDIT
     # TODO: Drop dependency on MLIRLinalgUtils
     #       Fixed in MLIR within https://reviews.llvm.org/D72821
     #       HEAD of llvm-project submodule points to an older revision.

--- a/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     XLAToLinalg

--- a/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
@@ -16,28 +16,11 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
     "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "dynamic_shape.mlir"
+    "exp.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt
+    MLIRmlir-translate
 )

--- a/iree/compiler/Translation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/test/CMakeLists.txt
@@ -16,28 +16,10 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "do_not_optimize.mlir"
+    "smoketest.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt
+    iree::tools::iree-translate
 )

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -48,16 +48,21 @@ iree_cc_library(
     iree::hal::buffer
     iree::hal::buffer_view
     iree::hal::command_buffer
+    iree::hal::descriptor_set
+    iree::hal::descriptor_set_layout
     iree::hal::device
     iree::hal::driver
     iree::hal::driver_registry
+    iree::hal::executable_layout
     iree::hal::fence
     iree::hal::heap_buffer
     iree::hal::semaphore
     iree::base::api
     iree::base::api_util
+    iree::base::ref_ptr
     iree::base::shape
     iree::base::tracing
+    absl::strings
     absl::span
   PUBLIC
 )
@@ -286,8 +291,8 @@ iree_cc_library(
     iree::hal::descriptor_set_layout
     iree::hal::device_info
     iree::hal::event
-    iree::hal::executable_layout
     iree::hal::executable_cache
+    iree::hal::executable_layout
     iree::hal::semaphore
     iree::base::ref_ptr
     iree::base::status

--- a/iree/hal/interpreter/CMakeLists.txt
+++ b/iree/hal/interpreter/CMakeLists.txt
@@ -82,8 +82,6 @@ iree_cc_library(
     bytecode_kernels
   HDRS
     "bytecode_kernels.h"
-    "bytecode_kernels_generic.h"
-    "bytecode_kernels_ruy.h"
   DEPS
     iree::base::shape
     iree::base::status

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -12,4 +12,124 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(benvanik): use bazel-to-cmake magic script.
+iree_cc_library(
+  NAME
+    vmla_cache
+  HDRS
+    "vmla_cache.h"
+  SRCS
+    "vmla_cache.cc"
+  DEPS
+    iree::hal::vmla::vmla_executable
+    iree::base::source_location
+    iree::base::status
+    iree::base::tracing
+    iree::hal::allocator
+    iree::hal::executable
+    iree::hal::executable_cache
+    iree::hal::executable_format
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_command_processor
+  HDRS
+    "vmla_command_processor.h"
+  SRCS
+    "vmla_command_processor.cc"
+  DEPS
+    iree::hal::vmla::vmla_executable
+    iree::base::status
+    iree::base::tracing
+    iree::hal::host::host_local_command_processor
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_device
+  HDRS
+    "vmla_device.h"
+  SRCS
+    "vmla_device.cc"
+  DEPS
+    iree::hal::vmla::vmla_cache
+    iree::hal::vmla::vmla_command_processor
+    iree::base::memory
+    iree::base::status
+    iree::base::tracing
+    iree::hal::command_buffer_validation
+    iree::hal::command_queue
+    iree::hal::device
+    iree::hal::fence
+    iree::hal::host::async_command_queue
+    iree::hal::host::host_event
+    iree::hal::host::host_local_allocator
+    iree::hal::host::host_submission_queue
+    iree::hal::host::inproc_command_buffer
+    absl::inlined_vector
+    absl::memory
+    absl::span
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_driver
+  HDRS
+    "vmla_driver.h"
+  SRCS
+    "vmla_driver.cc"
+  DEPS
+    iree::hal::vmla::vmla_device
+    iree::hal::device_info
+    iree::hal::driver
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_driver_module
+  SRCS
+    "vmla_driver_module.cc"
+  DEPS
+    iree::hal::vmla::vmla_driver
+    iree::base::init
+    iree::base::status
+    iree::hal::driver_registry
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_executable
+  HDRS
+    "vmla_executable.h"
+  SRCS
+    "vmla_executable.cc"
+  DEPS
+    iree::base::status
+    iree::hal::allocator
+    iree::hal::executable
+    iree::hal::executable_spec
+    absl::span
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_module
+  HDRS
+    "vmla_module.h"
+  SRCS
+    "vmla_module.cc"
+  DEPS
+    iree::base::api
+    iree::base::tracing
+    iree::vm
+    iree::vm::module_abi_cc
+    absl::span
+  PUBLIC
+)

--- a/iree/modules/check/dialect/test/CMakeLists.txt
+++ b/iree/modules/check/dialect/test/CMakeLists.txt
@@ -16,28 +16,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "ops.mlir"
+    "vm_import_conversion.mlir"
   DATA
+    iree::modules::check::dialect::check-opt
     iree::tools::IreeFileCheck
-    iree::tools::iree-opt
 )

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_test(
     iree::base::api
     iree::base::logging
     iree::hal::api
+    iree::hal::interpreter::interpreter_driver_module
     iree::modules::hal
     iree::testing::gtest_main
     iree::vm
@@ -59,6 +60,8 @@ iree_cc_library(
     iree::base::api
     iree::base::api_util
     iree::base::buffer_string_util
+    iree::base::shape
+    iree::base::shaped_buffer_string_util
     iree::hal::api
     iree::modules::hal
     iree::vm

--- a/iree/samples/custom_modules/dialect/test/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/test/CMakeLists.txt
@@ -16,28 +16,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "conversion.mlir"
+    "custom_ops.mlir"
   DATA
+    iree::samples::custom_modules::dialect::custom-opt
     iree::tools::IreeFileCheck
-    iree::tools::iree-opt
 )

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -12,31 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Implementations for iree/testing/
+iree_cc_library(
+  NAME
+    gtest_internal
+  HDRS
+    "gtest_internal.h"
+  DEPS
+    gtest
+  TESTONLY
+  PUBLIC
+)
 
-if(${IREE_BUILD_TESTS})
-
-  iree_cc_library(
-    NAME
-      gtest_internal
-    HDRS
-      "gtest_internal.h"
-    DEPS
-      gtest
-    PUBLIC
-  )
-
-  iree_cc_library(
-    NAME
-      gtest_main_internal
-    HDRS
-      "gtest_internal.h"
-    SRCS
-      "gtest_main_internal.cc"
-    DEPS
-      iree::base::init
-      gtest
-    PUBLIC
-  )
-
-endif()
+iree_cc_library(
+  NAME
+    gtest_main_internal
+  HDRS
+    "gtest_internal.h"
+  SRCS
+    "gtest_main_internal.cc"
+  DEPS
+    iree::base::init
+    gtest
+  TESTONLY
+  PUBLIC
+)

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -36,6 +36,8 @@ iree_bytecode_module(
     "bytecode_dispatch_test.mlir"
   CC_NAMESPACE
     "iree::vm"
+  TRANSLATE_TOOL
+    iree_tools_iree-translate
   TRANSLATION
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
@@ -52,7 +54,6 @@ iree_cc_library(
     "bytecode_module_impl.h"
     "bytecode_op_table.h"
   DEPS
-    iree::vm::bytecode_op_table_gen
     iree::vm::module
     iree::vm::ref
     iree::vm::stack
@@ -91,6 +92,8 @@ iree_bytecode_module(
     "bytecode_module_benchmark.mlir"
   CC_NAMESPACE
     "iree::vm"
+  TRANSLATE_TOOL
+    iree_tools_iree-translate
   TRANSLATION
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
@@ -115,7 +118,7 @@ iree_tablegen_library(
     -gen-iree-vm-op-table-defs bytecode_op_table.h
   TBLGEN
     IREE
- )
+)
 
 iree_cc_library(
   NAME


### PR DESCRIPTION
WIP. I'll break this into separate PRs once parts of its dep chain get merged.

These changes make it possible to run bazel_to_cmake across the entire iree/ directory (it will skip files it can't convert). Most of this was inventing new ways for it not to edit things it can't get completely right.

I also did some cleanup adding explicit arguments to the various rule functions. This makes the code simpler and more resilient.

Tested:
Ran bazel_to_cmake across the entire directory
56 tests pass before and after this change, but now we've got 154 tests instead of 145.