### PR TITLE
Add python3 and clang install steps to Windows+Bazel docs.

### DIFF
--- a/docs/GetStarted/getting_started_windows_bazel.md
+++ b/docs/GetStarted/getting_started_windows_bazel.md
@@ -30,6 +30,15 @@ the specific version IREE uses) by following the
 
 Also install [MSYS2](https://www.msys2.org/) by following Bazel's documentation.
 
+### Install Python3
+
+Instructions for installation can be found
+[here](https://www.python.org/downloads/windows/).
+
+### Install Clang
+
+Install Clang for `clang-cl.exe` from https://releases.llvm.org/download.html.
+
 ### Install Build Tools For Visual Studio
 
 Install the full Visual Studio or "Build Tools For Visual Studio" from the


### PR DESCRIPTION
`USE_CLANG_CL` won't work without installing Clang. We might be able to drop it if we change our `.bazelrc` flags.

Pulling in TensorFlow's Bazel workspace requires Python (and numpy). There are other quirks like setting `PYTHON_BIN_PATH` to a unix/style/path (not windows\style\path) and/or having `which python` return a path with no spaces in it, which I'd rather not go into here... hopefully some of that can be resolved in TF or we can help individual users as they run into issues.