### PR TITLE
Fix get element byte width function.

### DIFF
--- a/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
+++ b/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
@@ -34,7 +34,18 @@ namespace IREE {
 namespace HAL {
 
 int32_t getRoundedElementByteWidth(Type type) {
-  return (type.getIntOrFloatBitWidth() + 8 - 1) / 8;
+  auto bitWidth = 0;
+  if (type.isIntOrFloat()) {
+    bitWidth = type.getIntOrFloatBitWidth();
+  } else if (type.isIndex()) {
+    bitWidth = IndexType::kInternalStorageBitWidth;
+  } else {
+    llvm_unreachable(
+        "getRoundedElementByteWidth only support int, float"
+        "and index type now.");
+  }
+
+  return (bitWidth + 8 - 1) / 8;
 }
 
 SmallVector<Value, 4> getStaticShapeDims(Location loc, ShapedType shapedType,

--- a/iree/compiler/Dialect/VMLA/Conversion/TypeConverter.h
+++ b/iree/compiler/Dialect/VMLA/Conversion/TypeConverter.h
@@ -15,6 +15,7 @@
 #ifndef IREE_COMPILER_DIALECT_VMLA_CONVERSION_TYPECONVERTER_H_
 #define IREE_COMPILER_DIALECT_VMLA_CONVERSION_TYPECONVERTER_H_
 
+#include "mlir/IR/StandardTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
@@ -27,7 +28,18 @@ class VMLATypeConverter : public TypeConverter {
   // Returns the number of bytes an element of the given type occupies
   // post-conversion. For example, the size of i1 would be '1 byte'.
   static int32_t getRoundedElementByteWidth(Type type) {
-    return (type.getIntOrFloatBitWidth() + 8 - 1) / 8;
+    auto bitWidth = 0;
+    if (type.isIntOrFloat()) {
+      bitWidth = type.getIntOrFloatBitWidth();
+    } else if (type.isIndex()) {
+      bitWidth = IndexType::kInternalStorageBitWidth;
+    } else {
+      llvm_unreachable(
+          "getRoundedElementByteWidth only support int, float"
+          "and index type now.");
+    }
+
+    return (bitWidth + 8 - 1) / 8;
   }
 
   // TODO(benvanik): signature conversion for output buffers.


### PR DESCRIPTION
There is a `inidex` type in the case, 
```
func @add_ex_dispatch_0(%arg0: !vmla.interface) {
  %c0 = constant 0 : index
  %0 = hal.interface.load.constant offset = 0 : index
  %1 = shapex.make_ranked_shape %0 : (index) -> !shapex.ranked_shape<[?]>
  %2 = "shapex.to_extent_tensor"(%1) : (!shapex.ranked_shape<[?]>) -> tensor<1xindex>
  hal.interface.store.tensor %2, @legacy_io::@ret0, offset = %c0 : tensor<1xindex>
  return
}
```
In the pass `convert hal to vmla` or some other passes, will call the funtion `getRoundedElementByteWidth(Type type)`, and now the implementation is as follow :
```
int32_t getRoundedElementByteWidth(Type type) {
  return (type.getIntOrFloatBitWidth() + 8 - 1) / 8;
}
```
This `getIntOrFloatBitWidth` only support int and float. So fix it and add an assertion for unknow type. :)