### PR TITLE
CMake: Only build FileCheck if using bundled LLVM

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -386,8 +386,10 @@ if(${IREE_ENABLE_MLIR})
   add_custom_target(IreeFileCheck ALL
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/IreeFileCheck.sh IreeFileCheck
   )
-  add_custom_target(LLVMFileCheck ALL
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:FileCheck> FileCheck
-    DEPENDS FileCheck
-  )
+  if(${IREE_MLIR_DEP_MODE} STREQUAL "BUNDLED")
+    add_custom_target(LLVMFileCheck ALL
+      COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:FileCheck> FileCheck
+      DEPENDS FileCheck
+    )
+  endif()
 endif()


### PR DESCRIPTION
`$<TARGET_FILE:FileCheck>` cannot be resolved if `${IREE_MLIR_DEP_MODE}` isn't `BUNDLED`.