### PR TITLE
Add GitHub action to automatically update submodules

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,7 +18,8 @@ name: Update Submodules
 
 on:
   schedule:
-     - cron:  '*/15 * * * *'
+     # Every 15 minutes
+     - cron: '*/15 * * * *'
 
 jobs:
   update:
@@ -30,16 +31,13 @@ jobs:
         run: ./scripts/git/submodule_versions.py init
       - name: Updating submodules
         run: ./scripts/git/update_tf_llvm_submodules.py --update_build_files=true
-      - name: Checking whether LLVM submodule has changed
-        run: |
-          echo "::set-env name=has_llvm_diff::false"
-          git diff --cached --exit-code third_party/llvm-project || echo "::set-env name=has_llvm_diff::true"
       - name: Creating Pull Request
-        if: env.has_llvm_diff == 'true'
         uses: peter-evans/create-pull-request@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           commit-message: "Automatically update LLVM & TF submodules"
           title: "Update LLVM & TF submodules"
           body: "Automated submodule bump from .github/workflows/update_submodules.yml"
+          committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
+          reviewers: gmngeoffrey
           branch: "auto_submodule_update"

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,7 +18,7 @@ name: Update Submodules
 
 on:
   schedule:
-     - cron:  '*/5 * * * *'
+     - cron:  '*/15 * * * *'
 
 jobs:
   update:

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -1,0 +1,45 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a PR to update TF & LLVM submodules when TF moves to a new LLVM commit.
+
+name: Update Submodules
+
+on:
+  schedule:
+     - cron:  '*/5 * * * *'
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Initializing submodules
+        run: ./scripts/git/submodule_versions.py init
+      - name: Updating submodules
+        run: ./scripts/git/update_tf_llvm_submodules.py --update_build_files=true
+      - name: Checking whether LLVM submodule has changed
+        run: |
+          echo "::set-env name=has_llvm_diff::false"
+          git diff --cached --exit-code third_party/llvm-project || echo "::set-env name=has_llvm_diff::true"
+      - name: Creating Pull Request
+        if: env.has_llvm_diff == 'true'
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Automatically update LLVM & TF submodules"
+          title: "Update LLVM & TF submodules"
+          body: "Automated submodule bump from .github/workflows/update_submodules.yml"
+          branch: "auto_submodule_update"

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Creating Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
+          # Personal token is required to trigger additional automation (e.g. presubmits).
           token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           commit-message: "Automatically update LLVM & TF submodules"
           title: "Update LLVM & TF submodules"

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,8 +18,8 @@ name: Update Submodules
 
 on:
   schedule:
-     # Every 15 minutes
-     - cron: '*/15 * * * *'
+     # Every weekday at 14:00 UTC (06:00 PST/07:00 PDT)
+     - cron: '0 14 * * 1-5'
 
 jobs:
   update:
@@ -39,5 +39,6 @@ jobs:
           title: "Update LLVM & TF submodules"
           body: "Automated submodule bump from .github/workflows/update_submodules.yml"
           committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
+          # TODO(gcmn): Figure out a way to assign this to someone dynamically.
           reviewers: gmngeoffrey
           branch: "auto_submodule_update"

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -21,7 +21,7 @@ on:
      - cron:  '*/5 * * * *'
 
 jobs:
-  synchronize:
+  update:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository


### PR DESCRIPTION
The action creates a PR that bumps the TF submodule to HEAD and the LLVM submodule to match the commit used by TF.

This automates some of the toil of keeping the submodules up to date. The build cop is still responsible for reviewing and merging these PRs (including checking that the presubmit builds pass).

Note that if we have manually bumped the LLVM submodule hash and TF hasn't this could mean the PR moves the LLVM submodule back in history.

Tested:
Tried this out in my fork. Here is an example PR it creates: https://github.com/GMNGeoffrey/iree/pull/25