### PR TITLE
Update CI to use the :prod tag for docker images.

### DIFF
--- a/.github/workflows/bazel_build_fallthrough.yml
+++ b/.github/workflows/bazel_build_fallthrough.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow@sha256:ab6fcfad0b52e28ba2360596132a31f61f7b4bf12608660dfd6d7341981445b3
+    container: gcr.io/iree-oss/bazel-tensorflow:prod
     steps:
       - name: Printing environment
         run: |

--- a/.github/workflows/bazel_build_integrations.yml
+++ b/.github/workflows/bazel_build_integrations.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-18.04
-    container: gcr.io/iree-oss/bazel-tensorflow@sha256:ab6fcfad0b52e28ba2360596132a31f61f7b4bf12608660dfd6d7341981445b3
+    container: gcr.io/iree-oss/bazel-tensorflow:prod
     steps:
       - name: Printing environment
         run: |

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -21,18 +21,19 @@ set -e
 # Ensure correct authorization.
 gcloud auth configure-docker
 
+# Determine which image tag to update. Updates :latest by default.
+if [[ $* == --update-prod ]]; then
+  TAG="prod"
+else
+  TAG="latest"
+fi
+echo "Updating $TAG"
+
 # Build and push the bazel image.
-docker build --tag gcr.io/iree-oss/bazel build_tools/docker/bazel/
-docker push gcr.io/iree-oss/bazel
+docker build --tag gcr.io/iree-oss/bazel:$TAG build_tools/docker/bazel/
+docker push gcr.io/iree-oss/bazel:$TAG
 
 # Build and push the bazel-tensorflow image, which depends on
 # gcr.io/iree-oss/bazel
-docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
-docker push gcr.io/iree-oss/bazel-tensorflow
-
-echo '
-Remember to update all of the files using `bazel` and `bazel-tensorflow` images
-(e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
-to use the digests of the updated images.
-
-Use `docker images --digests` to view the digests.'
+docker build --tag gcr.io/iree-oss/bazel-tensorflow:$TAG build_tools/docker/bazel_tensorflow/
+docker push gcr.io/iree-oss/bazel-tensorflow:$TAG

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -22,12 +22,17 @@ set -e
 gcloud auth configure-docker
 
 # Determine which image tag to update. Updates :latest by default.
-if [[ $* == --update-prod ]]; then
-  TAG="prod"
-else
-  TAG="latest"
+TAG="latest"
+if [[ "$#" -ne 0  ]]; then
+  if [[ "$@" == "--update-prod" ]]; then
+    TAG="prod"
+  else
+    echo "Invalid commandline arguments. Accepts --update-prod or no arguments."
+    exit 1
+  fi
 fi
-echo "Updating $TAG"
+echo "Updating ${TAG}"
+
 
 # Build and push the bazel image.
 docker build --tag "gcr.io/iree-oss/bazel:${TAG}" build_tools/docker/bazel/

--- a/build_tools/docker/bazel/gcr_update.sh
+++ b/build_tools/docker/bazel/gcr_update.sh
@@ -30,10 +30,10 @@ fi
 echo "Updating $TAG"
 
 # Build and push the bazel image.
-docker build --tag gcr.io/iree-oss/bazel:$TAG build_tools/docker/bazel/
-docker push gcr.io/iree-oss/bazel:$TAG
+docker build --tag "gcr.io/iree-oss/bazel:${TAG}" build_tools/docker/bazel/
+docker push "gcr.io/iree-oss/bazel:${TAG}"
 
 # Build and push the bazel-tensorflow image, which depends on
 # gcr.io/iree-oss/bazel
-docker build --tag gcr.io/iree-oss/bazel-tensorflow:$TAG build_tools/docker/bazel_tensorflow/
-docker push gcr.io/iree-oss/bazel-tensorflow:$TAG
+docker build --tag "gcr.io/iree-oss/bazel-tensorflow:${TAG}" build_tools/docker/bazel_tensorflow/
+docker push "gcr.io/iree-oss/bazel-tensorflow:${TAG}"

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -30,5 +30,5 @@ fi
 echo "Updating $TAG"
 
 # Build and push the bazel-tensorflow image.
-docker build --tag gcr.io/iree-oss/bazel-tensorflow:$TAG build_tools/docker/bazel_tensorflow/
-docker push gcr.io/iree-oss/bazel-tensorflow:$TAG
+docker build --tag "gcr.io/iree-oss/bazel-tensorflow:${TAG}" build_tools/docker/bazel_tensorflow/
+docker push "gcr.io/iree-oss/bazel-tensorflow:${TAG}"

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -22,7 +22,7 @@ set -e
 gcloud auth configure-docker
 
 # Determine which image tag to update. Updates :latest by default.
-if [[ $* == *--update-prod ]]; then
+if [[ $* == --update-prod ]]; then
   TAG="prod"
 else
   TAG="latest"

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -22,12 +22,17 @@ set -e
 gcloud auth configure-docker
 
 # Determine which image tag to update. Updates :latest by default.
-if [[ $* == --update-prod ]]; then
-  TAG="prod"
-else
-  TAG="latest"
+TAG="latest"
+if [[ "$#" -ne 0  ]]; then
+  if [[ "$@" == "--update-prod" ]]; then
+    TAG="prod"
+  else
+    echo "Invalid commandline arguments. Accepts --update-prod or no arguments."
+    exit 1
+  fi
 fi
-echo "Updating $TAG"
+echo "Updating ${TAG}"
+
 
 # Build and push the bazel-tensorflow image.
 docker build --tag "gcr.io/iree-oss/bazel-tensorflow:${TAG}" build_tools/docker/bazel_tensorflow/

--- a/build_tools/docker/bazel_tensorflow/gcr_update.sh
+++ b/build_tools/docker/bazel_tensorflow/gcr_update.sh
@@ -21,13 +21,14 @@ set -e
 # Ensure correct authorization.
 gcloud auth configure-docker
 
+# Determine which image tag to update. Updates :latest by default.
+if [[ $* == *--update-prod ]]; then
+  TAG="prod"
+else
+  TAG="latest"
+fi
+echo "Updating $TAG"
+
 # Build and push the bazel-tensorflow image.
-docker build --tag gcr.io/iree-oss/bazel-tensorflow build_tools/docker/bazel_tensorflow/
-docker push gcr.io/iree-oss/bazel-tensorflow
-
-echo '
-Remember to update all of the files using the `bazel-tensorflow` image
-(e.g. .github/workflows/bazel_* and /kokoro/gcp_ubuntu/bazel/build_kokoro.sh)
-to use the digest of the updated image.
-
-Use `docker images --digests` to view the digest.'
+docker build --tag gcr.io/iree-oss/bazel-tensorflow:$TAG build_tools/docker/bazel_tensorflow/
+docker push gcr.io/iree-oss/bazel-tensorflow:$TAG

--- a/build_tools/docker/cmake/gcr_update.sh
+++ b/build_tools/docker/cmake/gcr_update.sh
@@ -21,13 +21,14 @@ set -e
 # Ensure correct authorization.
 gcloud auth configure-docker
 
+# Determine which image tag to update. Updates :latest by default.
+if [[ $* == --update-prod ]]; then
+  TAG="prod"
+else
+  TAG="latest"
+fi
+echo "Updating $TAG"
+
 # Build and push the cmake image.
-docker build --tag gcr.io/iree-oss/cmake build_tools/docker/cmake/
-docker push gcr.io/iree-oss/cmake
-
-echo '
-Remember to update all of the files using the `cmake` image (e.g.
-/kokoro/gcp_ubuntu/cmake/build_kokoro.sh) to use the digest of the updated
-image.
-
-Use `docker images --digests` to view the digest.'
+docker build --tag gcr.io/iree-oss/cmake:$TAG build_tools/docker/cmake/
+docker push gcr.io/iree-oss/cmake:$TAG

--- a/build_tools/docker/cmake/gcr_update.sh
+++ b/build_tools/docker/cmake/gcr_update.sh
@@ -22,12 +22,17 @@ set -e
 gcloud auth configure-docker
 
 # Determine which image tag to update. Updates :latest by default.
-if [[ $* == --update-prod ]]; then
-  TAG="prod"
-else
-  TAG="latest"
+TAG="latest"
+if [[ "$#" -ne 0  ]]; then
+  if [[ "$@" == "--update-prod" ]]; then
+    TAG="prod"
+  else
+    echo "Invalid commandline arguments. Accepts --update-prod or no arguments."
+    exit 1
+  fi
 fi
-echo "Updating $TAG"
+echo "Updating ${TAG}"
+
 
 # Build and push the cmake image.
 docker build --tag "gcr.io/iree-oss/cmake:${TAG}" build_tools/docker/cmake/

--- a/build_tools/docker/cmake/gcr_update.sh
+++ b/build_tools/docker/cmake/gcr_update.sh
@@ -30,5 +30,5 @@ fi
 echo "Updating $TAG"
 
 # Build and push the cmake image.
-docker build --tag gcr.io/iree-oss/cmake:$TAG build_tools/docker/cmake/
-docker push gcr.io/iree-oss/cmake:$TAG
+docker build --tag "gcr.io/iree-oss/cmake:${TAG}" build_tools/docker/cmake/
+docker push "gcr.io/iree-oss/cmake:${TAG}"

--- a/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/build_kokoro.sh
@@ -32,5 +32,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/bazel-tensorflow@sha256:ab6fcfad0b52e28ba2360596132a31f61f7b4bf12608660dfd6d7341981445b3 \
+  gcr.io/iree-oss/bazel-tensorflow:prod \
   kokoro/gcp_ubuntu/bazel/build.sh

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -31,5 +31,5 @@ docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/cmake@sha256:256d8aa56d5b50659581ff85a381848b14bcddc0dd9c9962baa4efa70b358aab \
+  gcr.io/iree-oss/cmake:prod \
   kokoro/gcp_ubuntu/cmake/build.sh


### PR DESCRIPTION
Moves from using `sha256`s for our docker versioning to using a `:prod` tag. 
Requires a `--update-prod` flag to be passed to the `gcr_update.sh` scripts for these images to be updated.