### PR TITLE
CMake: Fix test labels

### DIFF
--- a/bindings/python/build_tools/cmake/iree_py_test.cmake
+++ b/bindings/python/build_tools/cmake/iree_py_test.cmake
@@ -41,7 +41,8 @@ function(iree_py_test)
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
-  string(REPLACE "_" "/" _PACKAGE_PATH ${_PACKAGE_NAME})
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
 
   add_test(

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -105,16 +105,14 @@ function(iree_cc_test)
   set_property(GLOBAL APPEND PROPERTY _IREE_CC_BINARY_NAMES "${_NAME}")
   set_property(TARGET ${_NAME} PROPERTY DIRECT_DEPS ${_RULE_DEPS})
 
-  # We run all our tests through a custom test runner to allow temp directory
-  # cleanup upon test completion.
-
-  iree_package_ns(_PACKAGE_NS)
   string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
   add_test(
     NAME
       ${_NAME_PATH}
     COMMAND
+      # We run all our tests through a custom test runner to allow temp
+      # directory cleanup upon test completion.
       "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
       "$<TARGET_FILE:${_NAME}>"
     WORKING_DIRECTORY

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -108,7 +108,8 @@ function(iree_cc_test)
   # We run all our tests through a custom test runner to allow temp directory
   # cleanup upon test completion.
 
-  string(REPLACE "_" "/" _PACKAGE_PATH ${_PACKAGE_NAME})
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
   add_test(
     NAME

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -81,7 +81,8 @@ function(iree_check_test)
     iree_modules_check_iree-check-module
   )
 
-  string(REPLACE "_" "/" _PACKAGE_PATH ${_PACKAGE_NAME})
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
 
   add_test(

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -58,7 +58,6 @@ function(iree_lit_test)
     endif()
   endforeach(_DATA_DEP)
 
-  # We run all our tests through a custom test runner to allow setup and teardown.
   iree_package_ns(_PACKAGE_NS)
   string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
@@ -66,6 +65,8 @@ function(iree_lit_test)
     NAME
       ${_NAME_PATH}
     COMMAND
+      # We run all our tests through a custom test runner to allow setup
+      # and teardown.
       "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
       "${CMAKE_SOURCE_DIR}/iree/tools/run_lit.${IREE_HOST_SCRIPT_EXT}"
       ${_TEST_FILE_PATH}

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -59,7 +59,8 @@ function(iree_lit_test)
   endforeach(_DATA_DEP)
 
   # We run all our tests through a custom test runner to allow setup and teardown.
-  string(REPLACE "_" "/" _PACKAGE_PATH ${_PACKAGE_NAME})
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
   set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
   add_test(
     NAME


### PR DESCRIPTION
Prior to the changes all `_` in the path got replaced with `/`:

Before:
```
  Test  #30: iree/test/e2e/linalg/path:pw_add.mlir.test
  Test  #31: iree/test/e2e/linalg/path:pw_add_mul.mlir.test
  Test  #32: iree/test/e2e/linalg/path:pw_add_multiwg.mlir.test
  Test  #33: iree/test/e2e/linalg/path:reduce.mlir.test

  Test #268: iree/samples/custom/modules:custom_modules_test
  Test #269: iree/samples/custom/modules/dialect/test:conversion.mlir.test
  Test #270: iree/samples/custom/modules/dialect/test:custom_ops.mlir.test
  Test #271: iree/samples/simple/embedding:simple_embedding_test
```

After:
```
  Test  #30: iree/test/e2e/linalg_path:pw_add.mlir.test
  Test  #31: iree/test/e2e/linalg_path:pw_add_mul.mlir.test
  Test  #32: iree/test/e2e/linalg_path:pw_add_multiwg.mlir.test
  Test  #33: iree/test/e2e/linalg_path:reduce.mlir.test

  Test #268: iree/samples/custom_modules:custom_modules_test
  Test #269: iree/samples/custom_modules/dialect/test:conversion.mlir.test
  Test #270: iree/samples/custom_modules/dialect/test:custom_ops.mlir.test
  Test #271: iree/samples/simple_embedding:simple_embedding_test
```