### PR TITLE
Fixing LLVMJIT issues with incorrect use of llvm::Expected.

### DIFF
--- a/iree/hal/llvmjit/llvmjit_command_processor.cc
+++ b/iree/hal/llvmjit/llvmjit_command_processor.cc
@@ -45,7 +45,7 @@ Status LLVMJITCommandProcessor::Dispatch(
   auto* executable =
       static_cast<LLVMJITExecutable*>(dispatch_request.executable);
 
-  std::vector<UnrankedMemRefType<uint32_t>*> descriptors(
+  llvm::SmallVector<UnrankedMemRefType<uint32_t>*, 4> descriptors(
       dispatch_request.bindings.size());
   llvm::SmallVector<void*, 4> args(dispatch_request.bindings.size());
   for (size_t i = 0; i < dispatch_request.bindings.size(); ++i) {
@@ -65,6 +65,7 @@ Status LLVMJITCommandProcessor::Dispatch(
 
   return status;
 }
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_command_processor.h
+++ b/iree/hal/llvmjit/llvmjit_command_processor.h
@@ -28,6 +28,7 @@ class LLVMJITCommandProcessor final : public HostLocalCommandProcessor {
 
   Status Dispatch(const DispatchRequest& dispatch_request) override;
 };
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_device.cc
+++ b/iree/hal/llvmjit/llvmjit_device.cc
@@ -116,10 +116,13 @@ LLVMJITDevice::LLVMJITDevice(DeviceInfo device_info,
 
 StatusOr<ref_ptr<LLVMJITDevice>> LLVMJITDevice::CreateLLVMJITDevice(
     DeviceInfo device_info) {
-  auto execution_engine = std::move(llvm::orc::LLJITBuilder().create().get());
-  if (!execution_engine)
-    InternalErrorBuilder(IREE_LOC) << "Can't create LLJIT for llvmjit device";
-  return make_ref<LLVMJITDevice>(device_info, std::move(execution_engine));
+  auto execution_engine = llvm::orc::LLJITBuilder().create();
+  if (!execution_engine) {
+    return InternalErrorBuilder(IREE_LOC)
+           << "Can't create LLJIT for llvmjit device";
+  }
+  return make_ref<LLVMJITDevice>(device_info,
+                                 std::move(execution_engine.get()));
 }
 
 LLVMJITDevice::~LLVMJITDevice() = default;
@@ -179,6 +182,7 @@ Status LLVMJITDevice::WaitIdle(absl::Time deadline) {
   }
   return OkStatus();
 }
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_device.h
+++ b/iree/hal/llvmjit/llvmjit_device.h
@@ -70,6 +70,7 @@ class LLVMJITDevice final : public Device {
   mutable HostLocalAllocator allocator_;
   mutable absl::InlinedVector<std::unique_ptr<CommandQueue>, 1> command_queues_;
 };
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_driver.cc
+++ b/iree/hal/llvmjit/llvmjit_driver.cc
@@ -56,6 +56,7 @@ StatusOr<ref_ptr<Device>> LLVMJITDriver::CreateDevice(
     DriverDeviceID device_id) {
   return LLVMJITDevice::CreateLLVMJITDevice(GetDefaultDeviceInfo());
 }
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_driver.h
+++ b/iree/hal/llvmjit/llvmjit_driver.h
@@ -32,6 +32,7 @@ class LLVMJITDriver final : public Driver {
 
   StatusOr<ref_ptr<Device>> CreateDevice(DriverDeviceID device_id) override;
 };
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_driver_module.cc
+++ b/iree/hal/llvmjit/llvmjit_driver_module.cc
@@ -29,6 +29,7 @@ static StatusOr<ref_ptr<Driver>> CreateLLVMJITDriver() {
   llvm::InitializeNativeTargetAsmPrinter();
   return make_ref<LLVMJITDriver>();
 }
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_executable.cc
+++ b/iree/hal/llvmjit/llvmjit_executable.cc
@@ -33,6 +33,7 @@
 namespace iree {
 namespace hal {
 namespace llvmjit {
+
 // static
 StatusOr<ref_ptr<LLVMJITExecutable>> LLVMJITExecutable::Load(
     hal::Allocator* allocator, ExecutableSpec spec,
@@ -62,8 +63,7 @@ StatusOr<ref_ptr<LLVMJITExecutable>> LLVMJITExecutable::Load(
   auto dylib_serarch_generator =
       llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
           dataLayout.getGlobalPrefix());
-
-  if (!dylib_serarch_generator.get())
+  if (!dylib_serarch_generator)
     return UnavailableErrorBuilder(IREE_LOC)
            << "Can't resolve symbols in current process";
 
@@ -75,7 +75,7 @@ StatusOr<ref_ptr<LLVMJITExecutable>> LLVMJITExecutable::Load(
 
   for (const auto func_name : *entry_points) {
     auto func_symbol = execution_engine->lookup("invoke_" + func_name->str());
-    if (!func_symbol.get()) {
+    if (!func_symbol) {
       return NotFoundErrorBuilder(IREE_LOC)
              << "Can't JIT compile function : " << func_name;
     }
@@ -111,6 +111,7 @@ LLVMJITExecutable::LLVMJITExecutable(hal::Allocator* allocator,
 }
 
 LLVMJITExecutable::~LLVMJITExecutable() = default;
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_executable.h
+++ b/iree/hal/llvmjit/llvmjit_executable.h
@@ -57,6 +57,7 @@ class LLVMJITExecutable final : public Executable {
   ExecutableSpec spec_;
   std::vector<uint8_t> cloned_executable_data_;
 };
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_executable_cache.cc
+++ b/iree/hal/llvmjit/llvmjit_executable_cache.cc
@@ -52,6 +52,7 @@ StatusOr<ref_ptr<Executable>> LLVMJITExecutableCache::PrepareExecutable(
 
   return executable;
 }
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/llvmjit_executable_cache.h
+++ b/iree/hal/llvmjit/llvmjit_executable_cache.h
@@ -39,6 +39,7 @@ class LLVMJITExecutableCache final : public ExecutableCache {
   hal::Allocator* allocator_;
   llvm::orc::LLJIT* execution_engine_;
 };
+
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree

--- a/iree/hal/llvmjit/memref_runtime.h
+++ b/iree/hal/llvmjit/memref_runtime.h
@@ -173,4 +173,5 @@ void freeUnrankedDescriptor(UnrankedMemRefType<T> *desc) {
 }  // namespace llvmjit
 }  // namespace hal
 }  // namespace iree
+
 #endif  // IREE_HAL_LLVMJIT_LLVMJIT_MEMREF_RUNTIME_H_

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -18,18 +18,16 @@ add_subdirectory(test)
 # TODO: skip targets disabled by options.
 iree_select_compiler_opts(IREE_HAL_DRIVER_MODULES
   ALL
+    "iree::hal::llvmjit::llvmjit_driver_module"
     "iree::hal::vmla::vmla_driver_module"
     "iree::hal::vulkan::vulkan_driver_module"
-  CLANG_OR_GCC
-    "iree::hal::llvmjit::llvmjit_driver_module"
 )
 
 iree_select_compiler_opts(IREE_COMPILER_TARGET_BACKENDS
   ALL
+    "iree::compiler::Dialect::HAL::Target::LLVM"
     "iree::compiler::Dialect::HAL::Target::VMLA"
     "iree::compiler::Dialect::HAL::Target::VulkanSPIRV"
-  CLANG_OR_GCC
-    "iree::compiler::Dialect::HAL::Target::LLVM"
 )
 
 iree_cc_binary(


### PR DESCRIPTION
With this, LLVMJIT is usable on Windows/MSVC!