### PR TITLE
Rename target iree_opt_library to iree_opt_main

### DIFF
--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -53,7 +53,7 @@ cc_binary(
     name = "iree-tf-opt",
     deps = [
         ":tensorflow",
-        "//iree/tools:iree_opt_library",
+        "//iree/tools:iree_opt_main",
         "@llvm-project//mlir:MlirOptMain",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",

--- a/iree/compiler/Dialect/Modules/Strings/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/BUILD
@@ -32,7 +32,7 @@ cc_binary(
     name = "strings-opt",
     deps = [
         "//iree/compiler/Dialect/Modules/Strings/IR:Dialect",
-        "//iree/tools:iree_opt_library",
+        "//iree/tools:iree_opt_main",
     ],
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
@@ -37,7 +37,7 @@ iree_cc_binary(
     strings-opt
   DEPS
     iree::compiler::Dialect::Modules::Strings::IR::Dialect
-    iree::tools::iree_opt_library
+    iree::tools::iree_opt_main
 )
 
 iree_cc_binary(

--- a/iree/compiler/Dialect/Modules/TensorList/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/BUILD
@@ -37,7 +37,7 @@ cc_binary(
     name = "tensorlist-opt",
     deps = [
         "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
-        "//iree/tools:iree_opt_library",
+        "//iree/tools:iree_opt_main",
     ],
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -38,7 +38,7 @@ iree_cc_binary(
     tensorlist-opt
   DEPS
     iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
-    iree::tools::iree_opt_library
+    iree::tools::iree_opt_main
 )
 
 iree_cc_binary(

--- a/iree/modules/check/dialect/BUILD
+++ b/iree/modules/check/dialect/BUILD
@@ -80,7 +80,7 @@ cc_binary(
     name = "check-opt",
     deps = [
         ":dialect",
-        "//iree/tools:iree_opt_library",
+        "//iree/tools:iree_opt_main",
     ],
 )
 

--- a/iree/modules/check/dialect/CMakeLists.txt
+++ b/iree/modules/check/dialect/CMakeLists.txt
@@ -73,7 +73,7 @@ iree_cc_binary(
     check-opt
   DEPS
     ::dialect
-    iree::tools::iree_opt_library
+    iree::tools::iree_opt_main
 )
 add_executable(check-opt ALIAS iree_modules_check_dialect_check-opt)
 

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -83,7 +83,7 @@ cc_binary(
     name = "custom-opt",
     deps = [
         ":dialect",
-        "//iree/tools:iree_opt_library",
+        "//iree/tools:iree_opt_main",
     ],
 )
 

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -74,7 +74,7 @@ iree_cc_binary(
     custom-opt
   DEPS
     ::dialect
-    iree::tools::iree_opt_library
+    iree::tools::iree_opt_main
 )
 
 iree_cc_binary(

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -68,7 +68,7 @@ cc_binary(
 )
 
 cc_library(
-    name = "iree_opt_library",
+    name = "iree_opt_main",
     srcs = ["opt_main.cc"],
     deps = [
         "//iree/compiler/Dialect/IREE/IR",
@@ -112,7 +112,7 @@ cc_library(
 cc_binary(
     name = "iree-opt",
     deps = [
-        ":iree_opt_library",
+        ":iree_opt_main",
     ],
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -161,7 +161,7 @@ if(${IREE_BUILD_COMPILER})
 
   iree_cc_library(
     NAME
-      iree_opt_library
+      iree_opt_main
     SRCS
       "opt_main.cc"
     DEPS
@@ -218,7 +218,7 @@ if(${IREE_BUILD_COMPILER})
     NAME
       iree-opt
     DEPS
-      iree::tools::iree_opt_library
+      iree::tools::iree_opt_main
   )
 
   iree_cc_binary(


### PR DESCRIPTION
The target `iree_opt_library` includes a main function. Hence, renaming.