### PR TITLE
Run bazel_to_cmake on presubmit

### DIFF
--- a/.github/workflows/bazel_to_cmake.yml
+++ b/.github/workflows/bazel_to_cmake.yml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bazel to CMake
+
+on: [pull_request]
+
+jobs:
+  bazel_to_cmake:
+    name: Bazel to CMake Check
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checking out repository
+      uses: actions/checkout@v2
+    - name: Running bazel_to_cmake
+      run: |
+        ./build_tools/bazel_to_cmake/bazel_to_cmake.py --strict
+        git diff --exit-code


### PR DESCRIPTION
The action runs bazel_to_cmake.py in strict mode and confirms there are no diffs.