### PR TITLE
Separate the bindings and core Kokoro builds and build scripts.

### DIFF
--- a/build_tools/bazel/build_bindings.sh
+++ b/build_tools/bazel/build_bindings.sh
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the IREE project with bazel. Designed for CI, but can be run manually.
-# Looks at environment variables and uses CI-friendly defaults if they are not set.
+# Build IREE's bindings (//bindings/...) with bazel. Designed for CI, but can be
+# run manually.
+
+# Looks at environment variables and uses CI-friendly defaults if they are not
+# set.
 # IREE_LLVMJIT_DISABLE: Do not run tests that require LLVM-JIT. Default: 1
 # IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.

--- a/build_tools/bazel/build_bindings.sh
+++ b/build_tools/bazel/build_bindings.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the IREE project with bazel. Designed for CI, but can be run manually.
+# Looks at environment variables and uses CI-friendly defaults if they are not set.
+# IREE_LLVMJIT_DISABLE: Do not run tests that require LLVM-JIT. Default: 1
+# IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
+# BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.
+#   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--build_tag_filters)
+#   Default: "-nokokoro"
+# TEST_TAG_FILTERS: Passed to bazel to filter targets to test. Note that test
+#   targets excluded this way will also not be built.
+#   See https://docs.bazel.build/versions/master/command-line-reference.html#flag--test_tag_filters)
+#   Default: If IREE_VULKAN_DISABLE=1, "-nokokoro,-driver=vulkan". Else "-nokokoro".
+
+set -e
+set -x
+
+# Use user-environment variables if set, otherwise use CI-friendly defaults.
+if ! [[ -v IREE_LLVMJIT_DISABLE ]]; then
+  IREE_LLVMJIT_DISABLE=1
+fi
+if ! [[ -v IREE_VULKAN_DISABLE ]]; then
+  IREE_VULKAN_DISABLE=1
+fi
+declare -a test_env_args=(
+  --test_env=IREE_LLVMJIT_DISABLE=$IREE_LLVMJIT_DISABLE
+  --test_env=IREE_VULKAN_DISABLE=$IREE_VULKAN_DISABLE
+)
+
+declare -a default_build_tag_filters=("-nokokoro")
+declare -a default_test_tag_filters=("-nokokoro")
+
+# We can still build things that use vulkan. Only add to test tag filters.
+if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then
+  default_test_tag_filters+=("-driver=vulkan")
+fi
+# Use user-environment variables if set, otherwise use CI-friendly defaults.
+if ! [[ -v BUILD_TAG_FILTERS ]]; then
+  # String join on comma
+  BUILD_TAG_FILTERS="$(IFS="," ; echo "${default_build_tag_filters[*]?}")"
+fi
+if ! [[ -v TEST_TAG_FILTERS ]]; then
+  # String join on comma
+  TEST_TAG_FILTERS="$(IFS="," ; echo "${default_test_tag_filters[*]?}")"
+fi
+
+# Build and test everything in supported directories not excluded by the tag
+# filters.
+# Note that somewhat contrary to its name `bazel test` will also build
+# any non-test targets specified.
+# We use `bazel query //...` piped to `bazel test` rather than the simpler
+# `bazel test //...` because the latter excludes targets tagged "manual". The
+# "manual" tag allows targets to be excluded from human wildcard builds, but we
+# want them built by CI unless they are excluded with "nokokoro".
+bazel query //bindings/... | \
+  xargs bazel test ${test_env_args[@]} \
+    --config=generic_clang \
+    --build_tag_filters="${BUILD_TAG_FILTERS?}" \
+    --test_tag_filters="${TEST_TAG_FILTERS?}" \
+    --keep_going \
+    --test_output=errors \
+    --config=rs \
+    --config=rbe

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -66,7 +66,7 @@ fi
 # `bazel test //...` because the latter excludes targets tagged "manual". The
 # "manual" tag allows targets to be excluded from human wildcard builds, but we
 # want them built by CI unless they are excluded with "nokokoro".
-bazel query //iree/... + //bindings/... | \
+bazel query //iree/... | \
   xargs bazel test ${test_env_args[@]} \
     --config=generic_clang \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the IREE project with bazel. Designed for CI, but can be run manually.
-# Looks at environment variables and uses CI-friendly defaults if they are not set.
+# Build IREE's core (//iree/...) with bazel. Designed for CI, but can be run
+# manually.
+
+# Looks at environment variables and uses CI-friendly defaults if they are not
+# set.
 # IREE_LLVMJIT_DISABLE: Do not run tests that require LLVM-JIT. Default: 1
 # IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.

--- a/build_tools/bazel/build_tensorflow.sh
+++ b/build_tools/bazel/build_tensorflow.sh
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the IREE integrations with bazel. Designed for CI, but can be run
-# manually. Looks at environment variables and uses CI-friendly defaults if they
-# are not set.
+# Build IREE's integrations (//integrations/...) with bazel. Designed for CI,
+# but can be run manually.
+
+# Looks at environment variables and uses CI-friendly defaults if they are not
+# set.
 # IREE_LLVMJIT_DISABLE: Do not run tests that require LLVM-JIT. Default: 1
 # IREE_VULKAN_DISABLE: Do not run tests that require Vulkan. Default: 1
 # BUILD_TAG_FILTERS: Passed to bazel to filter targets to build.

--- a/kokoro/gcp_ubuntu/bazel/bindings/build.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For use within a IREE bazel docker image on a Kokoro VM.
+# For use within a IREE bazel-tensorflow docker image on a Kokoro VM.
 # Log some information about the environment, initialize the submodules and then
-# run the bazel tests.
+# run the bazel integrations tests.
 
 set -e
 set -x
@@ -36,4 +36,4 @@ echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init
 
 echo "Building and testing with bazel"
-./build_tools/bazel/build_core.sh
+./build_tools/bazel/build_bindings.sh

--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and test the project within the gcr.io/iree-oss/bazel-tensorflow
+# image using Kokoro.
+
+set -e
+set -x
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+# Kokoro checks out the repository here.
+WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+
+# Mount the checked out repository, make that the working directory and run the
+# tests in the bazel-tensorflow image.
+docker run \
+  --volume "${WORKDIR?}:${WORKDIR?}" \
+  --workdir="${WORKDIR?}" \
+  --rm \
+  gcr.io/iree-oss/bazel-tensorflow:prod \
+  kokoro/gcp_ubuntu/bazel/bindings/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless.
+rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"

--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -28,6 +28,7 @@ WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
 
 # Mount the checked out repository, make that the working directory and run the
 # tests in the bazel-tensorflow image.
+# TODO: Change image to gcr.io/iree-oss/bazel-bindings:prod once we create it.
 docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \

--- a/kokoro/gcp_ubuntu/bazel/bindings/common.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/common.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common configuration for Kokoro builds that run bazel on linux.
+
+build_file: "iree/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh"

--- a/kokoro/gcp_ubuntu/bazel/bindings/continuous.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/continuous.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.


### PR DESCRIPTION
- Forks and slightly modifies the `kokoro/gcp_ubuntu/bazel` configuration to run the bindings tests.
- Also moves `build_tools/bazel/build.sh` to `build_tools/bazel/build_core.sh` to match new organization semantics.
  - Another option would be to move all of the build scripts into `build_tools/bazel/build_scripts/*` (e.g. `build_tools/bazel/build_scripts/core.sh`

This change was tested to work in PR #2100. These tests will be enabled for everyone in a later internal change.