### PR TITLE
[vulkan] Pad descriptor length for strangely aligned buffers

### DIFF
--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -91,6 +91,7 @@ cc_library(
         ":pipeline_executable",
         ":status_util",
         ":vma_allocator",
+        "//iree/base:alignment",
         "//iree/base:arena",
         "//iree/base:math",
         "//iree/base:status",

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -86,6 +86,7 @@ iree_cc_library(
   COPTS
     "-DVK_NO_PROTOTYPES"
   DEPS
+    iree::base::alignment
     iree::base::arena
     iree::base::math
     iree::base::status

--- a/iree/hal/vulkan/descriptor_set_arena.cc
+++ b/iree/hal/vulkan/descriptor_set_arena.cc
@@ -14,6 +14,7 @@
 
 #include "iree/hal/vulkan/descriptor_set_arena.h"
 
+#include "iree/base/alignment.h"
 #include "iree/base/math.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/vulkan/status_util.h"
@@ -47,7 +48,24 @@ StatusOr<absl::Span<VkWriteDescriptorSet>> PopulateDescriptorSetWriteInfos(
     buffer_info.buffer = buffer->handle();
     // TODO(benvanik): properly subrange (add to BufferBinding).
     buffer_info.offset = binding.buffer->byte_offset();
-    buffer_info.range = binding.buffer->byte_length();
+    // Round up to a multiple of 32-bit. 32-bit is the most native bitwidth on
+    // GPUs; it has the best support compared to other bitwidths. We use VMA to
+    // manage GPU memory for us and VMA should already handled proper alignment
+    // when performing allocations; here we just need to provide the proper
+    // "view" to Vulkan drivers over the allocated memory.
+    //
+    // Note this is needed because we can see unusal buffers like tensor<3xi8>.
+    // Depending on GPU capabilities, this might not always be directly
+    // supported by the hardware. Under such circumstances, we need to emulate
+    // i8 support with i32. Shader CodeGen takes care of that: the shader will
+    // read the buffer as tensor<i32> and perform bit shifts to extract each
+    // byte and conduct computations. The extra additional byte is read but
+    // not really used by the shader. Here in application we need to match the
+    // ABI and provide the buffer as 32-bit aligned, otherwise the whole read by
+    // the shader is considered as out of bounds per the Vulkan spec.
+    // See https://github.com/google/iree/issues/2022#issuecomment-640617234
+    // for more details.
+    buffer_info.range = iree_align(binding.buffer->byte_length(), 4);
 
     auto& write_info = write_infos[i];
     write_info.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/2022