### PR TITLE
Enable ALWAYSLINK for python extentions build with CMake; Add py_libraries and py_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,3 +205,6 @@ endif()
 
 # Note: this must be called after all libraries have been declared.
 iree_complete_binary_link_options()
+if(${IREE_BUILD_PYTHON_BINDINGS})
+  iree_complete_py_extension_link_options()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ include(iree_glsl_vulkan)
 include(iree_spirv_kernel_cc_library)
 include(iree_pybind_cc_library)
 include(iree_py_extension)
+include(iree_py_library)
+include(iree_py_test)
 include(iree_lit_test)
 include(iree_alwayslink)
 

--- a/bindings/python/build_tools/cmake/iree_py_extension.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_extension.cmake
@@ -26,7 +26,7 @@ endif()
 # NAME: name of target
 # HDRS: List of public header files for the library
 # SRCS: List of source files for the library
-# DEPS: List of other libraries to be linked in to the binary targets
+# DEPS: List of other libraries to be linked in to the py extension targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
 # INCLUDES: Include directories to add to dependencies
@@ -110,7 +110,7 @@ function(iree_py_extension)
     endif()
     # Defer computing transitive dependencies and calling target_link_libraries()
     # until all libraries have been declared.
-    # Track target and deps, use in iree_complete_binary_link_options() later.
+    # Track target and deps, use in iree_complete_py_extension_link_options() later.
     set_property(GLOBAL APPEND PROPERTY _IREE_PY_EXTENSION_NAMES "${_NAME}")
     set_property(TARGET ${_NAME} PROPERTY DIRECT_DEPS ${_RULE_DEPS})
   endif()

--- a/bindings/python/build_tools/cmake/iree_py_extension.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_extension.cmake
@@ -114,3 +114,138 @@ function(iree_py_extension)
     endif()
   endif()
 endfunction()
+
+# Lists all transitive dependencies of DIRECT_DEPS in TRANSITIVE_DEPS.
+function(_iree_transitive_dependencies DIRECT_DEPS TRANSITIVE_DEPS)
+  set(_TRANSITIVE "")
+
+  foreach(_DEP ${DIRECT_DEPS})
+    _iree_transitive_dependencies_helper(${_DEP} _TRANSITIVE)
+  endforeach(_DEP)
+
+  set(${TRANSITIVE_DEPS} "${_TRANSITIVE}" PARENT_SCOPE)
+endfunction()
+
+# Recursive helper function for _iree_transitive_dependencies.
+# Performs a depth-first search through the dependency graph, appending all
+# dependencies of TARGET to the TRANSITIVE_DEPS list.
+function(_iree_transitive_dependencies_helper TARGET TRANSITIVE_DEPS)
+  if (NOT TARGET "${TARGET}")
+    # Excluded from the project, or invalid name? Just ignore.
+    return()
+  endif()
+
+  # Resolve aliases, canonicalize name formatting.
+  get_target_property(_ALIASED_TARGET ${TARGET} ALIASED_TARGET)
+  if(_ALIASED_TARGET)
+    set(_TARGET_NAME ${_ALIASED_TARGET})
+  else()
+    string(REPLACE "::" "_" _TARGET_NAME ${TARGET})
+  endif()
+
+  set(_RESULT "${${TRANSITIVE_DEPS}}")
+  if (${_TARGET_NAME} IN_LIST _RESULT)
+    # Already visited, ignore.
+    return()
+  endif()
+
+  # Append this target to the list. Dependencies of this target will be added
+  # (if valid and not already visited) in recursive function calls.
+  list(APPEND _RESULT ${_TARGET_NAME})
+
+  # Check for non-target identifiers again after resolving the alias.
+  if (NOT TARGET ${_TARGET_NAME})
+    return()
+  endif()
+
+  # Get the list of direct dependencies for this target.
+  get_target_property(_TARGET_TYPE ${_TARGET_NAME} TYPE)
+  if(NOT ${_TARGET_TYPE} STREQUAL "INTERFACE_LIBRARY")
+    get_target_property(_TARGET_DEPS ${_TARGET_NAME} LINK_LIBRARIES)
+  else()
+    get_target_property(_TARGET_DEPS ${_TARGET_NAME} INTERFACE_LINK_LIBRARIES)
+  endif()
+
+  if(_TARGET_DEPS)
+    # Recurse on each dependency.
+    foreach(_TARGET_DEP ${_TARGET_DEPS})
+      _iree_transitive_dependencies_helper(${_TARGET_DEP} _RESULT)
+    endforeach(_TARGET_DEP)
+  endif()
+
+  # Propagate the augmented list up to the parent scope.
+  set(${TRANSITIVE_DEPS} "${_RESULT}" PARENT_SCOPE)
+endfunction()
+
+# Sets target_link_libraries() on all registered py extensions.
+# This must be called after all libraries have been declared.
+function(iree_complete_py_extension_link_options)
+  get_property(_NAMES GLOBAL PROPERTY _IREE_PY_EXTENSION_NAMES)
+
+  foreach(_NAME ${_NAMES})
+    get_target_property(_DIRECT_DEPS ${_NAME} DIRECT_DEPS)
+
+    # List all dependencies, including transitive dependencies, then split the
+    # dependency list into one for whole archive (ALWAYSLINK) and one for
+    # standard linking (which only links in symbols that are directly used).
+    _iree_transitive_dependencies("${_DIRECT_DEPS}" _TRANSITIVE_DEPS)
+    set(_ALWAYS_LINK_DEPS "")
+    set(_STANDARD_DEPS "")
+    foreach(_DEP ${_TRANSITIVE_DEPS})
+      # Check if _DEP is a library with the ALWAYSLINK property set.
+      set(_DEP_IS_ALWAYSLINK OFF)
+      if (TARGET ${_DEP})
+        get_target_property(_DEP_TYPE ${_DEP} TYPE)
+        if(${_DEP_TYPE} STREQUAL "INTERFACE_LIBRARY")
+          # Can't be ALWAYSLINK since it's an INTERFACE library.
+          # We also can't even query for the property, since it isn't whitelisted.
+        else()
+          get_target_property(_DEP_IS_ALWAYSLINK ${_DEP} ALWAYSLINK)
+        endif()
+      endif()
+
+      # Append to the corresponding list of deps.
+      if(_DEP_IS_ALWAYSLINK)
+        list(APPEND _ALWAYS_LINK_DEPS ${_DEP})
+
+        # For MSVC, also add a `-WHOLEARCHIVE:` version of the dep.
+        # CMake treats -WHOLEARCHIVE[:lib] as a link flag and will not actually
+        # try to link the library in, so we need the flag *and* the dependency.
+        if(MSVC)
+          get_target_property(_ALIASED_TARGET ${_DEP} ALIASED_TARGET)
+          if (_ALIASED_TARGET)
+            list(APPEND _ALWAYS_LINK_DEPS "-WHOLEARCHIVE:${_ALIASED_TARGET}")
+          else()
+            list(APPEND _ALWAYS_LINK_DEPS "-WHOLEARCHIVE:${_DEP}")
+          endif()
+        endif()
+      else()
+        list(APPEND _STANDARD_DEPS ${_DEP})
+      endif()
+    endforeach(_DEP)
+
+    # Call into target_link_libraries with the lists of deps.
+    # TODO(scotttodd): `-Wl,-force_load` version
+    if(MSVC)
+      target_link_libraries(${_NAME}
+        PUBLIC
+          ${_ALWAYS_LINK_DEPS}
+          ${_STANDARD_DEPS}
+        PRIVATE
+          ${_RULE_LINKOPTS}
+          ${PYTHON_LIBRARY}
+      )
+    else()
+      target_link_libraries(${_NAME}
+        PUBLIC
+          "-Wl,--whole-archive"
+          ${_ALWAYS_LINK_DEPS}
+          "-Wl,--no-whole-archive"
+          ${_STANDARD_DEPS}
+        PRIVATE
+          ${_RULE_LINKOPTS}
+          ${PYTHON_LIBRARY}
+      )
+    endif()
+  endforeach(_NAME)
+endfunction()

--- a/bindings/python/build_tools/cmake/iree_py_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_library.cmake
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeParseArguments)
+
+# iree_py_library()
+#
+# CMake function to imitate Bazel's iree_py_library rule.
+#
+# Parameters:
+# NAME: name of target
+# SRCS: List of source files for the library
+# DEPS: List of other targets the test python libraries require
+
+function(iree_py_library)
+
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DEPS"
+    ${ARGN}
+  )
+
+  iree_package_ns(_PACKAGE_NS)
+  # Replace dependencies passed by ::name with ::iree::package::name
+  list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  # Add path to each source file
+  list(TRANSFORM _RULE_SRCS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+  add_custom_target(${_NAME} ALL
+    COMMAND ${CMAKE_COMMAND} -E copy "${_RULE_SRCS}" "${CMAKE_CURRENT_BINARY_DIR}/"
+    DEPENDS ${_RULE_DEPS}
+  )
+
+endfunction()

--- a/bindings/python/build_tools/cmake/iree_py_test.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_test.cmake
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeParseArguments)
+
+# iree_py_test()
+#
+# CMake function to imitate Bazel's iree_py_test rule.
+#
+# Parameters:
+# NAME: name of test
+# SRCS: List of source file
+# DEPS: List of deps the test requires
+
+function(iree_py_test)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DEPS"
+    ${ARGN}
+  )
+
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  add_test(
+    NAME ${_NAME}
+    COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRCS}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_property(TEST ${_NAME} PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}")
+  # TODO(marbre): Find out how to add deps to tests.
+  #               Similar to _RULE_DATA in iree_lit_test().
+
+endfunction()

--- a/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
+++ b/bindings/python/build_tools/cmake/iree_pybind_cc_library.cmake
@@ -106,7 +106,7 @@ function(iree_pybind_cc_library)
     set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
     set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
-    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "lib${_RULE_NAME}")
+    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
 
     if(NOT _uppercase_RULE_TYPE MATCHES "STATIC")
       set_property(TARGET ${_NAME} PROPERTY PREFIX "${PYTHON_MODULE_PREFIX}")

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -62,3 +62,10 @@ iree_pybind_cc_library(
   TYPE
     STATIC
 )
+
+iree_py_test(
+  NAME
+    compiler_test
+  SRCS
+    "compiler_test.py"
+)

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -51,5 +51,5 @@ iree_pybind_cc_library(
     MLIRParser
     MLIRPass
   TYPE
-    SHARED
+    STATIC
 )

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_py_library(
+  NAME
+    compiler
+  SRCS
+    "__init__.py"
+  DEPS
+    ::binding
+)
+
 iree_py_extension(
   NAME
     binding

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -84,3 +84,31 @@ iree_py_library(
   DEPS
     ::binding
 )
+
+iree_py_test(
+  NAME
+    function_abi_test
+  SRCS
+    "function_abi_test.py"
+)
+
+iree_py_test(
+  NAME
+    hal_test
+  SRCS
+    "hal_test.py"
+)
+
+iree_py_test(
+  NAME
+    system_api_test
+  SRCS
+    "system_api_test.py"
+)
+
+iree_py_test(
+  NAME
+    vm_test
+  SRCS
+    "vm_test.py"
+)

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -63,5 +63,5 @@ iree_pybind_cc_library(
     absl::optional
     absl::span
   TYPE
-    SHARED
+    STATIC
 )

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_py_library(
+  NAME
+    rt
+  SRCS
+    "__init__.py"
+    # "system_api.py"
+  DEPS
+    ::binding
+)
+
 iree_py_extension(
   NAME
     binding
@@ -64,4 +74,13 @@ iree_pybind_cc_library(
     absl::span
   TYPE
     STATIC
+)
+
+iree_py_library(
+  NAME
+    system_api
+  SRCS
+    "system_api.py"
+  DEPS
+    ::binding
 )


### PR DESCRIPTION
The python bindings with CMake were so far not fully functional.

* Adds ALWAYSLINK support to iree_py_extension(), similar to iree_cc_binary()
* Fixes the library name of targets generated by iree_py_extension()
* Changes the iree_py_extension() targets to STATIC objects
* Adds iree_py_library CMake module
* Adds iree_py_test CMake module
* Adds iree_py_library and iree_py_test targets

---

**Test status before**
98% tests passed, 3 tests failed out of 173

Total Test time (real) =  35.13 sec

The following tests FAILED:
        168 - iree_tools_vm_util_test (Failed)
        172 - iree_samples_custom_modules_custom_modules_test (Failed)
        173 - iree_samples_simple_embedding_simple_embedding_test (Failed)

**Test status afterwards**
98% tests passed, 3 tests failed out of 178

Total Test time (real) =  38.23 sec

The following tests FAILED:
        173 - iree_tools_vm_util_test (Failed)
        177 - iree_samples_custom_modules_custom_modules_test (Failed)
        178 - iree_samples_simple_embedding_simple_embedding_test (Failed)
