### PR TITLE
Enable RBE again

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,12 +52,12 @@ http_archive(
         "https://github.com/bazelbuild/bazel-toolchains/releases/download/2.1.0/bazel-toolchains-2.1.0.tar.gz",
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/2.1.0.tar.gz",
     ],
+    # Workaround for b/150158570. This patch needs to be updated if the bazel_toolchains version is updated.
+    patches = ["//build_tools/bazel:bazel_toolchains.patch"],
 )
 
-# Disable RBE until compatibility issues with the experimental_repo_remote_exec
-# flag are fixed.
-# load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-# rbe_autoconfig(name = "rbe_default")
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+rbe_autoconfig(name = "rbe_default")
 
 ###############################################################################
 

--- a/build_tools/bazel/BUILD
+++ b/build_tools/bazel/BUILD
@@ -16,3 +16,5 @@ package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
 )
+
+exports_files(["bazel_toolchains.patch"])

--- a/build_tools/bazel/bazel_toolchains.patch
+++ b/build_tools/bazel/bazel_toolchains.patch
@@ -1,0 +1,49 @@
+diff --git rules/rbe_repo.bzl rules/rbe_repo.bzl
+index afdf06e..68d7b3e 100644
+--- rules/rbe_repo.bzl
++++ rules/rbe_repo.bzl
+@@ -564,7 +564,7 @@ def _rbe_autoconfig_impl(ctx):
+             ctx.report_progress("creating export platform")
+             create_export_platform(
+                 ctx,
+-                exec_properties = ctx.attr.exec_properties,
++                exec_properties = ctx.attr.exec_properties1,
+                 image_name = resolve_rbe_original_image_name(ctx, image_name),
+                 name = name,
+                 toolchain_config_spec_name = toolchain_config_spec_name,
+@@ -592,7 +592,7 @@ def _rbe_autoconfig_impl(ctx):
+             ctx.report_progress("creating external repo platform")
+             create_external_repo_platform(
+                 ctx,
+-                exec_properties = ctx.attr.exec_properties,
++                exec_properties = ctx.attr.exec_properties1,
+                 image_name = resolve_rbe_original_image_name(ctx, image_name),
+                 name = name,
+                 use_legacy_platform_definition = ctx.attr.use_legacy_platform_definition,
+@@ -605,7 +605,7 @@ def _rbe_autoconfig_impl(ctx):
+         create_config_aliases(ctx, toolchain_config_spec_name)
+         create_alias_platform(
+             ctx,
+-            exec_properties = ctx.attr.exec_properties,
++            exec_properties = ctx.attr.exec_properties1,
+             image_name = resolve_rbe_original_image_name(ctx, image_name),
+             name = name,
+             toolchain_config_spec_name = toolchain_config_spec_name,
+@@ -755,7 +755,7 @@ _rbe_autoconfig = repository_rule(
+                    "example, [\"@bazel_tools//platforms:linux\"]. Default " +
+                    " is set to values for rbe-ubuntu16-04 container."),
+         ),
+-        "exec_properties": attr.string_dict(
++        "exec_properties1": attr.string_dict(
+             doc = (
+                 "Optional. The execution properties to be used when creating the " +
+                 "underlying platform. When providing this attribute, " +
+@@ -1167,7 +1167,7 @@ def rbe_autoconfig(
+         digest = digest,
+         env = env,
+         exec_compatible_with = exec_compatible_with,
+-        exec_properties = exec_properties,
++        exec_properties1 = exec_properties,
+         export_configs = export_configs,
+         java_home = java_home,
+         toolchain_config_suite_spec = toolchain_config_suite_spec_stripped,


### PR DESCRIPTION
This is a workaround to use rbe_autoconfig with
--experimental_repo_remote_exec. It had to be disabled before due
to a naming conflict [1]. More information at [2].

[1] https://github.com/google/iree/commit/b5331d220ba8790f5d0b0e1d76c60253489d39df
[2] https://github.com/bazelbuild/bazel/pull/11029