### PR TITLE
Add yaml lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,32 +22,32 @@ jobs:
     env:
       BASE_REF: ${{ github.base_ref }}
     steps:
-    - name: Installing dependencies
-      run: |
-        sudo add-apt-repository -y "deb http://mirror.enzu.com/ubuntu/ eoan main universe"
-        sudo apt-get update -qq
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
-        wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
-        chmod +x /tmp/git-clang-format
-    - name: Checking out repository
-      uses: actions/checkout@v2
-      # We have to explicitly fetch the base branch as well
-    - name: Fetching Base Branch
-      run: git fetch --no-tags --prune --depth=1 origin "${BASE_REF?}"
-    - name: Running clang-format on changed source files
-      run: |
-        /tmp/git-clang-format "origin/${BASE_REF?}" --binary=clang-format-9 --style=file
-        git diff --exit-code
+      - name: Installing dependencies
+        run: |
+          sudo add-apt-repository -y "deb http://mirror.enzu.com/ubuntu/ eoan main universe"
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
+          wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
+          chmod +x /tmp/git-clang-format
+      - name: Checking out repository
+        uses: actions/checkout@v2
+        # We have to explicitly fetch the base branch as well
+      - name: Fetching Base Branch
+        run: git fetch --no-tags --prune --depth=1 origin "${BASE_REF?}"
+      - name: Running clang-format on changed source files
+        run: |
+          /tmp/git-clang-format "origin/${BASE_REF?}" --binary=clang-format-9 --style=file
+          git diff --exit-code
 
   bazel_to_cmake:
     runs-on: ubuntu-18.04
     steps:
-    - name: Checking out repository
-      uses: actions/checkout@v2
-    - name: Running bazel_to_cmake
-      run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py
-    - name: Checking Diff
-      run: git diff --exit-code
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Running bazel_to_cmake
+        run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py
+      - name: Checking Diff
+        run: git diff --exit-code
 
   submodules:
     runs-on: ubuntu-18.04
@@ -60,6 +60,8 @@ jobs:
   yamllint:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-    - name: yaml-lint
-      uses: ibiqlik/action-yamllint@v1
+      - uses: actions/checkout@v2
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v1
+        with:
+          strict: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,3 +56,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Checking submodules
         run: ./scripts/git/submodule_versions.py check
+
+  yamllint:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@v1

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -50,4 +50,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref }}
-

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -33,16 +33,21 @@ jobs:
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
       - name: Updating submodules
-        run: ./scripts/git/update_tf_llvm_submodules.py --llvm_commit=KEEP --update_build_files=true
+        run: >
+          ./scripts/git/update_tf_llvm_submodules.py
+              --llvm_commit=KEEP
+              --update_build_files=true
       - name: Creating Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
-          # Personal token is required to trigger additional automation (e.g. presubmits).
+          # Personal token is required to trigger additional automation
+          # (e.g. presubmits).
           token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           commit-message: "Update TF submodule and LLVM BUILD files"
           title: "Update TF submodule and LLVM BUILD files"
           body: "Automated submodule bump from .github/workflows/update_submodules.yml"
-          committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
+          committer:
+            "Submodule Update Action <iree-github-actions-bot@google.com>"
           # TODO(gcmn): Figure out a way to assign this to someone dynamically.
           reviewers: gmngeoffrey
           branch: "auto_submodule_update"

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -33,21 +33,16 @@ jobs:
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
       - name: Updating submodules
-        run: >
-          ./scripts/git/update_tf_llvm_submodules.py
-              --llvm_commit=KEEP
-              --update_build_files=true
+        run: ./scripts/git/update_tf_llvm_submodules.py --llvm_commit=KEEP --update_build_files=true
       - name: Creating Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
-          # Personal token is required to trigger additional automation
-          # (e.g. presubmits).
+          # Personal token is required to trigger additional automation (e.g. presubmits).
           token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           commit-message: "Update TF submodule and LLVM BUILD files"
           title: "Update TF submodule and LLVM BUILD files"
           body: "Automated submodule bump from .github/workflows/update_submodules.yml"
-          committer:
-            "Submodule Update Action <iree-github-actions-bot@google.com>"
+          committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
           # TODO(gcmn): Figure out a way to assign this to someone dynamically.
           reviewers: gmngeoffrey
           branch: "auto_submodule_update"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -26,4 +26,5 @@ rules:
   octal-values: disable
   quoted-strings: disable
   trailing-spaces: enable
-  truthy: disable # GitHub actions don't appear to respect this
+  # GitHub actions don't appear to respect this
+  truthy: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,29 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments: enable
+  comments-indentation: enable
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy: disable # GitHub actions don't appear to respect this

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,30 +1,15 @@
----
-
-yaml-files:
-  - '*.yaml'
-  - '*.yml'
-  - '.yamllint'
+extends: default
 
 rules:
-  braces: enable
-  brackets: enable
-  colons: enable
-  commas: enable
-  comments: enable
-  comments-indentation: enable
-  document-end: disable
-  document-start: disable
-  empty-lines: enable
-  empty-values: disable
-  hyphens: enable
-  indentation: enable
-  key-duplicates: enable
-  key-ordering: disable
-  line-length: disable
-  new-line-at-end-of-file: enable
-  new-lines: enable
-  octal-values: disable
-  quoted-strings: disable
-  trailing-spaces: enable
-  # GitHub actions don't appear to respect this
+  # These do not appear to be conventional in GitHub actions.
+  document-end:
+    present: false
+  document-start:
+    present: false
+  # GitHub actions don't appear to respect this.
   truthy: disable
+  # We have lots of long strings and command lines.
+  line-length: disable
+
+ignore:
+  /third_party/*

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,7 +6,7 @@ rules:
     present: false
   document-start:
     present: false
-  # GitHub actions don't appear to respect this.
+  # GitHub actions use "on" for triggers.
   truthy: disable
   # We have lots of long strings and command lines.
   line-length: disable


### PR DESCRIPTION
Linting is nice. The main motivation is that otherwise when adding a new action it's basically impossible to find if parsing just failed and that's why your action isn't running.

Since we've got so many long strings and command lines, I turned off line-length checking. I also disabled document-start check, since I have never seen a GitHub Actions workflow that has one. Everything is either an error or silent, as it should be.