### PR TITLE
Drop alwayslink flag from Flow Analysis

### DIFF
--- a/iree/compiler/Dialect/Flow/Analysis/BUILD
+++ b/iree/compiler/Dialect/Flow/Analysis/BUILD
@@ -38,5 +38,4 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Analysis/CMakeLists.txt
@@ -33,6 +33,5 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::Utils
     iree::compiler::Dialect::IREE::IR
     tensorflow::mlir_xla
-  ALWAYSLINK
   PUBLIC
 )


### PR DESCRIPTION
Follow up to c0cbab6, which implements the static registration of the Flow Analysis pass. This allows to drop alwayslink.