### PR TITLE
Remove superfluous nokokoro tags

### DIFF
--- a/bindings/python/pyiree/common/BUILD
+++ b/bindings/python/pyiree/common/BUILD
@@ -31,7 +31,6 @@ pybind_cc_library(
         "binding.h",
         "status_utils.h",
     ],
-    tags = ["nokokoro"],
     deps = [
         "//iree/base:api",
         "//iree/base:status",

--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -53,7 +53,6 @@ iree_py_library(
         "__init__.py",
     ],
     srcs_version = "PY3",
-    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -68,7 +67,6 @@ iree_py_extension(
     copts = PYBIND_COPTS + PYBIND_EXTENSION_COPTS,
     features = PYBIND_FEATURES,
     linkstatic = 1,
-    tags = ["nokokoro"],
     win_def_file = "export.def",
     deps = [
         ":compiler_library",
@@ -85,7 +83,6 @@ pybind_cc_library(
         "compiler.h",
     ],
     copts = PYBIND_REGISTER_MLIR_PASSES,
-    tags = ["nokokoro"],
     deps = COMPILER_DEPS + [
         "//bindings/python/pyiree/common",
         "//iree/tools:init_passes_and_dialects",

--- a/bindings/python/pyiree/rt/BUILD
+++ b/bindings/python/pyiree/rt/BUILD
@@ -43,7 +43,6 @@ iree_py_library(
         "system_api.py",
     ],
     srcs_version = "PY3",
-    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -58,8 +57,6 @@ iree_py_extension(
     copts = PYBIND_COPTS + PYBIND_EXTENSION_COPTS,
     features = PYBIND_FEATURES,
     linkstatic = 1,
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     win_def_file = "export.def",
     deps = DRIVER_DEPS + [
         ":rt_library",
@@ -84,7 +81,6 @@ pybind_cc_library(
         "host_types.h",
         "vm.h",
     ],
-    tags = ["nokokoro"],
     deps = [
         "//bindings/python/pyiree/common",
         "//iree/base:api",
@@ -111,8 +107,6 @@ iree_py_library(
     name = "system_api",
     srcs = ["system_api.py"],
     srcs_version = "PY3",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -124,24 +118,18 @@ iree_py_test(
     srcs = ["function_abi_test.py"],
     python_version = "PY3",
     # TODO(laurenzo): Enable once test does not depend on a real vulkan device.
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     deps = NUMPY_DEPS + [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",
         "//bindings/python/pyiree/rt",
     ],
-    # TODO(b/145815906) Get this running in OSS CI.
 )
 
 iree_py_test(
     name = "hal_test",
     srcs = ["hal_test.py"],
     python_version = "PY3",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = NUMPY_DEPS + [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",
@@ -153,11 +141,7 @@ iree_py_test(
     name = "system_api_test",
     srcs = ["system_api_test.py"],
     python_version = "PY3",
-    tags = [
-        # TODO(b/145815906) Get this running in OSS CI.
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     deps = NUMPY_DEPS + [
         ":system_api",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -171,7 +155,6 @@ iree_py_test(
     name = "vm_test",
     srcs = ["vm_test.py"],
     python_version = "PY3",
-    tags = ["nokokoro"],
     deps = NUMPY_DEPS + [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -66,14 +66,11 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query "//iree/... + //bindings/..." | \
+bazel query //iree/... | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \
     --keep_going \
     --test_output=errors \
-    --config=rs
-
-# Disable RBE until compatibility issues with the experimental_repo_remote_exec
-# flag are fixed.
-#   --config=rbe
+    --config=rs \
+    --config=rbe

--- a/colab/BUILD.bazel
+++ b/colab/BUILD.bazel
@@ -18,8 +18,6 @@ py_binary(
     legacy_create_init = False,
     main = "dummy.py",
     python_version = "PY3",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "//bindings/python/pyiree/compiler",  # build_cleaner: keep

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -55,7 +55,6 @@ iree_py_library(
         "__init__.py",
     ],
     srcs_version = "PY3",
-    tags = ["nokokoro"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -71,7 +70,6 @@ iree_py_extension(
     copts = PYBIND_COPTS + PYBIND_EXTENSION_COPTS,
     features = PYBIND_FEATURES,
     linkstatic = 1,
-    tags = ["nokokoro"],
     win_def_file = "export.def",
     deps = [
         ":compiler_library",
@@ -88,7 +86,6 @@ pybind_cc_library(
     hdrs = [
         "register_tensorflow.h",
     ],
-    tags = ["nokokoro"],
     deps = SAVED_MODEL_TF_RUNTIME_DEPS + TF_XLA_PASS_DEPS + [
         "//bindings/python/pyiree/common",
         "//bindings/python/pyiree/compiler:compiler_library",
@@ -103,7 +100,6 @@ iree_py_test(
     name = "saved_model_test",
     srcs = ["saved_model_test.py"],
     python_version = "PY3",
-    tags = ["nokokoro"],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "@absl_py//absl/testing:absltest",
         "//integrations/tensorflow/bindings/python/pyiree/tf/compiler",

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/BUILD
@@ -30,7 +30,6 @@ iree_py_library(
         "tf_test_driver.py",
         "tf_test_utils.py",
     ],
-    tags = ["nokokoro"],
     deps = INTREE_TENSORFLOW_PY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/compiler",
         "//bindings/python/pyiree/rt",

--- a/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
@@ -36,10 +36,7 @@ iree_py_library(
         "__init__.py",
     ],
     srcs_version = "PY3",
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     deps = [
         ":binding",
         "//bindings/python:pathsetup",  # build_cleaner: keep
@@ -55,10 +52,7 @@ iree_py_extension(
     copts = PYBIND_COPTS + PYBIND_EXTENSION_COPTS,
     features = PYBIND_FEATURES,
     linkstatic = 1,
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     win_def_file = "export.def",
     deps = [
         ":compiler_library",
@@ -75,10 +69,7 @@ pybind_cc_library(
     hdrs = [
         "register_xla.h",
     ],
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     deps = [
         "//bindings/python/pyiree/common",
         "//bindings/python/pyiree/compiler:compiler_library",
@@ -93,10 +84,7 @@ iree_py_test(
     name = "xla_module_proto_test",
     srcs = ["xla_module_proto_test.py"],
     python_version = "PY3",
-    tags = [
-        "noga",
-        "nokokoro",
-    ],
+    tags = ["noga"],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "@absl_py//absl/testing:absltest",
         "//integrations/tensorflow/bindings/python/pyiree/xla/compiler",

--- a/integrations/tensorflow/compiler/test/BUILD
+++ b/integrations/tensorflow/compiler/test/BUILD
@@ -35,7 +35,6 @@ iree_lit_test_suite(
         "//integrations/tensorflow/compiler:iree-tf-opt",
         "//iree/tools:IreeFileCheck",
     ],
-    tags = ["nokokoro"],
 )
 
 iree_py_test(
@@ -50,8 +49,6 @@ iree_py_test(
         INTREE_FILECHECK_TARGET,
     ],
     python_version = "PY3",
-    # TODO(b/145815906) Get this running in OSS CI.
-    tags = ["nokokoro"],
     deps = INTREE_TENSORFLOW_PY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -90,11 +90,7 @@ package(
         name = name,
         srcs = [name + ".py"],
         python_version = "PY3",
-        # TODO(b/145815906) Get this running in OSS CI.
-        tags = [
-            "noga",
-            "nokokoro",
-        ],
+        tags = ["noga"],
         deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
             "//integrations/tensorflow/bindings/python/pyiree/tf/support",
         ],


### PR DESCRIPTION
The Kokoro CI only tests the `iree/` directory, so these are just noise.