### PR TITLE
Bazel to CMake: Harcode td filegroup support

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -299,6 +299,13 @@ class BuildFileFunctions(object):
     # Not implemented yet. Might be a no-op, or may want to evaluate the srcs
     # attribute and pass them along to any targets that depend on the filegroup.
     # Cross-package dependencies and complicated globs could be hard to handle.
+
+    # We have a bunch of filegroups that just contain TD files. CMake doesn't model
+    # this at all, so we'll just hardcode this special case.
+    # TODO(gcmn): Handle this robustly
+    if (name == "td_files"):
+      return
+
     self._convert_unimplemented_function("filegroup", name)
 
   def sh_binary(self, name, **kwargs):

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -96,6 +96,11 @@ class BuildFileFunctions(object):
 
   def __init__(self, converter):
     self.converter = converter
+    # TODO(gcmn): Do this in a less hard-coded way
+    self.PLATFORM_VULKAN_DEPS = []
+    self.PLATFORM_VULKAN_TEST_DEPS = ["//iree/testing:gtest_main"]
+    self.FLATBUFFER_SUPPORTS_REFLECTIONS = False
+    self.PLATFORM_VULKAN_LOADER_COPTS = []
 
   # ------------------------------------------------------------------------- #
   # Conversion utilities, written to reduce boilerplate and allow for reuse   #
@@ -296,6 +301,9 @@ class BuildFileFunctions(object):
     # Cross-package dependencies and complicated globs could be hard to handle.
     self._convert_unimplemented_function("filegroup", name)
 
+  def sh_binary(self, name, **kwargs):
+    self._convert_unimplemented_function("sh_binary", name)
+
   def exports_files(self, *args, **kwargs):
     # No mapping to CMake, ignore.
     pass
@@ -328,6 +336,14 @@ class BuildFileFunctions(object):
                                   "pattern": pattern
                               }
     return glob_vars
+
+  # TODO(gcmn) implement these types of functions in a less hard-coded way
+  def platform_trampoline_deps(self, basename, path = "base"):
+    return ["//iree/%s/internal:%s_internal" % (path, basename)]
+
+  def select(self, d):
+    self._convert_unimplemented_function("select", str(d))
+    return d["//conditions:default"]
 
   def config_setting(self, **kwargs):
     # No mapping to CMake, ignore.

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/Modules/Strings/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/IR/CMakeLists.txt
@@ -15,7 +15,6 @@
 add_subdirectory(test)
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
-# Unimplemented filegroup: td_files
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_subdirectory(Conversion)
 add_subdirectory(IR)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_embed_data(
   NAME
     tensorlist_imports

--- a/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     IR

--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_subdirectory(test)
 
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     Common

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(cts)
 add_subdirectory(host)
 add_subdirectory(interpreter)
 add_subdirectory(llvmjit)

--- a/iree/hal/cts/CMakeLists.txt
+++ b/iree/hal/cts/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_cc_library(
+  NAME
+    cts_test_base
+  HDRS
+    "cts_test_base.h"
+  DEPS
+    iree::base::status
+    iree::base::status_matchers
+    iree::hal::driver_registry
+    iree::hal::interpreter::interpreter_driver_module
+    iree::hal::vulkan::vulkan_driver_module
+    iree::testing::gtest_main
+  TESTONLY
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    allocator_test
+  SRCS
+    "allocator_test.cc"
+  DEPS
+    ::cts_test_base
+    iree::base::status
+    iree::base::status_matchers
+    iree::hal::driver_registry
+    iree::testing::gtest
+)
+
+iree_cc_test(
+  NAME
+    command_buffer_test
+  SRCS
+    "command_buffer_test.cc"
+  DEPS
+    ::cts_test_base
+    iree::base::status
+    iree::base::status_matchers
+    iree::hal::driver_registry
+    iree::testing::gtest
+)

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -52,10 +52,10 @@ iree_cc_test(
 iree_cc_binary(
   NAME
     iree-check-module
-  SRCS
-    "check_module_main.cc"
   OUT
     iree-check-module
+  SRCS
+    "check_module_main.cc"
   DEPS
     ::native_module
     absl::flags
@@ -66,7 +66,6 @@ iree_cc_binary(
     iree::base::init
     iree::base::source_location
     iree::base::status
-    # TODO(marbre): Add PLATFORM_VULKAN_DEPS
     iree::hal::interpreter::interpreter_driver_module
     iree::hal::vmla::vmla_driver_module
     iree::hal::vulkan::vulkan_driver_module
@@ -74,8 +73,6 @@ iree_cc_binary(
     iree::tools::vm_util
     iree::vm::bytecode_module
 )
-add_executable(iree-check-module ALIAS iree_modules_check_iree-check-module)
-
 
 iree_cc_library(
   NAME

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(test)
+
+file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(
   NAME
     dialect

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -19,6 +19,8 @@ iree_bytecode_module(
     "simple_embedding_test.mlir"
   CC_NAMESPACE
     "iree::samples"
+  TRANSLATE_TOOL
+    iree_tools_iree-translate
   TRANSLATION
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
@@ -30,20 +32,17 @@ iree_cc_test(
   SRCS
     "simple_embedding_test.cc"
   DEPS
-    iree::samples::simple_embedding::simple_embedding_test_bytecode_module_cc
+    ::simple_embedding_test_bytecode_module_cc
     absl::core_headers
     absl::strings
     iree::base::api
     iree::base::api_util
     iree::base::logging
     iree::hal::api
-    iree::modules::hal
-    iree::vm::bytecode_module
-    iree::vm
-    # These are the drivers we support running with and can produce
-    # executables for from the source MLIR.
     iree::hal::interpreter::interpreter_driver_module
     iree::hal::vulkan::vulkan_driver_module
-    # TODO(marbre): Set PLATFORM_VULKAN_TEST_DEPS somewhere instead of adding dependencies directly
+    iree::modules::hal
     iree::testing::gtest_main
+    iree::vm
+    iree::vm::bytecode_module
 )

--- a/iree/schemas/CMakeLists.txt
+++ b/iree/schemas/CMakeLists.txt
@@ -19,6 +19,11 @@ flatbuffer_cc_library(
     buffer_data_def_cc_fbs
   SRCS
     "buffer_data_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
   PUBLIC
 )
 
@@ -27,6 +32,11 @@ flatbuffer_cc_library(
     bytecode_module_def_cc_fbs
   SRCS
     "bytecode_module_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
   PUBLIC
 )
 
@@ -35,6 +45,11 @@ flatbuffer_cc_library(
     interpreter_module_def_cc_fbs
   SRCS
     "interpreter_module_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
   PUBLIC
 )
 
@@ -43,6 +58,11 @@ flatbuffer_cc_library(
     spirv_executable_def_cc_fbs
   SRCS
     "spirv_executable_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
   PUBLIC
 )
 
@@ -51,6 +71,11 @@ flatbuffer_cc_library(
     vmla_executable_def_cc_fbs
   SRCS
     "vmla_executable_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
   PUBLIC
 )
 
@@ -59,5 +84,22 @@ flatbuffer_cc_library(
     llvmir_executable_def_cc_fbs
   SRCS
     "llvmir_executable_def.fbs"
+  FLATC_ARGS
+    "--keep-prefix"
+    "--scoped-enums"
+    "--reflect-names"
+    "--gen-object-api"
+  PUBLIC
+)
+
+iree_cc_embed_data(
+  NAME
+    reflection_data
+  CC_FILE_OUTPUT
+    "reflection_data.cc"
+  H_FILE_OUTPUT
+    "reflection_data.h"
+  CPP_NAMESPACE
+    "iree::schemas"
   PUBLIC
 )

--- a/iree/testing/CMakeLists.txt
+++ b/iree/testing/CMakeLists.txt
@@ -12,44 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Testing utilities for IREE.
-
 add_subdirectory(internal)
 
-if(${IREE_BUILD_TESTS})
+iree_cc_library(
+  NAME
+    benchmark_main
+  SRCS
+    "benchmark_main.cc"
+  DEPS
+    benchmark
+    iree::base::init
+  ALWAYSLINK
+  TESTONLY
+  PUBLIC
+)
 
-  iree_cc_library(
-    NAME
-      benchmark_main
-    SRCS
-      "benchmark_main.cc"
-    DEPS
-      iree::base::init
-      benchmark
-    ALWAYSLINK
-    PUBLIC
-  )
+iree_cc_library(
+  NAME
+    gtest
+  HDRS
+    "gtest.h"
+  DEPS
+    iree::testing::internal::gtest_internal
+  TESTONLY
+  PUBLIC
+)
 
-  iree_cc_library(
-    NAME
-      gtest
-    HDRS
-      "gtest.h"
-    DEPS
-      iree::testing::internal::gtest_internal
-      iree::testing::internal::gtest_main_internal
-    PUBLIC
-  )
-
-  iree_cc_library(
-    NAME
-      gtest_main
-    HDRS
-      "gtest.h"
-    DEPS
-      iree::testing::internal::gtest_internal
-      iree::testing::internal::gtest_main_internal
-    PUBLIC
-  )
-
-endif()
+iree_cc_library(
+  NAME
+    gtest_main
+  HDRS
+    "gtest.h"
+  DEPS
+    iree::testing::internal::gtest_main_internal
+  TESTONLY
+  PUBLIC
+)


### PR DESCRIPTION
This is the only type of filegroup we really use. We already don't evaluate td_srcs in the CMake gentbl rules. It's a hack, but makes bazel_to_cmake work on a bunch more files, so I think worth it.

Run bazel_to_cmake in strict mode across the repo. The only things still giving errors are a few missing targets (Vulkan and Dawn) and sh_binary, which should be easy to solve.

Depends on https://github.com/google/iree/pull/832