### PR TITLE
CTest: Delete tmpdir if it wasn't previously

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -62,6 +62,8 @@ VULKAN_HEADERS_MAPPING = {
 }
 
 MLIR_EXPLICIT_TARGET_MAPPING = {
+    "@llvm-project//mlir:AllPassesAndDialects": ["MLIRAllDialects"],
+    "@llvm-project//mlir:AllPassesAndDialectsNoRegistration": ["MLIRAllDialects"],
     "@llvm-project//mlir:AffineDialectRegistration": ["MLIRAffineOps"],
     "@llvm-project//mlir:AffineToStandardTransforms": ["MLIRAffineToStandard"],
     "@llvm-project//mlir:CFGTransforms": ["MLIRLoopToStandard"],

--- a/build_tools/cmake/run_test.sh
+++ b/build_tools/cmake/run_test.sh
@@ -26,6 +26,7 @@ function cleanup() {
 }
 
 echo "Creating test environment"
+rm -rf "${TEST_TMPDIR?}" # In case this wasn't cleaned up previously
 mkdir "${TEST_TMPDIR?}"
 trap cleanup EXIT
 # Execute whatever we were passed.

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -24,6 +24,8 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
+export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
+
 EXCLUDED_TESTS=(
     iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test
     iree_hal_vulkan_dynamic_symbols_test
@@ -31,6 +33,7 @@ EXCLUDED_TESTS=(
     iree_tools_test_multiple_args.mlir.test
     iree_tools_test_scalars.mlir.test
     iree_tools_test_simple.mlir.test
+    iree_vm_bytecode_module_benchmark # Make this test not take an eternity
 )
 
 # Join with | and add anchors


### PR DESCRIPTION
If a previous test run was interrupted, it might not have cleaned up any temp directories and a subsequent run could fail on `mkdir`. Delete the temporary directory before trying to create it.

Depends on https://github.com/google/iree/pull/775