### PR TITLE
CMake: Add IREE/tools subdir also if not building the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ if(${IREE_BUILD_COMPILER})
 elseif(${IREE_ENABLE_LLVM})
   # If not building the compiler, tablegen is still needed
   # to generate vm ops so deep include it only.
+  add_subdirectory(iree/compiler/Dialect/IREE/Tools)
   add_subdirectory(iree/compiler/Dialect/VM/Tools)
 endif()
 


### PR DESCRIPTION
`iree-tblgen` depends on `iree::compiler::Dialect::IREE::Tools`, thus this should be build. However, untested.