### PR TITLE
Refactor CMake configuration

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -20,9 +20,9 @@ include(AbseilConfigureCopts)
 
 set(IREE_CXX_STANDARD 14)
 
-set(IREE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(IREE_ROOT_DIR ${PROJECT_SOURCE_DIR})
 list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR}
 )
 
@@ -92,7 +92,7 @@ set(FLATBUFFERS_BUILD_FLATC ON CACHE BOOL "" FORCE)
 set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_BUILD_GRPCTEST OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_INCLUDE_DIRS
-  "${CMAKE_CURRENT_SOURCE_DIR}/third_party/flatbuffers/include/"
+  "${PROJECT_SOURCE_DIR}/third_party/flatbuffers/include/"
 )
 iree_select_compiler_opts(FLATBUFFERS_COPTS
   CLANG
@@ -132,9 +132,9 @@ set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "" FORCE)
 set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "" FORCE)
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/llvm/include
+  ${PROJECT_SOURCE_DIR}/third_party/llvm-project/llvm/include
   ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/mlir/include
+  ${PROJECT_SOURCE_DIR}/third_party/llvm-project/mlir/include
   ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include
 )
 
@@ -146,7 +146,7 @@ set(IREE_TABLEGEN_EXE iree-tblgen)
 #-------------------------------------------------------------------------------
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tensorflow
+  ${PROJECT_SOURCE_DIR}/third_party/tensorflow
   ${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow
 )
 
@@ -155,5 +155,5 @@ list(APPEND IREE_COMMON_INCLUDE_DIRS
 #-------------------------------------------------------------------------------
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/google_tracing_framework/bindings/cpp/include
+  ${PROJECT_SOURCE_DIR}/third_party/google_tracing_framework/bindings/cpp/include
 )

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -23,7 +23,7 @@ set(IREE_CXX_STANDARD 14)
 set(IREE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
+  ${PROJECT_BINARY_DIR}
 )
 
 iree_select_compiler_opts(IREE_DEFAULT_COPTS
@@ -133,9 +133,9 @@ set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "" FORCE)
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/llvm/include
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/include
+  ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/include
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/mlir/include
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include
+  ${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include
 )
 
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
@@ -147,6 +147,7 @@ set(IREE_TABLEGEN_EXE iree-tblgen)
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tensorflow
+  ${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow
 )
 
 #-------------------------------------------------------------------------------

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
@@ -18,12 +18,12 @@ set(TF_MLIR_XLA_SRC_ROOT
 
 set(TF_MLIR_XLA_COPTS_BASE
   "-I${IREE_ROOT_DIR}/third_party/tensorflow/"
-  "-I${CMAKE_BINARY_DIR}/build_tools/third_party/tensorflow/"
+  "-I${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/"
 )
 
 # Create directories in the build tree for external_tablegen_library targets to use.
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/ir")
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/transforms")
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/ir")
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/transforms")
 
 external_cc_library(
   PACKAGE


### PR DESCRIPTION
* (Partially) Required to enable using IREE as subproject via `add_subdirectory` in an external project:
  Note, `CMAKE_BINARY_DIR` would refer to the build directory of the external project and not to the directory in which IREE is build, which breaks the build.
* Replaces `CMAKE_CURRENT_BINARY_DIR` and `CMAKE_BINARY_DIR` by `CMAKE_CURRENT_BINARY_DIR`
* Consequently also replaces `CMAKE_CURRENT_SOURCE_DIR` by `PROJECT_SOURCE_DIR`

Makes progress on #659.