### PR TITLE
Add support for DATA in CMake.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -375,6 +375,7 @@ class BuildFileFunctions(object):
                  hdrs=None,
                  textual_hdrs=None,
                  srcs=None,
+                 data=None,
                  deps=None,
                  alwayslink=False,
                  testonly=False,
@@ -386,39 +387,44 @@ class BuildFileFunctions(object):
     hdrs_block = self._convert_hdrs_block(hdrs)
     textual_hdrs_block = self._convert_textual_hdrs_block(textual_hdrs)
     srcs_block = self._convert_srcs_block(srcs)
+    data_block = self._convert_data_block(data)
     deps_block = self._convert_deps_block(deps)
     alwayslink_block = self._convert_alwayslink_block(alwayslink)
     testonly_block = self._convert_testonly_block(testonly)
 
     self.converter.body += """iree_cc_library(
-%(name_block)s%(hdrs_block)s%(textual_hdrs_block)s%(srcs_block)s%(deps_block)s%(alwayslink_block)s%(testonly_block)s  PUBLIC
+%(name_block)s%(hdrs_block)s%(textual_hdrs_block)s%(srcs_block)s%(data_block)s%(deps_block)s%(alwayslink_block)s%(testonly_block)s  PUBLIC
 )\n\n""" % {
     "name_block": name_block,
     "hdrs_block": hdrs_block,
     "textual_hdrs_block": textual_hdrs_block,
     "srcs_block": srcs_block,
+    "data_block": data_block,
     "deps_block": deps_block,
     "alwayslink_block": alwayslink_block,
     "testonly_block": testonly_block,
     }
 
-  def cc_test(self, name, hdrs=None, srcs=None, deps=None, **kwargs):
+  def cc_test(self, name, hdrs=None, srcs=None, data=None, deps=None, **kwargs):
     name_block = self._convert_name_block(name)
     hdrs_block = self._convert_hdrs_block(hdrs)
     srcs_block = self._convert_srcs_block(srcs)
+    data_block = self._convert_data_block(data)
     deps_block = self._convert_deps_block(deps)
 
     self.converter.body += """iree_cc_test(
-%(name_block)s%(hdrs_block)s%(srcs_block)s%(deps_block)s)\n\n""" % {
+%(name_block)s%(hdrs_block)s%(srcs_block)s%(data_block)s%(deps_block)s)\n\n""" % {
     "name_block": name_block,
     "hdrs_block": hdrs_block,
     "srcs_block": srcs_block,
+    "data_block": data_block,
     "deps_block": deps_block,
     }
 
   def cc_binary(self,
                 name,
                 srcs=None,
+                data=None,
                 deps=None,
                 linkopts=None,
                 testonly=False,
@@ -428,14 +434,16 @@ class BuildFileFunctions(object):
     name_block = self._convert_name_block(name)
     out_block = self._convert_out_block(name)
     srcs_block = self._convert_srcs_block(srcs)
+    data_block = self._convert_data_block(data)
     deps_block = self._convert_deps_block(deps)
     testonly_block = self._convert_testonly_block(testonly)
 
     self.converter.body += """iree_cc_binary(
-%(name_block)s%(out_block)s%(srcs_block)s%(deps_block)s%(testonly_block)s)\n\n""" % {
+%(name_block)s%(out_block)s%(srcs_block)s%(data_block)s%(deps_block)s%(testonly_block)s)\n\n""" % {
     "name_block": name_block,
     "out_block": out_block,
     "srcs_block": srcs_block,
+    "data_block": data_block,
     "deps_block": deps_block,
     "testonly_block": testonly_block,
     }

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -25,6 +25,7 @@ endif()
 # Parameters:
 # NAME: name of target (see Usage below)
 # SRCS: List of source files for the binary
+# DATA: List of other targets to be built with this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -59,7 +60,7 @@ function(iree_cc_binary)
     _RULE
     "TESTONLY"
     "NAME;OUT"
-    "SRCS;COPTS;DEFINES;LINKOPTS;DEPS"
+    "SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS"
     ${ARGN}
   )
 
@@ -100,6 +101,7 @@ function(iree_cc_binary)
       PRIVATE
         ${_RULE_COPTS}
     )
+    iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
 
     iree_package_ns(_PACKAGE_NS)
     # Replace dependencies passed by ::name with ::iree::package::name

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -25,7 +25,7 @@ endif()
 # Parameters:
 # NAME: name of target (see Usage below)
 # SRCS: List of source files for the binary
-# DATA: List of other targets to be built with this binary
+# DATA: List of other targets and files required for this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -101,7 +101,7 @@ function(iree_cc_binary)
       PRIVATE
         ${_RULE_COPTS}
     )
-    iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
+    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
 
     iree_package_ns(_PACKAGE_NS)
     # Replace dependencies passed by ::name with ::iree::package::name

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -23,6 +23,7 @@ include(CMakeParseArguments)
 # HDRS: List of public header files for the library
 # TEXTUAL_HDRS: List of public header files that cannot be compiled on their own
 # SRCS: List of source files for the library
+# DATA: List of other targets to be built with this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -68,7 +69,7 @@ function(iree_cc_library)
     _RULE
     "PUBLIC;ALWAYSLINK;TESTONLY"
     "NAME"
-    "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS;INCLUDES"
+    "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;INCLUDES"
     ${ARGN}
   )
 
@@ -123,6 +124,7 @@ function(iree_cc_library)
           ${_RULE_LINKOPTS}
           ${IREE_DEFAULT_LINKOPTS}
       )
+      iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
       target_compile_definitions(${_NAME}
         PUBLIC
           ${_RULE_DEFINES}
@@ -162,6 +164,7 @@ function(iree_cc_library)
           ${_RULE_LINKOPTS}
           ${IREE_DEFAULT_LINKOPTS}
       )
+      iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
       target_compile_definitions(${_NAME}
         INTERFACE
           ${_RULE_DEFINES}

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -23,7 +23,7 @@ include(CMakeParseArguments)
 # HDRS: List of public header files for the library
 # TEXTUAL_HDRS: List of public header files that cannot be compiled on their own
 # SRCS: List of source files for the library
-# DATA: List of other targets to be built with this binary
+# DATA: List of other targets and files required for this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -124,7 +124,7 @@ function(iree_cc_library)
           ${_RULE_LINKOPTS}
           ${IREE_DEFAULT_LINKOPTS}
       )
-      iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
+      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
       target_compile_definitions(${_NAME}
         PUBLIC
           ${_RULE_DEFINES}
@@ -164,7 +164,7 @@ function(iree_cc_library)
           ${_RULE_LINKOPTS}
           ${IREE_DEFAULT_LINKOPTS}
       )
-      iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
+      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
       target_compile_definitions(${_NAME}
         INTERFACE
           ${_RULE_DEFINES}

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -21,6 +21,7 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: name of target (see Usage below)
 # SRCS: List of source files for the binary
+# DATA: List of other targets to be built with this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -59,14 +60,14 @@ function(iree_cc_test)
     _RULE
     ""
     "NAME"
-    "SRCS;COPTS;DEFINES;LINKOPTS;DEPS"
+    "SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS"
     ${ARGN}
   )
 
   iree_package_ns(_PACKAGE_NS)
   # Replace dependencies passed by ::name with ::iree::package::name
   list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
-  
+
   # Prefix the library with the package name, so we get: iree_package_name
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
@@ -95,6 +96,7 @@ function(iree_cc_test)
     PRIVATE
       ${_RULE_LINKOPTS}
   )
+  iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
   # Add all IREE targets to a folder in the IDE for organization.
   set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
 

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -21,7 +21,7 @@ include(CMakeParseArguments)
 # Parameters:
 # NAME: name of target (see Usage below)
 # SRCS: List of source files for the binary
-# DATA: List of other targets to be built with this binary
+# DATA: List of other targets and files required for this binary
 # DEPS: List of other libraries to be linked in to the binary targets
 # COPTS: List of private compile options
 # DEFINES: List of public defines
@@ -96,7 +96,7 @@ function(iree_cc_test)
     PRIVATE
       ${_RULE_LINKOPTS}
   )
-  iree_data(NAME ${_NAME} DATA ${_RULE_DATA})
+  iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
   # Add all IREE targets to a folder in the IDE for organization.
   set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
 

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -160,11 +160,9 @@ function(iree_add_data_dependencies)
       if(NOT TARGET ${_DATA_TARGET})
         set(_INPUT_PATH "${CMAKE_SOURCE_DIR}/${_FILE_PATH}")
         set(_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${_FILE_PATH}")
-        add_custom_command(
-          OUTPUT ${_OUTPUT_PATH}
+        add_custom_target(${_DATA_TARGET}
           COMMAND ${CMAKE_COMMAND} -E copy ${_INPUT_PATH} ${_OUTPUT_PATH}
         )
-        add_custom_target(${_DATA_TARGET} DEPENDS ${_OUTPUT_PATH})
       endif()
 
       add_dependencies(${_RULE_NAME} ${_DATA_TARGET})

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -123,3 +123,51 @@ function(iree_select_compiler_opts OPTS)
   endif()
   set(${OPTS} ${_OPTS} PARENT_SCOPE)
 endfunction()
+
+#-------------------------------------------------------------------------------
+# Data dependencies
+#-------------------------------------------------------------------------------
+
+# Adds 'data' dependencies to a target.
+#
+# Parameters:
+# NAME: name of the target to add data dependencies to
+# DATA: List of targets and/or files in the source tree. Files should use the
+#       same format as targets (i.e. iree::package::subpackage::file.txt)
+function(iree_data)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME"
+    "DATA"
+    ${ARGN}
+  )
+
+  if(NOT _RULE_DATA)
+    return()
+  endif()
+
+  foreach(_DATA_LABEL ${_RULE_DATA})
+    if(TARGET ${_DATA_LABEL})
+      add_dependencies(${_RULE_NAME} ${_DATA_LABEL})
+    else()
+      # Not a target, assume to be a file instead.
+      string(REPLACE "::" "/" _FILE_PATH ${_DATA_LABEL})
+
+      # Create a target which copies the data file into the build directory.
+      # If this file is included in multiple rules, only create the target once.
+      string(REPLACE "::" "_" _DATA_TARGET ${_DATA_LABEL})
+      if(NOT TARGET ${_DATA_TARGET})
+        set(_INPUT_PATH "${CMAKE_SOURCE_DIR}/${_FILE_PATH}")
+        set(_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${_FILE_PATH}")
+        add_custom_command(
+          OUTPUT ${_OUTPUT_PATH}
+          COMMAND ${CMAKE_COMMAND} -E copy ${_INPUT_PATH} ${_OUTPUT_PATH}
+        )
+        add_custom_target(${_DATA_TARGET} DEPENDS ${_OUTPUT_PATH})
+      endif()
+
+      add_dependencies(${_RULE_NAME} ${_DATA_TARGET})
+    endif()
+  endforeach()
+endfunction()

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -134,7 +134,7 @@ endfunction()
 # NAME: name of the target to add data dependencies to
 # DATA: List of targets and/or files in the source tree. Files should use the
 #       same format as targets (i.e. iree::package::subpackage::file.txt)
-function(iree_data)
+function(iree_add_data_dependencies)
   cmake_parse_arguments(
     _RULE
     ""

--- a/iree/hal/cts/CMakeLists.txt
+++ b/iree/hal/cts/CMakeLists.txt
@@ -17,6 +17,8 @@ iree_cc_library(
     cts_test_base
   HDRS
     "cts_test_base.h"
+  DATA
+    iree::tools::sanitizer_suppressions.txt
   DEPS
     iree::base::status
     iree::base::status_matchers

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -31,6 +31,8 @@ iree_cc_test(
     simple_embedding_test
   SRCS
     "simple_embedding_test.cc"
+  DATA
+    iree::tools::sanitizer_suppressions.txt
   DEPS
     ::simple_embedding_test_bytecode_module_cc
     absl::core_headers


### PR DESCRIPTION
Roughly trying to mimic Bazel's behavior: https://docs.bazel.build/versions/master/build-ref.html#data. There are some differences that may require some iteration to get right.

I'm planning on using this soon for a Vulkan layer (a .so and .json file will be built/generated, and I want them accessible to `iree-run-mlir` and other binaries).