### PR TITLE
Fix publish_docs GitHub Action

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       IREE_DOC_BUILD_DIR: build-docs
     steps:
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 2.1.0
       - name: Checking out repository
         uses: actions/checkout@v2
         with:

--- a/build_tools/cmake/build_docs.sh
+++ b/build_tools/cmake/build_docs.sh
@@ -51,7 +51,9 @@ cd ${ROOT_DIR?}
 
 # Update op_coverage.md
 scripts/update_op_coverage.py ${BUILD_DIR}
-scripts/update_e2e_coverage.py ${BUILD_DIR}
+
+# Update e2e_coverage.md
+PYTHON_BIN=`which python3` scripts/update_e2e_coverage.py ${BUILD_DIR}
 
 # Copy a curated list of docs to publish. This is expected to cover all docs
 # under docs/ after they are refreshed.

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -98,12 +98,12 @@ def get_test_targets(test_suite_path):
   # Check if the suite exists (which may not be true for failing suites)
   target_dir = test_suite.split(':')[0]
   query = ['bazel', 'query', f'{target_dir}/...']
-  targets = subprocess.check_output(query, stderr=subprocess.DEVNULL)
+  targets = subprocess.check_output(query)
   if test_suite_path not in targets.decode('ascii'):
     return []
 
   query = ['bazel', 'query', f'tests({test_suite_path})']
-  tests = subprocess.check_output(query, stderr=subprocess.DEVNULL)
+  tests = subprocess.check_output(query)
   tests = tests.decode('ascii').split('\n')
   tests = list(filter(lambda s: s.startswith(f'{test_suite_path}_'), tests))
   tests = [test.replace(f'{test_suite_path}_', '') for test in tests]


### PR DESCRIPTION
Now we use `bazel query` to get e3e test status. We need to set
up the environment for Bazel.