### PR TITLE
[cmake] Support cross compilation towards Android with Windows host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,6 @@ list(APPEND CMAKE_MODULE_PATH
 #-------------------------------------------------------------------------------
 
 if(CMAKE_CROSSCOMPILING)
-  if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-    message(FATAL_ERROR "Cross compilation with Windows host system is not supported yet")
-  endif()
-
   message(STATUS "Detected cross compilation mode; configuring IREE on host...")
 
   # C/C++ compilers for host compilation.
@@ -344,7 +340,8 @@ if(CMAKE_CROSSCOMPILING)
   # Add a custom target to copy the flatc to the binary directory.
   add_custom_target(iree_host_flatc
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
-      "${IREE_HOST_BINARY_ROOT}/third_party/flatbuffers/flatc" "${IREE_HOST_BINARY_ROOT}/bin"
+      "${IREE_HOST_BINARY_ROOT}/third_party/flatbuffers/flatc${IREE_HOST_EXECUTABLE_SUFFIX}"
+      "${IREE_HOST_BINARY_ROOT}/bin"
     DEPENDS iree_host_build_flatc
     COMMENT "Installing host flatc..."
   )

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -20,8 +20,11 @@ include(CMakeParseArguments)
 
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
   set(IREE_HOST_SCRIPT_EXT "bat")
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/17553
+  set(IREE_HOST_EXECUTABLE_SUFFIX ".exe")
 else()
   set(IREE_HOST_SCRIPT_EXT "sh")
+  set(IREE_HOST_EXECUTABLE_SUFFIX "")
 endif()
 
 #-------------------------------------------------------------------------------
@@ -101,7 +104,7 @@ function(iree_get_executable_path OUTPUT_PATH_VAR TARGET)
   if(CMAKE_CROSSCOMPILING)
     # The target is defined in the CMake invocation for host. We don't have
     # access to the target; relying on the path here.
-    set(_OUTPUT_PATH "${IREE_HOST_BINARY_ROOT}/bin/${TARGET}")
+    set(_OUTPUT_PATH "${IREE_HOST_BINARY_ROOT}/bin/${TARGET}${IREE_HOST_EXECUTABLE_SUFFIX}")
     set(${OUTPUT_PATH_VAR} "${_OUTPUT_PATH}" PARENT_SCOPE)
   else()
     # The target is defined in this CMake invocation. We can query the location

--- a/docs/GetStarted/getting_started_android_cmake.md
+++ b/docs/GetStarted/getting_started_android_cmake.md
@@ -19,10 +19,10 @@ executables that can be run on the target platform.
 
 ### Set up host development environment
 
-The host platform should have been set up for developing IREE. Right now only
-Linux is supported; Windows and macOS support is coming. Please make sure you
-have followed the steps in
-[Get Started on Linux with CMake](./getting_started_linux_cmake.md).
+The host platform should have been set up for developing IREE. Right now Linux
+and Windows are supported. Please make sure you have followed the steps for
+[Linux](./getting_started_linux_cmake.md) or
+[Windows](./getting_started_windows_cmake.md).
 
 ### Install Android NDK
 
@@ -36,26 +36,33 @@ Alternatively, if you have installed
 [this guide](https://developer.android.com/studio/projects/install-ndk) to
 install Android NDK.
 
-After downloading, it is recommended to `export` the `ANDROID_NDK` environment
-variable pointing to the directory in your shell's rc file.
+After downloading, it is recommended to set the `ANDROID_NDK` environment
+variable pointing to the directory. For Linux, you can `export` in your shell's
+rc file. For Windows, you can search "environment variable" in the taskbar or
+use `Windows` + `R` to open the "Run" dialog to run
+`rundll32 sysdm.cpl,EditEnvironmentVariables`.
+
 
 ### Install Android Debug Bridge (ADB)
 
-Search your Linux distro's package manager to install `adb`. For example, on
-Ubuntu:
+For Linux, search your the distro's package manager to install `adb`.
+For example, on Ubuntu:
 
 ```shell
 $ sudo apt install adb
 ```
 
-## Build
+For Windows, download Android platform tools
+[here](https://dl.google.com/android/repository/platform-tools-latest-windows.zip)
+and extract. You may want to add the folder to the `PATH` environment variable.
 
-Configure:
+## Configure and build
+
+### Configure on Linux
 
 ```shell
 # Assuming in IREE source root
-
-$ cmake -G Ninja -B build-android/  \
+$ cmake -G Ninja -B build-android  \
     -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
     -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-29 \
     -DIREE_BUILD_COMPILER=OFF -DIREE_BUILD_TESTS=OFF -DIREE_BUILD_SAMPLES=OFF \
@@ -77,7 +84,31 @@ $ cmake -G Ninja -B build-android/  \
     does [not support](https://github.com/google/iree/issues/1269) GCC well at
     the moment.
 
-Build all targets:
+### Configure on Windows
+
+On Windows, we will need the full path to the `cl.exe` compiler. This can be
+obtained by [opening a developer command prompt window](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#developer_command_prompt) and type
+`where cl.exe`. Copy the path and substitue all `\` with `/` to get the
+CMake-style path. Then in a command prompt (`cmd.exe`):
+
+```cmd
+REM Assuming in IREE source root
+> cmake -G Ninja -B build-android  \
+    -DCMAKE_TOOLCHAIN_FILE="%ANDROID_NDK%/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-29 \
+    -DIREE_BUILD_COMPILER=OFF -DIREE_BUILD_TESTS=OFF -DIREE_BUILD_SAMPLES=OFF \
+    -DIREE_HOST_C_COMPILER="<cmake-style-path-to-cl.exe>" \
+    -DIREE_HOST_CXX_COMPILER="<cmake-style-path-to-cl.exe>" \
+    -DLLVM_HOST_TRIPLE="x86_64-pc-windows-msvc" \
+    -DCROSS_TOOLCHAIN_FLAGS_NATIVE="-DCMAKE_C_COMPILER=\"<cmake-style-path-to-cl.exe>\";-DCMAKE_CXX_COMPILER=\"<cmake-style-path-to-cl.exe>\""
+```
+
+* See the Linux section in the above for explanations of the used arguments.
+* We need to define `LLVM_HOST_TRIPLE` and `CROSS_TOOLCHAIN_FLAGS_NATIVE` in the
+  above because LLVM cannot properly detect host triple under Android CMake
+  toolchain file. This might be fixed later.
+
+### Build all targets
 
 ```shell
 $ cmake --build build-android/

--- a/docs/GetStarted/getting_started_android_cmake.md
+++ b/docs/GetStarted/getting_started_android_cmake.md
@@ -52,9 +52,13 @@ For example, on Ubuntu:
 $ sudo apt install adb
 ```
 
-For Windows, download Android platform tools
-[here](https://dl.google.com/android/repository/platform-tools-latest-windows.zip)
-and extract. You may want to add the folder to the `PATH` environment variable.
+For Windows, it's easier to get `adb` via Android Studio. `adb` is included in
+the Android SDK Platform-Tools package. You can download this package with the
+[SDK Manager](https://developer.android.com/studio/intro/update#sdk-manager),
+which installs it at `android_sdk/platform-tools/`. Or if you want the
+standalone Android SDK Platform-Tools package, you can
+[download it here](https://developer.android.com/studio/releases/platform-tools).
+You may also want to add the folder to the `PATH` environment variable.
 
 ## Configure and build
 
@@ -136,8 +140,7 @@ Translate a source MLIR into IREE module:
 
 ```shell
 # Assuming in IREE source root
-
-$ build-android/host/bin/iree-translate -- \
+$ build-android/host/bin/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
     -iree-hal-target-backends=vmla \
     iree/tools/test/simple.mlir \
@@ -147,7 +150,8 @@ $ build-android/host/bin/iree-translate -- \
 Then push the IREE runtime executable and module to the device:
 
 ```shell
-$ adb push iree/tools/iree-run-module /data/local/tmp/
+$ adb push build-android/iree/tools/iree-run-module /data/local/tmp/
+$ adb shell chmod +x /data/local/tmp/iree-run-module
 $ adb push /tmp/simple-vmla.vmfb /data/local/tmp/
 ```
 
@@ -172,8 +176,7 @@ Translate a source MLIR into IREE module:
 
 ```shell
 # Assuming in IREE source root
-
-$ build-android/host/bin/iree-translate -- \
+$ build-android/host/bin/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
     -iree-hal-target-backends=vulkan-spirv \
     iree/tools/test/simple.mlir \
@@ -183,7 +186,8 @@ $ build-android/host/bin/iree-translate -- \
 Then push the IREE runtime executable and module to the device:
 
 ```shell
-$ adb push iree/tools/iree-run-module /data/local/tmp/
+$ adb push build-android/iree/tools/iree-run-module /data/local/tmp/
+$ adb shell chmod +x /data/local/tmp/iree-run-module
 $ adb push /tmp/simple-vulkan.vmfb /data/local/tmp/
 ```
 


### PR DESCRIPTION
Using Windows as the host platform for cross compiling IREE towards
Android requires more cmake arguments than Linux. LLVM is having
problem of detecting host triple when CMake is invoked with Android
toolchain file. This means we need to manually pass in certain
configurations to help it figure out the proper compiler toolchain
for host.

This commit also changes various `TARGET` function parameter names
to `EXECUTABLE` given that for referencing "targets" on host, which
is under another CMake invocation, we need to relying on the generated
executable artifacts. Using `EXECUTABLE` is more clear.