### PR TITLE
A initial implementation to support llvm-ir backend codegen for dynamic shape

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/ResolveShapeOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/ResolveShapeOps.cpp
@@ -111,5 +111,9 @@ void ResolveShapeOpsPass::runOnFunction() {
 std::unique_ptr<OperationPass<FuncOp>> createResolveShapeOpsPass() {
   return std::make_unique<ResolveShapeOpsPass>();
 }
+
+static PassRegistration<ResolveShapeOpsPass> pass(
+   "iree-codege-resolve-shape",
+    "resolve shape");
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/HALInterfaceToMemrefArguments.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/HALInterfaceToMemrefArguments.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -50,6 +51,7 @@ bool operator<(IREE::HAL::InterfaceBindingOp aOp,
   return aOp.set().getZExtValue() < bOp.set().getZExtValue();
 }
 
+
 /// A pattern to process function interface. It replaces interface related ops
 /// with function arguments to match LLVM's CodeGen's ABI contract.
 ///
@@ -78,12 +80,16 @@ struct ProcessFuncInterfacePattern : public OpConversionPattern<FuncOp> {
           funcOp, "entry function should not have inputs");
 
     // Get interface buffers from all the blocks.
-    // TODO: Also handle hal.interface.load.constant for dynamic shape.
     SmallVector<IREE::PlaceholderOp, 8> bufferOps;
+    SmallVector<IREE::HAL::InterfaceLoadConstantOp, 8> loadOps;
     for (Block& block : funcOp.getBlocks()) {
-      for (Operation& op : block)
+      for (Operation& op : block) {
         if (auto phOp = dyn_cast<IREE::PlaceholderOp>(op))
           bufferOps.push_back(phOp);
+        if (auto phOp = dyn_cast<IREE::HAL::InterfaceLoadConstantOp>(op)) {
+          loadOps.push_back(phOp);
+        }
+      }
     }
 
     if (bufferOps.empty()) return failure();
@@ -143,10 +149,19 @@ struct ProcessFuncInterfacePattern : public OpConversionPattern<FuncOp> {
     for (auto bufferOp : bufferOps) {
       bufferOp.replaceAllUsesWith(
           newFuncOp.getArgument(bufferArgMap[bufferOp]));
+    
       rewriter.eraseOp(bufferOp);
     }
 
     rewriter.eraseOp(funcOp);
+
+    auto builder = OpBuilder::atBlockBegin(&(newFuncOp.getBlocks().front()));
+    for (auto loadOp: loadOps) {
+      auto moduleOp = loadOp.getParentOfType<ModuleOp>();
+      auto dim = builder.create<mlir::DimOp>(newFuncOp.front().front().getLoc(), newFuncOp.getArgument(0), loadOp.offset().getZExtValue());
+      loadOp.replaceAllUsesWith(dim.getOperation());
+      rewriter.replaceOp(loadOp, ValueRange({dim}));
+    }
     return success();
   }
 };

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -40,6 +40,7 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createLowerToCFGPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
+  passManager.addPass(createResolveShapeOpsPass());
 
   // Convert ExecuableOp entry function to use memref arguments.
   passManager.addPass(createHALInterfaceToMemrefArgumentsPass());

--- a/iree/test/e2e/regression/dynamic_abs.mlir
+++ b/iree/test/e2e/regression/dynamic_abs.mlir
@@ -1,4 +1,6 @@
 // RUN: iree-run-mlir -iree-hal-target-backends=vmla %s | IreeFileCheck %s
+// RUN: iree-run-mlir -iree-hal-target-backends=llvm-ir %s | IreeFileCheck %s
+
 
 // CHECK-LABEL: EXEC @dynamic_tensor
 func @dynamic_tensor() -> tensor<?x?xf32> attributes { iree.module.export } {


### PR DESCRIPTION
This PR may begin as a discussion

Now, llvm-ir backend can not support dynamic shape in hal codegen process

There are two major problems I found:

1) shapex dialect can not be resolved in llvm-ir hal pass pipeline. So I move the ResolveShapeOps which is used in vulcan-spriv backend into LLVMTarget pass pipeline to make it work

2)  hal.interface.load.constant  can not be converted and will cause a coredump . I try to solve this with DimOp in llvm-ir backend, not sure whether it's the proper way