### PR TITLE
Small NFC to enable predicate printing in custom VMLA assembly.

### DIFF
--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/ConvertStandardToVMLA.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/ConvertStandardToVMLA.cpp
@@ -102,8 +102,8 @@ struct CmpIOpConversion
     auto dst = VMLAConversionTarget::allocateOutputBuffer(
         srcOp.getLoc(), srcOp.getResult(), typeConverter, rewriter);
     auto newOp = rewriter.create<IREE::VMLA::CmpOp>(
-        srcOp.getLoc(), predicate, operands[0],
-        operands[1], dst, TypeAttr::get(inputType.getElementType()));
+        srcOp.getLoc(), predicate, operands[0], operands[1], dst,
+        TypeAttr::get(inputType.getElementType()));
     if (forceUnsigned) {
       newOp.setAttr("force_unsigned", UnitAttr::get(rewriter.getContext()));
     }
@@ -158,8 +158,8 @@ class CmpFOpConversion
     auto dst = VMLAConversionTarget::allocateOutputBuffer(
         srcOp.getLoc(), srcOp.getResult(), typeConverter, rewriter);
     auto newOp = rewriter.create<IREE::VMLA::CmpOp>(
-        srcOp.getLoc(), predicate, operands[0],
-        operands[1], dst, TypeAttr::get(inputType.getElementType()));
+        srcOp.getLoc(), predicate, operands[0], operands[1], dst,
+        TypeAttr::get(inputType.getElementType()));
     rewriter.replaceOp(srcOp, newOp.dst());
     return success();
   }

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/ConvertStandardToVMLA.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/ConvertStandardToVMLA.cpp
@@ -102,7 +102,7 @@ struct CmpIOpConversion
     auto dst = VMLAConversionTarget::allocateOutputBuffer(
         srcOp.getLoc(), srcOp.getResult(), typeConverter, rewriter);
     auto newOp = rewriter.create<IREE::VMLA::CmpOp>(
-        srcOp.getLoc(), static_cast<uint32_t>(predicate), operands[0],
+        srcOp.getLoc(), predicate, operands[0],
         operands[1], dst, TypeAttr::get(inputType.getElementType()));
     if (forceUnsigned) {
       newOp.setAttr("force_unsigned", UnitAttr::get(rewriter.getContext()));
@@ -158,7 +158,7 @@ class CmpFOpConversion
     auto dst = VMLAConversionTarget::allocateOutputBuffer(
         srcOp.getLoc(), srcOp.getResult(), typeConverter, rewriter);
     auto newOp = rewriter.create<IREE::VMLA::CmpOp>(
-        srcOp.getLoc(), static_cast<uint32_t>(predicate), operands[0],
+        srcOp.getLoc(), predicate, operands[0],
         operands[1], dst, TypeAttr::get(inputType.getElementType()));
     rewriter.replaceOp(srcOp, newOp.dst());
     return success();

--- a/iree/compiler/Dialect/VMLA/IR/VMLABase.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLABase.td
@@ -57,8 +57,6 @@ def VMLA_CmpPredicateAttr :
       VMLA_CmpPredicate_GT,
       VMLA_CmpPredicate_GE,
     ]> {
-  let returnType = "uint32_t";
-  let convertFromStorage = "static_cast<uint32_t>($_self.getInt())";
   let cppNamespace = "::mlir::iree_compiler::IREE::VMLA";
 }
 


### PR DESCRIPTION
Removes the `returnType` declaration in `VMLA_CmpPredicateAttr` and updates `ConvertStandardToVMLA.cpp` to reflect this change. Should be non-functional. Enables custom assembly formatting for the `vmla.cmp` op.