### PR TITLE
Simplifies backend specification for `tf_test_utils.py`.

### DIFF
--- a/build_tools/bazel/build_tensorflow.sh
+++ b/build_tools/bazel/build_tensorflow.sh
@@ -42,7 +42,6 @@ fi
 declare -a test_env_args=(
   --test_env=IREE_LLVMJIT_DISABLE=$IREE_LLVMJIT_DISABLE
   --test_env=IREE_VULKAN_DISABLE=$IREE_VULKAN_DISABLE
-  --test_env=IREE_AVAILABLE_BACKENDS="tf,iree_vmla,iree_llvmjit"
 )
 
 declare -a default_build_tag_filters=("-nokokoro")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -32,10 +32,8 @@ from pyiree import rt
 from pyiree.tf import compiler
 import tensorflow.compat.v2 as tf
 
-flags.DEFINE_string(
-    "override_backends", None,
-    "Explicit comma-delimited list of target backends. "
-    "(Overrides environment variables and auto detection)")
+flags.DEFINE_string("target_backends", None,
+                    "Explicit comma-delimited list of target backends.")
 flags.DEFINE_string(
     "debug_dir", None,
     "Specifies a directory to dump debug artifacts to. Defaults to "
@@ -506,12 +504,10 @@ def _instantiate_modules(compiled_modules_dict):
   return tuple_class(*module_insts)
 
 
-def compile_modules(backends=None, **kwargs):
+def compile_modules(**kwargs):
   """Decorator applied to a SavedModelTestCase subclass to compile modules.
 
   Args:
-    backends: an iterable of backend names to include (or None to use
-      environment defaults).
     **kwargs: name/Module constructor mappings. Each such arg will be added to
       the classes 'compiled_modules' field.
 
@@ -532,7 +528,7 @@ def compile_modules(backends=None, **kwargs):
       exported_names = ()
       if isinstance(ctor, tuple):
         ctor, exported_names = ctor
-      cls._modules_to_compile[name] = (ctor, exported_names, backends)
+      cls._modules_to_compile[name] = (ctor, exported_names)
 
     return cls
 
@@ -596,36 +592,26 @@ def _backend_spec_string_to_backends(backend_spec):
   return backends
 
 
-def get_override_backends():
-  """Gets the BackendInfo instances to test, as overridden by the user.
+def get_backends():
+  """Gets the BackendInfo instances to test.
+
+  By default all backends in BackendInfo will be used. Specific backends to
+  run on can be specified using the `--target_backends` flag. If only "tf" is
+  provided then it will be compared against itself.
 
   Returns:
-    Sequence of BackendInfo that should be used, or None if there is no
-    override.
+    Sequence of BackendInfo that should be used.
   """
-
-  if FLAGS.override_backends is not None:
-    backends_spec = FLAGS.override_backends
-    logging.info("Using backends from command line: %s", backends_spec)
+  if FLAGS.target_backends is not None:
+    logging.info("Using backends from command line: %s", FLAGS.target_backends)
+    backends = _backend_spec_string_to_backends(FLAGS.target_backends)
+    # If tf is the only backend then we will test it itself by adding tf_also.
+    if len(backends) == 1 and "tf" == backends[0].name:
+      backends.append(BackendInfo.ALL["tf_also"])
   else:
-    backends_spec = os.environ.get("IREE_OVERRIDE_BACKENDS")
-    if backends_spec is not None:
-      logging.info("Using backends from environment IREE_OVERRIDE_BACKENDS: %s",
-                   backends_spec)
-
-  if backends_spec:
-    return _backend_spec_string_to_backends(backends_spec)
-  else:
-    logging.info("No backend overrides.")
-    return None
-
-
-def get_available_backends():
-  """Gets the BackendInfo instances considered available for use."""
-  backend_spec = os.environ.get("IREE_AVAILABLE_BACKENDS")
-  if backend_spec is None:
-    return BackendInfo.ALL.values()
-  return _backend_spec_string_to_backends(backend_spec)
+    # If no backends are specified, use them all.
+    backends = list(BackendInfo.ALL.values())
+  return backends
 
 
 class SavedModelTestCase(tf.test.TestCase):
@@ -648,8 +634,7 @@ class SavedModelTestCase(tf.test.TestCase):
     super().setUpClass()
     cls.compiled_modules = {}
     if cls._modules_to_compile:
-      for name, (ctor, exported_names,
-                 backends) in cls._modules_to_compile.items():
+      for name, (ctor, exported_names) in cls._modules_to_compile.items():
 
         # Setup the debug directory.
         debug_parent_dir = FLAGS.debug_dir
@@ -672,34 +657,7 @@ class SavedModelTestCase(tf.test.TestCase):
 
         try:
           # Compile.
-          # Expand backend names to BackendInfo objects.
-          def _resolve(backend_spec):
-            if isinstance(backend_spec, BackendInfo):
-              return backend_spec
-            # Handle the string form.
-            return BackendInfo.ALL[backend_spec]
-
-          override_backends = get_override_backends()
-          if override_backends is not None:
-            backends = override_backends
-          elif backends is None:
-            backends = list(BackendInfo.ALL.keys())
-          backends = [_resolve(backend) for backend in backends]
-          # if "tf" is specified as a only backend then
-          # we will test it always against "tf" by adding "tf_also".
-          if len(backends) == 1 and "tf" == backends[0].name:
-            backends.append(BackendInfo.ALL["tf_also"])
-          available_backends = get_available_backends()
-          backends = [
-              backend for backend in backends if backend in available_backends
-          ]
-          if not backends:
-            # If no backends are available, then to avoid errors down the line,
-            # just use "tf", which should always be safe.
-            backends = [BackendInfo.ALL["tf"]]
-            logging.warning(
-                "Falling back to just `tf` backend because no other requested backends are available. Available backends '%s'",
-                [backend.name for backend in available_backends])
+          backends = get_backends()
           cls.compiled_modules[name] = dict([
               (backend.name, CompiledModule.create(ctor, exported_names,
                                                    backend))

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -579,14 +579,14 @@ BackendInfo.add(
     iree_compiler_targets=["llvm-ir"])
 
 
-def _backend_spec_string_to_backends(backend_spec):
+def _parse_target_backends(target_backends):
   """Decodes a comma-delimited string of backends into BackendInfo objects."""
   backends = []
-  for backend_name in backend_spec.split(","):
+  for backend_name in target_backends.split(","):
     if backend_name not in BackendInfo.ALL.keys():
       raise ValueError(
           "Invalid backend specification string '{}', unexpected name '{}';"
-          " valid names are '{}'".format(backend_spec, backend_name,
+          " valid names are '{}'".format(target_backends, backend_name,
                                          BackendInfo.ALL.keys()))
     backends.append(BackendInfo.ALL[backend_name])
   return backends
@@ -604,7 +604,7 @@ def get_backends():
   """
   if FLAGS.target_backends is not None:
     logging.info("Using backends from command line: %s", FLAGS.target_backends)
-    backends = _backend_spec_string_to_backends(FLAGS.target_backends)
+    backends = _parse_target_backends(FLAGS.target_backends)
     # If tf is the only backend then we will test it itself by adding tf_also.
     if len(backends) == 1 and "tf" == backends[0].name:
       backends.append(BackendInfo.ALL["tf_also"])

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -188,6 +188,11 @@ iree_py_test(
     name = "explicit_backend_test",
     srcs = ["explicit_backend_test.py"],
     main = "explicit_backend_test.py",
+    tags = [
+        "driver=vmla"
+        "driver=llvmjit"
+        "driver=vulkan"
+    ],
     python_version = "PY3",
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -189,9 +189,9 @@ iree_py_test(
     srcs = ["explicit_backend_test.py"],
     main = "explicit_backend_test.py",
     tags = [
-        "driver=vmla"
-        "driver=llvmjit"
-        "driver=vulkan"
+        "driver=vmla",
+        "driver=llvmjit",
+        "driver=vulkan",
     ],
     python_version = "PY3",
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -58,9 +58,9 @@ SPECIAL_CASES = [
 
 # keep sorted
 VMLA_FAILING = [
-    "fill_test.py",
-    "mandelbrot_test.py",
-    "ring_buffer_test.py",
+    "fill_test.py",  # TODO(jennik): Get this test working on IREE.
+    "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
+    "ring_buffer_test.py",  # TODO(b/148747011)
     "strings_test.py",
 ]
 
@@ -70,10 +70,10 @@ LLVM_FAILING = [
     "depth_conv_test.py",
     "dynamic_mlp_relu_test.py",
     "dynamic_mlp_test.py",
-    "fill_test.py",
-    "mandelbrot_test.py",
+    "fill_test.py",  # TODO(jennik): Get this test working on IREE.
+    "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
     "matrix_ops_test.py",
-    "ring_buffer_test.py",
+    "ring_buffer_test.py",  # TODO(b/148747011)
     "strings_test.py",
 ]
 
@@ -83,12 +83,12 @@ VULKAN_FAILING = [
     "depth_conv_test.py",
     "dynamic_mlp_relu_test.py",
     "dynamic_mlp_test.py",
-    "fill_test.py",
-    "mandelbrot_test.py",
+    "fill_test.py",  # TODO(jennik): Get this test working on IREE.
+    "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
     "matrix_ops_test.py",
-    "ring_buffer_test.py",
+    "ring_buffer_test.py",  # TODO(b/148747011)
     "strings_test.py",
-    "tensorlist_test.py",
+    "tensorlist_test.py",  # TODO(b/146900329): Triage op coverage for vulkan backend.
 ]
 
 TF_PASSING = glob(
@@ -163,6 +163,8 @@ iree_e2e_test_suite(
     ],
 )
 
+# TODO(laurenzo): Re-enable iree_vulkan once dynamic-slice is implemented
+# See https://github.com/google/iree/issues/1521
 iree_e2e_test_suite(
     name = "linspace_tests_failing",
     backends_to_srcs = {

--- a/integrations/tensorflow/e2e/batch_norm_test.py
+++ b/integrations/tensorflow/e2e/batch_norm_test.py
@@ -38,7 +38,7 @@ class BatchNormModule(tf.Module):
         variance_epsilon=1e-4)
 
 
-@tf_test_utils.compile_modules(backends=["iree_vmla"], bn=BatchNormModule)
+@tf_test_utils.compile_modules(bn=BatchNormModule)
 class BatchNormTest(tf_test_utils.SavedModelTestCase):
 
   def test_batch_norm_inference(self):

--- a/integrations/tensorflow/e2e/broadcasting_test.py
+++ b/integrations/tensorflow/e2e/broadcasting_test.py
@@ -28,8 +28,7 @@ class BroadcastingModule(tf.Module):
     return lhs + rhs
 
 
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], m=BroadcastingModule)
+@tf_test_utils.compile_modules(m=BroadcastingModule)
 class BroadcastingTest(tf_test_utils.SavedModelTestCase):
 
   def test_add_same_shape(self):

--- a/integrations/tensorflow/e2e/control_flow_test.py
+++ b/integrations/tensorflow/e2e/control_flow_test.py
@@ -38,9 +38,7 @@ class ControlFlowModule(tf.Module):
     return i
 
 
-# TODO(b/146900329): Triage op coverage for vulkan backend.
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], control_flow=ControlFlowModule)
+@tf_test_utils.compile_modules(control_flow=ControlFlowModule)
 class ControlFlowTest(tf_test_utils.SavedModelTestCase):
 
   def test_short_sequence(self):

--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -38,8 +38,7 @@ class Conv2dModule(tf.Module):
         img, kernel, [1, 1, 1, 1], "SAME", name="result")
 
 
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], conv2d=Conv2dModule)
+@tf_test_utils.compile_modules(conv2d=Conv2dModule)
 class ConvTest(tf_test_utils.SavedModelTestCase):
 
   def test_batched_feature_unpadded(self):

--- a/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
@@ -64,11 +64,7 @@ class Mlp(tf.Module):
     return tf.nn.softmax(self.mlp(x))
 
 
-@tf_test_utils.compile_modules(
-    backends=[
-        "tf",
-        "iree_vmla",
-    ], mlp=(Mlp, ["predict"]))
+@tf_test_utils.compile_modules(mlp=(Mlp, ["predict"]))
 class DynamicMlpTest(tf_test_utils.SavedModelTestCase):
 
   def test_dynamic_batch(self):

--- a/integrations/tensorflow/e2e/dynamic_mlp_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_test.py
@@ -60,8 +60,7 @@ class Mlp(tf.Module):
     return tf.nn.softmax(self.mlp(x))
 
 
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], mlp=(Mlp, ["predict"]))
+@tf_test_utils.compile_modules(mlp=(Mlp, ["predict"]))
 class DynamicMlpTest(tf_test_utils.SavedModelTestCase):
 
   def test_dynamic_batch(self):

--- a/integrations/tensorflow/e2e/fill_test.py
+++ b/integrations/tensorflow/e2e/fill_test.py
@@ -30,8 +30,7 @@ class FillModule(tf.Module):
     return tf.fill(dims, value)
 
 
-# TODO(jennik): Get this test working on IREE.
-@tf_test_utils.compile_modules(backends=["tf"], fill=FillModule)
+@tf_test_utils.compile_modules(fill=FillModule)
 class FillTest(tf_test_utils.SavedModelTestCase):
 
   def test_fill(self):

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -55,7 +55,7 @@ def iree_e2e_test_suite(
                 backend,
             )
             args = [
-                "--override_backends={},{}".format(reference_backend, backend),
+                "--target_backends={},{}".format(reference_backend, backend),
             ]
 
             # TODO(GH-2175): Simplify this after backend names are standardized.

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -42,14 +42,14 @@ DOC = """
 vision_model_test_manual is for manual testing of all keras vision models.
 Test will run only manually with all parameters specified manually, for example:
 bazel run -c opt integrations/tensorflow/e2e/keras:vision_model_test_manual -- \
---override_backends=tf,iree_vmla,iree_llvmjit \
+--target_backends=tf,iree_vmla,iree_llvmjit \
 --data=imagenet \
 --include_top=1 \
 --url=https://storage.googleapis.com/iree_models/ \
 --model=ResNet50
 
 Command arguments description:
---override_backends: can be combination of these: tf,iree_vmla,iree_llvmjit
+--target_backends: can be combination of these: tf,iree_vmla,iree_llvmjit
 --data: can be 'imagenet' or 'cifar10'.
     imagenet - input image size (1, 224, 224, 3)
     cifar10 - input image size (1, 32, 32, 3) - it is used for quick tests
@@ -87,8 +87,9 @@ VMLA_FAILING = [
 ]
 
 LLVM_FAILING = [
-    "lstm_test.py",
-    "lstm_static_test.py",
+    # TODO(silvasean): Get this test working on IREE.
+    "lstm_test.py",  # Needs TensorList with current Keras implementation.
+    "lstm_static_test.py",  # TODO(silvasean): Get this test working on other backends.
 ]
 
 VULKAN_FAILING = [

--- a/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
@@ -84,12 +84,20 @@ def iree_vision_test_suite(
                     if external_weights:
                         args.append("--url={}".format(external_weights))
 
+                    # TODO(GH-2175): Simplify this after backend names are standardized.
+                    driver = backend.replace("iree_", "")  # "iree_<driver>" --> "<driver>"
+                    if driver == "llvmjit":
+                        driver = "llvm"
+                    py_test_tags = ["driver={}".format(driver)]
+                    if tags != None:  # `is` is not supported.
+                        py_test_tags += tags
+
                     iree_py_test(
                         name = test_name,
                         main = "vision_model_test.py",
                         srcs = ["vision_model_test.py"],
                         args = args,
-                        tags = tags,
+                        tags = py_test_tags,
                         deps = deps,
                         size = size,
                         python_version = python_version,

--- a/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
@@ -79,7 +79,7 @@ def iree_vision_test_suite(
                         "--model={}".format(model),
                         "--data={}".format(dataset),
                         "--include_top=1",
-                        "--override_backends={}".format(",".join(test_backends)),
+                        "--target_backends={}".format(",".join(test_backends)),
                     ]
                     if external_weights:
                         args.append("--url={}".format(external_weights))

--- a/integrations/tensorflow/e2e/keras/lstm_static_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_test.py
@@ -39,9 +39,7 @@ def lstm_module():
   return module
 
 
-# TODO(silvasean): Get this test working on other backends.
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], lstm=(lstm_module, ["predict"]))
+@tf_test_utils.compile_modules(lstm=(lstm_module, ["predict"]))
 class LstmTest(tf_test_utils.SavedModelTestCase):
 
   def test_lstm(self):

--- a/integrations/tensorflow/e2e/keras/lstm_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_test.py
@@ -36,9 +36,7 @@ def lstm_module():
   return module
 
 
-# TODO(silvasean): Get this test working on IREE.
-# Needs TensorList with current Keras implementation.
-@tf_test_utils.compile_modules(backends=["tf"], lstm=(lstm_module, ["predict"]))
+@tf_test_utils.compile_modules(lstm=(lstm_module, ["predict"]))
 class LstmTest(tf_test_utils.SavedModelTestCase):
 
   def test_lstm(self):

--- a/integrations/tensorflow/e2e/keras/train/iree_train_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/train/iree_train_test_suite.bzl
@@ -51,7 +51,7 @@ def iree_train_test_suite(
 
         args = [
             "--optimizer_name={}".format(optimizer),
-            "--override_backends={}".format(backends),
+            "--target_backends={}".format(backends),
         ]
 
         iree_py_test(

--- a/integrations/tensorflow/e2e/keras/train/model_train_test.py
+++ b/integrations/tensorflow/e2e/keras/train/model_train_test.py
@@ -79,7 +79,7 @@ class ModelTrain(tf.Module):
 
 
 @tf_test_utils.compile_modules(
-    backends=["tf"], train_module=(ModelTrain.CreateModule, ["TrainStep"]))
+    train_module=(ModelTrain.CreateModule, ["TrainStep"]))
 class ModelTrainTest(tf_test_utils.SavedModelTestCase):
 
   def generate_regression_data(self, size=8):
@@ -96,7 +96,7 @@ class ModelTrainTest(tf_test_utils.SavedModelTestCase):
     inputs = inputs / max(inputs)
     targets = targets / max(targets)
 
-    # generate plynomial features
+    # generate polynomial features
     inputs = np.expand_dims(inputs, axis=1)
     polynomial = PolynomialFeatures(_DEGREE)  # returns: [1, a, b, a^2, ab, b^2]
     inputs = polynomial.fit_transform(inputs)

--- a/integrations/tensorflow/e2e/linspace_test.py
+++ b/integrations/tensorflow/e2e/linspace_test.py
@@ -33,10 +33,7 @@ class LinSpaceModule(tf.Module):
     return tf.linspace(start, stop, num)
 
 
-# TODO(laurenzo): Re-enable iree_vulkan once dynamic-slice is implemented
-# See https://github.com/google/iree/issues/1521
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], linspace=LinSpaceModule)
+@tf_test_utils.compile_modules(linspace=LinSpaceModule)
 class LinspaceTest(tf_test_utils.SavedModelTestCase):
 
   def test_linspace(self):

--- a/integrations/tensorflow/e2e/mandelbrot_test.py
+++ b/integrations/tensorflow/e2e/mandelbrot_test.py
@@ -94,8 +94,7 @@ class MandelbrotModule(tf.Module):
     return tf.reshape(in_the_set, shape=[view_pixels, view_pixels])
 
 
-# TODO(silvasean): Get this working on IREE.
-@tf_test_utils.compile_modules(backends=["tf"], mandelbrot=MandelbrotModule)
+@tf_test_utils.compile_modules(mandelbrot=MandelbrotModule)
 class MandelbrotTest(tf_test_utils.SavedModelTestCase):
 
   def test_mandelbrot(self):

--- a/integrations/tensorflow/e2e/math_test.py
+++ b/integrations/tensorflow/e2e/math_test.py
@@ -38,8 +38,7 @@ class MathModule(tf.Module):
     return tf.math.mod(x, 2.0)
 
 
-@tf_test_utils.compile_modules(
-    backends=["iree_vmla", "iree_vulkan"], math=MathModule)
+@tf_test_utils.compile_modules(math=MathModule)
 class MathTest(tf_test_utils.SavedModelTestCase):
 
   def test_abs(self):

--- a/integrations/tensorflow/e2e/matrix_ops_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_test.py
@@ -70,8 +70,7 @@ class MatrixOpsModule(tf.Module):
     return tf.matmul(lhs, rhs)
 
 
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], mat=MatrixOpsModule)
+@tf_test_utils.compile_modules(mat=MatrixOpsModule)
 class MatrixOpsTest(tf_test_utils.SavedModelTestCase):
 
   def test_basic_matmul(self):

--- a/integrations/tensorflow/e2e/resource_ops_test.py
+++ b/integrations/tensorflow/e2e/resource_ops_test.py
@@ -28,7 +28,7 @@ class ResourcesOpsModule(tf.Module):
     return self.counter.assign_add(value)
 
 
-@tf_test_utils.compile_modules(backends=[], resource_ops=ResourcesOpsModule)
+@tf_test_utils.compile_modules(resource_ops=ResourcesOpsModule)
 class ResourcesOpsTest(tf_test_utils.SavedModelTestCase):
 
   def test_add_assign(self):

--- a/integrations/tensorflow/e2e/ring_buffer_test.py
+++ b/integrations/tensorflow/e2e/ring_buffer_test.py
@@ -177,9 +177,7 @@ class StatefulRingBufferM(tf.Module):
     return self.rb(x)
 
 
-# TODO(b/148747011)
-@tf_test_utils.compile_modules(
-    backends=["tf"], rb=(StatefulRingBufferM, ["predict"]))
+@tf_test_utils.compile_modules(rb=(StatefulRingBufferM, ["predict"]))
 class StatefulRingBufferTest(tf_test_utils.SavedModelTestCase):
 
   def test_statefulringbuffer(self):

--- a/integrations/tensorflow/e2e/sliding_window_test.py
+++ b/integrations/tensorflow/e2e/sliding_window_test.py
@@ -75,8 +75,7 @@ class SlidingWindowM(tf.Module):
     return self.sw(x)
 
 
-@tf_test_utils.compile_modules(
-    backends=["tf"], sw=(SlidingWindowM, ["predict"]))
+@tf_test_utils.compile_modules(sw=(SlidingWindowM, ["predict"]))
 class SlidingWindowTest(tf_test_utils.SavedModelTestCase):
 
   def test_slidingwindow(self):

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -40,7 +40,7 @@ class StringsModule(tf.Module):
     return tf.strings.reduce_join(wps, 1)
 
 
-@tf_test_utils.compile_modules(backends=["tf"], strings=StringsModule)
+@tf_test_utils.compile_modules(strings=StringsModule)
 class StringsTest(tf_test_utils.SavedModelTestCase):
 
   def test_print_ids(self):

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -68,9 +68,7 @@ class TensorListModule(tf.Module):
     return ta.stack()
 
 
-# TODO(b/146900329): Triage op coverage for vulkan backend.
-@tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], tensorlist=TensorListModule)
+@tf_test_utils.compile_modules(tensorlist=TensorListModule)
 class TensorListTest(tf_test_utils.SavedModelTestCase):
 
   def test_identity_through_tensorlist(self):


### PR DESCRIPTION
This change simplifies the target backend specification for `tf_test_utils.py` by:
- Removing `IREE_AVAILABLE_BACKENDS`
- Removing `IREE_OVERRIDE_BACKENDS`
- Removing backend specification from `tf_test_utils.compile_modules()`
- Removing backend specification from all of the `e2e/...` test files (backend specification is now done in the `e2e/...` `BUILD` files).
- Renaming `--override_backends` to `--target_backends`

`TODOs`, bugs and issues are all moved from the test files into the `BUILD` files for easier tracking.