### PR TITLE
Make automatic submodule updates more frequent

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -18,8 +18,8 @@ name: Update Submodules
 
 on:
   schedule:
-     # Every weekday at 14:00 UTC (06:00 PST/07:00 PDT)
-     - cron: '0 14 * * 1-5'
+     # Every 6 hours at 0, 6, 12, 18 UTC (4, 10, 16, 22 PST)
+     - cron: '0 */6 * * *'
 
 jobs:
   update:


### PR DESCRIPTION
Every 6 hours. We can always ignore them if they're not needed, but given that we have people in various timezones, it's better to get good coverage. Also the weekend ones can just be ignored, but if someone is around and cares to update it will already be prepped for them.