### PR TITLE
Removes the bindings tests from the bazel core kokoro build.

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -71,7 +71,7 @@ fi
 # want them built by CI unless they are excluded with "nokokoro".
 # TODO: Remove bindings from this script once `linux_bazel_bindings` is enabled
 # on the Kokoro CI.
-bazel query //iree/... + //bindings/... | \
+bazel query //iree/... | \
   xargs bazel test ${test_env_args[@]} \
     --config=generic_clang \
     --build_tag_filters="${BUILD_TAG_FILTERS?}" \

--- a/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build and test IREE's core within the gcr.io/iree-oss/bazel-tensorflow
-# image using Kokoro.
+# Build and test IREE's core within the gcr.io/iree-oss/bazel image using
+# Kokoro.
 
 set -e
 set -x
@@ -27,14 +27,12 @@ export PS4='[$(date -u "+%T %Z")] '
 WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
 
 # Mount the checked out repository, make that the working directory and run the
-# tests in the bazel-tensorflow image.
-# TODO: Make this use the gcr.io/iree-oss/bazel:prod image once we separate out
-# the bindings from `build_core.sh`.
+# tests in the bazel image.
 docker run \
   --volume "${WORKDIR?}:${WORKDIR?}" \
   --workdir="${WORKDIR?}" \
   --rm \
-  gcr.io/iree-oss/bazel-tensorflow:prod \
+  gcr.io/iree-oss/bazel:prod \
   kokoro/gcp_ubuntu/bazel/core/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the


### PR DESCRIPTION
We can remove the bindings from the `linux_bazel`/`linux_bazel_core` build now that the bindings are set to run in their own build on pre/post submits.

This change also lets us use the smaller `gcr.io/iree-oss/bazel` docker image for our core build.