### PR TITLE
Add gmock dependency to gtest shim

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -70,7 +70,7 @@ EXPLICIT_TARGET_MAPPING = {
     # Misc single targets
     "@com_google_benchmark//:benchmark": ["benchmark"],
     "@com_github_google_flatbuffers//:flatbuffers": ["flatbuffers"],
-    "@com_google_googletest//:gtest": ["gtest"],
+    "@com_google_googletest//:gtest": ["gmock", "gtest"],
     "@renderdoc_api//:renderdoc_app": ["renderdoc_api::renderdoc_app"],
     "@sdl2//:SDL2": ["SDL2-static"]
 }

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "gtest_internal.h"
   DEPS
     gtest
+    gmock
   TESTONLY
   PUBLIC
 )
@@ -32,6 +33,7 @@ iree_cc_library(
     "gtest_main_internal.cc"
   DEPS
     gtest
+    gmock
     iree::base::init
   TESTONLY
   PUBLIC

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -18,8 +18,8 @@ iree_cc_library(
   HDRS
     "gtest_internal.h"
   DEPS
-    gtest
     gmock
+    gtest
   TESTONLY
   PUBLIC
 )
@@ -32,8 +32,8 @@ iree_cc_library(
   SRCS
     "gtest_main_internal.cc"
   DEPS
-    gtest
     gmock
+    gtest
     iree::base::init
   TESTONLY
   PUBLIC


### PR DESCRIPTION
This makes it possible to build a library that depends on this target (otherwise it can't find the gmock header).

At least a partial fix for https://github.com/google/iree/issues/951

Tested:
https://github.com/google/iree/pull/950 (use this in a library) with this commit patched in now builds