### PR TITLE
Up the maximum binding count in VMLA.

### DIFF
--- a/iree/hal/vmla/vmla_command_processor.cc
+++ b/iree/hal/vmla/vmla_command_processor.cc
@@ -32,6 +32,12 @@ namespace {
 Status MarshalIO(Interface* interface,
                  const DispatchRequest& dispatch_request) {
   IREE_TRACE_SCOPE0("VMLACommandProcessor::MarshalIO");
+  if (dispatch_request.bindings.size() >= Interface::kMaxBindings) {
+    return OutOfRangeErrorBuilder(IREE_LOC)
+           << "Too many bindings requested; wanted "
+           << dispatch_request.bindings.size() << " but have a maximum of "
+           << Interface::kMaxBindings;
+  }
 
   for (int i = 0; i < dispatch_request.bindings.size(); ++i) {
     const auto& binding = dispatch_request.bindings[i];

--- a/iree/hal/vmla/vmla_module.h
+++ b/iree/hal/vmla/vmla_module.h
@@ -98,7 +98,7 @@ class Buffer final : public RefObject<Buffer> {
 class Interface final : public RefObject<Interface> {
  public:
   static constexpr int kMaxSets = 4;
-  static constexpr int kMaxBindings = 8;
+  static constexpr int kMaxBindings = 32;
 
   struct Binding {
     vm::ref<Buffer> buffer;


### PR DESCRIPTION
Once descriptor sets are properly implemented this will not be required.