### PR TITLE
Turn on asserts by default in bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,9 +25,12 @@ build --copt=-Wno-unused-function
 # C++14 standard version is required.
 build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 
-# Default to an optimized build.
+# Default to an optimized build with asserts.
+# This is a good compromise between runtime and debugability.
 # Override via: "-c dbg" or --compilation_mode=dbg
 build --compilation_mode=opt
+build --copt=-UNDEBUG
+
 
 # Disable visibility checks (works around some private deps in TensorFlow that
 # are being unbundled soon anyway).

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,7 +31,6 @@ build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build --compilation_mode=opt
 build --copt=-UNDEBUG
 
-
 # Disable visibility checks (works around some private deps in TensorFlow that
 # are being unbundled soon anyway).
 build --nocheck_visibility


### PR DESCRIPTION
These are generally useful. At some point we might want to tweak the defaults or add more build configs, but if we're going to leave opt the default, then opt + asserts makes sense.

We've had issues that would've been diagnosed faster with asserts (e.g. https://github.com/google/iree/issues/1620)