### PR TITLE
Return void in iree_vm_stack_init.

### DIFF
--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -175,8 +175,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_create_with_modules(
       sizeof(iree_vm_module_state_t*) * module_count;
 
   iree_vm_context_t* context = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc(allocator, context_size, (void**)&context));
+  iree_allocator_malloc(allocator, context_size, (void**)&context);
   iree_atomic_store(&context->ref_count, 1);
   context->instance = instance;
   iree_vm_instance_retain(context->instance);
@@ -213,14 +212,9 @@ static void iree_vm_context_destroy(iree_vm_context_t* context) {
     // If we shrunk the stack (or made it so that it could dynamically grow)
     // then we could stack-allocate it here and not need the allocator at all.
     iree_vm_stack_t* stack = NULL;
-    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-        context->allocator, sizeof(iree_vm_stack_t), (void**)&stack));
-    iree_status_t status =
-        iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
-    if (!iree_status_is_ok(status)) {
-      iree_allocator_free(context->allocator, stack);
-      return status;
-    }
+    iree_allocator_malloc(context->allocator, sizeof(iree_vm_stack_t),
+                          (void**)&stack);
+    iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
 
     iree_vm_context_release_modules(context, stack, 0, context->list.count - 1);
 
@@ -334,12 +328,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_register_modules(
   iree_vm_stack_t* stack = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       context->allocator, sizeof(iree_vm_stack_t), (void**)&stack));
-  iree_status_t status =
-      iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
-  if (!iree_status_is_ok(status)) {
-    iree_allocator_free(context->allocator, stack);
-    return status;
-  }
+  iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
 
   // Retain all modules and allocate their state.
   assert(context->list.capacity >= context->list.count + module_count);

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -18,11 +18,10 @@
 
 #include "iree/vm/module.h"
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
     iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack) {
   memset(out_stack, 0, sizeof(iree_vm_stack_t));
   out_stack->state_resolver = state_resolver;
-  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT void IREE_API_CALL

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -113,7 +113,7 @@ typedef struct iree_vm_stack {
 } iree_vm_stack_t;
 
 // Constructs a stack in-place in |out_stack|.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
     iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack);
 
 // Destructs |stack|.


### PR DESCRIPTION
Fixes build of `iree/vm:context` on https://github.com/google/iree/pull/1955