### PR TITLE
Move testing_guide down in nav order.

### DIFF
--- a/scripts/prepare_doc_publication.py
+++ b/scripts/prepare_doc_publication.py
@@ -94,6 +94,7 @@ NAVI_ORDER_DICT = {
     'roadmap_design.md': 4,
     'roadmap.md': 5,
     'op_coverage.md': 6,
+    'testing_guide.md': 7,
 
     # Within 'Getting Started' use explicit ordering.
     # Alphabetical would put 'bazel' before 'cmake' and 'python' between 'linux'


### PR DESCRIPTION
Implicit ordering is putting it at the top of the list right now. The comment about alphabetical sorting seems incorrect?