### PR TITLE
Exclude third_party/ from clang-format presubmit.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -41,5 +41,5 @@ jobs:
     - name: Running clang-format on changed source files
       # TODO(benvanik): actually filter to changed files.
       run: |
-        /tmp/git-clang-format origin/master --binary=clang-format-9
+        /tmp/git-clang-format origin/master --binary=clang-format-9 --style=file
         git diff --exit-code

--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -1,0 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disable formatting for any code under third_party/, since we don't control it.
+DisableFormat: true


### PR DESCRIPTION
Should make the style check pass on https://github.com/google/iree/pull/696.

Reference: https://clang.llvm.org/docs/ClangFormatStyleOptions.html