### PR TITLE
Extend IREE_COMMON_INCLUDE_DIRS by tracing include path

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -150,3 +150,11 @@ set(IREE_TABLEGEN_EXE iree-tblgen)
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tensorflow
 )
+
+#-------------------------------------------------------------------------------
+# Third party: tracing
+#-------------------------------------------------------------------------------
+
+list(APPEND IREE_COMMON_INCLUDE_DIRS
+  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/google_tracing_framework/bindings/cpp/include
+)


### PR DESCRIPTION
Required within the CMake build for targets included tracing headers.