### PR TITLE
Added missing registerMlirPasses

### DIFF
--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -25,6 +25,7 @@
 #include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
 #include "iree/compiler/Dialect/VM/Transforms/Passes.h"
 #include "iree/tools/init_dialects.h"
+#include "iree/tools/init_passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
@@ -68,6 +69,7 @@ bool LLVMOnceInit() {
 
   // Register built-in MLIR dialects.
   mlir::registerMlirDialects();
+  mlir::registerMlirPasses();
 
   // Register any pass manager command line options.
   mlir::registerPassManagerCLOptions();

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -58,6 +58,7 @@
 #include "iree/hal/api.h"
 #include "iree/modules/hal/hal_module.h"
 #include "iree/tools/init_dialects.h"
+#include "iree/tools/init_passes.h"
 #include "iree/tools/vm_util.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -457,6 +457,7 @@ extern "C" int main(int argc, char** argv) {
   }
 
   mlir::registerMlirDialects();
+  mlir::registerMlirPasses();
   mlir::registerPassManagerCLOptions();
   llvm::InitLLVM init_llvm(argc_llvm, argv_llvm);
   llvm::cl::ParseCommandLineOptions(argc_llvm, argv_llvm);

--- a/iree/tools/translate_main.cc
+++ b/iree/tools/translate_main.cc
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
   mlir::registerMlirDialects();
+  mlir::registerMlirPasses();
   mlir::registerPassManagerCLOptions();
 
   // Add flags for all the registered translations.

--- a/iree/tools/translate_main.cc
+++ b/iree/tools/translate_main.cc
@@ -18,6 +18,7 @@
 // options, which is missing in MLIR's translation main entry function.
 
 #include "iree/tools/init_dialects.h"
+#include "iree/tools/init_passes.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"


### PR DESCRIPTION
registerMlirPasses was missing from E2E tests causing them to fail due to unregistered passes.