### PR TITLE
Add OrOp to IndexComputation and SPIR-V Lowering passes

### DIFF
--- a/iree/compiler/Translation/SPIRV/IndexComputation/IndexComputationPass.cpp
+++ b/iree/compiler/Translation/SPIRV/IndexComputation/IndexComputationPass.cpp
@@ -87,6 +87,7 @@ void IndexComputationPass::runOnFunction() {
       NoBroadcastPwOpIndexPropagation<xla_hlo::MaxOp>,
       NoBroadcastPwOpIndexPropagation<xla_hlo::MinOp>,
       NoBroadcastPwOpIndexPropagation<xla_hlo::MulOp>,
+      NoBroadcastPwOpIndexPropagation<xla_hlo::OrOp>,
       NoBroadcastPwOpIndexPropagation<xla_hlo::SubOp>,
       // XLA other ops:
       // TODO(ravishankarm): conv, dot.

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/IREEToSPIRVPass.cpp
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/IREEToSPIRVPass.cpp
@@ -136,6 +136,7 @@ static LogicalResult generateEntryFunction(spirv::ModuleOp spvModule,
       SPIRVPwOpLowering<xla_hlo::MaxOp, spirv::GLSLSMaxOp, spirv::GLSLFMaxOp>,
       SPIRVPwOpLowering<xla_hlo::MinOp, spirv::GLSLSMinOp, spirv::GLSLFMinOp>,
       SPIRVPwOpLowering<xla_hlo::MulOp, spirv::IMulOp, spirv::FMulOp>,
+      SPIRVPwOpLowering<xla_hlo::OrOp, spirv::LogicalOrOp>,
       SPIRVPwOpLowering<xla_hlo::SubOp, spirv::ISubOp, spirv::FSubOp>,
       // XLA other ops:
       CmpIOpSPIRVLowering, CmpFOpSPIRVLowering,

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/logical_ops.mlir
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/logical_ops.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-opt -split-input-file -iree-index-computation -simplify-spirv-affine-exprs=false -convert-iree-to-spirv -verify-diagnostics -o - %s | IreeFileCheck %s
+
+func @or(%arg0: memref<4xi1>, %arg1: memref<4xi1>, %arg2: memref<4xi1>)
+attributes {iree.executable.export, iree.executable.workgroup_size = dense<[32, 1, 1]> : tensor<3xi32>, iree.ordinal = 0 : i32} {
+  %0 = iree.load_input(%arg0 : memref<4xi1>) : tensor<4xi1>
+  %1 = iree.load_input(%arg1 : memref<4xi1>) : tensor<4xi1>
+  // CHECK: spv.LogicalOr
+  %2 = xla_hlo.or %0, %1 : tensor<4xi1>
+  iree.store_output(%2 : tensor<4xi1>, %arg2 : memref<4xi1>)
+  return
+}


### PR DESCRIPTION
Currently, the conversion from xla_hlo.or or std.or is supposed to
be performed by the XLA HLO -> Standard Pass but it is missing.
So this patch adds the OrOp as a recognized op in the index
computation and SPIR-V lowering passes.

TEST: Tested on toy example in iree-discuss.