### PR TITLE
Remove trailing whitespace from actions

### DIFF
--- a/.github/workflows/bazel_build_bindings.yml
+++ b/.github/workflows/bazel_build_bindings.yml
@@ -52,7 +52,7 @@ jobs:
           # excluded with "noga".
           bazel query '//bindings/...' \
             | xargs bazel test \
-              --config=generic_clang \            
+              --config=generic_clang \
               --build_tag_filters="-noga" \
               --test_tag_filters="-noga,-driver=vulkan" \
               --test_env=IREE_VULKAN_DISABLE=1 \

--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -52,7 +52,7 @@ jobs:
           # excluded with "noga".
           bazel query '//... -//iree/... -//bindings/... -//integrations/...' \
             | xargs bazel test \
-              --config=generic_clang \            
+              --config=generic_clang \
               --build_tag_filters="-noga" \
               --test_tag_filters="-noga,-driver=vulkan" \
               --test_env=IREE_VULKAN_DISABLE=1 \

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -52,7 +52,7 @@ jobs:
           # excluded with "noga".
           bazel query '//integrations/...' \
             | xargs bazel test \
-              --config=generic_clang \            
+              --config=generic_clang \
               --build_tag_filters="-noga" \
               --test_tag_filters="-noga,-driver=vulkan" \
               --test_env=IREE_VULKAN_DISABLE=1 \

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -50,4 +50,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref }}
-          
+


### PR DESCRIPTION
This actually causes build failures because the escape escapes the whitespace instead of the newline and then.... weird stuff happens https://github.com/google/iree/actions/runs/118510392