### PR TITLE
Use IREE_DEFAULT_BACKENDS in GitHub action

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -60,4 +60,4 @@ jobs:
           # tagged "manual". The "manual" tag allows targets to be excluded from
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "noga".
-          bazel query '//... except attr("tags", "noga", //...)' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_TEST_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors --keep_going
+          bazel query '//... except attr("tags", "noga", //...)' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_DEFAULT_BACKENDS="tf,iree_interpreter" --define=iree_tensorflow=true --test_output=errors --keep_going


### PR DESCRIPTION
Introduced in https://github.com/google/iree/commit/3cdfc638b5be92b5168c1cd93835a7593b4ce53a. This sets the default backends for tests that run on "all" backends. 

https://github.com/google/iree/commit/aed15812a515837f4aa76fa631a9d34f8751d95a made the env variable currently being used override the specification of the test which meant some tests started trying to run on unsupported platforms.