### PR TITLE
Update CMake configuration of iree::tools targets

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -100,7 +100,6 @@ iree_cc_library(
     iree::vm::module
     iree::vm::variant_list
     absl::span
-  PUBLIC
 )
 
 iree_cc_test(

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -232,7 +232,12 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Dialect::HAL::Target::VMLA
       iree::compiler::Dialect::HAL::Target::VulkanSPIRV
       iree::compiler::Dialect::HAL::Target::LLVM
+      iree::hal::interpreter::interpreter_driver_module
+      # TODO(b/142004903): enable when Dawn HAL implementation is functional
+      # iree::hal::dawn::dawn_driver_module
+      iree::hal::vmla::vmla_driver_module
       iree::hal::vulkan::vulkan_driver_module
+      iree::hal::llvmjit::llvmjit_driver_module
   )
   add_executable(iree-run-mlir ALIAS iree_tools_iree-run-mlir)
 
@@ -260,6 +265,7 @@ if(${IREE_BUILD_COMPILER})
       # iree::hal::dawn::dawn_driver_module
       iree::hal::vmla::vmla_driver_module
       iree::hal::vulkan::vulkan_driver_module
+      iree::hal::llvmjit::llvmjit_driver_module
   )
   add_executable(iree-run-module ALIAS iree_tools_iree-run-module)
 


### PR DESCRIPTION
**Tests failing before and afterwards:**

95% tests passed, 8 tests failed out of 173

The following tests FAILED:
          4 - iree_base_file_io_test (Failed)
        161 - iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test (Failed)
        168 - iree_tools_vm_util_test (Failed)
        169 - iree_tools_test_multiple_args.mlir.test (Failed)
        170 - iree_tools_test_scalars.mlir.test (Failed)
        171 - iree_tools_test_simple.mlir.test (Failed)
        172 - iree_samples_custom_modules_custom_modules_test (Child aborted)
        173 - iree_samples_simple_embedding_simple_embedding_test (Child aborted)