### PR TITLE
Change 'translation' to 'flags' list in iree_bytecode_module.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -144,8 +144,9 @@ class BuildFileFunctions(object):
     #    "cpp_namespace"
     return "  CPP_NAMESPACE\n    \"%s\"\n" % (cpp_namespace)
 
-  def _convert_translation_block(self, translation):
-    return "  TRANSLATION\n    \"%s\"\n" % (translation)
+  def _convert_translations_block(self, translations):
+    args_list = "\n".join(["    \"%s\"" % (t) for t in translations])
+    return "  TRANSLATIONS\n%s\n" % (args_list)
 
   def _convert_translate_tool_block(self, translate_tool):
     if translate_tool:
@@ -474,22 +475,22 @@ class BuildFileFunctions(object):
   def iree_bytecode_module(self,
                            name,
                            src,
-                           translation="-iree-mlir-to-vm-bytecode-module",
+                           translations=["-iree-mlir-to-vm-bytecode-module"],
                            translate_tool="//iree/tools:iree-translate",
                            cc_namespace=None):
     name_block = self._convert_name_block(name)
     src_block = self._convert_src_block(src)
     namespace_block = self._convert_cc_namespace_block(cc_namespace)
     translate_tool_block = self._convert_translate_tool_block(translate_tool)
-    translation_block = self._convert_translation_block(translation)
+    translations_block = self._convert_translations_block(translations)
 
     self.converter.body += """iree_bytecode_module(
-%(name_block)s%(src_block)s%(namespace_block)s%(translate_tool_block)s%(translation_block)s  PUBLIC\n)\n\n""" % {
+%(name_block)s%(src_block)s%(namespace_block)s%(translate_tool_block)s%(translations_block)s  PUBLIC\n)\n\n""" % {
     "name_block": name_block,
     "src_block": src_block,
     "namespace_block": namespace_block,
     "translate_tool_block": translate_tool_block,
-    "translation_block": translation_block,
+    "translations_block": translations_block,
     }
 
   def iree_flatbuffer_cc_library(self, name, srcs, flatc_args=None):

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -144,9 +144,9 @@ class BuildFileFunctions(object):
     #    "cpp_namespace"
     return "  CPP_NAMESPACE\n    \"%s\"\n" % (cpp_namespace)
 
-  def _convert_translations_block(self, translations):
-    args_list = "\n".join(["    \"%s\"" % (t) for t in translations])
-    return "  TRANSLATIONS\n%s\n" % (args_list)
+  def _convert_flags_block(self, flags):
+    flags_list = "\n".join(["    \"%s\"" % (flag) for flag in flags])
+    return "  FLAGS\n%s\n" % (flags_list)
 
   def _convert_translate_tool_block(self, translate_tool):
     if translate_tool:
@@ -475,22 +475,22 @@ class BuildFileFunctions(object):
   def iree_bytecode_module(self,
                            name,
                            src,
-                           translations=["-iree-mlir-to-vm-bytecode-module"],
+                           flags=["-iree-mlir-to-vm-bytecode-module"],
                            translate_tool="//iree/tools:iree-translate",
                            cc_namespace=None):
     name_block = self._convert_name_block(name)
     src_block = self._convert_src_block(src)
     namespace_block = self._convert_cc_namespace_block(cc_namespace)
     translate_tool_block = self._convert_translate_tool_block(translate_tool)
-    translations_block = self._convert_translations_block(translations)
+    flags_block = self._convert_flags_block(flags)
 
     self.converter.body += """iree_bytecode_module(
-%(name_block)s%(src_block)s%(namespace_block)s%(translate_tool_block)s%(translations_block)s  PUBLIC\n)\n\n""" % {
+%(name_block)s%(src_block)s%(namespace_block)s%(translate_tool_block)s%(flags_block)s  PUBLIC\n)\n\n""" % {
     "name_block": name_block,
     "src_block": src_block,
     "namespace_block": namespace_block,
     "translate_tool_block": translate_tool_block,
-    "translations_block": translations_block,
+    "flags_block": flags_block,
     }
 
   def iree_flatbuffer_cc_library(self, name, srcs, flatc_args=None):

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -21,8 +21,7 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: Name of target (see Note).
 # SRC: Source file to compile into a bytecode module.
-# TRANSLATIONS: Translation options to pass to the translation tool (list of
-#     strings).
+# FLAGS: Flags to pass to the translation tool (list of strings).
 # TRANSLATE_TOOL: Translation tool to invoke (CMake target).
 # CC_NAMESPACE: Wraps everything in a C++ namespace.
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
@@ -40,16 +39,16 @@ function(iree_bytecode_module)
     _RULE
     "PUBLIC;TESTONLY"
     "NAME;SRC;TRANSLATE_TOOL;CC_NAMESPACE"
-    "TRANSLATIONS"
+    "FLAGS"
     ${ARGN}
   )
 
   if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Set defaults for TRANSLATIONS and TRANSLATE_TOOL
-    if(DEFINED _RULE_TRANSLATION)
-      set(_TRANSLATIONS ${_RULE_TRANSLATIONS})
+    # Set defaults for FLAGS and TRANSLATE_TOOL
+    if(DEFINED _RULE_FLAGS)
+      set(_FLAGS ${_RULE_FLAGS})
     else()
-      set(_TRANSLATIONS "-iree-mlir-to-vm-bytecode-module")
+      set(_FLAGS "-iree-mlir-to-vm-bytecode-module")
     endif()
     if(DEFINED _RULE_TRANSLATE_TOOL)
       set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
@@ -60,7 +59,7 @@ function(iree_bytecode_module)
     # Resolve the executable binary path from the target name.
     set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:${_TRANSLATE_TOOL}>)
 
-    set(_ARGS "${_TRANSLATIONS}")
+    set(_ARGS "${_FLAGS}")
     list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
     list(APPEND _ARGS "-o")
     list(APPEND _ARGS "${_RULE_NAME}.module")

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -21,12 +21,13 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: Name of target (see Note).
 # SRC: Source file to compile into a bytecode module.
-# TRANSLATION: Translation option to pass to the translation tool (string).
+# TRANSLATIONS: Translation options to pass to the translation tool (list of
+#     strings).
 # TRANSLATE_TOOL: Translation tool to invoke (CMake target).
 # CC_NAMESPACE: Wraps everything in a C++ namespace.
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
-# Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC will be
-# in ${PACKAGE}/internal.
+#     Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC
+#     will be in ${PACKAGE}/internal.
 # TESTONLY: When added, this target will only be built if user passes
 #    -DIREE_BUILD_TESTS=ON to CMake.
 #
@@ -38,17 +39,17 @@ function(iree_bytecode_module)
   cmake_parse_arguments(
     _RULE
     "PUBLIC;TESTONLY"
-    "NAME;SRC;TRANSLATION;TRANSLATE_TOOL;CC_NAMESPACE"
-    ""
+    "NAME;SRC;TRANSLATE_TOOL;CC_NAMESPACE"
+    "TRANSLATIONS"
     ${ARGN}
   )
 
   if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Set defaults for TRANSLATION and TRANSLATE_TOOL
+    # Set defaults for TRANSLATIONS and TRANSLATE_TOOL
     if(DEFINED _RULE_TRANSLATION)
-      set(_TRANSLATION ${_RULE_TRANSLATION})
+      set(_TRANSLATIONS ${_RULE_TRANSLATIONS})
     else()
-      set(_TRANSLATION "-iree-mlir-to-vm-bytecode-module")
+      set(_TRANSLATIONS "-iree-mlir-to-vm-bytecode-module")
     endif()
     if(DEFINED _RULE_TRANSLATE_TOOL)
       set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
@@ -59,7 +60,7 @@ function(iree_bytecode_module)
     # Resolve the executable binary path from the target name.
     set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:${_TRANSLATE_TOOL}>)
 
-    set(_ARGS "${_TRANSLATION}")
+    set(_ARGS "${_TRANSLATIONS}")
     list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
     list(APPEND _ARGS "-o")
     list(APPEND _ARGS "${_RULE_NAME}.module")

--- a/iree/modules/check/BUILD
+++ b/iree/modules/check/BUILD
@@ -25,7 +25,7 @@ iree_bytecode_module(
     src = "check_test.mlir",
     cc_namespace = "iree::check",
     translate_tool = "//iree/modules/check/dialect:check-translate",
-    translations = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/modules/check/BUILD
+++ b/iree/modules/check/BUILD
@@ -25,7 +25,7 @@ iree_bytecode_module(
     src = "check_test.mlir",
     cc_namespace = "iree::check",
     translate_tool = "//iree/modules/check/dialect:check-translate",
-    translation = "-iree-mlir-to-vm-bytecode-module",
+    translations = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -24,7 +24,7 @@ iree_bytecode_module(
     "iree::check"
   TRANSLATE_TOOL
     iree_modules_check_dialect_check-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -24,7 +24,7 @@ iree_bytecode_module(
     "iree::check"
   TRANSLATE_TOOL
     iree_modules_check_dialect_check-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -53,5 +53,5 @@ iree_bytecode_module(
     src = "strings_module_test.mlir",
     cc_namespace = "iree::strings_module_test",
     translate_tool = "//iree/compiler/Dialect/Modules/Strings:strings-translate",
-    translations = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = ["-iree-mlir-to-vm-bytecode-module"],
 )

--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -53,5 +53,5 @@ iree_bytecode_module(
     src = "strings_module_test.mlir",
     cc_namespace = "iree::strings_module_test",
     translate_tool = "//iree/compiler/Dialect/Modules/Strings:strings-translate",
-    translation = "-iree-mlir-to-vm-bytecode-module",
+    translations = ["-iree-mlir-to-vm-bytecode-module"],
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -68,7 +68,7 @@ iree_bytecode_module(
     "iree::strings_module_test"
   TRANSLATE_TOOL
     iree_compiler_Dialect_Modules_Strings_strings-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -68,7 +68,7 @@ iree_bytecode_module(
     "iree::strings_module_test"
   TRANSLATE_TOOL
     iree_compiler_Dialect_Modules_Strings_strings-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     src = "tensorlist_test.mlir",
     cc_namespace = "iree::modules::tensorlist",
     translate_tool = "//iree/compiler/Dialect/Modules/TensorList:tensorlist-translate",
-    translations = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     src = "tensorlist_test.mlir",
     cc_namespace = "iree::modules::tensorlist",
     translate_tool = "//iree/compiler/Dialect/Modules/TensorList:tensorlist-translate",
-    translation = "-iree-mlir-to-vm-bytecode-module",
+    translations = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_bytecode_module(
     "iree::modules::tensorlist"
   TRANSLATE_TOOL
     iree_compiler_Dialect_Modules_TensorList_tensorlist-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_bytecode_module(
     "iree::modules::tensorlist"
   TRANSLATE_TOOL
     iree_compiler_Dialect_Modules_TensorList_tensorlist-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/samples/custom_modules/BUILD
+++ b/iree/samples/custom_modules/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     src = "custom_modules_test.mlir",
     cc_namespace = "iree::samples::custom_modules",
     translate_tool = "//iree/samples/custom_modules/dialect:custom-translate",
-    translations = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/samples/custom_modules/BUILD
+++ b/iree/samples/custom_modules/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     src = "custom_modules_test.mlir",
     cc_namespace = "iree::samples::custom_modules",
     translate_tool = "//iree/samples/custom_modules/dialect:custom-translate",
-    translation = "-iree-mlir-to-vm-bytecode-module",
+    translations = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -23,7 +23,7 @@ iree_bytecode_module(
     "iree::samples::custom_modules"
   TRANSLATE_TOOL
     iree_samples_custom_modules_dialect_custom-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -23,7 +23,7 @@ iree_bytecode_module(
     "iree::samples::custom_modules"
   TRANSLATE_TOOL
     iree_samples_custom_modules_dialect_custom-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     name = "simple_embedding_test_bytecode_module",
     src = "simple_embedding_test.mlir",
     cc_namespace = "iree::samples",
-    translations = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -24,7 +24,7 @@ iree_bytecode_module(
     name = "simple_embedding_test_bytecode_module",
     src = "simple_embedding_test.mlir",
     cc_namespace = "iree::samples",
-    translation = "-iree-mlir-to-vm-bytecode-module",
+    translations = ["-iree-mlir-to-vm-bytecode-module"],
 )
 
 cc_test(

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_bytecode_module(
     "iree::samples"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_bytecode_module(
     "iree::samples"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-mlir-to-vm-bytecode-module"
   PUBLIC
 )

--- a/iree/tools/compilation.bzl
+++ b/iree/tools/compilation.bzl
@@ -20,7 +20,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 def iree_bytecode_module(
         name,
         src,
-        translation = "-iree-mlir-to-vm-bytecode-module",
+        translations = ["-iree-mlir-to-vm-bytecode-module"],
         translate_tool = "//iree/tools:iree-translate",
         cc_namespace = None,
         visibility = None):
@@ -33,7 +33,7 @@ def iree_bytecode_module(
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (translate_tool),
-                translation,
+                " ".join(translations),
                 "-o $(location %s.module)" % (name),
                 "$(location %s)" % (src),
             ]),

--- a/iree/tools/compilation.bzl
+++ b/iree/tools/compilation.bzl
@@ -20,7 +20,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 def iree_bytecode_module(
         name,
         src,
-        translations = ["-iree-mlir-to-vm-bytecode-module"],
+        flags = ["-iree-mlir-to-vm-bytecode-module"],
         translate_tool = "//iree/tools:iree-translate",
         cc_namespace = None,
         visibility = None):
@@ -33,7 +33,7 @@ def iree_bytecode_module(
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (translate_tool),
-                " ".join(translations),
+                " ".join(flags),
                 "-o $(location %s.module)" % (name),
                 "$(location %s)" % (src),
             ]),

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -28,7 +28,7 @@ iree_bytecode_module(
     name = "bytecode_dispatch_test_module",
     src = "bytecode_dispatch_test.mlir",
     cc_namespace = "iree::vm",
-    translation = "-iree-vm-ir-to-bytecode-module",
+    translations = ["-iree-vm-ir-to-bytecode-module"],
 )
 
 cc_library(
@@ -79,7 +79,7 @@ iree_bytecode_module(
     name = "bytecode_module_benchmark_module",
     src = "bytecode_module_benchmark.mlir",
     cc_namespace = "iree::vm",
-    translation = "-iree-vm-ir-to-bytecode-module",
+    translations = ["-iree-vm-ir-to-bytecode-module"],
 )
 
 cc_test(

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -28,7 +28,7 @@ iree_bytecode_module(
     name = "bytecode_dispatch_test_module",
     src = "bytecode_dispatch_test.mlir",
     cc_namespace = "iree::vm",
-    translations = ["-iree-vm-ir-to-bytecode-module"],
+    flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 
 cc_library(
@@ -79,7 +79,7 @@ iree_bytecode_module(
     name = "bytecode_module_benchmark_module",
     src = "bytecode_module_benchmark.mlir",
     cc_namespace = "iree::vm",
-    translations = ["-iree-vm-ir-to-bytecode-module"],
+    flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 
 cc_test(

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -38,7 +38,7 @@ iree_bytecode_module(
     "iree::vm"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
 )
@@ -95,7 +95,7 @@ iree_bytecode_module(
     "iree::vm"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATIONS
+  FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
 )

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -38,7 +38,7 @@ iree_bytecode_module(
     "iree::vm"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
 )
@@ -95,7 +95,7 @@ iree_bytecode_module(
     "iree::vm"
   TRANSLATE_TOOL
     iree_tools_iree-translate
-  TRANSLATION
+  TRANSLATIONS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC
 )


### PR DESCRIPTION
This lets CMake treat the list of arguments as a list - otherwise it puts quotes around the full list, which iree-translate doesn't like.