### PR TITLE
Bazel to CMake: Don't evaluate glob during conversion

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -299,10 +299,9 @@ class BuildFileFunctions(object):
     # See https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
 
     if exclude_directories != 1:
-      self._convert_unimplemented_function("glob", name="with exclude")
+      self._convert_unimplemented_function("glob", "with exclude")
     if exclude:
-      self._convert_unimplemented_function(
-          "glob", name="with exclude_directories")
+      self._convert_unimplemented_function("glob", "with exclude_directories")
 
     glob_vars = []
     for pattern in include:

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -311,6 +311,7 @@ class BuildFileFunctions(object):
         # silently give different behavior, just error out.
         # See https://docs.bazel.build/versions/master/be/functions.html#glob
         raise NotImplementedError("Recursive globs not supported")
+      # Bazel `*.mlir` glob -> CMake Variable `_GLOB_X_MLIR`
       glob_var = "_GLOB_" + pattern.replace("*", "X").replace(".", "_").upper()
       glob_vars.append("${%s}" % (glob_var,))
       self.converter.body += ("file(GLOB %(var)s CONFIGURE_DEPENDS "

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -255,12 +255,14 @@ class BuildFileFunctions(object):
     deps_list = "\n".join(["    %s" % (dep,) for dep in deps_list])
     return "  DEPS\n%s\n" % (deps_list,)
 
-  def _convert_unimplemented_function(self, rule, *args, **kwargs):
-    name = kwargs.get("name", "unnamed")
-    message = "Unimplemented %(rule)s %(name)s\n" % {"rule": rule, "name": name}
+  def _convert_unimplemented_function(self, function, details=""):
+    message = "Unimplemented %(function)s: %(details)s" % {
+        "function": function,
+        "details": details,
+    }
     if not self.converter.first_error:
       self.converter.first_error = NotImplementedError(message)
-    self.converter.body += "# %s" % (message,)
+    self.converter.body += "# %s\n" % (message,)
 
   # ------------------------------------------------------------------------- #
   # Function handlers that convert BUILD definitions to CMake definitions.    #
@@ -280,11 +282,11 @@ class BuildFileFunctions(object):
   def iree_build_test(self, **kwargs):
     pass
 
-  def filegroup(self, **kwargs):
+  def filegroup(self, name, **kwargs):
     # Not implemented yet. Might be a no-op, or may want to evaluate the srcs
     # attribute and pass them along to any targets that depend on the filegroup.
     # Cross-package dependencies and complicated globs could be hard to handle.
-    self._convert_unimplemented_function("filegroup", **kwargs)
+    self._convert_unimplemented_function("filegroup", name)
 
   def exports_files(self, *args, **kwargs):
     # No mapping to CMake, ignore.
@@ -395,8 +397,7 @@ class BuildFileFunctions(object):
                     identifier=None,
                     **kwargs):
     if identifier:
-      self._convert_unimplemented_function(
-          "cc_embed_data (identifier)", name=name)
+      self._convert_unimplemented_function("cc_embed_data", name + " has identifier")
     name_block = self._convert_name_block(name)
     srcs_block = self._convert_srcs_block(srcs)
     cc_file_output_block = self._convert_cc_file_output_block(cc_file_output)

--- a/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "dispatchability.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "dispatch_ops.mlir"
-    "dispatch_regions.mlir"
-    "executable_ops.mlir"
-    "reduction_regions.mlir"
-    "stream_ops.mlir"
-    "tensor_folding.mlir"
-    "tensor_ops.mlir"
-    "variable_folding.mlir"
-    "variable_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "assign_executable_workloads.mlir"
-    "fold_compatible_dispatch_regions.mlir"
-    "form_streams.mlir"
-    "identify_dispatch_regions.mlir"
-    "identify_reduction_regions.mlir"
-    "legalize_input_types.mlir"
-    "materialize_and_merge_exported_reflection.mlir"
-    "materialize_exported_reflection.mlir"
-    "merge_exported_reflection.mlir"
-    "rematerialize_dispatch_constants.mlir"
-    "transformation.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "stream_ops.mlir"
-    "structural_ops.mlir"
-    "tensor_ops.mlir"
-    "variable_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "allocator_ops.mlir"
-    "buffer_ops.mlir"
-    "command_buffer_ops.mlir"
-    "device_ops.mlir"
-    "executable_ops.mlir"
-    "variable_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "allocator_ops.mlir"
-    "buffer_folding.mlir"
-    "buffer_ops.mlir"
-    "buffer_view_folding.mlir"
-    "buffer_view_ops.mlir"
-    "command_buffer_ops.mlir"
-    "descriptor_set_ops.mlir"
-    "device_ops.mlir"
-    "executable_ops.mlir"
-    "experimental_ops.mlir"
-    "variable_folding.mlir"
-    "variable_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "smoketest.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "transformation.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "bindings.mlir"
-    "do_not_optimize.mlir"
-    "parse_print.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "drop_compiler_hints.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "canonicalize.mlir"
-    "op_verification.mlir"
-    "parse_print.mlir"
-    "ranked_shape_type.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "convert-hlo-to-shape-dialect.mlir"
-    "expand_function_dynamic_dims.mlir"
-    "materialize_shape_calculations.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "register_allocation.mlir"
-    "value_liveness.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
@@ -12,17 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "arithmetic_ops.mlir"
-    "assignment_ops.mlir"
-    "comparison_ops.mlir"
-    "const_ops.mlir"
-    "control_flow_ops.mlir"
-    "func_attrs.mlir"
-    "structural_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
@@ -12,27 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "arithmetic_folding.mlir"
-    "arithmetic_ops.mlir"
-    "assignment_folding.mlir"
-    "assignment_ops.mlir"
-    "comparison_folding.mlir"
-    "comparison_ops.mlir"
-    "const_folding.mlir"
-    "const_ops.mlir"
-    "control_flow_folding.mlir"
-    "control_flow_ops.mlir"
-    "conversion_folding.mlir"
-    "conversion_ops.mlir"
-    "debug_folding.mlir"
-    "debug_ops.mlir"
-    "global_folding.mlir"
-    "global_ops.mlir"
-    "structural_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "module_encoding_smoke.mlir"
-    "reflection_attrs.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-translate

--- a/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "global_initialization.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/CMakeLists.txt
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "constant_ops.mlir"
-    "math_ops.mlir"
-    "shaping_ops.mlir"
-    "view_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "constant_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "conversion.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VMLA/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/test/CMakeLists.txt
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/VMLA/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/CMakeLists.txt
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "transformation.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "concat.mlir"
-    "constant.mlir"
-    "invalid_types_hl.mlir"
-    "invalid_types_ll.mlir"
-    "scalar_memref.mlir"
-    "tensor_memref.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
@@ -14,12 +14,12 @@
 
 add_subdirectory(xla)
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "clone.mlir"
-    "make_executable_abi.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "concat.mlir"
-    "dynamic_update_slice.mlir"
-    "gather.mlir"
-    "slice.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/IndexComputation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/IndexComputation/test/CMakeLists.txt
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "concatenate.mlir"
-    "copy.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "pad.mlir"
-    "reverse.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "pw_add.mlir"
-    "pw_add_e2e.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/ReductionCodegen/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/ReductionCodegen/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "ops.mlir"
-    "simple.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
@@ -12,31 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "adjust_integer_width.mlir"
-    "arithmetic_ops.mlir"
-    "broadcast.mlir"
-    "broadcast_in_dim.mlir"
-    "compare.mlir"
-    "concatenate.mlir"
-    "constant.mlir"
-    "convert.mlir"
-    "copy.mlir"
-    "exp_test.mlir"
-    "extract_element.mlir"
-    "gather.mlir"
-    "max.mlir"
-    "pad.mlir"
-    "reshape.mlir"
-    "reshape_dropdims.mlir"
-    "reverse.mlir"
-    "select.mlir"
-    "slice.mlir"
-    "store_reduce.mlir"
-    "transpose_add.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "arithmetic_ops.mlir"
-    "dynamic_shape.mlir"
-    "exp.mlir"
-    "linalg_tensor_to_buffer.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Translation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "do_not_optimize.mlir"
-    "smoketest.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/modules/check/dialect/test/CMakeLists.txt
+++ b/iree/modules/check/dialect/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "ops.mlir"
-    "vm_import_conversion.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::modules::check::dialect::check-opt
     iree::tools::IreeFileCheck

--- a/iree/modules/strings/dialect/test/CMakeLists.txt
+++ b/iree/modules/strings/dialect/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "conversion.mlir"
-    "strings_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::modules::strings::dialect::strings-opt
     iree::tools::IreeFileCheck

--- a/iree/samples/custom_modules/dialect/test/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/test/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "conversion.mlir"
-    "custom_ops.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::samples::custom_modules::dialect::custom-opt
     iree::tools::IreeFileCheck

--- a/iree/tools/test/CMakeLists.txt
+++ b/iree/tools/test/CMakeLists.txt
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "multiple_args.mlir"
-    "scalars.mlir"
-    "simple.mlir"
+    "${_GLOB_X_MLIR}"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-run-mlir


### PR DESCRIPTION
Evaluating during conversion seemed like a good idea but at least right now it's causing issues because people don't think to update a CMakeLists file when they haven't changed a build file. This does limit our globs more (no excludes), but I think for the purpose we actually use globs shouldn't be too much of a problem. We can revert if we've got some better automation to run bazel to cmake at some point.

Includes some cleanup of convert_unimplemented_function to make it more applicable to things that aren't rules. I tried out having it print out the entire set of args and kwargs the function was called with but actually getting this right would mean passing all these to the function and then to do that properly you have to use inspect on the functions and it ended up seeming a bit gross. Instead just allowed a free-form string message explaining the error.

Tested:
The same 8 tests fail before and after
95% tests passed, 8 tests failed out of 168

Total Test time (real) =  38.29 sec

The following tests FAILED:
	 74 - iree_compiler_Dialect_HAL_Target_test_lit_smoketest.mlir_test (Failed)
	 75 - iree_compiler_Dialect_HAL_Transforms_test_lit_transformation.mlir_test (Failed)
	158 - iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_lit_single_pw_op.mlir_test (Failed)
	163 - iree_compiler_Translation_test_lit_do_not_optimize.mlir_test (Failed)
	165 - iree_tools_vm_util_test (Failed)
	166 - iree_tools_test_lit_multiple_args.mlir_test (Failed)
	167 - iree_tools_test_lit_scalars.mlir_test (Failed)
	168 - iree_tools_test_lit_simple.mlir_test (Failed)