### PR TITLE
Bazel to CMake: Add mlir-translate mapping and implement one to many mapping

### DIFF
--- a/build_tools/scripts/bazel_to_cmake.py
+++ b/build_tools/scripts/bazel_to_cmake.py
@@ -32,7 +32,7 @@ import datetime
 import os
 import textwrap
 from collections import OrderedDict
-from itertools import repeat
+from itertools import repeat, chain
 import glob
 import re
 
@@ -209,7 +209,7 @@ class BuildFileFunctions(object):
       # results in linkage failures if the library including the gentbl dep is
       # marked as ALWAYSLINK.
       # This drops deps in the local namespace ending with '_gen' and 'Gen'
-      target = ""
+      target = [""]
     elif not target.startswith(("//iree", ":")):
       # External target, call helper method for special case handling.
       target = bazel_to_cmake_targets.convert_external_target(target)
@@ -220,6 +220,7 @@ class BuildFileFunctions(object):
       target = target.replace("//", "")  # iree/base:api
       target = target.replace(":", "::")  # iree/base::api or ::api
       target = target.replace("/", "::")  # iree::base::api
+      target = [target]
     return target
 
   def _convert_data_block(self, data):
@@ -231,6 +232,8 @@ class BuildFileFunctions(object):
     #    package1::target2
     #    package2::target
     data_list = [self._convert_target(dep) for dep in data]
+    # Flatten lists
+    data_list = list(chain.from_iterable(data_list))
     # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
     data_list = list(filter(None, OrderedDict(zip(data_list, repeat(None)))))
     data_list = "\n".join(["    %s" % (data,) for data in data_list])
@@ -245,6 +248,8 @@ class BuildFileFunctions(object):
     #    package1::target2
     #    package2::target
     deps_list = [self._convert_target(dep) for dep in deps]
+    # Flatten lists
+    deps_list = list(chain.from_iterable(deps_list))
     # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
     deps_list = list(filter(None, OrderedDict(zip(deps_list, repeat(None)))))
     deps_list = "\n".join(["    %s" % (dep,) for dep in deps_list])

--- a/build_tools/scripts/bazel_to_cmake_targets.py
+++ b/build_tools/scripts/bazel_to_cmake_targets.py
@@ -83,6 +83,8 @@ MLIR_EXPLICIT_TARGET_MAPPING = {
         "MLIRStandardToSPIRVTransforms",
     "@llvm-project//mlir:TableGen":
         "LLVMMLIRTableGen",
+    "@llvm-project//mlir:mlir-translate":
+        "mlir-translate",
     "@llvm-project//mlir:MlirTableGenMain":
         "MLIRTableGen",
     "@llvm-project//mlir:MlirOptMain":

--- a/build_tools/scripts/bazel_to_cmake_targets.py
+++ b/build_tools/scripts/bazel_to_cmake_targets.py
@@ -16,8 +16,8 @@
 # Bazel to CMake target name conversions used by bazel_to_cmake.py.
 
 ABSL_EXPLICIT_TARGET_MAPPING = {
-    "@com_google_absl//absl/flags:flag": "absl::flags",
-    "@com_google_absl//absl/flags:parse": "absl::flags_parse",
+    "@com_google_absl//absl/flags:flag": ["absl::flags"],
+    "@com_google_absl//absl/flags:parse": ["absl::flags_parse"],
 }
 
 
@@ -34,61 +34,61 @@ def _convert_absl_target(target):
     target_name = target.rsplit(":")[-1]
   else:
     target_name = target.rsplit("/")[-1]
-  return "absl::" + target_name
+  return ["absl::" + target_name]
 
 
 DEAR_IMGUI_EXPLICIT_TARGET_MAPPING = {
     "@dear_imgui":
-        "dear_imgui::dear_imgui",
+        ["dear_imgui::dear_imgui"],
     "@dear_imgui//:imgui_sdl_vulkan":
-        "dear_imgui::impl_sdl\n    dear_imgui::impl_vulkan",
+        ["dear_imgui::impl_sdl", "dear_imgui::impl_vulkan"],
 }
 
 LLVM_TARGET_MAPPING = {
-    "@llvm-project//llvm:support": "LLVMSupport",
-    "@llvm-project//llvm:tablegen": "LLVMTableGen",
+    "@llvm-project//llvm:support": ["LLVMSupport"],
+    "@llvm-project//llvm:tablegen": ["LLVMTableGen"],
 }
 
 VULKAN_HEADERS_MAPPING = {
     # TODO(scotttodd): Set -DVK_NO_PROTOTYPES to COPTS for _no_prototypes.
     #   Maybe add a wrapper CMake lib within build_tools/third_party/?
-    "@vulkan_headers//:vulkan_headers": "Vulkan::Headers",
-    "@vulkan_headers//:vulkan_headers_no_prototypes": "Vulkan::Headers",
+    "@vulkan_headers//:vulkan_headers": ["Vulkan::Headers"],
+    "@vulkan_headers//:vulkan_headers_no_prototypes": ["Vulkan::Headers"],
 }
 
 MLIR_EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:AffineDialectRegistration":
-        "MLIRAffineOps",
+        ["MLIRAffineOps"],
     "@llvm-project//mlir:AffineToStandardTransforms":
-        "MLIRAffineToStandard",
+        ["MLIRAffineToStandard"],
     "@llvm-project//mlir:GPUToSPIRVTransforms":
-        "MLIRGPUtoSPIRVTransforms",
+        ["MLIRGPUtoSPIRVTransforms"],
     "@llvm-project//mlir:GPUTransforms":
-        "MLIRGPU",
+        ["MLIRGPU"],
     "@llvm-project//mlir:LinalgDialectRegistration":
-        "MLIRLinalgOps",
+        ["MLIRLinalgOps"],
     "@llvm-project//mlir:LoopsToGPUPass":
-        "MLIRLoopsToGPU",
+        ["MLIRLoopsToGPU"],
     "@llvm-project//mlir:SPIRVDialect":
-        "MLIRSPIRV",
+        ["MLIRSPIRV"],
     "@llvm-project//mlir:SPIRVDialectRegistration":
-        "MLIRSPIRV",
+        ["MLIRSPIRV"],
     "@llvm-project//mlir:SPIRVLowering":
-        "MLIRSPIRV",
+        ["MLIRSPIRV"],
     "@llvm-project//mlir:SPIRVTranslateRegistration":
-        "MLIRSPIRVSerialization",
+        ["MLIRSPIRVSerialization"],
     "@llvm-project//mlir:StandardDialectRegistration":
-        "MLIRStandardOps",
+        ["MLIRStandardOps"],
     "@llvm-project//mlir:StandardToSPIRVConversions":
-        "MLIRStandardToSPIRVTransforms",
+        ["MLIRStandardToSPIRVTransforms"],
     "@llvm-project//mlir:TableGen":
-        "LLVMMLIRTableGen",
+        ["LLVMMLIRTableGen"],
     "@llvm-project//mlir:mlir-translate":
-        "mlir-translate",
+        ["mlir-translate"],
     "@llvm-project//mlir:MlirTableGenMain":
-        "MLIRTableGen",
+        ["MLIRTableGen"],
     "@llvm-project//mlir:MlirOptMain":
-        "MLIROptMain",
+        ["MLIROptMain"],
 }
 
 
@@ -100,7 +100,7 @@ def _convert_mlir_target(target):
   # Take "MLIR" and append the name part of the full target identifier, e.g.
   #   "@llvm-project//mlir:IR"   -> "MLIRIR"
   #   "@llvm-project//mlir:Pass" -> "MLIRPass"
-  return "MLIR" + target.rsplit(":")[-1]
+  return ["MLIR" + target.rsplit(":")[-1]]
 
 
 def convert_external_target(target):
@@ -122,29 +122,29 @@ def convert_external_target(target):
   if target.startswith("@com_google_absl"):
     return _convert_absl_target(target)
   if target == "@com_google_benchmark//:benchmark":
-    return "benchmark"
+    return ["benchmark"]
   if target == "@com_github_google_flatbuffers//:flatbuffers":
-    return "flatbuffers"
+    return ["flatbuffers"]
   if target.startswith("@dear_imgui"):
     return DEAR_IMGUI_EXPLICIT_TARGET_MAPPING[target]
   if target == "@com_google_googletest//:gtest":
-    return "gtest"
+    return ["gtest"]
   if target.startswith("@llvm-project//llvm"):
     return LLVM_TARGET_MAPPING[target]
   if target.startswith("@llvm-project//mlir"):
     return _convert_mlir_target(target)
   if target.startswith("@org_tensorflow//tensorflow/compiler/mlir"):
     # All Bazel targets map to a single CMake target.
-    return "tensorflow::mlir_xla"
+    return ["tensorflow::mlir_xla"]
   if target.startswith("@org_tensorflow//tensorflow/lite/experimental/ruy"):
     # All Bazel targets map to a single CMake target.
-    return "ruy"
+    return ["ruy"]
   if target == "@sdl2//:SDL2":
-    return "SDL2-static"
+    return ["SDL2-static"]
   if target.startswith("@vulkan_headers"):
     return VULKAN_HEADERS_MAPPING[target]
   if target == "@vulkan_sdk//:sdk":
     # The Bazel target maps to the IMPORTED target defined by FindVulkan().
-    return "Vulkan::Vulkan"
+    return ["Vulkan::Vulkan"]
 
   raise KeyError("No conversion found for target '%s'" % target)


### PR DESCRIPTION
 * Add mapping for mlir-translate
 * Allows to map a single dep to multiple deps without the need for string manipulations.
   See related discussion in #606.
 * Flattening of lists handled in _convert_{data,deps}_block()
