### PR TITLE
Enable synchronize submodules action to run on pushes to google branch

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - google
 
 jobs:
   synchronize:

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -20,6 +20,8 @@ on:
   push:
     branches:
       - master
+      # This branch doesn't exist yet, but may as part of shifting to a
+      # GitHub-first workflow.
       - google
 
 jobs:


### PR DESCRIPTION
This branch doesn't exist yet, but is something we're exploring as part of a GitHub first workflow. To enable testing of this workflow in my fork, we need to update the workflow now.