### PR TITLE
Use iree_cc_binary across the repo.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -243,7 +243,7 @@ class BuildFileFunctions(object):
   # Each function that may be found in a BUILD file must be listed here.      #
   # ------------------------------------------------------------------------- #
 
-  def load(self, *args):
+  def load(self, *args, **kwargs):
     # No mapping to CMake, ignore.
     pass
 
@@ -407,6 +407,9 @@ class BuildFileFunctions(object):
                             f"{deps_block}"
                             f"{testonly_block}"
                             f")\n\n")
+
+  # Effectively an alias in IREE code.
+  iree_cc_binary = cc_binary
 
   def cc_embed_data(self,
                     name,

--- a/iree/build_defs.oss.bzl
+++ b/iree/build_defs.oss.bzl
@@ -63,7 +63,6 @@ IREE_DRIVER_MODULES = [
 
 # Aliases to the Starlark cc rules.
 cc_library = _cc_library
-cc_binary = _cc_binary
 
 def iree_build_test(name, targets):
     """Dummy rule to ensure that targets build.
@@ -84,4 +83,15 @@ def iree_flatbuffer_cc_library(**kwargs):
     flatbuffer_cc_library(
         gen_reflections = False,
         **kwargs
+    )
+
+def cc_binary(linkopts = [], **kwargs):
+    """Wrapper around low-level cc_binary that adds flags."""
+    _cc_binary(
+        linkopts = linkopts + [
+            # Just include libraries that should be presumed in 2020.
+            "-ldl",
+            "-lpthread",
+        ],
+        **kwargs,
     )

--- a/iree/modules/check/BUILD
+++ b/iree/modules/check/BUILD
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//iree:build_defs.oss.bzl", "IREE_DRIVER_MODULES", "PLATFORM_VULKAN_DEPS")
+load("//iree:build_defs.oss.bzl", "IREE_DRIVER_MODULES", "PLATFORM_VULKAN_DEPS",
+     iree_cc_binary = "cc_binary")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -42,7 +43,7 @@ cc_test(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-check-module",
     testonly = True,
     srcs = ["check_module_main.cc"],

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//iree:build_defs.oss.bzl", iree_cc_binary = "cc_binary")
 load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
@@ -87,7 +88,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "custom-opt",
     srcs = ["custom_opt.cc"],
     deps = [
@@ -129,7 +130,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "custom-translate",
     srcs = ["custom_translate.cc"],
     deps = [

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -15,7 +15,8 @@
 # Misc tools used to optimize, translate, and evaluate IREE.
 # Compiler tooling, like the compiler, is not designed to run on device and is tagged as "hostonly".
 
-load("//iree:build_defs.oss.bzl", "IREE_DRIVER_MODULES", "PLATFORM_VULKAN_DEPS")
+load("//iree:build_defs.oss.bzl", "IREE_DRIVER_MODULES", "PLATFORM_VULKAN_DEPS",
+     iree_cc_binary = "cc_binary")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -27,7 +28,7 @@ exports_files([
     "sanitizer_suppressions.txt",
 ])
 
-cc_binary(
+iree_cc_binary(
     name = "iree-benchmark-module",
     testonly = True,
     srcs = ["benchmark_module_main.cc"],
@@ -47,7 +48,7 @@ cc_binary(
     ] + PLATFORM_VULKAN_DEPS + IREE_DRIVER_MODULES,
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-dump-module",
     srcs = ["dump_module_main.cc"],
     deps = [
@@ -193,7 +194,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-opt",
     tags = ["hostonly"],
     deps = [
@@ -201,7 +202,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-run-mlir",
     srcs = ["run_mlir_main.cc"],
     tags = ["hostonly"],
@@ -239,7 +240,7 @@ cc_binary(
     ] + PLATFORM_VULKAN_DEPS + IREE_DRIVER_MODULES,
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-run-module",
     srcs = ["run_module_main.cc"],
     deps = [
@@ -257,11 +258,8 @@ cc_binary(
     ] + PLATFORM_VULKAN_DEPS + IREE_DRIVER_MODULES,
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-tblgen",
-    linkopts = [
-        "-lpthread",
-    ],
     tags = ["hostonly"],
     deps = [
         "//iree/compiler/Dialect/IREE/Tools",
@@ -274,7 +272,7 @@ cc_binary(
 
 cc_library(
     name = "iree_translate_main",
-    srcs = ["translate_main.cc"],
+    srcs = ["translate_main.cc"],    
     deps = [
         ":init_compiler_modules",
         ":init_passes_and_dialects",
@@ -294,7 +292,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+iree_cc_binary(
     name = "iree-translate",
     tags = ["hostonly"],
     deps = [


### PR DESCRIPTION
* This has default link flags that should just be standard in 2020.
* Fixes an issue where upstream grew a dependency on the dl system library.