### PR TITLE
Restore resultstore upload to bazel build

### DIFF
--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -38,8 +38,8 @@ echo "Running with test env args: ${test_env_args[@]}"
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
 bazel query '//iree/... + //test/... + //bindings/... except attr("tags", "nokokoro", //...)' | \
-  xargs bazel test ${test_env_args[@]} --keep_going --test_output=errors
+  xargs bazel test ${test_env_args[@]} --keep_going --test_output=errors --config=rs
 
 # Disable RBE until compatibility issues with the experimental_repo_remote_exec
 # flag are fixed.
-#   --config=rbe --config=rs \
+#   --config=rbe


### PR DESCRIPTION
This works even if RBE is disabled and gives us a structured log output, which is nice