### PR TITLE
Bazel to CMake: Add conversion for mlir:GPUDialect

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -65,6 +65,7 @@ MLIR_EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:AffineDialectRegistration": ["MLIRAffineOps"],
     "@llvm-project//mlir:AffineToStandardTransforms": ["MLIRAffineToStandard"],
     "@llvm-project//mlir:CFGTransforms": ["MLIRLoopToStandard"],
+    "@llvm-project//mlir:GPUDialect": ["MLIRGPU"],
     "@llvm-project//mlir:GPUToSPIRVTransforms": ["MLIRGPUtoSPIRVTransforms"],
     "@llvm-project//mlir:GPUTransforms": ["MLIRGPU"],
     "@llvm-project//mlir:LinalgDialectRegistration": ["MLIRLinalgOps"],


### PR DESCRIPTION
Running `bazel_to_cmake` on `iree/compiler/Translation/SPIRV/LinalgToSPIRV/BUILD`, it was found that `mlir:GPUDialect` should be mapped to `MLIRGPU` and not to `MLIRGPUDialect`.