### PR TITLE
Refactor target names MlirOptLib and MlirOptMain

### DIFF
--- a/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel
+++ b/build_tools/bazel/third_party_import/llvm-project/overlay/mlir/BUILD.bazel
@@ -1680,7 +1680,7 @@ cc_library(
 
 # TODO(jpienaar): Update this.
 cc_library(
-    name = "MlirOptLib",
+    name = "MlirOptMain",
     srcs = [
         "lib/Support/MlirOptMain.cpp",
     ],
@@ -1757,13 +1757,13 @@ cc_binary(
 
 # TODO(jpienaar): This library should be removed.
 cc_library(
-    name = "MlirOptMain",
+    name = "MlirOptLib",
     srcs = [
         "tools/mlir-opt/mlir-opt.cpp",
     ],
     deps = [
         ":Analysis",
-        ":MlirOptLib",
+        ":MlirOptMain",
         ":Pass",
         ":Support",
         "@llvm-project//llvm:support",

--- a/iree/modules/check/dialect/BUILD
+++ b/iree/modules/check/dialect/BUILD
@@ -82,7 +82,7 @@ cc_binary(
     deps = [
         ":dialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
+        "@llvm-project//mlir:MlirOptLib",
     ],
 )
 

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -84,7 +84,7 @@ cc_binary(
     deps = [
         ":dialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
+        "@llvm-project//mlir:MlirOptLib",
     ],
 )
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -70,7 +70,7 @@ cc_library(
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:AffineDialectRegistration",
         "@llvm-project//mlir:LinalgDialectRegistration",
-        "@llvm-project//mlir:MlirOptLib",
+        "@llvm-project//mlir:MlirOptMain",
         "@llvm-project//mlir:StandardDialectRegistration",
         "@llvm-project//mlir:SPIRVDialectRegistration",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
@@ -84,7 +84,7 @@ cc_binary(
     name = "iree-opt",
     deps = [
         ":iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
+        "@llvm-project//mlir:MlirOptLib",
     ],
 )
 


### PR DESCRIPTION
Changes the names of Bazel targets to match MLIR's CMake configuration:
 * MlirOptLib -> MlirOptMain
 * MlirOptMain -> MlirOptLib

See discussion in #569