### PR TITLE
Cleanup format presubmit

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Presubmits
+name: Format
 
-on:
-  pull_request:
-    types: [opened, ready_for_review, synchronize]
+on: [pull_request]
 
 jobs:
   # Run clang-format and verify there are no errors. We don't want to bother
   # building until we've at least got clean code.
-  # TODO(benvanik): add other checks (license, etc).
-  lint:
-    name: Code Style Check
+  format:
+    name: Code Format Check
     runs-on: ubuntu-18.04
     steps:
     - name: Installing dependencies
@@ -39,7 +36,6 @@ jobs:
     - name: Fetching master
       run: git fetch --no-tags --prune --depth=1 origin master
     - name: Running clang-format on changed source files
-      # TODO(benvanik): actually filter to changed files.
       run: |
         /tmp/git-clang-format origin/master --binary=clang-format-9 --style=file
         git diff --exit-code


### PR DESCRIPTION
This workflow isn't our only presubmit so rename it.

Also cleaned some other weirdnesses:
1. Switch to default pull_request triggering like we have for other checks. The default is `[opened, synchronize, reopen]`, and I think that works fine for us (Ben was just copying from somewhere else). See https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
2. Remove TODO to only check changed files, `git-clang-format` already does that.

The other option was to merge all presubmits into one workflow. The only savings there is in some boilerplate (they don't actually share any state between jobs), so I went with this as it gave us more flexibility to decide independently when to run different checks. (e.g. we could also run all the checks on pushes to master, since we don't actually enforce github action checks and something failing them could be checked in). We can merge them later if we want.

