### PR TITLE
[cmake] Be explicit regarding C/C++ standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 #-------------------------------------------------------------------------------
 
 project(iree CXX C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -18,7 +18,7 @@ include(AbseilConfigureCopts)
 # C++ used within IREE
 #-------------------------------------------------------------------------------
 
-set(IREE_CXX_STANDARD 14)
+set(IREE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 
 set(IREE_ROOT_DIR ${PROJECT_SOURCE_DIR})
 list(APPEND IREE_COMMON_INCLUDE_DIRS


### PR DESCRIPTION
This avoids the "No CMAKE_CXX_STANDARD set, assuming 11" message
during CMake configuration.