### PR TITLE
Added assembly formatting for VMLA matmul, transpose and conversion ops.

### DIFF
--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/interface_ops.mlir
@@ -12,7 +12,7 @@ func @inc_rgn_dispatch_0() attributes {iree.module.export} {
   // CHECK-NEXT: %[[ARG0:.+]] = "vmla.buffer.view"(%[[SET0BINDING0]], %[[C0]], %[[C4]])
   %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<f32>
   // CHECK-NEXT: %[[TEMP:.+]] = "vmla.buffer.alloc"(%[[C4]])
-  // CHECK-NEXT: vmla.add(%[[ARG0]], %[[CST1]], %[[TEMP]]) : f32
+  // CHECK-NEXT: vmla.add %[[ARG0]], %[[CST1]], %[[TEMP]] : f32
   %1 = xla_hlo.add %0, %cst : tensor<f32>
   // CHECK-NEXT: %[[SET0BINDING1:.+]] = "vmla.interface.binding"([[INTERFACE]]) {binding = 1 : i32, set = 0 : i32}
   // CHECK-NEXT: "vmla.buffer.copy"(%[[TEMP]], %[[C0]], %[[SET0BINDING1]], %[[C0]], %[[C4]])

--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/interface_ops.mlir
@@ -12,7 +12,7 @@ func @inc_rgn_dispatch_0() attributes {iree.module.export} {
   // CHECK-NEXT: %[[ARG0:.+]] = "vmla.buffer.view"(%[[SET0BINDING0]], %[[C0]], %[[C4]])
   %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<f32>
   // CHECK-NEXT: %[[TEMP:.+]] = "vmla.buffer.alloc"(%[[C4]])
-  // CHECK-NEXT: vmla.add %[[ARG0]], %[[CST1]], %[[TEMP]] : f32
+  // CHECK-NEXT: vmla.add %[[ARG0]], %[[CST1]], out %[[TEMP]] : f32
   %1 = xla_hlo.add %0, %cst : tensor<f32>
   // CHECK-NEXT: %[[SET0BINDING1:.+]] = "vmla.interface.binding"([[INTERFACE]]) {binding = 1 : i32, set = 0 : i32}
   // CHECK-NEXT: "vmla.buffer.copy"(%[[TEMP]], %[[C0]], %[[SET0BINDING1]], %[[C0]], %[[C4]])

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
@@ -4,7 +4,7 @@
 func @abs_scalar(%arg0 : tensor<f32>) -> tensor<f32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 4
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs(%arg0, %[[BUF]]) : f32
+  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
   %0 = "xla_hlo.abs"(%arg0) : (tensor<f32>) -> tensor<f32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<f32>
@@ -16,7 +16,7 @@ func @abs_scalar(%arg0 : tensor<f32>) -> tensor<f32> attributes { sym_visibility
 func @abs_tensor(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs(%arg0, %[[BUF]]) : f32
+  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
   %0 = "xla_hlo.abs"(%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>
@@ -28,7 +28,7 @@ func @abs_tensor(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibi
 func @clamp(%arg0 : tensor<4xf32>, %arg1 : tensor<4xf32>, %arg2 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.clamp(%arg0, %arg1, %arg2, %[[BUF]]) : f32
+  // CHECK-NEXT: vmla.clamp %arg0, %arg1, %arg2, %[[BUF]] : f32
   %0 = "xla_hlo.clamp"(%arg0, %arg1, %arg2) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
@@ -4,7 +4,7 @@
 func @abs_scalar(%arg0 : tensor<f32>) -> tensor<f32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 4
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
+  // CHECK-NEXT: vmla.abs %arg0, out %[[BUF]] : f32
   %0 = "xla_hlo.abs"(%arg0) : (tensor<f32>) -> tensor<f32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<f32>
@@ -16,7 +16,7 @@ func @abs_scalar(%arg0 : tensor<f32>) -> tensor<f32> attributes { sym_visibility
 func @abs_tensor(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
+  // CHECK-NEXT: vmla.abs %arg0, out %[[BUF]] : f32
   %0 = "xla_hlo.abs"(%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>
@@ -28,7 +28,7 @@ func @abs_tensor(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibi
 func @clamp(%arg0 : tensor<4xf32>, %arg1 : tensor<4xf32>, %arg2 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.clamp %arg0, %arg1, %arg2, %[[BUF]] : f32
+  // CHECK-NEXT: vmla.clamp %arg0, %arg1, %arg2, out %[[BUF]] : f32
   %0 = "xla_hlo.clamp"(%arg0, %arg1, %arg2) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
@@ -8,10 +8,10 @@ func @transpose() -> tensor<24x7x10xf32> attributes { sym_visibility = "private"
   // CHECK-DAG: %[[DST_SHAPE:.+]] = shapex.const_ranked_shape : !shapex.ranked_shape<[24,7,10]>
   // CHECK-DAG: %[[DST_SIZE:.+]] = constant 6720 : index
   // CHECK-DAG: %[[DST:.+]] = "vmla.buffer.alloc"(%[[DST_SIZE]])
-  // CHECK-NEXT: vmla.transpose(
+  // CHECK-NEXT: vmla.transpose
   // CHECK-SAME:   %[[SRC]], %[[SRC_SHAPE]],
   // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]
-  // CHECK-SAME: ) {permutation = dense<[1, 0, 2]> : tensor<3xi32>}
+  // CHECK-SAME: {permutation = dense<[1, 0, 2]> : tensor<3xi32>}
   // CHECK-SAME: (!shapex.ranked_shape<[7,24,10]>,
   // CHECK-SAME:  !shapex.ranked_shape<[24,7,10]>) f32
   %0 = "xla_hlo.transpose"(%input) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<7x24x10xf32>) -> tensor<24x7x10xf32>

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
@@ -9,8 +9,8 @@ func @transpose() -> tensor<24x7x10xf32> attributes { sym_visibility = "private"
   // CHECK-DAG: %[[DST_SIZE:.+]] = constant 6720 : index
   // CHECK-DAG: %[[DST:.+]] = "vmla.buffer.alloc"(%[[DST_SIZE]])
   // CHECK-NEXT: vmla.transpose
-  // CHECK-SAME: %[[SRC]](%[[SRC_SHAPE]] !shapex.ranked_shape<[7,24,10]>),
-  // CHECK-SAME: out %[[DST]](%[[DST_SHAPE]] !shapex.ranked_shape<[24,7,10]>)
+  // CHECK-SAME: %[[SRC]](%[[SRC_SHAPE]] : !shapex.ranked_shape<[7,24,10]>),
+  // CHECK-SAME: out %[[DST]](%[[DST_SHAPE]] : !shapex.ranked_shape<[24,7,10]>)
   // CHECK-SAME: {permutation = dense<[1, 0, 2]> : tensor<3xi32>} : f32
   %0 = "xla_hlo.transpose"(%input) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<7x24x10xf32>) -> tensor<24x7x10xf32>
   // CHECK-NEXT: return %[[DST]]

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
@@ -9,11 +9,9 @@ func @transpose() -> tensor<24x7x10xf32> attributes { sym_visibility = "private"
   // CHECK-DAG: %[[DST_SIZE:.+]] = constant 6720 : index
   // CHECK-DAG: %[[DST:.+]] = "vmla.buffer.alloc"(%[[DST_SIZE]])
   // CHECK-NEXT: vmla.transpose
-  // CHECK-SAME:   %[[SRC]], %[[SRC_SHAPE]],
-  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]
-  // CHECK-SAME: {permutation = dense<[1, 0, 2]> : tensor<3xi32>}
-  // CHECK-SAME: (!shapex.ranked_shape<[7,24,10]>,
-  // CHECK-SAME:  !shapex.ranked_shape<[24,7,10]>) f32
+  // CHECK-SAME: %[[SRC]](%[[SRC_SHAPE]] !shapex.ranked_shape<[7,24,10]>),
+  // CHECK-SAME: out %[[DST]](%[[DST_SHAPE]] !shapex.ranked_shape<[24,7,10]>)
+  // CHECK-SAME: {permutation = dense<[1, 0, 2]> : tensor<3xi32>} : f32
   %0 = "xla_hlo.transpose"(%input) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<7x24x10xf32>) -> tensor<24x7x10xf32>
   // CHECK-NEXT: return %[[DST]]
   return %0 : tensor<24x7x10xf32>

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/transpose.mlir
@@ -8,10 +8,12 @@ func @transpose() -> tensor<24x7x10xf32> attributes { sym_visibility = "private"
   // CHECK-DAG: %[[DST_SHAPE:.+]] = shapex.const_ranked_shape : !shapex.ranked_shape<[24,7,10]>
   // CHECK-DAG: %[[DST_SIZE:.+]] = constant 6720 : index
   // CHECK-DAG: %[[DST:.+]] = "vmla.buffer.alloc"(%[[DST_SIZE]])
-  // CHECK-NEXT: "vmla.transpose"(
+  // CHECK-NEXT: vmla.transpose(
   // CHECK-SAME:   %[[SRC]], %[[SRC_SHAPE]],
   // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]
-  // CHECK-SAME: ) {element_type = f32, permutation = dense<[1, 0, 2]> : tensor<3xi32>}
+  // CHECK-SAME: ) {permutation = dense<[1, 0, 2]> : tensor<3xi32>}
+  // CHECK-SAME: (!shapex.ranked_shape<[7,24,10]>,
+  // CHECK-SAME:  !shapex.ranked_shape<[24,7,10]>) f32
   %0 = "xla_hlo.transpose"(%input) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<7x24x10xf32>) -> tensor<24x7x10xf32>
   // CHECK-NEXT: return %[[DST]]
   return %0 : tensor<24x7x10xf32>

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/math_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/math_ops.mlir
@@ -4,7 +4,7 @@
 func @absf(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
+  // CHECK-NEXT: vmla.abs %arg0, out %[[BUF]] : f32
   %0 = absf %arg0 : tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>
@@ -16,7 +16,7 @@ func @absf(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility =
 func @shr_signed(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.shr %arg0, %arg0, %[[BUF]] : i32
+  // CHECK-NEXT: vmla.shr %arg0, %arg0, out %[[BUF]] : i32
   %0 = shift_right_signed %arg0, %arg0 : tensor<4xi32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xi32>
@@ -28,7 +28,7 @@ func @shr_signed(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibi
 func @shr_unsigned(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.shr %arg0, %arg0, %[[BUF]] {force_unsigned} : i32
+  // CHECK-NEXT: vmla.shr %arg0, %arg0, out %[[BUF]] {force_unsigned} : i32
   %0 = shift_right_unsigned %arg0, %arg0 : tensor<4xi32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xi32>

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/math_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/math_ops.mlir
@@ -4,7 +4,7 @@
 func @absf(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.abs(%arg0, %[[BUF]]) : f32
+  // CHECK-NEXT: vmla.abs %arg0, %[[BUF]] : f32
   %0 = absf %arg0 : tensor<4xf32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xf32>
@@ -16,7 +16,7 @@ func @absf(%arg0 : tensor<4xf32>) -> tensor<4xf32> attributes { sym_visibility =
 func @shr_signed(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.shr(%arg0, %arg0, %[[BUF]]) : i32
+  // CHECK-NEXT: vmla.shr %arg0, %arg0, %[[BUF]] : i32
   %0 = shift_right_signed %arg0, %arg0 : tensor<4xi32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xi32>
@@ -28,7 +28,7 @@ func @shr_signed(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibi
 func @shr_unsigned(%arg0 : tensor<4xi32>) -> tensor<4xi32> attributes { sym_visibility = "private" } {
   // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 16
   // CHECK-NEXT: %[[BUF:.+]] = "vmla.buffer.alloc"(%[[BUF_SZ]])
-  // CHECK-NEXT: vmla.shr(%arg0, %arg0, %[[BUF]]) {force_unsigned} : i32
+  // CHECK-NEXT: vmla.shr %arg0, %arg0, %[[BUF]] {force_unsigned} : i32
   %0 = shift_right_unsigned %arg0, %arg0 : tensor<4xi32>
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xi32>

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -78,8 +78,8 @@ func @batch_matmul(
   %rhs_shape = shapex.make_ranked_shape %rhs_dim : (index) -> !shapex.ranked_shape<[3,?,4]>
   %dst_shape = shapex.const_ranked_shape : !shapex.ranked_shape<[3,4,4]>
   // CHECK: vm.call.variadic @vmla.batch.matmul.f32f32.f32(%arg0, [%c3, %c4, %arg1], %arg2, [%c3, %arg3, %c4], %arg4, [%c3, %c4, %c4])
-  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[3,4,?]>) : f32,
-                    %rhs(%rhs_shape : !shapex.ranked_shape<[3,?,4]>) : f32,
-                    out %dst(%dst_shape : !shapex.ranked_shape<[3,4,4]>) : f32
+  vmla.batch.matmul %lhs : f32(%lhs_shape : !shapex.ranked_shape<[3,4,?]>),
+                    %rhs : f32(%rhs_shape : !shapex.ranked_shape<[3,?,4]>),
+                    out %dst : f32(%dst_shape : !shapex.ranked_shape<[3,4,4]>)
   return
 }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -50,7 +50,9 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
   // CHECK-DAG: %c4 = vm.const.i32 4 : i32
   // CHECK-DAG: %c8 = vm.const.i32 8 : i32
   // CHECK-NEXT: vm.call.variadic @vmla.transpose.x16(%arg0, [%c4, %arg1, %c8], [%c1], %arg2, [%arg3, %c4, %c8]) : (!vm.ref<!vmla.buffer>, i32..., i32..., !vm.ref<!vmla.buffer>, i32...)
-  vmla.transpose %arg0, %rs0, %arg2, %rs1 { permutation = dense<[1]> : tensor<1xi32>} : (!shapex.ranked_shape<[4,?,8]>, !shapex.ranked_shape<[?,4,8]>) i16
+  vmla.transpose %arg0(%rs0 !shapex.ranked_shape<[4,?,8]>),
+                 out %arg2(%rs1 !shapex.ranked_shape<[?,4,8]>)
+                 {permutation = dense<[1]> : tensor<1xi32>} : i16
   return
 }
 
@@ -59,7 +61,7 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
 // CHECK-LABEL: vm.func @convert
 func @convert(%arg0 : !vmla.buffer, %arg1 : !vmla.buffer) {
   // CHECK-NEXT:  vm.call @vmla.convert.f32.i8(%arg0, %arg1)
-  vmla.convert %arg0, %arg1 : f32 -> i8
+  vmla.convert %arg0, out %arg1 : f32 -> i8
   return
 }
 
@@ -76,9 +78,8 @@ func @batch_matmul(
   %rhs_shape = shapex.make_ranked_shape %rhs_dim : (index) -> !shapex.ranked_shape<[3,?,4]>
   %dst_shape = shapex.const_ranked_shape : !shapex.ranked_shape<[3,4,4]>
   // CHECK: vm.call.variadic @vmla.batch.matmul.f32f32.f32(%arg0, [%c3, %c4, %arg1], %arg2, [%c3, %arg3, %c4], %arg4, [%c3, %c4, %c4])
-  vmla.batch.matmul %lhs, %lhs_shape, %rhs, %rhs_shape, %dst, %dst_shape :
-      (f32, !shapex.ranked_shape<[3,4,?]>,
-       f32, !shapex.ranked_shape<[3,?,4]>,
-       f32, !shapex.ranked_shape<[3,4,4]>)
+  vmla.batch.matmul %lhs(%lhs_shape !shapex.ranked_shape<[3,4,?]>) : f32,
+                    %rhs(%rhs_shape !shapex.ranked_shape<[3,?,4]>) : f32,
+                    out %dst(%dst_shape !shapex.ranked_shape<[3,4,4]>) : f32
   return
 }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -59,7 +59,7 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
 // CHECK-LABEL: vm.func @convert
 func @convert(%arg0 : !vmla.buffer, %arg1 : !vmla.buffer) {
   // CHECK-NEXT:  vm.call @vmla.convert.f32.i8(%arg0, %arg1)
-  "vmla.convert"(%arg0, %arg1) { src_type = f32, dst_type = i8 } : (!vmla.buffer, !vmla.buffer) -> ()
+  vmla.convert(%arg0, %arg1) : f32 -> i8
   return
 }
 

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -50,7 +50,7 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
   // CHECK-DAG: %c4 = vm.const.i32 4 : i32
   // CHECK-DAG: %c8 = vm.const.i32 8 : i32
   // CHECK-NEXT: vm.call.variadic @vmla.transpose.x16(%arg0, [%c4, %arg1, %c8], [%c1], %arg2, [%arg3, %c4, %c8]) : (!vm.ref<!vmla.buffer>, i32..., i32..., !vm.ref<!vmla.buffer>, i32...)
-  "vmla.transpose"(%arg0, %rs0, %arg2, %rs1) { permutation = dense<[1]> : tensor<1xi32>, element_type = i16 } : (!vmla.buffer, !shapex.ranked_shape<[4,?,8]>, !vmla.buffer, !shapex.ranked_shape<[?,4,8]>) -> ()
+  vmla.transpose %arg0, %rs0, %arg2, %rs1 { permutation = dense<[1]> : tensor<1xi32>} : (!shapex.ranked_shape<[4,?,8]>, !shapex.ranked_shape<[?,4,8]>) i16
   return
 }
 
@@ -59,7 +59,7 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
 // CHECK-LABEL: vm.func @convert
 func @convert(%arg0 : !vmla.buffer, %arg1 : !vmla.buffer) {
   // CHECK-NEXT:  vm.call @vmla.convert.f32.i8(%arg0, %arg1)
-  vmla.convert(%arg0, %arg1) : f32 -> i8
+  vmla.convert %arg0, %arg1 : f32 -> i8
   return
 }
 
@@ -76,13 +76,9 @@ func @batch_matmul(
   %rhs_shape = shapex.make_ranked_shape %rhs_dim : (index) -> !shapex.ranked_shape<[3,?,4]>
   %dst_shape = shapex.const_ranked_shape : !shapex.ranked_shape<[3,4,4]>
   // CHECK: vm.call.variadic @vmla.batch.matmul.f32f32.f32(%arg0, [%c3, %c4, %arg1], %arg2, [%c3, %arg3, %c4], %arg4, [%c3, %c4, %c4])
-  "vmla.batch.matmul"(%lhs, %lhs_shape, %rhs, %rhs_shape, %dst, %dst_shape)
-      { lhs_type = f32, rhs_type = f32, dst_type = f32 } :
-      (!vmla.buffer,
-       !shapex.ranked_shape<[3,4,?]>,
-       !vmla.buffer,
-       !shapex.ranked_shape<[3,?,4]>,
-       !vmla.buffer,
-       !shapex.ranked_shape<[3,4,4]>) -> ()
+  vmla.batch.matmul %lhs, %lhs_shape, %rhs, %rhs_shape, %dst, %dst_shape :
+      (f32, !shapex.ranked_shape<[3,4,?]>,
+       f32, !shapex.ranked_shape<[3,?,4]>,
+       f32, !shapex.ranked_shape<[3,4,4]>)
   return
 }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -78,8 +78,8 @@ func @batch_matmul(
   %rhs_shape = shapex.make_ranked_shape %rhs_dim : (index) -> !shapex.ranked_shape<[3,?,4]>
   %dst_shape = shapex.const_ranked_shape : !shapex.ranked_shape<[3,4,4]>
   // CHECK: vm.call.variadic @vmla.batch.matmul.f32f32.f32(%arg0, [%c3, %c4, %arg1], %arg2, [%c3, %arg3, %c4], %arg4, [%c3, %c4, %c4])
-  vmla.batch.matmul %lhs : f32(%lhs_shape : !shapex.ranked_shape<[3,4,?]>),
-                    %rhs : f32(%rhs_shape : !shapex.ranked_shape<[3,?,4]>),
-                    out %dst : f32(%dst_shape : !shapex.ranked_shape<[3,4,4]>)
+  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[3,4,?]>) : f32,
+                    %rhs(%rhs_shape : !shapex.ranked_shape<[3,?,4]>) : f32,
+                    out %dst(%dst_shape : !shapex.ranked_shape<[3,4,4]>) : f32
   return
 }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/conversion.mlir
@@ -50,8 +50,8 @@ func @shapeExpansion(%arg0 : !vmla.buffer, %arg1 : index, %arg2 : !vmla.buffer, 
   // CHECK-DAG: %c4 = vm.const.i32 4 : i32
   // CHECK-DAG: %c8 = vm.const.i32 8 : i32
   // CHECK-NEXT: vm.call.variadic @vmla.transpose.x16(%arg0, [%c4, %arg1, %c8], [%c1], %arg2, [%arg3, %c4, %c8]) : (!vm.ref<!vmla.buffer>, i32..., i32..., !vm.ref<!vmla.buffer>, i32...)
-  vmla.transpose %arg0(%rs0 !shapex.ranked_shape<[4,?,8]>),
-                 out %arg2(%rs1 !shapex.ranked_shape<[?,4,8]>)
+  vmla.transpose %arg0(%rs0 : !shapex.ranked_shape<[4,?,8]>),
+                 out %arg2(%rs1 : !shapex.ranked_shape<[?,4,8]>)
                  {permutation = dense<[1]> : tensor<1xi32>} : i16
   return
 }
@@ -78,8 +78,8 @@ func @batch_matmul(
   %rhs_shape = shapex.make_ranked_shape %rhs_dim : (index) -> !shapex.ranked_shape<[3,?,4]>
   %dst_shape = shapex.const_ranked_shape : !shapex.ranked_shape<[3,4,4]>
   // CHECK: vm.call.variadic @vmla.batch.matmul.f32f32.f32(%arg0, [%c3, %c4, %arg1], %arg2, [%c3, %arg3, %c4], %arg4, [%c3, %c4, %c4])
-  vmla.batch.matmul %lhs(%lhs_shape !shapex.ranked_shape<[3,4,?]>) : f32,
-                    %rhs(%rhs_shape !shapex.ranked_shape<[3,?,4]>) : f32,
-                    out %dst(%dst_shape !shapex.ranked_shape<[3,4,4]>) : f32
+  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[3,4,?]>) : f32,
+                    %rhs(%rhs_shape : !shapex.ranked_shape<[3,?,4]>) : f32,
+                    out %dst(%dst_shape : !shapex.ranked_shape<[3,4,4]>) : f32
   return
 }

--- a/iree/compiler/Dialect/VMLA/IR/VMLABase.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLABase.td
@@ -171,7 +171,7 @@ class VMLA_UnaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []> :
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = "$src`,` $dst attr-dict`:` $element_type";
+  let assemblyFormat = "$src`,` `out` $dst attr-dict `:` $element_type";
 }
 
 class VMLA_BinaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
@@ -185,7 +185,7 @@ class VMLA_BinaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = "$lhs`,` $rhs`,` $dst attr-dict `:` $element_type";
+  let assemblyFormat = "$lhs`,` $rhs`,` `out` $dst attr-dict `:` $element_type";
 }
 
 class VMLA_TernaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
@@ -200,7 +200,7 @@ class VMLA_TernaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = "$a`,` $b`,` $c`,` $dst attr-dict `:` $element_type";
+  let assemblyFormat = "$a`,` $b`,` $c`,` `out` $dst attr-dict `:` $element_type";
 }
 
 #endif  // IREE_DIALECT_VMLA_BASE

--- a/iree/compiler/Dialect/VMLA/IR/VMLABase.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLABase.td
@@ -171,7 +171,7 @@ class VMLA_UnaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []> :
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = "`(`$src`,` $dst`)` attr-dict`:` $element_type";
+  let assemblyFormat = "$src`,` $dst attr-dict`:` $element_type";
 }
 
 class VMLA_BinaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
@@ -185,7 +185,7 @@ class VMLA_BinaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = "`(`$lhs`,` $rhs`,` $dst`)` attr-dict `:` $element_type";
+  let assemblyFormat = "$lhs`,` $rhs`,` $dst attr-dict `:` $element_type";
 }
 
 class VMLA_TernaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
@@ -200,9 +200,7 @@ class VMLA_TernaryOp<string mnemonic, Attr typeAttr, list<OpTrait> traits = []>
     UnitAttr:$forceUnsigned
   );
 
-  let assemblyFormat = [{
-    `(`$a`,` $b`,` $c`,` $dst`)` attr-dict `:` $element_type
-  }];
+  let assemblyFormat = "$a`,` $b`,` $c`,` $dst attr-dict `:` $element_type";
 }
 
 #endif  // IREE_DIALECT_VMLA_BASE

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -178,6 +178,12 @@ def VMLA_TransposeOp : VMLA_ElementTypeOp<"transpose", [VMLA_IncludeShapes]> {
     VMLA_Shape:$dst_shape,
     VMLA_AnyTypeAttr:$element_type
   );
+
+  let assemblyFormat = [{
+    `(`$src`,` $src_shape`,` $dst`,` $dst_shape`)` attr-dict `:`
+    `(`type($src_shape)`,` type($dst_shape)`)`
+    $element_type
+  }];
 }
 
 def VMLA_ReverseOp : VMLA_ElementTypeOp<"reverse", [VMLA_IncludeShapes]> {

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -373,6 +373,11 @@ def VMLA_BatchMatMulPseudoOp : VMLA_Op<"batch.matmul.pseudo"> {
   let results = (outs
     AnyTensor:$dst
   );
+
+  let assemblyFormat = [{
+    `(`$lhs`,` $rhs`)` attr-dict `:`
+    `(`type($lhs)`,` type($rhs)`)` `->` type($dst)
+  }];
 }
 
 def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_IncludeShapes]> {

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -185,8 +185,8 @@ def VMLA_TransposeOp : VMLA_ElementTypeOp<"transpose", [VMLA_IncludeShapes]> {
   //   $element_type
   // }];
   let assemblyFormat = [{
-    $src`(`$src_shape type($src_shape)`)``,`
-    `out` $dst`(`$dst_shape type($dst_shape)`)` attr-dict `:` $element_type
+    $src`(`$src_shape `:` type($src_shape)`)``,`
+    `out` $dst`(`$dst_shape `:` type($dst_shape)`)` attr-dict `:` $element_type
   }];
 }
 
@@ -412,9 +412,9 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
   }];
 
   let assemblyFormat = [{
-    $lhs`(`$lhs_shape type($lhs_shape)`)` `:` $lhs_type`,`
-    $rhs`(`$rhs_shape type($rhs_shape)`)` `:` $rhs_type`,`
-    `out` $dst`(`$dst_shape type($dst_shape)`)` `:` $dst_type attr-dict
+    $lhs`(`$lhs_shape `:` type($lhs_shape)`)` `:` $lhs_type`,`
+    $rhs`(`$rhs_shape `:` type($rhs_shape)`)` `:` $rhs_type`,`
+    `out` $dst`(`$dst_shape `:` type($dst_shape)`)` `:` $dst_type attr-dict
   }];
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -179,11 +179,6 @@ def VMLA_TransposeOp : VMLA_ElementTypeOp<"transpose", [VMLA_IncludeShapes]> {
     VMLA_AnyTypeAttr:$element_type
   );
 
-  // let assemblyFormat = [{
-  //   $src`,` $src_shape`,` $dst`,` $dst_shape attr-dict `:`
-  //   `(`type($src_shape)`,` type($dst_shape)`)`
-  //   $element_type
-  // }];
   let assemblyFormat = [{
     $src`(`$src_shape `:` type($src_shape)`)``,`
     `out` $dst`(`$dst_shape `:` type($dst_shape)`)` attr-dict `:` $element_type

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -407,9 +407,9 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
   }];
 
   let assemblyFormat = [{
-    $lhs `:` $lhs_type`(`$lhs_shape `:` type($lhs_shape)`)``,`
-    $rhs `:` $rhs_type`(`$rhs_shape `:` type($rhs_shape)`)``,`
-    `out` $dst `:` $dst_type`(`$dst_shape `:` type($dst_shape)`)` attr-dict
+    $lhs`(`$lhs_shape `:` type($lhs_shape)`)` `:` $lhs_type`,`
+    $rhs`(`$rhs_shape `:` type($rhs_shape)`)` `:` $rhs_type`,`
+    `out` $dst`(`$dst_shape `:` type($dst_shape)`)` `:` $dst_type attr-dict
   }];
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -412,9 +412,9 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
   }];
 
   let assemblyFormat = [{
-    $lhs`(`$lhs_shape `:` type($lhs_shape)`)` `:` $lhs_type`,`
-    $rhs`(`$rhs_shape `:` type($rhs_shape)`)` `:` $rhs_type`,`
-    `out` $dst`(`$dst_shape `:` type($dst_shape)`)` `:` $dst_type attr-dict
+    $lhs `:` $lhs_type`(`$lhs_shape `:` type($lhs_shape)`)``,`
+    $rhs `:` $rhs_type`(`$rhs_shape `:` type($rhs_shape)`)``,`
+    `out` $dst `:` $dst_type`(`$dst_shape `:` type($dst_shape)`)` attr-dict
   }];
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -180,7 +180,7 @@ def VMLA_TransposeOp : VMLA_ElementTypeOp<"transpose", [VMLA_IncludeShapes]> {
   );
 
   let assemblyFormat = [{
-    `(`$src`,` $src_shape`,` $dst`,` $dst_shape`)` attr-dict `:`
+    $src`,` $src_shape`,` $dst`,` $dst_shape attr-dict `:`
     `(`type($src_shape)`,` type($dst_shape)`)`
     $element_type
   }];
@@ -304,7 +304,7 @@ def VMLA_ConvertOp : VMLA_Op<"convert", [VMLA_OpInterface]> {
   }];
 
   let assemblyFormat = [{
-    `(`$src`,` $dst`)` attr-dict `:` $src_type `->` $dst_type
+    $src`,` $dst attr-dict `:` $src_type `->` $dst_type
   }];
 }
 
@@ -381,7 +381,7 @@ def VMLA_BatchMatMulPseudoOp : VMLA_Op<"batch.matmul.pseudo"> {
   );
 
   let assemblyFormat = [{
-    `(`$lhs`,` $rhs`)` attr-dict `:`
+    $lhs`,` $rhs attr-dict `:`
     `(`type($lhs)`,` type($rhs)`)` `->` type($dst)
   }];
 }
@@ -408,9 +408,9 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
   }];
 
   let assemblyFormat = [{
-    `(`$lhs`,` $lhs_shape`,`
-       $rhs`,` $rhs_shape`,`
-       $dst`,` $dst_shape`)` attr-dict `:`
+    $lhs`,` $lhs_shape`,`
+    $rhs`,` $rhs_shape`,`
+    $dst`,` $dst_shape attr-dict `:`
     `(`$lhs_type`,` type($lhs_shape)`,`
        $rhs_type`,` type($rhs_shape)`,`
        $dst_type`,` type($dst_shape)`)`

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -400,6 +400,15 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
       state.addAttribute("dst_type", TypeAttr::get(resultTypes[0]));
     }
   }];
+
+  let assemblyFormat = [{
+    `(`$lhs`,` $lhs_shape`,`
+       $rhs`,` $rhs_shape`,`
+       $dst`,` $dst_shape`)` attr-dict `:`
+    `(`$lhs_type`,` type($lhs_shape)`,`
+       $rhs_type`,` type($rhs_shape)`,`
+       $dst_type`,` type($dst_shape)`)`
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -179,10 +179,14 @@ def VMLA_TransposeOp : VMLA_ElementTypeOp<"transpose", [VMLA_IncludeShapes]> {
     VMLA_AnyTypeAttr:$element_type
   );
 
+  // let assemblyFormat = [{
+  //   $src`,` $src_shape`,` $dst`,` $dst_shape attr-dict `:`
+  //   `(`type($src_shape)`,` type($dst_shape)`)`
+  //   $element_type
+  // }];
   let assemblyFormat = [{
-    $src`,` $src_shape`,` $dst`,` $dst_shape attr-dict `:`
-    `(`type($src_shape)`,` type($dst_shape)`)`
-    $element_type
+    $src`(`$src_shape type($src_shape)`)``,`
+    `out` $dst`(`$dst_shape type($dst_shape)`)` attr-dict `:` $element_type
   }];
 }
 
@@ -304,7 +308,7 @@ def VMLA_ConvertOp : VMLA_Op<"convert", [VMLA_OpInterface]> {
   }];
 
   let assemblyFormat = [{
-    $src`,` $dst attr-dict `:` $src_type `->` $dst_type
+    $src`,` `out` $dst attr-dict `:` $src_type `->` $dst_type
   }];
 }
 
@@ -408,12 +412,9 @@ def VMLA_BatchMatMulOp : VMLA_Op<"batch.matmul", [VMLA_OpInterface, VMLA_Include
   }];
 
   let assemblyFormat = [{
-    $lhs`,` $lhs_shape`,`
-    $rhs`,` $rhs_shape`,`
-    $dst`,` $dst_shape attr-dict `:`
-    `(`$lhs_type`,` type($lhs_shape)`,`
-       $rhs_type`,` type($rhs_shape)`,`
-       $dst_type`,` type($dst_shape)`)`
+    $lhs`(`$lhs_shape type($lhs_shape)`)` `:` $lhs_type`,`
+    $rhs`(`$rhs_shape type($rhs_shape)`)` `:` $rhs_type`,`
+    `out` $dst`(`$dst_shape type($dst_shape)`)` `:` $dst_type attr-dict
   }];
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -296,6 +296,10 @@ def VMLA_ConvertOp : VMLA_Op<"convert", [VMLA_OpInterface]> {
       state.addAttribute("dst_type", TypeAttr::get(resultTypes[0]));
     }
   }];
+
+  let assemblyFormat = [{
+    `(`$src`,` $dst`)` attr-dict `:` $src_type `->` $dst_type
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -6,8 +6,8 @@
 // CHECK-SAME: %[[SRC:[a-zA-Z0-9$._-]+]]
 // CHECK-SAME: %[[DST:[a-zA-Z0-9$._-]+]]
 func @unaryOp(%src : !vmla.buffer, %dst : !vmla.buffer) {
-  // CHECK: vmla.log(%[[SRC]], %[[DST]]) : f32
-  vmla.log(%src, %dst) : f32
+  // CHECK: vmla.log %[[SRC]], %[[DST]] : f32
+  vmla.log %src, %dst : f32
   return
 }
 
@@ -18,8 +18,8 @@ func @unaryOp(%src : !vmla.buffer, %dst : !vmla.buffer) {
 // CHECK-SAME: %[[RHS:[a-zA-Z0-9$._-]+]]
 // CHECK-SAME: %[[DST:[a-zA-Z0-9$._-]+]]
 func @binaryOp(%lhs : !vmla.buffer, %rhs : !vmla.buffer, %dst : !vmla.buffer) {
-  // CHECK: vmla.atan2(%[[LHS]], %[[RHS]], %[[DST]]) : f32
-  vmla.atan2(%lhs, %rhs, %dst) : f32
+  // CHECK: vmla.atan2 %[[LHS]], %[[RHS]], %[[DST]] : f32
+  vmla.atan2 %lhs, %rhs, %dst : f32
   return
 }
 
@@ -32,8 +32,8 @@ func @binaryOp(%lhs : !vmla.buffer, %rhs : !vmla.buffer, %dst : !vmla.buffer) {
 // CHECK-SAME: %[[DST:[a-zA-Z0-9$._-]+]]
 func @ternaryOp(%a : !vmla.buffer, %b : !vmla.buffer, %c : !vmla.buffer,
                 %dst : !vmla.buffer) {
-  // CHECK: vmla.clamp(%[[A]], %[[B]], %[[C]], %[[DST]]) : f32
-  vmla.clamp(%a, %b, %c, %dst) : f32
+  // CHECK: vmla.clamp %[[A]], %[[B]], %[[C]], %[[DST]] : f32
+  vmla.clamp %a, %b, %c, %dst : f32
   return
 }
 
@@ -44,8 +44,8 @@ func @ternaryOp(%a : !vmla.buffer, %b : !vmla.buffer, %c : !vmla.buffer,
 // CHECK-SAME: %[[SRC:[a-zA-Z0-9]+]]
 // CHECK-SAME: %[[DST:[a-zA-Z0-9]+]]
 func @vmla_convert(%src : !vmla.buffer, %dst : !vmla.buffer) {
-  // CHECK: vmla.convert(%[[SRC]], %[[DST]]) : f32 -> i8
-  vmla.convert(%src, %dst) : f32 -> i8
+  // CHECK: vmla.convert %[[SRC]], %[[DST]] : f32 -> i8
+  vmla.convert %src, %dst : f32 -> i8
   return
 }
 
@@ -56,10 +56,10 @@ func @vmla_convert(%src : !vmla.buffer, %dst : !vmla.buffer) {
 // CHECK-SAME: %[[RHS:[a-zA-Z0-9]+]]
 func @vmla_batch_matmul_pseudo(%lhs : tensor<32x256x128xf32>,
                                %rhs : tensor<32x1x128xf32>) {
-  // CHECK: vmla.batch.matmul.pseudo(%[[LHS]], %[[RHS]]) :
+  // CHECK: vmla.batch.matmul.pseudo %[[LHS]], %[[RHS]] :
   // CHECK-SAME: (tensor<32x256x128xf32>, tensor<32x1x128xf32>) ->
   // CHECK-SAME: tensor<32x1x256xf32>
-  %dst = vmla.batch.matmul.pseudo(%lhs, %rhs) :
+  %dst = vmla.batch.matmul.pseudo %lhs, %rhs :
     (tensor<32x256x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x256xf32>
   return
 }
@@ -79,16 +79,16 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
                         %rhs_shape : !shapex.ranked_shape<[32,1,784]>,
                         %dst : !vmla.buffer,
                         %dst_shape : !shapex.ranked_shape<[32,1,10]>) {
-  // CHECK:      vmla.batch.matmul(
+  // CHECK:      vmla.batch.matmul
   // CHECK-SAME:   %[[LHS]], %[[LHS_SHAPE]],
   // CHECK-SAME:   %[[RHS]], %[[RHS_SHAPE]],
-  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]) :
+  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]] :
   // CHECK-SAME: (f32, !shapex.ranked_shape<[32,10,784]>
   // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,784]>
   // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,10]>)
-  vmla.batch.matmul(%lhs, %lhs_shape,
+  vmla.batch.matmul %lhs, %lhs_shape,
                     %rhs, %rhs_shape,
-                    %dst, %dst_shape) :
+                    %dst, %dst_shape :
                    (f32, !shapex.ranked_shape<[32,10,784]>,
                     f32, !shapex.ranked_shape<[32,1,784]>,
                     f32, !shapex.ranked_shape<[32,1,10]>)
@@ -106,13 +106,13 @@ func @vmla_transpose(%src : !vmla.buffer,
                      %src_shape : !shapex.ranked_shape<[64,32,32,10]>,
                      %dst : !vmla.buffer,
                      %dst_shape : !shapex.ranked_shape<[64,10,32,32]>) {
-  // CHECK:      vmla.transpose(
+  // CHECK:      vmla.transpose
   // CHECK-SAME:   %[[SRC]], %[[SRC_SHAPE]],
-  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]])
+  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]
   // CHECK-SAME: {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} :
   // CHECK-SAME: (!shapex.ranked_shape<[64,32,32,10]>,
   // CHECK-SAME:  !shapex.ranked_shape<[64,10,32,32]>) f32
-  vmla.transpose(%src, %src_shape, %dst, %dst_shape)
+  vmla.transpose %src, %src_shape, %dst, %dst_shape
                 {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} :
                 (!shapex.ranked_shape<[64,32,32,10]>,
                  !shapex.ranked_shape<[64,10,32,32]>) f32

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -80,13 +80,13 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
                         %dst : !vmla.buffer,
                         %dst_shape : !shapex.ranked_shape<[8,1,4]>) {
   // CHECK:      vmla.batch.matmul
-  // CHECK-SAME: %[[LHS]](%[[LHS_SHAPE]] : !shapex.ranked_shape<[8,4,4]>) : f32,
-  // CHECK-SAME: %[[RHS]](%[[RHS_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32,
+  // CHECK-SAME: %[[LHS]] : f32(%[[LHS_SHAPE]] : !shapex.ranked_shape<[8,4,4]>),
+  // CHECK-SAME: %[[RHS]] : f32(%[[RHS_SHAPE]] : !shapex.ranked_shape<[8,1,4]>),
   // CHECK-SAME: out
-  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32
-  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[8,4,4]>) : f32,
-                    %rhs(%rhs_shape : !shapex.ranked_shape<[8,1,4]>) : f32,
-                    out %dst(%dst_shape : !shapex.ranked_shape<[8,1,4]>) : f32
+  // CHECK-SAME: %[[DST]] : f32(%[[DST_SHAPE]] : !shapex.ranked_shape<[8,1,4]>)
+  vmla.batch.matmul %lhs : f32(%lhs_shape : !shapex.ranked_shape<[8,4,4]>),
+                    %rhs : f32(%rhs_shape : !shapex.ranked_shape<[8,1,4]>),
+                    out %dst : f32(%dst_shape : !shapex.ranked_shape<[8,1,4]>)
   return
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -63,3 +63,32 @@ func @vmla_batch_matmul_pseudo(%lhs : tensor<32x256x128xf32>,
     (tensor<32x256x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x256xf32>
   return
 }
+
+// -----
+
+// CHECK-LABEL: @vmla_batch_matmul
+// CHECK-SAME: %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[LHS_SHAPE:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[RHS:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[RHS_SHAPE:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[DST:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[DST_SHAPE:[a-zA-Z0-9]+]]
+func @vmla_batch_matmul(%lhs : !vmla.buffer,
+                        %lhs_shape : !shapex.ranked_shape<[32,10,784]>,
+                        %rhs : !vmla.buffer,
+                        %rhs_shape : !shapex.ranked_shape<[32,1,784]>,
+                        %dst : !vmla.buffer,
+                        %dst_shape : !shapex.ranked_shape<[32,1,10]>) {
+  // CHECK: vmla.batch.matmul(%[[LHS]], %[[LHS_SHAPE]],
+  // CHECK-SAME: %[[RHS]], %[[RHS_SHAPE]], %[[DST]], %[[DST_SHAPE]]) :
+  // CHECK-SAME: (f32, !shapex.ranked_shape<[32,10,784]>
+  // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,784]>
+  // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,10]>)
+  vmla.batch.matmul(%lhs, %lhs_shape,
+                    %rhs, %rhs_shape,
+                    %dst, %dst_shape) :
+                    (f32, !shapex.ranked_shape<[32,10,784]>,
+                     f32, !shapex.ranked_shape<[32,1,784]>,
+                     f32, !shapex.ranked_shape<[32,1,10]>)
+  return
+}

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -79,8 +79,10 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
                         %rhs_shape : !shapex.ranked_shape<[32,1,784]>,
                         %dst : !vmla.buffer,
                         %dst_shape : !shapex.ranked_shape<[32,1,10]>) {
-  // CHECK: vmla.batch.matmul(%[[LHS]], %[[LHS_SHAPE]],
-  // CHECK-SAME: %[[RHS]], %[[RHS_SHAPE]], %[[DST]], %[[DST_SHAPE]]) :
+  // CHECK:      vmla.batch.matmul(
+  // CHECK-SAME:   %[[LHS]], %[[LHS_SHAPE]],
+  // CHECK-SAME:   %[[RHS]], %[[RHS_SHAPE]],
+  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]]) :
   // CHECK-SAME: (f32, !shapex.ranked_shape<[32,10,784]>
   // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,784]>
   // CHECK-SAME:  f32, !shapex.ranked_shape<[32,1,10]>)
@@ -90,5 +92,29 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
                     (f32, !shapex.ranked_shape<[32,10,784]>,
                      f32, !shapex.ranked_shape<[32,1,784]>,
                      f32, !shapex.ranked_shape<[32,1,10]>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @vmla_transpose
+// CHECK-SAME: %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[SRC_SHAPE:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[DST:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[DST_SHAPE:[a-zA-Z0-9]+]]
+func @vmla_transpose(%src : !vmla.buffer,
+                     %src_shape : !shapex.ranked_shape<[64,32,32,10]>,
+                     %dst : !vmla.buffer,
+                     %dst_shape : !shapex.ranked_shape<[64,10,32,32]>) {
+  // CHECK:      vmla.transpose(
+  // CHECK-SAME:   %[[SRC]], %[[SRC_SHAPE]],
+  // CHECK-SAME:   %[[DST]], %[[DST_SHAPE]])
+  // CHECK-SAME: {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} :
+  // CHECK-SAME: (!shapex.ranked_shape<[64,32,32,10]>,
+  // CHECK-SAME:  !shapex.ranked_shape<[64,10,32,32]>) f32
+  vmla.transpose(%src, %src_shape, %dst, %dst_shape)
+                {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} :
+                (!shapex.ranked_shape<[64,32,32,10]>,
+                 !shapex.ranked_shape<[64,10,32,32]>) f32
   return
 }

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -48,3 +48,18 @@ func @vmla_convert(%src : !vmla.buffer, %dst : !vmla.buffer) {
   vmla.convert(%src, %dst) : f32 -> i8
   return
 }
+
+// -----
+
+// CHECK-LABEL: @vmla_batch_matmul_pseudo
+// CHECK-SAME: %[[LHS:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[RHS:[a-zA-Z0-9]+]]
+func @vmla_batch_matmul_pseudo(%lhs : tensor<32x256x128xf32>,
+                               %rhs : tensor<32x1x128xf32>) {
+  // CHECK: vmla.batch.matmul.pseudo(%[[LHS]], %[[RHS]]) :
+  // CHECK-SAME: (tensor<32x256x128xf32>, tensor<32x1x128xf32>) ->
+  // CHECK-SAME: tensor<32x1x256xf32>
+  %dst = vmla.batch.matmul.pseudo(%lhs, %rhs) :
+    (tensor<32x256x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x256xf32>
+  return
+}

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -30,9 +30,21 @@ func @binaryOp(%lhs : !vmla.buffer, %rhs : !vmla.buffer, %dst : !vmla.buffer) {
 // CHECK-SAME: %[[B:[a-zA-Z0-9$._-]+]]
 // CHECK-SAME: %[[C:[a-zA-Z0-9$._-]+]]
 // CHECK-SAME: %[[DST:[a-zA-Z0-9$._-]+]]
-func @ternaryOp(%a : !vmla.buffer, %b : !vmla.buffer, %c : !vmla.buffer, 
+func @ternaryOp(%a : !vmla.buffer, %b : !vmla.buffer, %c : !vmla.buffer,
                 %dst : !vmla.buffer) {
   // CHECK: vmla.clamp(%[[A]], %[[B]], %[[C]], %[[DST]]) : f32
   vmla.clamp(%a, %b, %c, %dst) : f32
+  return
+}
+
+
+// -----
+
+// CHECK-LABEL: @vmla_convert
+// CHECK-SAME: %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME: %[[DST:[a-zA-Z0-9]+]]
+func @vmla_convert(%src : !vmla.buffer, %dst : !vmla.buffer) {
+  // CHECK: vmla.convert(%[[SRC]], %[[DST]]) : f32 -> i8
+  vmla.convert(%src, %dst) : f32 -> i8
   return
 }

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -89,9 +89,9 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
   vmla.batch.matmul(%lhs, %lhs_shape,
                     %rhs, %rhs_shape,
                     %dst, %dst_shape) :
-                    (f32, !shapex.ranked_shape<[32,10,784]>,
-                     f32, !shapex.ranked_shape<[32,1,784]>,
-                     f32, !shapex.ranked_shape<[32,1,10]>)
+                   (f32, !shapex.ranked_shape<[32,10,784]>,
+                    f32, !shapex.ranked_shape<[32,1,784]>,
+                    f32, !shapex.ranked_shape<[32,1,10]>)
   return
 }
 

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -74,19 +74,19 @@ func @vmla_batch_matmul_pseudo(%lhs : tensor<32x256x128xf32>,
 // CHECK-SAME: %[[DST:[a-zA-Z0-9]+]]
 // CHECK-SAME: %[[DST_SHAPE:[a-zA-Z0-9]+]]
 func @vmla_batch_matmul(%lhs : !vmla.buffer,
-                        %lhs_shape : !shapex.ranked_shape<[8,10,64]>,
+                        %lhs_shape : !shapex.ranked_shape<[8,4,4]>,
                         %rhs : !vmla.buffer,
-                        %rhs_shape : !shapex.ranked_shape<[8,1,64]>,
+                        %rhs_shape : !shapex.ranked_shape<[8,1,4]>,
                         %dst : !vmla.buffer,
-                        %dst_shape : !shapex.ranked_shape<[8,1,10]>) {
+                        %dst_shape : !shapex.ranked_shape<[8,1,4]>) {
   // CHECK:      vmla.batch.matmul
-  // CHECK-SAME: %[[LHS]](%[[LHS_SHAPE]] !shapex.ranked_shape<[8,10,64]>) : f32,
-  // CHECK-SAME: %[[RHS]](%[[RHS_SHAPE]] !shapex.ranked_shape<[8,1,64]>) : f32,
+  // CHECK-SAME: %[[LHS]](%[[LHS_SHAPE]] : !shapex.ranked_shape<[8,4,4]>) : f32,
+  // CHECK-SAME: %[[RHS]](%[[RHS_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32,
   // CHECK-SAME: out
-  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] !shapex.ranked_shape<[8,1,10]>) : f32
-  vmla.batch.matmul %lhs(%lhs_shape !shapex.ranked_shape<[8,10,64]>) : f32,
-                    %rhs(%rhs_shape !shapex.ranked_shape<[8,1,64]>) : f32,
-                    out %dst(%dst_shape !shapex.ranked_shape<[8,1,10]>) : f32
+  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32
+  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[8,4,4]>) : f32,
+                    %rhs(%rhs_shape : !shapex.ranked_shape<[8,1,4]>) : f32,
+                    out %dst(%dst_shape : !shapex.ranked_shape<[8,1,4]>) : f32
   return
 }
 
@@ -102,12 +102,12 @@ func @vmla_transpose(%src : !vmla.buffer,
                      %dst : !vmla.buffer,
                      %dst_shape : !shapex.ranked_shape<[64,10,32,32]>) {
   // CHECK:      vmla.transpose
-  // CHECK-SAME: %[[SRC]](%[[SRC_SHAPE]] !shapex.ranked_shape<[64,32,32,10]>),
+  // CHECK-SAME: %[[SRC]](%[[SRC_SHAPE]] : !shapex.ranked_shape<[64,32,32,10]>),
   // CHECK-SAME: out
-  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] !shapex.ranked_shape<[64,10,32,32]>)
+  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] : !shapex.ranked_shape<[64,10,32,32]>)
   // CHECK-SAME: {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} : f32
-  vmla.transpose %src(%src_shape !shapex.ranked_shape<[64,32,32,10]>),
-                 out %dst(%dst_shape !shapex.ranked_shape<[64,10,32,32]>)
+  vmla.transpose %src(%src_shape : !shapex.ranked_shape<[64,32,32,10]>),
+                 out %dst(%dst_shape : !shapex.ranked_shape<[64,10,32,32]>)
                  {permutation = dense<[0, 3, 2, 1]> : tensor<4xi32>} : f32
   return
 }

--- a/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/VMLA/IR/test/ops.mlir
@@ -80,13 +80,13 @@ func @vmla_batch_matmul(%lhs : !vmla.buffer,
                         %dst : !vmla.buffer,
                         %dst_shape : !shapex.ranked_shape<[8,1,4]>) {
   // CHECK:      vmla.batch.matmul
-  // CHECK-SAME: %[[LHS]] : f32(%[[LHS_SHAPE]] : !shapex.ranked_shape<[8,4,4]>),
-  // CHECK-SAME: %[[RHS]] : f32(%[[RHS_SHAPE]] : !shapex.ranked_shape<[8,1,4]>),
+  // CHECK-SAME: %[[LHS]](%[[LHS_SHAPE]] : !shapex.ranked_shape<[8,4,4]>) : f32,
+  // CHECK-SAME: %[[RHS]](%[[RHS_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32,
   // CHECK-SAME: out
-  // CHECK-SAME: %[[DST]] : f32(%[[DST_SHAPE]] : !shapex.ranked_shape<[8,1,4]>)
-  vmla.batch.matmul %lhs : f32(%lhs_shape : !shapex.ranked_shape<[8,4,4]>),
-                    %rhs : f32(%rhs_shape : !shapex.ranked_shape<[8,1,4]>),
-                    out %dst : f32(%dst_shape : !shapex.ranked_shape<[8,1,4]>)
+  // CHECK-SAME: %[[DST]](%[[DST_SHAPE]] : !shapex.ranked_shape<[8,1,4]>) : f32
+  vmla.batch.matmul %lhs(%lhs_shape : !shapex.ranked_shape<[8,4,4]>) : f32,
+                    %rhs(%rhs_shape : !shapex.ranked_shape<[8,1,4]>) : f32,
+                    out %dst(%dst_shape : !shapex.ranked_shape<[8,1,4]>) : f32
   return
 }
 

--- a/iree/compiler/Dialect/VMLA/Transforms/test/transformation.mlir
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/transformation.mlir
@@ -22,7 +22,7 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 // CHECK-NEXT:   %0 = "vmla.interface.binding"(%arg0) {binding = 0 : i32, set = 0 : i32} : (!vmla.interface) -> !vmla.buffer
 // CHECK-NEXT:   %1 = "vmla.buffer.view"(%0, %c0, %c16) : (!vmla.buffer, index, index) -> !vmla.buffer
 // CHECK-NEXT:   %2 = "vmla.buffer.alloc"(%c16) : (index) -> !vmla.buffer
-// CHECK-NEXT:   vmla.add %1, %1, %2 : f32
+// CHECK-NEXT:   vmla.add %1, %1, out %2 : f32
 // CHECK-NEXT:   %3 = "vmla.interface.binding"(%arg0) {binding = 1 : i32, set = 0 : i32} : (!vmla.interface) -> !vmla.buffer
 // CHECK-NEXT:   "vmla.buffer.copy"(%2, %c0, %3, %c0, %c16) : (!vmla.buffer, index, !vmla.buffer, index, index) -> ()
 // CHECK-NEXT:   return

--- a/iree/compiler/Dialect/VMLA/Transforms/test/transformation.mlir
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/transformation.mlir
@@ -22,7 +22,7 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 // CHECK-NEXT:   %0 = "vmla.interface.binding"(%arg0) {binding = 0 : i32, set = 0 : i32} : (!vmla.interface) -> !vmla.buffer
 // CHECK-NEXT:   %1 = "vmla.buffer.view"(%0, %c0, %c16) : (!vmla.buffer, index, index) -> !vmla.buffer
 // CHECK-NEXT:   %2 = "vmla.buffer.alloc"(%c16) : (index) -> !vmla.buffer
-// CHECK-NEXT:   vmla.add(%1, %1, %2) : f32
+// CHECK-NEXT:   vmla.add %1, %1, %2 : f32
 // CHECK-NEXT:   %3 = "vmla.interface.binding"(%arg0) {binding = 1 : i32, set = 0 : i32} : (!vmla.interface) -> !vmla.buffer
 // CHECK-NEXT:   "vmla.buffer.copy"(%2, %c0, %3, %c0, %c16) : (!vmla.buffer, index, !vmla.buffer, index, index) -> ()
 // CHECK-NEXT:   return


### PR DESCRIPTION
Summary:
- Adds assembly formatting for:
  - `vmla.convert`
  - `vmla.batch.matmul.pseudo`
  - `vmla.batch.matmul`
  - `vmla.transpose`
- Updates any tests that were affected by these changes.
- Adds a test for each of the ops above in `iree/compiler/Dialect/VMLA/IR/test/ops.mlir`

Incremental step for #1198.