### PR TITLE
Adds python2 numpy to bazel github workflows.

### DIFF
--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -46,6 +46,9 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          sudo apt-get install -y python-pip
+          python -m pip install --upgrade pip
+          python -m pip install numpy
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -46,6 +46,7 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          # Install python2 numpy. Temporary fix for issue #1737.
           sudo apt-get install -y python-pip
           python -m pip install --upgrade pip
           python -m pip install numpy

--- a/.github/workflows/bazel_build_core.yml
+++ b/.github/workflows/bazel_build_core.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clang libsdl2-dev
+          sudo apt-get install -y python-pip
+          python -m pip install --upgrade pip
+          python -m pip install numpy
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_core.yml
+++ b/.github/workflows/bazel_build_core.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clang libsdl2-dev
+          # Install python2 numpy. Temporary fix for issue #1737.
           sudo apt-get install -y python-pip
           python -m pip install --upgrade pip
           python -m pip install numpy

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -46,6 +46,9 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          sudo apt-get install -y python-pip
+          python -m pip install --upgrade pip
+          python -m pip install numpy
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -46,6 +46,7 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          # Install python2 numpy. Temporary fix for issue #1737.
           sudo apt-get install -y python-pip
           python -m pip install --upgrade pip
           python -m pip install numpy

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -46,6 +46,9 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          sudo apt-get install -y python-pip
+          python -m pip install --upgrade pip
+          python -m pip install numpy
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -46,6 +46,7 @@ jobs:
           # Update pip before using it so it picks up the latest versions of our dependencies.
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install numpy tf-nightly
+          # Install python2 numpy. Temporary fix for issue #1737.
           sudo apt-get install -y python-pip
           python -m pip install --upgrade pip
           python -m pip install numpy


### PR DESCRIPTION
Addresses the build failure described in issue #1737 until a cleaner solution can be implemented.