### PR TITLE
Remove alwayslink from benchmark_main

### DIFF
--- a/iree/testing/BUILD
+++ b/iree/testing/BUILD
@@ -29,7 +29,6 @@ cc_library(
         "//iree/base:init",
         "@com_google_benchmark//:benchmark",
     ],
-    alwayslink = 1,
 )
 
 cc_library(

--- a/iree/testing/CMakeLists.txt
+++ b/iree/testing/CMakeLists.txt
@@ -22,7 +22,6 @@ iree_cc_library(
   DEPS
     benchmark
     iree::base::init
-  ALWAYSLINK
   TESTONLY
   PUBLIC
 )


### PR DESCRIPTION
Verified locally that `iree/vm:bytecode_module_benchmark` was rebuild and passed.