### PR TITLE
Include Dispatch bit in full execution barrier src/dst stage masks.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -203,8 +203,11 @@ static void recordFullExecutionBarrier(Value commandBuffer, Location loc,
               IREE::HAL::AccessScopeBitfield::DispatchRead)
           .getResult();
   rewriter.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
-      loc, commandBuffer, IREE::HAL::ExecutionStageBitfield::CommandRetire,
-      IREE::HAL::ExecutionStageBitfield::CommandIssue,
+      loc, commandBuffer,
+      IREE::HAL::ExecutionStageBitfield::CommandRetire |
+          IREE::HAL::ExecutionStageBitfield::Dispatch,
+      IREE::HAL::ExecutionStageBitfield::CommandIssue |
+          IREE::HAL::ExecutionStageBitfield::Dispatch,
       ArrayRef<Value>{memoryBarrier}, ArrayRef<Value>{});
 }
 


### PR DESCRIPTION
I've been seeing these validation errors with iree-run-mlir and vulkan_inference_gui:


```
E iree/hal/vulkan/debug_reporter.cc:40] vkCmdPipelineBarrier(): pMemBarriers[0].srcAccessMask (0x40) is not supported by srcStageMask (0x1). The Vulkan spec states: Each element of pMemoryBarriers, pBufferMemoryBarriers and pImageMemoryBarriers must not have any access flag included in its srcAccessMask member if that bit is not supported by any of the pipeline stages in srcStageMask, as specified in the table of supported access types. (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdPipelineBarrier-pMemoryBarriers-01184)
E iree/hal/vulkan/debug_reporter.cc:40] vkCmdPipelineBarrier(): pMemBarriers[0].dstAccessMask (0x20) is not supported by dstStageMask (0x2000). The Vulkan spec states: Each element of pMemoryBarriers, pBufferMemoryBarriers and pImageMemoryBarriers must not have any access flag included in its dstAccessMask member if that bit is not supported by any of the pipeline stages in dstStageMask, as specified in the table of supported access types. (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCmdPipelineBarrier-pMemoryBarriers-01185)
```

RenderDoc also flags them, pointing to `vkCmdPipelineBarrier` with `srcStageMask` `VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT` and `pMemoryBarriers[0].srcAccessMask` `VK_ACCESS_SHADER_WRITE_BIT`. Among pipeline stages [that we use](https://github.com/google/iree/blob/master/iree/hal/vulkan/direct_command_buffer.cc#L32-L54), the Vulkan spec only says that `VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT` supports that access flag.

This change makes the validation errors go away and seems from my understanding based on reading the spec and looking at the HAL IR to be an appropriate fix.