### PR TITLE
Add bindings tests to kokoro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 rbe_autoconfig(
     name = "rbe_default",
     base_container_digest = 'sha256:ac36d37616b044ee77813fc7cd36607a6dc43c65357f3e2ca39f3ad723e426f6',
-    digest = "sha256:08e85ecb9d993cb6fc2da83a0b6bc357ab42e3c28039d9565e3819f2053a49d9",
+    digest = "sha256:61fd698572dc8b5fc9db11cb4ba4f138a915517b80617259bcaef8e1e4ffd3fb",
     registry = "gcr.io",
     repository = "iree-oss/rbe-toolchain"
 )

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -66,10 +66,11 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query //iree/... | \
+bazel query //iree/... + //bindings/... | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \
+    --define=iree_tensorflow=true \
     --keep_going \
     --test_output=errors \
     --config=rs \

--- a/build_tools/bazel/build.sh
+++ b/build_tools/bazel/build.sh
@@ -70,7 +70,6 @@ bazel query //iree/... + //bindings/... | \
   xargs bazel test ${test_env_args[@]} \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \
     --test_tag_filters="${TEST_TAG_FILTERS?}" \
-    --define=iree_tensorflow=true \
     --keep_going \
     --test_output=errors \
     --config=rs \

--- a/build_tools/docker/rbe_toolchain/Dockerfile
+++ b/build_tools/docker/rbe_toolchain/Dockerfile
@@ -26,17 +26,17 @@ RUN apt-get install -y python3 python3-pip
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy
 
-# Install python3.6 dev
+# Install dependencies for python3.6-dev
 RUN apt-get install -y software-properties-common
 # Remove the symlink to python3 from /opt/python3.6/bin/python3.6 and symlink it
 # to python3.5 to run a single command before resymlinking it to
 # /opt/python3.6/bin/python3.6.
-
 RUN rm /usr/bin/python3
 RUN ln -s /usr/bin/python3.5 /usr/bin/python3
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN rm /usr/bin/python3
 RUN ln -s /opt/python3.6/bin/python3.6 /usr/bin/python3
 
+# Install python3.6-dev
 RUN apt-get update
 RUN apt-get install -y python3.6 python3.6-dev

--- a/build_tools/docker/rbe_toolchain/Dockerfile
+++ b/build_tools/docker/rbe_toolchain/Dockerfile
@@ -28,14 +28,15 @@ RUN python3 -m pip install numpy
 
 # Install dependencies for python3.6-dev
 RUN apt-get install -y software-properties-common
-# Remove the symlink to python3 from /opt/python3.6/bin/python3.6 and symlink it
-# to python3.5 to run a single command before resymlinking it to
-# /opt/python3.6/bin/python3.6.
-RUN rm /usr/bin/python3
-RUN ln -s /usr/bin/python3.5 /usr/bin/python3
+# apt-add-repository requires a version of python with the softwareproperties
+# module. To use this command, we:
+#   1. remove the symlink to python3 from python3.6 and symlink it to python3.5
+#   2. run apt-add-repository with python3 = python3.5
+#   3. resymlink python3 to /opt/python3.6/bin/python3.6
+# See https://github.com/google/iree/issues/1966 for more information.
+RUN rm /usr/bin/python3 && ln -s /usr/bin/python3.5 /usr/bin/python3
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN rm /usr/bin/python3
-RUN ln -s /opt/python3.6/bin/python3.6 /usr/bin/python3
+RUN rm /usr/bin/python3 && ln -s /opt/python3.6/bin/python3.6 /usr/bin/python3
 
 # Install python3.6-dev
 RUN apt-get update

--- a/build_tools/docker/rbe_toolchain/Dockerfile
+++ b/build_tools/docker/rbe_toolchain/Dockerfile
@@ -25,3 +25,18 @@ RUN apt-get update
 RUN apt-get install -y python3 python3-pip
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy
+
+# Install python3.6 dev
+RUN apt-get install -y software-properties-common
+# Remove the symlink to python3 from /opt/python3.6/bin/python3.6 and symlink it
+# to python3.5 to run a single command before resymlinking it to
+# /opt/python3.6/bin/python3.6.
+
+RUN rm /usr/bin/python3
+RUN ln -s /usr/bin/python3.5 /usr/bin/python3
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN rm /usr/bin/python3
+RUN ln -s /opt/python3.6/bin/python3.6 /usr/bin/python3
+
+RUN apt-get update
+RUN apt-get install -y python3.6 python3.6-dev


### PR DESCRIPTION
- Tells `build.sh` to test `//bindings/...` as well as `//iree/...`
- Updates the RBE toolchain to include `python3.6-dev`, which enables building the bindings on RBE in a docker image.