### PR TITLE
Remove MLIRLinalgUtils dep and rerun bazel_to_cmake

### DIFF
--- a/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "expand_function_dynamic_dims.mlir"
+    "materialize_shape_calculations.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -28,11 +28,6 @@ iree_cc_library(
     MLIRIR
     MLIRLinalgOps
     MLIRLinalgTransforms
-    # bazel_to_cmake: DO NOT EDIT
-    # TODO: Drop dependency on MLIRLinalgUtils
-    #       Fixed in MLIR within https://reviews.llvm.org/D72821
-    #       HEAD of llvm-project submodule points to an older revision.
-    MLIRLinalgUtils
     MLIRLoopsToGPU
     MLIRPass
     MLIRSPIRV


### PR DESCRIPTION
We don't need this dep anymore now that we've imported the fix from LLVM.

Ran cmake_to_bazel over the whole project again and picked up a missing test file declaration, so including that too.

Tested:
Everything builds with cmake.
ctest has the same 4 failing tests before and after

```txt
 67 - iree_compiler_Dialect_HAL_Target_test_lit_smoketest.mlir_test (Failed)
 68 - iree_compiler_Dialect_HAL_Transforms_test_lit_transformation.mlir_test (Failed)
150 - iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_lit_single_pw_op.mlir_test (Failed)
154 - iree_compiler_Translation_test_lit_do_not_optimize.mlir_test (Failed)
```

Not great that one of those is in the dir I'm changing the dep. Looks like my version bump probably broke it. I think we shouldn't block on this until we're actually running the cmake tests in the CI though.