### PR TITLE
CMake rebuild script

### DIFF
--- a/build_tools/cmake/clean_build.sh
+++ b/build_tools/cmake/clean_build.sh
@@ -13,20 +13,14 @@
 # limitations under the License.
 
 # Build the IREE project with CMake. Designed for CI, but can be run manually.
+# This is equivalent to the build_tools/cmake/rebuild.sh script except it
+# first deletes the build directory to deal with any faulty caching.
 
 set -x
 set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
-
-"$CMAKE_BIN" --version
-ninja --version
-
 cd ${ROOT_DIR?}
 rm -rf build/
-mkdir build && cd build
-"$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
-"$CMAKE_BIN" --build .
-
+./build_tools/cmake/rebuild.sh

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the IREE project with CMake. Designed for CI, but can be run manually.
+# This uses previously cached build results and does not clear the build
+# directory. For a clean build, use build_tools/cmake/clean_build.sh
+
+set -x
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+
+"$CMAKE_BIN" --version
+ninja --version
+
+cd ${ROOT_DIR?}
+mkdir -p build && cd build
+"$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
+"$CMAKE_BIN" --build .
+

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -27,7 +27,14 @@ CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
 ninja --version
 
 cd ${ROOT_DIR?}
-mkdir -p build && cd build
+if [ -d "build" ] 
+then
+  echo "Build directory already exists. Will use cached results there." 
+else
+  echo "Build directory does not already exist. Creating a new one."
+  mkdir build
+fi
+cd build
 "$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild -DIREE_BUILD_COMPILER=ON -DIREE_BUILD_TESTS=ON -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_DEBUGGER=OFF ..
 "$CMAKE_BIN" --build .
 

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -14,7 +14,7 @@
 
 # Run all(ish) IREE tests with CTest. Designed for CI, but can be run manually.
 # Assumes that the project has already been built at ${REPO_ROOT}/build (e.g.
-# with build_tools/cmake/build.sh)
+# with build_tools/cmake/clean_build.sh)
 
 set -x
 set -e

--- a/iree/compiler/Dialect/BUILD
+++ b/iree/compiler/Dialect/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/Flow/BUILD
+++ b/iree/compiler/Dialect/Flow/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/IREE/BUILD
+++ b/iree/compiler/Dialect/IREE/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/Modules/BUILD
+++ b/iree/compiler/Dialect/Modules/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/Shape/BUILD
+++ b/iree/compiler/Dialect/Shape/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/Shape/Plugins/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/VM/BUILD
+++ b/iree/compiler/Dialect/VM/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/VM/Target/BUILD
+++ b/iree/compiler/Dialect/VM/Target/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Dialect/Vulkan/BUILD
+++ b/iree/compiler/Dialect/Vulkan/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Translation/Interpreter/BUILD
+++ b/iree/compiler/Translation/Interpreter/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/compiler/Translation/SPIRV/BUILD
+++ b/iree/compiler/Translation/SPIRV/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/modules/BUILD
+++ b/iree/modules/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/iree/samples/BUILD
+++ b/iree/samples/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(EmbeddedKernels)
-add_subdirectory(IndexComputation)
-add_subdirectory(LinalgToSPIRV)
-add_subdirectory(Passes)
-add_subdirectory(ReductionCodegen)
-add_subdirectory(XLAToSPIRV)
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)

--- a/kokoro/gcp_ubuntu/cmake/build.sh
+++ b/kokoro/gcp_ubuntu/cmake/build.sh
@@ -40,7 +40,7 @@ echo "Initializing submodules"
 # so a build failure only prevents building/testing things that depend on it and
 # we can still run the other tests.
 echo "Building with cmake"
-./build_tools/cmake/build.sh
+./build_tools/cmake/clean_build.sh
 
 echo "Testing with ctest"
 ./build_tools/cmake/test.sh


### PR DESCRIPTION
When iterating locally, it's useful to rebuild and rely on CMake's caching rather than doing a full clean build. CMake's caching is a bit sketchy sometimes, so it's also useful to do a full clean build. Split things out so we have a script for each.

Depends on https://github.com/google/iree/pull/1001