### PR TITLE
Change integrations/tensorflow/e2e tests to use iree_py_test.

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -16,6 +16,7 @@ load(
     "//bindings/python:build_defs.oss.bzl",
     "INTREE_TENSORFLOW_PY_DEPS",
     "NUMPY_DEPS",
+    "iree_py_test",
 )
 
 package(
@@ -24,7 +25,7 @@ package(
 )
 
 [
-    py_test(
+    iree_py_test(
         name = name,
         srcs = [name + ".py"],
         python_version = "PY3",
@@ -50,7 +51,7 @@ package(
     ]
 ]
 
-py_test(
+iree_py_test(
     name = "vulkan_conv_test",
     srcs = ["vulkan_conv_test.py"],
     python_version = "PY3",


### PR DESCRIPTION
Fixes OSS failures to import modules following https://github.com/google/iree/pull/682.