### PR TITLE
Set IREE_AVAILABLE_BACKENDS in Bazel CI

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -61,4 +61,13 @@ jobs:
           # tagged "manual". The "manual" tag allows targets to be excluded from
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "noga".
-          bazel query '//...' | xargs bazel test --build_tag_filters="-noga" --test_tag_filters="-noga,-driver=vulkan" --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_DEFAULT_BACKENDS="tf,iree_vmla" --define=iree_tensorflow=true --test_output=errors --keep_going
+          bazel query '//...' \
+            | xargs bazel test \
+              --build_tag_filters="-noga" \
+              --test_tag_filters="-noga,-driver=vulkan" \
+              --test_env=IREE_VULKAN_DISABLE=1 \
+              --test_env=IREE_DEFAULT_BACKENDS="tf,iree_vmla" \
+              --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla" \
+              --define=iree_tensorflow=true \
+              --test_output=errors \
+              --keep_going


### PR DESCRIPTION
This will replace IREE_DEFAULT_BACKENDS as part of https://github.com/google/iree/pull/1375, but we'll set both for now so that it can be submitted without further breakage (for annoying infra reasons, we can't submit workflow changes as part of the same PR).

Also finally added line breaks to this ridiculously long line. There's some yaml magic you can do with a chomp operator or something, but I just did boring old line continuations.

Tested: No. It's basically impossible.