### PR TITLE
Make submodule synchronize action push same branch

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -49,4 +49,5 @@ jobs:
         uses: ad-m/github-push-action@v0.5.0
         with:
           github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          branch: ${{ github.ref }}
           


### PR DESCRIPTION
By default it always pushes to master, which makes it unusable (and dangerous) on other branches. This makes it push to the same branch that triggered the event (which is always a push right now). The only branch other than `master` it's currently running on is `google`, which is something we're still experimenting with to move to a GitHub first workflow, but this will be necessary at that point.

Tested:
Tried this out on my fork and got it to push to the same branch (https://github.com/GMNGeoffrey/iree/runs/687933164) ![screenshot](https://user-images.githubusercontent.com/5732088/82293518-875b3380-9961-11ea-91ec-21537c81a220.png)
, since those commits are probably going to go away.

