### PR TITLE
Implement xla_hlo.compare and xla_hlo.select shape builder.

### DIFF
--- a/iree/compiler/Dialect/Shape/Plugins/XLA/XlaHloShapeBuilder.cpp
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/XlaHloShapeBuilder.cpp
@@ -283,6 +283,38 @@ Value rewriteDynamicReshape(RankedShapeType resultShape, DynamicReshapeOp op,
                                             op.output_shape());
 }
 
+Value rewriteSelectOp(RankedShapeType resultShape, SelectOp selectOp,
+                      OpBuilder &builder) {
+  // TODO: broadcast case
+  if (!selectOp) return nullptr;
+  auto loc = selectOp.getLoc();
+
+  auto trueType = selectOp.on_true().getType().dyn_cast<RankedTensorType>();
+  auto falseType = selectOp.on_false().getType().dyn_cast<RankedTensorType>();
+  auto predType = selectOp.pred().getType().dyn_cast<RankedTensorType>();
+  if (!trueType || !falseType || !predType) return nullptr;
+
+  assert(trueType.getRank() == resultShape.getRank() &&
+         trueType.getRank() == falseType.getRank() &&
+         trueType.getRank() == predType.getRank());
+
+  auto operandShapeValue = builder.create<GetRankedShapeOp>(
+      loc, RankedShapeType::get(trueType.getShape(), builder.getContext()),
+      selectOp.on_true());
+
+  // Map the dynamic dims.
+  SmallVector<Value, 4> dynamicDims;
+  for (int64_t i = 0, e = resultShape.getRank(); i < e; ++i) {
+    if (!resultShape.isDimDynamic(i)) continue;
+    auto dimValue = builder.create<RankedDimOp>(loc, builder.getIndexType(),
+                                                operandShapeValue,
+                                                builder.getI64IntegerAttr(i));
+    dynamicDims.push_back(dimValue);
+  }
+
+  return builder.create<MakeRankedShapeOp>(loc, resultShape, dynamicDims);
+}
+
 }  // namespace
 
 // Creates a custom op shape builder for XLA-HLO ops that are not otherwise
@@ -305,7 +337,9 @@ void populateXlaHloCustomOpShapeBuilder(CustomOpShapeBuilderList &builders) {
   INSERT_EW_OP(ShiftRightArithmeticOp);
   INSERT_EW_OP(ShiftRightLogicalOp);
   INSERT_EW_OP(SubOp);
+  INSERT_EW_OP(CompareOp);
 
+  b.insertOpRankedShapeBuilder<SelectOp>(rewriteSelectOp);
   b.insertOpRankedShapeBuilder<DotOp>(rewriteXlaDotOpShape);
   b.insertOpRankedShapeBuilder<RankedBroadcastInDimOp>(
       rewriteShapexRankedBroadcastInDim);

--- a/iree/test/e2e/regression/dynamic_compare_and_select.mlir
+++ b/iree/test/e2e/regression/dynamic_compare_and_select.mlir
@@ -1,0 +1,11 @@
+// RUN: (iree-run-mlir -iree-hal-target-backends=vmla -input-value="10xi32=[0,1,2,3,4,5,6,7,8,9]" -input-value="10xi32=[0,1,2,3,4,5,6,7,8,9]" -input-value="10xi32=[0,1,2,3,4,5,6,7,8,9]" -input-value="10xi32=[9,8,7,6,5,4,3,2,1,0]" %s) | IreeFileCheck %s
+
+// CHECK: EXEC @main
+// CHECK: 10xi32=9 8 7 6 5 4 3 2 1 0
+
+func @main(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>, %arg2: tensor<?xi32>, %arg3: tensor<?xi32>) -> tensor<?xi32> attributes {iree.module.export} {
+    %1 = "xla_hlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi1>
+    %2 = "xla_hlo.select"(%1, %arg2, %arg3) : (tensor<?xi1>, tensor<?xi32>, tensor<?xi32>) -> tensor<?xi32>
+    return %2 : tensor<?xi32>
+}
+


### PR DESCRIPTION
Hi, :)
I encountered a lowering  error in my testing graph, 
```
func @compare_select_dynamic(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>, %arg2: tensor<?xi32>, %arg3: tensor<?xi32>) -> tensor<?xi32> attributes {iree.module.export} {
    %1 = "xla_hlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi1>
    %2 = "xla_hlo.select"(%1, %arg2, %arg3) : (tensor<?xi1>, tensor<?xi32>, tensor<?xi32>) -> tensor<?xi32>
    return %2 : tensor<?xi32>
}
```
The inputs and outputs are dynamic shapes. After execute the commands below:
```
bazel run //integrations/tensorflow/compiler:iree-tf-translate -- --iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vmla /tmp/compare-select-dynamic.mlir > /tmp/compare-select-dynamic-byte.mlir
```
I encountered these errors:

```
INFO: Running command line: bazel-bin/integrations/tensorflow/compiler/iree-tf-translate --iree-mlir-to-vm-bytecode-module '-iree-hal-target-backends=vmla' /tmp/compare-select-dynamic.mlir
INFO: Build completed successfully, 8 total actions
/tmp/compare-select-dynamic.mlir:4:10: remark: unable to materialize shape calculation (unsupported op 'xla_hlo.compare'?): falling back to runtime resolution
    %1 = "xla_hlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi1>
         ^
/tmp/compare-select-dynamic.mlir:4:10: note: see current operation: %4 = "xla_hlo.compare"(%0, %1) {comparison_direction = "LT"} : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi1>
/tmp/compare-select-dynamic.mlir:5:10: remark: unable to materialize shape calculation (unsupported op 'xla_hlo.select'?): falling back to runtime resolution
    %2 = "xla_hlo.select"(%1, %arg2, %arg3) : (tensor<?xi1>, tensor<?xi32>, tensor<?xi32>) -> tensor<?xi32>
         ^
/tmp/compare-select-dynamic.mlir:5:10: note: see current operation: %9 = "xla_hlo.select"(%8, %2, %3) : (tensor<?xi1>, tensor<?xi32>, tensor<?xi32>) -> tensor<?xi32>
/tmp/compare-select-dynamic.mlir:4:10: error: operand #0 does not dominate this use
    %1 = "xla_hlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi1>
         ^
/tmp/compare-select-dynamic.mlir:4:10: note: see current operation: %4 = "std.dim"(%7#0) {index = 0 : index} : (tensor<?xi1>) -> index
/tmp/compare-select-dynamic.mlir:3:1: note: operand defined here
func @compare_select_dynamic(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>, %arg2: tensor<?xi32>, %arg3: tensor<?xi32>) -> tensor<?xi32> attributes {iree.module.export} {
^
/tmp/compare-select-dynamic.mlir:1:1: error: conversion from source -> vm failed

^
/tmp/compare-select-dynamic.mlir:0:0: note: see current operation: "module"() ( {
  "func"() ( {
  ^bb0(%arg0: tensor<?xi32>, %arg1: !shapex.ranked_shape<[?]>, %arg2: tensor<?xi32>, %arg3: !shapex.ranked_shape<[?]>, %arg4: tensor<?xi32>, %arg5: !shapex.ranked_shape<[?]>, %arg6: tensor<?xi32>, %arg7: !shapex.ranked_shape<[?]>):  // no predecessors
```
After debugging the code, I found that IREE not implement the shape builder of these xla_hlo instrcutions.
And I also implement a function `CompareOpConversion` to convert xla_hlo.compare to VMLA backend.
So please help to review the code if you get time :) 
Thanks so much .
