### PR TITLE
Add missing include to python bindings

### DIFF
--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -27,6 +27,7 @@
 #include "iree/tools/init_dialects.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"


### PR DESCRIPTION
The CMake build fails with

```
/home/mbrehler/repos/iree/bindings/python/pyiree/compiler/compiler.cc:64:14: error: no type named 'SetOneShotPipeSignalFunction' in namespace 'llvm::sys'
  llvm::sys::SetOneShotPipeSignalFunction(
  ~~~~~~~~~~~^
/home/mbrehler/repos/iree/bindings/python/pyiree/compiler/compiler.cc:65:18: error: definition or redeclaration of 'DefaultOneShotPipeSignalHandler' not allowed inside a function
      llvm::sys::DefaultOneShotPipeSignalHandler);
      ~~~~~~~~~~~^
/home/mbrehler/repos/iree/bindings/python/pyiree/compiler/compiler.cc:65:18: error: no member named 'DefaultOneShotPipeSignalHandler' in namespace 'llvm::sys'
      llvm::sys::DefaultOneShotPipeSignalHandler);
      ~~~~~~~~~~~^
/home/mbrehler/repos/iree/bindings/python/pyiree/compiler/compiler.cc:66:14: error: no member named 'PrintStackTraceOnErrorSignal' in namespace 'llvm::sys'
  llvm::sys::PrintStackTraceOnErrorSignal("pyiree");
```
caused by the missing include.