### PR TITLE
Remove alwayslink from HAL driver modules

### DIFF
--- a/iree/hal/llvmjit/BUILD
+++ b/iree/hal/llvmjit/BUILD
@@ -120,7 +120,6 @@ cc_library(
         #TODO(ataei): Link with native target dep.
         "@llvm-project//llvm:x86_code_gen",
     ],
-    alwayslink = 1,
 )
 
 cc_library(

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -130,7 +130,6 @@ iree_cc_library(
     iree::base::init
     iree::base::status
     iree::hal::driver_registry
-  ALWAYSLINK
   PUBLIC
 )
 

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -143,7 +143,6 @@ cc_library(
         "//iree/base:status",
         "//iree/hal:driver_registry",
     ],
-    alwayslink = 1,
 )
 
 cc_library(

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -151,7 +151,6 @@ iree_cc_library(
     iree::base::init
     iree::base::status
     iree::hal::driver_registry
-  ALWAYSLINK
   PUBLIC
 )
 


### PR DESCRIPTION
* Removes alwayslink from llvmjit driver module
* Removes alwayslink from vmla driver module
* The vulkan driver module already isn't marked alwayslink