### PR TITLE
CMake: Drop using find_package(Python3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 if(${IREE_BUILD_COMPILER} OR ${IREE_BUILD_PYTHON_BINDINGS})
   # Use the (deprecated) FindPythonInterp/FindPythonLibs functions before
-  # any of our dependencies do. If one dependency finds Python 2 (the default),
+  # any of our dependencies do. See
+  # https://pybind11.readthedocs.io/en/stable/faq.html#inconsistent-detection-of-python-version-in-cmake-and-pybind11
+  # If one dependency finds Python 2 (the default),
   # any others that try to find Python 3 will fail.
   # (Also come on, it's $CURRENT_YEAR - please just use Python 3 already.)
   find_package(PythonInterp 3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 #-------------------------------------------------------------------------------
 
 if(${IREE_BUILD_COMPILER} OR ${IREE_BUILD_PYTHON_BINDINGS})
-  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-  # Also use the (deprecated) FindPythonInterp/FindPythonLibs functions before
+  # Use the (deprecated) FindPythonInterp/FindPythonLibs functions before
   # any of our dependencies do. If one dependency finds Python 2 (the default),
   # any others that try to find Python 3 will fail.
   # (Also come on, it's $CURRENT_YEAR - please just use Python 3 already.)

--- a/bindings/python/build_tools/cmake/iree_py_extension.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_extension.cmake
@@ -73,7 +73,7 @@ function(iree_py_extension)
         "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
       PRIVATE
         ${PYBIND11_INCLUDE_DIR}
-        ${Python3_INCLUDE_DIRS}
+        ${PYTHON_INCLUDE_DIR}
     )
 
     target_compile_options(${_NAME}
@@ -88,7 +88,7 @@ function(iree_py_extension)
       PRIVATE
         ${_RULE_LINKOPTS}
         ${IREE_DEFAULT_LINKOPTS}
-        ${Python3_LIBRARIES}
+        ${PYTHON_LIBRARY}
     )
     target_compile_definitions(${_NAME}
       PUBLIC

--- a/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
@@ -70,7 +70,7 @@ function(iree_pybind_cc_library)
         "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
       PRIVATE
         ${PYBIND11_INCLUDE_DIR}
-        ${Python3_INCLUDE_DIRS}
+        ${PYTHON_INCLUDE_DIR}
     )
     target_compile_options(${_NAME}
       PRIVATE
@@ -84,7 +84,7 @@ function(iree_pybind_cc_library)
         ${_RULE_DEPS}
       PRIVATE
         pybind11
-        ${Python3_LIBRARIES}
+        ${PYTHON_LIBRARY}
         ${_RULE_LINKOPTS}
         ${IREE_DEFAULT_LINKOPTS}
     )


### PR DESCRIPTION
Followup to #700.

* `find_package(Python3)` detects python 3.7.
* `find_package(PythonInterp 3)` detects python 3.6.
* pybind11 uses it's own scripts, see [here](https://pybind11.readthedocs.io/en/stable/faq.html#inconsistent-detection-of-python-version-in-cmake-and-pybind11).
* Several deps still use the old logic to detect python.