### PR TITLE
Make GitHub Bazel Build actions easier to debug

### DIFF
--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -18,7 +18,11 @@ name: Bazel Build - Bindings
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+      # Run on pushes to branches with a special name indicating they'd like
+      # to run these actions.
+      - 'test-ga-bazel*'
 
 jobs:
   linux:

--- a/.github/workflows/bazel_build_core.yml
+++ b/.github/workflows/bazel_build_core.yml
@@ -18,13 +18,22 @@ name: Bazel Build - Core
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+      # Run on pushes to branches with a special name indicating they'd like
+      # to run these actions.
+      - 'test-ga-bazel*'
 
 jobs:
   linux:
     runs-on: ubuntu-18.04
     container: gcr.io/iree-oss/bazel
     steps:
+      - name: Printing environment
+        run: |
+          "$CXX" --version
+          "$CC" --version
+          "$PYTHON_BIN" --version
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -18,13 +18,22 @@ name: Bazel Build - Fallthrough
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+      # Run on pushes to branches with a special name indicating they'd like
+      # to run these actions.
+      - 'test-ga-bazel*'
 
 jobs:
   linux:
     runs-on: ubuntu-18.04
     container: gcr.io/iree-oss/bazel
     steps:
+      - name: Printing environment
+        run: |
+          "$CXX" --version
+          "$CC" --version
+          "$PYTHON_BIN" --version
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -18,13 +18,22 @@ name: Bazel Build - Integrations
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+      # Run on pushes to branches with a special name indicating they'd like
+      # to run these actions.
+      - 'test-ga-bazel*'
 
 jobs:
   linux:
     runs-on: ubuntu-18.04
     container: gcr.io/iree-oss/bazel-tensorflow
     steps:
+      - name: Printing environment
+        run: |
+          "$CXX" --version
+          "$CC" --version
+          "$PYTHON_BIN" --version
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Initializing submodules


### PR DESCRIPTION
Run the actions on push to branches prefixed with `test-ga-bazel` (ga="GitHub actions" as in the bazel tags) and have them print environment information right before checking out the repository.

Unfortunately, due to GitHub action limitations, the status results don't show up on the PR (I filed a ticket), but they are running in the fork (https://github.com/GMNGeoffrey/iree/runs/658076529). This should make it easier to test GitHub action changes.