### PR TITLE
Replace SRCS by TD_FILE in CMake's iree_tablegen_library()

### DIFF
--- a/build_tools/cmake/iree_tablegen_library.cmake
+++ b/build_tools/cmake/iree_tablegen_library.cmake
@@ -22,7 +22,7 @@ function(iree_tablegen_library)
     _RULE
     "TESTONLY"
     "NAME;TBLGEN"
-    "SRCS;OUTS"
+    "TD_FILE;OUTS"
     ${ARGN}
   )
 
@@ -37,7 +37,7 @@ function(iree_tablegen_library)
       set(_TBLGEN "MLIR")
     endif()
 
-    set(LLVM_TARGET_DEFINITIONS ${_RULE_SRCS})
+    set(LLVM_TARGET_DEFINITIONS ${_RULE_TD_FILE})
     set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
     list(APPEND _INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
     list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -174,7 +174,7 @@ class BuildFileFunctions(object):
       # -> CMake `${IREE_ROOT_DIR}/iree/dir/IR/td_file.td
       td_file = td_file.replace("//", "${IREE_ROOT_DIR}/")
       td_file = td_file.replace(":", "/")
-    return "  SRCS\n    \"%s\"\n" % (td_file)
+    return "  TD_FILE\n    \"%s\"\n" % (td_file)
 
   def _convert_tbl_outs_block(self, **kwargs):
     tbl_outs = kwargs.get("tbl_outs")
@@ -363,14 +363,14 @@ class BuildFileFunctions(object):
 
   def gentbl(self, **kwargs):
     name_block = self._convert_name_block(**kwargs)
-    srcs_block = self._convert_td_file_block(**kwargs)
+    td_file_block = self._convert_td_file_block(**kwargs)
     outs_block = self._convert_tbl_outs_block(**kwargs)
     tblgen_block = self._convert_tblgen_block(**kwargs)
 
     self.converter.body += """iree_tablegen_library(
-%(name_block)s%(srcs_block)s%(outs_block)s%(tblgen_block)s)\n\n""" % {
+%(name_block)s%(td_file_block)s%(outs_block)s%(tblgen_block)s)\n\n""" % {
     "name_block": name_block,
-    "srcs_block": srcs_block,
+    "td_file_block": td_file_block,
     "outs_block": outs_block,
     "tblgen_block": tblgen_block,
     }

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -46,7 +46,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     FlowEnumsGen
-  SRCS
+  TD_FILE
     FlowBase.td
   OUTS
     -gen-enum-decls FlowEnums.h.inc
@@ -56,7 +56,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     FlowOpInterfaceGen
-  SRCS
+  TD_FILE
     FlowBase.td
   OUTS
     -gen-op-interface-decls FlowOpInterface.h.inc
@@ -66,7 +66,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     FlowOpsGen
-  SRCS
+  TD_FILE
     FlowOps.td
   OUTS
     -gen-op-decls FlowOps.h.inc

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -67,7 +67,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     HALEnumsGen
-  SRCS
+  TD_FILE
     HALBase.td
   OUTS
     -gen-enum-decls HALEnums.h.inc
@@ -77,7 +77,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     HALOpInterfaceGen
-  SRCS
+  TD_FILE
     HALBase.td
   OUTS
     -gen-op-interface-decls HALOpInterface.h.inc
@@ -87,7 +87,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     HALOpsGen
-  SRCS
+  TD_FILE
     HALOps.td
   OUTS
     -gen-op-decls HALOps.h.inc

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -42,7 +42,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     IREEOpsGen
-  SRCS
+  TD_FILE
     IREEOps.td
   OUTS
     -gen-op-decls IREEOps.h.inc

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -40,7 +40,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     ShapeOpsGen
-  SRCS
+  TD_FILE
     ShapeOps.td
   OUTS
     -gen-op-decls ShapeOps.h.inc

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -49,7 +49,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     VMEnumsGen
-  SRCS
+  TD_FILE
     VMBase.td
   OUTS
     -gen-enum-decls VMEnums.h.inc
@@ -59,7 +59,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     VMOpsGen
-  SRCS
+  TD_FILE
     VMOps.td
   OUTS
     -gen-op-decls VMOps.h.inc
@@ -69,7 +69,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     VMOpEncoderGen
-  SRCS
+  TD_FILE
     VMOps.td
   OUTS
     -gen-iree-vm-op-encoder-defs VMOpEncoder.cpp.inc
@@ -80,7 +80,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     VMOpInterfaceGen
-  SRCS
+  TD_FILE
     VMBase.td
   OUTS
     -gen-op-interface-decls VMOpInterface.h.inc

--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -39,7 +39,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     CommonOpsGen
-  SRCS
+  TD_FILE
     CommonOps.td
   OUTS
     -gen-op-decls CommonOps.h.inc
@@ -85,7 +85,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     HLOpsGen
-  SRCS
+  TD_FILE
     HLOps.td
   OUTS
     -gen-op-decls HLOps.h.inc
@@ -95,7 +95,7 @@ iree_tablegen_library(
 iree_tablegen_library(
   NAME
     LLOpsGen
-  SRCS
+  TD_FILE
     LLOps.td
   OUTS
     -gen-op-decls LLOps.h.inc

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -45,7 +45,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     check_ops_gen
-  SRCS
+  TD_FILE
     check_ops.td
   OUTS
     -gen-op-decls check_ops.h.inc

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -109,7 +109,7 @@ iree_cc_test(
 iree_tablegen_library(
   NAME
     bytecode_op_table_gen
-  SRCS
+  TD_FILE
     "${IREE_ROOT_DIR}/iree/compiler/Dialect/VM/IR/VMOps.td"
   OUTS
     -gen-iree-vm-op-table-defs bytecode_op_table.h


### PR DESCRIPTION
In the Bazel world, `gentbl()` get's it's input file passed as `td_file`. Adopting to CMake.