### PR TITLE
Add separate IREE bindings bazel build

### DIFF
--- a/.github/workflows/bindings_bazel_build.yml
+++ b/.github/workflows/bindings_bazel_build.yml
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and tests iree bindings directory.
+
+name: Bindings Bazel Build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  linux:
+    runs-on: ubuntu-18.04
+    env:
+      CXX: clang++
+      CC: clang
+      PYTHON_BIN: /usr/bin/python3
+      # Install the version of Bazel that is required by our .bazelversion file.
+      BAZEL_VERSION: 2.1.0
+    steps:
+      - name: Installing bazel
+        run: |
+          # https://docs.bazel.build/versions/master/install-ubuntu.html
+          sudo apt-get install unzip zip
+          wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION?}/bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+          chmod +x bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+          ./bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh --user
+          rm bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+          echo "::add-path::${HOME?}/bin"
+      - name: Installing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang libsdl2-dev python3 python3-pip python3-setuptools
+          # Update pip before using it so it picks up the latest versions of our dependencies.
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install numpy tf-nightly
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Initializing submodules
+        run: ./scripts/git/submodule_versions.py init
+      - name: Building and testing with bazel
+        run: |
+          # Build and test everything in the bindings/ directory not explicitly
+          # marked as excluded from CI (using the tag
+          # "noga"="No GitHub Actions") or which uses vulkan at runtime.
+          # Note that somewhat contrary to its name `bazel test` will also build
+          # any non-test targets specified.
+          # We use `bazel query //...` piped to `bazel test` rather than the
+          # simpler `bazel test //...` because the latter excludes targets
+          # tagged "manual". The "manual" tag allows targets to be excluded from
+          # human wildcard builds, but we want them built by CI unless they are
+          # excluded with "noga".
+          bazel query '//bindings/...' \
+            | xargs bazel test \
+              --build_tag_filters="-noga" \
+              --test_tag_filters="-noga,-driver=vulkan" \
+              --test_env=IREE_VULKAN_DISABLE=1 \
+              --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla" \
+              --define=iree_tensorflow=true \
+              --test_output=errors \
+              --keep_going


### PR DESCRIPTION
This covers only the bindings/ directory.

This is just a fork of bazel_build.yml with a few edits to change the coverage. We can tweak things (like dropping the TF dep) later.

Part of addressing https://github.com/google/iree/issues/1588