### PR TITLE
Add MLIRLoopOpsTransforms dep to bindings::python::pyiree::compilter::compiler_library

### DIFF
--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -58,6 +58,7 @@ iree_pybind_cc_library(
     bindings::python::pyiree::common
     LLVMSupport
     MLIRIR
+    MLIRLoopOpsTransforms
     MLIRParser
     MLIRPass
   TYPE


### PR DESCRIPTION
Take over from dacda264b