### PR TITLE
Exclude integrations from bazel CI

### DIFF
--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -29,8 +29,8 @@ test_env_args=(
 )
 echo "Running with test env args: ${test_env_args[@]}"
 
-# Build and test everything not explicitly marked as excluded from CI (using the
-# tag "nokokoro").
+# Build and test everything in supported directories not explicitly marked as
+# excluded from CI (using the tag "nokokoro").
 # Note that somewhat contrary to its name `bazel test` will also build
 # any non-test targets specified.
 # We use `bazel query //...` piped to `bazel test` rather than the simpler

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -37,9 +37,8 @@ echo "Running with test env args: ${test_env_args[@]}"
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query '//... except attr("tags", "nokokoro", //...)' | \
-  xargs bazel test ${test_env_args[@]} --define=iree_tensorflow=true \
-    --keep_going --test_output=errors
+bazel query '//iree/... + //test/... + //bindings/... except attr("tags", "nokokoro", //...)' | \
+  xargs bazel test ${test_env_args[@]} --keep_going --test_output=errors
 
 # Disable RBE until compatibility issues with the experimental_repo_remote_exec
 # flag are fixed.


### PR DESCRIPTION
Limit bazel CI to supported directories (not `//integrations/...`). Integrations have far more dependencies (tensorflow) and we can keep them green at a slower cadence. We could consider running a separate CI for them, but for now they're covered by the very slow GitHub action.

This also helps reduce the latency for the build, which spiked when we had to turn off RBE. Presubmit for this PR was 15 minutes.

Like https://github.com/google/iree/pull/845, but doesn't try to also eliminate bazel query, which doesn't seem to have worked properly