### PR TITLE
Include sample subdirs in CMake build now that iree-translate runs.

### DIFF
--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(marbre): Add once iree-translate and custom-translate run without errors
-#add_subdirectory(custom_modules)
-#add_subdirectory(simple_embedding)
-#add_subdirectory(vulkan)
+add_subdirectory(custom_modules)
+add_subdirectory(simple_embedding)
+add_subdirectory(vulkan)

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -42,7 +42,7 @@ iree_cc_library(
 iree_tablegen_library(
   NAME
     custom_ops_gen
-  SRCS
+  TD_FILE
     custom_ops.td
   OUTS
     -gen-op-decls custom_ops.h.inc


### PR DESCRIPTION
This is possible thanks to #496 being fixed.