### PR TITLE
Add CMake configuration for tensorlist module

### DIFF
--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -29,6 +29,7 @@ export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
 EXCLUDED_TESTS=(
     iree_compiler_Translation_SPIRV_LinalgToSPIRV_test_pw_add.mlir.test
     iree_hal_vulkan_dynamic_symbols_test
+    iree_modules_tensorlist_tensorlist_test
     iree_tools_vm_util_test
     iree_tools_test_multiple_args.mlir.test
     iree_tools_test_scalars.mlir.test

--- a/iree/modules/CMakeLists.txt
+++ b/iree/modules/CMakeLists.txt
@@ -15,3 +15,4 @@
 add_subdirectory(check)
 add_subdirectory(hal)
 add_subdirectory(strings)
+add_subdirectory(tensorlist)

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_bytecode_module(
+  NAME
+    tensorlist_test_module
+  SRC
+    "tensorlist_test.mlir"
+  CC_NAMESPACE
+    "iree::modules::tensorlist"
+  TRANSLATE_TOOL
+    iree_compiler_Dialect_Modules_TensorList_tensorlist-translate
+  TRANSLATION
+    "-iree-mlir-to-vm-bytecode-module"
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    tensorlist_test
+  SRCS
+    "tensorlist_test.cc"
+  DEPS
+    ::native_module
+    ::tensorlist_test_module_cc
+    absl::core_headers
+    absl::strings
+    iree::base::api
+    iree::base::logging
+    iree::hal::api
+    iree::hal::interpreter::interpreter_driver_module
+    iree::modules::hal
+    iree::testing::gtest_main
+    iree::vm
+    iree::vm::bytecode_module
+    iree::vm::ref
+    iree::vm::variant_list
+)
+
+iree_cc_library(
+  NAME
+    native_module
+  HDRS
+    "native_module.h"
+  SRCS
+    "native_module.cc"
+  DEPS
+    iree::base::api
+    iree::base::api_util
+    iree::base::ref_ptr
+    iree::base::status
+    iree::hal::api
+    iree::modules::hal
+    iree::vm
+    iree::vm::module_abi_cc
+  PUBLIC
+)


### PR DESCRIPTION
Created with `bazel_to_cmake()`. Now required to build the python bindings.