### PR TITLE
Splitting out tensorflow/llvm from common includes.

### DIFF
--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -118,9 +118,9 @@ function(external_cc_library)
           ${_RULE_HDRS}
       )
       target_include_directories(${_NAME}
-        PUBLIC
-          "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-          "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+        PRIVATE
+          ${IREE_COMMON_INCLUDE_DIRS}
+          ${_RULE_INCLUDES}
       )
       target_compile_options(${_NAME}
         PRIVATE

--- a/build_tools/cmake/external_tablegen_library.cmake
+++ b/build_tools/cmake/external_tablegen_library.cmake
@@ -22,7 +22,7 @@ function(external_tablegen_library)
     _RULE
     "TESTONLY"
     "PACKAGE;NAME;ROOT;TBLGEN"
-    "SRCS;OUTS"
+    "SRCS;OUTS;INCLUDES"
     ${ARGN}
   )
 
@@ -35,8 +35,10 @@ function(external_tablegen_library)
     list(TRANSFORM _RULE_SRCS PREPEND ${_RULE_ROOT})
 
     set(LLVM_TARGET_DEFINITIONS ${_RULE_SRCS})
-    set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
-    list(APPEND _INCLUDE_DIRS ${_RULE_ROOT})
+    list(APPEND _INCLUDE_DIRS
+      "${_RULE_INCLUDES}"
+      "${_RULE_ROOT}"
+    )
     list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
     set(_OUTPUTS)
     while(_RULE_OUTS)

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -110,6 +110,8 @@ function(iree_cc_library)
         PUBLIC
           "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
           "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+          "$<INSTALL_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+          "$<INSTALL_INTERFACE:${_RULE_INCLUDES}>"
       )
       target_compile_options(${_NAME}
         PRIVATE
@@ -152,6 +154,7 @@ function(iree_cc_library)
       target_include_directories(${_NAME}
         INTERFACE
           "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+          "$<INSTALL_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
       )
       target_compile_options(${_NAME}
         INTERFACE

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -22,8 +22,9 @@ set(IREE_CXX_STANDARD 14)
 
 set(IREE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
+  "$<INSTALL_INTERFACE:include/>"
 )
 
 iree_select_compiler_opts(IREE_DEFAULT_COPTS
@@ -131,11 +132,11 @@ set(LLVM_TARGETS_TO_BUILD "WebAssembly;X86" CACHE STRING "" FORCE)
 set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "" FORCE)
 set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "" FORCE)
 
-list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/llvm/include
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm-project/mlir/include
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include
+list(APPEND LLVM_INCLUDE_DIRS
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/llvm-project/llvm/include>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/include>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/llvm-project/mlir/include>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir/include>"
 )
 
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
@@ -145,14 +146,15 @@ set(IREE_TABLEGEN_EXE iree-tblgen)
 # Third party: tensorflow
 #-------------------------------------------------------------------------------
 
-list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tensorflow
-)
+list(APPEND TENSORFLOW_INCLUDE_DIRS
+  ${PROJECT_SOURCE_DIR}/third_party/tensorflow
+  ${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow
+  )
 
 #-------------------------------------------------------------------------------
 # Third party: tracing
 #-------------------------------------------------------------------------------
 
-list(APPEND IREE_COMMON_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/google_tracing_framework/bindings/cpp/include
+list(APPEND TRACING_FRAMEWORK_INCLUDE_DIRS
+  ${PROJECT_SOURCE_DIR}/third_party/google_tracing_framework/bindings/cpp/include
 )

--- a/build_tools/cmake/iree_tablegen_doc.cmake
+++ b/build_tools/cmake/iree_tablegen_doc.cmake
@@ -50,7 +50,7 @@ function(iree_tablegen_doc)
     endif()
 
 
-    set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
+    set(_INCLUDE_DIRS ${LLVM_INCLUDE_DIRS})
     list(APPEND _INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
     list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
 

--- a/build_tools/cmake/iree_tablegen_library.cmake
+++ b/build_tools/cmake/iree_tablegen_library.cmake
@@ -22,7 +22,7 @@ function(iree_tablegen_library)
     _RULE
     "TESTONLY"
     "NAME;TBLGEN"
-    "TD_FILE;OUTS"
+    "TD_FILE;OUTS;INCLUDES"
     ${ARGN}
   )
 
@@ -38,8 +38,12 @@ function(iree_tablegen_library)
     endif()
 
     set(LLVM_TARGET_DEFINITIONS ${_RULE_TD_FILE})
-    set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
-    list(APPEND _INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+    list(APPEND _INCLUDE_DIRS
+      "${IREE_COMMON_INCLUDE_DIRS}"
+      "${LLVM_INCLUDE_DIRS}"
+      "${_RULE_INCLUDES}"
+    )
+    list(FILTER _INCLUDE_DIRS EXCLUDE REGEX "^$")
     list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
     set(_OUTPUTS)
     while(_RULE_OUTS)

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
@@ -57,8 +57,8 @@ external_cc_library(
   COPTS
     ${TF_MLIR_XLA_COPTS_BASE}
   INCLUDES
-    ${IREE_ROOT_DIR}/third_party/tensorflow/
-    ${CMAKE_BINARY_DIR}/build_tools/third_party/tensorflow/
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   DEPS
     absl::core_headers
     absl::flat_hash_set
@@ -88,6 +88,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "transforms/canonicalize.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-rewriters transforms/generated_canonicalize.inc
 )
@@ -103,6 +106,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "ir/hlo_ops.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-op-decls ir/hlo_ops.h.inc
     -gen-op-defs ir/hlo_ops.cc.inc
@@ -121,6 +127,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "ir/hlo_client_ops.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-op-decls ir/hlo_client_ops.h.inc
     -gen-op-defs ir/hlo_client_ops.cc.inc
@@ -137,6 +146,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "ir/hlo_ops_base.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-op-decls ir/hlo_ops_base.h.inc
     -gen-op-defs ir/hlo_ops_base.cc.inc
@@ -153,6 +165,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "transforms/legalize_to_standard_patterns.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-rewriters transforms/generated_legalize_to_standard.inc
 )
@@ -168,6 +183,9 @@ external_tablegen_library(
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
     "ir/lhlo_ops.td"
+  INCLUDES
+    ${LLVM_INCLUDE_DIRS}
+    ${TENSORFLOW_INCLUDE_DIRS}
   OUTS
     -gen-op-decls ir/lhlo_ops.h.inc
     -gen-op-defs ir/lhlo_ops.cc.inc


### PR DESCRIPTION
We only want those during builds of the project and not installs, and it
was a hack that they were ever in the common list.

Progress on #659.