### PR TITLE
Revise alwaylink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ if(${IREE_ENABLE_LLVM})
   endif()
 
   add_subdirectory(third_party/llvm-project/llvm EXCLUDE_FROM_ALL)
-  set_alwayslink_mlir_libs()
 
   # Reset CMAKE_BUILD_TYPE to its previous setting
   set(CMAKE_BUILD_TYPE "${_CMAKE_BUILD_TYPE}" CACHE STRING "Build type (default ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)

--- a/build_tools/cmake/iree_alwayslink.cmake
+++ b/build_tools/cmake/iree_alwayslink.cmake
@@ -54,24 +54,6 @@ function(set_alwayslink_property)
 endfunction()
 
 
-function(set_alwayslink_mlir_libs)
-  set(_ALWAYSLINK_LIBS_MLIR
-    # TODO(marbre): Check the previously added libs
-    MLIRAnalysis
-    MLIREDSC
-    MLIRParser
-    MLIRTransforms
-    MLIRTranslation
-    MLIRSupport
-  )
-
-  set_alwayslink_property(
-    ALWAYSLINK_LIBS
-      ${_ALWAYSLINK_LIBS_MLIR}
-  )
-endfunction()
-
-
 function(set_alwayslink_tensorflow_libs)
   set(_ALWAYSLINK_LIBS_TENSORFLOW
     tensorflow::mlir_xla

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
@@ -47,5 +47,4 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
@@ -42,6 +42,5 @@ iree_cc_library(
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::Shape::IR
     iree::compiler::Dialect::VM::IR
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
@@ -47,5 +47,4 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -42,6 +42,5 @@ iree_cc_library(
     iree::compiler::Dialect::VM::Conversion
     iree::compiler::Dialect::VM::Conversion::StandardToVM
     iree::compiler::Dialect::VM::IR
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -46,5 +46,4 @@ cc_library(
         "@llvm-project//mlir:TargetLLVMIR",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -41,6 +41,5 @@ iree_cc_library(
     iree::compiler::Translation::CodegenPasses
     iree::compiler::Translation::CodegenUtils
     iree::schemas::llvmir_executable_def_cc_fbs
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/VMLA/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/BUILD
@@ -39,5 +39,4 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/CMakeLists.txt
@@ -34,6 +34,5 @@ iree_cc_library(
     iree::compiler::Dialect::VM::Transforms
     iree::compiler::Dialect::VMLA::Transforms
     iree::schemas::vmla_executable_def_cc_fbs
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
@@ -49,5 +49,4 @@ cc_library(
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/CMakeLists.txt
@@ -44,6 +44,5 @@ iree_cc_library(
     iree::compiler::Translation::SPIRV::XLAToSPIRV
     iree::schemas::spirv_executable_def_cc_fbs
     tensorflow::mlir_xla
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -52,5 +52,4 @@ cc_library(
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -47,6 +47,5 @@ iree_cc_library(
     iree::compiler::Dialect::Shape::Transforms
     iree::compiler::Utils
     tensorflow::mlir_xla
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/BUILD
@@ -22,5 +22,4 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/CMakeLists.txt
@@ -31,6 +31,5 @@ iree_cc_library(
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::VM::Conversion
     iree::compiler::Dialect::VM::IR
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -76,6 +76,7 @@ cc_library(
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/Flow/Transforms",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
+        "//iree/compiler/Dialect/HAL/Transforms",
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/IREE/Transforms",
         "//iree/compiler/Dialect/Shape/IR",

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -265,7 +265,6 @@ cc_library(
         "@llvm-project//mlir:Translation",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_dialect_registration",
     ] + IREE_COMPILER_DIALECT_MODULES,
-    alwayslink = 1,
 )
 
 cc_binary(

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -282,7 +282,6 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Translation::SPIRV::XLAToSPIRV
       tensorflow::mlir_xla
       ${IREE_COMPILER_DIALECT_MODULES}
-    ALWAYSLINK
     PUBLIC
   )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -140,6 +140,7 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Dialect::Flow::IR
       iree::compiler::Dialect::Flow::Transforms
       iree::compiler::Dialect::HAL::IR::HALDialect
+      iree::compiler::Dialect::HAL::Transforms
       iree::compiler::Dialect::IREE::IR
       iree::compiler::Dialect::IREE::Transforms
       iree::compiler::Dialect::Shape::IR

--- a/iree/tools/init_passes.h
+++ b/iree/tools/init_passes.h
@@ -23,6 +23,7 @@
 #include <cstdlib>
 
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "iree/compiler/Dialect/IREE/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/Transforms/Passes.h"
 #include "iree/compiler/Dialect/VM/Transforms/Passes.h"
@@ -169,7 +170,7 @@ namespace iree_compiler {
 // global registry.
 inline void registerAllIreePasses() {
   IREE::Flow::registerFlowPasses();
-  // TODO: register HAL passes
+  IREE::HAL::registerHALPasses();
   IREE::registerIreePasses();
   Shape::registerShapePasses();
   IREE::VM::registerVMPasses();


### PR DESCRIPTION
This removes the alwayslink flag from several libraries in the Bazel and CMake config. Libraries marked alwayslink getting linked into executables with `"-Wl,--whole-archive"`.

* Drops alwaylink for IREE passes that are explicitly registered within the function `registerAllIreePasses()`.
* Drops alwayslink for the HAL targets. These are now explicitly registered with the function `registerHALTargetBackends()`.
* Completely removes alwayslink for MLIR in the CMake configuration. MLIR libs are no longer required to be linked in as whole archive.
* Drops the alwayslink flag from the `iree-translate` library which is linked into the final translate binaries, e.g. `custom-translate`.