### PR TITLE
Use a custom token for synchronize submodules action

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
       - name: Checking submodule state
@@ -43,5 +45,5 @@ jobs:
         if: env.has_diff == 'true'
         uses: ad-m/github-push-action@v0.5.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           


### PR DESCRIPTION
This allows the action to push to the protected master branch. For some reason (still discussing with GitHub support) we have to use the write access token when checking out the repository, not just when pushing, which is why https://github.com/google/iree/pull/1065 didn't work.

Note that the introduction of this token in GitHub secrets means that anyone with write access can push to the protected master branch, but only in a very convoluted fashion. We still avoid accidental pushes.

Tested:
Tried this out in a test branch (https://github.com/google/iree/tree/gcmn-test-submodule-sync)