### PR TITLE
Add note about working RenderDoc versions now that 1.7 is released.

### DIFF
--- a/docs/vulkan_and_spirv.md
+++ b/docs/vulkan_and_spirv.md
@@ -130,3 +130,6 @@ $ bazel build iree/tools:iree-run-mlir && LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$REND
 You can also launch IREE's headless programs through RenderDoc itself, just be
 sure to set the command line arguments appropriately. Saving capture settings in
 RenderDoc can help if you find yourself doing this frequently.
+
+Note: RenderDoc version 1.7 or higher is needed to record captures from IREE's
+headless compute programs.


### PR DESCRIPTION
Previously only nightly builds had the necessary fixes for IREE.

Relates to #52.