### PR TITLE
Removes default bazel cli entrypoint from our Docker images

### DIFF
--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -21,6 +21,9 @@
 FROM l.gcr.io/google/bazel:2.1.0
 WORKDIR /usr/src/git
 
+# Undo inherited bazel command line entrypoint.
+ENTRYPOINT []
+
 # Set environment variables.
 ENV CXX clang++
 ENV CC clang


### PR DESCRIPTION
This is a NFC with respect to what is currently in IREE, but simplifies a feature being developed.