### PR TITLE
[pyiree] Add missing dependency on compiler modules

### DIFF
--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -88,6 +88,7 @@ pybind_cc_library(
     tags = ["nokokoro"],
     deps = COMPILER_DEPS + [
         "//bindings/python/pyiree/common",
+        "//iree/tools:init_compiler_modules",
         "//iree/tools:init_passes_and_dialects",
         "//iree/tools:init_targets",
         "@llvm-project//llvm:support",

--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -33,7 +33,6 @@ package(
 COMPILER_DEPS = [
     # Transforms.
     "//iree/compiler/Dialect/Flow/Transforms",
-    "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
     "//iree/compiler/Dialect/HAL/Target",
     "//iree/compiler/Dialect/HAL/Transforms",
     "//iree/compiler/Dialect/Shape/IR",

--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -46,7 +46,6 @@ iree_pybind_cc_library(
   DEPS
     # Transforms. Adopted from the Bazel variable COMPILER_DEPS.
     iree::compiler::Dialect::Flow::Transforms
-    iree::compiler::Dialect::Modules::TensorList::IR::TensorListDialect
     iree::compiler::Dialect::HAL::Transforms
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::Shape::IR
@@ -57,6 +56,7 @@ iree_pybind_cc_library(
     iree::compiler::Dialect::HAL::Target::LLVM
     iree::compiler::Dialect::HAL::Target::VulkanSPIRV
     iree::compiler::Dialect::VM::Target::Bytecode
+    iree::tools::init_compiler_modules
     iree::tools::init_passes_and_dialects
     iree::tools::init_targets
     bindings::python::pyiree::common

--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -72,7 +72,7 @@ bool LLVMOnceInit() {
   // Register built-in MLIR dialects.
   mlir::registerMlirDialects();
 
-  // Register IREE dialects and HAL target backends.
+  // Register IREE dialects, compiler module dialects, and HAL target backends.
   mlir::iree_compiler::registerIreeDialects();
   mlir::iree_compiler::registerIreeCompilerModuleDialects();
   mlir::iree_compiler::registerHALTargetBackends();

--- a/bindings/python/pyiree/compiler/compiler.cc
+++ b/bindings/python/pyiree/compiler/compiler.cc
@@ -24,6 +24,7 @@
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
 #include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "iree/tools/init_compiler_modules.h"
 #include "iree/tools/init_dialects.h"
 #include "iree/tools/init_passes.h"
 #include "iree/tools/init_targets.h"
@@ -73,6 +74,7 @@ bool LLVMOnceInit() {
 
   // Register IREE dialects and HAL target backends.
   mlir::iree_compiler::registerIreeDialects();
+  mlir::iree_compiler::registerIreeCompilerModuleDialects();
   mlir::iree_compiler::registerHALTargetBackends();
 
   // Depending on the build environment the MLIR Passes may already be


### PR DESCRIPTION
This fixes the test failure seen on
//integrations/tensorflow/e2e:tensorlist_test.