### PR TITLE
[NFC] Remove `magic_depth` value from submodule updates.

### DIFF
--- a/scripts/git/submodule_versions.py
+++ b/scripts/git/submodule_versions.py
@@ -121,13 +121,7 @@ def init_submodules(repo_dir):
 
 def parallel_shallow_update_submodules(repo_dir):
   print("*** Making shallow clone of submodules")
-  # TODO(gcmn) Figure out a way to quickly fetch submodules without relying on
-  # target SHA being within 10000 commits of HEAD.
-  magic_depth = 10000
-  utils.execute([
-      "git", "submodule", "update", "--jobs", "8", "--depth",
-      str(magic_depth)
-  ],
+  utils.execute(["git", "submodule", "update", "--jobs", "8", "--depth", "1"],
                 cwd=repo_dir)
 
 


### PR DESCRIPTION
This didn't used to work and past attempts have failed (e.g. https://github.com/google/iree/pull/439), but something seems to have changed recently. Perhaps GitHub updated its git server to allow this option.