### PR TITLE
Use build/test_tag_filters in bazel build

### DIFF
--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -36,11 +36,6 @@ fi
 BUILD_TAG_FILTERS="${BUILD_TAG_FILTERS:-${default_build_tag_filters[@]?}}"
 TEST_TAG_FILTERS="${TEST_TAG_FILTERS:-${default_test_tag_filters[@]?}}"
 
-echo "Running with "
-echo "  test env args: ${test_env_args[@]?}"
-echo "  build_tag_filters: ${BUILD_TAG_FILTERS[@]?}"
-echo "  test_tag_filters: ${TEST_TAG_FILTERS[@]?}"
-
 # Build and test everything in supported directories not explicitly marked as
 # excluded from CI (using the tag "nokokoro").
 # Note that somewhat contrary to its name `bazel test` will also build

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -45,8 +45,8 @@ if ! [[ -v TEST_TAG_FILTERS ]]; then
   TEST_TAG_FILTERS="$(IFS="," ; echo "${default_test_tag_filters[*]?}")"
 fi
 
-# Build and test everything in supported directories not explicitly marked as
-# excluded from CI (using the tag "nokokoro").
+# Build and test everything in supported directories not excluded by the tag
+# filters.
 # Note that somewhat contrary to its name `bazel test` will also build
 # any non-test targets specified.
 # We use `bazel query //...` piped to `bazel test` rather than the simpler

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -33,8 +33,11 @@ declare -a default_test_tag_filters=("-nokokoro")
 if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
   default_test_tag_filters+=("-driver=vulkan")
 fi
-BUILD_TAG_FILTERS="${BUILD_TAG_FILTERS:-${default_build_tag_filters[@]?}}"
-TEST_TAG_FILTERS="${TEST_TAG_FILTERS:-${default_test_tag_filters[@]?}}"
+BUILD_TAG_FILTERS=("${BUILD_TAG_FILTERS:-${default_build_tag_filters[@]?}}")
+TEST_TAG_FILTERS=("${TEST_TAG_FILTERS:-${default_test_tag_filters[@]?}}")
+
+BUILD_TAG_FILTER_STRING="$(IFS="," ; echo "${BUILD_TAG_FILTERS[*]?}")"
+TEST_TAG_FILTER_STRING="$(IFS="," ; echo "${TEST_TAG_FILTERS[*]?}")"
 
 # Build and test everything in supported directories not explicitly marked as
 # excluded from CI (using the tag "nokokoro").
@@ -46,8 +49,8 @@ TEST_TAG_FILTERS="${TEST_TAG_FILTERS:-${default_test_tag_filters[@]?}}"
 # want them built by CI unless they are excluded with "nokokoro".
 bazel query "//iree/... + //bindings/..." | \
   xargs bazel test ${test_env_args[@]} \
-    --build_tag_filters="$BUILD_TAG_FILTERS" \
-    --test_tag_filters="$TEST_TAG_FILTERS" \
+    --build_tag_filters="${BUILD_TAG_FILTER_STRING?}" \
+    --test_tag_filters="${TEST_TAG_FILTER_STRING?}" \
     --keep_going \
     --test_output=errors \
     --config=rs

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -15,9 +15,17 @@
 # limitations under the License.
 
 # Build the IREE project with bazel. Designed for CI, but can be run manually.
+# Looks at environment variables and uses CI-friendly defaults if they are not set.
+# IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
+# BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.
+#   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--build_tag_filters)
+#   Default: "-nokokoro"
+# TEST_TAG_FILTERS: Passed to bazel to filter targets to test. Note that test
+#   targets excluded this way will also not be built.
+#   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--test_tag_filters)
+#   Default: If IREE_VULKAN_DISABLE=1, "-nokokoro,-driver=vulkan". Else "-nokokoro".
 
 set -e
-
 set -x
 
 # Use user-environment variables if set, otherwise use CI-friendly defaults.


### PR DESCRIPTION
Makes the test exclusions configurable. This is a little cleaner than the "nokokoro" tag attr query. We still have to use the bazel query to get the manual tests. This also allows tagging targets as requiring vulkan without an env variable, which I'm using in the check framework (it's not running in a shell).

Tested:
`./build_tools/bazel/build.sh` doesn't run vulkan tests (https://source.cloud.google.com/results/invocations/c46195d2-35eb-4bad-a0e7-f9d79cc8ee76)
`IREE_VULKAN_DISABLE=0 ./build_tools/bazel/build.sh` runs vulkan tests, some of which, incidentally, fail on my machine (https://source.cloud.google.com/results/invocations/70707baa-7168-4eec-bddd-b13012ad386f)
`IREE_VULKAN_DISABLE=1 ./build_tools/bazel/build.sh` doesn't run vulkan tests (https://source.cloud.google.com/results/invocations/37316314-1771-415c-a85b-13172bbcede7)
`IREE_VULKAN_DISABLE="" ./build_tools/bazel/build.sh` runs vulkan tests (https://source.cloud.google.com/results/invocations/539be494-4c0c-4067-a5a1-7798f699c10f)
None of them run or build things marked "nokokoro"
`TEST_TAG_FILTERS=foobar BUILD_TAG_FILTERS=foobar ./build_tools/bazel/build.sh` runs no tests (https://source.cloud.google.com/results/invocations/e2ce6bf7-d60f-42bb-8510-2086ac474241)
`TEST_TAG_FILTERS="foo,bar" BUILD_TAG_FILTERS="foo,baz" ./build_tools/bazel/build.sh` runs no tests and carries over the filters (https://source.cloud.google.com/results/invocations/63aec1dd-791b-4071-8821-b370a9f4d4e2)
`BUILD_TAG_FILTERS="" ./build_tools/bazel/build.sh` builds nokokoro targets (https://source.cloud.google.com/results/invocations/3a203ffa-cf51-4bc0-a2d7-0fcd2fa8da61)
`TEST_TAG_FILTERS="" ./build_tools/bazel/build.sh` runs vulkan tests (https://source.cloud.google.com/results/invocations/6f376ac4-b35a-4c13-9cbc-ea43dbc054f8/targets)
