### PR TITLE
Add CMake support for textual_headers

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -21,6 +21,7 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: name of target (see Note)
 # HDRS: List of public header files for the library
+# TEXTUAL_HDRS: List of public header files that cannot be compiled on their own
 # SRCS: List of source files for the library
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
@@ -67,7 +68,7 @@ function(iree_cc_library)
     _RULE
     "PUBLIC;ALWAYSLINK;TESTONLY"
     "NAME"
-    "HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS;INCLUDES"
+    "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS;INCLUDES"
     ${ARGN}
   )
 
@@ -97,6 +98,7 @@ function(iree_cc_library)
       target_sources(${_NAME}
         PRIVATE
           ${_RULE_SRCS}
+          ${_RULE_TEXTUAL_HDRS}
           ${_RULE_HDRS}
       )
       target_include_directories(${_NAME}

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -167,6 +167,9 @@ class BuildFileFunctions(object):
   def _convert_hdrs_block(self, hdrs):
     return self._convert_filelist_block("HDRS", hdrs)
 
+  def _convert_textual_hdrs_block(self, textual_hdrs):
+    return self._convert_filelist_block("TEXTUAL_HDRS", textual_hdrs)
+
   def _convert_srcs_block(self, srcs):
     return self._convert_filelist_block("SRCS", srcs)
 
@@ -332,26 +335,26 @@ class BuildFileFunctions(object):
   def cc_library(self,
                  name,
                  hdrs=[],
+                 textual_hdrs=[],
                  srcs=[],
                  deps=[],
                  alwayslink=False,
                  testonly=False,
-                 textual_hdrs=None,
                  **kwargs):
-    if textual_hdrs:
-      _convert_unimplemented_function("cc_library (textual_hdrs)", name=name)
     name_block = self._convert_name_block(name)
     hdrs_block = self._convert_hdrs_block(hdrs)
+    textual_hdrs_block = self._convert_textual_hdrs_block(textual_hdrs)
     srcs_block = self._convert_srcs_block(srcs)
     deps_block = self._convert_deps_block(deps)
     alwayslink_block = self._convert_alwayslink_block(alwayslink)
     testonly_block = self._convert_testonly_block(testonly)
 
     self.converter.body += """iree_cc_library(
-%(name_block)s%(hdrs_block)s%(srcs_block)s%(deps_block)s%(alwayslink_block)s%(testonly_block)s  PUBLIC
+%(name_block)s%(hdrs_block)s%(textual_hdrs_block)s%(srcs_block)s%(deps_block)s%(alwayslink_block)s%(testonly_block)s  PUBLIC
 )\n\n""" % {
     "name_block": name_block,
     "hdrs_block": hdrs_block,
+    "textual_hdrs_block": textual_hdrs_block,
     "srcs_block": srcs_block,
     "deps_block": deps_block,
     "alwayslink_block": alwayslink_block,

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -23,12 +23,13 @@ iree_cc_library(
     "HALOps.h"
     "HALOps.h.inc"
     "HALTypes.h"
+  TEXTUAL_HDRS
+    "HALOps.cpp.inc"
   SRCS
     "HALEnums.cpp.inc"
     "HALOpFolders.cpp"
     "HALOpInterface.cpp.inc"
     "HALOps.cpp"
-    "HALOps.cpp.inc"
     "HALTypes.cpp"
   DEPS
     iree::compiler::Dialect::IREE::IR

--- a/iree/hal/interpreter/CMakeLists.txt
+++ b/iree/hal/interpreter/CMakeLists.txt
@@ -82,6 +82,7 @@ iree_cc_library(
     bytecode_kernels
   HDRS
     "bytecode_kernels.h"
+  TEXTUAL_HDRS
     "bytecode_kernels_generic.h"
     "bytecode_kernels_ruy.h"
   DEPS


### PR DESCRIPTION
No real change on the CMake side at all, but allows a more convenient translation from Bazel:
* `TEXTUAL_HDRS` are still added via `target_sources()` internally.
* Since the docs on [target_sources](https://cmake.org/cmake/help/latest/command/target_sources.html) state that "PRIVATE and PUBLIC items will populate the SOURCES property of <target>", there is no need to add `TEXTUAL_HDRS` as `PUBLIC`.