### PR TITLE
Add `"no-remote"` tags to "external" targets.

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -190,6 +190,7 @@ iree_vision_test_suite(
         "external",
         "guitar",
         "manual",
+        "no-remote",
         "nokokoro",
         "notap",
     ],
@@ -218,6 +219,7 @@ iree_vision_test_suite(
     tags = [
         "external",
         "manual",
+        "no-remote",
         "nokokoro",
         "notap",
     ],


### PR DESCRIPTION
This prevents these targets from potentially running on remote servers that don't support non-hermetic tests.