### PR TITLE
Add temporary directory handling to ctest

### DIFF
--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -103,5 +103,7 @@ function(iree_cc_test)
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
   set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
-  add_test(NAME ${_NAME} COMMAND ${_NAME})
+  # We run all our tests through a custom test runner to allow setup and teardown.
+  add_test(NAME ${_NAME} COMMAND ${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.sh "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}")
+  set_property(TEST ${_NAME} PROPERTY ENVIRONMENT "TEST_TMPDIR=${_NAME}_test_tmpdir")
 endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -47,9 +47,11 @@ function(iree_lit_test)
 
   add_test(
     NAME ${_NAME}
-    COMMAND ${CMAKE_SOURCE_DIR}/iree/tools/run_lit.sh "${_TEST_FILE_PATH}"
+    # We run all our tests through a custom test runner to allow setup and teardown.
+    COMMAND ${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.sh ${CMAKE_SOURCE_DIR}/iree/tools/run_lit.sh ${_TEST_FILE_PATH}
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}" # Make sure the lit runner can find all the binaries
   )
+  set_property(TEST ${_NAME} PROPERTY ENVIRONMENT "TEST_TMPDIR=${_NAME}_test_tmpdir")
   # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
 endfunction()
 

--- a/build_tools/cmake/run_test.sh
+++ b/build_tools/cmake/run_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A wrapper around a test command that performs setup and teardown. This is
+# appranetly not supported natively in ctest/cmake.
+
+set -x
+set -e
+
+function cleanup() {
+  echo "Cleaning up test environment"
+  rm -rf ${TEST_TMPDIR?}
+}
+
+echo "Creating test environment"
+mkdir "${TEST_TMPDIR?}"
+trap cleanup EXIT
+# Execute whatever we were passed.
+"$@"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -25,13 +25,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
 EXCLUDED_TESTS=(
-    iree_base_file_io_test
     iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test
     iree_hal_vulkan_dynamic_symbols_test
     iree_tools_vm_util_test
-    iree_tools_test_multiple_args.mlir.test
-    iree_tools_test_scalars.mlir.test
-    iree_tools_test_simple.mlir.test
 )
 
 # Join with | and add anchors

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -28,6 +28,9 @@ EXCLUDED_TESTS=(
     iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test
     iree_hal_vulkan_dynamic_symbols_test
     iree_tools_vm_util_test
+    iree_tools_test_multiple_args.mlir.test
+    iree_tools_test_scalars.mlir.test
+    iree_tools_test_simple.mlir.test
 )
 
 # Join with | and add anchors


### PR DESCRIPTION
I tried many ways to do this natively in ctest/cmake, but none of them did what we wanted.

This runs each test through a custom shell script "run_test.sh" that sets up and tears down a temporary directory for the test.

This gets the file IO tests running on ctest and fixes the CLI smoketests locally, but not on the Kokoro VMs.

Closes https://github.com/google/iree/issues/731