### PR TITLE
Run Bazel to CMake.

### DIFF
--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRIR
+    MLIRInferTypeOpInterface
     MLIRParser
     MLIRSideEffects
     MLIRStandardOps


### PR DESCRIPTION
`./build_tools/bazel_to_cmake/bazel_to_cmake.py`