### PR TITLE
Add include(iree_add_all_subdirs) to main CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ include(iree_py_library)
 include(iree_py_test)
 include(iree_lit_test)
 include(iree_alwayslink)
+include(iree_add_all_subdirs)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 


### PR DESCRIPTION
Accidentally reverted this line while merging https://github.com/google/iree/pull/1002