### PR TITLE
Use newly introduced registerMlirDialects() in pyiree.compiler

### DIFF
--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -84,6 +84,7 @@ pybind_cc_library(
     tags = ["nokokoro"],
     deps = COMPILER_DEPS + [
         "//bindings/python/pyiree/common",
+        "//iree/tools:PassesAndDialects",
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:IR",

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_pybind_cc_library(
     iree::compiler::Dialect::HAL::Target::LLVM
     iree::compiler::Dialect::HAL::Target::VulkanSPIRV
     iree::compiler::Dialect::VM::Target::Bytecode
+    iree::tools::PassesAndDialects
     bindings::python::pyiree::common
     LLVMSupport
     MLIRIR

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -59,13 +59,6 @@ iree_pybind_cc_library(
     bindings::python::pyiree::common
     LLVMSupport
     MLIRIR
-    # TODO(marbre): The following deps are necessary as we still rely on
-    #  mlir::registerAllDialects(). In the Bazel build these are pulled in
-    #  by the dependency on mlir:AllPassesAndDialectsNoRegistration
-    MLIRNVVMIR # mlir:AllPassesAndDialectsNoRegistration
-    MLIRROCDLIR # mlir:AllPassesAndDialectsNoRegistration
-    MLIRQuantizerFxpMathConfig # mlir:AllPassesAndDialectsNoRegistration
-    MLIRQuantizerSupport # mlir:AllPassesAndDialectsNoRegistration
     MLIRLoopOpsTransforms
     MLIRParser
     MLIRPass

--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -24,11 +24,11 @@
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
 #include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "iree/tools/init_dialects.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Location.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -325,7 +325,7 @@ void CompilerModuleBundle::RunPassPipeline(
 }
 
 void SetupCommonCompilerBindings(pybind11::module m) {
-  mlir::registerAllDialects();
+  mlir::registerMlirDialects();
   py::class_<OpaqueBlob, std::shared_ptr<OpaqueBlob>>(m, "OpaqueBlob",
                                                       py::buffer_protocol())
       .def_buffer([](OpaqueBlob* self) -> py::buffer_info {


### PR DESCRIPTION
* Replaces `registerAllDialects()` by `registerMlirDialects()`
* The test `bindings_python_pyiree_compiler_compiler_test` fails otherwise, during a missing symbol somewhere in the ROCm dialect.