### PR TITLE
Mark Vulkan timeline semaphore support as required.

### DIFF
--- a/docs/vulkan_and_spirv.md
+++ b/docs/vulkan_and_spirv.md
@@ -137,8 +137,9 @@ for details).
 
 ### Development tips
 
-If you are running tests with Bazel, consider putting environment setup in a
-`user.bazelrc` file, such as:
+Bazel runs tests in a sandbox and environment variables must be passed through
+to the test runner. Consider putting environment setup in a `user.bazelrc`.
+For example:
 
 ```
 test --test_env="LD_LIBRARY_PATH={ABSOLUTE_PATH_TO_VULKAN_SDK}/x86_64/lib/"

--- a/docs/vulkan_and_spirv.md
+++ b/docs/vulkan_and_spirv.md
@@ -135,6 +135,17 @@ include the path to the associated manifest file (see the
 [docs](https://vulkan.lunarg.com/doc/view/latest/windows/loader_and_layer_interface.html)
 for details).
 
+### Development tips
+
+If you are running tests with Bazel, consider putting environment setup in a
+`user.bazelrc` file, such as:
+
+```
+test --test_env="LD_LIBRARY_PATH={ABSOLUTE_PATH_TO_VULKAN_SDK}/x86_64/lib/"
+test --test_env="LD_PRELOAD=libvulkan.so.1"
+test --test_env="VK_LAYER_PATH=$VK_LAYER_PATH:{ABSOLUTE_PATH_TO_BUILD_DIR}/vulkan_extensionlayer/layers"
+```
+
 ## SPIR-V
 
 ### Minimum Requirements

--- a/iree/hal/vulkan/api.cc
+++ b/iree/hal/vulkan/api.cc
@@ -90,6 +90,10 @@ ExtensibilitySpec GetInstanceExtensibilitySpec(
     const iree_hal_vulkan_features_t& features) {
   ExtensibilitySpec spec;
 
+  // Multiple extensions depend on VK_KHR_get_physical_device_properties2.
+  spec.required_extensions.push_back(
+      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+
   if (features & IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS) {
     spec.optional_layers.push_back("VK_LAYER_LUNARG_standard_validation");
   }
@@ -98,16 +102,8 @@ ExtensibilitySpec GetInstanceExtensibilitySpec(
     spec.optional_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
   }
 
-  if (features & IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS ||
-      features & IREE_HAL_VULKAN_ENABLE_TIMELINE_SEMAPHORES) {
-    spec.optional_extensions.push_back(
-        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-  }
-
-  if (features & IREE_HAL_VULKAN_ENABLE_TIMELINE_SEMAPHORES) {
-    // Polyfill layer - enable if present.
-    spec.optional_layers.push_back("VK_LAYER_KHRONOS_timeline_semaphore");
-  }
+  // Polyfill layer - enable if present.
+  spec.optional_layers.push_back("VK_LAYER_KHRONOS_timeline_semaphore");
 
   return spec;
 }
@@ -120,14 +116,11 @@ ExtensibilitySpec GetDeviceExtensibilitySpec(
   // work (such as those relied upon by SPIR-V kernels, etc).
   spec.required_extensions.push_back(
       VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
+  // Timeline semaphore support is required.
+  spec.required_extensions.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
   if (features & IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS) {
     spec.optional_extensions.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-  }
-
-  if (features & IREE_HAL_VULKAN_ENABLE_TIMELINE_SEMAPHORES) {
-    spec.optional_extensions.push_back(
-        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
   }
 
   return spec;

--- a/iree/hal/vulkan/api.h
+++ b/iree/hal/vulkan/api.h
@@ -56,9 +56,6 @@ typedef enum {
 
   // Use vkCmdPushDescriptorSetKHR.
   IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS = 1 << 2,
-
-  // Use VK_KHR_timeline_semaphore.
-  IREE_HAL_VULKAN_ENABLE_TIMELINE_SEMAPHORES = 1 << 3,
 } iree_hal_vulkan_features_t;
 
 // Vulkan driver creation options.

--- a/iree/hal/vulkan/dynamic_symbol_tables.h
+++ b/iree/hal/vulkan/dynamic_symbol_tables.h
@@ -363,9 +363,9 @@ namespace vulkan {
   DEV_PFN(REQUIRED, vkQueueWaitIdle)                                    \
                                                                         \
   /* Device extension: VK_KHR_timeline_semaphore */                     \
-  DEV_PFN(OPTIONAL, vkGetSemaphoreCounterValueKHR)                      \
-  DEV_PFN(OPTIONAL, vkWaitSemaphoresKHR)                                \
-  DEV_PFN(OPTIONAL, vkSignalSemaphoreKHR)
+  DEV_PFN(REQUIRED, vkGetSemaphoreCounterValueKHR)                      \
+  DEV_PFN(REQUIRED, vkWaitSemaphoresKHR)                                \
+  DEV_PFN(REQUIRED, vkSignalSemaphoreKHR)
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 #define IREE_VULKAN_DYNAMIC_SYMBOL_TABLE_ANDROID_KHR(INS_PFN, DEV_PFN) \

--- a/iree/hal/vulkan/vulkan_driver_module.cc
+++ b/iree/hal/vulkan/vulkan_driver_module.cc
@@ -30,8 +30,6 @@ ABSL_FLAG(bool, vulkan_debug_report, false,
           "Enables VK_EXT_debug_report and logs errors.");
 ABSL_FLAG(bool, vulkan_push_descriptors, true,
           "Enables use of vkCmdPushDescriptorSetKHR, if available.");
-ABSL_FLAG(bool, vulkan_timeline_semaphores, true,
-          "Enables VK_KHR_timeline_semaphore extension, if available.");
 
 namespace iree {
 namespace hal {
@@ -64,6 +62,12 @@ StatusOr<ref_ptr<Driver>> CreateVulkanDriver() {
   // work (such as those relied upon by SPIR-V kernels, etc).
   options.device_extensibility.required_extensions.push_back(
       VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
+  // Multiple extensions depend on VK_KHR_get_physical_device_properties2.
+  options.instance_extensibility.required_extensions.push_back(
+      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+  // Timeline semaphore support is required.
+  options.device_extensibility.required_extensions.push_back(
+      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
   if (absl::GetFlag(FLAGS_vulkan_validation_layers)) {
     options.instance_extensibility.optional_layers.push_back(
@@ -79,25 +83,14 @@ StatusOr<ref_ptr<Driver>> CreateVulkanDriver() {
         VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
   }
 
-  // Multiple extensions depend on VK_KHR_get_physical_device_properties2.
-  if (absl::GetFlag(FLAGS_vulkan_push_descriptors) ||
-      absl::GetFlag(FLAGS_vulkan_timeline_semaphores)) {
-    options.instance_extensibility.optional_extensions.push_back(
-        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-  }
-
   if (absl::GetFlag(FLAGS_vulkan_push_descriptors)) {
     options.device_extensibility.optional_extensions.push_back(
         VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
   }
 
-  if (absl::GetFlag(FLAGS_vulkan_timeline_semaphores)) {
-    // Polyfill layer - enable if present.
-    options.instance_extensibility.optional_layers.push_back(
-        "VK_LAYER_KHRONOS_timeline_semaphore");
-    options.device_extensibility.optional_extensions.push_back(
-        VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-  }
+  // Polyfill layer - enable if present.
+  options.instance_extensibility.optional_layers.push_back(
+      "VK_LAYER_KHRONOS_timeline_semaphore");
 
   // Create the driver and VkInstance.
   ASSIGN_OR_RETURN(auto driver, VulkanDriver::Create(options, std::move(syms)));

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -450,8 +450,7 @@ int iree::IreeMain(int argc, char** argv) {
       static_cast<iree_hal_vulkan_features_t>(
           IREE_HAL_VULKAN_ENABLE_VALIDATION_LAYERS |
           IREE_HAL_VULKAN_ENABLE_DEBUG_UTILS |
-          IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS |
-          IREE_HAL_VULKAN_ENABLE_TIMELINE_SEMAPHORES);
+          IREE_HAL_VULKAN_ENABLE_PUSH_DESCRIPTORS);
   std::vector<const char*> layers = GetInstanceLayers(iree_vulkan_features);
   std::vector<const char*> extensions =
       GetInstanceExtensions(window, iree_vulkan_features);


### PR DESCRIPTION
Developers using Vulkan, particularly those on Linux with older Vulkan drivers (Google engineers) will have some manual setup to do after this. Docs have been updated, but there is no one-size-fits-all set of steps to follow.

Timeline semaphores are not yet being used, but the current plan is to require them, at least until a simpler polyfill is added. Note that vulkan_extensionlayer does not yet build for Windows and SwiftShader lacks native support, so this will block using SwiftShader on Windows.

Progress on #1285.