### PR TITLE
Add HAL device creation test with DebugString method to log info.

### DIFF
--- a/docs/GetStarted/getting_started_linux_vulkan.md
+++ b/docs/GetStarted/getting_started_linux_vulkan.md
@@ -60,16 +60,16 @@ Tests in IREE's HAL "Conformance Test Suite" (CTS) actually exercise the Vulkan
 HAL, which includes checking for supported layers and extensions.
 
 Run the
-[allocator test](https://github.com/google/iree/blob/master/iree/hal/cts/allocator_test.cc):
+[device creation test](https://github.com/google/iree/blob/master/iree/hal/cts/device_creation_test.cc):
 
 ```shell
 # -- CMake --
 $ set VK_LOADER_DEBUG=all
-$ cmake --build build/ --target iree_hal_cts_allocator_test
-$ ./build/iree/hal/cts/iree_hal_cts_allocator_test
+$ cmake --build build/ --target iree_hal_cts_device_creation_test
+$ ./build/iree/hal/cts/iree_hal_cts_device_creation_test
 
 # -- Bazel --
-$ bazel test iree/hal/cts:allocator_test --test_env=VK_LOADER_DEBUG=all
+$ bazel test iree/hal/cts:device_creation_test --test_env=VK_LOADER_DEBUG=all --test_output=all
 ```
 
 If these tests pass, you can skip down to the next section.

--- a/docs/GetStarted/getting_started_windows_vulkan.md
+++ b/docs/GetStarted/getting_started_windows_vulkan.md
@@ -60,16 +60,16 @@ Tests in IREE's HAL "Conformance Test Suite" (CTS) actually exercise the Vulkan
 HAL, which includes checking for supported layers and extensions.
 
 Run the
-[allocator test](https://github.com/google/iree/blob/master/iree/hal/cts/allocator_test.cc):
+[device creation test](https://github.com/google/iree/blob/master/iree/hal/cts/device_creation_test.cc):
 
 ```powershell
 # -- CMake --
 > set VK_LOADER_DEBUG=all
-> cmake --build build\ --target iree_hal_cts_allocator_test
-> .\build\iree\hal\cts\iree_hal_cts_allocator_test.exe
+> cmake --build build\ --target iree_hal_cts_device_creation_test
+> .\build\iree\hal\cts\iree_hal_cts_device_creation_test.exe
 
 # -- Bazel --
-> bazel test iree/hal/cts:allocator_test --test_env=VK_LOADER_DEBUG=all
+> bazel test iree/hal/cts:device_creation_test --test_env=VK_LOADER_DEBUG=all --test_output=all
 ```
 
 If these tests pass, you can skip down to the next section.

--- a/iree/hal/BUILD
+++ b/iree/hal/BUILD
@@ -229,6 +229,7 @@ cc_library(
     deps = [
         "//iree/base:bitfield",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -250,6 +250,7 @@ iree_cc_library(
     "device_info.h"
   DEPS
     absl::core_headers
+    absl::strings
     iree::base::bitfield
   PUBLIC
 )

--- a/iree/hal/cts/BUILD
+++ b/iree/hal/cts/BUILD
@@ -64,3 +64,13 @@ cc_test(
         "//iree/testing:gtest",
     ],
 )
+
+cc_test(
+    name = "device_creation_test",
+    srcs = ["device_creation_test.cc"],
+    deps = [
+        ":cts_test_base",
+        "//iree/hal:driver_registry",
+        "//iree/testing:gtest",
+    ],
+)

--- a/iree/hal/cts/CMakeLists.txt
+++ b/iree/hal/cts/CMakeLists.txt
@@ -57,3 +57,14 @@ iree_cc_test(
     iree::hal::driver_registry
     iree::testing::gtest
 )
+
+iree_cc_test(
+  NAME
+    device_creation_test
+  SRCS
+    "device_creation_test.cc"
+  DEPS
+    ::cts_test_base
+    iree::hal::driver_registry
+    iree::testing::gtest
+)

--- a/iree/hal/cts/device_creation_test.cc
+++ b/iree/hal/cts/device_creation_test.cc
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/cts/cts_test_base.h"
+#include "iree/hal/driver_registry.h"
+#include "iree/testing/gtest.h"
+
+namespace iree {
+namespace hal {
+namespace cts {
+
+class DeviceCreationTest : public CtsTestBase {};
+
+TEST_P(DeviceCreationTest, CreateDevice) {
+  LOG(INFO) << "Device details:\n" << device_->DebugString();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllDrivers, DeviceCreationTest,
+                         ::testing::ValuesIn(DriverRegistry::shared_registry()
+                                                 ->EnumerateAvailableDrivers()),
+                         GenerateTestName());
+
+}  // namespace cts
+}  // namespace hal
+}  // namespace iree

--- a/iree/hal/dawn/BUILD
+++ b/iree/hal/dawn/BUILD
@@ -40,6 +40,7 @@ cc_library(
         "//third_party/dawn:libdawn_proc",  # build-cleaner: keep
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/hal/dawn/dawn_device.cc
+++ b/iree/hal/dawn/dawn_device.cc
@@ -15,6 +15,7 @@
 #include "iree/hal/dawn/dawn_device.h"
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
 #include "iree/base/status.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/command_queue.h"
@@ -80,6 +81,12 @@ DawnDevice::DawnDevice(const DeviceInfo& device_info,
 }
 
 DawnDevice::~DawnDevice() = default;
+
+std::string DawnDevice::DebugString() const {
+  return absl::StrCat(Device::DebugString(),  //
+                      "\n[DawnDevice]",       //
+                      "\n  Command Queues: ", command_queues_.size());
+}
 
 StatusOr<ref_ptr<DescriptorSetLayout>> DawnDevice::CreateDescriptorSetLayout(
     DescriptorSetLayout::UsageType usage_type,

--- a/iree/hal/dawn/dawn_device.h
+++ b/iree/hal/dawn/dawn_device.h
@@ -33,6 +33,8 @@ class DawnDevice final : public Device {
                       ::wgpu::Device backend_device);
   ~DawnDevice() override;
 
+  std::string DebugString() const override;
+
   Allocator* allocator() const override { return &allocator_; }
 
   absl::Span<CommandQueue*> dispatch_queues() const override {

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -43,6 +43,9 @@ class Device : public RefObject<Device> {
   // Information about device capabilities.
   const DeviceInfo& info() const { return device_info_; }
 
+  // Returns a debug string describing the device.
+  virtual std::string DebugString() const { return device_info_.DebugString(); }
+
   // TODO(benvanik): status (thermal, power mode, etc).
 
   // TODO(benvanik): throttling adjustment/power profile.

--- a/iree/hal/device_info.h
+++ b/iree/hal/device_info.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "iree/base/bitfield.h"
 
 namespace iree {
@@ -88,6 +90,21 @@ class DeviceInfo {
   // listing. This handle will not be valid across driver instances or outside
   // of the current process.
   DriverDeviceID device_id() const { return device_id_; }
+
+  // Returns a debug string describing the device information.
+  std::string DebugString() const {
+    std::string features = FormatBitfieldValue(
+        supported_features_, {
+                                 {DeviceFeature::kDebugging, "kDebugging"},
+                                 {DeviceFeature::kCoverage, "kCoverage"},
+                                 {DeviceFeature::kProfiling, "kProfiling"},
+                             });
+
+    return absl::StrCat("[DeviceInfo]",                              //
+                        "\n  Name: ", name_,                         //
+                        "\n  Supported features: [", features, "]",  //
+                        "\n  Device ID: ", device_id_);
+  }
 
  private:
   const std::string id_;

--- a/iree/hal/llvmjit/BUILD
+++ b/iree/hal/llvmjit/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "//iree/hal/host:inproc_command_buffer",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -85,6 +85,7 @@ iree_cc_library(
     absl::inlined_vector
     absl::memory
     absl::span
+    absl::strings
     iree::base::memory
     iree::base::status
     iree::base::tracing

--- a/iree/hal/llvmjit/llvmjit_device.cc
+++ b/iree/hal/llvmjit/llvmjit_device.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
 #include "iree/base/status.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/command_buffer_validation.h"
@@ -119,6 +120,12 @@ StatusOr<ref_ptr<LLVMJITDevice>> LLVMJITDevice::CreateLLVMJITDevice(
 }
 
 LLVMJITDevice::~LLVMJITDevice() = default;
+
+std::string LLVMJITDevice::DebugString() const {
+  return absl::StrCat(Device::DebugString(),  //
+                      "\n[LLVMJITDevice]",    //
+                      "\n  Command Queues: ", command_queues_.size());
+}
 
 ref_ptr<ExecutableCache> LLVMJITDevice::CreateExecutableCache() {
   IREE_TRACE_SCOPE0("LLVMJITDevice::CreateExecutableCache");

--- a/iree/hal/llvmjit/llvmjit_device.h
+++ b/iree/hal/llvmjit/llvmjit_device.h
@@ -32,6 +32,8 @@ class LLVMJITDevice final : public Device {
   explicit LLVMJITDevice(DeviceInfo device_info);
   ~LLVMJITDevice() override;
 
+  std::string DebugString() const override;
+
   Allocator* allocator() const override { return &allocator_; }
 
   absl::Span<CommandQueue*> dispatch_queues() const override {

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -113,6 +113,7 @@ cc_library(
         "//iree/vm:module",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -102,6 +102,7 @@ iree_cc_library(
     absl::inlined_vector
     absl::memory
     absl::span
+    absl::strings
     iree::base::memory
     iree::base::status
     iree::base::tracing

--- a/iree/hal/vmla/vmla_device.cc
+++ b/iree/hal/vmla/vmla_device.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
 #include "iree/base/status.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/command_buffer_validation.h"
@@ -122,6 +123,12 @@ VMLADevice::VMLADevice(DeviceInfo device_info, iree_vm_instance_t* instance,
 VMLADevice::~VMLADevice() {
   iree_vm_module_release(vmla_module_);
   iree_vm_instance_release(instance_);
+}
+
+std::string VMLADevice::DebugString() const {
+  return absl::StrCat(Device::DebugString(),  //
+                      "\n[VMLADevice]",       //
+                      "\n  Command Queues: ", command_queues_.size());
 }
 
 ref_ptr<ExecutableCache> VMLADevice::CreateExecutableCache() {

--- a/iree/hal/vmla/vmla_device.h
+++ b/iree/hal/vmla/vmla_device.h
@@ -33,6 +33,8 @@ class VMLADevice final : public Device {
                       iree_vm_module_t* vmla_module);
   ~VMLADevice() override;
 
+  std::string DebugString() const override;
+
   Allocator* allocator() const override { return &allocator_; }
 
   absl::Span<CommandQueue*> dispatch_queues() const override {

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -486,6 +486,14 @@ VulkanDevice::~VulkanDevice() {
   logical_device_.reset();
 }
 
+std::string VulkanDevice::DebugString() const {
+  return absl::StrCat(Device::DebugString(),                                 //
+                      "\n[VulkanDevice]",                                    //
+                      "\n  Command Queues: ", command_queues_.size(),        //
+                      "\n    - Dispatch Queues: ", dispatch_queues_.size(),  //
+                      "\n    - Transfer Queues: ", transfer_queues_.size());
+}
+
 ref_ptr<ExecutableCache> VulkanDevice::CreateExecutableCache() {
   IREE_TRACE_SCOPE0("VulkanDevice::CreateExecutableCache");
   return make_ref<PipelineCache>(add_ref(logical_device_));

--- a/iree/hal/vulkan/vulkan_device.h
+++ b/iree/hal/vulkan/vulkan_device.h
@@ -67,6 +67,8 @@ class VulkanDevice final : public Device {
 
   ~VulkanDevice() override;
 
+  std::string DebugString() const override;
+
   const ref_ptr<DynamicSymbols>& syms() const {
     return logical_device_->syms();
   }


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/1452 , but is missing some useful information from the printed messages. I wasn't quite sure how to make the logging more useful without tracking excess state in production builds (maybe could keep a reference to things like `ExtensibilitySpec` using `#ifndef NDEBUG`?)

Logs look like this:

```
λ .\build\iree\hal\cts\iree_hal_cts_device_creation_test.exe
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from AllDrivers/DeviceCreationTest
[ RUN      ] AllDrivers/DeviceCreationTest.CreateDevice/vmla
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:35] Creating driver 'vmla'...
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:44] Creating default device...
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:46] Created device 'vmla'
I ..\iree\hal\cts\device_creation_test.cc:26] Device details:
[DeviceInfo]
  Name: vmla
  Supported features: []
  Device ID: 0
[VMLADevice]
  Command Queues: 1
[       OK ] AllDrivers/DeviceCreationTest.CreateDevice/vmla (20 ms)
[ RUN      ] AllDrivers/DeviceCreationTest.CreateDevice/vulkan
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:35] Creating driver 'vulkan'...
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:44] Creating default device...
[vk_mem_alloc.h : 15777] RAW: vmaCreateAllocator
I F:\dev\projects\iree\iree/hal/cts/cts_test_base.h:46] Created device 'GeForce GTX 980 Ti'
I ..\iree\hal\cts\device_creation_test.cc:26] Device details:
[DeviceInfo]
  Name: GeForce GTX 980 Ti
  Supported features: []
  Device ID: 1953488053952
[VulkanDevice]
  Command Queues: 3
    - Dispatch Queues: 2
    - Transfer Queues: 1
[vk_mem_alloc.h : 15787] RAW: vmaDestroyAllocator
[       OK ] AllDrivers/DeviceCreationTest.CreateDevice/vulkan (362 ms)
[----------] 2 tests from AllDrivers/DeviceCreationTest (384 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (387 ms total)
[  PASSED  ] 2 tests.
```