### PR TITLE
Include cstring instead of string

### DIFF
--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -24,8 +24,8 @@
 #include <vulkan/vulkan.h>
 
 #include <array>
+#include <cstring>
 #include <set>
-#include <string>
 #include <vector>
 
 // IREE's C API:


### PR DESCRIPTION
To use `std::strcmp`, it's required to include `<cstring>` instead of `<string>`. Otherwise the vulkan example fails to compile with clang 9:
`iree/samples/vulkan/vulkan_inference_gui.cc:121:11: error: no member named 'strcmp' in namespace 'std'; did you mean simply 'strcmp'?`