### PR TITLE
Adds doc generation for a TensorFlow E2E coverage table.

### DIFF
--- a/build_tools/cmake/build_docs.sh
+++ b/build_tools/cmake/build_docs.sh
@@ -51,6 +51,7 @@ cd ${ROOT_DIR?}
 
 # Update op_coverage.md
 scripts/update_op_coverage.py ${BUILD_DIR}
+scripts/update_e2e_coverage.py ${BUILD_DIR}
 
 # Copy a curated list of docs to publish. This is expected to cover all docs
 # under docs/ after they are refreshed.

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Test coverage across backends for e2e tests is defined directly in the BUILD
+# files. A coverage table generated from this file can be viewed here:
+#   https://google.github.io/iree/TensorFlowE2ECoverage
+# Updates made to test suite names should also be reflected here:
+#   https://github.com/google/iree/blob/master/scripts/update_e2e_coverage.py
+
 load(
     "//bindings/python:build_defs.oss.bzl",
     "INTREE_TENSORFLOW_PY_DEPS",

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Test coverage across backends for e2e tests is defined directly in the BUILD
+# files. A coverage table generated from this file can be viewed here:
+#   https://google.github.io/iree/TensorFlowE2ECoverage
+# Updates made to test suite names should also be reflected here:
+#   https://github.com/google/iree/blob/master/scripts/update_e2e_coverage.py
+
 load(
     "//bindings/python:build_defs.oss.bzl",
     "INTREE_TENSORFLOW_PY_DEPS",

--- a/scripts/prepare_doc_publication.py
+++ b/scripts/prepare_doc_publication.py
@@ -60,6 +60,7 @@ DOC_TITLE_DICT = {
     'getting_started_python.md': 'Python',
     'cmake_options_and_variables.md': 'CMake Options and Variables',
     'op_coverage.md': 'XLA HLO Operation Coverage',
+    'e2e_coverage.md': 'TensorFlow E2E Coverage',
     'roadmap.md': 'Short-term Focus Areas',
     'roadmap_design.md': 'Long-term Design Roadmap',
     'iree_community.md': 'Community',
@@ -87,6 +88,7 @@ PERMALINK_DICT = {
     'developer_overview.md': 'DeveloperOverview',
     'testing_guide.md': 'TestingGuide',
     'op_coverage.md': 'HLOOpCoverage',
+    'e2e_coverage.md': 'TensorFlowE2ECoverage',
     'roadmap.md': 'FocusAreas',
     'roadmap_design.md': 'DesignRoadmap',
     'iree_community.md': 'Community',
@@ -104,8 +106,9 @@ NAVI_ORDER_DICT = {
     'roadmap_design.md': 4,
     'roadmap.md': 5,
     'op_coverage.md': 6,
-    'testing_guide.md': 7,
-    'iree_community.md': 8,
+    'e2e_coverage.md': 7,
+    'testing_guide.md': 8,
+    'iree_community.md': 9,
 
     # Within 'Getting Started' use explicit ordering.
     # Alphabetical would put 'bazel' before 'cmake' and 'python' between 'linux'
@@ -136,7 +139,10 @@ DIRECTORY_TITLE_DICT = {
 }
 
 # A dictionary containing the supporting JavaScript files for each doc.
-JS_FILES_DICT = {'op_coverage.md': ['js/add_classes.js']}
+JS_FILES_DICT = {
+  'op_coverage.md': ['js/add_classes.js'],
+  'e2e_coverage.md': ['js/add_classes.js'],
+}
 
 
 def process_file(basedir, relpath, filename):

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Updates coverage of TensorFlow e2e tests on all backends.
+
+Example usage: python3 update_e2e_coverage.py build-docs
+"""
+
+import argparse
+import collections
+import os
+import subprocess
+
+
+REFERENCE_BACKEND = 'tf'
+# Assumes that tests are expanded for the tf_also, iree_vmla, iree_llvmjit and
+# iree_vulkan backends.
+BACKENDS_TO_TITLES = collections.OrderedDict([
+    ('tf_also', 'tensorflow'),
+    ('iree_vmla', 'vmla'),
+    ('iree_llvmjit', 'llvm-ir'),
+    ('iree_vulkan', 'vulkan-spirv'),
+])
+
+TEST_SUITES_TO_HEADERS = {
+    '//integrations/tensorflow/e2e:e2e_tests':
+        'End to end TensorFlow tests',
+    '//integrations/tensorflow/e2e/keras:keras_tests':
+        'End to end tests written using tf.keras',
+    '//integrations/tensorflow/e2e/keras:vision_external_tests':
+        'End to end tests of tf.keras.applications vision models',
+}
+
+# Some test suites are generated from a single source. This allows us to point
+# to the right test file when generating test URLs.
+SINGLE_SOURCE_SUITES = {
+    '//integrations/tensorflow/e2e/keras:vision_external_tests':
+        'vision_model_test',
+}
+
+# The symbols to show in the table if the operation is supported or not.
+SUCCESS_ELEMENT = '<span class="success-table-element">✓</span>'
+FAILURE_ELEMENT = '<span class="failure-table-element">✗</span>'
+
+MAIN_URL = 'https://github.com/google/iree/tree/main'
+TARGETS_URL = os.path.join(MAIN_URL, 'iree/compiler/Dialect/HAL/Target')
+
+E2E_COVERAGE_DESCRIPTION = f"""# TensorFlow End to End Coverage
+There are three backend [targets]({TARGETS_URL}) in IREE:
+
+- vmla
+- llvm-ir
+- vulkan-spirv
+
+The table shows the supported TensorFlow functions and models on each backend.
+
+"""
+
+
+def parse_arguments():
+  """Parses command-line options."""
+  parser = argparse.ArgumentParser(
+      description='Generates Markdown files for op coverage table')
+  parser.add_argument(
+      'build_dir', metavar='BUILD_PATH', type=str, help='Base build directory.')
+
+  parsed_args = parser.parse_args()
+  if not os.path.isdir(parsed_args.build_dir):
+    raise parser.error('expected path to a directory')
+
+  return parsed_args
+
+
+def create_markdown_table(rows):
+  """Converts a 2D array to a Markdown table."""
+  return '\n'.join([' | '.join(row) for row in rows])
+
+
+def get_name_and_backend(test_string):
+  """Splits a pathless test target into its name and comparison backend."""
+  name, backend = test_string.split(f'__{REFERENCE_BACKEND}__')
+  return name, backend
+
+
+def get_test_targets(test_suite_path):
+  """Returns a list of test targets stripped of paths and suite names."""
+  # Check if the suite exists (which may not be true for failing suites)
+  target_dir = test_suite.split(':')[0]
+  query = ['bazel', 'query', f'{target_dir}/...']
+  targets = subprocess.check_output(query, stderr=subprocess.DEVNULL)
+  if test_suite_path not in targets.decode('ascii'):
+    return []
+
+  query = ['bazel', 'query', f'tests({test_suite_path})']
+  tests = subprocess.check_output(query, stderr=subprocess.DEVNULL)
+  tests = tests.decode('ascii').split('\n')
+  tests = list(filter(lambda s: s.startswith(f'{test_suite_path}_'), tests))
+  tests = [test.replace(f'{test_suite_path}_', '') for test in tests]
+  return tests
+
+
+def get_suite_metadata(test_suite):
+  """Gets all test names, and passing and failing test-backend pairs."""
+  passing = get_test_targets(test_suite)
+  failing = get_test_targets(f'{test_suite}_failing')
+  passing = [get_name_and_backend(test) for test in passing]
+  failing = [get_name_and_backend(test) for test in failing]
+  passing_names = [test[0] for test in passing]
+  failing_names = [test[0] for test in failing]
+  all_names = list(sorted(set(passing_names + failing_names)))
+  return all_names, passing, failing
+
+
+def get_name_element(test_suite, name):
+  """Returns a Markdown hyperlink pointing to the test source on GitHub."""
+  # Convert `//path/to/tests:test_suite` to `path/to/tests`
+  test_path = test_suite.split(':')[0]
+  test_path = test_path.replace('//', '')
+
+  if test_suite in SINGLE_SOURCE_SUITES:
+    test_name = SINGLE_SOURCE_SUITES[test_suite]
+  else:
+    test_name = name
+
+  test_url = os.path.join(MAIN_URL, test_path, f'{test_name}.py')
+  return f'[{name}]({test_url})'
+
+
+def generate_table(test_suite):
+  """Generates an e2e backend coverage Markdown table."""
+  all_names, passing, _ = get_suite_metadata(test_suite)
+
+  # Generate a dictionary mapping test names to their backend coverage.
+  table = collections.defaultdict(lambda: [False] * len(BACKENDS_TO_TITLES))
+  ordered_backends = list(BACKENDS_TO_TITLES.keys())
+  for name, backend in passing:
+    table[name][ordered_backends.index(backend)] = True
+
+  # Create a header for the coverage table.
+  ordered_backend_titles = list(BACKENDS_TO_TITLES.values())
+  first_row = ['target'] + ordered_backend_titles
+  second_row = [':-:' for _ in first_row]
+
+  # Generate the coverage table as a 2D array.
+  rows = [first_row, second_row]
+  for name, backends in sorted(table.items()):
+    row = [get_name_element(test_suite, name)]
+    row.extend([
+        SUCCESS_ELEMENT if backend else FAILURE_ELEMENT for backend in backends
+    ])
+    rows.append(row)
+  return create_markdown_table(rows)
+
+
+if __name__ == '__main__':
+  args = parse_arguments()
+
+  content = []
+  for test_suite, header in TEST_SUITES_TO_HEADERS.items():
+    content.append(f'## {header}')
+    content.append(generate_table(test_suite))
+  content = '\n\n'.join(content) + '\n'  # Trailing newline.
+
+  table_path = os.path.join(args.build_dir, 'doc', 'e2e_coverage.md')
+  with open(table_path, 'w', encoding='utf-8') as f:
+    f.write(E2E_COVERAGE_DESCRIPTION)
+    f.write(content)


### PR DESCRIPTION
`update_e2e_coverage.py` is branched from `update_op_coverage.py`, but uses `bazel query` to get the coverage metadata from the `integrations/tensorflow/e2e/...` `BUILD` files.

I manually tested that doc publication works according [the docs](https://github.com/google/iree/tree/gh-pages#making-complex-changes).

![tf_e2e_coverage](https://user-images.githubusercontent.com/40036383/85147998-74f44400-b204-11ea-8852-a67c44a41b16.png)