### PR TITLE
Fix tensorflow test crashes.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,7 @@ build --copt=-Wno-unused-const-variable
 build --copt=-Wno-extern-c-compat
 # Technically UB but needed for intrusive ptrs
 build --copt=-Wno-invalid-offsetof
+build --copt=-Wno-unused-function
 
 # C++14 standard version is required.
 build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14

--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -84,7 +84,7 @@ py::object PyRawUnpackResults(FunctionAbi* self, VmVariantList& f_args) {
   for (size_t i = 0, e = py_results.size(); i < e; ++i) {
     py_result_tuple[i] = std::move(py_results[i]);
   }
-  return py_result_tuple;
+  return std::move(py_result_tuple);  // Without move, warns of copy.
 }
 
 // RAII wrapper for a Py_buffer which calls PyBuffer_Release when it goes

--- a/docs/getting_started_on_linux.md
+++ b/docs/getting_started_on_linux.md
@@ -132,7 +132,18 @@ replacements as needed):
 
 ```
 build --disk_cache=/REPLACE/WITH/CACHE/DIR
-build:debug --compilation_mode=dbg --copt=-O2 --per_file_copt=iree@-O0 --strip=never
+
+# Use --config=debug to compile iree and llvm without optimizations
+# and with assertions enabled.
+build:debug --config=asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-O0' --strip=never
+
+# Use --config=asserts to enable assertions in iree and llvm.
+build:asserts --compilation_mode=opt '--per_file_copt=iree|llvm@-UNDEBUG'
+
+# Bazel sandboxes the environment... because reasons, so punch through
+# the path to swiftshader if needed (i.e. if your machine does not have
+# a supported GPU/driver).
+test --test_env=VK_ICD_FILENAMES=/path/to/your/vk_swiftshader_icd.json
 ```
 
 ### Build

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -36,6 +36,7 @@ SAVED_MODEL_TF_RUNTIME_DEPS = [
 ]
 
 TF_XLA_PASS_DEPS = [
+    "//integrations/tensorflow/compiler:dialect_registration",
     "//integrations/tensorflow/compiler:tensorflow",
     "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
 ]


### PR DESCRIPTION
* There was a missing dep on :dialect_registration.
* Also updated instructions with more recommendations for user.bazelrc that aid debugging and running with swiftshader.
* Fixed a couple of warnings that I observed (fixed one, disabled one).

Fixes #1000