### PR TITLE
Improve docs on CMake variables and options

### DIFF
--- a/docs/GetStarted/cmake_options_and_variables.md
+++ b/docs/GetStarted/cmake_options_and_variables.md
@@ -24,12 +24,14 @@ Enables instrumented runtime tracing. Defaults to `OFF`.
 
 #### `IREE_ENABLE_MLIR`:BOOL
 
-Enables MLIR/LLVM dependencies. Defaults to `ON`.
+Enables MLIR/LLVM dependencies. Defaults to `ON`. MLIR/LLVM dependencies are
+required if the IREE compiler should be build. Therefore, the option is
+automatically set to `ON` if `IREE_BUILD_COMPILER` is set to `ON`.
 
 #### `IREE_ENABLE_EMITC`:BOOL
 
-Enables MLIR EmitC dependencies. Defaults to OFF. Requires that
-`IREE_ENABLE_MLIR` is set to `ON`.
+Enables the build of the out-of-tree MLIR dialect EmitC. Defaults to `OFF`. To
+build the EmitC dialect, `IREE_ENABLE_MLIR` must be set to `ON`.
 
 #### `IREE_BUILD_COMPILER`:BOOL
 
@@ -53,7 +55,7 @@ Builds the IREE debugger app. Defaults to `OFF`.
 
 #### `IREE_BUILD_PYTHON_BINDINGS`:BOOL
 
-Builds the IREE python bindings Defaults to `OFF`.
+Builds the IREE python bindings. Defaults to `OFF`.
 
 #### `IREE_BUILD_EXPERIMENTAL`:BOOL
 
@@ -75,7 +77,9 @@ building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
 
 #### `IREE_ENABLE_LLD`:BOOL
 
-Use lld when linking. Defaults to `OFF`.
+Use lld when linking. Defaults to `OFF`. This option is equivalent to
+`-DIREE_USE_LINKER=lld`. The option `IREE_ENABLE_LLD` and `IREE_USE_LINKER` can
+not be set at the same time.
 
 #### `IREE_MLIR_DEP_MODE`:STRING
 

--- a/docs/GetStarted/cmake_options_and_variables.md
+++ b/docs/GetStarted/cmake_options_and_variables.md
@@ -1,4 +1,20 @@
-# IREE-specific CMake Options and Variables
+# CMake Options and Variables
+
+## Frequently-used CMake Variables
+
+*   `CMAKE_BUILD_TYPE`:STRING
+
+    Sets the build type. Possible values are `Release`, `Debug`,
+    `RelWithDebInfo`/`FastBuild` and `MinSizeRel`. If unset, build type is set
+    to `Release`.
+
+*   `CMAKE_<LANG>_COMPILER`:STRING
+
+    This is the command that will be used as the `<LANG>` compiler, which are
+    `C` and `CXX` in IREE. These variables are set to compile IREE with
+    `clang` or rather `clang++`. Once set, these variables can not be changed.
+
+## IREE-specific CMake Options and Variables
 
 This gives a brief explanation of IREE specific CMake options and variables.
 
@@ -67,6 +83,8 @@ This gives a brief explanation of IREE specific CMake options and variables.
     `DISABLED` or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the
     variable `MLIR_DIR` needs to be passed and that LLVM needs to be compiled
     with `LLVM_ENABLE_RTTI` set to `ON`.
+
+## MLIR-specific CMake Options and Variables
 
 *   `MLIR_DIR`:STRING
 

--- a/docs/GetStarted/cmake_options_and_variables.md
+++ b/docs/GetStarted/cmake_options_and_variables.md
@@ -2,13 +2,13 @@
 
 ## Frequently-used CMake Variables
 
-### `CMAKE_BUILD_TYPE`:STRING
+#### `CMAKE_BUILD_TYPE`:STRING
 
 Sets the build type. Possible values are `Release`, `Debug`,
 `RelWithDebInfo`/`FastBuild` and `MinSizeRel`. If unset, build type is set to
 `Release`.
 
-### `CMAKE_<LANG>_COMPILER`:STRING
+#### `CMAKE_<LANG>_COMPILER`:STRING
 
 This is the command that will be used as the `<LANG>` compiler, which are `C`
 and `CXX` in IREE. These variables are set to compile IREE with `clang` or
@@ -18,66 +18,66 @@ rather `clang++`. Once set, these variables can not be changed.
 
 This gives a brief explanation of IREE specific CMake options and variables.
 
-### `IREE_ENABLE_RUNTIME_TRACING`:BOOL
+#### `IREE_ENABLE_RUNTIME_TRACING`:BOOL
 
 Enables instrumented runtime tracing. Defaults to `OFF`.
 
-### `IREE_ENABLE_MLIR`:BOOL
+#### `IREE_ENABLE_MLIR`:BOOL
 
 Enables MLIR/LLVM dependencies. Defaults to `ON`.
 
-### `IREE_ENABLE_EMITC`:BOOL
+#### `IREE_ENABLE_EMITC`:BOOL
 
 Enables MLIR EmitC dependencies. Defaults to OFF. Requires that
 `IREE_ENABLE_MLIR` is set to `ON`.
 
-### `IREE_BUILD_COMPILER`:BOOL
+#### `IREE_BUILD_COMPILER`:BOOL
 
 Builds the IREE compiler. Defaults to `ON`.
 
-### `IREE_BUILD_TESTS`:BOOL
+#### `IREE_BUILD_TESTS`:BOOL
 
 Builds IREE unit tests. Defaults to `ON`.
 
-### `IREE_BUILD_DOCS`:BOOL
+#### `IREE_BUILD_DOCS`:BOOL
 
 Builds IREE documentation. Defaults to `OFF`.
 
-### `IREE_BUILD_SAMPLES`:BOOL
+#### `IREE_BUILD_SAMPLES`:BOOL
 
 Builds IREE sample projects. Defaults to `ON`.
 
-### `IREE_BUILD_DEBUGGER`:BOOL
+#### `IREE_BUILD_DEBUGGER`:BOOL
 
 Builds the IREE debugger app. Defaults to `OFF`.
 
-### `IREE_BUILD_PYTHON_BINDINGS`:BOOL
+#### `IREE_BUILD_PYTHON_BINDINGS`:BOOL
 
 Builds the IREE python bindings Defaults to `OFF`.
 
-### `IREE_BUILD_EXPERIMENTAL`:BOOL
+#### `IREE_BUILD_EXPERIMENTAL`:BOOL
 
 Builds experimental projects. Defaults to `OFF`.
 
-### `IREE_HAL_DRIVERS_TO_BUILD`:STRING
+#### `IREE_HAL_DRIVERS_TO_BUILD`:STRING
 
 *This does not have any effect at the moment, but will be supported in the
 future!* Semicolon-separated list of HAL drivers to build, or `all` for
 building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
 `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan;VMLA"`.
 
-### `IREE_TARGET_BACKENDS_TO_BUILD`:STRING
+#### `IREE_TARGET_BACKENDS_TO_BUILD`:STRING
 
 *This does not have any effect at the moment, but will be supported in the
 future!* Semicolon-separated list of HAL drivers to build, or `all` for
 building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
 `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan_SPIRV;VMLA"`.
 
-### `IREE_ENABLE_LLD`:BOOL
+#### `IREE_ENABLE_LLD`:BOOL
 
 Use lld when linking. Defaults to `OFF`.
 
-### `IREE_MLIR_DEP_MODE`:STRING
+#### `IREE_MLIR_DEP_MODE`:STRING
 
 Defines the MLIR dependency mode. Case-sensitive. Can be `BUNDLED`, `DISABLED`
 or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the variable
@@ -86,7 +86,7 @@ or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the variable
 
 ## MLIR-specific CMake Options and Variables
 
-### `MLIR_DIR`:STRING
+#### `MLIR_DIR`:STRING
 
 Specifies the path where to look for the installed MLIR/LLVM packages.
 Required if `IREE_MLIR_DEP_MODE` is set to `INSTALLED`.

--- a/docs/GetStarted/cmake_options_and_variables.md
+++ b/docs/GetStarted/cmake_options_and_variables.md
@@ -25,7 +25,7 @@ Enables instrumented runtime tracing. Defaults to `OFF`.
 #### `IREE_ENABLE_MLIR`:BOOL
 
 Enables MLIR/LLVM dependencies. Defaults to `ON`. MLIR/LLVM dependencies are
-required if the IREE compiler should be build. Therefore, the option is
+required when building the IREE compiler components. Therefore, the option is
 automatically set to `ON` if `IREE_BUILD_COMPILER` is set to `ON`.
 
 #### `IREE_ENABLE_EMITC`:BOOL

--- a/docs/GetStarted/cmake_options_and_variables.md
+++ b/docs/GetStarted/cmake_options_and_variables.md
@@ -2,91 +2,91 @@
 
 ## Frequently-used CMake Variables
 
-*   `CMAKE_BUILD_TYPE`:STRING
+### `CMAKE_BUILD_TYPE`:STRING
 
-    Sets the build type. Possible values are `Release`, `Debug`,
-    `RelWithDebInfo`/`FastBuild` and `MinSizeRel`. If unset, build type is set
-    to `Release`.
+Sets the build type. Possible values are `Release`, `Debug`,
+`RelWithDebInfo`/`FastBuild` and `MinSizeRel`. If unset, build type is set to
+`Release`.
 
-*   `CMAKE_<LANG>_COMPILER`:STRING
+### `CMAKE_<LANG>_COMPILER`:STRING
 
-    This is the command that will be used as the `<LANG>` compiler, which are
-    `C` and `CXX` in IREE. These variables are set to compile IREE with
-    `clang` or rather `clang++`. Once set, these variables can not be changed.
+This is the command that will be used as the `<LANG>` compiler, which are `C`
+and `CXX` in IREE. These variables are set to compile IREE with `clang` or
+rather `clang++`. Once set, these variables can not be changed.
 
 ## IREE-specific CMake Options and Variables
 
 This gives a brief explanation of IREE specific CMake options and variables.
 
-*   `IREE_ENABLE_RUNTIME_TRACING`:BOOL
+### `IREE_ENABLE_RUNTIME_TRACING`:BOOL
 
-    Enables instrumented runtime tracing. Defaults to `OFF`.
+Enables instrumented runtime tracing. Defaults to `OFF`.
 
-*   `IREE_ENABLE_MLIR`:BOOL
+### `IREE_ENABLE_MLIR`:BOOL
 
-    Enables MLIR/LLVM dependencies. Defaults to `ON`.
+Enables MLIR/LLVM dependencies. Defaults to `ON`.
 
-*   `IREE_ENABLE_EMITC`:BOOL
+### `IREE_ENABLE_EMITC`:BOOL
 
-    Enables MLIR EmitC dependencies. Defaults to OFF. Requires that
-    `IREE_ENABLE_MLIR` is set to `ON`.
+Enables MLIR EmitC dependencies. Defaults to OFF. Requires that
+`IREE_ENABLE_MLIR` is set to `ON`.
 
-*   `IREE_BUILD_COMPILER`:BOOL
+### `IREE_BUILD_COMPILER`:BOOL
 
-    Builds the IREE compiler. Defaults to `ON`.
+Builds the IREE compiler. Defaults to `ON`.
 
-*   `IREE_BUILD_TESTS`:BOOL
+### `IREE_BUILD_TESTS`:BOOL
 
-    Builds IREE unit tests. Defaults to `ON`.
+Builds IREE unit tests. Defaults to `ON`.
 
-*   `IREE_BUILD_DOCS`:BOOL
+### `IREE_BUILD_DOCS`:BOOL
 
-    Builds IREE documentation. Defaults to `OFF`.
+Builds IREE documentation. Defaults to `OFF`.
 
-*   `IREE_BUILD_SAMPLES`:BOOL
+### `IREE_BUILD_SAMPLES`:BOOL
 
-    Builds IREE sample projects. Defaults to `ON`.
+Builds IREE sample projects. Defaults to `ON`.
 
-*   `IREE_BUILD_DEBUGGER`:BOOL
+### `IREE_BUILD_DEBUGGER`:BOOL
 
-    Builds the IREE debugger app. Defaults to `OFF`.
+Builds the IREE debugger app. Defaults to `OFF`.
 
-*   `IREE_BUILD_PYTHON_BINDINGS`:BOOL
+### `IREE_BUILD_PYTHON_BINDINGS`:BOOL
 
-    Builds the IREE python bindings Defaults to `OFF`.
+Builds the IREE python bindings Defaults to `OFF`.
 
-*   `IREE_BUILD_EXPERIMENTAL`:BOOL
+### `IREE_BUILD_EXPERIMENTAL`:BOOL
 
-    Builds experimental projects. Defaults to `OFF`.
+Builds experimental projects. Defaults to `OFF`.
 
-*   `IREE_HAL_DRIVERS_TO_BUILD`:STRING
+### `IREE_HAL_DRIVERS_TO_BUILD`:STRING
 
-    *This does not have any effect at the moment, but will be supported in the
-    future!* Semicolon-separated list of HAL drivers to build, or `all` for
-    building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
-    `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan;VMLA"`.
+*This does not have any effect at the moment, but will be supported in the
+future!* Semicolon-separated list of HAL drivers to build, or `all` for
+building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
+`-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan;VMLA"`.
 
-*   `IREE_TARGET_BACKENDS_TO_BUILD`:STRING
+### `IREE_TARGET_BACKENDS_TO_BUILD`:STRING
 
-    *This does not have any effect at the moment, but will be supported in the
-    future!* Semicolon-separated list of HAL drivers to build, or `all` for
-    building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
-    `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan_SPIRV;VMLA"`.
+*This does not have any effect at the moment, but will be supported in the
+future!* Semicolon-separated list of HAL drivers to build, or `all` for
+building all HAL drivers. Case-insensitive. Defaults to `all`. Example:
+`-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan_SPIRV;VMLA"`.
 
-*   `IREE_ENABLE_LLD`:BOOL
+### `IREE_ENABLE_LLD`:BOOL
 
-    Use lld when linking. Defaults to `OFF`.
+Use lld when linking. Defaults to `OFF`.
 
-*   `IREE_MLIR_DEP_MODE`:STRING
+### `IREE_MLIR_DEP_MODE`:STRING
 
-    Defines the MLIR dependency mode. Case-sensitive. Can be `BUNDLED`,
-    `DISABLED` or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the
-    variable `MLIR_DIR` needs to be passed and that LLVM needs to be compiled
-    with `LLVM_ENABLE_RTTI` set to `ON`.
+Defines the MLIR dependency mode. Case-sensitive. Can be `BUNDLED`, `DISABLED`
+or `INSTALLED`. Defaults to `BUNDLED`. If set to `INSTALLED`, the variable
+`MLIR_DIR` needs to be passed and that LLVM needs to be compiled with
+`LLVM_ENABLE_RTTI` set to `ON`.
 
 ## MLIR-specific CMake Options and Variables
 
-*   `MLIR_DIR`:STRING
+### `MLIR_DIR`:STRING
 
-    Specifies the path where to look for the installed MLIR/LLVM packages.
-    Required if `IREE_MLIR_DEP_MODE` is set to `INSTALLED`.
+Specifies the path where to look for the installed MLIR/LLVM packages.
+Required if `IREE_MLIR_DEP_MODE` is set to `INSTALLED`.

--- a/docs/GetStarted/getting_started_linux_cmake.md
+++ b/docs/GetStarted/getting_started_linux_cmake.md
@@ -79,6 +79,7 @@ $ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
 > file has options for configuring which parts of the project to enable.
+> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_linux_cmake.md
+++ b/docs/GetStarted/getting_started_linux_cmake.md
@@ -78,8 +78,8 @@ $ cmake -G Ninja -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
-> file has options for configuring which parts of the project to enable.
-> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
+> file has options for configuring which parts of the project to enable.<br>
+> &nbsp;&nbsp;&nbsp;&nbsp;These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -79,6 +79,7 @@ by IREE.
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
 > file has options for configuring which parts of the project to enable.
+> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_macos_cmake.md
+++ b/docs/GetStarted/getting_started_macos_cmake.md
@@ -78,8 +78,8 @@ by IREE.
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
-> file has options for configuring which parts of the project to enable.
-> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
+> file has options for configuring which parts of the project to enable.<br>
+> &nbsp;&nbsp;&nbsp;&nbsp;These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_windows_cmake.md
+++ b/docs/GetStarted/getting_started_windows_cmake.md
@@ -76,8 +76,8 @@ Configure:
 > Tip:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
-> file has options for configuring which parts of the project to enable.
-> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
+> file has options for configuring which parts of the project to enable.<br>
+> &nbsp;&nbsp;&nbsp;&nbsp;These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 

--- a/docs/GetStarted/getting_started_windows_cmake.md
+++ b/docs/GetStarted/getting_started_windows_cmake.md
@@ -77,6 +77,7 @@ Configure:
 > &nbsp;&nbsp;&nbsp;&nbsp;The root
 > [CMakeLists.txt](https://github.com/google/iree/blob/master/CMakeLists.txt)
 > file has options for configuring which parts of the project to enable.
+> These are further documented in [CMake Options and Variables](cmake_options_and_variables.md).
 
 Build all targets:
 


### PR DESCRIPTION
* Improve description of IREE-specific CMake Options and Variables
* Add section on Frequently-used CMake Variables
* Add links from building with CMake docs
* Revise style (use sections instead of bullet points)