### PR TITLE
Modify mappings in MLIR_EXPLICIT_TARGET_MAPPING

### DIFF
--- a/build_tools/scripts/bazel_to_cmake_targets.py
+++ b/build_tools/scripts/bazel_to_cmake_targets.py
@@ -74,6 +74,8 @@ MLIR_EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:StandardToSPIRVConversions":
         "MLIRStandardToSPIRVTransforms",
     "@llvm-project//mlir:MlirOptMain":
+        "MLIRMlirOptLib",
+    "@llvm-project//mlir:MlirOptLib":
         "MLIROptMain",
 }
 


### PR DESCRIPTION
In Bazel the targets map to the following source files:

* `"@llvm-project//mlir:MlirOptLib"`	->		`lib/Support/MlirOptMain.cpp`
https://github.com/google/iree/blob/6fbc32764c6fc38ad18f3ca9396778f79ded0c5e/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel#L1683-L1686

* `"@llvm-project//mlir:MlirOptMain"`	->	`tools/mlir-opt/mlir-opt.cpp`
https://github.com/google/iree/blob/6fbc32764c6fc38ad18f3ca9396778f79ded0c5e/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel#L1760-L1763

In CMake the mapping is different one:
* `MLIRMlirOptLib`						->		`mlir-opt.cpp`
https://github.com/llvm/llvm-project/blob/0133cc60e4e230ee2c176c23eff5aa2f4ee17a75/mlir/tools/mlir-opt/CMakeLists.txt#L13-L15

* `MLIROptMain` 						->		`MlirOptMain.cpp`
https://github.com/llvm/llvm-project/blob/0133cc60e4e230ee2c176c23eff5aa2f4ee17a75/mlir/lib/Support/CMakeLists.txt#L20-L21