### PR TITLE
Remove sidechannel dispatchability state and use the MLIR analysis cache

### DIFF
--- a/iree/compiler/Dialect/Flow/Analysis/Dispatchability.cpp
+++ b/iree/compiler/Dialect/Flow/Analysis/Dispatchability.cpp
@@ -154,5 +154,10 @@ bool Dispatchability::isDispatchable(FuncOp funcOp) {
   return isDispatchable(funcOp.getName());
 }
 
+bool Dispatchability::isInvalidated(
+    const AnalysisManager::PreservedAnalyses &pa) {
+  return !pa.isPreserved<Dispatchability>();
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Analysis/Dispatchability.cpp
+++ b/iree/compiler/Dialect/Flow/Analysis/Dispatchability.cpp
@@ -156,7 +156,7 @@ bool Dispatchability::isDispatchable(FuncOp funcOp) {
 
 bool Dispatchability::isInvalidated(
     const AnalysisManager::PreservedAnalyses &pa) {
-  return !pa.isPreserved<Dispatchability>();
+  return false;
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Flow/Analysis/Dispatchability.h
+++ b/iree/compiler/Dialect/Flow/Analysis/Dispatchability.h
@@ -17,6 +17,7 @@
 
 #include "mlir/IR/Function.h"
 #include "mlir/IR/Module.h"
+#include "mlir/Pass/AnalysisManager.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -49,6 +50,7 @@ class Dispatchability {
   // Returns true if |funcOp| is dispatchable.
   bool isDispatchable(StringRef funcName);
   bool isDispatchable(FuncOp funcOp);
+  bool isInvalidated(const AnalysisManager::PreservedAnalyses &pa);
 
  private:
   // Returns true if the given function is dispatch compatible.

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchabilityAnalysis.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchabilityAnalysis.cpp
@@ -28,9 +28,6 @@ class DispatchabilityAnalysisPass
     : public OperationPass<DispatchabilityAnalysisPass, ModuleOp> {
  public:
   DispatchabilityAnalysisPass() = default;
-  explicit DispatchabilityAnalysisPass(
-      std::shared_ptr<llvm::StringMap<FuncOp>> dispatchableFuncOps)
-      : dispatchableFuncOps_(std::move(dispatchableFuncOps)) {}
 
   void runOnOperation() override {
     // Force creation (or caching) of dispatchability information.
@@ -48,10 +45,8 @@ class DispatchabilityAnalysisPass
   std::shared_ptr<llvm::StringMap<FuncOp>> dispatchableFuncOps_;
 };
 
-std::unique_ptr<OpPassBase<ModuleOp>> createDispatchabilityAnalysisPass(
-    std::shared_ptr<llvm::StringMap<FuncOp>> dispatchableFuncOps) {
-  return std::make_unique<DispatchabilityAnalysisPass>(
-      std::move(dispatchableFuncOps));
+std::unique_ptr<OpPassBase<ModuleOp>> createDispatchabilityAnalysisPass() {
+  return std::make_unique<DispatchabilityAnalysisPass>();
 }
 
 static PassRegistration<DispatchabilityAnalysisPass> pass(

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -161,10 +161,7 @@ class OutlineDispatchRegionsPass
  public:
   OutlineDispatchRegionsPass() = default;
 
-<<<<<<< HEAD
   void runOnOperation() override {
-=======
-  void runOnModule() override {
     auto dispatchability = getCachedAnalysis<Dispatchability>();
     llvm::StringMap<FuncOp> dispatchableFuncOps;
     if (dispatchability.hasValue()) {
@@ -175,7 +172,6 @@ class OutlineDispatchRegionsPass
       });
     }
 
->>>>>>> Remove sidechannel dispatchability state and use the MLIR analysis cache
     // TODO(benvanik): replace with a pattern rewriter?
     auto funcOps = llvm::to_vector<32>(getOperation().getOps<FuncOp>());
     for (auto funcOp : funcOps) {

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -166,15 +166,14 @@ class OutlineDispatchRegionsPass
 =======
   void runOnModule() override {
     auto dispatchability = getCachedAnalysis<Dispatchability>();
-    if (!dispatchability.hasValue()) {
-      getModule().emitError()
-          << " dispatchability analysis not performed "
-             "on module; run -iree-flow-dispatchability-analysis first";
-      return signalPassFailure();
-    }
     llvm::StringMap<FuncOp> dispatchableFuncOps;
-    dispatchability.getValue().get().walkDispatchableOps(
-        [&](FuncOp funcOp) { dispatchableFuncOps[funcOp.getName()] = funcOp; });
+    if (dispatchability.hasValue()) {
+      // if we do not get dispatchability from cache,
+      // we should keep dispatchableFuncOps empty to be comptaible as before
+      dispatchability.getValue().get().walkDispatchableOps([&](FuncOp funcOp) {
+        dispatchableFuncOps[funcOp.getName()] = funcOp;
+      });
+    }
 
 >>>>>>> Remove sidechannel dispatchability state and use the MLIR analysis cache
     // TODO(benvanik): replace with a pattern rewriter?

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -165,10 +165,10 @@ class OutlineDispatchRegionsPass
   void runOnOperation() override {
 =======
   void runOnModule() override {
-    auto dispatchability = getCachedParentAnalysis<Dispatchability>();
+    auto dispatchability = getCachedAnalysis<Dispatchability>();
     if (!dispatchability.hasValue()) {
       getModule().emitError()
-          << "dispatchability analysis not performed "
+          << " dispatchability analysis not performed "
              "on module; run -iree-flow-dispatchability-analysis first";
       return signalPassFailure();
     }

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -100,10 +100,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // First perform module-level analysis that following passes will use to query
   // per-function dispatchability information. We run this first so that it only
   // needs to run once and will be cached for all of the following passes.
-  // TODO(b/144784188): avoid this and instead rely on AnalysisManager cache.
-  auto dispatchableFuncOps = std::make_shared<llvm::StringMap<FuncOp>>();
-  passManager.addPass(
-      IREE::Flow::createDispatchabilityAnalysisPass(dispatchableFuncOps));
+  passManager.addPass(IREE::Flow::createDispatchabilityAnalysisPass());
 
   // Create all of the dispatch regions, CSE their workloads, and fold.
   passManager.addPass(IREE::Flow::createIdentifyDispatchRegionsPass());
@@ -117,8 +114,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
 
   // Outline the dispatch regions into their own functions. This separates the
   // sequencer functions performing dispatches from the dispatchees.
-  passManager.addPass(
-      IREE::Flow::createOutlineDispatchRegionsPass(dispatchableFuncOps));
+  passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
 
   // Cleanup identity ops that clutter up the IR and canonicalize.
   passManager.addNestedPass<FuncOp>(createCanonicalizerPass());

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -93,8 +93,7 @@ std::unique_ptr<OpPassBase<FuncOp>> createMergeExportedReflection();
 // Analyzes a module to identify which functions are dispatchable.
 // This information is cached on the module and is used by other FuncOp-scoped
 // passes to quickly access the module-level dispatchability information.
-std::unique_ptr<OpPassBase<ModuleOp>> createDispatchabilityAnalysisPass(
-    std::shared_ptr<llvm::StringMap<FuncOp>> dispatchableFuncOps);
+std::unique_ptr<OpPassBase<ModuleOp>> createDispatchabilityAnalysisPass();
 
 // Identifies dispatchable regions of functions and wraps them in
 // flow.dispatch_regions.
@@ -107,8 +106,7 @@ std::unique_ptr<OpPassBase<FuncOp>> createFoldCompatibleDispatchRegionsPass();
 std::unique_ptr<OpPassBase<FuncOp>> createRematerializeDispatchConstantsPass();
 
 // Outlines dispatch regions into executables.
-std::unique_ptr<OpPassBase<ModuleOp>> createOutlineDispatchRegionsPass(
-    std::shared_ptr<llvm::StringMap<FuncOp>> dispatchableFuncOps);
+std::unique_ptr<OpPassBase<ModuleOp>> createOutlineDispatchRegionsPass();
 
 //===----------------------------------------------------------------------===//
 // Optimizations


### PR DESCRIPTION
fix #1233
by adding isInvalidate to Dispatchability , we remove the  nasty hack by expose dispatchableFuncOps between different passes
