### PR TITLE
Run check workflows on push as well

### DIFF
--- a/.github/workflows/bazel_to_cmake.yml
+++ b/.github/workflows/bazel_to_cmake.yml
@@ -14,7 +14,7 @@
 
 name: Bazel to CMake
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   bazel_to_cmake:

--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -16,7 +16,7 @@
 
 name: Check Submodules
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   submodules:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@
 
 name: Format
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   # Run clang-format and verify there are no errors. We don't want to bother


### PR DESCRIPTION
These are cheap and it's useful to be able to see their state on master since we don't actually block submit on them. I think there's no real harm in having them on all pushes either. We can turn them back off it they get noisy or something.