### PR TITLE
Loads symbols from the device.

### DIFF
--- a/iree/hal/vulkan/dynamic_symbol_tables.h
+++ b/iree/hal/vulkan/dynamic_symbol_tables.h
@@ -72,7 +72,7 @@ namespace vulkan {
   DEV_PFN(EXCLUDED, vkCmdDebugMarkerEndEXT)                             \
   DEV_PFN(EXCLUDED, vkCmdDebugMarkerInsertEXT)                          \
   DEV_PFN(REQUIRED, vkCmdDispatch)                                      \
-  DEV_PFN(REQUIRED, vkCmdDispatchBase)                                  \
+  DEV_PFN(EXCLUDED, vkCmdDispatchBase)                                  \
   DEV_PFN(EXCLUDED, vkCmdDispatchBaseKHR)                               \
   DEV_PFN(REQUIRED, vkCmdDispatchIndirect)                              \
   DEV_PFN(EXCLUDED, vkCmdDraw)                                          \
@@ -222,7 +222,7 @@ namespace vulkan {
   DEV_PFN(EXCLUDED, vkGetBufferMemoryRequirements2)                     \
   DEV_PFN(EXCLUDED, vkGetBufferMemoryRequirements2KHR)                  \
   DEV_PFN(EXCLUDED, vkGetCalibratedTimestampsEXT)                       \
-  DEV_PFN(REQUIRED, vkGetDescriptorSetLayoutSupport)                    \
+  DEV_PFN(EXCLUDED, vkGetDescriptorSetLayoutSupport)                    \
   DEV_PFN(EXCLUDED, vkGetDescriptorSetLayoutSupportKHR)                 \
   DEV_PFN(EXCLUDED, vkGetDeviceGroupPeerMemoryFeatures)                 \
   DEV_PFN(EXCLUDED, vkGetDeviceGroupPeerMemoryFeaturesKHR)              \
@@ -277,7 +277,7 @@ namespace vulkan {
   DEV_PFN(REQUIRED, vkSetEvent)                                         \
   DEV_PFN(EXCLUDED, vkSetHdrMetadataEXT)                                \
   DEV_PFN(EXCLUDED, vkSetLocalDimmingAMD)                               \
-  DEV_PFN(REQUIRED, vkTrimCommandPool)                                  \
+  DEV_PFN(EXCLUDED, vkTrimCommandPool)                                  \
   DEV_PFN(EXCLUDED, vkTrimCommandPoolKHR)                               \
   DEV_PFN(REQUIRED, vkUnmapMemory)                                      \
   DEV_PFN(EXCLUDED, vkUnregisterObjectsNVX)                             \

--- a/iree/hal/vulkan/native_timeline_semaphore.cc
+++ b/iree/hal/vulkan/native_timeline_semaphore.cc
@@ -122,6 +122,9 @@ Status NativeTimelineSemaphore::Wait(uint64_t value, absl::Time deadline) {
   // device loss event may return either VK_SUCCESS *or* VK_ERROR_DEVICE_LOST.
   // We may want to explicitly query for device loss after a successful wait
   // to ensure we consistently return errors.
+  if (!logical_device_->syms()->vkWaitSemaphores) {
+    return UnknownErrorBuilder(IREE_LOC) << "vkWaitSemaphores not defined";
+  }
   VkResult result = logical_device_->syms()->vkWaitSemaphores(
       *logical_device_, &wait_info, timeout_nanos);
   if (result == VK_ERROR_DEVICE_LOST) {

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -201,7 +201,7 @@ absl::InlinedVector<std::unique_ptr<CommandQueue>, 4> CreateCommandQueues(
 
 // static
 StatusOr<ref_ptr<VulkanDevice>> VulkanDevice::Create(
-    ref_ptr<Driver> driver, const DeviceInfo& device_info,
+    ref_ptr<Driver> driver, VkInstance instance, const DeviceInfo& device_info,
     VkPhysicalDevice physical_device,
     const ExtensibilitySpec& extensibility_spec,
     const ref_ptr<DynamicSymbols>& syms,
@@ -314,6 +314,8 @@ StatusOr<ref_ptr<VulkanDevice>> VulkanDevice::Create(
   VK_RETURN_IF_ERROR(syms->vkCreateDevice(physical_device, &device_create_info,
                                           logical_device->allocator(),
                                           logical_device->mutable_value()));
+  RETURN_IF_ERROR(logical_device->syms()->LoadFromDevice(
+      instance, logical_device->value()));
   IREE_ENABLE_LEAK_CHECKS();
 
   // Create the device memory allocator.

--- a/iree/hal/vulkan/vulkan_device.h
+++ b/iree/hal/vulkan/vulkan_device.h
@@ -51,8 +51,8 @@ class VulkanDevice final : public Device {
  public:
   // Creates a device that manages its own VkDevice.
   static StatusOr<ref_ptr<VulkanDevice>> Create(
-      ref_ptr<Driver> driver, const DeviceInfo& device_info,
-      VkPhysicalDevice physical_device,
+      ref_ptr<Driver> driver, VkInstance instance,
+      const DeviceInfo& device_info, VkPhysicalDevice physical_device,
       const ExtensibilitySpec& extensibility_spec,
       const ref_ptr<DynamicSymbols>& syms,
       DebugCaptureManager* debug_capture_manager);

--- a/iree/hal/vulkan/vulkan_driver.cc
+++ b/iree/hal/vulkan/vulkan_driver.cc
@@ -288,9 +288,9 @@ StatusOr<ref_ptr<Device>> VulkanDriver::CreateDevice(DriverDeviceID device_id) {
   // This may fail if the device was enumerated but is in exclusive use,
   // disabled by the system, or permission is denied.
   ASSIGN_OR_RETURN(auto device, VulkanDevice::Create(
-                                    add_ref(this), device_info, physical_device,
-                                    device_extensibility_spec_, syms(),
-                                    renderdoc_capture_manager_.get()));
+                                    add_ref(this), instance(), device_info,
+                                    physical_device, device_extensibility_spec_,
+                                    syms(), renderdoc_capture_manager_.get()));
 
   LOG(INFO) << "Created Vulkan Device: " << device->info().name();
 


### PR DESCRIPTION
* Gets the vulkan tests to passing on physical GPUs with timeline semaphores.
* Ben mentioned a bigger refactor but putting this out there as a minimal fix.

Fixes #2018