### PR TITLE
Run bazel_to_cmake in strict mode.

### DIFF
--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -102,8 +102,8 @@ iree_cc_library(
     iree::hal::fence
     iree::hal::host::async_command_queue
     iree::hal::host::host_descriptor_set
-    iree::hal::host::host_executable_layout
     iree::hal::host::host_event
+    iree::hal::host::host_executable_layout
     iree::hal::host::host_local_allocator
     iree::hal::host::host_submission_queue
     iree::hal::host::inproc_command_buffer


### PR DESCRIPTION
```
$ ./build_tools/bazel_to_cmake/bazel_to_cmake.py --strict
```