### PR TITLE
CMake: Fix setting test properties

### DIFF
--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -117,10 +117,9 @@ function(iree_cc_test)
     WORKING_DIRECTORY
       "${CMAKE_BINARY_DIR}"
     )
-  set_property(
-    TEST
-      ${_NAME_PATH}
-    PROPERTY
+  set_tests_properties(
+    ${_NAME_PATH}
+    PROPERTIES
       ENVIRONMENT
         "TEST_TMPDIR=${_NAME}_test_tmpdir"
       LABELS

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -117,12 +117,6 @@ function(iree_cc_test)
     WORKING_DIRECTORY
       "${CMAKE_BINARY_DIR}"
     )
-  set_tests_properties(
-    ${_NAME_PATH}
-    PROPERTIES
-      ENVIRONMENT
-        "TEST_TMPDIR=${_NAME}_test_tmpdir"
-      LABELS
-        ${_PACKAGE_PATH}
-  )
+  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${_NAME}_test_tmpdir")
+  set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_PACKAGE_PATH}")
 endfunction()

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -70,10 +70,9 @@ function(iree_lit_test)
     WORKING_DIRECTORY
       "${CMAKE_BINARY_DIR}"
   )
-  set_property(
-    TEST
-      ${_NAME_PATH}
-    PROPERTY
+  set_tests_properties(
+    ${_NAME_PATH}
+    PROPERTIES
       ENVIRONMENT
         "TEST_TMPDIR=${_NAME}_test_tmpdir"
       LABELS

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -70,16 +70,10 @@ function(iree_lit_test)
     WORKING_DIRECTORY
       "${CMAKE_BINARY_DIR}"
   )
-  set_tests_properties(
-    ${_NAME_PATH}
-    PROPERTIES
-      ENVIRONMENT
-        "TEST_TMPDIR=${_NAME}_test_tmpdir"
-      LABELS
-        ${_PACKAGE_PATH}
-      REQUIRED_FILES
-        "${_TEST_FILE_PATH}"
-  )
+  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${_NAME}_test_tmpdir")
+  set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_PACKAGE_PATH}")
+  set_property(TEST ${_NAME_PATH} PROPERTY REQUIRED_FILES "${_TEST_FILE_PATH}")
+
   # TODO(gcmn): Figure out how to indicate a dependency on _RULE_DATA being built
 endfunction()
 


### PR DESCRIPTION
set_property lets you set a *single* property with multiple values, so currently this is treating LABELS as an environment variable or something...

https://cmake.org/cmake/help/v3.13/command/set_property.html
https://cmake.org/cmake/help/v3.13/command/set_tests_properties.html

CMake error checking sucks.

Now the per-label time of the tests shows up when running ctest:
```
Label Time Summary:
iree/base                                                    =   0.11 sec*proc (11 tests)
iree/compiler/Dialect/Flow/Analysis/test                     =   0.75 sec*proc (1 test)
iree/compiler/Dialect/Flow/IR/test                           =   1.49 sec*proc (8 tests)
iree/compiler/Dialect/Flow/Transforms/test                   =   1.93 sec*proc (10 tests)
iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test          =   0.70 sec*proc (4 tests)
iree/compiler/Dialect/HAL/Conversion/HALToVM/test            =   1.41 sec*proc (6 tests)
iree/compiler/Dialect/HAL/IR/test                            =   2.43 sec*proc (13 tests)
iree/compiler/Dialect/HAL/Target/LLVM/test                   =   0.49 sec*proc (2 tests)
iree/compiler/Dialect/HAL/Target/VMLA/test                   =   0.29 sec*proc (1 test)
iree/compiler/Dialect/HAL/Target/test                        =   0.26 sec*proc (1 test)
iree/compiler/Dialect/HAL/Transforms/test                    =   0.71 sec*proc (4 tests)
iree/compiler/Dialect/IREE/IR/test                           =   0.57 sec*proc (3 tests)
iree/compiler/Dialect/IREE/Transforms/test                   =   0.17 sec*proc (1 test)
iree/compiler/Dialect/Modules/Check/test                     =   0.19 sec*proc (1 test)
iree/compiler/Dialect/Modules/Strings/IR/test                =   0.19 sec*proc (1 test)
iree/compiler/Dialect/Modules/TensorList/Conversion/test     =   0.19 sec*proc (1 test)
iree/compiler/Dialect/Modules/TensorList/IR/test             =   0.17 sec*proc (1 test)
iree/compiler/Dialect/Shape/IR/test                          =   0.75 sec*proc (4 tests)
iree/compiler/Dialect/Shape/Plugins/XLA/test                 =   0.16 sec*proc (1 test)
iree/compiler/Dialect/Shape/Transforms/test                  =   0.94 sec*proc (5 tests)
iree/compiler/Dialect/VM/Analysis/test                       =   0.39 sec*proc (2 tests)
iree/compiler/Dialect/VM/Conversion/StandardToVM/test        =   1.32 sec*proc (7 tests)
iree/compiler/Dialect/VM/IR/test                             =   3.26 sec*proc (17 tests)
iree/compiler/Dialect/VM/Target/Bytecode/test                =   0.50 sec*proc (3 tests)
iree/compiler/Dialect/VM/Transforms/test                     =   0.35 sec*proc (2 tests)
iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test         =   0.18 sec*proc (1 test)
iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test         =   2.03 sec*proc (11 tests)
iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test    =   0.50 sec*proc (3 tests)
iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test          =   0.43 sec*proc (1 test)
iree/compiler/Dialect/VMLA/Transforms/test                   =   0.36 sec*proc (2 tests)
iree/compiler/Dialect/Vulkan/IR/test                         =   0.19 sec*proc (1 test)
iree/compiler/Dialect/Vulkan/Utils/test                      =   0.23 sec*proc (1 test)
iree/compiler/Translation/CodegenPasses/test                 =   2.20 sec*proc (11 tests)
iree/compiler/Translation/SPIRV/IndexComputation/test        =   1.79 sec*proc (10 tests)
iree/compiler/Translation/SPIRV/XLAToSPIRV/test              =   4.49 sec*proc (21 tests)
iree/compiler/Translation/test                               =   0.56 sec*proc (2 tests)
iree/hal                                                     =   0.03 sec*proc (2 tests)
iree/hal/cts                                                 =   0.52 sec*proc (2 tests)
iree/hal/host                                                =   0.56 sec*proc (3 tests)
iree/hal/vmla                                                =   0.01 sec*proc (1 test)
iree/modules/check                                           =   0.24 sec*proc (1 test)
iree/modules/check/test                                      =   0.91 sec*proc (2 tests)
iree/modules/strings                                         =   0.04 sec*proc (1 test)
iree/modules/tensorlist                                      =   0.05 sec*proc (1 test)
iree/test/e2e/linalg/path                                    =   0.65 sec*proc (4 tests)
iree/test/e2e/xla                                            =  33.67 sec*proc (48 tests)
iree/tools                                                   =   0.02 sec*proc (1 test)
iree/tools/test                                              =   4.38 sec*proc (3 tests)
iree/vm                                                      =  10.08 sec*proc (5 tests)
```