### PR TITLE
Adds MacOS support to run_lit.sh and adds MacOS getting started.

### DIFF
--- a/build_tools/cmake/build_docs.sh
+++ b/build_tools/cmake/build_docs.sh
@@ -71,5 +71,7 @@ cp docs/GetStarted/getting_started_windows_vulkan.md ${BUILD_DIR}/doc/GetStarted
 cp docs/GetStarted/getting_started_linux_bazel.md ${BUILD_DIR}/doc/GetStarted/
 cp docs/GetStarted/getting_started_linux_cmake.md ${BUILD_DIR}/doc/GetStarted/
 cp docs/GetStarted/getting_started_linux_vulkan.md ${BUILD_DIR}/doc/GetStarted/
+cp docs/GetStarted/getting_started_macos_bazel.md ${BUILD_DIR}/doc/GetStarted/
+cp docs/GetStarted/getting_started_macos_cmake.md ${BUILD_DIR}/doc/GetStarted/
 cp docs/GetStarted/getting_started_python.md ${BUILD_DIR}/doc/GetStarted/
 cp docs/GetStarted/generic_vulkan_env_setup.md ${BUILD_DIR}/doc/GetStarted/

--- a/docs/GetStarted/getting_started_linux_bazel.md
+++ b/docs/GetStarted/getting_started_linux_bazel.md
@@ -32,13 +32,6 @@ We recommend Clang. GCC is not fully supported.
 $ sudo apt install clang
 ```
 
-Set environment variables for Bazel:
-
-```shell
-export CC=clang
-export CXX=clang++
-```
-
 ### Install python3 numpy
 
 ```
@@ -116,7 +109,8 @@ Translate a
 and execute a function in the compiled module:
 
 ```shell
-$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir \
+    -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/GetStarted/getting_started_linux_bazel.md
+++ b/docs/GetStarted/getting_started_linux_bazel.md
@@ -32,13 +32,6 @@ We recommend Clang. GCC is not fully supported.
 $ sudo apt install clang
 ```
 
-Set environment variables for Bazel:
-
-```shell
-export CC=clang
-export CXX=clang++
-```
-
 ### Install python3 numpy
 
 ```shell

--- a/docs/GetStarted/getting_started_linux_bazel.md
+++ b/docs/GetStarted/getting_started_linux_bazel.md
@@ -20,7 +20,7 @@ documented separately, as they require further setup.
 ### Install Bazel
 
 Install Bazel version > 2.0.0 (see
-[.bazelversion](https://github.com/google/iree/blob/master/.bazelversion) for
+[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion) for
 the specific version IREE uses) by following the
 [official docs](https://docs.bazel.build/versions/master/install.html).
 

--- a/docs/GetStarted/getting_started_linux_bazel.md
+++ b/docs/GetStarted/getting_started_linux_bazel.md
@@ -34,7 +34,7 @@ $ sudo apt install clang
 
 ### Install python3 numpy
 
-```
+```shell
 $ python3 -m pip install numpy
 ```
 
@@ -76,7 +76,7 @@ level.
 You can put a user.bazelrc at the root of the repository and it will be ignored
 by git. The recommended contents for Linux are:
 
-```
+```shell
 build --disk_cache=/tmp/bazel-cache
 
 # Use --config=debug to compile iree and llvm without optimizations

--- a/docs/GetStarted/getting_started_linux_bazel.md
+++ b/docs/GetStarted/getting_started_linux_bazel.md
@@ -32,6 +32,13 @@ We recommend Clang. GCC is not fully supported.
 $ sudo apt install clang
 ```
 
+Set environment variables for Bazel:
+
+```shell
+export CC=clang
+export CXX=clang++
+```
+
 ### Install python3 numpy
 
 ```shell

--- a/docs/GetStarted/getting_started_linux_cmake.md
+++ b/docs/GetStarted/getting_started_linux_cmake.md
@@ -72,7 +72,7 @@ $ git submodule update --init
 Configure:
 
 ```shell
-$ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+$ cmake -G Ninja -B build/ .
 ```
 
 > Tip:<br>

--- a/docs/GetStarted/getting_started_linux_cmake.md
+++ b/docs/GetStarted/getting_started_linux_cmake.md
@@ -72,7 +72,7 @@ $ git submodule update --init
 Configure:
 
 ```shell
-$ cmake -G Ninja -B build/ .
+$ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
 ```
 
 > Tip:<br>

--- a/docs/GetStarted/getting_started_linux_cmake.md
+++ b/docs/GetStarted/getting_started_linux_cmake.md
@@ -72,13 +72,13 @@ $ git submodule update --init
 Configure:
 
 ```shell
-$ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+$ cmake -G Ninja -B build/ .
 ```
 
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
-> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt) file
-> has options for configuring which parts of the project to enable.
+> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
+> file has options for configuring which parts of the project to enable.
 
 Build all targets:
 
@@ -102,7 +102,8 @@ Translate a
 and execute a function in the compiled module:
 
 ```shell
-$ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+$ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
+    -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -23,40 +23,10 @@ Contributions related to macOS support and documentation are welcome however.
 
 ### Install Bazel
 
-Install the version of Bazel found in
-[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion).
-
-#### Install Xcode
-
-Running this may be sufficient (and takes up much less disk space):
-
-```shell
-$ xcode-select --install
-```
-
-If you run into complications, see the
-[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x)
-for guidance.
-
-#### Download and install Bazel from a binary
-
-```shell
-# Example using Bazel version `2.1.0`
-$ export BAZEL_VERSION=2.1.0  # Use the version in .bazelversion
-
-# Download and install. `sudo` is required because the installer writes to 
-# `/usr/local/bin/`, which is read only by default.
-$ curl -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
-$ chmod +x "bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
-$ sudo ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
-
-# Add to path in `.zshrc`. Swap with `.bashrc` if you are using bash.
-$ echo -e '\n# Add bazel to PATH:\nexport PATH="${PATH}:${HOME}/bin"' >> ~/.zshrc
-$ source ~/.zshrc
-
-# Confirm the version
-$ bazel --version # 2.1.0
-```
+Install Bazel version > 2.0.0 (see 
+[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion) 
+for the specific version IREE uses) by following the 
+[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x).
 
 ### Install python3 numpy
 

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -30,7 +30,7 @@ Install the version of Bazel found in
 
 Running this may be sufficient (and takes up much less disk space):
 
-```
+```shell
 $ xcode-select --install
 ```
 
@@ -40,7 +40,7 @@ for guidance.
 
 #### Download and install Bazel from a binary
 
-```
+```shell
 # Example using Bazel version `2.1.0`
 $ export BAZEL_VERSION=2.1.0  # Use the version in .bazelversion
 
@@ -59,7 +59,7 @@ $ bazel --version # 2.1.0
 
 ### Install python3 numpy
 
-```
+```shell
 $ python3 -m pip install numpy --user
 ```
 
@@ -103,7 +103,7 @@ level.
 You can put a user.bazelrc at the root of the repository and it will be ignored
 by git. The recommended contents for Linux/MacOS are:
 
-```
+```shell
 build --disk_cache=/tmp/bazel-cache
 
 # Use --config=debug to compile iree and llvm without optimizations

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -1,4 +1,4 @@
-# Getting Started on Linux with Bazel
+# Getting Started on MacOS with Bazel
 
 <!--
 Notes to those updating this guide:
@@ -6,31 +6,61 @@ Notes to those updating this guide:
     * This document should be __simple__ and cover essential items only.
       Notes for optional components should go in separate files.
 
-    * This document parallels getting_started_windows_bazel.md and
-      getting_started_macos_bazel.md
+    * This document parallels getting_started_linux_bazel.md and
+      getting_started_windows_bazel.md
       Please keep them in sync.
 -->
 
 This guide walks through building the core compiler and runtime parts of IREE
 from source. Auxiliary components like the Python bindings and Vulkan driver are
-documented separately, as they require further setup.
+not documented for MacOS at this time.
+
+IREE is not officially supported on MacOS at this time. It may work, but it is
+not a part of our open source CI, and may be intermittently broken.
+Contributions related to MacOS support and documentation are welcome however.
 
 ## Prerequisites
 
 ### Install Bazel
 
-Install Bazel version > 2.0.0 (see
-[.bazelversion](https://github.com/google/iree/blob/master/.bazelversion) for
-the specific version IREE uses) by following the
-[official docs](https://docs.bazel.build/versions/master/install.html).
+Install the version of Bazel found in
+[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion).
+
+#### Install xcode.
+
+If you've already installed `xcode-select` and this fails with it can likely be
+ignored.
+
+```
+$ sudo xcodebuild -license accept
+```
+
+#### Download and install Bazel from a binary.
+```
+# Example using Bazel version `2.1.0`
+$ export BAZEL_VERSION=2.1.0
+
+# Download and install
+$ curl -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+$ chmod +x "bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+$ ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
+
+# Add to path
+$ echo -e '\n# Add bazel to PATH:\nexport PATH="${PATH}:${HOME}/bin"' >> ~/.zshrc
+$ source ~/.zshrc
+
+# Confirm the version
+$ bazel --version # 2.1.0
+```
+
+See the
+[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x)
+for additional guidance if needed.
 
 ### Install a Compiler
 
-We recommend Clang. GCC is not fully supported.
-
-```shell
-$ sudo apt install clang
-```
+We recommend Clang. GCC is not fully supported. Appropriate versions of `clang`
+and `clang++` ship with MacOS by default.
 
 Set environment variables for Bazel:
 
@@ -42,7 +72,7 @@ export CXX=clang++
 ### Install python3 numpy
 
 ```
-$ python3 -m pip install numpy
+$ python3 -m pip install numpy --user
 ```
 
 ## Clone and Build
@@ -64,16 +94,18 @@ $ python3 configure_bazel.py
 
 ### Build
 
-Run all core tests:
+Run all core tests that pass on our OSS CI:
 
 ```shell
-$ bazel test -k iree/...
+$ bazel test -k //iree/... \
+    --test_env=IREE_VULKAN_DISABLE=1 \
+    --build_tag_filters="-nokokoro" \
+    --test_tag_filters="--nokokoro,-driver=vulkan"
 ```
 
 > Tip:<br>
-> &nbsp;&nbsp;&nbsp;&nbsp;You can add flags like
-> `--test_env=IREE_VULKAN_DISABLE=1` to your test command to change how/which
-> tests run.
+> &nbsp;&nbsp;&nbsp;&nbsp;Not all tests are passing on MacOS, but the build does
+> complete successfully at the time of writing.
 
 In general, build artifacts will be under the `bazel-bin` directory at the top
 level.
@@ -81,7 +113,7 @@ level.
 ## Recommended user.bazelrc
 
 You can put a user.bazelrc at the root of the repository and it will be ignored
-by git. The recommended contents for Linux are:
+by git. The recommended contents for Linux/MacOS are:
 
 ```
 build --disk_cache=/tmp/bazel-cache
@@ -123,7 +155,10 @@ $ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir -input-valu
 
 *   For an introduction to IREE's project structure and developer tools, see
     [Developer Overview](../developer_overview.md)
+<!--
+TODO: Link to MacOS versions of these guides once they are developed.
 *   To target GPUs using Vulkan, see
     [Getting Started on Linux with Vulkan](getting_started_linux_vulkan.md)
 *   To use IREE's Python bindings, see
     [Getting Started with Python](getting_started_python.md)
+ -->

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -21,12 +21,24 @@ Contributions related to macOS support and documentation are welcome however.
 
 ## Prerequisites
 
+### Install Homebrew
+
+This guide uses [Homebrew](https://brew.sh/) to install IREE's dependencies.
+
+```shell
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
 ### Install Bazel
 
-Install Bazel version > 2.0.0 (see 
-[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion) 
-for the specific version IREE uses) by following the 
-[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x).
+Install Bazel via Homebrew:
+
+```shell
+$ brew install bazel
+```
+
+Note: when you first run `bazel` to build IREE, it will prompt you to copy and
+run a shell command to select the right version.
 
 ### Install python3 numpy
 

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -1,4 +1,4 @@
-# Getting Started on MacOS with Bazel
+# Getting Started on macOS with Bazel
 
 <!--
 Notes to those updating this guide:
@@ -13,11 +13,11 @@ Notes to those updating this guide:
 
 This guide walks through building the core compiler and runtime parts of IREE
 from source. Auxiliary components like the Python bindings and Vulkan driver are
-not documented for MacOS at this time.
+not documented for macOS at this time.
 
-IREE is not officially supported on MacOS at this time. It may work, but it is
+IREE is not officially supported on macOS at this time. It may work, but it is
 not a part of our open source CI, and may be intermittently broken.
-Contributions related to MacOS support and documentation are welcome however.
+Contributions related to macOS support and documentation are welcome however.
 
 ## Prerequisites
 
@@ -93,7 +93,7 @@ $ bazel test -k //iree/... \
 ```
 
 > Tip:<br>
-> &nbsp;&nbsp;&nbsp;&nbsp;Not all tests are passing on MacOS, but the build does
+> &nbsp;&nbsp;&nbsp;&nbsp;Not all tests are passing on macOS, but the build does
 > complete successfully at the time of writing.
 
 In general, build artifacts will be under the `bazel-bin` directory at the top
@@ -102,7 +102,7 @@ level.
 ## Recommended user.bazelrc
 
 You can put a user.bazelrc at the root of the repository and it will be ignored
-by git. The recommended contents for Linux/MacOS are:
+by git. The recommended contents for Linux/macOS are:
 
 ```shell
 build --disk_cache=/tmp/bazel-cache
@@ -146,7 +146,7 @@ $ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir \
 *   For an introduction to IREE's project structure and developer tools, see
     [Developer Overview](../developer_overview.md)
 <!--
-TODO: Link to MacOS versions of these guides once they are developed.
+TODO: Link to macOS versions of these guides once they are developed.
 *   To target GPUs using Vulkan, see
     [Getting Started on Linux with Vulkan](getting_started_linux_vulkan.md)
 *   To use IREE's Python bindings, see

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -44,10 +44,11 @@ for guidance.
 # Example using Bazel version `2.1.0`
 $ export BAZEL_VERSION=2.1.0  # Use the version in .bazelversion
 
-# Download and install
+# Download and install. `sudo` is required because the installer writes to 
+# `/usr/local/bin/`, which is read only by default.
 $ curl -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 $ chmod +x "bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
-$ ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
+$ sudo ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 
 # Add to path in `.zshrc`. Swap with `.bashrc` if you are using bash.
 $ echo -e '\n# Add bazel to PATH:\nexport PATH="${PATH}:${HOME}/bin"' >> ~/.zshrc

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -26,36 +26,36 @@ Contributions related to MacOS support and documentation are welcome however.
 Install the version of Bazel found in
 [`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion).
 
-#### Install xcode.
+#### Install Xcode.
 
-If you've already installed `xcode-select` and this fails with it can likely be
-ignored.
+Running this may be sufficient (and takes up much less disk space):
 
 ```
-$ sudo xcodebuild -license accept
+$ xcode-select --install
 ```
+
+If you run into complications, see the
+[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x)
+for guidance.
 
 #### Download and install Bazel from a binary.
+
 ```
 # Example using Bazel version `2.1.0`
-$ export BAZEL_VERSION=2.1.0
+$ export BAZEL_VERSION=2.1.0  # Use the version in .bazelversion
 
 # Download and install
 $ curl -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 $ chmod +x "bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 $ ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 
-# Add to path
+# Add to path in `.zshrc`. Swap with `.bashrc` if you are using bash.
 $ echo -e '\n# Add bazel to PATH:\nexport PATH="${PATH}:${HOME}/bin"' >> ~/.zshrc
 $ source ~/.zshrc
 
 # Confirm the version
 $ bazel --version # 2.1.0
 ```
-
-See the
-[official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x)
-for additional guidance if needed.
 
 ### Install a Compiler
 

--- a/docs/GetStarted/getting_started_macos_bazel.md
+++ b/docs/GetStarted/getting_started_macos_bazel.md
@@ -26,7 +26,7 @@ Contributions related to MacOS support and documentation are welcome however.
 Install the version of Bazel found in
 [`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion).
 
-#### Install Xcode.
+#### Install Xcode
 
 Running this may be sufficient (and takes up much less disk space):
 
@@ -38,7 +38,7 @@ If you run into complications, see the
 [official docs](https://docs.bazel.build/versions/master/install-os-x.html#install-with-installer-mac-os-x)
 for guidance.
 
-#### Download and install Bazel from a binary.
+#### Download and install Bazel from a binary
 
 ```
 # Example using Bazel version `2.1.0`
@@ -55,18 +55,6 @@ $ source ~/.zshrc
 
 # Confirm the version
 $ bazel --version # 2.1.0
-```
-
-### Install a Compiler
-
-We recommend Clang. GCC is not fully supported. Appropriate versions of `clang`
-and `clang++` ship with MacOS by default.
-
-Set environment variables for Bazel:
-
-```shell
-export CC=clang
-export CXX=clang++
 ```
 
 ### Install python3 numpy
@@ -148,7 +136,8 @@ Translate a
 and execute a function in the compiled module:
 
 ```shell
-$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir \
+    -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -1,4 +1,4 @@
-# Getting Started on MacOS with CMake
+# Getting Started on macOS with CMake
 
 <!--
 Notes to those updating this guide:
@@ -13,11 +13,11 @@ Notes to those updating this guide:
 
 This guide walks through building the core compiler and runtime parts of IREE
 from source. Auxiliary components like the Python bindings and Vulkan driver are
-not documented for MacOS at this time.
+not documented for macOS at this time.
 
-IREE is not officially supported on MacOS at this time. It may work, but it is
+IREE is not officially supported on macOS at this time. It may work, but it is
 not a part of our open source CI, and may be intermittently broken.
-Contributions related to MacOS support and documentation are welcome however.
+Contributions related to macOS support and documentation are welcome however.
 
 ## Prerequisites
 
@@ -72,7 +72,7 @@ Configure:
 $ cmake -G Ninja -B build/ .
 ```
 
-Note: this should use `Clang` by default on MacOS. `GCC` is not fully supported
+Note: this should use `Clang` by default on macOS. `GCC` is not fully supported
 by IREE.
 
 > Tip:<br>
@@ -111,7 +111,7 @@ $ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
 *   For an introduction to IREE's project structure and developer tools, see
     [Developer Overview](../developer_overview.md)
 <!--
-TODO: Link to MacOS versions of these guides once they are developed.
+TODO: Link to macOS versions of these guides once they are developed.
 *   To target GPUs using Vulkan, see
     [Getting Started on Linux with Vulkan](getting_started_linux_vulkan.md)
 *   To use IREE's Python bindings, see

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -1,4 +1,4 @@
-# Getting Started on Linux with CMake
+# Getting Started on MacOS with CMake
 
 <!--
 Notes to those updating this guide:
@@ -6,50 +6,52 @@ Notes to those updating this guide:
     * This document should be __simple__ and cover essential items only.
       Notes for optional components should go in separate files.
 
-    * This document parallels getting_started_windows_cmake.md and
-      getting_started_macos_bazel.md
+    * This document parallels getting_started_linux_cmake.md and
+      getting_started_windows_cmake.md
       Please keep them in sync.
 -->
 
 This guide walks through building the core compiler and runtime parts of IREE
 from source. Auxiliary components like the Python bindings and Vulkan driver are
-documented separately, as they require further setup.
+not documented for MacOS at this time.
+
+IREE is not officially supported on MacOS at this time. It may work, but it is
+not a part of our open source CI, and may be intermittently broken.
+Contributions related to MacOS support and documentation are welcome however.
 
 ## Prerequisites
 
-### Install CMake
+### Install Homebrew
 
-IREE uses CMake version `>= 3.13`. First try installing via your distribution's
-package manager and verify the version:
+This guide uses [Homebrew](https://brew.sh/) to install IREE's dependencies.
 
 ```shell
-$ sudo apt install cmake
-$ cmake --version # >= 3.13
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-Some package managers (like `apt`) distribute old versions of cmake. If your
-package manager installs a version `< 3.13`, then follow the installation
-instructions [here](https://cmake.org/install/) to install a newer version (e.g.
-the latest).
+### Install CMake
 
-> Tip:<br>
-> &nbsp;&nbsp;&nbsp;&nbsp;Your editor of choice likely has plugins for CMake,
-> such as the Visual Studio Code
-> [CMake Tools](https://github.com/microsoft/vscode-cmake-tools) extension.
+IREE uses [CMake](https://cmake.org/) version `>= 3.13`. Brew ships the latest
+release.
+
+```shell
+$ brew install cmake
+$ cmake --version  # >= 3.13
+```
 
 ### Install Ninja
 
 [Ninja](https://ninja-build.org/) is a fast build system that you can use as a
-CMake generator. Follow Ninja's
-[installing documentation](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
+CMake generator.
+
+```
+$ brew install ninja
+```
 
 ### Install a Compiler
 
-We recommend Clang. GCC is not fully supported.
-
-```shell
-$ sudo apt install clang
-```
+We recommend Clang. GCC is not fully supported. Appropriate versions of `clang`
+and `clang++` ship with MacOS by default.
 
 ## Clone and Build
 
@@ -109,7 +111,10 @@ $ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir -input-value
 
 *   For an introduction to IREE's project structure and developer tools, see
     [Developer Overview](../developer_overview.md)
+<!--
+TODO: Link to MacOS versions of these guides once they are developed.
 *   To target GPUs using Vulkan, see
     [Getting Started on Linux with Vulkan](getting_started_linux_vulkan.md)
 *   To use IREE's Python bindings, see
     [Getting Started with Python](getting_started_python.md)
+ -->

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -48,11 +48,6 @@ CMake generator.
 $ brew install ninja
 ```
 
-### Install a Compiler
-
-We recommend Clang. GCC is not fully supported. Appropriate versions of `clang`
-and `clang++` ship with MacOS by default.
-
 ## Clone and Build
 
 ### Clone
@@ -74,13 +69,13 @@ $ git submodule update --init
 Configure:
 
 ```shell
-$ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+$ cmake -G Ninja -B build/ .
 ```
 
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
-> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt) file
-> has options for configuring which parts of the project to enable.
+> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
+> file has options for configuring which parts of the project to enable.
 
 Build all targets:
 
@@ -104,7 +99,8 @@ Translate a
 and execute a function in the compiled module:
 
 ```shell
-$ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+$ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
+    -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -44,7 +44,7 @@ $ cmake --version  # >= 3.13
 [Ninja](https://ninja-build.org/) is a fast build system that you can use as a
 CMake generator.
 
-```
+```shell
 $ brew install ninja
 ```
 

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -72,6 +72,9 @@ Configure:
 $ cmake -G Ninja -B build/ .
 ```
 
+Note: this should use `Clang` by default on MacOS. `GCC` is not fully supported
+by IREE.
+
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)

--- a/docs/GetStarted/getting_started_windows_bazel.md
+++ b/docs/GetStarted/getting_started_windows_bazel.md
@@ -25,7 +25,7 @@ documented separately, as they require further setup.
 ### Install Bazel
 
 Install Bazel version > 2.0.0 (see
-[.bazelversion](https://github.com/google/iree/blob/master/.bazelversion) for
+[`.bazelversion`](https://github.com/google/iree/blob/master/.bazelversion) for
 the specific version IREE uses) by following the
 [official docs](https://docs.bazel.build/versions/master/install-windows.html).
 

--- a/docs/GetStarted/getting_started_windows_bazel.md
+++ b/docs/GetStarted/getting_started_windows_bazel.md
@@ -6,12 +6,13 @@ Notes to those updating this guide:
     * This document should be __simple__ and cover essential items only.
       Notes for optional components should go in separate files.
 
-    * This document parallels getting_started_linux_bazel.md.
+    * This document parallels getting_started_linux_bazel.md and
+      getting_started_macos_bazel.md
       Please keep them in sync.
 -->
 
 This guide walks through building the core compiler and runtime parts of IREE
-from source. Auxilary components like the Python bindings and Vulkan driver are
+from source. Auxiliary components like the Python bindings and Vulkan driver are
 documented separately, as they require further setup.
 
 ## Prerequisites

--- a/docs/GetStarted/getting_started_windows_cmake.md
+++ b/docs/GetStarted/getting_started_windows_cmake.md
@@ -75,8 +75,8 @@ Configure:
 
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
-> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt) file
-> has options for configuring which parts of the project to enable.
+> [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
+> file has options for configuring which parts of the project to enable.
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_windows_cmake.md
+++ b/docs/GetStarted/getting_started_windows_cmake.md
@@ -6,12 +6,13 @@ Notes to those updating this guide:
     * This document should be __simple__ and cover essential items only.
       Notes for optional components should go in separate files.
 
-    * This document parallels getting_started_linux_cmake.md.
+    * This document parallels getting_started_linux_cmake.md and
+      getting_started_macos_cmake.md
       Please keep them in sync.
 -->
 
 This guide walks through building the core compiler and runtime parts of IREE
-from source. Auxilary components like the Python bindings and Vulkan driver are
+from source. Auxiliary components like the Python bindings and Vulkan driver are
 documented separately, as they require further setup.
 
 ## Prerequisites

--- a/iree/tools/run_lit.sh
+++ b/iree/tools/run_lit.sh
@@ -30,7 +30,10 @@ set -e
 function find_executables() {
   set -e
   local p="$1"
-  if [ -z "$cygpath" ]; then
+  if [ "$(uname)" == "Darwin" ]; then
+    # For MacOS, xtype isn't avaliable and perm can't use `/u=x,g=x,o=x` syntax.
+    find "${p}" -type l -perm +111
+  elif [ -z "$cygpath" ]; then
     # For non-windows, use the perm based executable check, which has been
     # supported by find for a very long time.
     find "${p}" -xtype f -perm /u=x,g=x,o=x -print

--- a/iree/tools/run_lit.sh
+++ b/iree/tools/run_lit.sh
@@ -31,7 +31,7 @@ function find_executables() {
   set -e
   local p="$1"
   if [ "$(uname)" == "Darwin" ]; then
-    # For MacOS, xtype isn't avaliable and perm can't use `/u=x,g=x,o=x` syntax.
+    # For macOS, xtype isn't avaliable and perm can't use `/u=x,g=x,o=x` syntax.
     find "${p}" -type l -perm +111
   elif [ -z "$cygpath" ]; then
     # For non-windows, use the perm based executable check, which has been

--- a/packaging/python/common_setup.py
+++ b/packaging/python/common_setup.py
@@ -123,7 +123,7 @@ def setup(**kwargs):
 
   # Need to include platform specific extensions binaries:
   #  Windows: .pyd
-  #  MacOS: .dylib
+  #  macOS: .dylib
   #  Other: .so
   # Unfortunately, bazel is imprecise and scatters .so files around, so
   # need to be specific.

--- a/scripts/prepare_doc_publication.py
+++ b/scripts/prepare_doc_publication.py
@@ -54,6 +54,8 @@ DOC_TITLE_DICT = {
     'getting_started_windows_bazel.md': 'Windows with Bazel',
     'getting_started_windows_cmake.md': 'Windows with CMake',
     'getting_started_windows_vulkan.md': 'Windows with Vulkan',
+    'getting_started_macos_bazel.md': 'macOS with Bazel',
+    'getting_started_macos_cmake.md': 'macOS with CMake',
     'generic_vulkan_env_setup.md': 'Generic Vulkan Setup',
     'getting_started_python.md': 'Python',
     'op_coverage.md': 'XLA HLO Operation Coverage',
@@ -76,6 +78,8 @@ PERMALINK_DICT = {
     'getting_started_windows_bazel.md': 'GetStarted/WindowsBazel',
     'getting_started_windows_cmake.md': 'GetStarted/WindowsCMake',
     'getting_started_windows_vulkan.md': 'GetStarted/WindowsVulkan',
+    'getting_started_macos_cmake.md': 'GetStarted/macOSCMake',
+    'getting_started_macos_vulkan.md': 'GetStarted/macOSVulkan',
     'generic_vulkan_env_setup.md': 'GetStarted/GenericVulkanSetup',
     'getting_started_python.md': 'GetStarted/Python',
     'developer_overview.md': 'DeveloperOverview',
@@ -110,8 +114,10 @@ NAVI_ORDER_DICT = {
     'getting_started_windows_cmake.md': 4,
     'getting_started_windows_bazel.md': 5,
     'getting_started_windows_vulkan.md': 6,
-    'getting_started_python.md': 7,
-    'generic_vulkan_env_setup.md': 8,
+    'getting_started_macos_cmake.md': 7,
+    'getting_started_macos_bazel.md': 8
+    'getting_started_python.md': 9,
+    'generic_vulkan_env_setup.md': 10,
 }
 
 # A dictionary containing source directory to section tile mappings.

--- a/scripts/prepare_doc_publication.py
+++ b/scripts/prepare_doc_publication.py
@@ -115,7 +115,7 @@ NAVI_ORDER_DICT = {
     'getting_started_windows_bazel.md': 5,
     'getting_started_windows_vulkan.md': 6,
     'getting_started_macos_cmake.md': 7,
-    'getting_started_macos_bazel.md': 8
+    'getting_started_macos_bazel.md': 8,
     'getting_started_python.md': 9,
     'generic_vulkan_env_setup.md': 10,
 }


### PR DESCRIPTION
This puts MacOS at a point where all but 8 of the core IREE tests are passing on Bazel. Both the Bazel and Cmake builds complete successfully on my laptop.

The getting started documentation include disclaimers that we do not actively support MacOS.

Python3 numpy is added as a dependency to the Linux and MacOS Bazel builds to reflect the effects of using `python3 configure_bazel.py`.

This change also adds a lot of small fixes to the getting started docs more broadly, as they were requested by reviewers.