### PR TITLE
Revise alwayslink in CodegenPasses and CodegenUtils

### DIFF
--- a/iree/compiler/Translation/CodegenPasses/BUILD
+++ b/iree/compiler/Translation/CodegenPasses/BUILD
@@ -65,5 +65,4 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:map_xla_to_scalar_op",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Translation/CodegenPasses/CMakeLists.txt
+++ b/iree/compiler/Translation/CodegenPasses/CMakeLists.txt
@@ -54,6 +54,5 @@ iree_cc_library(
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Translation::CodegenUtils
     tensorflow::mlir_xla
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Translation/CodegenPasses/LinalgVectorTransform.cpp
+++ b/iree/compiler/Translation/CodegenPasses/LinalgVectorTransform.cpp
@@ -41,5 +41,10 @@ static PassRegistration<IREELinalgVectorTransformPass> pass(
     "iree-linalg-vector-transforms", "Lower linalg to vector dialect");
 
 }  // namespace
+
+std::unique_ptr<FunctionPass> createIREELinalgVectorTransformPass() {
+  return std::make_unique<IREELinalgVectorTransformPass>();
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Translation/CodegenPasses/Passes.h
+++ b/iree/compiler/Translation/CodegenPasses/Passes.h
@@ -68,6 +68,14 @@ void populateHLOToLinalgOnBuffersConversionPatterns(
 void populateHLOToLinalgOnTensorsConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns);
 
+/// Register all Codegen passes
+inline void registerCodegenPasses() {
+  createHALInterfaceToMemrefPass();
+  createHLOToLinalgOnBuffersPass();
+  createHLOToLinalgOnTensorsPass();
+  createLinalgOnTensorsFusionPass();
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Translation/CodegenPasses/Passes.h
+++ b/iree/compiler/Translation/CodegenPasses/Passes.h
@@ -39,9 +39,6 @@ void addHLOToLinalgOnBuffersPasses(OpPassManager &pm);
 /// memrefs.
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createHALInterfaceToMemrefPass();
 
-/// Creates XLA-HLO preprocessing transformation pass.
-std::unique_ptr<OperationPass<FuncOp>> createHLOPreprocessingPass();
-
 /// Creates XLA-HLO to Linalg on buffers transformation pass.
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnBuffersPass();
 

--- a/iree/compiler/Translation/CodegenPasses/Passes.h
+++ b/iree/compiler/Translation/CodegenPasses/Passes.h
@@ -49,6 +49,9 @@ std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass();
 /// producer consumer fusion.
 std::unique_ptr<OperationPass<FuncOp>> createLinalgOnTensorsFusionPass();
 
+/// Creates IREE Linalg Vector transformation pass.
+std::unique_ptr<FunctionPass> createIREELinalgVectorTransformPass();
+
 /// Populates the patterns that convert from XLA to Linalg on tensors. Imports
 /// patterns from XLA, as well as some IREE specific modifications.
 void populateHLOToLinalgOnTensorsConversionPatterns(
@@ -71,6 +74,7 @@ inline void registerCodegenPasses() {
   createHLOToLinalgOnBuffersPass();
   createHLOToLinalgOnTensorsPass();
   createLinalgOnTensorsFusionPass();
+  createIREELinalgVectorTransformPass();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Translation/CodegenPasses/Passes.h
+++ b/iree/compiler/Translation/CodegenPasses/Passes.h
@@ -17,8 +17,8 @@
 // IREE specific passes used in the XLA to Linalg conversion
 //
 //===----------------------------------------------------------------------===//
-#ifndef IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H
-#define IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H
+#ifndef IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H_
+#define IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H_
 #include <memory>
 
 #include "mlir/IR/Function.h"
@@ -79,4 +79,4 @@ inline void registerCodegenPasses() {
 }  // namespace iree_compiler
 }  // namespace mlir
 
-#endif  // IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H
+#endif  // IREE_COMPILER_TRANSLATION_CODEGENPASSES_PASSES_H_

--- a/iree/compiler/Translation/CodegenUtils/BUILD
+++ b/iree/compiler/Translation/CodegenUtils/BUILD
@@ -35,5 +35,4 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
     ],
-    alwayslink = 1,
 )

--- a/iree/compiler/Translation/CodegenUtils/CMakeLists.txt
+++ b/iree/compiler/Translation/CodegenUtils/CMakeLists.txt
@@ -28,6 +28,5 @@ iree_cc_library(
     MLIRSupport
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::IREE::IR
-  ALWAYSLINK
   PUBLIC
 )

--- a/iree/compiler/Translation/CodegenUtils/CodegenUtils.h
+++ b/iree/compiler/Translation/CodegenUtils/CodegenUtils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H
-#define IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H
+#ifndef IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H_
+#define IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H_
 
 #include "mlir/IR/Function.h"
 #include "mlir/Support/LogicalResult.h"
@@ -53,4 +53,4 @@ LogicalResult updateWorkGroupSize(Operation *op,
 }  // namespace iree_compiler
 }  // namespace mlir
 
-#endif  // IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H
+#endif  // IREE_COMPILER_TRANSLATION_CODEGENUTILS_CODEGENUTILS_H_

--- a/iree/tools/opt_main.cc
+++ b/iree/tools/opt_main.cc
@@ -17,6 +17,7 @@
 // Based on mlir-opt but without registering passes and dialects we don't care
 // about.
 
+#include "iree/compiler/Translation/CodegenPasses/Passes.h"
 #include "iree/compiler/Translation/SPIRV/init_translations.h"
 #include "iree/tools/init_compiler_modules.h"
 #include "iree/tools/init_dialects.h"
@@ -70,6 +71,7 @@ int main(int argc, char **argv) {
   mlir::iree_compiler::registerAllIreePasses();
   mlir::iree_compiler::registerHALTargetBackends();
   mlir::iree_compiler::registerSPRIVTranslation();
+  mlir::iree_compiler::registerCodegenPasses();
   llvm::InitLLVM y(argc, argv);
 
   // Register MLIRContext command-line options like


### PR DESCRIPTION
* Implements explicit registration of CodegenPasses
* Drops alwayslink from CodegenPasses and CodegenUtils
* Removes createHLOPreprocessingPass() from CodegenPasses header:
  * Implemented in `compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp`
  * Only added to the passManager within `compiler/Dialect/Flow/Transforms/Passes.cpp`
  * Also/Already declared in `compiler/Dialect/Flow/Transforms/Passes.h`
* Further, adjusts define guards to match Google C++ Style Guide 