### PR TITLE
[vulkan] Add Windows RenderDoc DLL search path and log capture path

### DIFF
--- a/iree/hal/vulkan/renderdoc_capture_manager.cc
+++ b/iree/hal/vulkan/renderdoc_capture_manager.cc
@@ -33,6 +33,7 @@ namespace {
 static const char* kRenderDocSearchNames[] = {
 #if defined(IREE_PLATFORM_WINDOWS)
     "renderdoc.dll",
+    "C:/Program Files/RenderDoc/renderdoc.dll",
 #else
     "librenderdoc.so",
 #endif  // IREE_PLATFORM_WINDOWS
@@ -67,7 +68,8 @@ Status RenderDocCaptureManager::Connect() {
            << "Failed to get RenderDoc API object";
   }
 
-  LOG(INFO) << "Connected to RenderDoc's API";
+  LOG(INFO) << "Connected to RenderDoc's API; writing captures to "
+            << renderdoc_api_->GetCaptureFilePathTemplate();
 
   return OkStatus();
 }


### PR DESCRIPTION
On Windows RenderDoc is installed at C:/Program Files/RenderDoc
by default. Add that path into the renderdoc.dll search path.

Also let RenderDoc log its capture path so it's easier to find
out.