### PR TITLE
CMake: Add ALWAYSLINK to vulkan_driver_module

### DIFF
--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -506,5 +506,6 @@ iree_cc_library(
     iree::hal::driver_registry
     iree::hal::vulkan::dynamic_symbols
     iree::hal::vulkan::vulkan_driver
+  ALWAYSLINK
   PUBLIC
 )


### PR DESCRIPTION
`vulkan_driver_module` is flagged alwayslink in the Bazel config.