### PR TITLE
CMake: Fix passing TESTONLY and PUBLIC to other CMake modules

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -70,14 +70,17 @@ function(iree_bytecode_module)
       DEPENDS ${_TRANSLATE_TOOL}
     )
 
+    if(_RULE_TESTONLY)
+      set(_TESTONLY_ARG "TESTONLY")
+    endif()
+    if(_RULE_PUBLIC)
+      set(_PUBLIC_ARG "PUBLIC")
+    endif()
+
     if(DEFINED _RULE_CC_NAMESPACE)
       iree_cc_embed_data(
         NAME
           "${_RULE_NAME}_cc"
-        PUBLIC
-          "${_RULE_PUBLIC}"
-        TESTONLY
-          "${_RULE_TESTONLY}"
         IDENTIFIER
           "${_RULE_NAME}"
         GENERATED_SRCS
@@ -89,6 +92,8 @@ function(iree_bytecode_module)
         CPP_NAMESPACE
           "${_RULE_CC_NAMESPACE}"
         FLATTEN
+        "${_PUBLIC_ARG}"
+        "${_TESTONLY_ARG}"
       )
     endif()
   endif()

--- a/build_tools/cmake/iree_cc_embed_data.cmake
+++ b/build_tools/cmake/iree_cc_embed_data.cmake
@@ -82,12 +82,19 @@ function(iree_cc_embed_data)
       DEPENDS generate_cc_embed_data ${_RULE_SRCS} ${_RULE_GENERATED_SRCS}
     )
 
+    if(_RULE_TESTONLY)
+      set(_TESTONLY_ARG "TESTONLY")
+    endif()
+    if(_RULE_PUBLIC)
+      set(_PUBLIC_ARG "PUBLIC")
+    endif()
+
     iree_cc_library(
       NAME ${_RULE_NAME}
-      PUBLIC ${_RULE_PUBLIC}
-      TESTONLY ${_RULE_TESTONLY}
       HDRS "${_RULE_H_FILE_OUTPUT}"
       SRCS "${_RULE_CC_FILE_OUTPUT}"
+      "${_PUBLIC_ARG}"
+      "${_TESTONLY_ARG}"
     )
   endif()
 endfunction()

--- a/build_tools/cmake/iree_spirv_kernel_cc_library.cmake
+++ b/build_tools/cmake/iree_spirv_kernel_cc_library.cmake
@@ -53,13 +53,16 @@ function(iree_spirv_kernel_cc_library)
       )
     endforeach(_SRC)
 
+    if(_RULE_TESTONLY)
+      set(_TESTONLY_ARG "TESTONLY")
+    endif()
+    if(_RULE_PUBLIC)
+      set(_PUBLIC_ARG "PUBLIC")
+    endif()
+
     iree_cc_embed_data(
       NAME
         "${_RULE_NAME}"
-      PUBLIC
-        "${_RULE_PUBLIC}"
-      TESTONLY
-        "${_RULE_TESTONLY}"
       GENERATED_SRCS
         "${_SPV_FILES}"
       CC_FILE_OUTPUT
@@ -69,6 +72,8 @@ function(iree_spirv_kernel_cc_library)
       CPP_NAMESPACE
         "mlir::iree_compiler::spirv_kernels"
       FLATTEN
+      "${_PUBLIC_ARG}"
+      "${_TESTONLY_ARG}"
     )
   endif()
 endfunction()


### PR DESCRIPTION
These were handled as single value variables before by the calling
modules, but are defined as options within the modules itself.

Related to #1330