### PR TITLE
Fix and update CMake configuration

### DIFF
--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -60,12 +60,15 @@ function(set_alwayslink_mlir_libs)
     MLIRAnalysis
     MLIREDSC
     MLIRIR
+    MLIRLoopToStandard
     MLIRParser
     MLIRPass
     MLIRSPIRV
     MLIRSPIRVSerialization
     MLIRSPIRVTransforms
     MLIRStandardOps
+    MLIRStandardToLLVM
+    MLIRTargetLLVMIR
     MLIRTransforms
     MLIRTranslation
     MLIRSupport

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -20,22 +20,20 @@ iree_cc_library(
   SRCS
     "LLVMTarget.cpp"
   DEPS
-    LLVMIR
-    MLIRCFGTransforms
-    MLIRIR
-    MLIRLLVMTransforms
-    MLIRLinalgOps
-    MLIRLinalgTransforms
-    MLIRPass
-    MLIRStandardOps
-    MLIRStandardToSPIRVTransforms
-    MLIRSupport
-    MLIRTransforms
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
-    iree::compiler::Dialect::IREE::IR
     iree::compiler::Translation::XLAToLinalg
     iree::compiler::Translation::XLAToLinalg::IREELinalgTensorToBuffer
     iree::schemas::llvmir_executable_def_cc_fbs
+    LLVMCore
+    MLIRLoopToStandard
+    MLIRIR
+    MLIRStandardToLLVM
+    MLIRLinalgOps
+    MLIRLinalgTransforms
+    MLIRStandardOps
+    MLIRSupport
+    MLIRTargetLLVMIR
+    MLIRTransforms
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
 iree_cc_library(
   NAME
     LLVM

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -162,6 +162,11 @@ if(${IREE_BUILD_COMPILER})
       MLIRSPIRVTransforms
       MLIRTranslation
       tensorflow::mlir_xla
+      # TODO(marbre): Move the HAL::Target deps to TARGET_COMPILER_BACKENDS
+      iree::compiler::Dialect::HAL::Target::LegacyInterpreter
+      iree::compiler::Dialect::HAL::Target::VMLA
+      iree::compiler::Dialect::HAL::Target::VulkanSPIRV
+      iree::compiler::Dialect::HAL::Target::LLVM
     ALWAYSLINK
   )
 
@@ -224,7 +229,9 @@ if(${IREE_BUILD_COMPILER})
       # TODO(marbre): Add PLATFORM_VULKAN_DEPS
       # TODO(marbre): Move the HAL::Target deps to TARGET_COMPILER_BACKENDS
       iree::compiler::Dialect::HAL::Target::LegacyInterpreter
+      iree::compiler::Dialect::HAL::Target::VMLA
       iree::compiler::Dialect::HAL::Target::VulkanSPIRV
+      iree::compiler::Dialect::HAL::Target::LLVM
       iree::hal::vulkan::vulkan_driver_module
   )
   add_executable(iree-run-mlir ALIAS iree_tools_iree-run-mlir)
@@ -264,8 +271,6 @@ if(${IREE_BUILD_COMPILER})
     DEPS
       iree::compiler::Dialect::Flow::Conversion
       iree::compiler::Dialect::HAL::Conversion
-      iree::compiler::Dialect::HAL::Target::LegacyInterpreter
-      iree::compiler::Dialect::HAL::Target::VulkanSPIRV
       iree::compiler::Dialect::VM::Target::Bytecode
       iree::compiler::Translation::IREEVM
       iree::compiler::Translation::SPIRV::XLAToSPIRV
@@ -286,6 +291,11 @@ if(${IREE_BUILD_COMPILER})
       MLIRTranslation
       MLIRVectorOps
       tensorflow::mlir_xla
+      # TODO(marbre): Move the HAL::Target deps to TARGET_COMPILER_BACKENDS
+      iree::compiler::Dialect::HAL::Target::LegacyInterpreter
+      iree::compiler::Dialect::HAL::Target::VMLA
+      iree::compiler::Dialect::HAL::Target::VulkanSPIRV
+      iree::compiler::Dialect::HAL::Target::LLVM
     ALWAYSLINK
   )
 


### PR DESCRIPTION
* Fixes the configuration for `iree::compiler::Dialect::HAL::Target::LLVM`
* Updates CMake configuration for `iree::tools` targets
* Enables `iree_compiler_Dialect_HAL_Target_LLVM_test_binaryop_test.mlir.test`

This fixes some tests failing before on my local machine:

**Before:**
93% tests passed, 12 tests failed out of 171

The following tests FAILED:
          4 - iree_base_file_io_test (Failed)
         20 - iree_hal_vulkan_dynamic_symbols_test (Child aborted)
         75 - iree_compiler_Dialect_HAL_Target_test_smoketest.mlir.test (Failed)
         76 - iree_compiler_Dialect_HAL_Transforms_test_transformation.mlir.test (Failed)
        159 - iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test (Failed)
        164 - iree_compiler_Translation_test_do_not_optimize.mlir.test (Failed)
        166 - iree_tools_vm_util_test (Failed)
        167 - iree_tools_test_multiple_args.mlir.test (Failed)
        168 - iree_tools_test_scalars.mlir.test (Failed)
        169 - iree_tools_test_simple.mlir.test (Failed)
        170 - iree_samples_custom_modules_custom_modules_test (Child aborted)
        171 - iree_samples_simple_embedding_simple_embedding_test (Child aborted)

**Afterwards:**
95% tests passed, 9 tests failed out of 172

The following tests FAILED:
          4 - iree_base_file_io_test (Failed)
         20 - iree_hal_vulkan_dynamic_symbols_test (Child aborted)
        160 - iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test (Failed)
        167 - iree_tools_vm_util_test (Failed)
        168 - iree_tools_test_multiple_args.mlir.test (Failed)
        169 - iree_tools_test_scalars.mlir.test (Failed)
        170 - iree_tools_test_simple.mlir.test (Failed)
        171 - iree_samples_custom_modules_custom_modules_test (Child aborted)
        172 - iree_samples_simple_embedding_simple_embedding_test (Child aborted)
