### PR TITLE
Remove simple_compute_test docs, show running all tests on Bazel/Win.

### DIFF
--- a/docs/getting_started_on_windows.md
+++ b/docs/getting_started_on_windows.md
@@ -165,22 +165,13 @@ git submodule update $IREE_CLONE_ARGS --recursive
 ### Build
 
 ```shell
-# TODO: Add more things as they come online.
-# Unit tests.
-bazel test --config=windows //iree/compiler/...
-
-# Sample computation on the interpreter.
-bazel run --config=windows iree/tools/iree-run-mlir -- \
-    $(pwd)/iree/samples/hal/simple_compute_test.mlir \
-    --input_values="4xf32=1.0 2.0 3.0 4.0\n4xf32=2.0 4.0 6.0 8.0" \
-    --target_backends=interpreter-bytecode
-
-# Sample computation via vulkan/spirv.
-bazel run --config=windows iree/tools/iree-run-mlir -- \
-    $(pwd)/iree/samples/hal/simple_compute_test.mlir \
-    --input_values="4xf32=1.0 2.0 3.0 4.0\n4xf32=2.0 4.0 6.0 8.0" \
-    --target_backends=vulkan
+# Run all core tests
+bazel test -k --config=windows iree/...
 ```
+
+In general, build artifacts will be under the `bazel-bin` directory at the top
+level.
+
 
 ## Recommended user.bazelrc
 

--- a/docs/vulkan_and_spirv.md
+++ b/docs/vulkan_and_spirv.md
@@ -53,9 +53,7 @@ logging during the loader initialization. This is especially useful when trying
 to verify expected paths are being searched for layers or driver JSON manifests.
 
 The simplest test for ensuring that The Vulkan loader and IREE are correctly
-configured together is //iree/hal/vulkan:dynamic_symbols_test. Once that works,
-you should also be able to run //iree/samples/hal:simple_compute_test and see
-the Vulkan HAL in action.
+configured together is //iree/hal/vulkan:dynamic_symbols_test.
 
 #### Enabling Validation Layers
 


### PR DESCRIPTION
* `simple_compute_test` was deleted back with the VM2 migration
* Not all tests pass on Windows, but we expect most of the tree to build now.