### PR TITLE
Introduce IREE_{HAL_DRIVERS,TARGET_BACKENDS}_TO_BUILD to CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,11 @@ option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 option(IREE_BUILD_EXPERIMENTAL "Builds experimental projects." OFF)
 
-#TODO: Generated IREE_BACKEND_* don't have any effect yet. Make is functional!
-set(IREE_BACKENDS_TO_BUILD "all"
-  CACHE STRING "Semicolon-separated list of backends to build, or \"all\"." FORCE)
+#TODO: Make is functional!
+set(IREE_HAL_BACKENDS_TO_BUILD "all"
+  CACHE STRING "Semicolon-separated list of HAL backends to build, or \"all\"." FORCE)
+set(IREE_COMPILER_BACKENDS_TO_BUILD "all"
+  CACHE STRING "Semicolon-separated list of compiler backends to build, or \"all\"." FORCE)
 
 if(${IREE_BUILD_SAMPLES} OR ${IREE_BUILD_EXPERIMENTAL})
   set(IREE_BUILD_COMPILER ON CACHE BOOL "Build the IREE compiler for sample projects." FORCE)
@@ -66,22 +68,40 @@ set(IREE_ALL_BACKENDS
   VMLA
 )
 
-if( IREE_BACKENDS_TO_BUILD STREQUAL "all" )
-  set( IREE_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
+
+if( IREE_HAL_BACKENDS_TO_BUILD STREQUAL "all" )
+  set( IREE_HAL_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
 endif()
+message(STATUS "Building HAL backends ${IREE_HAL_BACKENDS_TO_BUILD}")
 
-message(STATUS "Building IREE backends ${IREE_BACKENDS_TO_BUILD}")
-
-# Default every IREE_BACKEND_* to OFF
-foreach(_backend ${IREE_ALL_BACKENDS})
+# Default every IREE_HAL_BACKEND_* to OFF
+foreach(_backend ${IREE_HAL_BACKENDS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_BACKEND_${uppercase_backend} OFF CACHE BOOL "" FORCE)
+  set(IREE_HAL_BACKEND_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
 
-# Set IREE_BACKEND_* based on configuration
-foreach(_backend ${IREE_BACKENDS_TO_BUILD})
+# Set IREE_HAL_BACKEND_* based on configuration
+foreach(_backend ${IREE_HAL_BACKENDS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_BACKEND_${uppercase_backend} ON CACHE BOOL "" FORCE)
+  set(IREE_HAL_BACKEND_${uppercase_backend} ON CACHE BOOL "" FORCE)
+endforeach()
+
+
+if( IREE_COMPILER_BACKENDS_TO_BUILD STREQUAL "all" )
+  set( IREE_COMPILER_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
+endif()
+message(STATUS "Building compiler backends ${IREE_COMPILER_BACKENDS_TO_BUILD}")
+
+# Default every IREE_COMPILER_BACKENDS_* to OFF
+foreach(_backend ${IREE_COMPILER_BACKENDS_TO_BUILD})
+  string(TOUPPER "${_backend}" uppercase_backend)
+  set(IREE_COMPILER_BACKENDS_${uppercase_backend} OFF CACHE BOOL "" FORCE)
+endforeach()
+
+# Set IREE_COMPILER_BACKENDS_* based on configuration
+foreach(_backend ${IREE_COMPILER_BACKENDS_TO_BUILD})
+  string(TOUPPER "${_backend}" uppercase_backend)
+  set(IREE_COMPILER_BACKENDS_${uppercase_backend} ON CACHE BOOL "" FORCE)
 endforeach()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 option(IREE_BUILD_EXPERIMENTAL "Builds experimental projects." OFF)
 
+#TODO: Generated IREE_BACKEND_* don't have any effect yet. Make is functional!
+set(IREE_BACKENDS_TO_BUILD "all"
+  CACHE STRING "Semicolon-separated list of backends to build, or \"all\"." FORCE)
+
 if(${IREE_BUILD_SAMPLES} OR ${IREE_BUILD_EXPERIMENTAL})
   set(IREE_BUILD_COMPILER ON CACHE BOOL "Build the IREE compiler for sample projects." FORCE)
 endif()
@@ -54,6 +58,32 @@ endif()
 #-------------------------------------------------------------------------------
 # IREE-specific CMake configuration
 #-------------------------------------------------------------------------------
+
+# List of all backends to be built by default:
+set(IREE_ALL_BACKENDS
+  LLVM
+  Vulkan_SPIRV
+  VMLA
+)
+
+if( IREE_BACKENDS_TO_BUILD STREQUAL "all" )
+  set( IREE_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
+endif()
+
+message(STATUS "Building IREE backends ${IREE_BACKENDS_TO_BUILD}")
+
+# Default every IREE_BACKEND_* to OFF
+foreach(_backend ${IREE_ALL_BACKENDS})
+  string(TOUPPER "${_backend}" uppercase_backend)
+  set(IREE_BACKEND_${uppercase_backend} OFF CACHE BOOL "" FORCE)
+endforeach()
+
+# Set IREE_BACKEND_* based on configuration
+foreach(_backend ${IREE_BACKENDS_TO_BUILD})
+  string(TOUPPER "${_backend}" uppercase_backend)
+  set(IREE_BACKEND_${uppercase_backend} ON CACHE BOOL "" FORCE)
+endforeach()
+
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 # List of all backends to be built by default:
 set(IREE_ALL_BACKENDS
   LLVM
-  Vulkan_SPIRV
+  Vulkan
   VMLA
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
 option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 option(IREE_BUILD_EXPERIMENTAL "Builds experimental projects." OFF)
 
-#TODO: Make is functional!
-set(IREE_HAL_BACKENDS_TO_BUILD "all"
-  CACHE STRING "Semicolon-separated list of HAL backends to build, or \"all\"." FORCE)
-set(IREE_COMPILER_BACKENDS_TO_BUILD "all"
-  CACHE STRING "Semicolon-separated list of compiler backends to build, or \"all\"." FORCE)
+#TODO: Make this functional!
+set(IREE_HAL_DRIVERS_TO_BUILD "all"
+  CACHE STRING "Semicolon-separated list of HAL drivers to build, or \"all\"." FORCE)
+set(IREE_TARGET_BACKENDS_TO_BUILD "all"
+  CACHE STRING "Semicolon-separated list of target backends to build, or \"all\"." FORCE)
 
 if(${IREE_BUILD_SAMPLES} OR ${IREE_BUILD_EXPERIMENTAL})
   set(IREE_BUILD_COMPILER ON CACHE BOOL "Build the IREE compiler for sample projects." FORCE)
@@ -61,47 +61,53 @@ endif()
 # IREE-specific CMake configuration
 #-------------------------------------------------------------------------------
 
-# List of all backends to be built by default:
-set(IREE_ALL_BACKENDS
+# List of all HAL drivers to be built by default:
+set(IREE_ALL_HAL_DRIVERS
   LLVM
   Vulkan
   VMLA
 )
 
-
-if( IREE_HAL_BACKENDS_TO_BUILD STREQUAL "all" )
-  set( IREE_HAL_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
+if( IREE_HAL_DRIVERS_TO_BUILD STREQUAL "all" )
+  set( IREE_HAL_DRIVERS_TO_BUILD ${IREE_ALL_HAL_DRIVERS} )
 endif()
-message(STATUS "Building HAL backends ${IREE_HAL_BACKENDS_TO_BUILD}")
+message(STATUS "Building HAL drivers ${IREE_HAL_DRIVERS_TO_BUILD}")
 
-# Default every IREE_HAL_BACKEND_* to OFF
-foreach(_backend ${IREE_HAL_BACKENDS_TO_BUILD})
+# Default every IREE_HAL_DRIVER_* to OFF
+foreach(_backend ${IREE_ALL_HAL_DRIVERS})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_HAL_BACKEND_${uppercase_backend} OFF CACHE BOOL "" FORCE)
+  set(IREE_HAL_DRIVER_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
 
-# Set IREE_HAL_BACKEND_* based on configuration
-foreach(_backend ${IREE_HAL_BACKENDS_TO_BUILD})
+# Set IREE_HAL_DRIVER_* based on configuration
+foreach(_backend ${IREE_HAL_DRIVERS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_HAL_BACKEND_${uppercase_backend} ON CACHE BOOL "" FORCE)
+  set(IREE_HAL_DRIVER_${uppercase_backend} ON CACHE BOOL "" FORCE)
 endforeach()
 
 
-if( IREE_COMPILER_BACKENDS_TO_BUILD STREQUAL "all" )
-  set( IREE_COMPILER_BACKENDS_TO_BUILD ${IREE_ALL_BACKENDS} )
+# List of all target backends to be built by default:
+set(IREE_ALL_TARGET_BACKENDS
+  LLVMIR
+  Vulkan_SPIRV
+  VMLA
+)
+
+if( IREE_TARGET_BACKENDS_TO_BUILD STREQUAL "all" )
+  set( IREE_TARGET_BACKENDS_TO_BUILD ${IREE_ALL_TARGET_BACKENDS} )
 endif()
-message(STATUS "Building compiler backends ${IREE_COMPILER_BACKENDS_TO_BUILD}")
+message(STATUS "Building target backends ${IREE_TARGET_BACKENDS_TO_BUILD}")
 
-# Default every IREE_COMPILER_BACKENDS_* to OFF
-foreach(_backend ${IREE_COMPILER_BACKENDS_TO_BUILD})
+# Default every IREE_TARGET_BACKEND_* to OFF
+foreach(_backend ${IREE_ALL_TARGET_BACKENDS})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_COMPILER_BACKENDS_${uppercase_backend} OFF CACHE BOOL "" FORCE)
+  set(IREE_TARGET_BACKEND_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
 
-# Set IREE_COMPILER_BACKENDS_* based on configuration
-foreach(_backend ${IREE_COMPILER_BACKENDS_TO_BUILD})
+# Set IREE_TARGET_BACKEND_* based on configuration
+foreach(_backend ${IREE_TARGET_BACKENDS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
-  set(IREE_COMPILER_BACKENDS_${uppercase_backend} ON CACHE BOOL "" FORCE)
+  set(IREE_TARGET_BACKEND_${uppercase_backend} ON CACHE BOOL "" FORCE)
 endforeach()
 
 


### PR DESCRIPTION
* Introduces `IREE_HAL_DRIVERS_TO_BUILD` and `IREE_TARGET_BACKENDS_TO_BUILD`
* Generates `IREE_HAL_DRIVER_*` variables based on configuration
* Generates `IREE_TARGET_BACKEND_*` variables based on configuration