### PR TITLE
Rename target iree_translate_library to iree_translate_main

### DIFF
--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -64,6 +64,6 @@ cc_binary(
     name = "iree-tf-translate",
     deps = [
         ":tensorflow",
-        "//iree/tools:iree_translate_library",
+        "//iree/tools:iree_translate_main",
     ],
 )

--- a/iree/compiler/Dialect/Modules/Strings/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/BUILD
@@ -40,6 +40,6 @@ cc_binary(
     name = "strings-translate",
     deps = [
         "//iree/compiler/Dialect/Modules/Strings/IR:Dialect",
-        "//iree/tools:iree_translate_library",
+        "//iree/tools:iree_translate_main",
     ],
 )

--- a/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
@@ -47,5 +47,5 @@ iree_cc_binary(
     strings-translate
   DEPS
     iree::compiler::Dialect::Modules::Strings::IR::Dialect
-    iree::tools::iree_translate_library
+    iree::tools::iree_translate_main
 )

--- a/iree/compiler/Dialect/Modules/TensorList/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/BUILD
@@ -45,6 +45,6 @@ cc_binary(
     name = "tensorlist-translate",
     deps = [
         "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
-        "//iree/tools:iree_translate_library",
+        "//iree/tools:iree_translate_main",
     ],
 )

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -48,5 +48,5 @@ iree_cc_binary(
     tensorlist-translate
   DEPS
     iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
-    iree::tools::iree_translate_library
+    iree::tools::iree_translate_main
 )

--- a/iree/modules/check/dialect/BUILD
+++ b/iree/modules/check/dialect/BUILD
@@ -88,6 +88,6 @@ cc_binary(
     name = "check-translate",
     deps = [
         ":dialect",
-        "//iree/tools:iree_translate_library",
+        "//iree/tools:iree_translate_main",
     ],
 )

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -84,6 +84,6 @@ iree_cc_binary(
     check-translate
   DEPS
     ::dialect
-    iree::tools::iree_translate_library
+    iree::tools::iree_translate_main
 )
 add_executable(check-translate ALIAS iree_modules_check_dialect_check-translate)

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -91,6 +91,6 @@ cc_binary(
     name = "custom-translate",
     deps = [
         ":dialect",
-        "//iree/tools:iree_translate_library",
+        "//iree/tools:iree_translate_main",
     ],
 )

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -84,5 +84,5 @@ iree_cc_binary(
     custom-translate
   DEPS
     ::dialect
-    iree::tools::iree_translate_library
+    iree::tools::iree_translate_main
 )

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -182,7 +182,7 @@ cc_binary(
 )
 
 cc_library(
-    name = "iree_translate_library",
+    name = "iree_translate_main",
     srcs = ["translate_main.cc"],
     deps = [
         "//iree/compiler/Dialect/VM/Target/Bytecode",
@@ -204,7 +204,7 @@ cc_library(
 cc_binary(
     name = "iree-translate",
     deps = [
-        ":iree_translate_library",
+        ":iree_translate_main",
     ],
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -268,7 +268,7 @@ if(${IREE_BUILD_COMPILER})
 
   iree_cc_library(
     NAME
-      iree_translate_library
+      iree_translate_main
     SRCS
       "translate_main.cc"
     DEPS
@@ -299,7 +299,7 @@ if(${IREE_BUILD_COMPILER})
     NAME
       iree-translate
     DEPS
-      iree::tools::iree_translate_library
+      iree::tools::iree_translate_main
   )
 
   # TODO(*): define these with a rule instead (like iree_sh_binary).


### PR DESCRIPTION
The target `iree_translate_library` includes a main function. Hence, renaming.