### PR TITLE
[vulkan] Search for libvulkan.so for Android

### DIFF
--- a/iree/hal/vulkan/dynamic_symbols.cc
+++ b/iree/hal/vulkan/dynamic_symbols.cc
@@ -76,7 +76,9 @@ static constexpr const FunctionPtrInfo kDynamicFunctionPtrInfos[] = {
                                       DEV_PFN_FUNCTION_PTR)};
 
 static const char* kVulkanLoaderSearchNames[] = {
-#if defined(IREE_PLATFORM_WINDOWS)
+#if defined(IREE_PLATFORM_ANDROID)
+    "libvulkan.so",
+#elif defined(IREE_PLATFORM_WINDOWS)
     "vulkan-1.dll",
 #else
     "libvulkan.so.1",


### PR DESCRIPTION
The Vulkan loader on installed as /system/lib[64]/libvulkan.so.
We don't have libvulkan.so.1 on Android.