### PR TITLE
Set IREE_AVAILABLE_BACKENDS in Bazel CI

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -61,4 +61,12 @@ jobs:
           # tagged "manual". The "manual" tag allows targets to be excluded from
           # human wildcard builds, but we want them built by CI unless they are
           # excluded with "noga".
-          bazel query '//...' | xargs bazel test --build_tag_filters="-noga" --test_tag_filters="-noga,-driver=vulkan" --test_env=IREE_VULKAN_DISABLE=1 --test_env=IREE_DEFAULT_BACKENDS="tf,iree_vmla" --define=iree_tensorflow=true --test_output=errors --keep_going
+          bazel query '//...' \
+            | xargs bazel test \
+              --build_tag_filters="-noga" \
+              --test_tag_filters="-noga,-driver=vulkan" \
+              --test_env=IREE_VULKAN_DISABLE=1 \
+              --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla" \
+              --define=iree_tensorflow=true \
+              --test_output=errors \
+              --keep_going


### PR DESCRIPTION
This replaced IREE_DEFAULT_BACKENDS with https://github.com/google/iree/commit/85303d0c1dee5f7b82c65c12f049ac37b7d4bf19. I earlier tried to change this to set both to avoid an intermediate breakage (https://github.com/google/iree/commit/ebfbc922e429d607509f68e8ec97f47e68e584fc#diff-2ef12a800b55d4c81acc58774f511f6c), but it was accidentally reverted in https://github.com/google/iree/commit/2775e3eedb7696bee08ee8ad4db3101856c304cc by issues with our syncing automation, which can't handle workflow files because of silly GitHub restrictions.

Also finally added line breaks to this ridiculously long line. There's some yaml magic you can do with a chomp operator or something, but I just did boring old line continuations.

Tested: No. It's basically impossible.