### PR TITLE
Remove alwayslink from IREE conversion lib

### DIFF
--- a/iree/compiler/Dialect/IREE/Conversion/BUILD
+++ b/iree/compiler/Dialect/IREE/Conversion/BUILD
@@ -30,5 +30,4 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Transforms",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/Conversion/CMakeLists.txt
@@ -25,6 +25,5 @@ iree_cc_library(
     MLIRIR
     MLIRTransforms
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )


### PR DESCRIPTION
E.g. linked into `iree::compiler::Dialect::HAL::Conversion::FlowToHAL` which is not marked alwayslink (and currently not explicitly registered(?)) and `iree::compiler::Dialect::VM::Transforms` which is explicitly registered with `createConversionPass()` called by `registerVMPasses()`.