### PR TITLE
Add support for building an IREE/TensorFlow wheel.

### DIFF
--- a/bindings/python/packaging/README.md
+++ b/bindings/python/packaging/README.md
@@ -1,0 +1,45 @@
+# Python packaging scripts.
+
+Note that packages will be placed in `bindings/python/packaging/dist` with
+the canonical instructions. However, the setup scripts can be run from
+anywhere and will create `build` and `dist` directories where run. Wheels can
+be installed with `pip3 install --user dist/*.whl`.
+
+## Building core wheels
+
+Most of IREE is built/packaged with CMake. Canonical instructions follow:
+
+### Linux
+
+```shell
+export LDFLAGS=-fuse-ld=/usr/bin/ld.lld-10
+export CMAKE_BUILD_ROOT=$HOME/build-iree-release
+export IREE_SRC=$HOME/src/iree
+rm -Rf $CMAKE_BUILD_ROOT; mkdir -p $CMAKE_BUILD_ROOT
+cmake -GNinja -B$CMAKE_BUILD_ROOT -H$IREE_SRC \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -DIREE_BUILD_PYTHON_BINDINGS=ON -DIREE_BUILD_SAMPLES=OFF
+(cd $CMAKE_BUILD_ROOT && ninja)
+(cd $IREE_SRC/bindings/python/packaging && (
+rm -Rf build;
+python3 setup_compiler.py bdist_wheel;
+rm -Rf build;
+python3 setup_rt.py bdist_wheel))
+```
+
+## Building IREE/TensorFlow wheels
+
+TensorFlow integration must be built via Bazel. Canonical instructions follow:
+
+### Linux
+
+```shell
+export IREE_SRC=$HOME/src/iree
+cd $IREE_SRC
+bazel build -c opt \
+  //integrations/tensorflow/bindings/python/packaging:all_tf_packages
+(cd $IREE_SRC/bindings/python/packaging && (
+rm -Rf build;
+python3 setup_tf.py bdist_wheel))
+```

--- a/bindings/python/packaging/common_setup.py
+++ b/bindings/python/packaging/common_setup.py
@@ -40,9 +40,11 @@ def get_default_date_version():
   return today.strftime("%Y%m%d")
 
 
-def get_setup_defaults(sub_project, description):
+def get_setup_defaults(sub_project, description, package_dir=None):
+  if not package_dir:
+    package_dir = get_package_dir()
   return {
-      "name": "google-iree-%s-pkg" % (sub_project,),
+      "name": "google-iree-%s" % (sub_project,),
       "version": get_default_date_version(),
       "author": "The IREE Team at Google",
       "author_email": "iree-discuss@googlegroups.com",
@@ -51,7 +53,7 @@ def get_setup_defaults(sub_project, description):
       "long_description_content_type": "text/plain",
       "url": "https://github.com/google/iree",
       "package_dir": {
-          "": get_package_dir()
+          "": package_dir,
       },
       "classifiers": [
           "Programming Language :: Python :: 3",

--- a/bindings/python/packaging/setup_tf.py
+++ b/bindings/python/packaging/setup_tf.py
@@ -64,6 +64,7 @@ def find_bazel_runfiles_dir():
     "python")
   if not os.path.isdir(package_path):
     print("ERROR: Could not find built python package:", package_path)
+    sys.exit(1)
   return package_path
 
 

--- a/bindings/python/packaging/setup_tf.py
+++ b/bindings/python/packaging/setup_tf.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build platform specific wheel files for the pyiree.tf packages.
+# Built artifacts are per-platform and build out of the build tree.
+# Usage:
+# ------
+#  bazel build -c opt //integrations/tensorflow/bindings/python/packaging:all_tf_packages
+#  python3 ./setup_tf.py bdist_wheel
+#
+# Tips:
+# Optionally add: --define=PYIREE_TF_DISABLE_KERNELS=1
+# to build a 'thin' (less functional) version without TensorFlow kernels.
+# This should not be done for released binaries but can help while developing.
+#
+# Note that this script violates our general policy of keeping TensorFlow
+# things in the integrations/tensorflow directory because it is more convenient
+# to have all packaging scripts in one place, and this will not grow further
+# dependencies.
+
+import os
+import setuptools
+import sys
+
+# Ensure that path starts here for execution as a script.
+sys.path.insert(0, os.path.dirname(__file__))
+import common_setup
+
+
+def find_bazel_runfiles_dir():
+  bazel_bin = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "bazel-bin"))
+  if not os.path.isdir(bazel_bin):
+    print("ERROR: Could not find bazel-bin:", bazel_bin)
+    sys.exit(1)
+  # Find the path to the runfiles of the built target:
+  #   //integrations/tensorflow/bindings/python/packaging:all_tf_packages
+  runfiles_dir = os.path.join(
+    bazel_bin, "integrations", "tensorflow", "bindings", "python",
+    "packaging", "all_tf_packages.runfiles")
+  if not os.path.isdir(runfiles_dir):
+    print("ERROR: Could not find build target 'all_tf_packages':", runfiles_dir)
+    print("Make sure to build target", 
+          "//integrations/tensorflow/bindings/python/packaging:all_tf_packages")
+    sys.exit(1)
+  # And finally seek into the corresponding path in the runfiles dir.
+  # Aren't bazel paths fun???
+  # Note that the "iree_core" path segment corresponds to the workspace name.
+  package_path = os.path.join(
+    runfiles_dir, "iree_core", "integrations", "tensorflow", "bindings", 
+    "python")
+  if not os.path.isdir(package_path):
+    print("ERROR: Could not find built python package:", package_path)
+  return package_path
+
+
+def run():
+  package_dir = find_bazel_runfiles_dir()
+  packages = setuptools.find_namespace_packages(
+      package_dir,
+      include=["pyiree.tf.compiler", "pyiree.tf.compiler.*",
+               "pyiree.tf.support", "pyiree.tf.support.*"],
+      exclude=["*.CMakeFiles"])
+  print("Found packages:", packages)
+  if not packages:
+    print("ERROR: Did not find packages under", package_dir)
+    sys.exit(1)
+  setup_kwargs = common_setup.get_setup_defaults(
+      sub_project="tf", description="IREE TensorFlow Compiler",
+      package_dir=package_dir)
+  common_setup.setup(packages=packages, **setup_kwargs)
+
+
+if __name__ == "__main__":
+  run()

--- a/integrations/tensorflow/bindings/python/packaging/BUILD.bazel
+++ b/integrations/tensorflow/bindings/python/packaging/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a dummy binary that has the side-effect of building all of the TF
+# python bindings. It is used to build wheel files.
+py_binary(
+    name = "all_tf_packages",
+    srcs = ["dummy_exclude_from_package.py"],
+    legacy_create_init = False,
+    main = "dummy_exclude_from_package.py",
+    python_version = "PY3",
+    deps = [
+        "//bindings/python:pathsetup",  # build_cleaner: keep
+        "//integrations/tensorflow/bindings/python/pyiree/tf/compiler",  # build_cleaner: keep
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",  # build_cleaner: keep
+    ],
+)

--- a/integrations/tensorflow/bindings/python/packaging/dummy_exclude_from_package.py
+++ b/integrations/tensorflow/bindings/python/packaging/dummy_exclude_from_package.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -30,18 +30,32 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+config_setting(
+    name = "disable_kernels",
+    define_values = {"PYIREE_TF_DISABLE_KERNELS": "1"},
+)
+
 # Runtime deps needed to compile the tensorflow compiler.
+# As of 2020-04-13, robust constant folding is dependent on the legacy
+# TensorFlow executor, which requires kernels to operate on/simplify
+# the graph. This should become less necessary as more robust support
+# is implemented as part of the MLIR-based tf2xla bridge. This adds
+# about ~350 files to the system, many of which are quite heavy to
+# compile. Excluding them disables TensorFlow constant propagation, 
+# which can cause non-optimized binaries (and tickle bugs and unimplemented
+# features). However, it is allowed, especially for development because it
+# is such a burden to build them. Disable kernels with this command line
+# options:
+#   --define=PYIREE_TF_DISABLE_KERNELS=1
+# See: https://github.com/google/iree/issues/1506
 SAVED_MODEL_TF_RUNTIME_DEPS = [
     "@org_tensorflow//tensorflow/core:ops",
-    # As of 2020-04-13, robust constant folding is dependent on the legacy
-    # TensorFlow executor, which requires kernels to operate on/simplify
-    # the graph. This should become less necessary as more robust support
-    # is implemented as part of the MLIR-based tf2xla bridge. This adds
-    # about ~350 files to the system, many of which are quite heavy to
-    # compile.
-    # See: https://github.com/google/iree/issues/1506
-    "@org_tensorflow//tensorflow/core/kernels:array",
-]
+] + select({
+    ":disable_kernels": [],
+    "//conditions:default": [
+        "@org_tensorflow//tensorflow/core/kernels:array"
+    ],
+})
 
 TF_XLA_PASS_DEPS = [
     "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_dialect_registration",


### PR DESCRIPTION
* Tested on Debian/Buster.
* When installing these wheels, I was able to run the integrations/tensorflow/e2e tests directly without building (just python3 file.py)
* It might be nice at some point to also package the compiler tools (iree-opt, etc) since it would be an easy way to distribute them.

Progress on #1677