### PR TITLE
Copy Kokoro continuous build configs to be by branch name

### DIFF
--- a/kokoro/gcp_ubuntu/bazel/bindings/continuous.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/continuous.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/google.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/main.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/bindings/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/bazel/bindings/presubmit.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/continuous.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/continuous.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/google.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/main.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/core/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/bazel/core/presubmit.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/continuous.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/continuous.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/google.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/google.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/main.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/main.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/bazel/integrations/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/bazel/integrations/presubmit.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/continuous.cfg
+++ b/kokoro/gcp_ubuntu/cmake/continuous.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/google.cfg
+++ b/kokoro/gcp_ubuntu/cmake/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/google.cfg
+++ b/kokoro/gcp_ubuntu/cmake/google.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/main.cfg
+++ b/kokoro/gcp_ubuntu/cmake/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (upstream only) job
+# configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/main.cfg
+++ b/kokoro/gcp_ubuntu/cmake/main.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.

--- a/kokoro/gcp_ubuntu/cmake/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/cmake/presubmit.cfg
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 # Deliberately blank as everything necessary is configured in common files, but
-# file must still exist to match corresponding (upstream only) job
+# file must still exist to match corresponding (internal only) job
 # configurations that trigger the builds.


### PR DESCRIPTION
This introduces new build configs that will be identified by their branch name. Because we're moving to having multiple persistent branches on which we want CI, we need to distinguish between these with multiple Kokoro jobs (with multiple statuses).

Note that there is no actual configuration in these configs, since the common config has everything they need.

Also changed comments in all of these configs to refer to the Google source repository as "internal" instead of "upstream".

Part of https://github.com/google/iree/issues/2279