### PR TITLE
Remove Cmake env var setting for Vulkan-ExtensionLayer.

### DIFF
--- a/docs/getting_started_linux_vulkan.md
+++ b/docs/getting_started_linux_vulkan.md
@@ -117,13 +117,16 @@ $ VK_ICD_FILENAMES=$PWD/build-swiftshader/Linux/vk_swiftshader_icd.json
 
 ### Setting up Vulkan-ExtensionLayer
 
-IREE's CMake build includes the extension layer automatically. If you are using
-Bazel and are missing support for `VK_KHR_timeline_semaphore`, setup the
-extension layer.
+If you are missing support for `VK_KHR_timeline_semaphore`, setup the extension
+layer.
 
 Build:
 
 ```shell
+# -- CMake --
+$ cmake --build build/ --target vk_layer_khronos_timeline_semaphore
+
+# -- Bazel --
 $ bazel build @vulkan_extensionlayer//:libVkLayer_khronos_timeline_semaphore.so @vulkan_extensionlayer//:VkLayer_khronos_timeline_semaphore_json
 ```
 
@@ -131,7 +134,11 @@ You should then also set the `VK_LAYER_PATH` environment variable to include the
 path to the built layer:
 
 ```shell
-$ VK_LAYER_PATH=$VK_LAYER_PATH:$PWD/bazel-bin/external/vulkan_extensionlayer/
+# -- CMake --
+$ VK_LAYER_PATH=$PWD/build/third_party/vulkan_extensionlayer/layers/:$VK_LAYER_PATH
+
+# -- Bazel --
+$ VK_LAYER_PATH=$PWD/bazel-bin/external/vulkan_extensionlayer/:$VK_LAYER_PATH
 ```
 
 ### Support in Bazel Tests

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -167,7 +167,6 @@ iree_cc_library(
     "dynamic_symbols.cc"
   COPTS
     "-DVK_NO_PROTOTYPES"
-    "-DIREE_VK_LAYER_PATH_EXTRAS=${CMAKE_BINARY_DIR}/third_party/vulkan_extensionlayer/layers"
   DEPS
     absl::core_headers
     absl::memory
@@ -517,7 +516,5 @@ iree_cc_library(
     iree::hal::driver_registry
     iree::hal::vulkan::dynamic_symbols
     iree::hal::vulkan::vulkan_driver
-  DATA
-    vk_layer_khronos_timeline_semaphore
   PUBLIC
 )

--- a/iree/hal/vulkan/dynamic_symbols.cc
+++ b/iree/hal/vulkan/dynamic_symbols.cc
@@ -15,7 +15,6 @@
 #include "iree/hal/vulkan/dynamic_symbols.h"
 
 #include <cstddef>
-#include <cstdlib>
 
 #include "absl/base/attributes.h"
 #include "absl/base/macros.h"
@@ -131,31 +130,6 @@ StatusOr<ref_ptr<DynamicSymbols>> DynamicSymbols::Create(
 // static
 StatusOr<ref_ptr<DynamicSymbols>> DynamicSymbols::CreateFromSystemLoader() {
   IREE_TRACE_SCOPE0("DynamicSymbols::CreateFromSystemLoader");
-
-#define IREE_STRINGIFY_(x) #x
-#define IREE_STRING_(x) IREE_STRINGIFY_(x)
-
-#if defined(IREE_VK_LAYER_PATH_EXTRAS)
-  std::string vk_layer_path_extras = IREE_STRING_(IREE_VK_LAYER_PATH_EXTRAS);
-#if defined(IREE_PLATFORM_WINDOWS)
-// TODO(scotttodd): Layer discovery on Windows
-#else
-  const char* vk_layer_path = ::getenv("VK_LAYER_PATH");
-  std::string combined_path;
-  if (vk_layer_path) {
-    combined_path = absl::StrCat(vk_layer_path, ":", vk_layer_path_extras);
-  } else {
-    combined_path = vk_layer_path_extras;
-  }
-  ::setenv("VK_LAYER_PATH", combined_path.c_str(), 0);
-#endif  // IREE_PLATFORM_WINDOWS
-#else
-// Leave VK_LAYER_PATH unchanged and rely on the system Vulkan loader to
-// discover layers at the default path(s).
-#endif  // IREE_VK_LAYER_PATH_EXTRAS
-
-#undef IREE_STRINGIFY_
-#undef IREE_STRING_
 
   ASSIGN_OR_RETURN(
       auto loader_library,


### PR DESCRIPTION
There was a bug in here (`setenv` wasn't overwriting) and consistency with Bazel is fine.

Progress on https://github.com/google/iree/issues/1285