### PR TITLE
Add javatests to bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -28,3 +28,4 @@ iree/tools/web
 
 # TODO: enable this when Java bindings are wired up.
 bindings/java
+bindings/javatests


### PR DESCRIPTION
bindings/java is already excluded as it does not build and neither does javatests. Without this you get errors when trying to `bazel build bindings/...`

```
ERROR: /usr/local/google/home/gcmn/git/iree-fork/bindings/javatests/com/google/iree/BUILD:20:1: no such package 'third_party/java/junit': Package is considere
d deleted due to --deleted_packages and referenced by '//bindings/javatests/com/google/iree:ContextTest' 
```