### PR TITLE
Run CMake in a docker container on Kokoro and add bindings tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,6 @@ include(iree_check_test)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 
-# FastBuild requires -DCMAKE_C_COMPILER=clang and -DCMAKE_CXX_COMPILER=clang++
-# (or the CC/CXX environment variables) to be specified.
 set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
 set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used for linking binaries during fast builds." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ include(iree_check_test)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 
-# FastBuild requires that the CXX environment variable is set, otherwise errors
-# like `unrecognized debug output level 'mlt'` will occur.
+# FastBuild requires -DCMAKE_C_COMPILER=clang and -DCMAKE_CXX_COMPILER=clang++
+# (or the CC/CXX environment variables) to be specified.
 set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
 set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used for linking binaries during fast builds." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ include(iree_check_test)
 
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
 
+# FastBuild requires that the CXX environment variable is set, otherwise errors
+# like `unrecognized debug output level 'mlt'` will occur.
 set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
 set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used for linking binaries during fast builds." FORCE)

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -90,6 +90,8 @@ iree_py_test(
     function_abi_test
   SRCS
     "function_abi_test.py"
+  LABELS
+    "nokokoro"
 )
 
 iree_py_test(

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -27,9 +27,9 @@ CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
 ninja --version
 
 cd ${ROOT_DIR?}
-if [ -d "build" ] 
+if [ -d "build" ]
 then
-  echo "Build directory already exists. Will use cached results there." 
+  echo "Build directory already exists. Will use cached results there."
 else
   echo "Build directory does not already exist. Creating a new one."
   mkdir build
@@ -43,4 +43,3 @@ cd build
                       -DIREE_BUILD_DEBUGGER=OFF \
                       -DIREE_BUILD_PYTHON_BINDINGS=ON ..
 "$CMAKE_BIN" --build .
-

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -36,6 +36,8 @@ else
 fi
 cd build
 "$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild \
+                      -DCMAKE_C_COMPILER=clang \
+                      -DCMAKE_CXX_COMPILER=clang++ \
                       -DIREE_BUILD_COMPILER=ON \
                       -DIREE_BUILD_TESTS=ON \
                       -DIREE_BUILD_SAMPLES=OFF \

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -36,8 +36,6 @@ else
 fi
 cd build
 "$CMAKE_BIN" -G Ninja -DCMAKE_BUILD_TYPE=FastBuild \
-                      -DCMAKE_C_COMPILER=clang \
-                      -DCMAKE_CXX_COMPILER=clang++ \
                       -DIREE_BUILD_COMPILER=ON \
                       -DIREE_BUILD_TESTS=ON \
                       -DIREE_BUILD_SAMPLES=OFF \

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -38,18 +38,18 @@ declare -a label_exclude_args=(
   ^nokokoro$
 
   # TODO(b/151445957) Enable the python tests when the Kokoro VMs support them.
-  # See also, https://github.com/google/iree/issues/1346.
+
   # Exclude all tests in a directory.
   # Put the whole directory with anchors for exact matches.
   # For example:
   #   ^bindings/python/pyiree/rt$
-  ^bindings$
+
   # Exclude all tests in some subdirectories.
   # Put the whole parent directory with only a starting anchor.
   # Use a trailing slash to avoid prefix collisions.
   # For example:
   #   ^bindings/
-  ^bindings/
+
 )
 
 # Join on "|"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -28,7 +28,8 @@ export IREE_LLVMJIT_DISABLE=${IREE_LLVMJIT_DISABLE:-1}
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
-# over from Bazel tags), every test should be labeled with the directory it is in.
+# over from Bazel tags), every test should be labeled with the directory it is
+# in.
 declare -a label_exclude_args=(
   # Exclude specific labels.
   # Put the whole label with anchors for exact matches.
@@ -47,7 +48,6 @@ declare -a label_exclude_args=(
   # Use a trailing slash to avoid prefix collisions.
   # For example:
   #   ^bindings/
-
 )
 
 # Join on "|"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -37,8 +37,6 @@ declare -a label_exclude_args=(
   ^driver=vulkan$
   ^nokokoro$
 
-  # TODO(b/151445957) Enable the python tests when the Kokoro VMs support them.
-
   # Exclude all tests in a directory.
   # Put the whole directory with anchors for exact matches.
   # For example:

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -33,6 +33,6 @@ docker push gcr.io/iree-oss/bazel-tensorflow
 echo '
 Remember to update all of the files using `bazel` and `bazel-tensorflow` images
 (e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
-to use the IDs of the updated images.
+to use the digests of the updated images.
 
-Use `docker images --digests` to view the IDs.'
+Use `docker images --digests` to view the digests.'

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -28,6 +28,6 @@ docker push gcr.io/iree-oss/bazel-tensorflow
 echo '
 Remember to update all of the files using the `bazel-tensorflow` image
 (e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
-to use the IDs of the updated image.
+to use the digest of the updated image.
 
-Use `docker images --digests` to view the ID.'
+Use `docker images --digests` to view the digest.'

--- a/build_tools/docker/cmake/Dockerfile
+++ b/build_tools/docker/cmake/Dockerfile
@@ -17,20 +17,6 @@
 # Build using:
 # docker build --tag gcr.io/iree-oss/cmake build_tools/docker/cmake/
 
-# Run using:
-# docker run -it --rm --entrypoint bash \
-#   --volume /home/phoenix/iree/fork:/usr/src/iree/ \
-#   gcr.io/iree-oss/cmake
-
-# Build and test IREE.
-# cmake -G Ninja -B build/ \
-#   -DCMAKE_C_COMPILER=clang \
-#   -DCMAKE_CXX_COMPILER=clang++ \
-#   -DIREE_BUILD_PYTHON_BINDINGS=ON .
-# cmake --build build/
-# ./build_tools/cmake/test.sh
-
-
 # Set up the image and working directory.
 FROM ubuntu:18.04
 WORKDIR /usr/src/iree/
@@ -40,11 +26,12 @@ RUN apt-get update
 # Update cmake to v3.13+, which is ahead of apt-get's version (3.10.2).
 # Install dependencies, including an old version of cmake to bootstrap.
 RUN apt-get install -y clang cmake libssl-dev wget
+ENV CMAKE_VERSION 3.13.5
 RUN mkdir ./cmake_install \
   && cd cmake_install \
-  && wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2.tar.gz \
-  && tar -xzvf cmake-3.17.2.tar.gz \
-  && cd cmake-3.17.2/ \
+  && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
+  && tar -xzvf cmake-${CMAKE_VERSION}.tar.gz \
+  && cd cmake-${CMAKE_VERSION}/ \
   && cmake . \
   && make \
   && make install

--- a/build_tools/docker/cmake/Dockerfile
+++ b/build_tools/docker/cmake/Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get update
 
 # Update cmake to v3.13+, which is ahead of apt-get's version (3.10.2).
 # Install dependencies, including an old version of cmake to bootstrap.
-RUN apt-get install -y clang cmake libssl-dev wget
 ENV CMAKE_VERSION 3.13.5
-RUN mkdir ./cmake_install \
+RUN apt-get install -y clang cmake libssl-dev wget \
+  && mkdir ./cmake_install \
   && cd cmake_install \
   && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
   && tar -xzvf cmake-${CMAKE_VERSION}.tar.gz \
@@ -37,13 +37,15 @@ RUN mkdir ./cmake_install \
   && make install
 
 # Install dependencies.
-RUN apt-get install -y git
-RUN apt-get install -y ninja-build
-RUN apt-get install -y python3 python3-pip python3-setuptools
-
-# Install dependencies for the python bindings tests.
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install numpy absl-py
+RUN apt-get install -y \
+  git \
+  ninja-build \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  # Install dependencies for the python bindings tests.
+  && python3 -m pip install --upgrade pip \
+  && python3 -m pip install numpy absl-py
 
 # Environment variables for IREE.
 ENV CC /usr/bin/clang

--- a/build_tools/docker/cmake/Dockerfile
+++ b/build_tools/docker/cmake/Dockerfile
@@ -44,3 +44,7 @@ RUN apt-get install -y python3 python3-pip python3-setuptools
 # Install dependencies for the python bindings tests.
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy absl-py
+
+# Environment variables for IREE.
+ENV CC /usr/bin/clang
+ENV CXX /usr/bin/clang++

--- a/build_tools/docker/cmake/Dockerfile
+++ b/build_tools/docker/cmake/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# An image for building IREE using CMake.
+
+# Build using:
+# docker build --tag gcr.io/iree-oss/cmake build_tools/docker/cmake/
+
+# Run using:
+# docker run -it --rm --entrypoint bash \
+#   --volume /home/phoenix/iree/fork:/usr/src/iree/ \
+#   gcr.io/iree-oss/cmake
+
+# Build IREE.
+# cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+# cmake --build build/
+
+
+# Set up the image and working directory.
+FROM ubuntu:18.04
+WORKDIR /usr/src/iree/
+
+RUN apt-get update
+
+# Update cmake to v3.13+, which is ahead of apt-get's version (3.10.2).
+# Install dependencies, including an old version of cmake to bootstrap.
+RUN apt-get install -y clang cmake libssl-dev wget
+RUN mkdir ./cmake_install \
+  && cd cmake_install \
+  && wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2.tar.gz \
+  && tar -xzvf cmake-3.17.2.tar.gz \
+  && cd cmake-3.17.2/ \
+  && cmake . \
+  && make \
+  && make install
+
+# Install dependencies.
+RUN apt-get install -y git
+RUN apt-get install -y ninja-build
+RUN apt-get install -y python3 python3-pip python3-setuptools
+
+# Install dependencies for the python bindings tests.
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install numpy absl-py

--- a/build_tools/docker/cmake/Dockerfile
+++ b/build_tools/docker/cmake/Dockerfile
@@ -22,9 +22,13 @@
 #   --volume /home/phoenix/iree/fork:/usr/src/iree/ \
 #   gcr.io/iree-oss/cmake
 
-# Build IREE.
-# cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+# Build and test IREE.
+# cmake -G Ninja -B build/ \
+#   -DCMAKE_C_COMPILER=clang \
+#   -DCMAKE_CXX_COMPILER=clang++ \
+#   -DIREE_BUILD_PYTHON_BINDINGS=ON .
 # cmake --build build/
+# ./build_tools/cmake/test.sh
 
 
 # Set up the image and working directory.

--- a/build_tools/docker/cmake/gcr_update.sh
+++ b/build_tools/docker/cmake/gcr_update.sh
@@ -24,3 +24,10 @@ gcloud auth configure-docker
 # Build and push the cmake image.
 docker build --tag gcr.io/iree-oss/cmake build_tools/docker/cmake/
 docker push gcr.io/iree-oss/cmake
+
+echo '
+Remember to update all of the files using the `cmake` image (e.g.
+/kokoro/gcp_ubuntu/cmake/build_kokoro.sh) to use the digest of the updated
+image.
+
+Use `docker images --digests` to view the digest.'

--- a/build_tools/docker/cmake/gcr_update.sh
+++ b/build_tools/docker/cmake/gcr_update.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and pushes the cmake image to gcr.io/iree-oss/
+
+set -x
+set -e
+
+# Ensure correct authorization.
+gcloud auth configure-docker
+
+# Build and push the cmake image.
+docker build --tag gcr.io/iree-oss/cmake build_tools/docker/cmake/
+docker push gcr.io/iree-oss/cmake

--- a/build_tools/docker/rbe_toolchain/gcr_update.sh
+++ b/build_tools/docker/rbe_toolchain/gcr_update.sh
@@ -27,6 +27,6 @@ docker push gcr.io/iree-oss/rbe-toolchain
 
 echo '
 Remember to update the rbe_default digest in the WORKSPACE file to reflect the
-new ID for the container.
+new digest for the container.
 
-Use `docker images --digests` to view the ID.'
+Use `docker images --digests` to view the digest.'

--- a/kokoro/gcp_ubuntu/cmake/build.sh
+++ b/kokoro/gcp_ubuntu/cmake/build.sh
@@ -22,10 +22,14 @@ set -x
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
+export CMAKE_BIN="$(which cmake)"
+export CC="$(which clang)"
+export CXX="$(which clang++)"
+
 # Check these exist and print the versions for later debugging
-cmake --version
-clang --version
-clang++ --version
+"$CMAKE_BIN" --version
+"$CC" --version
+"$CXX" --version
 python3 --version
 
 echo "Initializing submodules"

--- a/kokoro/gcp_ubuntu/cmake/build.sh
+++ b/kokoro/gcp_ubuntu/cmake/build.sh
@@ -22,10 +22,6 @@ set -x
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-export CMAKE_BIN="$(which cmake)"
-export CC="$(which clang-6.0)"
-export CXX="$(which clang++-6.0)"
-
 # Check these exist and print the versions for later debugging
 cmake --version
 clang --version

--- a/kokoro/gcp_ubuntu/cmake/build.sh
+++ b/kokoro/gcp_ubuntu/cmake/build.sh
@@ -22,11 +22,8 @@ set -x
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-export CMAKE_BIN="$(which cmake)"
-export CC="$(which clang)"
-export CXX="$(which clang++)"
-
 # Check these exist and print the versions for later debugging
+export CMAKE_BIN="$(which cmake)"
 "$CMAKE_BIN" --version
 "$CC" --version
 "$CXX" --version

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -31,5 +31,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/cmake@sha256:2c99189f3bc544557b80182ff7124717f5cab4e75e220ff88e9cf99b03abd4aa \
+  gcr.io/iree-oss/cmake@sha256:959e6c23ac90fa2d47200263287cc49fb37683608996335cede68370b451cdc8 \
   kokoro/gcp_ubuntu/cmake/build.sh

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -31,5 +31,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/cmake@sha256:959e6c23ac90fa2d47200263287cc49fb37683608996335cede68370b451cdc8 \
+  gcr.io/iree-oss/cmake@sha256:256d8aa56d5b50659581ff85a381848b14bcddc0dd9c9962baa4efa70b358aab \
   kokoro/gcp_ubuntu/cmake/build.sh

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -40,5 +40,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/cmake \
+  gcr.io/iree-oss/cmake@sha256:bcc5097c1eb2a6dc808351a69fa452766e8392b47b2c58d833f5bcf541afc95d \
   kokoro/gcp_ubuntu/cmake/build.sh

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -14,22 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the project with cmake using Kokoro.
+# Build and test the project within the gcr.io/iree-oss/cmake using Kokoro.
 
 set -e
 set -x
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
-
-export CMAKE_BIN="$(which cmake)"
-export CC="$(which clang-6.0)"
-export CXX="$(which clang++-6.0)"
-
-# Check these exist and print the versions for later debugging
-"$CMAKE_BIN" --version
-"$CC" --version
-"$CXX" --version
 
 # Kokoro checks out the repository here.
 WORKDIR=${KOKORO_ARTIFACTS_DIR?}/github/iree

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -31,5 +31,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/cmake@sha256:bcc5097c1eb2a6dc808351a69fa452766e8392b47b2c58d833f5bcf541afc95d \
+  gcr.io/iree-oss/cmake@sha256:2c99189f3bc544557b80182ff7124717f5cab4e75e220ff88e9cf99b03abd4aa \
   kokoro/gcp_ubuntu/cmake/build.sh

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -27,19 +27,18 @@ export CC="$(which clang-6.0)"
 export CXX="$(which clang++-6.0)"
 
 # Check these exist and print the versions for later debugging
-cmake --version
-clang --version
-clang++ --version
-python3 --version
+"$CMAKE_BIN" --version
+"$CC" --version
+"$CXX" --version
 
-echo "Initializing submodules"
-./scripts/git/submodule_versions.py init
+# Kokoro checks out the repository here.
+WORKDIR=${KOKORO_ARTIFACTS_DIR?}/github/iree
 
-# TODO(gcmn): It would be nice to be able to build and test as much as possible,
-# so a build failure only prevents building/testing things that depend on it and
-# we can still run the other tests.
-echo "Building with cmake"
-./build_tools/cmake/clean_build.sh
-
-echo "Testing with ctest"
-./build_tools/cmake/test.sh
+# Mount the checked out repository, make that the working directory and run the
+# tests in the cmake image.
+docker run \
+  --volume "${WORKDIR?}:${WORKDIR?}" \
+  --workdir="${WORKDIR?}" \
+  --rm \
+  gcr.io/iree-oss/cmake \
+  kokoro/gcp_ubuntu/cmake/build.sh

--- a/kokoro/gcp_ubuntu/cmake/common.cfg
+++ b/kokoro/gcp_ubuntu/cmake/common.cfg
@@ -16,4 +16,4 @@
 
 # Common configuration for Kokoro builds that run cmake on linux.
 
-build_file: "iree/kokoro/gcp_ubuntu/cmake/build.sh"
+build_file: "iree/kokoro/gcp_ubuntu/cmake/build_kokoro.sh"


### PR DESCRIPTION
- Adds a docker container `gcr.io/iree-oss/cmake` for running cmake builds
- Updates the Kokoro VMs to build and run tests for the cmake build inside of this container

Resolves #1346 and b/151445957