### PR TITLE
Add VK_KHR_timeline_semaphore functions to Vulkan symbol table.

### DIFF
--- a/iree/hal/vulkan/dynamic_symbol_tables.h
+++ b/iree/hal/vulkan/dynamic_symbol_tables.h
@@ -360,7 +360,12 @@ namespace vulkan {
   DEV_PFN(OPTIONAL, vkQueueInsertDebugUtilsLabelEXT)                    \
   DEV_PFN(EXCLUDED, vkQueuePresentKHR)                                  \
   DEV_PFN(REQUIRED, vkQueueSubmit)                                      \
-  DEV_PFN(REQUIRED, vkQueueWaitIdle)
+  DEV_PFN(REQUIRED, vkQueueWaitIdle)                                    \
+                                                                        \
+  // Device extension: VK_KHR_timeline_semaphore                        \
+  DEV_PFN(OPTIONAL, vkGetSemaphoreCounterValueKHR)                      \
+  DEV_PFN(OPTIONAL, vkWaitSemaphoresKHR)                                \
+  DEV_PFN(OPTIONAL, vkSignalSemaphoreKHR)
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 #define IREE_VULKAN_DYNAMIC_SYMBOL_TABLE_ANDROID_KHR(INS_PFN, DEV_PFN) \

--- a/iree/hal/vulkan/dynamic_symbol_tables.h
+++ b/iree/hal/vulkan/dynamic_symbol_tables.h
@@ -362,7 +362,7 @@ namespace vulkan {
   DEV_PFN(REQUIRED, vkQueueSubmit)                                      \
   DEV_PFN(REQUIRED, vkQueueWaitIdle)                                    \
                                                                         \
-  // Device extension: VK_KHR_timeline_semaphore                        \
+  /* Device extension: VK_KHR_timeline_semaphore */                     \
   DEV_PFN(OPTIONAL, vkGetSemaphoreCounterValueKHR)                      \
   DEV_PFN(OPTIONAL, vkWaitSemaphoresKHR)                                \
   DEV_PFN(OPTIONAL, vkSignalSemaphoreKHR)


### PR DESCRIPTION
Optional for now, then we can set to required once `VK_LAYER_KHRONOS_timeline_semaphore` is hooked up in all environments.