### PR TITLE
Decouple dialects from shared static registration.

### DIFF
--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -43,18 +43,24 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_dialect_registration",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
     ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "dialect_registration",
+    srcs = ["DialectRegistration.cpp"],
+    deps = ["@org_tensorflow//tensorflow/compiler/mlir/tensorflow"],
     alwayslink = 1,
 )
 
 cc_binary(
     name = "iree-tf-opt",
     deps = [
+        ":dialect_registration",
         ":tensorflow",
         "//iree/tools:iree_opt_main",
-        "@llvm-project//mlir:MlirOptMain",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
     ],

--- a/integrations/tensorflow/compiler/DialectRegistration.cpp
+++ b/integrations/tensorflow/compiler/DialectRegistration.cpp
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorflow/compiler/mlir/tensorflow/ir/control_flow_ops.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_device.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_executor.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_saved_model.h"
+
+namespace mlir {
+
+// Static initialization for TF dialect registration.
+static DialectRegistration<TFControlFlow::TFControlFlowDialect>
+    tf_control_flow_ops;
+static DialectRegistration<TF::TensorFlowDialect> tf_ops;
+static DialectRegistration<tf_executor::TensorFlowExecutorDialect>
+    tf_executor_dialect;
+static DialectRegistration<tf_device::TensorFlowDeviceDialect>
+    tf_device_dialect;
+static DialectRegistration<tf_saved_model::TensorFlowSavedModelDialect>
+    tf_saved_model_dialect;
+
+}  // namespace mlir

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
@@ -47,7 +47,6 @@ cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_dialect_registration",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
     ],
 )

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
@@ -39,7 +39,6 @@ cc_library(
         "//iree/schemas:spirv_executable_def_cc_fbs",
         "@com_github_google_flatbuffers//:flatbuffers",
         "@llvm-project//llvm:support",
-        "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -21,7 +21,6 @@ iree_cc_library(
     "VulkanSPIRVTarget.cpp"
   DEPS
     LLVMSupport
-    MLIRAllDialects
     MLIRIR
     MLIRParser
     MLIRPass

--- a/iree/compiler/Translation/BUILD
+++ b/iree/compiler/Translation/BUILD
@@ -34,7 +34,6 @@ cc_library(
         "//iree/compiler/Dialect/VM/Target/Bytecode",
         "//iree/compiler/Dialect/VM/Transforms",
         "@llvm-project//llvm:support",
-        "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -27,7 +27,6 @@ iree_cc_library(
     "IREEVM.cpp"
   DEPS
     LLVMSupport
-    MLIRAllDialects
     MLIRIR
     MLIRPass
     MLIRSupport


### PR DESCRIPTION
Decouple dialects from shared static registration.

This is necessary to merge https://github.com/google/iree/pull/919 because upstream the registration targets register dialects with static initialization.

We should probably go through and cleanup our registration across iree-opt, iree-tf-opt, python bindings, iree-translate, etc. to get some consistency, but this will at least allow us to move forward.
