### PR TITLE
CMake: Add tensorlist deps to python bindings

### DIFF
--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_pybind_cc_library(
   DEPS
     # Transforms. Adopted from the Bazel variable COMPILER_DEPS.
     iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
     iree::compiler::Dialect::HAL::Transforms
     iree::compiler::Dialect::HAL::Target::ExecutableTarget
     iree::compiler::Dialect::VM::Transforms

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_pybind_cc_library(
     iree::base::signature_mangle
     iree::hal::api
     iree::modules::hal
+    iree::modules::tensorlist::native_module
     iree::vm
     iree::vm::bytecode_module
     iree::vm::invocation


### PR DESCRIPTION
Followup to #795. Depends on #802.