### PR TITLE
Update CMake Build for iree/modules

### DIFF
--- a/iree/modules/CMakeLists.txt
+++ b/iree/modules/CMakeLists.txt
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(check)
 add_subdirectory(hal)
 add_subdirectory(strings)

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -34,8 +34,8 @@ iree_cc_test(
   SRCS
     "check_test.cc"
   DEPS
-    iree::modules::check::check_test_module_cc
-    iree::modules::check::native_module
+    ::check_test_module_cc
+    ::native_module
     iree::base::api
     iree::base::logging
     iree::hal::api

--- a/iree/modules/check/dialect/BUILD
+++ b/iree/modules/check/dialect/BUILD
@@ -43,7 +43,6 @@ cc_library(
         ":check_imports",
         ":check_ops_gen",
         "//iree/compiler/Dialect/VM/Conversion",
-        "//iree/samples/custom_modules/dialect:custom_imports",
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# bazel_to_cmake: DO NOT EDIT
 add_subdirectory(test)
 
 iree_cc_library(
@@ -28,10 +29,8 @@ iree_cc_library(
     "check_ops.cc.inc"
     "conversion_patterns.cc"
   DEPS
-    iree::modules::check::dialect::check_imports
-    iree::modules::check::dialect::check_ops_gen
+    ::check_imports
     iree::compiler::Dialect::VM::Conversion
-    iree::samples::custom_modules::dialect::custom_imports
     LLVMSupport
     MLIRIR
     MLIRParser
@@ -46,7 +45,7 @@ iree_tablegen_library(
   NAME
     check_ops_gen
   TD_FILE
-    check_ops.td
+    "check_ops.td"
   OUTS
     -gen-op-decls check_ops.h.inc
     -gen-op-defs check_ops.cc.inc
@@ -64,23 +63,28 @@ iree_cc_embed_data(
   CPP_NAMESPACE
     "mlir::iree_compiler::IREE::Check"
   FLATTEN
+  PUBLIC
 )
 
 iree_cc_binary(
   NAME
     check-opt
+  OUT
+    check-opt
   DEPS
-    iree::modules::check::dialect
+    ::dialect
     iree::tools::iree_opt_library
     # MLIRMlirOptLib: includes main(); The equivalent Bazel library is MLIROptMain.
     # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
     MLIRMlirOptLib
 )
+add_executable(check-opt ALIAS iree_modules_check_dialect_check-opt)
 
 iree_cc_binary(
   NAME
     check-translate
   DEPS
-    iree::modules::check::dialect
+    ::dialect
     iree::tools::iree_translate_library
 )
+add_executable(check-translate ALIAS iree_modules_check_dialect_check-translate)

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,30 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(suderman): fix cmake build
-# bazel_to_cmake: DO NOT EDIT
-
 add_subdirectory(dialect)
 
 iree_cc_library(
   NAME
-    strings
+    strings_module
   HDRS
     "strings_module.h"
   SRCS
     "strings_module.cc"
   DEPS
     iree::base::api
-    iree::base::api_util
-    iree::base::tracing
-    iree::hal::api
-    iree::hal::command_queue
-    iree::hal::device
+    iree::base::logging
     iree::vm
+    iree::vm::bytecode_module
+    iree::vm::module
     iree::vm::module_abi_cc
-    absl::core_headers
-    absl::memory
+    iree::vm::ref
+    iree::vm::stack
+    iree::vm::types
+    absl::inlined_vector
     absl::strings
     absl::span
+    benchmark
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    strings_module_test
+  SRCS
+    "strings_module_test.cc"
+  DEPS
+    ::strings_module
+    ::strings_module_test_module_cc
+    iree::base::api
+    iree::base::logging
+    iree::testing::gtest_main
+    iree::vm::bytecode_module
+    iree::vm::context
+    iree::vm::instance
+    iree::vm::module
+    iree::vm::ref
+    iree::vm::stack
+    iree::vm::types
+    absl::inlined_vector
+    absl::strings
+    benchmark
+)
+
+iree_bytecode_module(
+  NAME
+    strings_module_test_module
+  SRC
+    "strings_module_test.mlir"
+  CC_NAMESPACE
+    "iree::strings_module_test"
+  TRANSLATE_TOOL
+    iree_modules_strings_dialect_strings-translate
+  TRANSLATION
+    "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/strings/dialect/CMakeLists.txt
+++ b/iree/modules/strings/dialect/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# bazel_to_cmake: DO NOT EDIT
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     dialect
@@ -24,14 +27,15 @@ iree_cc_library(
     "strings_dialect.cc"
     "strings_ops.cc.inc"
   DEPS
+    ::strings_imports
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRPass
     MLIRSupport
     MLIRTransforms
-    iree::compiler::Dialect::VM::Conversion
-    iree::modules::strings::dialect::strings_imports
   ALWAYSLINK
   PUBLIC
 )
@@ -40,7 +44,7 @@ iree_tablegen_library(
   NAME
     strings_ops_gen
   TD_FILE
-    strings_ops.td
+    "strings_ops.td"
   OUTS
     -gen-op-decls strings_ops.h.inc
     -gen-op-defs strings_ops.cc.inc
@@ -58,5 +62,28 @@ iree_cc_embed_data(
   CPP_NAMESPACE
     "mlir::iree_compiler::IREE::Strings"
   FLATTEN
+  PUBLIC
 )
 
+iree_cc_binary(
+  NAME
+    strings-opt
+  OUT
+    strings-opt
+  DEPS
+    ::dialect
+    iree::tools::iree_opt_library
+    # MLIRMlirOptLib: includes main(); The equivalent Bazel library is MLIROptMain.
+    # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
+    MLIRMlirOptLib
+)
+add_executable(strings-opt ALIAS iree_modules_strings_dialect_strings-opt)
+
+iree_cc_binary(
+  NAME
+    strings-translate
+  DEPS
+    ::dialect
+    iree::tools::iree_translate_library
+)
+add_executable(strings-translate ALIAS iree_modules_strings_dialect_strings-translate)

--- a/iree/modules/strings/dialect/test/conversion.mlir
+++ b/iree/modules/strings/dialect/test/conversion.mlir
@@ -1,19 +1,3 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// Tests the (automatic) conversion from the strings dialect to the VM dialect.
-
 // RUN: strings-opt %s -iree-vm-conversion -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @i32ToStringOp


### PR DESCRIPTION
Iree modules and their corresponding tests were not yet building
with cmake. Updating the CMake files to build custom compilers
for each module, then use those modules to power their
corresponding tests.