### PR TITLE
Fix Windows path used for test_env in docs.

### DIFF
--- a/docs/GetStarted/getting_started_windows_vulkan.md
+++ b/docs/GetStarted/getting_started_windows_vulkan.md
@@ -102,7 +102,7 @@ using the `--test_env` flag. A user.bazelrc file using SwiftShader looks like
 this (substitute for the `{}` paths):
 
 ```
-test --test_env="VK_ICD_FILENAMES={PATH_TO_IREE}/build-swiftshader/Windows/vk_swiftshader_icd.json"
+test --test_env="VK_ICD_FILENAMES={PATH_TO_IREE}\\build-swiftshader\\Windows\\vk_swiftshader_icd.json"
 ```
 
 ## Using IREE's Vulkan Compiler Target and Runtime Driver


### PR DESCRIPTION
Actually tested this one, as part of

```
test:vk_swiftshader --test_env="VK_ICD_FILENAMES=D:\\dev\\projects\\iree\\build-swiftshader\\Windows\\vk_swiftshader_icd.json"
```

with `--config=vk_swiftshader` passed to `bazel test`.