### PR TITLE
CMake target MLIRQuantOps renamed to MLIRQuant upstream

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -92,7 +92,7 @@ iree_cc_library(
     MLIRLoopOps
     MLIRLoopOpsTransforms
     MLIRLoopsToGPU
-    MLIRQuantOps
+    MLIRQuant
     MLIRQuantizerTransforms
     MLIRSDBM
     MLIRSPIRV


### PR DESCRIPTION
The CMake tarhet MLIRQuantOps was renamed to MLIRQuant with commit https://github.com/llvm/llvm-project/commit/6946ca4b4cb11086423cc9c8834050236923e5c6.