### PR TITLE
Add missing dep to docs gen

### DIFF
--- a/iree/compiler/Dialect/Modules/Strings/IR/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/IR/BUILD
@@ -101,6 +101,7 @@ iree_tablegen_doc(
     td_file = "Ops.td",
     td_srcs = [
         ":td_files",
+        "//iree/compiler/Dialect/HAL/IR:td_files",
         "//iree/compiler/Dialect/IREE/IR:td_files",
         "@llvm-project//mlir:StdOpsTdFiles",
     ],


### PR DESCRIPTION
A collision between https://github.com/google/iree/pull/1278 and https://github.com/google/iree/pull/1283 caused this dep to be missing.