### PR TITLE
Add ConvertShapeToShapex to flow transform pass pipeline.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "//iree/compiler/Dialect/Flow/Conversion/StandardToFlow",
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/Flow/Utils",
+        "//iree/compiler/Dialect/Shape/Conversion",
         "//iree/compiler/Dialect/Shape/IR",
         "//iree/compiler/Dialect/Shape/Transforms",
         "//iree/compiler/Dialect/Shape/Utils:TypeConversion",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::Conversion::StandardToFlow
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Utils
+    iree::compiler::Dialect::Shape::Conversion
     iree::compiler::Dialect::Shape::IR
     iree::compiler::Dialect::Shape::Transforms
     iree::compiler::Dialect::Shape::Utils::TypeConversion

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "iree/compiler/Dialect/Shape/Conversion/Passes.h"
 #include "iree/compiler/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
@@ -39,6 +40,9 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // Flatten structured control flow to our CFG.
   passManager.addNestedPass<FuncOp>(xla_hlo::createLegalizeControlFlowPass());
   passManager.addPass(createHLOPreprocessingPass());
+
+  // Convert `shape` dialect to `shapex` dialect.
+  passManager.addPass(Shape::createConvertShapeToShapexPass());
 
   // Flatten tuples (like tuple<tensor<...>, tensor<...>>) so we can do
   // fine-grained tensor tracking.


### PR DESCRIPTION
Hi, 
CHLO dialect will be convert to HLO dialect in the `HLOToHLOPreprocessing` pass, 
I have a testing as follows
```
func @add(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
  %0 = xla_chlo.broadcast_add %arg0, %arg1 : (tensor<?xi32>, tensor<?xi32>) -> tensor<?xi32>
  return %0 : tensor<?xi32>
}
```

after the `HLOToHLOPreprocessing` pass, will be lowered to :

```
func @add(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
  %0 = shape.shape_of %arg0 : tensor<?xi32>
  %1 = shape.shape_of %arg1 : tensor<?xi32>
  %2 = "shape.broadcast"(%0, %1) : (!shape.shape, !shape.shape) -> !shape.shape
  %3 = "shape.to_extent_tensor"(%2) : (!shape.shape) -> tensor<1xindex>
  %4 = "xla_hlo.dynamic_broadcast_in_dim"(%arg0, %3) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<?xi32>, tensor<1xindex>) -> tensor<?xi32>
  %5 = "xla_hlo.dynamic_broadcast_in_dim"(%arg1, %3) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<?xi32>, tensor<1xindex>) -> tensor<?xi32>
  %6 = xla_hlo.add %4, %5 : tensor<?xi32>
  return %6 : tensor<?xi32>
}
```

There is not a pass to convert shape dialect to shapex dialect on the flow pass pipe. Here is a fix.
Thanks :) 
