### PR TITLE
Add GitHub Action to automatically publish docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,62 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  linux:
+    runs-on: ubuntu-18.04
+    env:
+      IREE_DOC_BUILD_DIR: build-docs
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+      - name: Fetching gh-pages branch
+        run: |
+          git fetch origin gh-pages
+      - name: Initializing submodules
+        run: ./scripts/git/submodule_versions.py init
+      - name: Installing Ninja build
+        uses: seanmiddleditch/gha-setup-ninja@v1
+      - name: Building documentation
+        run: |
+          ./build_tools/cmake/build_docs.sh
+          # Patch the MarkDown files with front matter for rendering
+          ./scripts/prepare_doc_publication.py ${IREE_DOC_BUILD_DIR}/doc
+      - name: Updating gh-pages branch
+        run: |
+          git checkout -f gh-pages
+          cp -rf ${IREE_DOC_BUILD_DIR}/doc/* docs/
+          git add docs/
+          echo "::set-env name=has_diff::false"
+          git diff --cached --exit-code || echo "::set-env name=has_diff::true"
+      - name: Committing updates
+        if: env.has_diff == 'true'
+        run: |
+          git config --local user.email "iree-github-actions-bot@google.com"
+          git config --local user.name "Doc Publish Action"
+          git commit -am "Automatically update GitHub Pages"
+      - name: Pushing changes
+        if: env.has_diff == 'true'
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          branch: gh-pages


### PR DESCRIPTION
This commit adds a GitHub action to automatically publish doc
changes to the `gh-pages` branch, which will be rendered nicely
on https://goole.google.io/iree. This includes both docs directly
checked into the docs/ directory and docs auto-generated from
TableGen definitions. For now the former only contains IREE
Design Roadmap; the hope is to refresh existing docs and publish
them one by one.