### PR TITLE
Build vulkan_extensionlayer with Bazel.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,6 +171,12 @@ maybe(new_local_repository,
 )
 
 maybe(new_local_repository,
+    name = "vulkan_extensionlayer",
+    path = "third_party/vulkan_extensionlayer",
+    build_file = "build_tools/third_party/vulkan_extensionlayer/BUILD.overlay",
+)
+
+maybe(new_local_repository,
     name = "vulkan_memory_allocator",
     path = "third_party/vulkan_memory_allocator",
     build_file = "build_tools/third_party/vulkan_memory_allocator/BUILD.overlay",

--- a/build_tools/bazel/template_rule.bzl
+++ b/build_tools/bazel/template_rule.bzl
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Rule for simple expansion of template files. This performs a simple
+# search over the template file for the keys in substitutions,
+# and replaces them with the corresponding values.
+#
+# Typical usage:
+#   load("//build_tools/bazel:template_rule.bzl", "template_rule")
+#   template_rule(
+#       name = "ExpandMyTemplate",
+#       src = "my.template",
+#       out = "my.txt",
+#       substitutions = {
+#         "$VAR1": "foo",
+#         "$VAR2": "bar",
+#       }
+#   )
+#
+# Args:
+#   name: The name of the rule.
+#   template: The template file to expand
+#   out: The destination of the expanded file
+#   substitutions: A dictionary mapping strings to their substitutions
+
+def template_rule_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.src,
+        output = ctx.outputs.out,
+        substitutions = ctx.attr.substitutions,
+    )
+
+template_rule = rule(
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "substitutions": attr.string_dict(mandatory = True),
+        "out": attr.output(mandatory = True),
+    },
+    # output_to_genfiles is required for header files.
+    output_to_genfiles = True,
+    implementation = template_rule_impl,
+)

--- a/build_tools/third_party/vulkan_extensionlayer/BUILD.overlay
+++ b/build_tools/third_party/vulkan_extensionlayer/BUILD.overlay
@@ -1,0 +1,91 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@iree_core//build_tools/bazel:template_rule.bzl", "template_rule")
+
+package(default_visibility = ["//visibility:public"])
+
+COMMON_COPTS = [
+    "-fno-builtin-memcmp",
+    "-fno-strict-aliasing",
+    "-fvisibility=hidden",
+    "-Wall",
+    "-Wextra",
+    "-Wno-implicit-fallthrough",
+    "-Wno-missing-field-initializers",
+    "-Wno-nonnull",
+    "-Wno-sign-compare",
+    "-Wno-string-conversion",
+    "-Wno-unused-const-variable",
+    "-Wno-unused-function",
+    "-Wno-unused-parameter",
+    "-Wno-unused-private-field",
+    "-Wpointer-arith",
+]
+
+COPTS = COMMON_COPTS + [
+    "-std=c++11",
+    "-fno-rtti",
+]
+
+C_COPTS = COMMON_COPTS + [
+    "-std=c99",
+    # Require a recent enough POSIX source to get # pthead_condattr_setclock.
+    "-D_POSIX_C_SOURCE=200112",
+]
+
+LINKOPTS = [
+    "-Wl,-Bsymbolic,--exclude-libs,ALL",
+    # We ignore the -Wl,--version-script=... option from upstream
+]
+
+cc_library(
+    name = "hash_table",
+    srcs = [
+        "layers/hash_table.cpp",
+        "layers/hash_table.h",
+    ],
+    copts = COPTS,
+)
+
+cc_binary(
+    name = "libVkLayer_khronos_timeline_semaphore.so",
+    srcs = [
+        "layers/hash_table.h",
+        "layers/list.h",
+        "layers/timeline_semaphore.c",
+        "layers/vk_alloc.h",
+        "layers/vk_util.h",
+    ],
+    copts = C_COPTS,
+    linkopts = LINKOPTS,
+    linkshared = 1,
+    deps = [
+        ":hash_table",
+        "@iree_vulkan_headers//:vulkan_headers",
+    ],
+)
+
+# TODO(scotttodd): Fetch VK_VERSION dynamically
+#   CMake: `VK_VERSION=1.1.${vk_header_version}`
+#          (regex match on vulkan_core.h from VulkanHeaders)
+template_rule(
+    name = "VkLayer_khronos_timeline_semaphore_json",
+    src = "layers/json/VkLayer_khronos_timeline_semaphore.json.in",
+    out = "VkLayer_khronos_timeline_semaphore.json",
+    substitutions = {
+        "@RELATIVE_LAYER_BINARY@": "./libVkLayer_khronos_timeline_semaphore.so",
+        "@VK_VERSION@": "1.1.133",
+    }
+)


### PR DESCRIPTION
Lifted template_rule from TF, BUILD setup from (Google) upstream.

Might adapt this to instead link the code in directly, but this at least offers a comparison point with the current CMake build.