### PR TITLE
Add forked and revised mlir-opt.cc as opt_main.cc

### DIFF
--- a/iree/compiler/Dialect/Modules/Strings/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/BUILD
@@ -33,7 +33,6 @@ cc_binary(
     deps = [
         "//iree/compiler/Dialect/Modules/Strings/IR:Dialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
     ],
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
@@ -36,7 +36,6 @@ iree_cc_binary(
   OUT
     strings-opt
   DEPS
-    MLIRMlirOptMain
     iree::compiler::Dialect::Modules::Strings::IR::Dialect
     iree::tools::iree_opt_library
 )

--- a/iree/compiler/Dialect/Modules/TensorList/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/BUILD
@@ -38,7 +38,6 @@ cc_binary(
     deps = [
         "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
     ],
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -37,7 +37,6 @@ iree_cc_binary(
   OUT
     tensorlist-opt
   DEPS
-    MLIRMlirOptMain
     iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
     iree::tools::iree_opt_library
 )

--- a/iree/modules/check/dialect/BUILD
+++ b/iree/modules/check/dialect/BUILD
@@ -81,7 +81,6 @@ cc_binary(
     deps = [
         ":dialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
     ],
 )
 

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -74,7 +74,6 @@ iree_cc_binary(
   DEPS
     ::dialect
     iree::tools::iree_opt_library
-    MLIRMlirOptMain
 )
 add_executable(check-opt ALIAS iree_modules_check_dialect_check-opt)
 

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -84,7 +84,6 @@ cc_binary(
     deps = [
         ":dialect",
         "//iree/tools:iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
     ],
 )
 

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -74,7 +74,6 @@ iree_cc_binary(
     custom-opt
   DEPS
     ::dialect
-    MLIRMlirOptMain
     iree::tools::iree_opt_library
 )
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -67,6 +67,7 @@ cc_binary(
 
 cc_library(
     name = "iree_opt_library",
+    srcs = ["opt_main.cc"],
     deps = [
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/IREE/Transforms",
@@ -108,7 +109,6 @@ cc_binary(
     name = "iree-opt",
     deps = [
         ":iree_opt_library",
-        "@llvm-project//mlir:MlirOptMain",
     ],
 )
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -98,6 +98,8 @@ cc_library(
         "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirOptLib",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_dialect_registration",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_control_flow",

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -95,6 +95,7 @@ cc_library(
         "//iree/compiler/Translation/SPIRV/XLAToSPIRV",
         "//iree/compiler/Translation/SPIRV/LinalgToSPIRV",
         "@llvm-project//llvm:support",
+        "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirOptLib",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -159,6 +159,8 @@ if(${IREE_BUILD_COMPILER})
   iree_cc_library(
     NAME
       iree_opt_library
+    SRCS
+      "opt_main.cc"
     DEPS
       iree::compiler::Dialect::IREE::IR
       iree::compiler::Dialect::IREE::Transforms
@@ -217,7 +219,6 @@ if(${IREE_BUILD_COMPILER})
       iree-opt
     DEPS
       iree::tools::iree_opt_library
-      MLIRMlirOptMain
   )
 
   iree_cc_binary(

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -22,8 +22,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
-using namespace mlir;
-
 namespace mlir {
 // Defined in the test directory, no public header.
 void registerConvertToTargetEnvPass();
@@ -78,70 +76,72 @@ static llvm::cl::opt<bool>
                  llvm::cl::desc("Run the verifier after each transformation pass"),
                  llvm::cl::init(true));
 
+namespace mlir {
 void registerTestPasses() {
-  registerConvertToTargetEnvPass();
-  registerInliner();
-  registerMemRefBoundCheck();
-  registerPassManagerTestPass();
-  registerPatternsTestPass();
-  registerPrintOpAvailabilityPass();
-  registerSimpleParametricTilingPass();
-  registerSymbolTestPasses();
-  registerTestAffineDataCopyPass();
-  registerTestAllReduceLoweringPass();
-  registerTestCallGraphPass();
-  registerTestConstantFold();
-  registerTestFunc();
-  registerTestGpuMemoryPromotionPass();
-  registerTestLinalgTransforms();
-  registerTestLivenessPass();
-  registerTestLoopFusion();
-  registerTestLoopMappingPass();
-  registerTestMatchers();
-  registerTestMemRefDependenceCheck();
-  registerTestMemRefStrideCalculation();
-  registerTestOpaqueLoc();
-  registerTestParallelismDetection();
-  registerTestVectorConversions();
-  registerTestVectorToLoopsPass();
-  registerVectorizerTestPass();
+  mlir::registerConvertToTargetEnvPass();
+  mlir::registerInliner();
+  mlir::registerMemRefBoundCheck();
+  mlir::registerPassManagerTestPass();
+  mlir::registerPatternsTestPass();
+  mlir::registerPrintOpAvailabilityPass();
+  mlir::registerSimpleParametricTilingPass();
+  mlir::registerSymbolTestPasses();
+  mlir::registerTestAffineDataCopyPass();
+  mlir::registerTestAllReduceLoweringPass();
+  mlir::registerTestCallGraphPass();
+  mlir::registerTestConstantFold();
+  mlir::registerTestFunc();
+  mlir::registerTestGpuMemoryPromotionPass();
+  mlir::registerTestLinalgTransforms();
+  mlir::registerTestLivenessPass();
+  mlir::registerTestLoopFusion();
+  mlir::registerTestLoopMappingPass();
+  mlir::registerTestMatchers();
+  mlir::registerTestMemRefDependenceCheck();
+  mlir::registerTestMemRefStrideCalculation();
+  mlir::registerTestOpaqueLoc();
+  mlir::registerTestParallelismDetection();
+  mlir::registerTestVectorConversions();
+  mlir::registerTestVectorToLoopsPass();
+  mlir::registerVectorizerTestPass();
 
   // The following passes are using global initializers, just link them in.
   if (std::getenv("bar") != (char *)-1)
     return;
 
   // TODO: move these to the test folder.
-  createTestMemRefBoundCheckPass();
-  createTestMemRefDependenceCheckPass();
+  mlir::createTestMemRefBoundCheckPass();
+  mlir::createTestMemRefDependenceCheckPass();
 }
+} // namespace mlir
 
 int main(int argc, char **argv) {
-  registerAllDialects();
-  registerAllPasses();
-  registerTestPasses();
+  mlir::registerAllDialects();
+  mlir::registerAllPasses();
+  mlir::registerTestPasses();
   llvm::InitLLVM y(argc, argv);
 
   // Register any pass manager command line options.
-  registerPassManagerCLOptions();
-  PassPipelineCLParser passPipeline("", "Compiler passes to run");
+  mlir::registerPassManagerCLOptions();
+  mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
   // Parse pass names in main to ensure static initialization completed.
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR modular optimizer driver\n");
 
   // Set up the input file.
   std::string errorMessage;
-  auto file = openInputFile(inputFilename, &errorMessage);
+  auto file = mlir::openInputFile(inputFilename, &errorMessage);
   if (!file) {
     llvm::errs() << errorMessage << "\n";
     return 1;
   }
 
-  auto output = openOutputFile(outputFilename, &errorMessage);
+  auto output = mlir::openOutputFile(outputFilename, &errorMessage);
   if (!output) {
     llvm::errs() << errorMessage << "\n";
     exit(1);
   }
 
-  return failed(MlirOptMain(output->os(), std::move(file), passPipeline,
+  return failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
                             splitInputFile, verifyDiagnostics, verifyPasses));
 }

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -1,14 +1,20 @@
-//===- mlir-opt.cpp - MLIR Optimizer Driver -------------------------------===//
+// Copyright 2020 Google LLC
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//===----------------------------------------------------------------------===//
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
-// Main entry function for mlir-opt for when built as standalone binary.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Main entry function for iree-opt and derived binaries.
 //
-//===----------------------------------------------------------------------===//
+// Based on mlir-opt but without registering passes and dialects we don't care about.
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
@@ -127,7 +133,7 @@ int main(int argc, char **argv) {
 
   // Parse pass names in main to ensure static initialization completed.
   llvm::cl::ParseCommandLineOptions(argc, argv,
-                                    "MLIR modular optimizer driver\n");
+                                    "IREE modular optimizer driver\n");
 
   // Set up the input file.
   std::string errorMessage;

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
 #include "mlir/Analysis/Passes.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -17,10 +21,6 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/MlirOptMain.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/ToolOutputFile.h"
 
 namespace mlir {
 // Defined in the test directory, no public header.
@@ -50,31 +50,32 @@ void registerTestParallelismDetection();
 void registerTestVectorConversions();
 void registerTestVectorToLoopsPass();
 void registerVectorizerTestPass();
-} // namespace mlir
+}  // namespace mlir
 
-static llvm::cl::opt<std::string>
-    inputFilename(llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::init("-"));
+static llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
+                                                llvm::cl::desc("<input file>"),
+                                                llvm::cl::init("-"));
 
-static llvm::cl::opt<std::string> outputFilename("o", llvm::cl::desc("Output filename"),
-                                           llvm::cl::value_desc("filename"),
-                                           llvm::cl::init("-"));
+static llvm::cl::opt<std::string> outputFilename(
+    "o", llvm::cl::desc("Output filename"), llvm::cl::value_desc("filename"),
+    llvm::cl::init("-"));
 
-static llvm::cl::opt<bool>
-    splitInputFile("split-input-file",
-                   llvm::cl::desc("Split the input file into pieces and process each "
-                            "chunk independently"),
-                   llvm::cl::init(false));
+static llvm::cl::opt<bool> splitInputFile(
+    "split-input-file",
+    llvm::cl::desc("Split the input file into pieces and process each "
+                   "chunk independently"),
+    llvm::cl::init(false));
 
-static llvm::cl::opt<bool>
-    verifyDiagnostics("verify-diagnostics",
-                      llvm::cl::desc("Check that emitted diagnostics match "
-                               "expected-* lines on the corresponding line"),
-                      llvm::cl::init(false));
+static llvm::cl::opt<bool> verifyDiagnostics(
+    "verify-diagnostics",
+    llvm::cl::desc("Check that emitted diagnostics match "
+                   "expected-* lines on the corresponding line"),
+    llvm::cl::init(false));
 
-static llvm::cl::opt<bool>
-    verifyPasses("verify-each",
-                 llvm::cl::desc("Run the verifier after each transformation pass"),
-                 llvm::cl::init(true));
+static llvm::cl::opt<bool> verifyPasses(
+    "verify-each",
+    llvm::cl::desc("Run the verifier after each transformation pass"),
+    llvm::cl::init(true));
 
 namespace mlir {
 void registerTestPasses() {
@@ -106,14 +107,13 @@ void registerTestPasses() {
   mlir::registerVectorizerTestPass();
 
   // The following passes are using global initializers, just link them in.
-  if (std::getenv("bar") != (char *)-1)
-    return;
+  if (std::getenv("bar") != (char *)-1) return;
 
   // TODO: move these to the test folder.
   mlir::createTestMemRefBoundCheckPass();
   mlir::createTestMemRefDependenceCheckPass();
 }
-} // namespace mlir
+}  // namespace mlir
 
 int main(int argc, char **argv) {
   mlir::registerAllDialects();
@@ -126,7 +126,8 @@ int main(int argc, char **argv) {
   mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
   // Parse pass names in main to ensure static initialization completed.
-  llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR modular optimizer driver\n");
+  llvm::cl::ParseCommandLineOptions(argc, argv,
+                                    "MLIR modular optimizer driver\n");
 
   // Set up the input file.
   std::string errorMessage;
@@ -143,5 +144,6 @@ int main(int argc, char **argv) {
   }
 
   return failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
-                            splitInputFile, verifyDiagnostics, verifyPasses));
+                                  splitInputFile, verifyDiagnostics,
+                                  verifyPasses));
 }

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -1,0 +1,148 @@
+//===- mlir-opt.cpp - MLIR Optimizer Driver -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Main entry function for mlir-opt for when built as standalone binary.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/Passes.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/MlirOptMain.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+using namespace llvm;
+using namespace mlir;
+
+namespace mlir {
+// Defined in the test directory, no public header.
+void registerConvertToTargetEnvPass();
+void registerInliner();
+void registerMemRefBoundCheck();
+void registerPassManagerTestPass();
+void registerPatternsTestPass();
+void registerPrintOpAvailabilityPass();
+void registerSimpleParametricTilingPass();
+void registerSymbolTestPasses();
+void registerTestAffineDataCopyPass();
+void registerTestAllReduceLoweringPass();
+void registerTestCallGraphPass();
+void registerTestConstantFold();
+void registerTestFunc();
+void registerTestGpuMemoryPromotionPass();
+void registerTestLinalgTransforms();
+void registerTestLivenessPass();
+void registerTestLoopFusion();
+void registerTestLoopMappingPass();
+void registerTestMatchers();
+void registerTestMemRefDependenceCheck();
+void registerTestMemRefStrideCalculation();
+void registerTestOpaqueLoc();
+void registerTestParallelismDetection();
+void registerTestVectorConversions();
+void registerTestVectorToLoopsPass();
+void registerVectorizerTestPass();
+} // namespace mlir
+
+static cl::opt<std::string>
+    inputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));
+
+static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+                                           cl::value_desc("filename"),
+                                           cl::init("-"));
+
+static cl::opt<bool>
+    splitInputFile("split-input-file",
+                   cl::desc("Split the input file into pieces and process each "
+                            "chunk independently"),
+                   cl::init(false));
+
+static cl::opt<bool>
+    verifyDiagnostics("verify-diagnostics",
+                      cl::desc("Check that emitted diagnostics match "
+                               "expected-* lines on the corresponding line"),
+                      cl::init(false));
+
+static cl::opt<bool>
+    verifyPasses("verify-each",
+                 cl::desc("Run the verifier after each transformation pass"),
+                 cl::init(true));
+
+void registerTestPasses() {
+  registerConvertToTargetEnvPass();
+  registerInliner();
+  registerMemRefBoundCheck();
+  registerPassManagerTestPass();
+  registerPatternsTestPass();
+  registerPrintOpAvailabilityPass();
+  registerSimpleParametricTilingPass();
+  registerSymbolTestPasses();
+  registerTestAffineDataCopyPass();
+  registerTestAllReduceLoweringPass();
+  registerTestCallGraphPass();
+  registerTestConstantFold();
+  registerTestFunc();
+  registerTestGpuMemoryPromotionPass();
+  registerTestLinalgTransforms();
+  registerTestLivenessPass();
+  registerTestLoopFusion();
+  registerTestLoopMappingPass();
+  registerTestMatchers();
+  registerTestMemRefDependenceCheck();
+  registerTestMemRefStrideCalculation();
+  registerTestOpaqueLoc();
+  registerTestParallelismDetection();
+  registerTestVectorConversions();
+  registerTestVectorToLoopsPass();
+  registerVectorizerTestPass();
+
+  // The following passes are using global initializers, just link them in.
+  if (std::getenv("bar") != (char *)-1)
+    return;
+
+  // TODO: move these to the test folder.
+  createTestMemRefBoundCheckPass();
+  createTestMemRefDependenceCheckPass();
+}
+
+int main(int argc, char **argv) {
+  registerAllDialects();
+  registerAllPasses();
+  registerTestPasses();
+  InitLLVM y(argc, argv);
+
+  // Register any pass manager command line options.
+  registerPassManagerCLOptions();
+  PassPipelineCLParser passPipeline("", "Compiler passes to run");
+
+  // Parse pass names in main to ensure static initialization completed.
+  cl::ParseCommandLineOptions(argc, argv, "MLIR modular optimizer driver\n");
+
+  // Set up the input file.
+  std::string errorMessage;
+  auto file = openInputFile(inputFilename, &errorMessage);
+  if (!file) {
+    llvm::errs() << errorMessage << "\n";
+    return 1;
+  }
+
+  auto output = openOutputFile(outputFilename, &errorMessage);
+  if (!output) {
+    llvm::errs() << errorMessage << "\n";
+    exit(1);
+  }
+
+  return failed(MlirOptMain(output->os(), std::move(file), passPipeline,
+                            splitInputFile, verifyDiagnostics, verifyPasses));
+}

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -22,7 +22,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
-using namespace llvm;
 using namespace mlir;
 
 namespace mlir {
@@ -55,29 +54,29 @@ void registerTestVectorToLoopsPass();
 void registerVectorizerTestPass();
 } // namespace mlir
 
-static cl::opt<std::string>
-    inputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));
+static llvm::cl::opt<std::string>
+    inputFilename(llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::init("-"));
 
-static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
-                                           cl::value_desc("filename"),
-                                           cl::init("-"));
+static llvm::cl::opt<std::string> outputFilename("o", llvm::cl::desc("Output filename"),
+                                           llvm::cl::value_desc("filename"),
+                                           llvm::cl::init("-"));
 
-static cl::opt<bool>
+static llvm::cl::opt<bool>
     splitInputFile("split-input-file",
-                   cl::desc("Split the input file into pieces and process each "
+                   llvm::cl::desc("Split the input file into pieces and process each "
                             "chunk independently"),
-                   cl::init(false));
+                   llvm::cl::init(false));
 
-static cl::opt<bool>
+static llvm::cl::opt<bool>
     verifyDiagnostics("verify-diagnostics",
-                      cl::desc("Check that emitted diagnostics match "
+                      llvm::cl::desc("Check that emitted diagnostics match "
                                "expected-* lines on the corresponding line"),
-                      cl::init(false));
+                      llvm::cl::init(false));
 
-static cl::opt<bool>
+static llvm::cl::opt<bool>
     verifyPasses("verify-each",
-                 cl::desc("Run the verifier after each transformation pass"),
-                 cl::init(true));
+                 llvm::cl::desc("Run the verifier after each transformation pass"),
+                 llvm::cl::init(true));
 
 void registerTestPasses() {
   registerConvertToTargetEnvPass();
@@ -120,14 +119,14 @@ int main(int argc, char **argv) {
   registerAllDialects();
   registerAllPasses();
   registerTestPasses();
-  InitLLVM y(argc, argv);
+  llvm::InitLLVM y(argc, argv);
 
   // Register any pass manager command line options.
   registerPassManagerCLOptions();
   PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
   // Parse pass names in main to ensure static initialization completed.
-  cl::ParseCommandLineOptions(argc, argv, "MLIR modular optimizer driver\n");
+  llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR modular optimizer driver\n");
 
   // Set up the input file.
   std::string errorMessage;

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -14,7 +14,8 @@
 
 // Main entry function for iree-opt and derived binaries.
 //
-// Based on mlir-opt but without registering passes and dialects we don't care about.
+// Based on mlir-opt but without registering passes and dialects we don't care
+// about.
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"


### PR DESCRIPTION
Follow up to the discussion with @antiagainst started [here](https://github.com/google/iree/pull/762#issuecomment-587492092). This serves as the basis to reduce the number of registered and linked passes.