### PR TITLE
Fix mapping of mlir:SPIRVLowering dep

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -72,7 +72,7 @@ MLIR_EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:LoopsToGPUPass": ["MLIRLoopsToGPU"],
     "@llvm-project//mlir:SPIRVDialect": ["MLIRSPIRV"],
     "@llvm-project//mlir:SPIRVDialectRegistration": ["MLIRSPIRV"],
-    "@llvm-project//mlir:SPIRVLowering": ["MLIRSPIRV"],
+    "@llvm-project//mlir:SPIRVLowering": ["MLIRSPIRV", "MLIRSPIRVTransforms"],
     "@llvm-project//mlir:SPIRVTranslateRegistration": [
         "MLIRSPIRVSerialization"
     ],

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     MLIRIR
     MLIRPass
     MLIRSPIRV
+    MLIRSPIRVTransforms
     MLIRSPIRVSerialization
     MLIRSupport
     MLIRTransforms

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
     MLIRLoopsToGPU
     MLIRPass
     MLIRSPIRV
+    MLIRSPIRVTransforms
     MLIRStandardOps
     MLIRStandardToSPIRVTransforms
     MLIRSupport

--- a/iree/compiler/Translation/SPIRV/Passes/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Passes/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     MLIRIR
     MLIRPass
     MLIRSPIRV
+    MLIRSPIRVTransforms
     MLIRStandardOps
     MLIRTransforms
   ALWAYSLINK

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     MLIRIR
     MLIRPass
     MLIRSPIRV
+    MLIRSPIRVTransforms
     MLIRStandardOps
     MLIRStandardToSPIRVTransforms
     MLIRSupport


### PR DESCRIPTION
Working on the python bindings buildable with CMake, but currently not fully functional, I noticed that the Bazel target `@llvm-project//mlir:SPIRVLowering` not only maps to `MLIRSPIRV`, but in addition needs to be mapped to `MLIRSPIRVTransforms`.