### PR TITLE
Bazel to cmake: Sort target lists

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -31,7 +31,6 @@ import bazel_to_cmake_targets
 import datetime
 import os
 import textwrap
-from collections import OrderedDict
 from itertools import repeat, chain
 import glob
 import re
@@ -234,8 +233,12 @@ class BuildFileFunctions(object):
     targets = [self._convert_target(t) for t in targets]
     # Flatten lists
     targets = list(chain.from_iterable(targets))
-    # Remove Falsey (None and empty string) values and duplicates, preserving the original ordering.
-    targets = list(filter(None, OrderedDict(zip(targets, repeat(None)))))
+    # Remove duplicates
+    targets = set(targets)
+    # Remove Falsey (None and empty string) values
+    targets = filter(None, targets)
+    # Sort the targets and convert to a list
+    targets = sorted(targets)
     target_list_string = "\n".join(["    %s" % (t,) for t in targets])
     return "  %s\n%s\n" % (
         list_name,

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -20,11 +20,11 @@ iree_cc_library(
   SRCS
     "file_handle_win32.cc"
   DEPS
+    absl::memory
+    absl::strings
     iree::base::platform_headers
     iree::base::status
     iree::base::target_platform
-    absl::memory
-    absl::strings
   PUBLIC
 )
 
@@ -36,12 +36,12 @@ iree_cc_library(
     "file_io_win32.cc"
   DEPS
     ::file_handle_win32
+    absl::memory
+    absl::strings
     iree::base::file_io_hdrs
     iree::base::platform_headers
     iree::base::status
     iree::base::target_platform
-    absl::memory
-    absl::strings
   PUBLIC
 )
 
@@ -53,12 +53,12 @@ iree_cc_library(
     "file_mapping_win32.cc"
   DEPS
     ::file_handle_win32
+    absl::memory
+    absl::strings
     iree::base::file_mapping_hdrs
     iree::base::platform_headers
     iree::base::target_platform
     iree::base::tracing
-    absl::memory
-    absl::strings
   PUBLIC
 )
 
@@ -70,9 +70,9 @@ iree_cc_library(
   SRCS
     "init_internal.cc"
   DEPS
+    absl::flags_parse
     iree::base::initializer
     iree::base::target_platform
-    absl::flags_parse
   PUBLIC
 )
 
@@ -84,9 +84,9 @@ iree_cc_library(
   SRCS
     "logging.cc"
   DEPS
-    iree::base::platform_headers
     absl::core_headers
     absl::flags
+    iree::base::platform_headers
   PUBLIC
 )
 
@@ -129,14 +129,14 @@ iree_cc_library(
   DEPS
     ::logging_internal
     ::ostringstream
+    absl::core_headers
+    absl::flags
+    absl::memory
+    absl::stacktrace
+    absl::strings
     iree::base::platform_headers
     iree::base::source_location
     iree::base::target_platform
-    absl::core_headers
-    absl::stacktrace
-    absl::flags
-    absl::memory
-    absl::strings
   PUBLIC
 )
 
@@ -146,10 +146,10 @@ iree_cc_library(
   HDRS
     "status_matchers.h"
   DEPS
+    absl::optional
+    absl::strings
     iree::base::status
     iree::testing::gtest
-    absl::strings
-    absl::optional
   TESTONLY
   PUBLIC
 )

--- a/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
@@ -23,14 +23,14 @@ iree_cc_library(
     "Dispatchability.cpp"
     "DispatchabilityTest.cpp"
   DEPS
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::Flow::Utils
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRSupport
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::Utils
+    iree::compiler::Dialect::IREE::IR
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
@@ -23,9 +23,9 @@ iree_cc_library(
   SRCS
     "TypeConverter.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRParser
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
   PUBLIC
 )

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
@@ -22,12 +22,12 @@ iree_cc_library(
   SRCS
     "ConvertHLOToFlow.cpp"
   DEPS
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::IREE::IR
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
@@ -22,12 +22,12 @@ iree_cc_library(
   SRCS
     "ConvertStandardToFlow.cpp"
   DEPS
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -36,14 +36,6 @@ iree_cc_library(
     "PrePostPartitioningConversion.cpp"
     "RematerializeDispatchConstants.cpp"
   DEPS
-    iree::base::signature_mangle
-    iree::compiler::Dialect::Flow::Analysis
-    iree::compiler::Dialect::Flow::Conversion
-    iree::compiler::Dialect::Flow::Conversion::HLOToFlow
-    iree::compiler::Dialect::Flow::Conversion::StandardToFlow
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::Flow::Utils
-    iree::compiler::Utils
     LLVMSupport
     MLIRAnalysis
     MLIRIR
@@ -52,6 +44,14 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::base::signature_mangle
+    iree::compiler::Dialect::Flow::Analysis
+    iree::compiler::Dialect::Flow::Conversion
+    iree::compiler::Dialect::Flow::Conversion::HLOToFlow
+    iree::compiler::Dialect::Flow::Conversion::StandardToFlow
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::Utils
+    iree::compiler::Utils
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
@@ -22,11 +22,11 @@ iree_cc_library(
     "DispatchUtils.cpp"
     "WorkloadUtils.cpp"
   DEPS
-    iree::compiler::Dialect::Flow::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
+    iree::compiler::Dialect::Flow::IR
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
@@ -26,12 +26,12 @@ iree_cc_library(
     "ConversionTarget.cpp"
     "TypeConverter.cpp"
   DEPS
+    MLIRIR
+    MLIRStandardOps
+    MLIRTransforms
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::HAL::Utils
     iree::compiler::Dialect::IREE::IR
-    MLIRIR
-    MLIRStandardOps
-    MLIRTransforms
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
@@ -26,6 +26,11 @@ iree_cc_library(
     "ConvertTensorOps.cpp"
     "ConvertVariableOps.cpp"
   DEPS
+    LLVMSupport
+    MLIRIR
+    MLIRPass
+    MLIRStandardOps
+    MLIRTransforms
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::Conversion
     iree::compiler::Dialect::HAL::IR
@@ -35,11 +40,6 @@ iree_cc_library(
     iree::compiler::Dialect::IREE::Conversion::PreserveCompilerHints
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::VM::IR
-    LLVMSupport
-    MLIRIR
-    MLIRPass
-    MLIRStandardOps
-    MLIRTransforms
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -30,18 +30,18 @@ iree_cc_library(
     "ConvertHALToVM.cpp"
     "ConvertVariableOps.cpp"
   DEPS
-    iree::compiler::Dialect::HAL::hal_imports
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::HAL::Utils
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
-    iree::compiler::Dialect::VM::Conversion::StandardToVM
-    iree::compiler::Dialect::VM::IR
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::Utils
+    iree::compiler::Dialect::HAL::hal_imports
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::Conversion::StandardToVM
+    iree::compiler::Dialect::VM::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -28,13 +28,13 @@ iree_cc_library(
     "ExecutableTarget.cpp"
     "LegacyUtil.cpp"
   DEPS
+    LLVMSupport
+    MLIRIR
+    MLIRStandardOps
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Utils
-    LLVMSupport
-    MLIRIR
-    MLIRStandardOps
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -22,20 +22,20 @@ iree_cc_library(
   SRCS
     "LLVMTarget.cpp"
   DEPS
+    LLVMCore
+    MLIRIR
+    MLIRLinalgOps
+    MLIRLinalgTransforms
+    MLIRLoopToStandard
+    MLIRStandardOps
+    MLIRStandardToLLVM
+    MLIRSupport
+    MLIRTargetLLVMIR
+    MLIRTransforms
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
     iree::compiler::Translation::XLAToLinalg
     iree::compiler::Translation::XLAToLinalg::IREELinalgTensorToBuffer
     iree::schemas::llvmir_executable_def_cc_fbs
-    LLVMCore
-    MLIRLoopToStandard
-    MLIRIR
-    MLIRStandardToLLVM
-    MLIRLinalgOps
-    MLIRLinalgTransforms
-    MLIRStandardOps
-    MLIRSupport
-    MLIRTargetLLVMIR
-    MLIRTransforms
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
@@ -20,6 +20,12 @@ iree_cc_library(
   SRCS
     "LegacyInterpreterTarget.cpp"
   DEPS
+    LLVMSupport
+    MLIRIR
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+    flatbuffers
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
@@ -29,12 +35,6 @@ iree_cc_library(
     iree::compiler::Translation::Interpreter::Serialization
     iree::compiler::Translation::Interpreter::Transforms
     iree::compiler::Utils
-    flatbuffers
-    LLVMSupport
-    MLIRIR
-    MLIRPass
-    MLIRSupport
-    MLIRTransforms
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
@@ -20,9 +20,9 @@ iree_cc_library(
   SRCS
     "VMLATarget.cpp"
   DEPS
-    iree::compiler::Dialect::HAL::Target::ExecutableTarget
     LLVMSupport
     MLIRSupport
+    iree::compiler::Dialect::HAL::Target::ExecutableTarget
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -20,6 +20,16 @@ iree_cc_library(
   SRCS
     "VulkanSPIRVTarget.cpp"
   DEPS
+    LLVMSupport
+    MLIRAllDialects
+    MLIRIR
+    MLIRPass
+    MLIRSPIRV
+    MLIRSPIRVSerialization
+    MLIRSPIRVTransforms
+    MLIRSupport
+    MLIRTransforms
+    flatbuffers
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
     iree::compiler::Dialect::IREE::IR
@@ -27,16 +37,6 @@ iree_cc_library(
     iree::compiler::Translation::SPIRV::LinalgToSPIRV
     iree::compiler::Translation::SPIRV::XLAToSPIRV
     iree::schemas::spirv_executable_def_cc_fbs
-    flatbuffers
-    LLVMSupport
-    MLIRAllDialects
-    MLIRIR
-    MLIRPass
-    MLIRSPIRV
-    MLIRSPIRVTransforms
-    MLIRSPIRVSerialization
-    MLIRSupport
-    MLIRTransforms
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -23,15 +23,15 @@ iree_cc_library(
     "Passes.cpp"
     "TranslateExecutables.cpp"
   DEPS
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::HAL::Conversion::FlowToHAL
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::HAL::Target::ExecutableTarget
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::HAL::Conversion::FlowToHAL
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::Target::ExecutableTarget
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
@@ -20,11 +20,11 @@ iree_cc_library(
   SRCS
     "TypeUtils.cpp"
   DEPS
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
@@ -20,9 +20,9 @@ iree_cc_library(
   SRCS
     "PreserveCompilerHints.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/IREE/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Transforms/CMakeLists.txt
@@ -22,9 +22,9 @@ iree_cc_library(
   SRCS
     "DropCompilerHints.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRPass
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/CMakeLists.txt
@@ -22,10 +22,10 @@ iree_cc_library(
   SRCS
     "ConvertHALToVM.cpp"
   DEPS
+    MLIRPass
+    MLIRTransforms
     iree::compiler::Dialect::HAL::Conversion
     iree::compiler::Dialect::Modules::TensorList::IR
     iree::compiler::Dialect::VM::Conversion
-    MLIRPass
-    MLIRTransforms
   PUBLIC
 )

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/CMakeLists.txt
@@ -20,9 +20,9 @@ iree_cc_library(
   SRCS
     "XlaHloShapeBuilder.cpp"
   DEPS
-    iree::compiler::Dialect::Shape::IR
     LLVMSupport
     MLIRIR
+    iree::compiler::Dialect::Shape::IR
     tensorflow::mlir_xla
   PUBLIC
 )

--- a/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
@@ -26,12 +26,12 @@ iree_cc_library(
     "MaterializeShapeCalculations.cpp"
     "TieDynamicShapes.cpp"
   DEPS
-    iree::compiler::Dialect::Shape::IR
-    iree::compiler::Dialect::Shape::Plugins::XLA::XlaHloShapeBuilder
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::Shape::IR
+    iree::compiler::Dialect::Shape::Plugins::XLA::XlaHloShapeBuilder
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
@@ -26,13 +26,13 @@ iree_cc_library(
     "ValueLiveness.cpp"
     "ValueLivenessTest.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::IR
     LLVMSupport
     MLIRAnalysis
     MLIRIR
     MLIRPass
     MLIRSupport
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
@@ -27,12 +27,12 @@ iree_cc_library(
     "ImportUtils.cpp"
     "TypeConverter.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::Shape::IR
-    iree::compiler::Dialect::VM::IR
     MLIRIR
     MLIRParser
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::Shape::IR
+    iree::compiler::Dialect::VM::IR
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
@@ -23,9 +23,6 @@ iree_cc_library(
     "ConvertStandardToVM.cpp"
     "ConvertStandardToVMPass.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
-    iree::compiler::Dialect::VM::IR
     LLVMSupport
     MLIRIR
     MLIRPass
@@ -33,6 +30,9 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
@@ -29,18 +29,18 @@ iree_cc_library(
     "TranslationFlags.cpp"
     "TranslationRegistration.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Analysis
-    iree::compiler::Dialect::VM::IR
-    iree::compiler::Dialect::VM::Transforms
-    iree::schemas::bytecode_module_def_cc_fbs
-    flatbuffers
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRSupport
     MLIRTransforms
     MLIRTranslation
+    flatbuffers
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Analysis
+    iree::compiler::Dialect::VM::IR
+    iree::compiler::Dialect::VM::Transforms
+    iree::schemas::bytecode_module_def_cc_fbs
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Tools/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Tools/CMakeLists.txt
@@ -19,10 +19,10 @@ iree_cc_library(
     "VMOpEncoderGen.cpp"
     "VMOpTableGen.cpp"
   DEPS
+    LLVMMLIRTableGen
     LLVMSupport
     LLVMTableGen
     MLIRSupport
-    LLVMMLIRTableGen
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -25,16 +25,16 @@ iree_cc_library(
     "OrdinalAllocation.cpp"
     "Passes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::Conversion::PreserveCompilerHints
-    iree::compiler::Dialect::VM::Conversion
-    iree::compiler::Dialect::VM::Conversion::StandardToVM
-    iree::compiler::Dialect::VM::IR
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::IREE::Conversion::PreserveCompilerHints
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::Conversion::StandardToVM
+    iree::compiler::Dialect::VM::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VMLA/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/CMakeLists.txt
@@ -26,12 +26,12 @@ iree_cc_library(
     "ConversionTarget.cpp"
     "TypeConverter.cpp"
   DEPS
+    MLIRIR
+    MLIRStandardOps
+    MLIRTransforms
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::Shape::IR
     iree::compiler::Dialect::VMLA::IR
     iree::compiler::Dialect::VMLA::IR::VMLADialect
-    MLIRIR
-    MLIRStandardOps
-    MLIRTransforms
   PUBLIC
 )

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/CMakeLists.txt
@@ -22,15 +22,15 @@ iree_cc_library(
   SRCS
     "ConvertHLOToVMLA.cpp"
   DEPS
+    MLIRIR
+    MLIRPass
+    MLIRStandardOps
+    MLIRTransforms
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::Shape::IR
     iree::compiler::Dialect::VMLA::Conversion
     iree::compiler::Dialect::VMLA::IR
     iree::compiler::Dialect::VMLA::IR::VMLADialect
-    MLIRIR
-    MLIRPass
-    MLIRStandardOps
-    MLIRTransforms
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
@@ -22,14 +22,14 @@ iree_cc_library(
   SRCS
     "ConvertStandardToVMLA.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VMLA::Conversion
-    iree::compiler::Dialect::VMLA::IR
-    iree::compiler::Dialect::VMLA::IR::VMLADialect
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VMLA::Conversion
+    iree::compiler::Dialect::VMLA::IR
+    iree::compiler::Dialect::VMLA::IR::VMLADialect
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/CMakeLists.txt
@@ -22,16 +22,16 @@ iree_cc_library(
   SRCS
     "ConvertVMLAToVM.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
-    iree::compiler::Dialect::VM::Conversion::StandardToVM
-    iree::compiler::Dialect::VM::IR
-    iree::compiler::Dialect::VMLA::vmla_imports
-    iree::compiler::Dialect::VMLA::IR
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::Conversion::StandardToVM
+    iree::compiler::Dialect::VM::IR
+    iree::compiler::Dialect::VMLA::IR
+    iree::compiler::Dialect::VMLA::vmla_imports
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VMLA/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Transforms/CMakeLists.txt
@@ -23,18 +23,18 @@ iree_cc_library(
     "Conversion.cpp"
     "Passes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::Transforms
-    iree::compiler::Dialect::Shape::IR
-    iree::compiler::Dialect::VMLA::Conversion
-    iree::compiler::Dialect::VMLA::Conversion::HLOToVMLA
-    iree::compiler::Dialect::VMLA::Conversion::StandardToVMLA
-    iree::compiler::Dialect::VMLA::IR
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRStandardOps
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::IREE::Transforms
+    iree::compiler::Dialect::Shape::IR
+    iree::compiler::Dialect::VMLA::Conversion
+    iree::compiler::Dialect::VMLA::Conversion::HLOToVMLA
+    iree::compiler::Dialect::VMLA::Conversion::StandardToVMLA
+    iree::compiler::Dialect::VMLA::IR
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -25,6 +25,12 @@ iree_cc_library(
   SRCS
     "IREEVM.cpp"
   DEPS
+    LLVMSupport
+    MLIRAllDialects
+    MLIRIR
+    MLIRPass
+    MLIRSupport
+    MLIRTranslation
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::Conversion::HALToVM
@@ -34,12 +40,6 @@ iree_cc_library(
     iree::compiler::Dialect::VM::Conversion::StandardToVM
     iree::compiler::Dialect::VM::Target::Bytecode
     iree::compiler::Dialect::VM::Transforms
-    LLVMSupport
-    MLIRAllDialects
-    MLIRIR
-    MLIRPass
-    MLIRSupport
-    MLIRTranslation
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
@@ -28,14 +28,14 @@ iree_cc_library(
     "VMFunctionTableBuilder.cpp"
     "VMModuleBuilder.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::Interpreter::Utils
-    iree::schemas::interpreter_module_def_cc_fbs
-    iree::schemas::bytecode::interpreter_bytecode_v0
-    flatbuffers
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
+    flatbuffers
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::Interpreter::Utils
+    iree::schemas::bytecode::interpreter_bytecode_v0
+    iree::schemas::interpreter_module_def_cc_fbs
   PUBLIC
 )

--- a/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
@@ -37,13 +37,6 @@ iree_cc_library(
     "LowerXLAToIreeDialect.cpp"
     "MakeExecutableABI.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::Interpreter::IR
-    iree::compiler::Translation::Interpreter::IR::Common
-    iree::compiler::Translation::Interpreter::Serialization
-    iree::compiler::Translation::Interpreter::Utils
-    iree::compiler::Utils
-    iree::schemas::bytecode::interpreter_bytecode_v0
     LLVMSupport
     MLIRAnalysis
     MLIRIR
@@ -52,6 +45,13 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::Interpreter::IR
+    iree::compiler::Translation::Interpreter::IR::Common
+    iree::compiler::Translation::Interpreter::Serialization
+    iree::compiler::Translation::Interpreter::Utils
+    iree::compiler::Utils
+    iree::schemas::bytecode::interpreter_bytecode_v0
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
@@ -23,8 +23,6 @@ iree_cc_library(
     "MemRefUtils.cpp"
     "OpCreationUtils.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::Interpreter::IR::Common
     LLVMSupport
     MLIRIR
     MLIRPass
@@ -32,6 +30,8 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::Interpreter::IR::Common
     tensorflow::mlir_xla
   PUBLIC
 )

--- a/iree/compiler/Translation/SPIRV/EmbeddedKernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/EmbeddedKernels/CMakeLists.txt
@@ -22,11 +22,11 @@ iree_cc_library(
   SRCS
     "EmbeddedKernels.cpp"
   DEPS
-    iree::compiler::Translation::SPIRV::EmbeddedKernels::Kernels
-    iree::schemas::spirv_executable_def_cc_fbs
-    flatbuffers
     MLIRIR
     MLIRSupport
+    flatbuffers
+    iree::compiler::Translation::SPIRV::EmbeddedKernels::Kernels
+    iree::schemas::spirv_executable_def_cc_fbs
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/SPIRV/IndexComputation/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/IndexComputation/CMakeLists.txt
@@ -42,14 +42,14 @@ iree_cc_library(
     "IndexComputationPass.cpp"
     "XLAIndexPropagation.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::SPIRV::IndexComputation::IndexComputationAttrGen
-    iree::compiler::Utils
     LLVMSupport
     MLIRIR
     MLIRPass
     MLIRSPIRV
     MLIRStandardOps
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::SPIRV::IndexComputation::IndexComputationAttrGen
+    iree::compiler::Utils
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -24,9 +24,6 @@ iree_cc_library(
     "LinalgFusion.cpp"
     "LowerToSPIRV.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::XLAToLinalg::IREELinalgTensorToBuffer
-    iree::compiler::Utils
     LLVMSupport
     MLIRAffineOps
     MLIRAffineToStandard
@@ -45,6 +42,9 @@ iree_cc_library(
     MLIRStandardToSPIRVTransforms
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::XLAToLinalg::IREELinalgTensorToBuffer
+    iree::compiler::Utils
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/SPIRV/ReductionCodegen/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/ReductionCodegen/CMakeLists.txt
@@ -23,13 +23,13 @@ iree_cc_library(
     "PrepareReductionDispatch.cpp"
     "ReductionFnLowering.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRPass
     MLIRSPIRV
     MLIRSPIRVTransforms
     MLIRStandardOps
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
     tensorflow::mlir_xla
   PUBLIC
 )

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
@@ -29,11 +29,6 @@ iree_cc_library(
     "SPIRVLowering.cpp"
     "XLAToSPIRV.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Translation::SPIRV::IndexComputation
-    iree::compiler::Translation::SPIRV::Passes
-    iree::compiler::Translation::SPIRV::ReductionCodegen
-    iree::compiler::Utils
     LLVMSupport
     MLIRAffineOps
     MLIRAffineToStandard
@@ -45,6 +40,11 @@ iree_cc_library(
     MLIRStandardToSPIRVTransforms
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Translation::SPIRV::IndexComputation
+    iree::compiler::Translation::SPIRV::Passes
+    iree::compiler::Translation::SPIRV::ReductionCodegen
+    iree::compiler::Utils
     tensorflow::mlir_xla
   ALWAYSLINK
   PUBLIC

--- a/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
@@ -43,13 +43,13 @@ iree_cc_library(
   SRCS
     "LinalgTensorToBuffer.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     MLIRIR
     MLIRLinalgOps
     MLIRPass
     MLIRStandardOps
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Utils/CMakeLists.txt
+++ b/iree/compiler/Utils/CMakeLists.txt
@@ -24,7 +24,6 @@ iree_cc_library(
     "IREECodegenUtils.cpp"
     "TypeConversionUtils.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRPass
@@ -32,6 +31,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::IREE::IR
     tensorflow::mlir_xla
   PUBLIC
 )

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -28,11 +28,11 @@ iree_cc_library(
     "allocator.cc"
   DEPS
     ::buffer
+    absl::span
     iree::base::ref_ptr
     iree::base::source_location
     iree::base::status
     iree::base::tracing
-    absl::span
   PUBLIC
 )
 
@@ -58,13 +58,13 @@ iree_cc_library(
     ::fence
     ::heap_buffer
     ::semaphore
+    absl::span
+    absl::strings
     iree::base::api
     iree::base::api_util
     iree::base::ref_ptr
     iree::base::shape
     iree::base::tracing
-    absl::strings
-    absl::span
   PUBLIC
 )
 
@@ -87,14 +87,14 @@ iree_cc_library(
     "buffer.cc"
   DEPS
     ::resource
+    absl::core_headers
+    absl::span
+    absl::strings
+    absl::variant
     iree::base::bitfield
     iree::base::logging
     iree::base::source_location
     iree::base::status
-    absl::core_headers
-    absl::strings
-    absl::span
-    absl::variant
   PUBLIC
 )
 
@@ -107,10 +107,10 @@ iree_cc_test(
   DEPS
     ::buffer
     ::heap_buffer
+    absl::span
     iree::base::status
     iree::base::status_matchers
     iree::testing::gtest_main
-    absl::span
 )
 
 iree_cc_library(
@@ -122,11 +122,11 @@ iree_cc_library(
     "buffer_view.cc"
   DEPS
     ::buffer
+    absl::inlined_vector
+    absl::strings
     iree::base::shape
     iree::base::source_location
     iree::base::status
-    absl::inlined_vector
-    absl::strings
   PUBLIC
 )
 
@@ -155,11 +155,11 @@ iree_cc_library(
     ::allocator
     ::buffer_view
     ::heap_buffer
+    absl::optional
+    absl::strings
     iree::base::buffer_string_util
     iree::base::source_location
     iree::base::status
-    absl::strings
-    absl::optional
   PUBLIC
 )
 
@@ -189,10 +189,10 @@ iree_cc_library(
     ::event
     ::executable
     ::resource
+    absl::core_headers
     iree::base::bitfield
     iree::base::shape
     iree::base::status
-    absl::core_headers
   PUBLIC
 )
 
@@ -219,11 +219,11 @@ iree_cc_library(
     ::command_buffer
     ::fence
     ::semaphore
+    absl::span
+    absl::time
     iree::base::bitfield
     iree::base::status
     iree::base::time
-    absl::time
-    absl::span
   PUBLIC
 )
 
@@ -259,10 +259,10 @@ iree_cc_test(
   DEPS
     ::deferred_buffer
     ::heap_buffer
+    absl::memory
     iree::base::status_matchers
     iree::hal::testing::mock_allocator
     iree::testing::gtest_main
-    absl::memory
 )
 
 iree_cc_library(
@@ -305,10 +305,10 @@ iree_cc_library(
     ::executable_cache
     ::executable_layout
     ::semaphore
+    absl::time
     iree::base::ref_ptr
     iree::base::status
     iree::base::time
-    absl::time
   PUBLIC
 )
 
@@ -318,8 +318,8 @@ iree_cc_library(
   HDRS
     "device_info.h"
   DEPS
-    iree::base::bitfield
     absl::core_headers
+    iree::base::bitfield
   PUBLIC
 )
 
@@ -339,13 +339,13 @@ iree_cc_library(
     ::executable_format
     ::fence
     ::heap_buffer
+    absl::span
+    absl::synchronization
+    absl::time
     iree::base::source_location
     iree::base::status
     iree::base::time
     iree::base::tracing
-    absl::synchronization
-    absl::time
-    absl::span
   PUBLIC
 )
 
@@ -380,11 +380,11 @@ iree_cc_library(
     "driver_registry.cc"
   DEPS
     ::driver
+    absl::core_headers
+    absl::synchronization
     iree::base::initializer
     iree::base::ref_ptr
     iree::base::status
-    absl::core_headers
-    absl::synchronization
   PUBLIC
 )
 
@@ -478,11 +478,11 @@ iree_cc_library(
   DEPS
     ::allocator
     ::buffer
+    absl::core_headers
     iree::base::source_location
     iree::base::status
     iree::base::tracing
     iree::hal::host::host_buffer
-    absl::core_headers
   PUBLIC
 )
 

--- a/iree/hal/host/CMakeLists.txt
+++ b/iree/hal/host/CMakeLists.txt
@@ -21,12 +21,12 @@ iree_cc_library(
     "async_command_queue.cc"
   DEPS
     ::host_submission_queue
+    absl::core_headers
+    absl::synchronization
     iree::base::status
     iree::base::tracing
     iree::hal::command_queue
     iree::hal::fence
-    absl::core_headers
-    absl::synchronization
   PUBLIC
 )
 
@@ -38,6 +38,8 @@ iree_cc_test(
   DEPS
     ::async_command_queue
     ::host_submission_queue
+    absl::memory
+    absl::time
     iree::base::status
     iree::base::status_matchers
     iree::base::time
@@ -45,8 +47,6 @@ iree_cc_test(
     iree::hal::testing::mock_command_buffer
     iree::hal::testing::mock_command_queue
     iree::testing::gtest_main
-    absl::memory
-    absl::time
 )
 
 iree_cc_library(
@@ -57,11 +57,11 @@ iree_cc_library(
   SRCS
     "host_buffer.cc"
   DEPS
+    absl::core_headers
     iree::base::logging
     iree::base::source_location
     iree::base::status
     iree::hal::buffer
-    absl::core_headers
   PUBLIC
 )
 
@@ -85,13 +85,13 @@ iree_cc_library(
   SRCS
     "host_fence.cc"
   DEPS
+    absl::core_headers
+    absl::inlined_vector
+    absl::span
+    absl::synchronization
     iree::base::status
     iree::base::tracing
     iree::hal::fence
-    absl::core_headers
-    absl::inlined_vector
-    absl::synchronization
-    absl::span
   PUBLIC
 )
 
@@ -102,10 +102,10 @@ iree_cc_test(
     "host_fence_test.cc"
   DEPS
     ::host_fence
+    absl::time
     iree::base::status
     iree::base::status_matchers
     iree::testing::gtest_main
-    absl::time
 )
 
 iree_cc_library(
@@ -149,15 +149,15 @@ iree_cc_library(
     "host_submission_queue.cc"
   DEPS
     ::host_fence
+    absl::core_headers
+    absl::inlined_vector
+    absl::synchronization
     iree::base::intrusive_list
     iree::base::status
     iree::base::tracing
     iree::hal::command_queue
     iree::hal::fence
     iree::hal::semaphore
-    absl::core_headers
-    absl::inlined_vector
-    absl::synchronization
   PUBLIC
 )
 

--- a/iree/hal/interpreter/CMakeLists.txt
+++ b/iree/hal/interpreter/CMakeLists.txt
@@ -55,6 +55,11 @@ iree_cc_library(
     "type.cc"
   DEPS
     ::bytecode_kernels
+    absl::core_headers
+    absl::inlined_vector
+    absl::optional
+    absl::span
+    absl::strings
     iree::base::flatbuffer_util
     iree::base::logging
     iree::base::memory
@@ -67,13 +72,8 @@ iree_cc_library(
     iree::hal::executable
     iree::hal::executable_spec
     iree::hal::heap_buffer
-    iree::schemas::interpreter_module_def_cc_fbs
     iree::schemas::bytecode::interpreter_bytecode_v0
-    absl::core_headers
-    absl::inlined_vector
-    absl::strings
-    absl::optional
-    absl::span
+    iree::schemas::interpreter_module_def_cc_fbs
   PUBLIC
 )
 
@@ -86,16 +86,16 @@ iree_cc_library(
     "bytecode_kernels_generic.h"
     "bytecode_kernels_ruy.h"
   DEPS
-    iree::base::shape
-    iree::base::status
-    iree::base::tracing
-    iree::hal::buffer_view
     absl::algorithm
     absl::core_headers
     absl::flat_hash_set
     absl::inlined_vector
     absl::memory
     absl::span
+    iree::base::shape
+    iree::base::status
+    iree::base::tracing
+    iree::hal::buffer_view
     ruy
   PUBLIC
 )
@@ -121,13 +121,13 @@ iree_cc_library(
     "interpreter_command_processor.cc"
   DEPS
     ::bytecode_executable
+    absl::inlined_vector
+    absl::span
     iree::base::source_location
     iree::base::status
     iree::base::tracing
     iree::hal::buffer_view
     iree::hal::host::host_local_command_processor
-    absl::inlined_vector
-    absl::span
   PUBLIC
 )
 
@@ -142,6 +142,9 @@ iree_cc_library(
     ::bytecode_cache
     ::bytecode_kernels
     ::interpreter_command_processor
+    absl::inlined_vector
+    absl::memory
+    absl::span
     iree::base::memory
     iree::base::status
     iree::base::tracing
@@ -154,9 +157,6 @@ iree_cc_library(
     iree::hal::host::host_local_allocator
     iree::hal::host::host_submission_queue
     iree::hal::host::inproc_command_buffer
-    absl::inlined_vector
-    absl::memory
-    absl::span
   PUBLIC
 )
 

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -20,11 +20,11 @@ iree_cc_library(
   SRCS
     "llvmjit_executable.cc"
   DEPS
+    absl::span
     iree::base::status
     iree::hal::allocator
     iree::hal::executable
     iree::hal::executable_spec
-    absl::span
   PUBLIC
 )
 
@@ -71,6 +71,9 @@ iree_cc_library(
   DEPS
     ::llvmjit_command_processor
     ::llvmjit_executable_cache
+    absl::inlined_vector
+    absl::memory
+    absl::span
     iree::base::memory
     iree::base::status
     iree::base::tracing
@@ -83,9 +86,6 @@ iree_cc_library(
     iree::hal::host::host_local_allocator
     iree::hal::host::host_submission_queue
     iree::hal::host::inproc_command_buffer
-    absl::inlined_vector
-    absl::memory
-    absl::span
   PUBLIC
 )
 

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -21,15 +21,15 @@ iree_cc_library(
     "op_kernels_generic.h"
     "op_kernels_ruy.h"
   DEPS
-    iree::base::shape
-    iree::base::status
-    iree::base::tracing
     absl::algorithm
     absl::core_headers
     absl::flat_hash_set
     absl::inlined_vector
     absl::memory
     absl::span
+    iree::base::shape
+    iree::base::status
+    iree::base::tracing
     ruy
   PUBLIC
 )
@@ -95,6 +95,9 @@ iree_cc_library(
   DEPS
     ::vmla_cache
     ::vmla_command_processor
+    absl::inlined_vector
+    absl::memory
+    absl::span
     iree::base::memory
     iree::base::status
     iree::base::tracing
@@ -109,9 +112,6 @@ iree_cc_library(
     iree::hal::host::inproc_command_buffer
     iree::vm::instance
     iree::vm::module
-    absl::inlined_vector
-    absl::memory
-    absl::span
   PUBLIC
 )
 
@@ -156,6 +156,8 @@ iree_cc_library(
   SRCS
     "vmla_executable.cc"
   DEPS
+    absl::inlined_vector
+    absl::span
     iree::base::api_util
     iree::base::status
     iree::base::tracing
@@ -166,8 +168,6 @@ iree_cc_library(
     iree::vm::context
     iree::vm::instance
     iree::vm::module
-    absl::inlined_vector
-    absl::span
   PUBLIC
 )
 
@@ -180,6 +180,7 @@ iree_cc_library(
     "vmla_module.cc"
   DEPS
     ::op_kernels
+    absl::span
     iree::base::api
     iree::base::memory
     iree::base::ref_ptr
@@ -187,6 +188,5 @@ iree_cc_library(
     iree::vm
     iree::vm::module_abi_cc
     iree::vm::types
-    absl::span
   PUBLIC
 )

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -36,6 +36,8 @@ iree_cc_test(
   DEPS
     ::check_test_module_cc
     ::native_module
+    absl::core_headers
+    absl::strings
     iree::base::api
     iree::base::logging
     iree::hal::api
@@ -44,8 +46,6 @@ iree_cc_test(
     iree::vm
     iree::vm::bytecode_module
     iree::vm::ref
-    absl::core_headers
-    absl::strings
 )
 
 iree_cc_library(
@@ -56,6 +56,7 @@ iree_cc_library(
   SRCS
     "native_module.cc"
   DEPS
+    absl::strings
     iree::base::api
     iree::base::api_util
     iree::base::buffer_string_util
@@ -63,6 +64,5 @@ iree_cc_library(
     iree::modules::hal
     iree::vm
     iree::vm::module_abi_cc
-    absl::strings
   PUBLIC
 )

--- a/iree/modules/hal/CMakeLists.txt
+++ b/iree/modules/hal/CMakeLists.txt
@@ -20,6 +20,11 @@ iree_cc_library(
   SRCS
     "hal_module.cc"
   DEPS
+    absl::core_headers
+    absl::inlined_vector
+    absl::memory
+    absl::span
+    absl::strings
     iree::base::api
     iree::base::api_util
     iree::base::tracing
@@ -28,10 +33,5 @@ iree_cc_library(
     iree::hal::device
     iree::vm
     iree::vm::module_abi_cc
-    absl::core_headers
-    absl::inlined_vector
-    absl::memory
-    absl::strings
-    absl::span
   PUBLIC
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -22,6 +22,10 @@ iree_cc_library(
   SRCS
     "strings_module.cc"
   DEPS
+    absl::inlined_vector
+    absl::span
+    absl::strings
+    benchmark
     iree::base::api
     iree::base::logging
     iree::vm
@@ -31,10 +35,6 @@ iree_cc_library(
     iree::vm::ref
     iree::vm::stack
     iree::vm::types
-    absl::inlined_vector
-    absl::strings
-    absl::span
-    benchmark
   PUBLIC
 )
 
@@ -46,6 +46,9 @@ iree_cc_test(
   DEPS
     ::strings_module
     ::strings_module_test_module_cc
+    absl::inlined_vector
+    absl::strings
+    benchmark
     iree::base::api
     iree::base::logging
     iree::testing::gtest_main
@@ -56,9 +59,6 @@ iree_cc_test(
     iree::vm::ref
     iree::vm::stack
     iree::vm::types
-    absl::inlined_vector
-    absl::strings
-    benchmark
 )
 
 iree_bytecode_module(

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -36,6 +36,8 @@ iree_cc_test(
   DEPS
     ::custom_modules_test_module_cc
     ::native_module
+    absl::core_headers
+    absl::strings
     iree::base::api
     iree::base::logging
     iree::hal::api
@@ -45,8 +47,6 @@ iree_cc_test(
     iree::vm
     iree::vm::bytecode_module
     iree::vm::ref
-    absl::core_headers
-    absl::strings
 )
 
 iree_cc_library(

--- a/iree/schemas/bytecode/CMakeLists.txt
+++ b/iree/schemas/bytecode/CMakeLists.txt
@@ -18,7 +18,7 @@ iree_cc_library(
   HDRS
     "interpreter_bytecode_v0.h"
   DEPS
-    iree::base::bitfield
     absl::core_headers
+    iree::base::bitfield
   PUBLIC
 )

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -31,8 +31,8 @@ iree_cc_library(
   SRCS
     "gtest_main_internal.cc"
   DEPS
-    iree::base::init
     gtest
+    iree::base::init
   TESTONLY
   PUBLIC
 )

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -24,9 +24,9 @@ iree_cc_test(
     ::instance
     ::invocation
     ::module
+    absl::strings
     iree::base::logging
     iree::testing::gtest_main
-    absl::strings
 )
 
 iree_bytecode_module(
@@ -59,11 +59,11 @@ iree_cc_library(
     ::stack
     ::types
     ::value
+    flatbuffers
     iree::base::api
     iree::base::flatbuffer_util
     iree::base::target_platform
     iree::schemas::bytecode_module_def_cc_fbs
-    flatbuffers
   PUBLIC
 )
 
@@ -77,12 +77,12 @@ iree_cc_test(
     ::bytecode_module_benchmark_module_cc
     ::module
     ::stack
-    iree::base::api
-    iree::base::logging
-    iree::testing::benchmark_main
     absl::inlined_vector
     absl::strings
     benchmark
+    iree::base::api
+    iree::base::logging
+    iree::testing::benchmark_main
 )
 
 iree_bytecode_module(
@@ -187,12 +187,12 @@ iree_cc_library(
     ::ref_cc
     ::stack
     ::types
+    absl::span
+    absl::strings
     iree::base::api
     iree::base::api_util
     iree::base::ref_ptr
     iree::base::status
-    absl::strings
-    absl::span
   PUBLIC
 )
 
@@ -228,8 +228,8 @@ iree_cc_library(
   DEPS
     ::ref
     ::types
-    iree::base::api
     absl::core_headers
+    iree::base::api
   PUBLIC
 )
 


### PR DESCRIPTION
There's been some previous discussion about sorting cmake dependencies vs preserving the order from bazel (https://github.com/google/iree/issues/538).

I think we've come to a point where we're going to have to switch to alphabetical order. I've just about got bazel_to_cmake working upstream, where the order of dependencies is different, so there's no way we can have it preserve order and have that.

The good news is that this means it should be possible to enforce that people run the tool as a presubmit, which should keep those files up to date much better.