### PR TITLE
Exclude vulkan driver check tests from Bazel CI

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Building and testing with bazel
         run: |
           # Build and test everything not explicitly marked as excluded from CI
-          # (using the tag "noga"="No GitHub Actions").
+          # (using the tag "noga"="No GitHub Actions") or which uses vulkan at
+          # runtime.
           # Note that somewhat contrary to its name `bazel test` will also build
           # any non-test targets specified.
           # We use `bazel query //...` piped to `bazel test` rather than the
@@ -60,4 +61,4 @@ jobs:
           # tagged "manual". The "manual" tag allows targets to be excluded from
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "noga".
-          bazel query '//... except attr("tags", "noga", //...)' | xargs bazel test --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_DEFAULT_BACKENDS="tf,iree_vmla" --define=iree_tensorflow=true --test_output=errors --keep_going
+          bazel query '//...' | xargs bazel test --build_tag_filters="-noga" --test_tag_filters="-noga,-driver=vulkan" --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_DEFAULT_BACKENDS="tf,iree_vmla" --define=iree_tensorflow=true --test_output=errors --keep_going


### PR DESCRIPTION
Switches to use a build/test tag filter approach similar to the Kokoro CI (https://github.com/google/iree/commit/2dd77cca30c7c0af60b2895b3d8de4f7f00b776a). I'd like to factor this all out into a script with better documentation and such, but just trying to unbreak the CI right now.

Tested: No