### PR TITLE
Build our own Bazel docker images, and add SHA256 IDs to our CI tests

### DIFF
--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow
+    container: gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1
+    container: gcr.io/iree-oss/bazel-tensorflow@sha256:18e4d648ebd367cfab7596fff769639d526cffc1f526be88488660ff4575f3ce
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_core.yml
+++ b/.github/workflows/bazel_build_core.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel
+    container: gcr.io/iree-oss/bazel@sha256:71877c59c543ad430968cc230edd5c560a391a939baa943c036fd976b1b35417
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_core.yml
+++ b/.github/workflows/bazel_build_core.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel@sha256:71877c59c543ad430968cc230edd5c560a391a939baa943c036fd976b1b35417
+    container: gcr.io/iree-oss/bazel@sha256:3fd72776fc3a97d99e43ac9972a4b9a57ca055f372a4000f26a24c0e914e7d6f
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel
+    container: gcr.io/iree-oss/bazel@sha256:71877c59c543ad430968cc230edd5c560a391a939baa943c036fd976b1b35417
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel@sha256:71877c59c543ad430968cc230edd5c560a391a939baa943c036fd976b1b35417
+    container: gcr.io/iree-oss/bazel@sha256:3fd72776fc3a97d99e43ac9972a4b9a57ca055f372a4000f26a24c0e914e7d6f
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow
+    container: gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1
+    container: gcr.io/iree-oss/bazel-tensorflow@sha256:18e4d648ebd367cfab7596fff769639d526cffc1f526be88488660ff4575f3ce
     steps:
       - name: Printing environment
         run: |

--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -18,11 +18,10 @@
 # docker build --tag gcr.io/iree-oss/bazel build_tools/docker/bazel/
 
 # Set up the image and working directory.
-FROM l.gcr.io/google/bazel:2.1.0
+FROM ubuntu:18.04
 WORKDIR /usr/src/git
 
-# Undo inherited bazel command line entrypoint.
-ENTRYPOINT []
+RUN apt-get update
 
 # Set environment variables.
 ENV CXX clang++
@@ -32,9 +31,20 @@ ENV PYTHON_BIN /usr/bin/python3
 # Install the newest version of git. This is necessary because the checkout
 # action (https://github.com/actions/checkout) requires `git >= 2.18` for this
 # action to work with git submodules.
+RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:git-core/ppa
 RUN apt-get update
 RUN apt-get install -y git
+
+# Install Bazel.
+# https://docs.bazel.build/versions/master/install-ubuntu.html
+ENV BAZEL_VERSION 2.1.0
+RUN apt-get install unzip zip wget
+RUN wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION?}/bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+RUN chmod +x bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+RUN ./bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh --user
+RUN rm bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh
+ENV PATH "/root/bin:$PATH"
 
 # Install core IREE dependencies.
 RUN apt-get install -y clang libsdl2-dev

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -29,3 +29,10 @@ docker push gcr.io/iree-oss/bazel
 # gcr.io/iree-oss/bazel
 docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
 docker push gcr.io/iree-oss/bazel-tensorflow
+
+echo '
+Remember to update all of the files using `bazel` and `bazel-tensorflow` images
+(e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
+to use the IDs of the updated images.
+
+Use `docker images --no-trunk` to view the IDs.'

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -35,4 +35,4 @@ Remember to update all of the files using `bazel` and `bazel-tensorflow` images
 (e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
 to use the IDs of the updated images.
 
-Use `docker images --no-trunk` to view the IDs.'
+Use `docker images --digests` to view the IDs.'

--- a/build_tools/docker/bazel_tensorflow/Dockerfile
+++ b/build_tools/docker/bazel_tensorflow/Dockerfile
@@ -22,22 +22,7 @@
 FROM gcr.io/iree-oss/bazel
 WORKDIR /usr/src/git
 
-# Update python3 to 3.6
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y python3.6 python3.6-dev
-
-# Replace with the block below with
-#     ENV PYTHON_BIN /usr/bin/python3.6
-# once PYTHON_BIN also controls Bazel's runtime interpreter (issue:
-# https://github.com/google/iree/issues/1875).
-# For now, create a symlink from correct python version to the system's python3
-# (which PYTHON_BIN currently points to).
-# This makes many things unhappy (e.g. add-apt-repository).
-RUN rm /usr/bin/python3
-RUN ln -s /usr/bin/python3.6 /usr/bin/python3
-
-# Install tensorflow and numpy
-RUN apt-get install -y python3-pip python3-setuptools
+# Install python3, tensorflow and numpy.
+RUN apt-get install -y python3 python3-dev python3-pip python3-setuptools
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy tf-nightly

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -30,4 +30,4 @@ Remember to update all of the files using the `bazel-tensorflow` image
 (e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
 to use the IDs of the updated image.
 
-Use `docker images --no-trunk` to view the ID.'
+Use `docker images --digests` to view the ID.'

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -24,3 +24,10 @@ gcloud auth configure-docker
 # Build and push the bazel-tensorflow image.
 docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
 docker push gcr.io/iree-oss/bazel-tensorflow
+
+echo '
+Remember to update all of the files using the `bazel-tensorflow` image
+(e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
+to use the IDs of the updated image.
+
+Use `docker images --no-trunk` to view the ID.'

--- a/build_tools/docker/gcloud_setup.sh
+++ b/build_tools/docker/gcloud_setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Installs GCloud and prompts the user to set up authorization.
+
+set -x
+set -e
+
+# Install dependencies.
+URI="deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main"
+echo $URI | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get install -y apt-transport-https ca-certificates gnupg curl
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+  apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+apt-get update && apt-get install -y google-cloud-sdk
+apt-get install -y google-cloud-sdk-app-engine-java
+
+# Setup auth.
+gcloud init
+gcloud auth application-default login --no-launch-browser

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -26,7 +26,7 @@ docker build --tag gcr.io/iree-oss/rbe-toolchain build_tools/docker/rbe_toolchai
 docker push gcr.io/iree-oss/rbe-toolchain
 
 echo '
-Remember to update the rbe_defualt digest in the WORKSPACE file to reflect the
+Remember to update the rbe_default digest in the WORKSPACE file to reflect the
 new ID for the container.
 
 Use `docker images --digests` to view the ID.'

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -29,4 +29,4 @@ echo '
 Remember to update the rbe_defualt digest in the WORKSPACE file to reflect the
 new ID for the container.
 
-Use `docker images --no-trunk` to view the ID.'
+See `latest: digest: sha256:<ID>` from earlier in this script.'

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -24,3 +24,9 @@ gcloud auth configure-docker
 # Build and push the rbe-toolchain image.
 docker build --tag gcr.io/iree-oss/rbe-toolchain build_tools/docker/rbe_toolchain/
 docker push gcr.io/iree-oss/rbe-toolchain
+
+echo '
+Remember to update the rbe_defualt digest in the WORKSPACE file to reflect the
+new ID for the container.
+
+Use `docker images --no-trunk` to view the ID.'

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -29,4 +29,4 @@ echo '
 Remember to update the rbe_defualt digest in the WORKSPACE file to reflect the
 new ID for the container.
 
-See `latest: digest: sha256:<ID>` from earlier in this script.'
+Use `docker images --digests` to view the ID.'

--- a/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
@@ -32,5 +32,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1 \
+  gcr.io/iree-oss/bazel-tensorflow@sha256:18e4d648ebd367cfab7596fff769639d526cffc1f526be88488660ff4575f3ce \
   kokoro/gcp_ubuntu/bazel/build.sh

--- a/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
@@ -32,5 +32,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/bazel-tensorflow \
+  gcr.io/iree-oss/bazel-tensorflow@sha256:279ffff87cb8e1325628f3e5d8f9babef280d3f3c9b34ac9f24a99239941f0e1 \
   kokoro/gcp_ubuntu/bazel/build.sh


### PR DESCRIPTION
- Bases our `bazel` and `bazel-tensorflow` images off of `ubuntu:18.04` instead of `l.gcr.io/google/bazel:2.1.0`.
  - `ubuntu:18.04` has system `python3 --version = 3.6.9`, which allows us to use `python3.6` without changing the system `python3` (and breaking lots of other things in the process).
- Explicitly points our CI to specific versions of these images using their `SHA256` IDs.
  - This will ensure that if broken versions of these images are uploaded to GCR the CI won't break for everyone, which greatly simplifies testing changes on Kokoro.