### PR TITLE
Replace further registerAllDialects() calls by registerMlirDialects()

### DIFF
--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -152,6 +152,7 @@ cc_binary(
     name = "iree-run-mlir",
     srcs = ["run_mlir_main.cc"],
     deps = [
+        ":PassesAndDialects",
         ":vm_util",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
@@ -170,7 +171,6 @@ cc_binary(
         "//iree/vm:bytecode_module",
         "//iree/vm:value",
         "@llvm-project//llvm:support",
-        "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LoopOpsTransforms",
         "@llvm-project//mlir:Parser",
@@ -217,11 +217,11 @@ cc_library(
     name = "iree_translate_main",
     srcs = ["translate_main.cc"],
     deps = [
+        ":PassesAndDialects",
         "//iree/compiler/Dialect/VM/Target/Bytecode",
         "//iree/compiler/Translation:IREEVM",
         "//iree/compiler/Translation/SPIRV/XLAToSPIRV",
         "@llvm-project//llvm:support",
-        "@llvm-project//mlir:AllPassesAndDialectsNoRegistration",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LoopOpsTransforms",
         "@llvm-project//mlir:Pass",

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -71,8 +71,6 @@ iree_cc_library(
     MLIRGPUtoSPIRVTransforms
     MLIRIR
     MLIRLLVMIR
-    MLIRNVVMIR
-    MLIRROCDLIR
     MLIRLinalgOps
     MLIRLinalgToLLVM
     MLIRLinalgToSPIRVTransforms

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -56,6 +56,7 @@
 #include "iree/compiler/Translation/IREEVM.h"
 #include "iree/hal/api.h"
 #include "iree/modules/hal/hal_module.h"
+#include "iree/tools/init_dialects.h"
 #include "iree/tools/vm_util.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"
@@ -68,7 +69,6 @@
 #include "mlir/IR/Function.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Module.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
@@ -455,7 +455,7 @@ extern "C" int main(int argc, char** argv) {
     }
   }
 
-  mlir::registerAllDialects();
+  mlir::registerMlirDialects();
   mlir::registerPassManagerCLOptions();
   llvm::InitLLVM init_llvm(argc_llvm, argv_llvm);
   llvm::cl::ParseCommandLineOptions(argc_llvm, argv_llvm);

--- a/iree/tools/translate_main.cc
+++ b/iree/tools/translate_main.cc
@@ -17,13 +17,13 @@
 // We need this entry function because we want to register PassManager CLI
 // options, which is missing in MLIR's translation main entry function.
 
+#include "iree/tools/init_dialects.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
@@ -47,7 +47,7 @@ static llvm::cl::opt<bool> splitInputFile(
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
-  mlir::registerAllDialects();
+  mlir::registerMlirDialects();
   mlir::registerPassManagerCLOptions();
 
   // Add flags for all the registered translations.


### PR DESCRIPTION
* Use `registerMlirDialects()` in translate_main and run_mlir_main
* CMake: Drop NNVM and ROCDL IR from `PassesAndDialects` target
* Bazel: Replace `mlir:AllPassesAndDialectsNoRegistration deps`