### PR TITLE
Bazel to CMake: run in strict mode across iree

### DIFF
--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -336,7 +336,10 @@ class BuildFileFunctions(object):
                  deps=[],
                  alwayslink=False,
                  testonly=False,
+                 textual_hdrs = None,
                  **kwargs):
+    if textual_hdrs:
+      _convert_unimplemented_function("cc_library (textual_hdrs)", name=name)
     name_block = self._convert_name_block(name)
     hdrs_block = self._convert_hdrs_block(hdrs)
     srcs_block = self._convert_srcs_block(srcs)
@@ -392,7 +395,7 @@ class BuildFileFunctions(object):
                     identifier=None,
                     **kwargs):
     if identifier:
-      self._convert_unimplemented_function("cc_embed_data", name=name)
+      self._convert_unimplemented_function("cc_embed_data (identifier)", name=name)
     name_block = self._convert_name_block(name)
     srcs_block = self._convert_srcs_block(srcs)
     cc_file_output_block = self._convert_cc_file_output_block(cc_file_output)

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -53,6 +53,11 @@ def parse_arguments():
       help="Prints results instead of writing files",
       action="store_true",
       default=False)
+  parser.add_argument(
+      "--strict",
+      help="Does not try to generate files where it cannot convert completely",
+      action="store_true",
+      default=False)
 
   # Specify only one of these (defaults to --root_dir=iree).
   group = parser.add_mutually_exclusive_group()
@@ -252,10 +257,10 @@ class BuildFileFunctions(object):
 
   def _convert_unimplemented_function(self, rule, *args, **kwargs):
     name = kwargs.get("name", "unnamed")
-    self.converter.body += "# Unimplemented %(rule)s %(name)s\n" % {
-        "rule": rule,
-        "name": name
-    }
+    message = "Unimplemented %(rule)s %(name)s\n" % {"rule": rule, "name": name}
+    if not self.converter.first_error:
+      self.converter.first_error = NotImplementedError(message)
+    self.converter.body += "# %s" % (message,)
 
   # ------------------------------------------------------------------------- #
   # Function handlers that convert BUILD definitions to CMake definitions.    #
@@ -290,8 +295,9 @@ class BuildFileFunctions(object):
     # conversion time. This avoids issues with different glob semantics and dire
     # warnings about not knowing when to reevaluate the glob.
     # See https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
+
     if exclude_directories != 1:
-      raise ValueError("Non-default exclude_directories not supported")
+      raise NotImplementedError("Non-default exclude_directories not supported")
 
     filepaths = []
     for pattern in include:
@@ -300,7 +306,7 @@ class BuildFileFunctions(object):
         # We have no uses of recursive globs. Rather than try to emulate them or
         # silently give different behavior, just error out.
         # See https://docs.bazel.build/versions/master/be/functions.html#glob
-        raise ValueError("Recursive globs not supported")
+        raise NotImplementedError("Recursive globs not supported")
 
       filepaths += glob.glob(self.converter.directory_path + "/" + pattern)
 
@@ -308,7 +314,7 @@ class BuildFileFunctions(object):
     for pattern in exclude:
       if "**" in pattern:
         # See comment above
-        raise ValueError("Recursive globs not supported")
+        raise NotImplementedError("Recursive globs not supported")
       exclude_filepaths.update(
           glob.glob(self.converter.directory_path + "/" + pattern))
 
@@ -479,6 +485,7 @@ class Converter(object):
     self.body = ""
     self.directory_path = directory_path
     self.rel_build_file_path = rel_build_file_path
+    self.first_error = None
 
   def convert(self, copyright_line):
     # One `add_subdirectory(name)` per subdirectory.
@@ -531,15 +538,15 @@ def GetDict(obj):
   return ret
 
 
-def convert_directory_tree(root_directory_path, write_files):
+def convert_directory_tree(root_directory_path, write_files, strict):
   print("convert_directory_tree: %s" % (root_directory_path,))
   # Process directories starting at leaves so we can skip add_directory on
   # subdirs without a CMakeLists file.
   for root, dirs, file_names in os.walk(root_directory_path, topdown=False):
-    convert_directory(root, write_files)
+    convert_directory(root, write_files, strict)
 
 
-def convert_directory(directory_path, write_files):
+def convert_directory(directory_path, write_files, strict):
   if not os.path.isdir(directory_path):
     raise FileNotFoundError("Cannot find directory '%s'" % (directory_path,))
 
@@ -588,12 +595,14 @@ def convert_directory(directory_path, write_files):
     try:
       exec(build_file_code, GetDict(BuildFileFunctions(converter)))
       converted_text = converter.convert(copyright_line)
+      if strict and converter.first_error:
+        raise converter.first_error
       if write_allowed:
         with open(cmakelists_file_path, "wt") as cmakelists_file:
           cmakelists_file.write(converted_text)
       else:
         print(converted_text)
-    except NameError as e:
+    except (NameError, NotImplementedError) as e:
       print(
           "Failed to convert %s. Missing a rule handler in bazel_to_cmake.py?" %
           (rel_build_file_path))
@@ -612,9 +621,11 @@ def main(args):
   write_files = not args.preview
 
   if args.root_dir:
-    convert_directory_tree(os.path.join(repo_root, args.root_dir), write_files)
+    convert_directory_tree(
+        os.path.join(repo_root, args.root_dir), write_files, args.strict)
   elif args.dir:
-    convert_directory(os.path.join(repo_root, args.dir), write_files)
+    convert_directory(
+        os.path.join(repo_root, args.dir), write_files, args.strict)
 
 
 if __name__ == "__main__":

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     iree::base::target_platform
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -41,6 +42,7 @@ iree_cc_library(
     iree::base::target_platform
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -57,6 +59,7 @@ iree_cc_library(
     iree::base::tracing
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -70,6 +73,7 @@ iree_cc_library(
     iree::base::initializer
     iree::base::target_platform
     absl::flags_parse
+  PUBLIC
 )
 
 iree_cc_library(
@@ -83,6 +87,7 @@ iree_cc_library(
     iree::base::platform_headers
     absl::core_headers
     absl::flags
+  PUBLIC
 )
 
 iree_cc_library(
@@ -90,6 +95,7 @@ iree_cc_library(
     source_location_internal
   HDRS
     "source_location.h"
+  PUBLIC
 )
 
 iree_cc_library(
@@ -120,6 +126,7 @@ iree_cc_library(
     absl::flags
     absl::memory
     absl::strings
+  PUBLIC
 )
 
 iree_cc_library(
@@ -133,4 +140,5 @@ iree_cc_library(
     absl::strings
     absl::optional
   TESTONLY
+  PUBLIC
 )

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     HLOToFlow

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
@@ -15,28 +15,6 @@
 iree_lit_test_suite(
   NAME
     lit
-  SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     StandardToFlow

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
@@ -15,28 +15,6 @@
 iree_lit_test_suite(
   NAME
     lit
-  SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/CMakeLists.txt
@@ -30,4 +30,5 @@ iree_cc_embed_data(
   CPP_NAMESPACE
     "mlir::iree_compiler"
   FLATTEN
+  PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
@@ -28,9 +28,9 @@ iree_cc_library(
   DEPS
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
+    iree::compiler::Dialect::HAL::Utils
     iree::compiler::Dialect::IREE::IR
     MLIRIR
-    MLIRParser
     MLIRStandardOps
     MLIRTransforms
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
 add_subdirectory(LegacyInterpreter)
-add_subdirectory(VulkanSPIRV)
 add_subdirectory(VMLA)
+add_subdirectory(VulkanSPIRV)
+add_subdirectory(test)
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "TypeUtils.cpp"
   DEPS
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRStandardOps
     MLIRTransforms

--- a/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
@@ -16,27 +16,10 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "canonicalize.mlir"
+    "op_verification.mlir"
+    "parse_print.mlir"
+    "ranked_shape_type.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     Transforms
@@ -21,11 +23,8 @@ iree_cc_library(
     "ExpandFunctionDynamicDims.cpp"
   DEPS
     iree::compiler::Dialect::Shape::IR
-    LLVMSupport
     MLIRIR
     MLIRPass
-    MLIRSupport
-    MLIRTransformUtils
     MLIRTransforms
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
@@ -16,27 +16,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "expand_function_dynamic_dims.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(Interpreter)
 add_subdirectory(SPIRV)
 add_subdirectory(XLAToLinalg)
+add_subdirectory(test)
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     MLIRIR
     MLIRLinalgOps
     MLIRLinalgTransforms
+    # bazel_to_cmake: DO NOT EDIT
     # TODO: Drop dependency on MLIRLinalgUtils
     #       Fixed in MLIR within https://reviews.llvm.org/D72821
     #       HEAD of llvm-project submodule points to an older revision.

--- a/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     XLAToLinalg

--- a/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
@@ -16,28 +16,11 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
     "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "dynamic_shape.mlir"
+    "exp.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt
+    MLIRmlir-translate
 )

--- a/iree/compiler/Translation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/test/CMakeLists.txt
@@ -16,28 +16,10 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "do_not_optimize.mlir"
+    "smoketest.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt
+    iree::tools::iree-translate
 )

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -48,16 +48,21 @@ iree_cc_library(
     iree::hal::buffer
     iree::hal::buffer_view
     iree::hal::command_buffer
+    iree::hal::descriptor_set
+    iree::hal::descriptor_set_layout
     iree::hal::device
     iree::hal::driver
     iree::hal::driver_registry
+    iree::hal::executable_layout
     iree::hal::fence
     iree::hal::heap_buffer
     iree::hal::semaphore
     iree::base::api
     iree::base::api_util
+    iree::base::ref_ptr
     iree::base::shape
     iree::base::tracing
+    absl::strings
     absl::span
   PUBLIC
 )
@@ -286,8 +291,8 @@ iree_cc_library(
     iree::hal::descriptor_set_layout
     iree::hal::device_info
     iree::hal::event
-    iree::hal::executable_layout
     iree::hal::executable_cache
+    iree::hal::executable_layout
     iree::hal::semaphore
     iree::base::ref_ptr
     iree::base::status

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -12,4 +12,124 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(benvanik): use bazel-to-cmake magic script.
+iree_cc_library(
+  NAME
+    vmla_cache
+  HDRS
+    "vmla_cache.h"
+  SRCS
+    "vmla_cache.cc"
+  DEPS
+    iree::hal::vmla::vmla_executable
+    iree::base::source_location
+    iree::base::status
+    iree::base::tracing
+    iree::hal::allocator
+    iree::hal::executable
+    iree::hal::executable_cache
+    iree::hal::executable_format
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_command_processor
+  HDRS
+    "vmla_command_processor.h"
+  SRCS
+    "vmla_command_processor.cc"
+  DEPS
+    iree::hal::vmla::vmla_executable
+    iree::base::status
+    iree::base::tracing
+    iree::hal::host::host_local_command_processor
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_device
+  HDRS
+    "vmla_device.h"
+  SRCS
+    "vmla_device.cc"
+  DEPS
+    iree::hal::vmla::vmla_cache
+    iree::hal::vmla::vmla_command_processor
+    iree::base::memory
+    iree::base::status
+    iree::base::tracing
+    iree::hal::command_buffer_validation
+    iree::hal::command_queue
+    iree::hal::device
+    iree::hal::fence
+    iree::hal::host::async_command_queue
+    iree::hal::host::host_event
+    iree::hal::host::host_local_allocator
+    iree::hal::host::host_submission_queue
+    iree::hal::host::inproc_command_buffer
+    absl::inlined_vector
+    absl::memory
+    absl::span
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_driver
+  HDRS
+    "vmla_driver.h"
+  SRCS
+    "vmla_driver.cc"
+  DEPS
+    iree::hal::vmla::vmla_device
+    iree::hal::device_info
+    iree::hal::driver
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_driver_module
+  SRCS
+    "vmla_driver_module.cc"
+  DEPS
+    iree::hal::vmla::vmla_driver
+    iree::base::init
+    iree::base::status
+    iree::hal::driver_registry
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_executable
+  HDRS
+    "vmla_executable.h"
+  SRCS
+    "vmla_executable.cc"
+  DEPS
+    iree::base::status
+    iree::hal::allocator
+    iree::hal::executable
+    iree::hal::executable_spec
+    absl::span
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    vmla_module
+  HDRS
+    "vmla_module.h"
+  SRCS
+    "vmla_module.cc"
+  DEPS
+    iree::base::api
+    iree::base::tracing
+    iree::vm
+    iree::vm::module_abi_cc
+    absl::span
+  PUBLIC
+)

--- a/iree/modules/check/dialect/test/CMakeLists.txt
+++ b/iree/modules/check/dialect/test/CMakeLists.txt
@@ -16,28 +16,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "ops.mlir"
+    "vm_import_conversion.mlir"
   DATA
+    iree::modules::check::dialect::check-opt
     iree::tools::IreeFileCheck
-    iree::tools::iree-opt
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(suderman): fix cmake build
+# bazel_to_cmake: DO NOT EDIT
+
 iree_cc_library(
   NAME
     strings

--- a/iree/modules/strings/dialect/test/CMakeLists.txt
+++ b/iree/modules/strings/dialect/test/CMakeLists.txt
@@ -16,28 +16,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "conversion.mlir"
+    "strings_ops.mlir"
   DATA
+    iree::modules::strings::dialect::strings-opt
     iree::tools::IreeFileCheck
-    iree::tools::iree-opt
 )

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_test(
     iree::base::api
     iree::base::logging
     iree::hal::api
+    iree::hal::interpreter::interpreter_driver_module
     iree::modules::hal
     iree::testing::gtest_main
     iree::vm
@@ -59,6 +60,8 @@ iree_cc_library(
     iree::base::api
     iree::base::api_util
     iree::base::buffer_string_util
+    iree::base::shape
+    iree::base::shaped_buffer_string_util
     iree::hal::api
     iree::modules::hal
     iree::vm

--- a/iree/samples/custom_modules/dialect/test/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/test/CMakeLists.txt
@@ -16,28 +16,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "conversion.mlir"
+    "custom_ops.mlir"
   DATA
+    iree::samples::custom_modules::dialect::custom-opt
     iree::tools::IreeFileCheck
-    iree::tools::iree-opt
 )

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -12,31 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Implementations for iree/testing/
+iree_cc_library(
+  NAME
+    gtest_internal
+  HDRS
+    "gtest_internal.h"
+  DEPS
+    gtest
+  TESTONLY
+  PUBLIC
+)
 
-if(${IREE_BUILD_TESTS})
-
-  iree_cc_library(
-    NAME
-      gtest_internal
-    HDRS
-      "gtest_internal.h"
-    DEPS
-      gtest
-    PUBLIC
-  )
-
-  iree_cc_library(
-    NAME
-      gtest_main_internal
-    HDRS
-      "gtest_internal.h"
-    SRCS
-      "gtest_main_internal.cc"
-    DEPS
-      iree::base::init
-      gtest
-    PUBLIC
-  )
-
-endif()
+iree_cc_library(
+  NAME
+    gtest_main_internal
+  HDRS
+    "gtest_internal.h"
+  SRCS
+    "gtest_main_internal.cc"
+  DEPS
+    iree::base::init
+    gtest
+  TESTONLY
+  PUBLIC
+)

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -36,6 +36,8 @@ iree_bytecode_module(
     "bytecode_dispatch_test.mlir"
   CC_NAMESPACE
     "iree::vm"
+  TRANSLATE_TOOL
+    iree_tools_iree-translate
   TRANSLATION
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
@@ -52,7 +54,6 @@ iree_cc_library(
     "bytecode_module_impl.h"
     "bytecode_op_table.h"
   DEPS
-    iree::vm::bytecode_op_table_gen
     iree::vm::module
     iree::vm::ref
     iree::vm::stack
@@ -91,6 +92,8 @@ iree_bytecode_module(
     "bytecode_module_benchmark.mlir"
   CC_NAMESPACE
     "iree::vm"
+  TRANSLATE_TOOL
+    iree_tools_iree-translate
   TRANSLATION
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
@@ -115,7 +118,7 @@ iree_tablegen_library(
     -gen-iree-vm-op-table-defs bytecode_op_table.h
   TBLGEN
     IREE
- )
+)
 
 iree_cc_library(
   NAME


### PR DESCRIPTION
This puts all files in line with the generator's output where we expect the generator to just work

Changes include:
1. Adding PUBLIC to a bunch of rules
2. Adding missing CMakeLists.txt files, mostly to test directories, but also in `iree/hal/vmla` which has a TODO for "magic script" :-P
3. iree/testing/internal/CMakeLists.txt uses TESTONLY instead of an explicit if block around IREE_BUILD_TESTS
4. A few other deps get added and removed.

Depends on https://github.com/google/iree/pull/592

Tested:
Everything builds with cmake and all the same tests pass with ctest. `iree_compiler_Dialect_HAL_Target_test_lit_smoketest.mlir_test` and `iree_compiler_Dialect_HAL_Transforms_test_lit_transformation.mlir_test` still fail and `iree_compiler_Translation_test_lit_do_not_optimize.mlir_test` is a newly failing test