### PR TITLE
Refactor CMake target iree_opt_library and targets depending on it

### DIFF
--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -71,6 +71,7 @@ function(set_alwayslink_mlir_libs)
     MLIRSupport
     MLIRVectorOps
     MLIRLinalgOps
+    MLIROptMain
   )
 
   set_alwayslink_property(

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -71,6 +71,8 @@ function(set_alwayslink_mlir_libs)
     MLIRSupport
     MLIRVectorOps
     MLIRLinalgOps
+    # MLIROptMain: lib; The equivalent Bazel library is MLIROptLib.
+    # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
     MLIROptMain
   )
 

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -72,7 +72,7 @@ iree_cc_binary(
   DEPS
     iree::modules::check::dialect
     iree::tools::iree_opt_library
-    MLIROptMain
+    MLIRMlirOptLib
 )
 
 iree_cc_binary(

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -72,6 +72,8 @@ iree_cc_binary(
   DEPS
     iree::modules::check::dialect
     iree::tools::iree_opt_library
+    # MLIRMlirOptLib: includes main(); The equivalent Bazel library is MLIROptMain.
+    # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
     MLIRMlirOptLib
 )
 

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -71,6 +71,8 @@ iree_cc_binary(
   DEPS
     iree::samples::custom_modules::dialect
     iree::tools::iree_opt_library
+      # MLIRMlirOptLib: includes main(); The equivalent Bazel library is MLIROptMain.
+      # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
     MLIRMlirOptLib
 )
 

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -71,7 +71,7 @@ iree_cc_binary(
   DEPS
     iree::samples::custom_modules::dialect
     iree::tools::iree_opt_library
-    MLIROptMain
+    MLIRMlirOptLib
 )
 
 iree_cc_binary(

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -81,6 +81,8 @@ if(${IREE_BUILD_COMPILER})
       MLIRAffineOps
       MLIRLinalgOps
       MLIRLinalgUtils
+      # MLIROptMain: lib; The equivalent Bazel library is MLIROptLib.
+      # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
       MLIROptMain
       MLIRStandardOps
       MLIRSPIRV
@@ -98,6 +100,8 @@ if(${IREE_BUILD_COMPILER})
       iree-opt
     DEPS
       iree::tools::iree_opt_library
+      # MLIRMlirOptLib: includes main(); The equivalent Bazel library is MLIROptMain.
+      # TODO(marbre): Replace with appropriate target after upstreams CMake is revised.
       MLIRMlirOptLib
   )
   add_executable(iree-opt ALIAS iree_tools_iree-opt)

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -52,8 +52,6 @@ if(${IREE_BUILD_COMPILER})
   iree_cc_library(
     NAME
       iree_opt_library
-    SRCS
-      "${IREE_ROOT_DIR}/third_party/llvm-project/mlir/tools/mlir-opt/mlir-opt.cpp"
     DEPS
       iree::compiler::Dialect::IREE::IR
       iree::compiler::Dialect::IREE::Transforms
@@ -83,6 +81,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRAffineOps
       MLIRLinalgOps
       MLIRLinalgUtils
+      MLIROptMain
       MLIRStandardOps
       MLIRSPIRV
       MLIRSPIRVSerialization
@@ -99,7 +98,7 @@ if(${IREE_BUILD_COMPILER})
       iree-opt
     DEPS
       iree::tools::iree_opt_library
-      MLIROptMain
+      MLIRMlirOptLib
   )
   add_executable(iree-opt ALIAS iree_tools_iree-opt)
 


### PR DESCRIPTION
 * Don't compile source file into iree_opt_main
 * Instead link MLIRMlirOptLib into executables
 * Add dep on MLIROptMain to iree_opt_main

ctest: before: 7 tests failed out of 158
       after:  7 tests failed out of 158