### PR TITLE
Updates mnist_tensorflow to use the vmla driver when running on CPU.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # Python
 *.pyc
+**/.ipynb_checkpoints/
 
 # Visual Studio files
 .vs/

--- a/colab/mnist_tensorflow.ipynb
+++ b/colab/mnist_tensorflow.ipynb
@@ -134,7 +134,7 @@
         "  driver_name = \"vulkan\"\n",
         "else:\n",
         "  backend_name = \"vmla\"\n",
-        "  driver_name = \"interpreter\"\n",
+        "  driver_name = \"vmla\"\n",
         "tf.print(\"Using IREE compiler backend '%s' and runtime driver '%s'\" % (backend_name, driver_name))\n",
         "\n",
         "#@markdown -----\n",


### PR DESCRIPTION
Changes the `driver_name` variable from `"interpreter"` to `"vmla"` so that the notebook works when not using Vulkan.

I also added `**/.ipynb_checkpoints/` to `.gitignore` to prevent that from accidentally being added.