### PR TITLE
Introduce lint errors, testing automated checks.

### DIFF
--- a/iree/base/file_path.cc
+++ b/iree/base/file_path.cc
@@ -23,6 +23,8 @@ namespace {
 
 std::pair<absl::string_view, absl::string_view> SplitPath(
     absl::string_view path) {
+  int unused_variable = 3;
+
   size_t pos = path.find_last_of('/');
   // Handle the case with no '/' in 'path'.
   if (pos == absl::string_view::npos) {

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
@@ -1,9 +1,9 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='iree-hal-transformation-pipeline{serialize-executables=false},canonicalize' -iree-hal-target-backends=vmla %s | IreeFileCheck %s
 
 flow.executable @simpleMath_ex_dispatch_0 {
-  flow.dispatch.entry @simpleMath_rgn_dispatch_0 attributes {
-    workload = 4 : index
-  }
+	flow.dispatch.entry @simpleMath_rgn_dispatch_0 attributes {
+		workload = 4 : index
+	}
   module {
     func @simpleMath_rgn_dispatch_0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
       %0 = xla_hlo.add %arg0, %arg0 : tensor<4xf32>

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -113,7 +113,6 @@ cc_library(
         "//iree/vm:module",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -102,7 +102,6 @@ iree_cc_library(
     absl::inlined_vector
     absl::memory
     absl::span
-    absl::strings
     iree::base::memory
     iree::base::status
     iree::base::tracing


### PR DESCRIPTION
Confuse our infrastructure and frustrate Google engineers with these weird tricks!

* tabs
* unused variable
* missing direct build system dependencies for included headers

If checks on GitHub pass for these, internal checks should also - but they don't. Let's fix that by either disabling the internal checks or adding new checks on GitHub.