### PR TITLE
Always print out the Vulkan device created for clarity

### DIFF
--- a/iree/hal/vulkan/vulkan_driver.cc
+++ b/iree/hal/vulkan/vulkan_driver.cc
@@ -292,6 +292,8 @@ StatusOr<ref_ptr<Device>> VulkanDriver::CreateDevice(DriverDeviceID device_id) {
                                     device_extensibility_spec_, syms(),
                                     renderdoc_capture_manager_.get()));
 
+  LOG(INFO) << "Created Vulkan Device: " << device->info().name();
+
   return device;
 }
 


### PR DESCRIPTION
This can be very useful for confirming the Vulkan implementation
used as we switch between real GPU and SwiftShader freqently.