### PR TITLE
Move compilation toolchain configuration under utility definitions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,29 +125,6 @@ list(APPEND CMAKE_MODULE_PATH
 )
 
 #-------------------------------------------------------------------------------
-# IREE compilation toolchain configuration
-#-------------------------------------------------------------------------------
-
-# Enable using lld as the linker for C/C++ targets. This affects IREE and all
-# dependency projects.
-option(IREE_ENABLE_LLD "Use lld when linking" OFF)
-
-string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
-
-set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
-set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)
-set(CMAKE_EXE_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used for linking binaries during fast builds." FORCE)
-set(CMAKE_SHARED_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used by the shared libraries linker binaries during fast builds." FORCE)
-mark_as_advanced(
-  CMAKE_CXX_FLAGS_FASTBUILD
-  CMAKE_C_FLAGS_FASTBUILD
-  CMAKE_EXE_LINKER_FLAGS_FASTBUILD
-  CMAKE_SHARED_LINKER_FLAGS_FASTBUILD
-)
-
-include(iree_setup_toolchain)
-
-#-------------------------------------------------------------------------------
 # IREE utility definitions
 #-------------------------------------------------------------------------------
 
@@ -175,6 +152,29 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+#-------------------------------------------------------------------------------
+# IREE compilation toolchain configuration
+#-------------------------------------------------------------------------------
+
+# Enable using lld as the linker for C/C++ targets. This affects IREE and all
+# dependency projects.
+option(IREE_ENABLE_LLD "Use lld when linking" OFF)
+
+string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
+
+set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
+set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used for linking binaries during fast builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_FASTBUILD "-Wl,-S" CACHE STRING "Flags used by the shared libraries linker binaries during fast builds." FORCE)
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_FASTBUILD
+  CMAKE_C_FLAGS_FASTBUILD
+  CMAKE_EXE_LINKER_FLAGS_FASTBUILD
+  CMAKE_SHARED_LINKER_FLAGS_FASTBUILD
+)
+
+include(iree_setup_toolchain)
 
 #-------------------------------------------------------------------------------
 # Third-party dependencies


### PR DESCRIPTION
Fixes builds on Windows, since `IREE_DEFAULT_COPTS` is defined in `iree_copts.cmake`.