### PR TITLE
Refactor iree_alwayslink.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ include(iree_spirv_kernel_cc_library)
 include(iree_pybind_cc_library)
 include(iree_glob_lit_tests)
 include(iree_lit_test)
+include(iree_alwayslink)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 
@@ -124,6 +125,7 @@ if(${IREE_ENABLE_LLVM})
   endif()
 
   add_subdirectory(third_party/llvm-project/llvm EXCLUDE_FROM_ALL)
+  set_alwayslink_mlir_libs()
 
   # Reset CMAKE_BUILD_TYPE to its previous setting
   set(CMAKE_BUILD_TYPE "${_CMAKE_BUILD_TYPE}" CACHE STRING "Build type (default ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)
@@ -133,6 +135,7 @@ endif()
 
 if(${IREE_BUILD_COMPILER})
   add_subdirectory(build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla EXCLUDE_FROM_ALL)
+  set_alwayslink_tensorflow_libs()
 endif()
 
 if(${IREE_BUILD_DEBUGGER} OR ${IREE_BUILD_SAMPLES})
@@ -184,6 +187,3 @@ add_subdirectory(iree/tools)
 if(${IREE_BUILD_SAMPLES})
   add_subdirectory(iree/samples)
 endif()
-
-# Set ALWAYSLINK property after all targets have been created
-include(iree_alwayslink)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -12,30 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CMakeParseArguments)
+
 # Additional libraries containing statically registered functions/flags, which
 # should always be linked in to binaries.
 
-set(_ALWAYSLINK_LIBS
-  MLIRAffineOps
-  MLIRAnalysis
-  MLIREDSC
-  MLIRIR
-  MLIRParser
-  MLIRPass
-  MLIRSPIRV
-  MLIRSPIRVSerialization
-  MLIRSPIRVTransforms
-  MLIRStandardOps
-  MLIRTransforms
-  MLIRTranslation
-  MLIRSupport
-  MLIRVectorOps
-  MLIRLinalgOps
-  tensorflow::mlir_xla
-)
 
-foreach(LIB ${_ALWAYSLINK_LIBS})
-  if(TARGET LIB)
-    set_property(TARGET ${LIB} PROPERTY ALWAYSLINK 1)
-  endif()
-endforeach(LIB)
+# set_alwayslink_property()
+#
+# CMake function to set the ALWAYSLINK on external libraries
+#
+# Parameters:
+# ALWAYSLINK_LIBS: List of libraries
+# SKIP_NONEXISTING: When added, ALWAYSLINK is only set on existing libraries.
+
+function(set_alwayslink_property)
+  cmake_parse_arguments(
+    _RULE
+    "SKIP_NONEXISTING"
+    ""
+    "ALWAYSLINK_LIBS"
+    ${ARGN}
+  )
+
+  foreach(_LIB ${_RULE_ALWAYSLINK_LIBS})
+    # If SKIP_NONEXISTING is false: Always try to set the property.
+    # If SKIP_NONEXISTING is true : Only set the property if the target exists.
+    if((_RULE_SKIP_NONEXISTING AND TARGET ${_LIB}) OR NOT _RULE_SKIP_NONEXISTING)
+
+      # Check if the target is an aliased target.
+      # If so get the non aliased target.
+      get_target_property(_ALIASED_TARGET ${_LIB} ALIASED_TARGET)
+      if(_ALIASED_TARGET)
+        set(_LIB ${_ALIASED_TARGET})
+      endif()
+
+      set_property(TARGET ${_LIB} PROPERTY ALWAYSLINK 1)
+    endif()
+  endforeach()
+endfunction()
+
+
+function(set_alwayslink_mlir_libs)
+  set(_ALWAYSLINK_LIBS_MLIR
+    MLIRAffineOps
+    MLIRAnalysis
+    MLIREDSC
+    MLIRIR
+    MLIRParser
+    MLIRPass
+    MLIRSPIRV
+    MLIRSPIRVSerialization
+    MLIRSPIRVTransforms
+    MLIRStandardOps
+    MLIRTransforms
+    MLIRTranslation
+    MLIRSupport
+    MLIRVectorOps
+    MLIRLinalgOps
+  )
+
+  set_alwayslink_property(
+    ALWAYSLINK_LIBS
+      ${_ALWAYSLINK_LIBS_MLIR}
+  )
+endfunction()
+
+
+function(set_alwayslink_tensorflow_libs)
+  set(_ALWAYSLINK_LIBS_TENSORFLOW
+    tensorflow::mlir_xla
+  )
+
+  set_alwayslink_property(
+    ALWAYSLINK_LIBS
+      ${_ALWAYSLINK_LIBS_TENSORFLOW}
+  )
+endfunction()

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -38,17 +38,18 @@ function(set_alwayslink_property)
   foreach(_LIB ${_RULE_ALWAYSLINK_LIBS})
     # If SKIP_NONEXISTING is false: Always try to set the property.
     # If SKIP_NONEXISTING is true : Only set the property if the target exists.
-    if((_RULE_SKIP_NONEXISTING AND TARGET ${_LIB}) OR NOT _RULE_SKIP_NONEXISTING)
-
-      # Check if the target is an aliased target.
-      # If so get the non aliased target.
-      get_target_property(_ALIASED_TARGET ${_LIB} ALIASED_TARGET)
-      if(_ALIASED_TARGET)
-        set(_LIB ${_ALIASED_TARGET})
-      endif()
-
-      set_property(TARGET ${_LIB} PROPERTY ALWAYSLINK 1)
+    if(NOT TARGET ${_LIB} AND _RULE_SKIP_NONEXISTING)
+      continue()
     endif()
+
+    # Check if the target is an aliased target.
+    # If so get the non aliased target.
+    get_target_property(_ALIASED_TARGET ${_LIB} ALIASED_TARGET)
+    if(_ALIASED_TARGET)
+      set(_LIB ${_ALIASED_TARGET})
+    endif()
+
+    set_property(TARGET ${_LIB} PROPERTY ALWAYSLINK 1)
   endforeach()
 endfunction()
 


### PR DESCRIPTION
* Splits setting ALWAYSLINK properties into multiple function calls
* Sets ALWAYSLINK directly after the config for targets is generated
* Makes checking if a target exists optional (generate an error by
  default if a target does not exist)
* Reintroduces checking for alias targets (e.g. tensorflow normaly is)

Closes #496