### PR TITLE
Add CMake deps on additional MLIR dialects

### DIFF
--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -58,6 +58,13 @@ iree_pybind_cc_library(
     bindings::python::pyiree::common
     LLVMSupport
     MLIRIR
+    # TODO(marbre): The following deps are necessary as we still rely on
+    #  mlir::registerAllDialects(). In the Bazel build these are pulled in
+    #  by the dependency on mlir:AllPassesAndDialectsNoRegistration
+    MLIRNVVMIR # mlir:AllPassesAndDialectsNoRegistration
+    MLIRROCDLIR # mlir:AllPassesAndDialectsNoRegistration
+    MLIRQuantizerFxpMathConfig # mlir:AllPassesAndDialectsNoRegistration
+    MLIRQuantizerSupport # mlir:AllPassesAndDialectsNoRegistration
     MLIRLoopOpsTransforms
     MLIRParser
     MLIRPass


### PR DESCRIPTION
* Unbreaks building the python bindings with CMake
* Allows the ctest `bindings_python_pyiree_compiler_compiler_test` to pass
* The other python tests are still broken, see #905