### PR TITLE
Don't run submodule update workflow on forks

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,11 +18,13 @@ name: Update Submodules
 
 on:
   schedule:
-     # Every weekday at 14:00 UTC (06:00 PST/07:00 PDT)
-     - cron: '0 14 * * 1-5'
+     # Every five minutes
+     - cron: '*/5 * * * *'
 
 jobs:
   update:
+    # Don't run this in everyone's forks.
+    if: github.repository == 'gmngeoffrey/iree'
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,8 +18,8 @@ name: Update Submodules
 
 on:
   schedule:
-     # Every five minutes
-     - cron: '*/5 * * * *'
+     # Every weekday at 14:00 UTC (06:00 PST/07:00 PDT)
+     - cron: '0 14 * * 1-5'
 
 jobs:
   update:

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   update:
     # Don't run this in everyone's forks.
-    if: github.repository == 'gmngeoffrey/iree'
+    if: github.repository == 'google/iree'
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository


### PR DESCRIPTION
This would be really annoying and is totally unnecessary. I don't want a PR every day from everyone's fork :-D

Tested:
Tried this out in my fork, both filtering to my fork repository (https://github.com/GMNGeoffrey/iree/runs/522552789) and filtering to the main repository (https://github.com/GMNGeoffrey/iree/actions/runs/59835678)