### PR TITLE
Bazel to CMake: Refactor _convert_target()

### DIFF
--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -204,13 +204,7 @@ class BuildFileFunctions(object):
 
   def _convert_target(self, target):
     if target.startswith(":"):
-      # Bazel package-relative `:logging` -> CMake absolute `iree::base::logging`
-      package = os.path.dirname(self.converter.rel_build_file_path)
-      package = package.replace(os.path.sep, "::")
-      if package.endswith(target):
-        target = package  # Omit target if it matches the package name
-      else:
-        target = package + ":" + target
+      target = target.replace(":", "::")
       if target.endswith("_gen"):
         # Files created by gentbl have to be included as source and header files
         # and not as a dependency. Adding these targets to the dependencies list,

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -205,13 +205,12 @@ class BuildFileFunctions(object):
   def _convert_target(self, target):
     if target.startswith(":"):
       target = target.replace(":", "::")
-      if target.endswith("_gen"):
+      if target.endswith(("_gen","Gen")):
         # Files created by gentbl have to be included as source and header files
         # and not as a dependency. Adding these targets to the dependencies list,
         # results in linkage failures if the library including the gentbl dep is
         # marked as ALWAYSLINK.
-        # TODO: Some targets not to be included end to "Gen", but others like
-        #       LLVMTableGen still need to be included.
+        # This drops deps in the local namespace ending with '_gen' and 'Gen'
         return ""
     elif not target.startswith("//iree"):
       # External target, call helper method for special case handling.

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -203,23 +203,22 @@ class BuildFileFunctions(object):
       return ""
 
   def _convert_target(self, target):
-    if target.startswith(":"):
-      target = target.replace(":", "::")
-      if target.endswith(("_gen","Gen")):
-        # Files created by gentbl have to be included as source and header files
-        # and not as a dependency. Adding these targets to the dependencies list,
-        # results in linkage failures if the library including the gentbl dep is
-        # marked as ALWAYSLINK.
-        # This drops deps in the local namespace ending with '_gen' and 'Gen'
-        return ""
-    elif not target.startswith("//iree"):
+    if target.startswith(":") and target.endswith(("_gen","Gen")):
+      # Files created by gentbl have to be included as source and header files
+      # and not as a dependency. Adding these targets to the dependencies list,
+      # results in linkage failures if the library including the gentbl dep is
+      # marked as ALWAYSLINK.
+      # This drops deps in the local namespace ending with '_gen' and 'Gen'
+      target = ""
+    elif not target.startswith(("//iree",":")):
       # External target, call helper method for special case handling.
       target = bazel_to_cmake_targets.convert_external_target(target)
     else:
+      # Bazel `:api`            -> CMake `::api`
       # Bazel `//iree/base`     -> CMake `iree::base`
       # Bazel `//iree/base:api` -> CMake `iree::base::api`
       target = target.replace("//", "")  # iree/base:api
-      target = target.replace(":", "::")  # iree/base::api
+      target = target.replace(":", "::")  # iree/base::api or ::api
       target = target.replace("/", "::")  # iree::base::api
     return target
 

--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -203,14 +203,14 @@ class BuildFileFunctions(object):
       return ""
 
   def _convert_target(self, target):
-    if target.startswith(":") and target.endswith(("_gen","Gen")):
+    if target.startswith(":") and target.endswith(("_gen", "Gen")):
       # Files created by gentbl have to be included as source and header files
       # and not as a dependency. Adding these targets to the dependencies list,
       # results in linkage failures if the library including the gentbl dep is
       # marked as ALWAYSLINK.
       # This drops deps in the local namespace ending with '_gen' and 'Gen'
       target = ""
-    elif not target.startswith(("//iree",":")):
+    elif not target.startswith(("//iree", ":")):
       # External target, call helper method for special case handling.
       target = bazel_to_cmake_targets.convert_external_target(target)
     else:


### PR DESCRIPTION
* Don't add full package name to local deps
* Handles local deps and IREE deps including the full package name within the same conversion block
* Drop local deps ending on `_gen` or `Gen`