### PR TITLE
Delete artifacts directory after kokoro build

### DIFF
--- a/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
@@ -34,3 +34,7 @@ docker run \
   --rm \
   gcr.io/iree-oss/bazel-tensorflow@sha256:ab6fcfad0b52e28ba2360596132a31f61f7b4bf12608660dfd6d7341981445b3 \
   kokoro/gcp_ubuntu/bazel/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless. 
+rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -33,3 +33,7 @@ docker run \
   --rm \
   gcr.io/iree-oss/cmake@sha256:256d8aa56d5b50659581ff85a381848b14bcddc0dd9c9962baa4efa70b358aab \
   kokoro/gcp_ubuntu/cmake/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless. 
+rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"


### PR DESCRIPTION
Kokoro will rsync this entire directory back to the executor orchestrating the build which takes forever and is totally useless.

Should shave 1-15 minutes off of build times (no idea why the time is so variable)