### PR TITLE
[Bazel->CMake] Use generic target mapping for LLVM

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -24,16 +24,6 @@ EXPLICIT_TARGET_MAPPING = {
     "@dear_imgui//:imgui_sdl_vulkan": [
         "dear_imgui::impl_sdl", "dear_imgui::impl_vulkan"
     ],
-    # LLVM
-    "@llvm-project//llvm:AsmParser": ["LLVMAsmParser"],
-    "@llvm-project//llvm:Core": ["LLVMCore"],
-    "@llvm-project//llvm:ExecutionEngine": ["LLVMExecutionEngine"],
-    "@llvm-project//llvm:Passes": ["LLVMPasses"],
-    "@llvm-project//llvm:Target": ["LLVMTarget"],
-    "@llvm-project//llvm:Support": ["LLVMSupport"],
-    "@llvm-project//llvm:OrcJIT": ["LLVMOrcJIT"],
-    "@llvm-project//llvm:TableGen": ["LLVMTableGen"],
-    "@llvm-project//llvm:X86CodeGen": ["LLVMX86CodeGen"],
     # MLIR
     "@llvm-project//mlir:AllPassesAndDialects": ["MLIRAllDialects"],
     "@llvm-project//mlir:AllPassesAndDialectsNoRegistration": [

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -102,6 +102,14 @@ def _convert_mlir_target(target):
   return ["MLIR" + target.rsplit(":")[-1]]
 
 
+def _convert_llvm_target(target):
+  # Default to a pattern substitution approach.
+  # Prepend "LLVM" to the Bazel target name.
+  #   "@llvm-project//llvm:AsmParser" -> "LLVMAsmParser"
+  #   "@llvm-project//llvm:Core" -> "LLVMCore"
+  return ["LLVM" + target.rsplit(":")[-1]]
+
+
 def convert_external_target(target):
   """Converts an external (non-IREE) Bazel target to a list of CMake targets.
 
@@ -122,6 +130,8 @@ def convert_external_target(target):
     return EXPLICIT_TARGET_MAPPING[target]
   if target.startswith("@com_google_absl//absl"):
     return _convert_absl_target(target)
+  if target.startswith("@llvm-project//llvm"):
+    return _convert_llvm_target(target)
   if target.startswith("@llvm-project//mlir"):
     return _convert_mlir_target(target)
   if target.startswith("@org_tensorflow//tensorflow/compiler/mlir"):


### PR DESCRIPTION
LLVM Bazel target names now align with upstream CMake/LLVMBuild library names, so we don't need to do custom mapping.