### PR TITLE
Add unit test for DynamicLibrary.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -416,6 +416,7 @@ class BuildFileFunctions(object):
                     srcs,
                     cc_file_output,
                     h_file_output,
+                    testonly=False,
                     cpp_namespace=None,
                     strip_prefix=None,
                     flatten=False,
@@ -428,6 +429,7 @@ class BuildFileFunctions(object):
     srcs_block = self._convert_srcs_block(srcs)
     cc_file_output_block = self._convert_cc_file_output_block(cc_file_output)
     h_file_output_block = self._convert_h_file_output_block(h_file_output)
+    testonly_block = self._convert_testonly_block(testonly)
     namespace_block = self._convert_cpp_namespace_block(cpp_namespace)
     flatten_block = self._convert_flatten_block(flatten)
 
@@ -436,6 +438,7 @@ class BuildFileFunctions(object):
                             f"{srcs_block}"
                             f"{cc_file_output_block}"
                             f"{h_file_output_block}"
+                            f"{testonly_block}"
                             f"{namespace_block}"
                             f"{flatten_block}"
                             f"  PUBLIC\n)\n\n")

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -33,6 +33,7 @@ include(CMakeParseArguments)
 # PUBLIC: Add this so that this library will be exported under iree::
 # Also in IDE, target will appear in IREE folder while non PUBLIC will be in IREE/internal.
 # TESTONLY: When added, this target will only be built if user passes -DIREE_BUILD_TESTS=ON to CMake.
+# SHARED: If set, will compile to a shared object.
 #
 # Note:
 # By default, iree_cc_library will always create a library named iree_${NAME},
@@ -67,7 +68,7 @@ include(CMakeParseArguments)
 function(iree_cc_library)
   cmake_parse_arguments(
     _RULE
-    "PUBLIC;ALWAYSLINK;TESTONLY"
+    "PUBLIC;ALWAYSLINK;TESTONLY;SHARED"
     "NAME"
     "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;INCLUDES"
     ${ARGN}
@@ -103,7 +104,12 @@ function(iree_cc_library)
   endif()
 
   if(NOT _RULE_IS_INTERFACE)
-    add_library(${_NAME} STATIC "")
+    if (_RULE_SHARED)
+      add_library(${_NAME} SHARED "")
+    else()
+      add_library(${_NAME} STATIC "")
+    endif()
+
     target_sources(${_NAME}
       PRIVATE
         ${_RULE_SRCS}

--- a/build_tools/embed_data/build_defs.bzl
+++ b/build_tools/embed_data/build_defs.bzl
@@ -19,6 +19,7 @@ def cc_embed_data(
         srcs,
         cc_file_output,
         h_file_output,
+        testonly = False,
         cpp_namespace = None,
         strip_prefix = None,
         flatten = False,
@@ -49,6 +50,7 @@ def cc_embed_data(
       srcs: List of files to embed.
       cc_file_output: The CC implementation file to output.
       h_file_output: The H header file to output.
+      testonly: If True, only testonly targets can depend on this target.
       cpp_namespace: Wraps everything in a C++ namespace.
       strip_prefix: Strips this verbatim prefix from filenames (in the TOC).
       flatten: Removes all directory components from filenames (in the TOC).
@@ -80,10 +82,12 @@ def cc_embed_data(
         ],
         tools = [generator],
         cmd = "%s $(SRCS) %s" % (generator_location, flags),
+        testonly = testonly,
     )
     native.cc_library(
         name = name,
         hdrs = [h_file_output],
         srcs = [cc_file_output],
+        testonly = testonly,
         **kwargs
     )

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -160,14 +160,14 @@ cc_library(
 
 cc_binary(
     name = "dynamic_library_test_library.so",
-    testonly = 1,
+    testonly = True,
     srcs = ["dynamic_library_test_library.cc"],
-    linkshared = 1,
+    linkshared = True,
 )
 
 cc_embed_data(
     name = "dynamic_library_test_library",
-    testonly = 1,
+    testonly = True,
     srcs = [":dynamic_library_test_library.so"],
     cc_file_output = "dynamic_library_test_library_embed.cc",
     cpp_namespace = "iree",

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -14,6 +14,7 @@
 
 # Common types and utilities used in the IREE codebase.
 
+load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 load("//iree:build_defs.oss.bzl", "platform_trampoline_deps")
 
 package(
@@ -154,6 +155,37 @@ cc_library(
         ":tracing",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_binary(
+    name = "dynamic_library_test_library.so",
+    testonly = 1,
+    srcs = ["dynamic_library_test_library.cc"],
+    linkshared = 1,
+)
+
+cc_embed_data(
+    name = "dynamic_library_test_library",
+    testonly = 1,
+    srcs = [":dynamic_library_test_library.so"],
+    cc_file_output = "dynamic_library_test_library_embed.cc",
+    cpp_namespace = "iree",
+    flatten = True,
+    h_file_output = "dynamic_library_test_library_embed.h",
+)
+
+cc_test(
+    name = "dynamic_library_test",
+    srcs = ["dynamic_library_test.cc"],
+    deps = [
+        ":dynamic_library",
+        ":dynamic_library_test_library",
+        ":file_io",
+        ":status",
+        ":status_matchers",
+        ":target_platform",
+        "//iree/testing:gtest_main",
     ],
 )
 

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(internal)
+iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
@@ -168,7 +168,7 @@ iree_cc_library(
     "dynamic_library_win32.cc"
   LINKOPTS
     ${_DYNAMIC_LIBRARY_LINKOPTS}
-DEPS
+  DEPS
     ::logging
     ::platform_headers
     ::status
@@ -177,6 +177,47 @@ DEPS
     absl::memory
     absl::span
   PUBLIC
+)
+
+iree_cc_binary(
+  NAME
+    dynamic_library_test_library.so
+  OUT
+    dynamic_library_test_library.so
+  SRCS
+    "dynamic_library_test_library.cc"
+  TESTONLY
+)
+
+iree_cc_embed_data(
+  NAME
+    dynamic_library_test_library
+  SRCS
+    ":dynamic_library_test_library.so"
+  CC_FILE_OUTPUT
+    "dynamic_library_test_library_embed.cc"
+  H_FILE_OUTPUT
+    "dynamic_library_test_library_embed.h"
+  TESTONLY
+  CPP_NAMESPACE
+    "iree"
+  FLATTEN
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    dynamic_library_test
+  SRCS
+    "dynamic_library_test.cc"
+  DEPS
+    ::dynamic_library
+    ::dynamic_library_test_library
+    ::file_io
+    ::status
+    ::status_matchers
+    ::target_platform
+    iree::testing::gtest_main
 )
 
 iree_cc_library(
@@ -201,6 +242,7 @@ iree_cc_library(
     "file_io.h"
   DEPS
     ::status
+    absl::strings
   PUBLIC
 )
 
@@ -359,15 +401,16 @@ iree_cc_library(
 iree_cc_library(
   NAME
     main
+  HDRS
+    "main.h"
   SRCS
     "main_posix.cc"
     "main_win32.cc"
-  HDRS
-    "main.h"
   DEPS
-    iree::base::logging
-    iree::base::platform_headers
-    iree::base::target_platform
+    ::logging
+    ::platform_headers
+    ::target_platform
+  PUBLIC
 )
 
 iree_cc_library(

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -179,7 +179,10 @@ iree_cc_library(
   PUBLIC
 )
 
-iree_cc_binary(
+# TODO(scotttodd): clean up bazel_to_cmake handling here
+#   * this is a cc_binary in Bazel, but `linkshared` fits iree_cc_library better
+#   * the output file name is platform-specific, get it with $<TARGET_FILE:>
+iree_cc_library(
   NAME
     dynamic_library_test_library.so
   OUT
@@ -187,13 +190,14 @@ iree_cc_binary(
   SRCS
     "dynamic_library_test_library.cc"
   TESTONLY
+  SHARED
 )
 
 iree_cc_embed_data(
   NAME
     dynamic_library_test_library
-  SRCS
-    ":dynamic_library_test_library.so"
+  GENERATED_SRCS
+    "$<TARGET_FILE:iree::base::dynamic_library_test_library.so>"
   CC_FILE_OUTPUT
     "dynamic_library_test_library_embed.cc"
   H_FILE_OUTPUT

--- a/iree/base/dynamic_library_test.cc
+++ b/iree/base/dynamic_library_test.cc
@@ -31,8 +31,15 @@ static const char* kUnknownName = "library_that_does_not_exist.so";
 class DynamicLibraryTest : public ::testing::Test {
  public:
   static void SetUpTestCase() {
+    // Making files available to tests, particularly across operating systems
+    // and build tools (Bazel/CMake) is complicated. Rather than include a test
+    // dynamic library as a "testdata" file, we use cc_embed_data to package
+    // the file so it's embedded in a C++ module, then write that embedded file
+    // to a platform/test-environment specific temp file for loading.
+
     std::string base_name = "dynamic_library_test_library";
     ASSERT_OK_AND_ASSIGN(library_temp_path_, file_io::GetTempFile(base_name));
+    // System APIs for loading dynamic libraries typically require an extension.
 #if defined(IREE_PLATFORM_WINDOWS)
     library_temp_path_ += ".dll";
 #else

--- a/iree/base/dynamic_library_test.cc
+++ b/iree/base/dynamic_library_test.cc
@@ -1,0 +1,95 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/dynamic_library.h"
+
+#include <string>
+
+#include "iree/base/dynamic_library_test_library_embed.h"
+#include "iree/base/file_io.h"
+#include "iree/base/status.h"
+#include "iree/base/status_matchers.h"
+#include "iree/base/target_platform.h"
+#include "iree/testing/gtest.h"
+
+namespace iree {
+namespace {
+
+static const char* kUnknownName = "library_that_does_not_exist.so";
+
+class DynamicLibraryTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    std::string base_name = "dynamic_library_test_library";
+    ASSERT_OK_AND_ASSIGN(library_temp_path_, file_io::GetTempFile(base_name));
+#if defined(IREE_PLATFORM_WINDOWS)
+    library_temp_path_ += ".dll";
+#else
+    library_temp_path_ += ".so";
+#endif
+
+    const auto* file_toc = dynamic_library_test_library_create();
+    absl::string_view file_data(reinterpret_cast<const char*>(file_toc->data),
+                                file_toc->size);
+    ASSERT_OK(file_io::SetFileContents(library_temp_path_, file_data));
+
+    LOG(INFO) << "Embedded test library written to temp path: "
+              << library_temp_path_;
+  }
+
+  static std::string library_temp_path_;
+};
+
+std::string DynamicLibraryTest::library_temp_path_;
+
+TEST_F(DynamicLibraryTest, LoadLibrarySuccess) {
+  auto library_or = DynamicLibrary::Load(library_temp_path_.c_str());
+  ASSERT_OK(library_or);
+
+  auto library = std::move(library_or.value());
+
+  EXPECT_EQ(library_temp_path_, library->file_name());
+}
+
+TEST_F(DynamicLibraryTest, LoadLibraryFailure) {
+  auto library_or = DynamicLibrary::Load(kUnknownName);
+  EXPECT_TRUE(IsUnavailable(library_or.status()));
+}
+
+TEST_F(DynamicLibraryTest, LoadLibraryTwice) {
+  ASSERT_OK_AND_ASSIGN(auto library1,
+                       DynamicLibrary::Load(library_temp_path_.c_str()));
+  ASSERT_OK_AND_ASSIGN(auto library2,
+                       DynamicLibrary::Load(library_temp_path_.c_str()));
+}
+
+TEST_F(DynamicLibraryTest, GetSymbolSuccess) {
+  ASSERT_OK_AND_ASSIGN(auto library,
+                       DynamicLibrary::Load(library_temp_path_.c_str()));
+
+  auto times_two_fn = library->GetSymbol<int (*)(int)>("times_two");
+  ASSERT_NE(nullptr, times_two_fn);
+  EXPECT_EQ(246, times_two_fn(123));
+}
+
+TEST_F(DynamicLibraryTest, GetSymbolFailure) {
+  ASSERT_OK_AND_ASSIGN(auto library,
+                       DynamicLibrary::Load(library_temp_path_.c_str()));
+
+  auto unknown_fn = library->GetSymbol<int (*)(int)>("unknown");
+  EXPECT_EQ(nullptr, unknown_fn);
+}
+
+}  // namespace
+}  // namespace iree

--- a/iree/base/dynamic_library_test_library.cc
+++ b/iree/base/dynamic_library_test_library.cc
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+#define IREE_API_EXPORT extern "C"
+#else
+#define IREE_API_EXPORT
+#endif  // __cplusplus
+
+#if defined(_WIN32)
+#define IREE_SYM_EXPORT __declspec(dllexport)
+#else
+#define IREE_SYM_EXPORT
+#endif  // _WIN32
+
+IREE_API_EXPORT int IREE_SYM_EXPORT times_two(int value) { return value * 2; }


### PR DESCRIPTION
Redo of https://github.com/google/iree/pull/1992, this time using `cc_embed_data` -> `file_io::GetTempFile` to work around platform and build system dependent runfiles + data dependency paths in tests. The same `file_io::GetTempFile` trick is used to load from a dynamic library stored within a flatbuffer in the `DyLib` HAL backend.

Still somewhat messy, but way better than that first attempt.