### PR TITLE
Add GetTempFile, avoid copies in SetFileContents with string_view.

### DIFF
--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -120,6 +120,6 @@ function(iree_cc_test)
       "${CMAKE_BINARY_DIR}"
     )
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
-  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${_NAME}_test_tmpdir")
+  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_NAME}_test_tmpdir")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
 endfunction()

--- a/iree/base/file_io.h
+++ b/iree/base/file_io.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "iree/base/status.h"
 
 namespace iree {
@@ -32,7 +33,7 @@ Status FileExists(const std::string& path);
 StatusOr<std::string> GetFileContents(const std::string& path);
 
 // Synchronously writes a string into a file, overwriting its contents.
-Status SetFileContents(const std::string& path, const std::string& content);
+Status SetFileContents(const std::string& path, absl::string_view content);
 
 // Deletes the file at the provided path.
 Status DeleteFile(const std::string& path);
@@ -44,6 +45,14 @@ Status DeleteFile(const std::string& path);
 // physical storage locations).
 Status MoveFile(const std::string& source_path,
                 const std::string& destination_path);
+
+// Gets a platform and environment-dependent path for temporary files.
+std::string GetTempPath();
+
+// Gets a temporary file name and returns its absolute path.
+// The particular path chosen is platform and environment-dependent.
+// Unique characters will be automatically inserted after |base_name|.
+StatusOr<std::string> GetTempFile(const std::string& base_name);
 
 }  // namespace file_io
 }  // namespace iree

--- a/iree/base/file_io_test.cc
+++ b/iree/base/file_io_test.cc
@@ -78,6 +78,28 @@ TEST(FileIo, MoveFile) {
   EXPECT_EQ(to_write, read);
 }
 
+TEST(FileIo, GetTempPath) {
+  auto temp_path = GetTempPath();
+  EXPECT_NE("", temp_path);
+}
+
+TEST(FileIo, GetTempFile) {
+  ASSERT_OK_AND_ASSIGN(std::string path1, GetTempFile("foo"));
+  EXPECT_TRUE(path1.find("foo") != std::string::npos);
+
+  // Should be able to set file contents at the given path.
+  // Note that the file may or may not exist, depending on the platform, and
+  // a file must be created at the path before calling GetTempFile again, or
+  // else the same path may be returned.
+  auto to_write = GetUniqueContents("GetTempFile");
+  ASSERT_OK(SetFileContents(path1, to_write));
+
+  // Create another temp file with the same base name, check for a unique path.
+  ASSERT_OK_AND_ASSIGN(std::string path2, GetTempFile("foo"));
+  EXPECT_TRUE(path2.find("foo") != std::string::npos);
+  EXPECT_NE(path1, path2);
+}
+
 }  // namespace
 }  // namespace file_io
 }  // namespace iree

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -43,6 +43,7 @@ cc_library(
     deps = [
         ":file_handle_win32",
         "//iree/base:file_io_hdrs",
+        "//iree/base:file_path",
         "//iree/base:platform_headers",
         "//iree/base:status",
         "//iree/base:target_platform",

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     absl::memory
     absl::strings
     iree::base::file_io_hdrs
+    iree::base::file_path
     iree::base::platform_headers
     iree::base::status
     iree::base::target_platform


### PR DESCRIPTION
* Platform and environment dependent temporary paths and files are useful for tests and runtime code that operates on files. I'm planning on using this for a "Dynamic Library" HAL backend ("dylib") at runtime, since functions like `dlopen` operate primarily with files on disk.
* If data already exists outside of a `std::string`, accepting `absl::string_view` avoids the need for a copy into a `std::string`.

**Note**: This will need changes as part of merging, which I'll work on directly (don't add `ready to pull`)