### PR TITLE
Reenable RBE

### DIFF
--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -66,14 +66,11 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query "//iree/... + //bindings/..." | \
+bazel query //iree/... | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \
     --keep_going \
     --test_output=errors \
-    --config=rs
-
-# Disable RBE until compatibility issues with the experimental_repo_remote_exec
-# flag are fixed.
-#   --config=rbe
+    --config=rs \
+    --config=rbe


### PR DESCRIPTION
With https://github.com/google/iree/commit/ff42ec3d6e9b534772575dde2306914746c9bffc that worked around naming conflicts with experimental_repo_remote_exec and https://github.com/google/iree/commit/59ff572d330e6820b4b96b9c03e9c58f944295d7 removing glslang (and therefore a ton of compiler warnings that are errors on RBE) we can enable this again. The only thing that doesn't work is building `//bindings/python/pyiree/compiler:compiler_test`. I opted to disable that test so we can avoid further regressions here. We weren't able to re-enable RBE a while ago because a bunch of those glslang issues sneaked in while it was disabled, and I'd like to avoid that in the future. This drops all our presubmit builds to 5 minutes, which means they could actually be submit-blocking like CMake, which seems worth it in the interim.

So that the build config is honest about what's happening, it only lists `//iree/...` as the build target. All the targets under bindings would be excluded anyway. I think this is a reasonable target set to have for the core CI, though we should likely have additional builds that run other target sets. Given that the directory is specified explicitly this allows removing a bunch of superfluous "nokokoro" tags from BUILD targets outside of the iree directory.