### PR TITLE
Rollup of runtime-related fixes for MSVC/Windows.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -22,6 +22,15 @@ package(
 )
 
 cc_library(
+    name = "alignment",
+    hdrs = ["alignment.h"],
+    deps = [
+        ":platform_headers",
+        ":target_platform",
+    ],
+)
+
+cc_library(
     name = "api",
     srcs = ["api.cc"],
     hdrs = ["api.h"],

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -16,6 +16,17 @@ add_subdirectory(internal)
 
 iree_cc_library(
   NAME
+    alignment
+  HDRS
+    "alignment.h"
+  DEPS
+    iree::base::platform_headers
+    iree::base::target_platform
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     api
   HDRS
     "api.h"

--- a/iree/base/alignment.h
+++ b/iree/base/alignment.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of the primitives from stdalign.h used for cross-target
+// value alignment specification and queries.
+
+#ifndef IREE_BASE_ALIGNMENT_H_
+#define IREE_BASE_ALIGNMENT_H_
+
+#include "iree/base/platform_headers.h"
+#include "iree/base/target_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// https://en.cppreference.com/w/c/language/_Alignas
+// https://en.cppreference.com/w/c/language/_Alignof
+#if defined(IREE_COMPILER_MSVC)
+#define iree_alignas(x) __declspec(align(x))
+#define iree_alignof(x) __alignof(x)
+#else
+#define iree_alignas(x) __attribute__((__aligned__(x)))
+#define iree_alignof(x) __alignof__(x)
+#endif  // IREE_COMPILER_*
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_BASE_ALIGNMENT_H_

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -96,12 +96,6 @@ extern "C" {
 #define IREE_API_PTR
 #endif  // _WIN32
 
-#if defined(_MSC_VER)
-#define IREE_ALIGNAS(x) __declspec(align(x))
-#else
-#define IREE_ALIGNAS(x) __attribute__((aligned(x)))
-#endif  // _MSC_VER
-
 #if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
      __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define IREE_IS_LITTLE_ENDIAN 1

--- a/iree/hal/buffer_mapping_test.cc
+++ b/iree/hal/buffer_mapping_test.cc
@@ -41,7 +41,7 @@ static void* const kValidPtr = reinterpret_cast<void*>(0xBEEFCAFEF00D1234ull);
 
 class MockBuffer : public Buffer {
  public:
-  using Buffer::MappingMode;
+  using MappingMode = Buffer::MappingMode;
 
   MockBuffer(Allocator* allocator, MemoryTypeBitfield memory_type,
              MemoryAccessBitfield allowed_access, BufferUsageBitfield usage,

--- a/iree/modules/strings/strings_module.cc
+++ b/iree/modules/strings/strings_module.cc
@@ -46,7 +46,7 @@ iree_status_t vmstring_create(iree_string_view_t value,
   vmstring_t* message = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       allocator, sizeof(vmstring_t) + value.size, (void**)&message));
-  message->ref_object.counter = 1;
+  message->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
   message->allocator = allocator;
   message->value.data = ((const char*)message) + sizeof(vmstring_t);
   message->value.size = value.size;

--- a/iree/samples/custom_modules/native_module.cc
+++ b/iree/samples/custom_modules/native_module.cc
@@ -60,7 +60,7 @@ iree_status_t iree_custom_message_create(iree_string_view_t value,
   iree_custom_message_t* message = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       allocator, sizeof(iree_custom_message_t) + value.size, (void**)&message));
-  message->ref_object.counter = 1;
+  message->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
   message->allocator = allocator;
   message->value.data = ((const char*)message) + sizeof(iree_custom_message_t);
   message->value.size = value.size;
@@ -75,7 +75,7 @@ iree_status_t iree_custom_message_wrap(iree_string_view_t value,
   iree_custom_message_t* message = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       allocator, sizeof(iree_custom_message_t), (void**)&message));
-  message->ref_object.counter = 1;
+  message->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
   message->allocator = allocator;
   message->value = value;  // Unowned.
   *out_message = message;

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -14,25 +14,25 @@
 
 add_subdirectory(test)
 
-set(IREE_HAL_DRIVER_MODULES)
-list(APPEND IREE_HAL_DRIVER_MODULES
-    "iree::hal::interpreter::interpreter_driver_module")
-list(APPEND IREE_HAL_DRIVER_MODULES
-    "iree::hal::llvmjit::llvmjit_driver_module")
-list(APPEND IREE_HAL_DRIVER_MODULES
-    "iree::hal::vmla::vmla_driver_module")
-list(APPEND IREE_HAL_DRIVER_MODULES
-    "iree::hal::vulkan::vulkan_driver_module")
+# TODO: iree_select_target_platform macros.
+# TODO: skip targets disabled by options.
+iree_select_compiler_opts(IREE_HAL_DRIVER_MODULES
+  ALL
+    "iree::hal::vmla::vmla_driver_module"
+    "iree::hal::vulkan::vulkan_driver_module"
+  CLANG_OR_GCC
+    "iree::hal::interpreter::interpreter_driver_module"
+    "iree::hal::llvmjit::llvmjit_driver_module"
+)
 
-set(IREE_COMPILER_TARGET_BACKENDS)
-list(APPEND IREE_COMPILER_TARGET_BACKENDS
-    "iree::compiler::Dialect::HAL::Target::LegacyInterpreter")
-list(APPEND IREE_COMPILER_TARGET_BACKENDS
-    "iree::compiler::Dialect::HAL::Target::LLVM")
-list(APPEND IREE_COMPILER_TARGET_BACKENDS
-    "iree::compiler::Dialect::HAL::Target::VMLA")
-list(APPEND IREE_COMPILER_TARGET_BACKENDS
-    "iree::compiler::Dialect::HAL::Target::VulkanSPIRV")
+iree_select_compiler_opts(IREE_COMPILER_TARGET_BACKENDS
+  ALL
+    "iree::compiler::Dialect::HAL::Target::VMLA"
+    "iree::compiler::Dialect::HAL::Target::VulkanSPIRV"
+  CLANG_OR_GCC
+    "iree::compiler::Dialect::HAL::Target::LegacyInterpreter"
+    "iree::compiler::Dialect::HAL::Target::LLVM"
+)
 
 iree_cc_binary(
   NAME

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -254,11 +254,11 @@ Status EvaluateFunction(iree_vm_context_t* context,
             << absl::string_view(function_name.data, function_name.size)
             << std::endl;
   ASSIGN_OR_RETURN(auto input_descs, ParseInputSignature(function));
-  ASSIGN_OR_RETURN(
-      auto* input_list,
-      ParseToVariantList(input_descs, allocator,
-                         absl::MakeConstSpan(&input_values_flag.front(),
-                                             input_values_flag.size())));
+  auto input_values_list = absl::MakeConstSpan(
+      input_values_flag.empty() ? nullptr : &input_values_flag.front(),
+      input_values_flag.size());
+  ASSIGN_OR_RETURN(auto* input_list, ParseToVariantList(input_descs, allocator,
+                                                        input_values_list));
 
   ASSIGN_OR_RETURN(auto output_descs, ParseOutputSignature(function));
   // Prepare outputs list to accept the results from the invocation.

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -49,6 +49,7 @@ cc_library(
         ":stack",
         ":types",
         ":value",
+        "//iree/base:alignment",
         "//iree/base:api",
         "//iree/base:flatbuffer_util",
         "//iree/base:target_platform",
@@ -211,6 +212,7 @@ cc_library(
     deps = [
         ":module",
         ":ref",
+        "//iree/base:alignment",
         "//iree/base:api",
     ],
 )

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_cc_library(
     ::types
     ::value
     flatbuffers
+    iree::base::alignment
     iree::base::api
     iree::base::flatbuffer_util
     iree::base::target_platform
@@ -247,6 +248,7 @@ iree_cc_library(
   DEPS
     ::module
     ::ref
+    iree::base::alignment
     iree::base::api
   PUBLIC
 )

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -28,8 +28,11 @@
 #include <stdio.h>
 #define IREE_DISPATCH_LOG_OPCODE(op_name) \
   fprintf(stderr, "DISPATCH %d %s\n", (int)offset, op_name)
+#define IREE_DISPATCH_LOG_CALL(target_function) \
+  fprintf(stderr, "CALL -> %s\n", iree_vm_function_name(&target_function).data);
 #else
 #define IREE_DISPATCH_LOG_OPCODE(...)
+#define IREE_DISPATCH_LOG_CALL(...)
 #endif  // IREE_DISPATCH_LOGGING
 
 #if defined(IREE_COMPILER_MSVC) && !defined(IREE_COMPILER_CLANG)
@@ -714,10 +717,7 @@ iree_status_t iree_vm_bytecode_dispatch(
         target_function.ordinal = function_ordinal;
       }
 
-#if IREE_DISPATCH_LOGGING
-      iree_string_view_t target_name = iree_vm_function_name(&target_function);
-      fprintf(stderr, "CALL -> %s\n", target_name.data);
-#endif  // IREE_DISPATCH_LOGGING
+      IREE_DISPATCH_LOG_CALL(target_function);
 
       // Remap registers from caller to callee.
       iree_vm_stack_frame_t* callee_frame = NULL;
@@ -803,10 +803,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       target_function =
           module_state->import_table[function_ordinal & 0x7FFFFFFFu];
 
-#if IREE_DISPATCH_LOGGING
-      iree_string_view_t target_name = iree_vm_function_name(&target_function);
-      fprintf(stderr, "VCALL -> %s\n", target_name.data);
-#endif  // IREE_DISPATCH_LOGGING
+      IREE_DISPATCH_LOG_CALL(target_function);
 
       // Remap registers from caller to callee.
       iree_vm_stack_frame_t* callee_frame = NULL;

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "iree/base/alignment.h"
 #include "iree/base/target_platform.h"
 #include "iree/vm/bytecode_module_impl.h"
 #include "iree/vm/bytecode_op_table.h"
@@ -117,7 +118,7 @@ typedef struct {
     uint8_t dst_reg;
   } pairs[];
 } iree_vm_register_remap_list_t;
-static_assert(alignof(iree_vm_register_remap_list_t) == 1,
+static_assert(iree_alignof(iree_vm_register_remap_list_t) == 1,
               "Expecting byte alignment (to avoid padding)");
 static_assert(offsetof(iree_vm_register_remap_list_t, pairs) == 1,
               "Expect no padding in the struct");

--- a/iree/vm/ref.h
+++ b/iree/vm/ref.h
@@ -153,7 +153,7 @@ iree_vm_ref_lookup_registered_type(iree_string_view_t full_name);
 //
 // Usage (C):
 //  my_type_t* my_type = (my_type_t*)malloc(sizeof(my_type_t));
-//  my_type.ref_object.counter = 1;
+//  my_type.ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
 //  iree_vm_ref_t my_ref;
 //  iree_vm_ref_wrap_assign(my_type, IREE_VM_REF_TYPE_MY_TYPE, &my_ref);
 //  iree_vm_ref_release(&my_ref);

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -15,10 +15,10 @@
 #ifndef IREE_VM_STACK_H_
 #define IREE_VM_STACK_H_
 
-#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 
+#include "iree/base/alignment.h"
 #include "iree/base/api.h"
 #include "iree/vm/module.h"
 #include "iree/vm/ref.h"
@@ -50,7 +50,7 @@ typedef int64_t iree_vm_source_offset_t;
 // Register banks for use within a stack frame.
 typedef struct {
   // Integer registers.
-  IREE_ALIGNAS(16) int32_t i32[IREE_I32_REGISTER_COUNT];
+  iree_alignas(16) int32_t i32[IREE_I32_REGISTER_COUNT];
   // Reference counted registers.
   iree_vm_ref_t ref[IREE_REF_REGISTER_COUNT];
   // Total number of valid ref registers used by the function.
@@ -66,7 +66,7 @@ typedef struct {
   uint8_t size;
   uint8_t registers[];
 } iree_vm_register_list_t;
-static_assert(alignof(iree_vm_register_list_t) == 1,
+static_assert(iree_alignof(iree_vm_register_list_t) == 1,
               "Expecting byte alignment (to avoid padding)");
 static_assert(offsetof(iree_vm_register_list_t, registers) == 1,
               "Expect no padding in the struct");


### PR DESCRIPTION
With this iree-run-module/iree-opt/iree-translate/iree-run-mlir will build with MSVC. Fixes #827 