### PR TITLE
Change submodule synchronize action to user with CLA

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Committing updates
         if: env.has_diff == 'true'
         run: |
-          git config --local user.email "noreply+action@github.com"
+          git config --local user.email "iree-github-actions-bot@google.com"
           git config --local user.name "Submodule Synchronize Action"
           git commit -am "Synchronize submodules"
       - name: Pushing changes


### PR DESCRIPTION
Otherwise when merging between branches, googlebot complains that the user hasn't signed the CLA.

Part of https://github.com/google/iree/issues/2279