### PR TITLE
Make format workflow compatible with multiple base branches

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@
 
 name: Format
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   # Run clang-format and verify there are no errors. We don't want to bother
@@ -22,6 +22,8 @@ jobs:
   format:
     name: Code Format Check
     runs-on: ubuntu-18.04
+    env:
+      BASE_REF: ${{ github.base_ref }}
     steps:
     - name: Installing dependencies
       run: |
@@ -32,10 +34,10 @@ jobs:
         chmod +x /tmp/git-clang-format
     - name: Checking out repository
       uses: actions/checkout@v2
-      # We have to explicitly fetch master as well
-    - name: Fetching master
-      run: git fetch --no-tags --prune --depth=1 origin master
+      # We have to explicitly fetch the base branch as well
+    - name: Fetching Base Branch
+      run: git fetch --no-tags --prune --depth=1 origin "${BASE_REF?}"
     - name: Running clang-format on changed source files
       run: |
-        /tmp/git-clang-format origin/master --binary=clang-format-9 --style=file
+        /tmp/git-clang-format "origin/${BASE_REF?}" --binary=clang-format-9 --style=file
         git diff --exit-code


### PR DESCRIPTION
This allows it to work on pull requests to any branch, which is helpful as we're moving to a multi-branch strategy.

Also stops the workflow from running on every push. This isn't currently useful on the `master` branch because it's just comparing it to itself, and it's mostly noise because it means the action runs 3 times on every commit. We should probably make a separate action if we want to support this.