### PR TITLE
CMake function to add all subdirectories

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -574,18 +574,9 @@ class Converter(object):
     self.first_error = None
 
   def convert(self, copyright_line):
-    # One `add_subdirectory(name)` per subdirectory.
-    add_subdir_commands = []
-    for root, dirs, _ in os.walk(self.directory_path):
-      for d in sorted(dirs):
-        if os.path.isfile(os.path.join(root, d, "CMakeLists.txt")):
-          add_subdir_commands.append("add_subdirectory(%s)" % (d,))
-      # Stop walk, only add direct subdirectories.
-      break
-
     converted_file = self.template % {
         "copyright_line": copyright_line,
-        "add_subdirectories": "\n".join(add_subdir_commands),
+        "add_subdirectories": "iree_add_all_subdirs()",
         "body": self.body,
     }
 
@@ -626,9 +617,7 @@ def GetDict(obj):
 
 def convert_directory_tree(root_directory_path, write_files, strict):
   print("convert_directory_tree: %s" % (root_directory_path,))
-  # Process directories starting at leaves so we can skip add_directory on
-  # subdirs without a CMakeLists file.
-  for root, _, _ in os.walk(root_directory_path, topdown=False):
+  for root, _, _ in os.walk(root_directory_path):
     convert_directory(root, write_files, strict)
 
 

--- a/build_tools/cmake/iree_add_all_subdirs.cmake
+++ b/build_tools/cmake/iree_add_all_subdirs.cmake
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# iree_add_all_subidrs
+#
+# CMake function to add all subdirectories of the current directory that contain
+# a CMakeLists.txt file
+#
+# Takes no arguments.
+function(iree_add_all_subdirs)
+  FILE(GLOB _CHILDREN RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+  SET(_DIRLIST "")
+  foreach(_CHILD ${_CHILDREN})
+    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_CHILD} AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_CHILD}/CMakeLists.txt)
+      LIST(APPEND _DIRLIST ${_CHILD})
+    endif()
+  endforeach()
+
+  foreach(subdir ${_DIRLIST})
+    add_subdirectory(${subdir})
+  endforeach()
+endfunction()

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     file_handle_win32

--- a/iree/compiler/CMakeLists.txt
+++ b/iree/compiler/CMakeLists.txt
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Dialect)
-add_subdirectory(Translation)
-add_subdirectory(Utils)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/CMakeLists.txt
+++ b/iree/compiler/Dialect/CMakeLists.txt
@@ -12,11 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Flow)
-add_subdirectory(HAL)
-add_subdirectory(IREE)
-add_subdirectory(Modules)
-add_subdirectory(Shape)
-add_subdirectory(VM)
-add_subdirectory(VMLA)
-add_subdirectory(Vulkan)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Flow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/CMakeLists.txt
@@ -12,8 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Analysis)
-add_subdirectory(Conversion)
-add_subdirectory(IR)
-add_subdirectory(Transforms)
-add_subdirectory(Utils)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(HLOToFlow)
-add_subdirectory(StandardToFlow)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Utils

--- a/iree/compiler/Dialect/HAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/CMakeLists.txt
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Conversion)
-add_subdirectory(IR)
-add_subdirectory(Target)
-add_subdirectory(Transforms)
-add_subdirectory(Utils)
+iree_add_all_subdirs()
 
 iree_cc_embed_data(
   NAME

--- a/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(FlowToHAL)
-add_subdirectory(HALToVM)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CMakeLists.txt
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(LLVM)
-add_subdirectory(LegacyInterpreter)
-add_subdirectory(VMLA)
-add_subdirectory(VulkanSPIRV)
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LegacyInterpreter/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     LegacyInterpreter

--- a/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     VulkanSPIRV

--- a/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Utils/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Utils

--- a/iree/compiler/Dialect/IREE/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/CMakeLists.txt
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Conversion)
-add_subdirectory(IR)
-add_subdirectory(Transforms)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     PreserveCompilerHints

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/IREE/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Modules/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/CMakeLists.txt
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Strings)
-add_subdirectory(TensorList)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Conversion)
-add_subdirectory(IR)
+iree_add_all_subdirs()
 
 iree_cc_embed_data(
   NAME

--- a/iree/compiler/Dialect/Modules/Strings/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/Conversion/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Conversion

--- a/iree/compiler/Dialect/Modules/Strings/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/Modules/Strings/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Strings/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Conversion)
-add_subdirectory(IR)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_embed_data(

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/Modules/TensorList/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Shape/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/CMakeLists.txt
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(IR)
-add_subdirectory(Plugins)
-add_subdirectory(Transforms)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Shape/Plugins/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Plugins/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(XLA)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Analysis/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Analysis/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/CMakeLists.txt
@@ -12,9 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Analysis)
-add_subdirectory(Conversion)
-add_subdirectory(IR)
-add_subdirectory(Target)
-add_subdirectory(Tools)
-add_subdirectory(Transforms)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(StandardToVM)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VM/Target/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Bytecode)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/VM/Tools/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Tools/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Tools

--- a/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/CMakeLists.txt
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Conversion)
-add_subdirectory(IR)
-add_subdirectory(Transforms)
+iree_add_all_subdirs()
 
 iree_cc_embed_data(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/CMakeLists.txt
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(HALToVMLA)
-add_subdirectory(HLOToVMLA)
-add_subdirectory(StandardToVMLA)
-add_subdirectory(VMLAToVM)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/VMLA/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/VMLA/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/VMLA/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Vulkan/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/CMakeLists.txt
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(IR)
-add_subdirectory(Utils)
+iree_add_all_subdirs()

--- a/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Dialect/Vulkan/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Dialect/Vulkan/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/Utils/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Dialect/Vulkan/Utils/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/Utils/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(CodegenUtils)
-add_subdirectory(Interpreter)
-add_subdirectory(SPIRV)
-add_subdirectory(XLAToLinalg)
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/CodegenUtils/CMakeLists.txt
+++ b/iree/compiler/Translation/CodegenUtils/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     CodegenUtils

--- a/iree/compiler/Translation/Interpreter/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/CMakeLists.txt
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(IR)
-add_subdirectory(Serialization)
-add_subdirectory(Transforms)
-add_subdirectory(Utils)
+iree_add_all_subdirs()

--- a/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/IR/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Serialization/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Serialization

--- a/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(xla)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(

--- a/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Transforms/test/xla/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
+++ b/iree/compiler/Translation/Interpreter/Utils/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Utils

--- a/iree/compiler/Translation/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/CMakeLists.txt
@@ -12,8 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(XLAToSPIRV)
+iree_add_all_subdirs()

--- a/iree/compiler/Translation/SPIRV/EmbeddedKernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/EmbeddedKernels/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Kernels)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/SPIRV/EmbeddedKernels/Kernels/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/EmbeddedKernels/Kernels/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_spirv_kernel_cc_library(
   NAME
     Kernels

--- a/iree/compiler/Translation/SPIRV/IndexComputation/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/IndexComputation/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_tablegen_library(
   NAME

--- a/iree/compiler/Translation/SPIRV/IndexComputation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/IndexComputation/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/LinalgToSPIRV/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     LinalgToSPIRV

--- a/iree/compiler/Translation/SPIRV/Passes/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/Passes/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Passes

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Translation/SPIRV/XLAToSPIRV/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Translation/XLAToLinalg/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Translation/test/CMakeLists.txt
+++ b/iree/compiler/Translation/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/compiler/Utils/CMakeLists.txt
+++ b/iree/compiler/Utils/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     Utils

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(cts)
-add_subdirectory(host)
-add_subdirectory(interpreter)
-add_subdirectory(llvmjit)
-add_subdirectory(testing)
-add_subdirectory(vmla)
-add_subdirectory(vulkan)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/hal/cts/CMakeLists.txt
+++ b/iree/hal/cts/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     cts_test_base

--- a/iree/hal/host/CMakeLists.txt
+++ b/iree/hal/host/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     async_command_queue

--- a/iree/hal/interpreter/CMakeLists.txt
+++ b/iree/hal/interpreter/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     bytecode_cache

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     llvmjit_executable

--- a/iree/hal/testing/CMakeLists.txt
+++ b/iree/hal/testing/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     mock_allocator

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     op_kernels

--- a/iree/modules/CMakeLists.txt
+++ b/iree/modules/CMakeLists.txt
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(check)
-add_subdirectory(hal)
-add_subdirectory(strings)
-add_subdirectory(tensorlist)
+iree_add_all_subdirs()

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(dialect)
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 iree_bytecode_module(
   NAME

--- a/iree/modules/check/dialect/test/CMakeLists.txt
+++ b/iree/modules/check/dialect/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/modules/check/test/CMakeLists.txt
+++ b/iree/modules/check/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/modules/hal/CMakeLists.txt
+++ b/iree/modules/hal/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     hal

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     strings_module

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_bytecode_module(
   NAME
     tensorlist_test_module

--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(custom_modules)
-add_subdirectory(simple_embedding)
-add_subdirectory(vulkan)
+iree_add_all_subdirs()

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(dialect)
+iree_add_all_subdirs()
 
 iree_bytecode_module(
   NAME

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(test)
+iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_TD CONFIGURE_DEPENDS *.td)
 iree_cc_library(

--- a/iree/samples/custom_modules/dialect/test/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_bytecode_module(
   NAME
     simple_embedding_test_bytecode_module

--- a/iree/schemas/CMakeLists.txt
+++ b/iree/schemas/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(bytecode)
+iree_add_all_subdirs()
 
 flatbuffer_cc_library(
   NAME

--- a/iree/schemas/bytecode/CMakeLists.txt
+++ b/iree/schemas/bytecode/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     interpreter_bytecode_v0

--- a/iree/testing/CMakeLists.txt
+++ b/iree/testing/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(internal)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME

--- a/iree/testing/internal/CMakeLists.txt
+++ b/iree/testing/internal/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     gtest_internal

--- a/iree/tools/test/CMakeLists.txt
+++ b/iree/tools/test/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 file(GLOB _GLOB_X_MLIR CONFIGURE_DEPENDS *.mlir)
 iree_lit_test_suite(
   NAME

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_add_all_subdirs()
+
 iree_cc_test(
   NAME
     bytecode_dispatch_test


### PR DESCRIPTION
Rather than doing this as part of generating the files with bazel_to_cmake, we can just have each file add all its subdirectories. Only adds directories that have a CMakeLists.txt file (same as the current bazel_to_cmake logic).

Depends on https://github.com/google/iree/pull/1003

This has a few advantages:
1. We don't have to remember to update the CMakeLists file (or rerun bazel_to_cmake) when adding a directory.
2. Any directory's CMakeLists file is dependent only on the corresponding BUILD file (plus the previous version of the CMakeLists for instructions like "DO NOT EDIT" and the correct license year).
3. As a consequence of (2), there is no ordering dependence on the directories processed by bazel_to_cmake, so we can always only run it on directory's with modified BUILD files.
4. This makes it possible to integrate bazel_to_cmake as a hermetic genrule with in bazel (with a few additional tweaks).

It shifts more work onto the cmake side (away from generation), however. To make sure it doesn't increase build times as a result, I tested out the comparative build times on my workstation. There is no substantial difference. Also it still runs the same number of tests (and they all pass).

Configure only:
```shell
$ rm -rf build/ && mkdir build && cd build && time cmake -G Ninja -DCMAKE_BUILD_TYPE=FastBuild -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
```
Before:
```shell
real	0m25.487s
user	0m17.906s
sys	0m7.606s
```
After:
```shell
real	0m25.418s
user	0m17.844s
sys	0m7.599s
```

Clean build:
```shell
$ time ./build_tools/cmake/clean_build.sh
```
Before:
```shell
real	6m36.789s
user	63m54.858s
sys	3m52.994s
```
After:
```shell
real	6m38.352s
user	63m55.938s
sys	3m50.222s
```

Rebuild (no changes):
```shell
$ time ./build_tools/cmake/rebuild.sh
```
Before:
```shell
real	1m36.174s
user	13m7.361s
sys	1m2.658s
```
After:
```shell
real	1m35.235s
user	13m5.488s
sys	1m3.178s
```

Test
```shell
$ time ./build_tools/cmake/test.sh
```
Before:
```shell
100% tests passed, 0 tests failed out of 211

Total Test time (real) =   4.10 sec

real	0m4.140s
user	0m16.732s
sys	0m13.647s
```

After:
```shell
100% tests passed, 0 tests failed out of 211

Total Test time (real) =   4.04 sec

real	0m4.089s
user	0m16.738s
sys	0m13.516s
```