### PR TITLE
Add wrapper around main() for use in Windows GUI applications.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -307,6 +307,20 @@ cc_library(
 )
 
 cc_library(
+    name = "main",
+    srcs = [
+        "main_posix.cc",
+        "main_win32.cc",
+    ],
+    hdrs = ["main.h"],
+    deps = [
+        ":logging",
+        ":platform_headers",
+        ":target_platform",
+    ],
+)
+
+cc_library(
     name = "math",
     hdrs = ["math.h"],
     deps = [

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -360,6 +360,20 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    main
+  SRCS
+    "main_posix.cc"
+    "main_win32.cc"
+  HDRS
+    "main.h"
+  DEPS
+    iree::base::logging
+    iree::base::platform_headers
+    iree::base::target_platform
+)
+
+iree_cc_library(
+  NAME
     math
   HDRS
     "math.h"

--- a/iree/base/main.h
+++ b/iree/base/main.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BASE_MAIN_H_
+#define IREE_BASE_MAIN_H_
+
+namespace iree {
+
+int IreeMain(int argc, char** argv);
+
+}  // namespace iree
+
+#endif  // IREE_BASE_MAIN_H_

--- a/iree/base/main_posix.cc
+++ b/iree/base/main_posix.cc
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/main.h"
+#include "iree/base/platform_headers.h"
+
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_APPLE) || \
+    defined(IREE_PLATFORM_LINUX)
+
+namespace iree {
+namespace {
+
+extern "C" int main(int argc, char** argv) { return IreeMain(argc, argv); }
+
+}  // namespace
+}  // namespace iree
+
+#endif  // IREE_PLATFORM_*

--- a/iree/base/main_win32.cc
+++ b/iree/base/main_win32.cc
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "iree/base/logging.h"
+#include "iree/base/main.h"
+#include "iree/base/platform_headers.h"
+#include "iree/base/target_platform.h"
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+#include <combaseapi.h>
+#include <shellapi.h>
+
+namespace iree {
+namespace {
+
+// Entry point when using /SUBSYSTEM:CONSOLE is the standard main().
+extern "C" int main(int argc, char** argv) { return IreeMain(argc, argv); }
+
+// Entry point when using /SUBSYSTEM:WINDOWS.
+extern "C" int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
+  // Convert command line to an argv-like format.
+  // NOTE: the command line that comes in with the WinMain arg is garbage.
+  int argc = 0;
+  wchar_t** argv_w = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+  if (!argc || !argv_w) {
+    LOG(FATAL) << "Unable to parse command line";
+    return 1;
+  }
+
+  // Convert all args to narrow char strings.
+  std::vector<std::string> allocated_strings(argc);
+  std::vector<char*> argv_a(argc);
+  for (int i = 0; i < argc; ++i) {
+    size_t char_length = wcslen(argv_w[i]);
+    allocated_strings[i].resize(char_length);
+    argv_a[i] = const_cast<char*>(allocated_strings[i].data());
+    std::wcstombs(argv_a[i], argv_w[i], char_length + 1);
+  }
+  ::LocalFree(argv_w);
+
+  // Setup COM on the main thread.
+  // NOTE: this may fail if COM has already been initialized - that's OK.
+  ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+  // Run standard main function.
+  int exit_code = IreeMain(argc, argv_a.data());
+
+  // Release arg memory.
+  argv_a.clear();
+  allocated_strings.clear();
+
+  return exit_code;
+}
+
+}  // namespace
+}  // namespace iree
+
+#endif  // IREE_PLATFORM_WINDOWS

--- a/iree/samples/vulkan/BUILD
+++ b/iree/samples/vulkan/BUILD
@@ -56,7 +56,10 @@ cc_binary(
         "@vulkan_headers//:vulkan_headers_no_prototypes",
         "@vulkan_sdk//:sdk",
     ],
-    linkopts = [
-        "-SUBSYSTEM:WINDOWS",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [
+            "-SUBSYSTEM:WINDOWS",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/iree/samples/vulkan/BUILD
+++ b/iree/samples/vulkan/BUILD
@@ -43,6 +43,7 @@ cc_binary(
         ":simple_mul_bytecode_module_cc",
         "//iree/base:api",
         "//iree/base:logging",
+        "//iree/base:main",
         "//iree/hal:api",
         "//iree/hal/vulkan:api",
         "//iree/modules/hal",
@@ -54,5 +55,8 @@ cc_binary(
         "@sdl2//:SDL2",
         "@vulkan_headers//:vulkan_headers_no_prototypes",
         "@vulkan_sdk//:sdk",
+    ],
+    linkopts = [
+        "-SUBSYSTEM:WINDOWS",
     ],
 )

--- a/iree/samples/vulkan/CMakeLists.txt
+++ b/iree/samples/vulkan/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_binary(
       dear_imgui::impl_vulkan
       iree::base::api
       iree::base::logging
+      iree::base::main
       iree::hal::api
       iree::hal::vulkan::api
       iree::modules::hal
@@ -53,4 +54,6 @@ iree_cc_binary(
       iree::vm::bytecode_module
       SDL2-static
       Vulkan::Vulkan
+    LINKOPTS
+      "-SUBSYSTEM:WINDOWS"
 )

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -40,6 +40,7 @@
 #include "absl/base/macros.h"
 #include "absl/types/span.h"
 #include "iree/base/logging.h"
+#include "iree/base/main.h"
 
 // NOTE: order matters here, imgui must come first:
 #include "third_party/dear_imgui/imgui.h"
@@ -429,7 +430,7 @@ static void FramePresent(ImGui_ImplVulkanH_Window* wd) {
       wd->ImageCount;  // Now we can use the next set of semaphores
 }
 
-extern "C" int main(int argc, char** argv) {
+int iree::IreeMain(int argc, char** argv) {
   // --------------------------------------------------------------------------
   // Create a window.
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {


### PR DESCRIPTION
With this, I can build the `all` target through CMake on Windows.

---

Currently only using the wrapper in `vulkan_inference_gui`, where it matters.

Each binary that needs a window should include `-SUBSYSTEM:WINDOWS` in `linkopts` and use `iree::IreeMain()`. The `iree::base::main` library will handle routing to the appropriate function.

We also discussed linking in a single .cc file with similar handling as part of the `iree_cc_binary` CMake function so source files could use the standard `main()` format without adjustment, but I had some difficulties setting that up.