### PR TITLE
Adds a test suite for running e2e tests on all backends

### DIFF
--- a/build_tools/bazel/build_tensorflow.sh
+++ b/build_tools/bazel/build_tensorflow.sh
@@ -42,7 +42,7 @@ fi
 declare -a test_env_args=(
   --test_env=IREE_LLVMJIT_DISABLE=$IREE_LLVMJIT_DISABLE
   --test_env=IREE_VULKAN_DISABLE=$IREE_VULKAN_DISABLE
-  --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla"
+  --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla,iree_llvmjit"
 )
 
 declare -a default_build_tag_filters=("-nokokoro")

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -28,8 +28,23 @@ package(
 )
 
 iree_e2e_test_suite(
+    # TODO(GH-2082): `linspace_test.py` fails in the `bazel-tensorflow` image.
+    name = "linspace_test",
+    srcs = ["linspace_test.py"],
+    reference_backend = "tf",
+    backends = ["iree_vmla", "iree_llvmjit", "iree_vulkan"],
+    tags = [
+        "nokokoro",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+
+iree_e2e_test_suite(
     name = "e2e",
-    srcs = glob(["*_test.py"]),
+    srcs = glob(["*_test.py"], exclude = ["linspace_test.py"]),
     reference_backend = "tf",
     backends = ["iree_vmla", "iree_llvmjit", "iree_vulkan"],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -16,11 +16,10 @@ load(
     "//bindings/python:build_defs.oss.bzl",
     "INTREE_TENSORFLOW_PY_DEPS",
     "NUMPY_DEPS",
-    "iree_py_test",
 )
 load(
-    "//build_tools/bazel:iree_py_test_suite.bzl",
-    "iree_py_test_suite",
+    "//integrations/tensorflow/e2e:iree_e2e_test_suite.bzl",
+    "iree_e2e_test_suite",
 )
 
 package(
@@ -28,26 +27,11 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-iree_py_test(
-    # TODO(GH-2082): `linspace_test.py` fails due to an unknown location error.
-    name = "linspace_test",
-    srcs = ["linspace_test.py"],
-    main = "linspace_test.py",
-    python_version = "PY3",
-    tags = [
-        "nokokoro",
-    ],
-    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
-        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
-    ],
-)
-
-iree_py_test_suite(
+iree_e2e_test_suite(
     name = "e2e",
-    srcs = glob(
-        ["*_test.py"],
-        exclude = ["linspace_test.py"],
-    ),
+    srcs = glob(["*_test.py"]),
+    reference_backend = "tf",
+    backends = ["iree_vmla", "iree_llvmjit", "iree_vulkan"],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -17,8 +17,8 @@ instructions.
 
 If you do not have your environment setup to use IREE with Vulkan (see
 [the doc](../../../docs/vulkan_and_spirv.md)), then you can run the tests with
-`IREE_AVAILABLE_BACKENDS=tf,iree_vmla` (that is, by omitting `iree_vulkan` from
-the list of available backends).
+`IREE_AVAILABLE_BACKENDS=tf,iree_vmla,iree_llvmjit` (that is, by omitting
+`iree_vulkan` from the list of available backends).
 
 ## Running tests
 

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -60,7 +60,7 @@ def iree_e2e_test_suite(
             # TODO(GH-2175): Simplify this after backend names are standardized.
             driver = backend.replace("iree_", "")  # "iree_<driver>" --> "<driver>"
             if driver == "llvmjit":
-                driver == "llvm"
+                driver = "llvm"
             py_test_tags = ["driver={}".format(driver)]
             if tags != None:  # `is` is not supported.
                 py_test_tags += tags

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -57,6 +57,7 @@ def iree_e2e_test_suite(
                 "--override_backends={},{}".format(reference_backend, backend)
             ]
 
+            # TODO(GH-2175): Simplify this after backend names are standardized.
             driver = backend.split("_")[-1]  # "iree_<driver>" --> "<driver>"
             if driver == "llvmjit":
                 driver == "llvm"

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -58,7 +58,7 @@ def iree_e2e_test_suite(
             ]
 
             # TODO(GH-2175): Simplify this after backend names are standardized.
-            driver = backend.split("_")[-1]  # "iree_<driver>" --> "<driver>"
+            driver = backend.replace("iree_", "")  # "iree_<driver>" --> "<driver>"
             if driver == "llvmjit":
                 driver == "llvm"
             py_test_tags = ["driver={}".format(driver)]

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -1,0 +1,88 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Macro for building a test suite to run the e2e tests on all backends."""
+
+load("//bindings/python:build_defs.oss.bzl", "iree_py_test")
+
+def iree_e2e_test_suite(
+        name,
+        srcs,
+        reference_backend,
+        backends,
+        deps = None,
+        tags = None,
+        python_version = "PY3",
+        **kwargs):
+    """Creates a iree_py_test for each backend and file in srcs and a test suite that bundles them.
+
+    Args:
+      name:
+        name of the generated test suite.
+      srcs:
+        test file sources.
+      reference_backend:
+        the backend to use as a source of truth for the expected output results.
+      backends:
+        a list of backends to run the tests in each src on. Each test is tagged
+        with "driver=backend".
+      deps:
+        test dependencies.
+      tags:
+        tags to apply to the test. Note that as in standard test suites, manual
+        is treated specially and will also apply to the test suite itself.
+      python_version:
+        the python version to run the tests with. Uses python3 by default.
+      **kwargs:
+        Any additional arguments that will be passed to the underlying tests and
+        test_suite.
+    """
+    tests = []
+    for src in srcs:
+        for backend in backends:
+            test_name = "{}_{}_{}_{}".format(
+                name, src[:-3], reference_backend, backend)
+            args = [
+                "--override_backends={},{}".format(reference_backend, backend)
+            ]
+
+            driver = backend.split("_")[-1]  # "iree_<driver>" --> "<driver>"
+            if driver == "llvmjit":
+                driver == "llvm"
+            py_test_tags = ["driver={}".format(driver)]
+            if tags != None:  # `is` is not supported.
+                py_test_tags += tags
+
+            iree_py_test(
+                name = test_name,
+                main = src,
+                srcs = [src],
+                deps = deps,
+                tags = py_test_tags,
+                python_version = python_version,
+                **kwargs
+            )
+            tests.append(test_name)
+
+    native.test_suite(
+        name = name,
+        tests = tests,
+        # Note that only the manual tag really has any effect here. Others are
+        # used for test suite filtering, but all tests are passed the same tags.
+        tags = tags,
+        # If there are kwargs that need to be passed here which only apply to
+        # the generated tests and not to test_suite, they should be extracted
+        # into separate named arguments.
+        **kwargs
+    )


### PR DESCRIPTION
As a followup to #2158, this change creates a test suite to run the e2e tests to run on the `iree_vmla` and `iree_llvmjit` backends to run in the OSS CI, and on the `iree_vulkan` backend outside of it.

Each test file has three test targets created for it, and the tests for a specific backend can be filtered for. For example:
```bash
>>> bazel query 'attr("tags", "driver=llvm", //integrations/tensorflow/e2e/...)'
//integrations/tensorflow/e2e:e2e_tensorlist_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_strings_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_sliding_window_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_simple_stateful_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_simple_arithmetic_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_ring_buffer_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_resource_ops_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_matrix_ops_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_math_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_mandelbrot_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_linspace_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_gather_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_fill_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_exported_names_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_dynamic_mlp_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_dynamic_mlp_relu_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_depth_conv_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_conv_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_control_flow_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_broadcasting_test_tf_iree_llvmjit
//integrations/tensorflow/e2e:e2e_batch_norm_test_tf_iree_llvmjit
```