### PR TITLE
[WIP] A initial implementation to support llvm-ir backend codegen for dynamic shape 

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/ResolveShapeOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/ResolveShapeOps.cpp
@@ -111,5 +111,8 @@ void ResolveShapeOpsPass::runOnFunction() {
 std::unique_ptr<OperationPass<FuncOp>> createResolveShapeOpsPass() {
   return std::make_unique<ResolveShapeOpsPass>();
 }
+
+static PassRegistration<ResolveShapeOpsPass> pass("iree-codege-resolve-shape",
+                                                  "resolve shape");
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/HALInterfaceToMemrefArguments.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/HALInterfaceToMemrefArguments.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -78,12 +79,16 @@ struct ProcessFuncInterfacePattern : public OpConversionPattern<FuncOp> {
           funcOp, "entry function should not have inputs");
 
     // Get interface buffers from all the blocks.
-    // TODO: Also handle hal.interface.load.constant for dynamic shape.
     SmallVector<IREE::PlaceholderOp, 8> bufferOps;
+    SmallVector<IREE::HAL::InterfaceLoadConstantOp, 8> loadOps;
     for (Block& block : funcOp.getBlocks()) {
-      for (Operation& op : block)
+      for (Operation& op : block) {
         if (auto phOp = dyn_cast<IREE::PlaceholderOp>(op))
           bufferOps.push_back(phOp);
+        if (auto phOp = dyn_cast<IREE::HAL::InterfaceLoadConstantOp>(op)) {
+          loadOps.push_back(phOp);
+        }
+      }
     }
 
     if (bufferOps.empty()) return failure();
@@ -143,10 +148,20 @@ struct ProcessFuncInterfacePattern : public OpConversionPattern<FuncOp> {
     for (auto bufferOp : bufferOps) {
       bufferOp.replaceAllUsesWith(
           newFuncOp.getArgument(bufferArgMap[bufferOp]));
+
       rewriter.eraseOp(bufferOp);
     }
 
     rewriter.eraseOp(funcOp);
+
+    auto builder = OpBuilder::atBlockBegin(&(newFuncOp.getBlocks().front()));
+    for (auto loadOp : loadOps) {
+      auto dim = builder.create<mlir::DimOp>(newFuncOp.front().front().getLoc(),
+                                             newFuncOp.getArgument(0),
+                                             loadOp.offset().getZExtValue());
+      loadOp.replaceAllUsesWith(dim.getOperation());
+      rewriter.replaceOp(loadOp, ValueRange({dim}));
+    }
     return success();
   }
 };

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -40,6 +40,7 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createLowerToCFGPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
+  passManager.addPass(createResolveShapeOpsPass());
 
   // Convert ExecuableOp entry function to use memref arguments.
   passManager.addPass(createHALInterfaceToMemrefArgumentsPass());


### PR DESCRIPTION
This PR may begin as a discussion

Now, llvm-ir backend can not support dynamic shape in hal codegen process

There are two major problems I found:

1. shapex dialect can not be resolved in llvm-ir hal pass pipeline. So I move the ResolveShapeOps which is used in vulcan-spriv backend into LLVMTarget pass pipeline to make it work

2. hal.interface.load.constant can not be converted and will cause a coredump . I try to solve this with DimOp in llvm-ir backend, not sure whether it's the proper way

detail in https://github.com/google/iree/issues/2013
however, there a some problem remain:

1. after I insert a DimOp into ```HALInterfaceToMemrefArgumentsPass``` pass, iree-run-mlir will cause a  coredump 
```

#27 llvm::orc::ExecutionSession::~ExecutionSession() (this=0x3b65bc0) at external/llvm-project/llvm/include/llvm/ExecutionEngine/Orc/Core.h:1088
#28 0x0000000000f0bfbc in llvm::orc::LLJIT::~LLJIT() ()
#29 0x0000000000eed965 in operator() (__ptr=0x3b65950, this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:81
#30 ~unique_ptr (this=0x3b867c8) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:277
#31 ~LLVMJITExecutable (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#32 iree::hal::llvmjit::LLVMJITExecutable::~LLVMJITExecutable() (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#33 0x0000000000eb5a87 in iree_vm_ref_release (ref=0x3b9723c) at iree/vm/ref.c:213
#34 0x0000000000e75a0c in iree_vm_bytecode_module_free_state(void*, iree_vm_module_state*) (self=<optimized out>, module_state=0x3b971e0) at iree/vm/bytecode_module.cc:484
#35 0x0000000000eb502f in iree_vm_context_release_modules (context=0x3b97160, stack=0x3c9d640, start=0, end=<optimized out>) at iree/vm/context.c:131
---Type <return> to continue, or q <return> to quit---
#36 0x0000000000eb4d9a in iree_vm_context_destroy (context=0x3b97160) at iree/vm/context.c:219
#37 0x0000000000eb4e56 in iree_vm_context_release (context=0x7fff21f9bdd0) at iree/vm/context.c:250
#38 0x000000000043ac98 in operator() (this=<optimized out>, ordinal=1) at iree/tools/run_mlir_main.cc:358
#39 iree::(anonymous namespace)::EvaluateFunctions(iree_vm_instance*, absl::lts_2020_02_25::string_view, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (instance=0x39952d0, driver_name=..., flatbuffer_data=...) at iree/tools/run_mlir_main.cc:365
#40 0x0000000000438750 in iree::(anonymous namespace)::EvaluateFile(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >) (file_buffer=...)
    at iree/tools/run_mlir_main.cc:402
#41 0x0000000000434f4d in RunFile (mlir_filename=...) at iree/tools/run_mlir_main.cc:449
#27 llvm::orc::ExecutionSession::~ExecutionSession() (this=0x3b65bc0) at external/llvm-project/llvm/include/llvm/ExecutionEngine/Orc/Core.h:1088
#28 0x0000000000f0bfbc in llvm::orc::LLJIT::~LLJIT() ()
#29 0x0000000000eed965 in operator() (__ptr=0x3b65950, this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:81
#30 ~unique_ptr (this=0x3b867c8) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:277
#31 ~LLVMJITExecutable (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#32 iree::hal::llvmjit::LLVMJITExecutable::~LLVMJITExecutable() (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#33 0x0000000000eb5a87 in iree_vm_ref_release (ref=0x3b9723c) at iree/vm/ref.c:213
#34 0x0000000000e75a0c in iree_vm_bytecode_module_free_state(void*, iree_vm_module_state*) (self=<optimized out>, module_state=0x3b971e0) at iree/vm/bytecode_module.cc:484
#35 0x0000000000eb502f in iree_vm_context_release_modules (context=0x3b97160, stack=0x3c9d640, start=0, end=<optimized out>) at iree/vm/context.c:131
---Type <return> to continue, or q <return> to quit---
#36 0x0000000000eb4d9a in iree_vm_context_destroy (context=0x3b97160) at iree/vm/context.c:219
#37 0x0000000000eb4e56 in iree_vm_context_release (context=0x7fff21f9bdd0) at iree/vm/context.c:250
#38 0x000000000043ac98 in operator() (this=<optimized out>, ordinal=1) at iree/tools/run_mlir_main.cc:358
#39 iree::(anonymous namespace)::EvaluateFunctions(iree_vm_instance*, absl::lts_2020_02_25::string_view, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (instance=0x39952d0, driver_name=..., flatbuffer_data=...) at iree/tools/run_mlir_main.cc:365
#40 0x0000000000438750 in iree::(anonymous namespace)::EvaluateFile(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >) (file_buffer=...)
    at iree/tools/run_mlir_main.cc:402
#41 0x0000000000434f4d in RunFile (mlir_filename=...) at iree/tools/run_mlir_main.cc:449
#27 llvm::orc::ExecutionSession::~ExecutionSession() (this=0x3b65bc0) at external/llvm-project/llvm/include/llvm/ExecutionEngine/Orc/Core.h:1088
#28 0x0000000000f0bfbc in llvm::orc::LLJIT::~LLJIT() ()
#29 0x0000000000eed965 in operator() (__ptr=0x3b65950, this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:81
#30 ~unique_ptr (this=0x3b867c8) at /usr/lib/gcc/x86_64-pc-linux-gnu/8.4.0/../../../../include/c++/8.4.0/bits/unique_ptr.h:277
#31 ~LLVMJITExecutable (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#32 iree::hal::llvmjit::LLVMJITExecutable::~LLVMJITExecutable() (this=0x3b86740) at iree/hal/llvmjit/llvmjit_executable.cc:115
#33 0x0000000000eb5a87 in iree_vm_ref_release (ref=0x3b9723c) at iree/vm/ref.c:213
#34 0x0000000000e75a0c in iree_vm_bytecode_module_free_state(void*, iree_vm_module_state*) (self=<optimized out>, module_state=0x3b971e0) at iree/vm/bytecode_module.cc:484
#35 0x0000000000eb502f in iree_vm_context_release_modules (context=0x3b97160, stack=0x3c9d640, start=0, end=<optimized out>) at iree/vm/context.c:131
---Type <return> to continue, or q <return> to quit---
#36 0x0000000000eb4d9a in iree_vm_context_destroy (context=0x3b97160) at iree/vm/context.c:219
#37 0x0000000000eb4e56 in iree_vm_context_release (context=0x7fff21f9bdd0) at iree/vm/context.c:250
#38 0x000000000043ac98 in operator() (this=<optimized out>, ordinal=1) at iree/tools/run_mlir_main.cc:358
#39 iree::(anonymous namespace)::EvaluateFunctions(iree_vm_instance*, absl::lts_2020_02_25::string_view, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (instance=0x39952d0, driver_name=..., flatbuffer_data=...) at iree/tools/run_mlir_main.cc:365
#40 0x0000000000438750 in iree::(anonymous namespace)::EvaluateFile(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >) (file_buffer=...)
    at iree/tools/run_mlir_main.cc:402
#41 0x0000000000434f4d in RunFile (mlir_filename=...) at iree/tools/run_mlir_main.cc:449
```

I seems that coredump is generated by ```iree_vm_context_release```  I wonder whether use DimOp to replace InterfaceLoadConstantOp will cause a  ABI in-compatible . 

2. I don't know whether it's correct to insert ResolveShapeOps into llvm-ir backend hal pass pipeline

@stellaraccident please help me review this and propose a correct way to make this PR land properly