### PR TITLE
Partially take over modifications added by bazel_to_cmake in non-strict mode

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -33,12 +33,12 @@ iree_cc_library(
     "FlowOps.cpp.inc"
     "FlowTypes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )
@@ -47,7 +47,7 @@ iree_tablegen_library(
   NAME
     FlowEnumsGen
   TD_FILE
-    FlowBase.td
+    "FlowBase.td"
   OUTS
     -gen-enum-decls FlowEnums.h.inc
     -gen-enum-defs FlowEnums.cpp.inc
@@ -57,7 +57,7 @@ iree_tablegen_library(
   NAME
     FlowOpInterfaceGen
   TD_FILE
-    FlowBase.td
+    "FlowBase.td"
   OUTS
     -gen-op-interface-decls FlowOpInterface.h.inc
     -gen-op-interface-defs FlowOpInterface.cpp.inc
@@ -67,7 +67,7 @@ iree_tablegen_library(
   NAME
     FlowOpsGen
   TD_FILE
-    FlowOps.td
+    "FlowOps.td"
   OUTS
     -gen-op-decls FlowOps.h.inc
     -gen-op-defs FlowOps.cpp.inc

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -32,13 +32,13 @@ iree_cc_library(
     "HALOps.cpp"
     "HALTypes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    iree::compiler::Dialect::IREE::IR
   PUBLIC
 )
 
@@ -50,17 +50,17 @@ iree_cc_library(
   SRCS
     "HALDialect.cpp"
   DEPS
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::HAL::hal_imports
-    iree::compiler::Dialect::HAL::Conversion::HALToVM
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
+    ::IR
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    iree::compiler::Dialect::HAL::Conversion::HALToVM
+    iree::compiler::Dialect::HAL::hal_imports
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
   ALWAYSLINK
   PUBLIC
 )
@@ -69,7 +69,7 @@ iree_tablegen_library(
   NAME
     HALEnumsGen
   TD_FILE
-    HALBase.td
+    "HALBase.td"
   OUTS
     -gen-enum-decls HALEnums.h.inc
     -gen-enum-defs HALEnums.cpp.inc
@@ -79,7 +79,7 @@ iree_tablegen_library(
   NAME
     HALOpInterfaceGen
   TD_FILE
-    HALBase.td
+    "HALBase.td"
   OUTS
     -gen-op-interface-decls HALOpInterface.h.inc
     -gen-op-interface-defs HALOpInterface.cpp.inc
@@ -89,7 +89,7 @@ iree_tablegen_library(
   NAME
     HALOpsGen
   TD_FILE
-    HALOps.td
+    "HALOps.td"
   OUTS
     -gen-op-decls HALOps.h.inc
     -gen-op-defs HALOps.cpp.inc

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -38,12 +38,11 @@ iree_cc_library(
   PUBLIC
 )
 
-
 iree_tablegen_library(
   NAME
     IREEOpsGen
   TD_FILE
-    IREEOps.td
+    "IREEOps.td"
   OUTS
     -gen-op-decls IREEOps.h.inc
     -gen-op-defs IREEOps.cpp.inc

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -30,22 +30,21 @@ iree_cc_library(
     "ShapeOps.cpp.inc"
     "ShapeTypes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRStandardOps
     MLIRSupport
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )
-
 
 iree_tablegen_library(
   NAME
     ShapeOpsGen
   TD_FILE
-    ShapeOps.td
+    "ShapeOps.td"
   OUTS
     -gen-op-decls ShapeOps.h.inc
     -gen-op-defs ShapeOps.cpp.inc

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -36,12 +36,12 @@ iree_cc_library(
     "VMOps.cpp.inc"
     "VMTypes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )
@@ -50,7 +50,7 @@ iree_tablegen_library(
   NAME
     VMEnumsGen
   TD_FILE
-    VMBase.td
+    "VMBase.td"
   OUTS
     -gen-enum-decls VMEnums.h.inc
     -gen-enum-defs VMEnums.cpp.inc
@@ -60,7 +60,7 @@ iree_tablegen_library(
   NAME
     VMOpsGen
   TD_FILE
-    VMOps.td
+    "VMOps.td"
   OUTS
     -gen-op-decls VMOps.h.inc
     -gen-op-defs VMOps.cpp.inc
@@ -70,7 +70,7 @@ iree_tablegen_library(
   NAME
     VMOpEncoderGen
   TD_FILE
-    VMOps.td
+    "VMOps.td"
   OUTS
     -gen-iree-vm-op-encoder-defs VMOpEncoder.cpp.inc
   TBLGEN
@@ -81,7 +81,7 @@ iree_tablegen_library(
   NAME
     VMOpInterfaceGen
   TD_FILE
-    VMBase.td
+    "VMBase.td"
   OUTS
     -gen-op-interface-decls VMOpInterface.h.inc
     -gen-op-interface-defs VMOpInterface.cpp.inc

--- a/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
@@ -24,20 +24,23 @@ iree_cc_library(
     "VMLAOps.h.inc"
     "VMLATraits.h"
     "VMLATypes.h"
+  TEXTUAL_HDRS
+    "VMLAOps.cpp.inc"
   SRCS
     "VMLAEnums.cpp.inc"
     "VMLAOpInterface.cpp.inc"
     "VMLAOps.cpp"
-    "VMLAOps.cpp.inc"
     "VMLATypes.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::Shape::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    MLIRTranslation
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::Shape::IR
+    iree::compiler::Dialect::VM::IR
   PUBLIC
 )
 
@@ -49,16 +52,16 @@ iree_cc_library(
   SRCS
     "VMLADialect.cpp"
   DEPS
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
-    iree::compiler::Dialect::VMLA::Conversion::VMLAToVM
-    iree::compiler::Dialect::VMLA::vmla_imports
+    ::IR
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRStandardOps
     MLIRSupport
     MLIRTransformUtils
+    iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VMLA::Conversion::VMLAToVM
+    iree::compiler::Dialect::VMLA::vmla_imports
   ALWAYSLINK
   PUBLIC
 )
@@ -67,7 +70,7 @@ iree_tablegen_library(
   NAME
     VMLAEnumsGen
   TD_FILE
-    VMLABase.td
+    "VMLABase.td"
   OUTS
     -gen-enum-decls VMLAEnums.h.inc
     -gen-enum-defs VMLAEnums.cpp.inc
@@ -77,7 +80,7 @@ iree_tablegen_library(
   NAME
     VMLAOpsGen
   TD_FILE
-    VMLAOps.td
+    "VMLAOps.td"
   OUTS
     -gen-op-decls VMLAOps.h.inc
     -gen-op-defs VMLAOps.cpp.inc
@@ -87,7 +90,7 @@ iree_tablegen_library(
   NAME
     VMLAOpInterfaceGen
   TD_FILE
-    VMLABase.td
+    "VMLABase.td"
   OUTS
     -gen-op-interface-decls VMLAOpInterface.h.inc
     -gen-op-interface-defs VMLAOpInterface.cpp.inc

--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -26,12 +26,11 @@ iree_cc_library(
     "CommonOps.cpp"
     "CommonOps.cpp.inc"
   DEPS
-    iree::compiler::Translation::Interpreter::IR::CommonOpsGen
-    iree::compiler::Dialect::IREE::IR
     LLVMSupport
     MLIRIR
     MLIRStandardOps
     MLIRSupport
+    iree::compiler::Dialect::IREE::IR
   ALWAYSLINK
   PUBLIC
 )
@@ -40,7 +39,7 @@ iree_tablegen_library(
   NAME
     CommonOpsGen
   TD_FILE
-    CommonOps.td
+    "CommonOps.td"
   OUTS
     -gen-op-decls CommonOps.h.inc
     -gen-op-defs CommonOps.cpp.inc
@@ -66,18 +65,16 @@ iree_cc_library(
     "LLOps.cpp.inc"
     "OpWriters.cpp"
   DEPS
-    iree::compiler::Translation::Interpreter::IR::Common
-    iree::compiler::Translation::Interpreter::IR::HLOpsGen
-    iree::compiler::Translation::Interpreter::IR::LLOpsGen
+    ::Common
+    LLVMSupport
+    MLIRIR
+    MLIRStandardOps
+    MLIRSupport
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Translation::Interpreter::Serialization
     iree::compiler::Translation::Interpreter::Utils
     iree::compiler::Utils
     iree::schemas::bytecode::interpreter_bytecode_v0
-    LLVMSupport
-    MLIRIR
-    MLIRStandardOps
-    MLIRSupport
   ALWAYSLINK
   PUBLIC
 )
@@ -86,7 +83,7 @@ iree_tablegen_library(
   NAME
     HLOpsGen
   TD_FILE
-    HLOps.td
+    "HLOps.td"
   OUTS
     -gen-op-decls HLOps.h.inc
     -gen-op-defs HLOps.cpp.inc
@@ -96,7 +93,7 @@ iree_tablegen_library(
   NAME
     LLOpsGen
   TD_FILE
-    LLOps.td
+    "LLOps.td"
   OUTS
     -gen-op-decls LLOps.h.inc
     -gen-op-defs LLOps.cpp.inc

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -24,17 +24,17 @@ iree_cc_library(
     "custom_dialect.cc"
     "custom_ops.cc.inc"
   DEPS
-    iree::samples::custom_modules::dialect::custom_imports
-    iree::compiler::Dialect::HAL::Conversion
-    iree::compiler::Dialect::HAL::IR
-    iree::compiler::Dialect::IREE::IR
-    iree::compiler::Dialect::VM::Conversion
+    ::custom_imports
     LLVMSupport
     MLIRIR
     MLIRParser
     MLIRPass
     MLIRSupport
     MLIRTransforms
+    iree::compiler::Dialect::HAL::Conversion
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::VM::Conversion
   ALWAYSLINK
   PUBLIC
 )
@@ -43,7 +43,7 @@ iree_tablegen_library(
   NAME
     custom_ops_gen
   TD_FILE
-    custom_ops.td
+    "custom_ops.td"
   OUTS
     -gen-op-decls custom_ops.h.inc
     -gen-op-defs custom_ops.cc.inc
@@ -61,6 +61,7 @@ iree_cc_embed_data(
   CPP_NAMESPACE
     "mlir::iree_compiler::IREE::Custom"
   FLATTEN
+  PUBLIC
 )
 
 iree_cc_binary(
@@ -69,9 +70,9 @@ iree_cc_binary(
   OUT
     custom-opt
   DEPS
-    iree::samples::custom_modules::dialect
-    iree::tools::iree_opt_library
+    ::dialect
     MLIRMlirOptMain
+    iree::tools::iree_opt_library
 )
 
 iree_cc_binary(
@@ -80,6 +81,6 @@ iree_cc_binary(
   OUT
     custom-translate
   DEPS
-    iree::samples::custom_modules::dialect
+    ::dialect
     iree::tools::iree_translate_library
 )


### PR DESCRIPTION
Updates to the CMake configuration, assisted by `bazel_to_cmake.py`.