### PR TITLE
Include VK_LAYER_KHRONOS_timeline_semaphore with CMake Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/vulkan_extensionlayer EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/renderdoc_api EXCLUDE_FROM_ALL)
+add_subdirectory(build_tools/third_party/vulkan_extensionlayer EXCLUDE_FROM_ALL)
 
 if(${IREE_ENABLE_LLVM})
   # If CMAKE_BUILD_TYPE is FastBuild, set to Debug for llvm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/abseil-cpp EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
+add_subdirectory(third_party/vulkan_extensionlayer EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/renderdoc_api EXCLUDE_FROM_ALL)
 
 if(${IREE_ENABLE_LLVM})

--- a/build_tools/third_party/vulkan_extensionlayer/CMakeLists.txt
+++ b/build_tools/third_party/vulkan_extensionlayer/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_NAME "vk_layer_khronos_timeline_semaphore")
+
+add_custom_target(${_NAME})
+
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+  # Polyfill layer does not build on Windows.
+else()
+  iree_add_data_dependencies(
+    NAME
+      ${_NAME}
+    DATA
+      VkLayer_khronos_timeline_semaphore
+      VkLayer_khronos_timeline_semaphore-json
+  )
+endif()

--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -168,6 +168,7 @@ cc_library(
         "//iree/base:tracing",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@vulkan_headers//:vulkan_headers_no_prototypes",
     ],

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -167,6 +167,7 @@ iree_cc_library(
     "dynamic_symbols.cc"
   COPTS
     "-DVK_NO_PROTOTYPES"
+    "-DIREE_VK_LAYER_PATH_EXTRAS=${CMAKE_BINARY_DIR}/third_party/vulkan_extensionlayer/layers"
   DEPS
     absl::core_headers
     absl::memory
@@ -231,6 +232,25 @@ iree_cc_library(
     Vulkan::Headers
   PUBLIC
 )
+
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+  iree_cc_library(
+    NAME
+      layer_khronos_timeline_semaphore
+    DATA
+      # Polyfill layer does not build on Windows.
+    PUBLIC
+  )
+else()
+  iree_cc_library(
+    NAME
+      layer_khronos_timeline_semaphore
+    DATA
+      VkLayer_khronos_timeline_semaphore
+      VkLayer_khronos_timeline_semaphore-json
+    PUBLIC
+  )
+endif()
 
 iree_cc_library(
   NAME
@@ -490,6 +510,7 @@ iree_cc_library(
     iree::base::tracing
     iree::hal::driver_registry
     iree::hal::vulkan::dynamic_symbols
+    iree::hal::vulkan::layer_khronos_timeline_semaphore
     iree::hal::vulkan::vulkan_driver
   PUBLIC
 )

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
     absl::core_headers
     absl::memory
     absl::span
+    absl::strings
     iree::base::dynamic_library
     iree::base::platform_headers
     iree::base::ref_ptr

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -233,25 +233,6 @@ iree_cc_library(
   PUBLIC
 )
 
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
-  iree_cc_library(
-    NAME
-      layer_khronos_timeline_semaphore
-    DATA
-      # Polyfill layer does not build on Windows.
-    PUBLIC
-  )
-else()
-  iree_cc_library(
-    NAME
-      layer_khronos_timeline_semaphore
-    DATA
-      VkLayer_khronos_timeline_semaphore
-      VkLayer_khronos_timeline_semaphore-json
-    PUBLIC
-  )
-endif()
-
 iree_cc_library(
   NAME
     legacy_fence
@@ -510,7 +491,8 @@ iree_cc_library(
     iree::base::tracing
     iree::hal::driver_registry
     iree::hal::vulkan::dynamic_symbols
-    iree::hal::vulkan::layer_khronos_timeline_semaphore
     iree::hal::vulkan::vulkan_driver
+  DATA
+    vk_layer_khronos_timeline_semaphore
   PUBLIC
 )


### PR DESCRIPTION
Using the Vulkan Loader for now, see [these docs](https://vulkan.lunarg.com/doc/view/1.1.70.1/windows/loader_and_layer_interface.html#user-content-layer-discovery). We're also discussing ways to inject the layer ourselves, outside of the loader. That will reduce binary size and deployment complexity.

Bazel is up next.

Windows isn't yet supported by the layer.