### PR TITLE
[cmake] NFC: Perform early exit where possible

### DIFF
--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -85,7 +85,6 @@ function(external_cc_library)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -85,106 +85,109 @@ function(external_cc_library)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name.
-    string(REPLACE "::" "_" _PACKAGE_NAME ${_RULE_PACKAGE})
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
+  endif()
 
-    # Prefix paths with the root.
-    list(TRANSFORM _RULE_HDRS PREPEND ${_RULE_ROOT})
-    list(TRANSFORM _RULE_SRCS PREPEND ${_RULE_ROOT})
+  # Prefix the library with the package name.
+  string(REPLACE "::" "_" _PACKAGE_NAME ${_RULE_PACKAGE})
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
-    # Check if this is a header-only library.
-    # Note that as of February 2019, many popular OS's (for example, Ubuntu
-    # 16.04 LTS) only come with cmake 3.5 by default.  For this reason, we can't
-    # use list(FILTER...)
-    set(_CC_SRCS "${_RULE_SRCS}")
-    foreach(src_file IN LISTS _CC_SRCS)
-      if(${src_file} MATCHES ".*\\.(h|inc)")
-        list(REMOVE_ITEM _CC_SRCS "${src_file}")
-      endif()
-    endforeach()
-    if("${_CC_SRCS}" STREQUAL "")
-      set(_RULE_IS_INTERFACE 1)
+  # Prefix paths with the root.
+  list(TRANSFORM _RULE_HDRS PREPEND ${_RULE_ROOT})
+  list(TRANSFORM _RULE_SRCS PREPEND ${_RULE_ROOT})
+
+  # Check if this is a header-only library.
+  # Note that as of February 2019, many popular OS's (for example, Ubuntu
+  # 16.04 LTS) only come with cmake 3.5 by default.  For this reason, we can't
+  # use list(FILTER...)
+  set(_CC_SRCS "${_RULE_SRCS}")
+  foreach(src_file IN LISTS _CC_SRCS)
+    if(${src_file} MATCHES ".*\\.(h|inc)")
+      list(REMOVE_ITEM _CC_SRCS "${src_file}")
+    endif()
+  endforeach()
+  if("${_CC_SRCS}" STREQUAL "")
+    set(_RULE_IS_INTERFACE 1)
+  else()
+    set(_RULE_IS_INTERFACE 0)
+  endif()
+
+  if(NOT _RULE_IS_INTERFACE)
+    add_library(${_NAME} STATIC "")
+    target_sources(${_NAME}
+      PRIVATE
+        ${_RULE_SRCS}
+        ${_RULE_HDRS}
+    )
+    target_include_directories(${_NAME}
+      PUBLIC
+        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+        "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+    )
+    target_compile_options(${_NAME}
+      PRIVATE
+        ${_RULE_COPTS}
+        ${IREE_DEFAULT_COPTS}
+    )
+    target_link_libraries(${_NAME}
+      PUBLIC
+        ${_RULE_DEPS}
+      PRIVATE
+        ${_RULE_LINKOPTS}
+        ${IREE_DEFAULT_LINKOPTS}
+    )
+    target_compile_definitions(${_NAME}
+      PUBLIC
+        ${_RULE_DEFINES}
+    )
+    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+
+    if(DEFINED _RULE_ALWAYSLINK)
+      set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
+    endif()
+
+    # Add all external targets to a a folder in the IDE for organization.
+    if(_RULE_PUBLIC)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER third_party)
+    elseif(_RULE_TESTONLY)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER third_party/test)
     else()
-      set(_RULE_IS_INTERFACE 0)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER third_party/internal)
     endif()
 
-    if(NOT _RULE_IS_INTERFACE)
-      add_library(${_NAME} STATIC "")
-      target_sources(${_NAME}
-        PRIVATE
-          ${_RULE_SRCS}
-          ${_RULE_HDRS}
-      )
-      target_include_directories(${_NAME}
-        PUBLIC
-          "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-          "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
-      )
-      target_compile_options(${_NAME}
-        PRIVATE
-          ${_RULE_COPTS}
-          ${IREE_DEFAULT_COPTS}
-      )
-      target_link_libraries(${_NAME}
-        PUBLIC
-          ${_RULE_DEPS}
-        PRIVATE
-          ${_RULE_LINKOPTS}
-          ${IREE_DEFAULT_LINKOPTS}
-      )
-      target_compile_definitions(${_NAME}
-        PUBLIC
-          ${_RULE_DEFINES}
-      )
-      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+    # INTERFACE libraries can't have the CXX_STANDARD property set
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+  else()
+    # Generating header-only library
+    add_library(${_NAME} INTERFACE)
+    target_include_directories(${_NAME}
+      INTERFACE
+        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+        "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+    )
+    target_compile_options(${_NAME}
+      INTERFACE
+        ${_RULE_COPTS}
+        ${IREE_DEFAULT_COPTS}
+    )
+    target_link_libraries(${_NAME}
+      INTERFACE
+        ${_RULE_DEPS}
+        ${_RULE_LINKOPTS}
+        ${IREE_DEFAULT_LINKOPTS}
+    )
+    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+    target_compile_definitions(${_NAME}
+      INTERFACE
+        ${_RULE_DEFINES}
+    )
+  endif()
 
-      if(DEFINED _RULE_ALWAYSLINK)
-        set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
-      endif()
-
-      # Add all external targets to a a folder in the IDE for organization.
-      if(_RULE_PUBLIC)
-        set_property(TARGET ${_NAME} PROPERTY FOLDER third_party)
-      elseif(_RULE_TESTONLY)
-        set_property(TARGET ${_NAME} PROPERTY FOLDER third_party/test)
-      else()
-        set_property(TARGET ${_NAME} PROPERTY FOLDER third_party/internal)
-      endif()
-
-      # INTERFACE libraries can't have the CXX_STANDARD property set
-      set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
-      set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
-    else()
-      # Generating header-only library
-      add_library(${_NAME} INTERFACE)
-      target_include_directories(${_NAME}
-        INTERFACE
-          "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-          "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
-      )
-      target_compile_options(${_NAME}
-        INTERFACE
-          ${_RULE_COPTS}
-          ${IREE_DEFAULT_COPTS}
-      )
-      target_link_libraries(${_NAME}
-        INTERFACE
-          ${_RULE_DEPS}
-          ${_RULE_LINKOPTS}
-          ${IREE_DEFAULT_LINKOPTS}
-      )
-      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
-      target_compile_definitions(${_NAME}
-        INTERFACE
-          ${_RULE_DEFINES}
-      )
-    endif()
-
-    add_library(${_RULE_PACKAGE}::${_RULE_NAME} ALIAS ${_NAME})
-    if(${_RULE_PACKAGE} STREQUAL ${_RULE_NAME})
-      add_library(${_RULE_PACKAGE} ALIAS ${_NAME})
-    endif()
+  add_library(${_RULE_PACKAGE}::${_RULE_NAME} ALIAS ${_NAME})
+  if(${_RULE_PACKAGE} STREQUAL ${_RULE_NAME})
+    add_library(${_RULE_PACKAGE} ALIAS ${_NAME})
   endif()
 endfunction()

--- a/build_tools/cmake/external_tablegen_library.cmake
+++ b/build_tools/cmake/external_tablegen_library.cmake
@@ -26,33 +26,36 @@ function(external_tablegen_library)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name.
-    string(REPLACE "::" "_" _PACKAGE_NAME ${_RULE_PACKAGE})
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
-
-    # Prefix source paths with the root.
-    list(TRANSFORM _RULE_SRCS PREPEND ${_RULE_ROOT})
-
-    set(LLVM_TARGET_DEFINITIONS ${_RULE_SRCS})
-    set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
-    list(APPEND _INCLUDE_DIRS ${_RULE_ROOT})
-    list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
-    set(_OUTPUTS)
-    while(_RULE_OUTS)
-      list(GET _RULE_OUTS 0 _COMMAND)
-      list(REMOVE_AT _RULE_OUTS 0)
-      list(GET _RULE_OUTS 0 _FILE)
-      list(REMOVE_AT _RULE_OUTS 0)
-      tablegen(${_RULE_TBLGEN} ${_FILE} ${_COMMAND} ${_INCLUDE_DIRS})
-      list(APPEND _OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${_FILE})
-    endwhile()
-    add_custom_target(${_NAME}_target DEPENDS ${_OUTPUTS})
-    set_target_properties(${_NAME}_target PROPERTIES FOLDER "Tablegenning")
-
-    add_library(${_NAME} INTERFACE)
-    add_dependencies(${_NAME} ${_NAME}_target)
-
-    add_library(${_RULE_PACKAGE}::${_RULE_NAME} ALIAS ${_NAME})
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
   endif()
+
+  # Prefix the library with the package name.
+  string(REPLACE "::" "_" _PACKAGE_NAME ${_RULE_PACKAGE})
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  # Prefix source paths with the root.
+  list(TRANSFORM _RULE_SRCS PREPEND ${_RULE_ROOT})
+
+  set(LLVM_TARGET_DEFINITIONS ${_RULE_SRCS})
+  set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
+  list(APPEND _INCLUDE_DIRS ${_RULE_ROOT})
+  list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
+  set(_OUTPUTS)
+  while(_RULE_OUTS)
+    list(GET _RULE_OUTS 0 _COMMAND)
+    list(REMOVE_AT _RULE_OUTS 0)
+    list(GET _RULE_OUTS 0 _FILE)
+    list(REMOVE_AT _RULE_OUTS 0)
+    tablegen(${_RULE_TBLGEN} ${_FILE} ${_COMMAND} ${_INCLUDE_DIRS})
+    list(APPEND _OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${_FILE})
+  endwhile()
+  add_custom_target(${_NAME}_target DEPENDS ${_OUTPUTS})
+  set_target_properties(${_NAME}_target PROPERTIES FOLDER "Tablegenning")
+
+  add_library(${_NAME} INTERFACE)
+  add_dependencies(${_NAME} ${_NAME}_target)
+
+  add_library(${_RULE_PACKAGE}::${_RULE_NAME} ALIAS ${_NAME})
 endfunction()

--- a/build_tools/cmake/external_tablegen_library.cmake
+++ b/build_tools/cmake/external_tablegen_library.cmake
@@ -26,7 +26,6 @@ function(external_tablegen_library)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/flatbuffer_cc_library.cmake
+++ b/build_tools/cmake/flatbuffer_cc_library.cmake
@@ -71,59 +71,62 @@ function(flatbuffer_cc_library)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name, so we get: iree_package_name
-    iree_package_name(_PACKAGE_NAME)
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
-
-    if(NOT DEFINED _RULE_FLATC_ARGS)
-      set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS
-        # Preserve root-relative include paths in generated code.
-        "--keep-prefix"
-        # Use C++11 'enum class' for enums.
-        "--scoped-enums"
-        # Include reflection tables used for dumping debug representations.
-        "--reflect-names"
-        # Generate FooT types for unpack/pack support. Note that this should only
-        # be used in tooling as the code size/runtime overhead is non-trivial.
-        "--gen-object-api"
-      )
-    else()
-      set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS ${_RULE_FLATC_ARGS})
-    endif()
-
-    build_flatbuffers(
-      "${_RULE_SRCS}"
-      "${IREE_ROOT_DIR}"
-      "${_NAME}_gen"  # custom_target_name
-      "${_RULE_DEPS}" # additional_dependencies
-      "${CMAKE_CURRENT_BINARY_DIR}" # generated_include_dir
-      "${CMAKE_CURRENT_BINARY_DIR}" # binary_schemas_dir
-      "" # copy_text_schemas_dir
-    )
-
-    add_library(${_NAME} INTERFACE)
-    add_dependencies(${_NAME} ${_NAME}_gen)
-    target_include_directories(${_NAME}
-      INTERFACE
-        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-        ${CMAKE_CURRENT_BINARY_DIR}
-      )
-    target_link_libraries(${_NAME}
-      INTERFACE
-        flatbuffers
-        ${_RULE_LINKOPTS}
-        ${IREE_DEFAULT_LINKOPTS}
-    )
-    target_compile_definitions(${_NAME}
-      INTERFACE
-        ${_RULE_DEFINES}
-    )
-
-    # Alias the iree_package_name library to iree::package::name.
-    # This lets us more clearly map to Bazel and makes it possible to
-    # disambiguate the underscores in paths vs. the separators.
-    iree_package_ns(_PACKAGE_NS)
-    add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
   endif()
+
+  # Prefix the library with the package name, so we get: iree_package_name
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  if(NOT DEFINED _RULE_FLATC_ARGS)
+    set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS
+      # Preserve root-relative include paths in generated code.
+      "--keep-prefix"
+      # Use C++11 'enum class' for enums.
+      "--scoped-enums"
+      # Include reflection tables used for dumping debug representations.
+      "--reflect-names"
+      # Generate FooT types for unpack/pack support. Note that this should only
+      # be used in tooling as the code size/runtime overhead is non-trivial.
+      "--gen-object-api"
+    )
+  else()
+    set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS ${_RULE_FLATC_ARGS})
+  endif()
+
+  build_flatbuffers(
+    "${_RULE_SRCS}"
+    "${IREE_ROOT_DIR}"
+    "${_NAME}_gen"  # custom_target_name
+    "${_RULE_DEPS}" # additional_dependencies
+    "${CMAKE_CURRENT_BINARY_DIR}" # generated_include_dir
+    "${CMAKE_CURRENT_BINARY_DIR}" # binary_schemas_dir
+    "" # copy_text_schemas_dir
+  )
+
+  add_library(${_NAME} INTERFACE)
+  add_dependencies(${_NAME} ${_NAME}_gen)
+  target_include_directories(${_NAME}
+    INTERFACE
+      "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+      ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  target_link_libraries(${_NAME}
+    INTERFACE
+      flatbuffers
+      ${_RULE_LINKOPTS}
+      ${IREE_DEFAULT_LINKOPTS}
+  )
+  target_compile_definitions(${_NAME}
+    INTERFACE
+      ${_RULE_DEFINES}
+  )
+
+  # Alias the iree_package_name library to iree::package::name.
+  # This lets us more clearly map to Bazel and makes it possible to
+  # disambiguate the underscores in paths vs. the separators.
+  iree_package_ns(_PACKAGE_NS)
+  add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
 endfunction()

--- a/build_tools/cmake/flatbuffer_cc_library.cmake
+++ b/build_tools/cmake/flatbuffer_cc_library.cmake
@@ -71,7 +71,6 @@ function(flatbuffer_cc_library)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -43,7 +43,6 @@ function(iree_bytecode_module)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -43,58 +43,61 @@ function(iree_bytecode_module)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Set defaults for FLAGS and TRANSLATE_TOOL
-    if(DEFINED _RULE_FLAGS)
-      set(_FLAGS ${_RULE_FLAGS})
-    else()
-      set(_FLAGS "-iree-mlir-to-vm-bytecode-module")
-    endif()
-    if(DEFINED _RULE_TRANSLATE_TOOL)
-      set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
-    else()
-      set(_TRANSLATE_TOOL "iree_tools_iree-translate")
-    endif()
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
+  endif()
 
-    # Resolve the executable binary path from the target name.
-    set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:${_TRANSLATE_TOOL}>)
+  # Set defaults for FLAGS and TRANSLATE_TOOL
+  if(DEFINED _RULE_FLAGS)
+    set(_FLAGS ${_RULE_FLAGS})
+  else()
+    set(_FLAGS "-iree-mlir-to-vm-bytecode-module")
+  endif()
+  if(DEFINED _RULE_TRANSLATE_TOOL)
+    set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
+  else()
+    set(_TRANSLATE_TOOL "iree_tools_iree-translate")
+  endif()
 
-    set(_ARGS "${_FLAGS}")
-    list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
-    list(APPEND _ARGS "-o")
-    list(APPEND _ARGS "${_RULE_NAME}.module")
+  # Resolve the executable binary path from the target name.
+  set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:${_TRANSLATE_TOOL}>)
 
-    add_custom_command(
-      OUTPUT "${_RULE_NAME}.module"
-      COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_ARGS}
-      DEPENDS ${_TRANSLATE_TOOL}
+  set(_ARGS "${_FLAGS}")
+  list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
+  list(APPEND _ARGS "-o")
+  list(APPEND _ARGS "${_RULE_NAME}.module")
+
+  add_custom_command(
+    OUTPUT "${_RULE_NAME}.module"
+    COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_ARGS}
+    DEPENDS ${_TRANSLATE_TOOL}
+  )
+
+  if(_RULE_TESTONLY)
+    set(_TESTONLY_ARG "TESTONLY")
+  endif()
+  if(_RULE_PUBLIC)
+    set(_PUBLIC_ARG "PUBLIC")
+  endif()
+
+  if(DEFINED _RULE_CC_NAMESPACE)
+    iree_cc_embed_data(
+      NAME
+        "${_RULE_NAME}_cc"
+      IDENTIFIER
+        "${_RULE_NAME}"
+      GENERATED_SRCS
+        "${_RULE_NAME}.module"
+      CC_FILE_OUTPUT
+        "${_RULE_NAME}.cc"
+      H_FILE_OUTPUT
+        "${_RULE_NAME}.h"
+      CPP_NAMESPACE
+        "${_RULE_CC_NAMESPACE}"
+      FLATTEN
+      "${_PUBLIC_ARG}"
+      "${_TESTONLY_ARG}"
     )
-
-    if(_RULE_TESTONLY)
-      set(_TESTONLY_ARG "TESTONLY")
-    endif()
-    if(_RULE_PUBLIC)
-      set(_PUBLIC_ARG "PUBLIC")
-    endif()
-
-    if(DEFINED _RULE_CC_NAMESPACE)
-      iree_cc_embed_data(
-        NAME
-          "${_RULE_NAME}_cc"
-        IDENTIFIER
-          "${_RULE_NAME}"
-        GENERATED_SRCS
-          "${_RULE_NAME}.module"
-        CC_FILE_OUTPUT
-          "${_RULE_NAME}.cc"
-        H_FILE_OUTPUT
-          "${_RULE_NAME}.h"
-        CPP_NAMESPACE
-          "${_RULE_CC_NAMESPACE}"
-        FLATTEN
-        "${_PUBLIC_ARG}"
-        "${_TESTONLY_ARG}"
-      )
-    endif()
   endif()
 endfunction()

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -64,66 +64,69 @@ function(iree_cc_binary)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name, so we get: iree_package_name
-    iree_package_name(_PACKAGE_NAME)
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
-
-    add_executable(${_NAME} "")
-    add_executable(${_RULE_NAME} ALIAS ${_NAME})
-    if(_RULE_SRCS)
-      target_sources(${_NAME}
-        PRIVATE
-          ${_RULE_SRCS}
-      )
-    else()
-      set(_DUMMY_SRC "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}_dummy.cc")
-      file(WRITE ${_DUMMY_SRC} "")
-      target_sources(${_NAME}
-        PRIVATE
-          ${_DUMMY_SRC}
-      )
-    endif()
-    if(_RULE_OUT)
-      set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_OUT}")
-    else()
-      set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
-    endif()
-    target_include_directories(${_NAME}
-      PUBLIC
-        ${IREE_COMMON_INCLUDE_DIRS}
-    )
-    target_compile_definitions(${_NAME}
-      PUBLIC
-        ${_RULE_DEFINES}
-    )
-    target_compile_options(${_NAME}
-      PRIVATE
-        ${_RULE_COPTS}
-    )
-    target_link_options(${_NAME}
-      PRIVATE
-        ${_RULE_LINKOPTS}
-    )
-    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
-
-    iree_package_ns(_PACKAGE_NS)
-    # Replace dependencies passed by ::name with ::iree::package::name
-    list(TRANSFORM _RULE_DATA REPLACE "^::" "${_PACKAGE_NS}::")
-    list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
-
-    # Add all IREE targets to a folder in the IDE for organization.
-    set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/binaries)
-
-    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
-    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
-
-    # Defer computing transitive dependencies and calling target_link_libraries()
-    # until all libraries have been declared.
-    # Track target and deps, use in iree_complete_binary_link_options() later.
-    set_property(GLOBAL APPEND PROPERTY _IREE_CC_BINARY_NAMES "${_NAME}")
-    set_property(TARGET ${_NAME} PROPERTY DIRECT_DEPS ${_RULE_DEPS})
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
   endif()
+
+  # Prefix the library with the package name, so we get: iree_package_name
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  add_executable(${_NAME} "")
+  add_executable(${_RULE_NAME} ALIAS ${_NAME})
+  if(_RULE_SRCS)
+    target_sources(${_NAME}
+      PRIVATE
+        ${_RULE_SRCS}
+    )
+  else()
+    set(_DUMMY_SRC "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}_dummy.cc")
+    file(WRITE ${_DUMMY_SRC} "")
+    target_sources(${_NAME}
+      PRIVATE
+        ${_DUMMY_SRC}
+    )
+  endif()
+  if(_RULE_OUT)
+    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_OUT}")
+  else()
+    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
+  endif()
+  target_include_directories(${_NAME}
+    PUBLIC
+      ${IREE_COMMON_INCLUDE_DIRS}
+  )
+  target_compile_definitions(${_NAME}
+    PUBLIC
+      ${_RULE_DEFINES}
+  )
+  target_compile_options(${_NAME}
+    PRIVATE
+      ${_RULE_COPTS}
+  )
+  target_link_options(${_NAME}
+    PRIVATE
+      ${_RULE_LINKOPTS}
+  )
+  iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+
+  iree_package_ns(_PACKAGE_NS)
+  # Replace dependencies passed by ::name with ::iree::package::name
+  list(TRANSFORM _RULE_DATA REPLACE "^::" "${_PACKAGE_NS}::")
+  list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+
+  # Add all IREE targets to a folder in the IDE for organization.
+  set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/binaries)
+
+  set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
+  set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+
+  # Defer computing transitive dependencies and calling target_link_libraries()
+  # until all libraries have been declared.
+  # Track target and deps, use in iree_complete_binary_link_options() later.
+  set_property(GLOBAL APPEND PROPERTY _IREE_CC_BINARY_NAMES "${_NAME}")
+  set_property(TARGET ${_NAME} PROPERTY DIRECT_DEPS ${_RULE_DEPS})
 endfunction()
 
 # Lists all transitive dependencies of DIRECT_DEPS in TRANSITIVE_DEPS.

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -64,7 +64,6 @@ function(iree_cc_binary)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/iree_cc_embed_data.cmake
+++ b/build_tools/cmake/iree_cc_embed_data.cmake
@@ -48,53 +48,56 @@ function(iree_cc_embed_data)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    if(DEFINED _RULE_IDENTIFIER)
-      set(_IDENTIFIER ${_RULE_IDENTIFIER})
-    else()
-      set(_IDENTIFIER ${_RULE_NAME})
-    endif()
-
-    set(_ARGS)
-    list(APPEND _ARGS "--output_header=${_RULE_H_FILE_OUTPUT}")
-    list(APPEND _ARGS "--output_impl=${_RULE_CC_FILE_OUTPUT}")
-    list(APPEND _ARGS "--identifier=${_IDENTIFIER}")
-    if(DEFINED _RULE_CPP_NAMESPACE)
-      list(APPEND _ARGS "--cpp_namespace=${_RULE_CPP_NAMESPACE}")
-    endif()
-    if(DEFINED _RULE_STRIP_PREFIX})
-      list(APPEND _ARGS "--strip_prefix=${_RULE_STRIP_PREFIX}")
-    endif()
-    if(DEFINED _RULE_FLATTEN})
-      list(APPEND _ARGS "--flatten")
-    endif()
-
-    foreach(SRC ${_RULE_SRCS})
-      list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${SRC}")
-    endforeach(SRC)
-    foreach(SRC ${_RULE_GENERATED_SRCS})
-      list(APPEND _ARGS "${SRC}")
-    endforeach(SRC)
-
-    add_custom_command(
-      OUTPUT "${_RULE_H_FILE_OUTPUT}" "${_RULE_CC_FILE_OUTPUT}"
-      COMMAND generate_cc_embed_data ${_ARGS}
-      DEPENDS generate_cc_embed_data ${_RULE_SRCS} ${_RULE_GENERATED_SRCS}
-    )
-
-    if(_RULE_TESTONLY)
-      set(_TESTONLY_ARG "TESTONLY")
-    endif()
-    if(_RULE_PUBLIC)
-      set(_PUBLIC_ARG "PUBLIC")
-    endif()
-
-    iree_cc_library(
-      NAME ${_RULE_NAME}
-      HDRS "${_RULE_H_FILE_OUTPUT}"
-      SRCS "${_RULE_CC_FILE_OUTPUT}"
-      "${_PUBLIC_ARG}"
-      "${_TESTONLY_ARG}"
-    )
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
   endif()
+
+  if(DEFINED _RULE_IDENTIFIER)
+    set(_IDENTIFIER ${_RULE_IDENTIFIER})
+  else()
+    set(_IDENTIFIER ${_RULE_NAME})
+  endif()
+
+  set(_ARGS)
+  list(APPEND _ARGS "--output_header=${_RULE_H_FILE_OUTPUT}")
+  list(APPEND _ARGS "--output_impl=${_RULE_CC_FILE_OUTPUT}")
+  list(APPEND _ARGS "--identifier=${_IDENTIFIER}")
+  if(DEFINED _RULE_CPP_NAMESPACE)
+    list(APPEND _ARGS "--cpp_namespace=${_RULE_CPP_NAMESPACE}")
+  endif()
+  if(DEFINED _RULE_STRIP_PREFIX})
+    list(APPEND _ARGS "--strip_prefix=${_RULE_STRIP_PREFIX}")
+  endif()
+  if(DEFINED _RULE_FLATTEN})
+    list(APPEND _ARGS "--flatten")
+  endif()
+
+  foreach(SRC ${_RULE_SRCS})
+    list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${SRC}")
+  endforeach(SRC)
+  foreach(SRC ${_RULE_GENERATED_SRCS})
+    list(APPEND _ARGS "${SRC}")
+  endforeach(SRC)
+
+  add_custom_command(
+    OUTPUT "${_RULE_H_FILE_OUTPUT}" "${_RULE_CC_FILE_OUTPUT}"
+    COMMAND generate_cc_embed_data ${_ARGS}
+    DEPENDS generate_cc_embed_data ${_RULE_SRCS} ${_RULE_GENERATED_SRCS}
+  )
+
+  if(_RULE_TESTONLY)
+    set(_TESTONLY_ARG "TESTONLY")
+  endif()
+  if(_RULE_PUBLIC)
+    set(_PUBLIC_ARG "PUBLIC")
+  endif()
+
+  iree_cc_library(
+    NAME ${_RULE_NAME}
+    HDRS "${_RULE_H_FILE_OUTPUT}"
+    SRCS "${_RULE_CC_FILE_OUTPUT}"
+    "${_PUBLIC_ARG}"
+    "${_TESTONLY_ARG}"
+  )
 endfunction()

--- a/build_tools/cmake/iree_cc_embed_data.cmake
+++ b/build_tools/cmake/iree_cc_embed_data.cmake
@@ -48,7 +48,6 @@ function(iree_cc_embed_data)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -73,114 +73,117 @@ function(iree_cc_library)
     ${ARGN}
   )
 
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
   iree_package_ns(_PACKAGE_NS)
   # Replace dependencies passed by ::name with ::iree::package::name
   list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
   list(TRANSFORM _RULE_DATA REPLACE "^::" "${_PACKAGE_NS}::")
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name, so we get: iree_package_name.
-    iree_package_name(_PACKAGE_NAME)
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+  # Prefix the library with the package name, so we get: iree_package_name.
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
-    # Check if this is a header-only library.
-    # Note that as of February 2019, many popular OS's (for example, Ubuntu
-    # 16.04 LTS) only come with cmake 3.5 by default.  For this reason, we can't
-    # use list(FILTER...)
-    set(_CC_SRCS "${_RULE_SRCS}")
-    foreach(src_file IN LISTS _CC_SRCS)
-      if(${src_file} MATCHES ".*\\.(h|inc)")
-        list(REMOVE_ITEM _CC_SRCS "${src_file}")
-      endif()
-    endforeach()
-    if("${_CC_SRCS}" STREQUAL "")
-      set(_RULE_IS_INTERFACE 1)
+  # Check if this is a header-only library.
+  # Note that as of February 2019, many popular OS's (for example, Ubuntu
+  # 16.04 LTS) only come with cmake 3.5 by default.  For this reason, we can't
+  # use list(FILTER...)
+  set(_CC_SRCS "${_RULE_SRCS}")
+  foreach(src_file IN LISTS _CC_SRCS)
+    if(${src_file} MATCHES ".*\\.(h|inc)")
+      list(REMOVE_ITEM _CC_SRCS "${src_file}")
+    endif()
+  endforeach()
+  if("${_CC_SRCS}" STREQUAL "")
+    set(_RULE_IS_INTERFACE 1)
+  else()
+    set(_RULE_IS_INTERFACE 0)
+  endif()
+
+  if(NOT _RULE_IS_INTERFACE)
+    add_library(${_NAME} STATIC "")
+    target_sources(${_NAME}
+      PRIVATE
+        ${_RULE_SRCS}
+        ${_RULE_TEXTUAL_HDRS}
+        ${_RULE_HDRS}
+    )
+    target_include_directories(${_NAME}
+      PUBLIC
+        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+        "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
+    )
+    target_compile_options(${_NAME}
+      PRIVATE
+        ${_RULE_COPTS}
+        ${IREE_DEFAULT_COPTS}
+    )
+
+    target_link_libraries(${_NAME}
+      PUBLIC
+        ${_RULE_DEPS}
+      PRIVATE
+        ${_RULE_LINKOPTS}
+        ${IREE_DEFAULT_LINKOPTS}
+    )
+    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+    target_compile_definitions(${_NAME}
+      PUBLIC
+        ${_RULE_DEFINES}
+    )
+
+    if(DEFINED _RULE_ALWAYSLINK)
+      set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
+    endif()
+
+    # Add all IREE targets to a folder in the IDE for organization.
+    if(_RULE_PUBLIC)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER})
+    elseif(_RULE_TESTONLY)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
     else()
-      set(_RULE_IS_INTERFACE 0)
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/internal)
     endif()
 
-    if(NOT _RULE_IS_INTERFACE)
-      add_library(${_NAME} STATIC "")
-      target_sources(${_NAME}
-        PRIVATE
-          ${_RULE_SRCS}
-          ${_RULE_TEXTUAL_HDRS}
-          ${_RULE_HDRS}
-      )
-      target_include_directories(${_NAME}
-        PUBLIC
-          "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-          "$<BUILD_INTERFACE:${_RULE_INCLUDES}>"
-      )
-      target_compile_options(${_NAME}
-        PRIVATE
-          ${_RULE_COPTS}
-          ${IREE_DEFAULT_COPTS}
-      )
+    # INTERFACE libraries can't have the CXX_STANDARD property set.
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
+    set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+  else()
+    # Generating header-only library.
+    add_library(${_NAME} INTERFACE)
+    target_include_directories(${_NAME}
+      INTERFACE
+        "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
+    )
+    target_compile_options(${_NAME}
+      INTERFACE
+        ${_RULE_COPTS}
+        ${IREE_DEFAULT_COPTS}
+    )
+    target_link_libraries(${_NAME}
+      INTERFACE
+        ${_RULE_DEPS}
+        ${_RULE_LINKOPTS}
+        ${IREE_DEFAULT_LINKOPTS}
+    )
+    iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
+    target_compile_definitions(${_NAME}
+      INTERFACE
+        ${_RULE_DEFINES}
+    )
+  endif()
 
-      target_link_libraries(${_NAME}
-        PUBLIC
-          ${_RULE_DEPS}
-        PRIVATE
-          ${_RULE_LINKOPTS}
-          ${IREE_DEFAULT_LINKOPTS}
-      )
-      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
-      target_compile_definitions(${_NAME}
-        PUBLIC
-          ${_RULE_DEFINES}
-      )
-
-      if(DEFINED _RULE_ALWAYSLINK)
-        set_property(TARGET ${_NAME} PROPERTY ALWAYSLINK 1)
-      endif()
-
-      # Add all IREE targets to a folder in the IDE for organization.
-      if(_RULE_PUBLIC)
-        set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER})
-      elseif(_RULE_TESTONLY)
-        set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/test)
-      else()
-        set_property(TARGET ${_NAME} PROPERTY FOLDER ${IREE_IDE_FOLDER}/internal)
-      endif()
-
-      # INTERFACE libraries can't have the CXX_STANDARD property set.
-      set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD ${IREE_CXX_STANDARD})
-      set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
-    else()
-      # Generating header-only library.
-      add_library(${_NAME} INTERFACE)
-      target_include_directories(${_NAME}
-        INTERFACE
-          "$<BUILD_INTERFACE:${IREE_COMMON_INCLUDE_DIRS}>"
-      )
-      target_compile_options(${_NAME}
-        INTERFACE
-          ${_RULE_COPTS}
-          ${IREE_DEFAULT_COPTS}
-      )
-      target_link_libraries(${_NAME}
-        INTERFACE
-          ${_RULE_DEPS}
-          ${_RULE_LINKOPTS}
-          ${IREE_DEFAULT_LINKOPTS}
-      )
-      iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
-      target_compile_definitions(${_NAME}
-        INTERFACE
-          ${_RULE_DEFINES}
-      )
-    endif()
-
-    # Alias the iree_package_name library to iree::package::name.
-    # This lets us more clearly map to Bazel and makes it possible to
-    # disambiguate the underscores in paths vs. the separators.
-    add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
-    iree_package_dir(_PACKAGE_DIR)
-    if(${_RULE_NAME} STREQUAL ${_PACKAGE_DIR})
-      # If the library name matches the package then treat it as a default.
-      # For example, foo/bar/ library 'bar' would end up as 'foo::bar'.
-      add_library(${_PACKAGE_NS} ALIAS ${_NAME})
-    endif()
+  # Alias the iree_package_name library to iree::package::name.
+  # This lets us more clearly map to Bazel and makes it possible to
+  # disambiguate the underscores in paths vs. the separators.
+  add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
+  iree_package_dir(_PACKAGE_DIR)
+  if(${_RULE_NAME} STREQUAL ${_PACKAGE_DIR})
+    # If the library name matches the package then treat it as a default.
+    # For example, foo/bar/ library 'bar' would end up as 'foo::bar'.
+    add_library(${_PACKAGE_NS} ALIAS ${_NAME})
   endif()
 endfunction()

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -73,7 +73,6 @@ function(iree_cc_library)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -32,6 +32,10 @@ include(CMakeParseArguments)
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 function(iree_check_test)
+  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""
@@ -39,9 +43,6 @@ function(iree_check_test)
     "COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
-    return()
-  endif()
 
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
@@ -126,6 +127,10 @@ endfunction()
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
 function(iree_check_single_backend_test_suite)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""
@@ -133,9 +138,6 @@ function(iree_check_single_backend_test_suite)
     "SRCS;COMPILER_FLAGS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_TESTS)
-    return()
-  endif()
 
   foreach(_SRC IN LISTS _RULE_SRCS)
     set(_TEST_NAME "${_RULE_NAME}_${_SRC}")
@@ -183,6 +185,10 @@ endfunction()
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
 function(iree_check_test_suite)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""
@@ -190,9 +196,6 @@ function(iree_check_test_suite)
     "SRCS;TARGET_BACKENDS;DRIVERS;RUNNER_ARGS;LABELS"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_TESTS)
-    return()
-  endif()
 
   if(NOT DEFINED _RULE_TARGET_BACKENDS AND NOT DEFINED _RULE_DRIVERS)
     set(_RULE_TARGET_BACKENDS "vmla" "vulkan-spirv" "llvm-ir")

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -31,6 +31,10 @@ include(CMakeParseArguments)
 # TODO(gcmn): allow using alternative driver
 # A driver other than the default iree/tools/run_lit.sh is not currently supported.
 function(iree_lit_test)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""
@@ -38,9 +42,6 @@ function(iree_lit_test)
     "DATA;LABELS"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_TESTS)
-    return()
-  endif()
 
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
@@ -101,6 +102,10 @@ endfunction()
 # TODO(gcmn): allow using alternative driver
 # A driver other than the default iree/tools/run_lit.sh is not currently supported.
 function(iree_lit_test_suite)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""
@@ -108,9 +113,6 @@ function(iree_lit_test_suite)
     "SRCS;DATA;LABELS"
     ${ARGN}
   )
-  IF(NOT IREE_BUILD_TESTS)
-    return()
-  endif()
 
   foreach(_TEST_FILE ${_RULE_SRCS})
     get_filename_component(_TEST_BASENAME ${_TEST_FILE} NAME)

--- a/build_tools/cmake/iree_tablegen_library.cmake
+++ b/build_tools/cmake/iree_tablegen_library.cmake
@@ -26,38 +26,41 @@ function(iree_tablegen_library)
     ${ARGN}
   )
 
-  if(NOT _RULE_TESTONLY OR IREE_BUILD_TESTS)
-    # Prefix the library with the package name, so we get: iree_package_name
-    iree_package_name(_PACKAGE_NAME)
-    set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
-
-    if(${_RULE_TBLGEN} MATCHES "IREE")
-      set(_TBLGEN "IREE")
-    else()
-      set(_TBLGEN "MLIR")
-    endif()
-
-    set(LLVM_TARGET_DEFINITIONS ${_RULE_TD_FILE})
-    set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
-    list(APPEND _INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
-    list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
-    set(_OUTPUTS)
-    while(_RULE_OUTS)
-      list(GET _RULE_OUTS 0 _COMMAND)
-      list(REMOVE_AT _RULE_OUTS 0)
-      list(GET _RULE_OUTS 0 _FILE)
-      list(REMOVE_AT _RULE_OUTS 0)
-      tablegen(${_TBLGEN} ${_FILE} ${_COMMAND} ${_INCLUDE_DIRS})
-      list(APPEND _OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${_FILE})
-    endwhile()
-    add_custom_target(${_NAME}_target DEPENDS ${_OUTPUTS})
-    set_target_properties(${_NAME}_target PROPERTIES FOLDER "Tablegenning")
-
-    add_library(${_NAME} INTERFACE)
-    add_dependencies(${_NAME} ${_NAME}_target)
-
-    # Alias the iree_package_name library to iree::package::name.
-    iree_package_ns(_PACKAGE_NS)
-    add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
+  # Return early if this is test only but we are not building tests.
+  if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
+    return()
   endif()
+
+  # Prefix the library with the package name, so we get: iree_package_name
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+
+  if(${_RULE_TBLGEN} MATCHES "IREE")
+    set(_TBLGEN "IREE")
+  else()
+    set(_TBLGEN "MLIR")
+  endif()
+
+  set(LLVM_TARGET_DEFINITIONS ${_RULE_TD_FILE})
+  set(_INCLUDE_DIRS ${IREE_COMMON_INCLUDE_DIRS})
+  list(APPEND _INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+  list(TRANSFORM _INCLUDE_DIRS PREPEND "-I")
+  set(_OUTPUTS)
+  while(_RULE_OUTS)
+    list(GET _RULE_OUTS 0 _COMMAND)
+    list(REMOVE_AT _RULE_OUTS 0)
+    list(GET _RULE_OUTS 0 _FILE)
+    list(REMOVE_AT _RULE_OUTS 0)
+    tablegen(${_TBLGEN} ${_FILE} ${_COMMAND} ${_INCLUDE_DIRS})
+    list(APPEND _OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${_FILE})
+  endwhile()
+  add_custom_target(${_NAME}_target DEPENDS ${_OUTPUTS})
+  set_target_properties(${_NAME}_target PROPERTIES FOLDER "Tablegenning")
+
+  add_library(${_NAME} INTERFACE)
+  add_dependencies(${_NAME} ${_NAME}_target)
+
+  # Alias the iree_package_name library to iree::package::name.
+  iree_package_ns(_PACKAGE_NS)
+  add_library(${_PACKAGE_NS}::${_RULE_NAME} ALIAS ${_NAME})
 endfunction()

--- a/build_tools/cmake/iree_tablegen_library.cmake
+++ b/build_tools/cmake/iree_tablegen_library.cmake
@@ -26,7 +26,6 @@ function(iree_tablegen_library)
     ${ARGN}
   )
 
-  # Return early if this is test only but we are not building tests.
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
   endif()


### PR DESCRIPTION
This reduces the level of nesting and should make the code more
readable.