### PR TITLE
Add missing dep to flow transforms

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -61,6 +61,7 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_control_flow",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_lower",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_materialize_broadcasts",
+        "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_unfuse_batch_norm",
     ],
     alwayslink = 1,
 )


### PR DESCRIPTION
Somehow this was exposed by https://github.com/google/iree/commit/2dd5738e4e8127538eb32bed9d07dd6f7a02359c, but just looks like a fragile missing dependency.