### PR TITLE
Implement and use registerIreeDialects()

### DIFF
--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -68,6 +68,7 @@ bool LLVMOnceInit() {
 
   // Register built-in MLIR dialects.
   mlir::registerMlirDialects();
+  mlir::iree_compiler::registerIreeDialects();
 
   // Register any pass manager command line options.
   mlir::registerPassManagerCLOptions();

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -58,8 +58,6 @@ function(set_alwayslink_mlir_libs)
   set(_ALWAYSLINK_LIBS_MLIR
     # Dep tagged ALWAYSLINK for mlir-translate
     MLIRSPIRVSerialization
-    # Required IR targets
-    MLIRIR
     # Required passes
     MLIRPass
     # TODO(marbre): Check the previously added libs

--- a/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/BUILD
@@ -56,7 +56,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -41,7 +41,6 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/HAL/IR/BUILD
+++ b/iree/compiler/Dialect/HAL/IR/BUILD
@@ -80,7 +80,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -65,7 +65,6 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::hal_imports
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::VM::Conversion
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/IREE/IR/BUILD
+++ b/iree/compiler/Dialect/IREE/IR/BUILD
@@ -52,7 +52,6 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -37,7 +37,6 @@ iree_cc_library(
     MLIRSideEffects
     MLIRStandardOps
     MLIRSupport
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/Shape/IR/BUILD
+++ b/iree/compiler/Dialect/Shape/IR/BUILD
@@ -57,7 +57,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -42,7 +42,6 @@ iree_cc_library(
     MLIRSupport
     MLIRTransforms
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/VM/IR/BUILD
+++ b/iree/compiler/Dialect/VM/IR/BUILD
@@ -64,7 +64,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -46,7 +46,6 @@ iree_cc_library(
     MLIRSupport
     MLIRTransformUtils
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/VMLA/IR/BUILD
+++ b/iree/compiler/Dialect/VMLA/IR/BUILD
@@ -79,7 +79,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/IR/CMakeLists.txt
@@ -64,7 +64,6 @@ iree_cc_library(
     iree::compiler::Dialect::VM::Conversion
     iree::compiler::Dialect::VMLA::Conversion::VMLAToVM
     iree::compiler::Dialect::VMLA::vmla_imports
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/Vulkan/IR/BUILD
+++ b/iree/compiler/Dialect/Vulkan/IR/BUILD
@@ -48,7 +48,6 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],
-    alwayslink = 1,
 )
 
 gentbl(

--- a/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
@@ -35,7 +35,6 @@ iree_cc_library(
     MLIRIR
     MLIRSupport
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/tools/init_dialects.h
+++ b/iree/tools/init_dialects.h
@@ -20,6 +20,12 @@
 #ifndef IREE_TOOLS_INIT_DIALECTS_H_
 #define IREE_TOOLS_INIT_DIALECTS_H_
 
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
+#include "iree/compiler/Dialect/VM/IR/VMDialect.h"
+#include "iree/compiler/Dialect/VMLA/IR/VMLADialect.h"
+#include "iree/compiler/Dialect/Vulkan/IR/VulkanDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/FxpMathOps/FxpMathOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
@@ -54,6 +60,26 @@ inline void registerMlirDialects() {
   }();
   (void)init_once;
 }
+}  // namespace mlir
+
+namespace mlir {
+namespace iree_compiler {
+
+// This function should be called before creating any MLIRContext if one expect
+// all the possible dialects to be made available to the context automatically.
+inline void registerIreeDialects() {
+  static bool init_once = []() {
+    registerDialect<IREE::Flow::FlowDialect>();
+    registerDialect<IREE::HAL::HALDialect>();
+    registerDialect<ShapeDialect>();
+    registerDialect<IREE::VM::VMDialect>();
+    registerDialect<IREE::VMLA::VMLADialect>();
+    registerDialect<IREE::Vulkan::VulkanDialect>();
+    return true;
+  }();
+  (void)init_once;
+}
+}  // namespace iree_compiler
 }  // namespace mlir
 
 #endif  // IREE_TOOLS_INIT_DIALECTS_H_

--- a/iree/tools/init_dialects.h
+++ b/iree/tools/init_dialects.h
@@ -22,6 +22,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/IREE/IR/IREEDialect.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
 #include "iree/compiler/Dialect/VMLA/IR/VMLADialect.h"
@@ -72,6 +73,7 @@ inline void registerIreeDialects() {
     registerDialect<IREE::Flow::FlowDialect>();
     registerDialect<IREE::HAL::HALDialect>();
     registerDialect<ShapeDialect>();
+    registerDialect<IREEDialect>();
     registerDialect<IREE::VM::VMDialect>();
     registerDialect<IREE::VMLA::VMLADialect>();
     registerDialect<IREE::Vulkan::VulkanDialect>();

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -60,6 +60,7 @@ static llvm::cl::opt<bool> allowUnregisteredDialects(
 
 int main(int argc, char **argv) {
   mlir::registerMlirDialects();
+  mlir::iree_compiler::registerIreeDialects();
   mlir::registerMlirPasses();
   llvm::InitLLVM y(argc, argv);
 

--- a/iree/tools/run_mlir_main.cc
+++ b/iree/tools/run_mlir_main.cc
@@ -457,6 +457,7 @@ extern "C" int main(int argc, char** argv) {
   }
 
   mlir::registerMlirDialects();
+  mlir::iree_compiler::registerIreeDialects();
   mlir::registerPassManagerCLOptions();
   llvm::InitLLVM init_llvm(argc_llvm, argv_llvm);
   llvm::cl::ParseCommandLineOptions(argc_llvm, argv_llvm);

--- a/iree/tools/translate_main.cc
+++ b/iree/tools/translate_main.cc
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
   mlir::registerMlirDialects();
+  mlir::iree_compiler::registerIreeDialects();
   mlir::registerPassManagerCLOptions();
 
   // Add flags for all the registered translations.


### PR DESCRIPTION
* Equivalent to `registerMlirDialects()` for IREE dialects
* Allows to avoid alwayslink