### PR TITLE
Add CMake configuration for TensorList module

### DIFF
--- a/iree/compiler/Dialect/CMakeLists.txt
+++ b/iree/compiler/Dialect/CMakeLists.txt
@@ -15,5 +15,6 @@
 add_subdirectory(Flow)
 add_subdirectory(HAL)
 add_subdirectory(IREE)
+add_subdirectory(Modules)
 add_subdirectory(Shape)
 add_subdirectory(VM)

--- a/iree/compiler/Dialect/Modules/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(TensorList)

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(Conversion)
+add_subdirectory(IR)
+
+iree_cc_embed_data(
+  NAME
+    tensorlist_imports
+  SRCS
+    "tensorlist.imports.mlir"
+  CC_FILE_OUTPUT
+    "tensorlist.imports.cc"
+  H_FILE_OUTPUT
+    "tensorlist.imports.h"
+  CPP_NAMESPACE
+    "mlir::iree_compiler::IREE::TensorList"
+  FLATTEN
+  PUBLIC
+)
+
+iree_cc_binary(
+  NAME
+    tensorlist-opt
+  OUT
+    tensorlist-opt
+  DEPS
+    MLIRMlirOptMain
+    iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
+    iree::tools::iree_opt_library
+)
+
+iree_cc_binary(
+  NAME
+    tensorlist-translate
+  OUT
+    tensorlist-translate
+  DEPS
+    iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
+    iree::tools::iree_translate_library
+)

--- a/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(test)
+
+iree_cc_library(
+  NAME
+    IR
+  HDRS
+    "TensorListOps.h"
+    "TensorListOps.h.inc"
+    "TensorListTypes.h"
+  TEXTUAL_HDRS
+    "TensorListOps.cpp.inc"
+  SRCS
+    "TensorListOps.cpp"
+    "TensorListTypes.cpp"
+  DEPS
+    LLVMSupport
+    MLIRIR
+    MLIRParser
+    MLIRStandardOps
+    MLIRSupport
+    MLIRTransformUtils
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    TensorListDialect
+  HDRS
+    "TensorListDialect.h"
+  SRCS
+    "TensorListDialect.cpp"
+  DEPS
+    ::IR
+    LLVMSupport
+    MLIRIR
+    MLIRParser
+    MLIRTransformUtils
+    iree::compiler::Dialect::HAL::Conversion
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::Modules::TensorList::Conversion
+    iree::compiler::Dialect::Modules::TensorList::tensorlist_imports
+    iree::compiler::Dialect::VM::Conversion
+  ALWAYSLINK
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    TensorListOpsGen
+  TD_FILE
+    "TensorListOps.td"
+  OUTS
+    -gen-op-decls TensorListOps.h.inc
+    -gen-op-defs TensorListOps.cpp.inc
+)


### PR DESCRIPTION
Wasn't converted running in strict mode due to unimplemented filegroup `td_files`.

The additional tests, now included, pass on my machine:

**98% tests passed, 3 tests failed out of 184**

The following tests FAILED:
        179 - iree_tools_vm_util_test (Failed)
        183 - iree_samples_custom_modules_custom_modules_test (Failed)
        184 - iree_samples_simple_embedding_simple_embedding_test (Failed)
