### PR TITLE
Run Bazel to CMake.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -20,9 +20,9 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "ConvertToLLVM.cpp"
     "HALInterfaceToMemrefArguments.cpp"
     "Passes.cpp"
-    "ConvertToLLVM.cpp"
   DEPS
     MLIRAffineToStandard
     MLIRIR


### PR DESCRIPTION
`./build_tools/bazel_to_cmake/bazel_to_cmake.py`

Broken at head