### PR TITLE
CMake: Add vmla_driver_module dep to pyiree runtime

### DIFF
--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_py_extension(
   DEPS
     iree::hal::vulkan::vulkan_driver_module
     iree::hal::llvmjit::llvmjit_driver_module
+    iree::hal::vmla::vmla_driver_module
     ::rt_library
     bindings::python::pyiree::common
     iree::base::initializer


### PR DESCRIPTION
Dep was added to Bazel. Allows to pass all tests locally.