### PR TITLE
Add guards around more components which require building the compiler.

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -39,7 +39,7 @@ function(iree_check_test)
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_TESTS)
+  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
     return()
   endif()
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -358,10 +358,12 @@ iree_cc_test(
     iree::vm::variant_list
 )
 
-add_custom_target(IreeFileCheck ALL
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/IreeFileCheck.sh IreeFileCheck
-)
-add_custom_target(LLVMFileCheck ALL
-  COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:FileCheck> FileCheck
-  DEPENDS FileCheck
-)
+if(${IREE_ENABLE_LLVM})
+  add_custom_target(IreeFileCheck ALL
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/IreeFileCheck.sh IreeFileCheck
+  )
+  add_custom_target(LLVMFileCheck ALL
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:FileCheck> FileCheck
+    DEPENDS FileCheck
+  )
+endif()


### PR DESCRIPTION
A step towards supporting compiler-less (https://github.com/google/iree/issues/357) and Python-less (https://github.com/google/iree/issues/1779) builds