### PR TITLE
Drop custom gtest configuration

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -91,8 +91,6 @@ function(iree_cc_binary)
     target_include_directories(${_NAME}
       PUBLIC
         ${IREE_COMMON_INCLUDE_DIRS}
-      PRIVATE
-        ${GTEST_INCLUDE_DIRS}
     )
     target_compile_definitions(${_NAME}
       PUBLIC

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -79,8 +79,6 @@ function(iree_cc_test)
   target_include_directories(${_NAME}
     PUBLIC
       ${IREE_COMMON_INCLUDE_DIRS}
-    PRIVATE
-      ${GTEST_INCLUDE_DIRS}
   )
   target_compile_definitions(${_NAME}
     PUBLIC

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -111,10 +111,6 @@ set(ENABLE_CTEST OFF CACHE BOOL "" FORCE)
 #-------------------------------------------------------------------------------
 
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-set(GTEST_INCLUDE_DIRS
-  "${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/include/"
-  "${CMAKE_CURRENT_SOURCE_DIR}/third_party/googlemock/include/"
-)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
We currently hardcode gtest include directories in a few places. This doesn't seem to be necessary, and should be taken care of by gtest itself at https://github.com/google/googletest/blob/e588eb1ff9ff6598666279b737b27f983156ad85/googletest/CMakeLists.txt#L118

Related to #951 