### PR TITLE
Handle multiple arguments in iree_bytecode_module

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -43,6 +43,8 @@ function(iree_bytecode_module)
     ${ARGN}
   )
 
+string(REPLACE " " ";" _RULE_TRANSLATION ${_RULE_TRANSLATION})
+
   if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
     # Set defaults for TRANSLATION and TRANSLATE_TOOL
     if(DEFINED _RULE_TRANSLATION)


### PR DESCRIPTION
The _ARGS variable is a list of all the command line arguments
to pass to iree-translate. When passing in multiple strings in
TRANSLATION, we need to convert the string to a list otherwise
iree-translate interprets them incorrectly.

TEST: Tested on vulkan_gui_inference example with x * y * 2
      and translation string "-iree-mlir-to-vm-bytecode-module \
      -iree-hal-target-backends=vulkan-spirv"