### PR TITLE
Enable python bindings tests on RBE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,7 +57,14 @@ http_archive(
 )
 
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-rbe_autoconfig(name = "rbe_default")
+
+rbe_autoconfig(
+    name = "rbe_default",
+    base_container_digest = 'sha256:ac36d37616b044ee77813fc7cd36607a6dc43c65357f3e2ca39f3ad723e426f6',
+    digest = "sha256:08e85ecb9d993cb6fc2da83a0b6bc357ab42e3c28039d9565e3819f2053a49d9",
+    registry = "gcr.io",
+    repository = "iree-oss/rbe-toolchain"
+)
 
 ###############################################################################
 

--- a/bindings/python/pyiree/rt/BUILD
+++ b/bindings/python/pyiree/rt/BUILD
@@ -118,7 +118,7 @@ iree_py_test(
     srcs = ["function_abi_test.py"],
     python_version = "PY3",
     # TODO(laurenzo): Enable once test does not depend on a real vulkan device.
-    tags = ["noga"],
+    tags = ["noga", "nokokoro"],
     deps = NUMPY_DEPS + [
         "//bindings/python:pathsetup",  # build_cleaner: keep
         "@absl_py//absl/testing:absltest",

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -66,7 +66,7 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query "//iree/... + //bindings/..." | \
+bazel query //iree/... | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -66,7 +66,7 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query //iree/... | \
+bazel query "//iree/... + //bindings/..." | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \

--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds an image for running IREE on bazel.
+# An image for building IREE using bazel.
+
+# Build using:
+# docker build --tag gcr.io/iree-oss/bazel build_tools/docker/bazel/
 
 # Set up the image and working directory.
 FROM l.gcr.io/google/bazel:2.1.0

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and pushes bazel and bazel-tensorflow images to gcr.io/iree-oss/
+
+set -x
+set -e
+
+# Ensure correct authorization.
+gcloud auth configure-docker
+
+# Build and push the bazel image.
+docker build --tag gcr.io/iree-oss/bazel build_tools/docker/bazel/
+docker push gcr.io/iree-oss/bazel
+
+# Build and push the bazel-tensorflow image, which depends on
+# gcr.io/iree-oss/bazel
+docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
+docker push gcr.io/iree-oss/bazel-tensorflow

--- a/build_tools/docker/bazel_tensorflow/Dockerfile
+++ b/build_tools/docker/bazel_tensorflow/Dockerfile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds an image for running IREE on bazel with python bindings and tensorflow
-# integrations. Requires that the bazel image has already been built. Build
-# using:
-# docker build --tag bazel-tensorflow build_tools/docker/bazel_tensorflow/
+# An image for building IREE with python bindings and tensorflow integrations
+# using bazel.
+
+# Build using:
+# docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
 
 # Set up the image and working directory.
-FROM bazel
+FROM gcr.io/iree-oss/bazel
 WORKDIR /usr/src/git
 
 # Update python3 to 3.6

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds and pushes bazel and bazel-tensorflow images to gcr.io/iree-oss/ from
-# within the GCP IREE-OSS project.
+# Builds and pushes the bazel-tensorflow image to gcr.io/iree-oss/
 
 set -x
 set -e
@@ -22,12 +21,6 @@ set -e
 # Ensure correct authorization.
 gcloud auth configure-docker
 
-# Build and push the bazel image.
-docker build --tag bazel build_tools/docker/bazel/
-docker tag bazel gcr.io/iree-oss/bazel
-docker push gcr.io/iree-oss/bazel
-
 # Build and push the bazel-tensorflow image.
-docker build --tag bazel-tensorflow build_tools/docker/bazel_tensorflow/
-docker tag bazel-tensorflow gcr.io/iree-oss/bazel-tensorflow
+docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
 docker push gcr.io/iree-oss/bazel-tensorflow

--- a/build_tools/docker/rbe_toolchain/Dockerfile
+++ b/build_tools/docker/rbe_toolchain/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# An image for building IREE in RBE's remmote execution environments.
+# The parent image requires gcloud authorization to download
+
+# Build using:
+# gcloud auth configure-docker
+# docker build --tag gcr.io/iree-oss/rbe-toolchain build_tools/docker/rbe_toolchain/
+
+FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:ac36d37616b044ee77813fc7cd36607a6dc43c65357f3e2ca39f3ad723e426f6
+
+RUN apt-get update
+RUN apt-get install -y python3 python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install numpy

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and pushes the rbe-toolchain image to gcr.io/iree-oss/
+
+set -x
+set -e
+
+# Ensure correct authorization.
+gcloud auth configure-docker
+
+# Build and push the rbe-toolchain image.
+docker build --tag gcr.io/iree-oss/rbe-toolchain build_tools/docker/rbe_toolchain/
+docker push gcr.io/iree-oss/rbe-toolchain


### PR DESCRIPTION
- Adds a custom toolchain image for RBE with `python3 numpy` to enable building and testing python bindings in their remote execution environment.
- Updates `WORKSPACE` to use this image when autogenerating the toolchain.
- Adds a script for updating the `gcr.io/iree-oss/rbe-toolchain` image on GCR.
- Cleans up the `bazel` and `bazel-tensorflow` update scripts.