### PR TITLE
VectorOps was renamed to Vector, update deps

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -101,7 +101,7 @@ iree_cc_library(
     MLIRStandardOps
     MLIRStandardToSPIRVTransforms
     MLIRTransforms
-    MLIRVectorOps
+    MLIRVector
   PUBLIC
 )
 


### PR DESCRIPTION
Required in addition to #1131.