### PR TITLE
Temporarily disable testing keras_lstm_static_test on GitHub Actions

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -46,7 +46,6 @@ package(
         "exported_names_test",
         "tensorlist_test",
         "keras_lstm_test",
-        "keras_lstm_static_test",
         "mandelbrot_test",
         "matrix_ops_test",
         "ring_buffer_test",
@@ -54,6 +53,23 @@ package(
         "simple_arithmetic_test",
         "simple_stateful_test",
         "strings_test",
+    ]
+]
+
+# TODO(GH-1620): Merge this with the above after fixing the failure on GitHub
+# Actions.
+[
+    iree_py_test(
+        name = name,
+        srcs = [name + ".py"],
+        python_version = "PY3",
+        tags = ["nokokoro", "noga"],
+        deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+            "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+        ],
+    )
+    for name in [
+        "keras_lstm_static_test",
     ]
 ]
 

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -29,8 +29,6 @@ package(
         name = name,
         srcs = [name + ".py"],
         python_version = "PY3",
-        # TODO(b/145815906) Get this running in OSS CI.
-        tags = ["nokokoro"],
         deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
             "//integrations/tensorflow/bindings/python/pyiree/tf/support",
         ],
@@ -56,23 +54,6 @@ package(
     ]
 ]
 
-# TODO(GH-1620): Merge this with the above after fixing the failure on GitHub
-# Actions.
-[
-    iree_py_test(
-        name = name,
-        srcs = [name + ".py"],
-        python_version = "PY3",
-        tags = ["nokokoro", "noga"],
-        deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
-            "//integrations/tensorflow/bindings/python/pyiree/tf/support",
-        ],
-    )
-    for name in [
-        "keras_lstm_static_test",
-    ]
-]
-
 [
     iree_py_test(
         name = "keras_vision_model_" + model_name + "_test",
@@ -87,7 +68,6 @@ package(
         tags = [
             "large",
             "manual",
-            "nokokoro",
         ],
         deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
             "//integrations/tensorflow/bindings/python/pyiree/tf/support",
@@ -107,6 +87,7 @@ package(
         name = name,
         srcs = [name + ".py"],
         python_version = "PY3",
+        # TODO(b/145815906) Get this running in OSS CI.
         tags = ["noga"],
         deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
             "//integrations/tensorflow/bindings/python/pyiree/tf/support",
@@ -116,5 +97,8 @@ package(
         "conv_test",
         "linspace_test",
         "math_test",
+        # TODO(GH-1620): Re-enable this after fixing the failure on
+        # GitHub Actions.
+        "keras_lstm_static_test",
     ]
 ]


### PR DESCRIPTION
https://github.com/google/iree/issues/1620 is filed to investigate
and fix the test failure. Until then, disable this to unblock
master and avoid hiding other issues.

Removed leftover `nokokoro` tags along the way.