### PR TITLE
Using a bunch of scratch registers when there are complex CFGs.

### DIFF
--- a/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h
+++ b/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h
@@ -94,8 +94,12 @@ class RegisterAllocation {
 
   // Maximum allocated register ordinals.
   // May be -1 if no registers of the specific type were allocated.
-  uint16_t getMaxI32RegisterOrdinal() { return maxI32RegisterOrdinal_; }
-  uint16_t getMaxRefRegisterOrdinal() { return maxRefRegisterOrdinal_; }
+  uint16_t getMaxI32RegisterOrdinal() {
+    return maxI32RegisterOrdinal_ + scratchI32RegisterCount_;
+  }
+  uint16_t getMaxRefRegisterOrdinal() {
+    return maxRefRegisterOrdinal_ + scratchRefRegisterCount_;
+  }
 
   // Maps a |value| to a register with no move bit set.
   // Prefer mapUseToRegister when a move is desired.
@@ -114,6 +118,8 @@ class RegisterAllocation {
  private:
   int maxI32RegisterOrdinal_ = -1;
   int maxRefRegisterOrdinal_ = -1;
+  int scratchI32RegisterCount_ = 0;
+  int scratchRefRegisterCount_ = 0;
 
   // Cached liveness information.
   ValueLiveness liveness_;

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -273,8 +273,6 @@ Optional<EncodedBytecodeFunction> BytecodeEncoder::encodeFunction(
     funcOp.emitError() << "register allocation failed";
     return llvm::None;
   }
-  result.i32RegisterCount = registerAllocation.getMaxI32RegisterOrdinal() + 1;
-  result.refRegisterCount = registerAllocation.getMaxRefRegisterOrdinal() + 1;
 
   V0BytecodeEncoder encoder(&typeTable, &registerAllocation);
   for (auto &block : funcOp.getBlocks()) {
@@ -310,6 +308,8 @@ Optional<EncodedBytecodeFunction> BytecodeEncoder::encodeFunction(
     return llvm::None;
   }
   result.bytecodeData = bytecodeData.getValue();
+  result.i32RegisterCount = registerAllocation.getMaxI32RegisterOrdinal() + 1;
+  result.refRegisterCount = registerAllocation.getMaxRefRegisterOrdinal() + 1;
   return result;
 }
 


### PR DESCRIPTION
The assertion was there from when we had a limited register set, but now
that we have 32k of each type we can just use as many as we want.