### PR TITLE
[cmake] Handle CROSS_TOOLCHAIN_FLAGS_NATIVE internally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,21 @@ if(CMAKE_CROSSCOMPILING)
 
   # Set the host build directory for LLVM to our directory. Otherwise it will
   # follow its own convention.
-  set(LLVM_NATIVE_BUILD "${IREE_HOST_BINARY_ROOT}/third_party/llvm-project/llvm")
+  set(LLVM_NATIVE_BUILD
+      "${IREE_HOST_BINARY_ROOT}/third_party/llvm-project/llvm"
+      CACHE FILEPATH "directory containing host artifacts for LLVM"
+  )
+
+  # And set host C/C++ compiler for LLVM. This makes cross compilation using
+  # Windows as the host platform nicer. Because we have various development
+  # evnironments on Windows (CMD, Cygwin, MSYS, etc.), LLVM can have problems
+  # figuring out the host triple and toolchain. We are passing in the host
+  # C/C++ compiler toolchain for IREE anyway; so we can give LLVM side some
+  # help here. This hides some complexity and ugliness from the users.
+  set(CROSS_TOOLCHAIN_FLAGS_NATIVE
+      "-DCMAKE_C_COMPILER=\"${IREE_HOST_C_COMPILER}\";-DCMAKE_CXX_COMPILER=\"${IREE_HOST_CXX_COMPILER}\""
+      CACHE FILEPATH "LLVM toolchain configuration for host build"
+  )
 
   include(iree_cross_compile)
 

--- a/docs/GetStarted/getting_started_android_cmake.md
+++ b/docs/GetStarted/getting_started_android_cmake.md
@@ -92,8 +92,7 @@ $ cmake -G Ninja -B build-android  \
 
 On Windows, we will need the full path to the `cl.exe` compiler. This can be
 obtained by [opening a developer command prompt window](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#developer_command_prompt) and type
-`where cl.exe`. Copy the path and substitue all `\` with `/` to get the
-CMake-style path. Then in a command prompt (`cmd.exe`):
+`where cl.exe`. Then in a command prompt (`cmd.exe`):
 
 ```cmd
 REM Assuming in IREE source root
@@ -101,16 +100,15 @@ REM Assuming in IREE source root
     -DCMAKE_TOOLCHAIN_FILE="%ANDROID_NDK%/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="arm64-v8a" -DANDROID_PLATFORM=android-29 \
     -DIREE_BUILD_COMPILER=OFF -DIREE_BUILD_SAMPLES=OFF \
-    -DIREE_HOST_C_COMPILER="<cmake-style-path-to-cl.exe>" \
-    -DIREE_HOST_CXX_COMPILER="<cmake-style-path-to-cl.exe>" \
-    -DLLVM_HOST_TRIPLE="x86_64-pc-windows-msvc" \
-    -DCROSS_TOOLCHAIN_FLAGS_NATIVE="-DCMAKE_C_COMPILER=\"<cmake-style-path-to-cl.exe>\";-DCMAKE_CXX_COMPILER=\"<cmake-style-path-to-cl.exe>\""
+    -DIREE_HOST_C_COMPILER="<full-path-to-cl.exe>" \
+    -DIREE_HOST_CXX_COMPILER="<full-path-to-cl.exe>" \
+    -DLLVM_HOST_TRIPLE="x86_64-pc-windows-msvc"
 ```
 
 * See the Linux section in the above for explanations of the used arguments.
-* We need to define `LLVM_HOST_TRIPLE` and `CROSS_TOOLCHAIN_FLAGS_NATIVE` in the
-  above because LLVM cannot properly detect host triple under Android CMake
-  toolchain file. This might be fixed later.
+* We need to define `LLVM_HOST_TRIPLE` in the above because LLVM cannot properly
+  detect host triple under Android CMake toolchain file. This might be fixed
+  later.
 
 ### Build all targets
 
@@ -161,7 +159,10 @@ Log into Android:
 $ adb shell
 
 android $ cd /data/local/tmp/
-android $ ./iree-run-module -driver=vmla -input_file=simple-vmla.vmfb -entry_function=abs -inputs="i32=-5"
+android $ ./iree-run-module -driver=vmla \
+          -input_file=simple-vmla.vmfb \
+          -entry_function=abs \
+          -inputs="i32=-5"
 
 EXEC @abs
 i32=5
@@ -197,7 +198,10 @@ Log into Android:
 $ adb shell
 
 android $ cd /data/local/tmp/
-android $ ./iree-run-module -driver=vulkan -input_file=simple-vulkan.vmfb -entry_function=abs -inputs="i32=-5"
+android $ ./iree-run-module -driver=vulkan \
+          -input_file=simple-vulkan.vmfb \
+          -entry_function=abs \
+          -inputs="i32=-5"
 
 EXEC @abs
 i32=5


### PR DESCRIPTION
`CROSS_TOOLCHAIN_FLAGS_NATIVE` is the CMake variable LLVM uses
to set toolchain parameters for the host build. We are passing in
host C/C++ compilers anyway and they are the same. Hide the
complicity internally.

This should be less ugly than the previous lengthy command. ;) 