### PR TITLE
Implement forked registerAllTranslations() as registerMlirTranslations()

### DIFF
--- a/iree/tools/init_translations.h
+++ b/iree/tools/init_translations.h
@@ -39,6 +39,6 @@ inline void registerMlirTranslations() {
   }();
   (void)init_once;
 }
-} // namespace mlir
+}  // namespace mlir
 
-#endif // IREE_TOOLS_INIT_TRANSLATIONS_H_
+#endif  // IREE_TOOLS_INIT_TRANSLATIONS_H_

--- a/iree/tools/init_translations.h
+++ b/iree/tools/init_translations.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines a helper to trigger the registration of all translations
+// in and out of MLIR to the system.
+//
+// Based on MLIR's InitAllTranslations but without translations we don't care
+// about.
+
+#ifndef IREE_TOOLS_INIT_TRANSLATIONS_H_
+#define IREE_TOOLS_INIT_TRANSLATIONS_H_
+
+namespace mlir {
+
+void registerFromLLVMIRTranslation();
+void registerToLLVMIRTranslation();
+void registerToSPIRVTranslation();
+
+// This function should be called before creating any MLIRContext if one
+// expects all the possible translations to be made available to the context
+// automatically.
+inline void registerMlirTranslations() {
+  static bool init_once = []() {
+    registerFromLLVMIRTranslation();
+    registerToLLVMIRTranslation();
+    registerToSPIRVTranslation();
+    return true;
+  }();
+  (void)init_once;
+}
+} // namespace mlir
+
+#endif // IREE_TOOLS_INIT_TRANSLATIONS_H_


### PR DESCRIPTION
With https://reviews.llvm.org/D77515, the need for static global ctors is removed from `mlir-translate` and thus can be also removed from `iree-translate`. This already forks the header file `mlir/include/mlir/InitAllTranslations.h` and removes translations not used so far within IREE.