### PR TITLE
Replace cooperative matrix marker by an analysis class

### DIFF
--- a/experimental/ModelBuilder/test/TestVectorToGPU.cpp
+++ b/experimental/ModelBuilder/test/TestVectorToGPU.cpp
@@ -48,7 +48,6 @@
 #include "mlir/Dialect/SPIRV/SPIRVOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
-#include "iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h"
 
 using namespace mlir;                    // NOLINT
 using namespace mlir::edsc;              // NOLINT
@@ -214,14 +213,6 @@ void testCooperativeMatMul() {
         .vectorize<linalg::MatmulOp>();
     modelBuilder.getModuleRef()->walk(
         [&](FuncOp fn) { strategy.transform(fn); });
-    // TODO(thomasraoux): Markers are used as a workaround, those will either
-    // moved within the vectorToGPU pass only or will be replace by op
-    // interface.
-    modelBuilder.getModuleRef()->walk([&](Operation *op) {
-      if (isa<vector::ContractionOp>(op) || isa<vector::TransferReadOp>(op) ||
-          isa<vector::TransferWriteOp>(op))
-        iree_compiler::setCooperativeMatrixMarker(op);
-    });
     addLoweringPasses(pm, {resRows, resColumns, 1}, {typeA, typeB, typeC});
   };
   runner.compile(options, {vulkanWrapper});

--- a/iree/compiler/Conversion/LinalgToSPIRV/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/BUILD
@@ -22,6 +22,7 @@ cc_library(
     srcs = [
         "ConvertToGPUPass.cpp",
         "ConvertToSPIRVPass.cpp",
+        "CooperativeMatrixAnalysis.cpp",
         "LinalgTileAndFusePass.cpp",
         "MarkerUtils.cpp",
         "Passes.cpp",
@@ -31,6 +32,7 @@ cc_library(
     ],
     hdrs = [
         "Attributes.h",
+        "CooperativeMatrixAnalysis.h",
         "MarkerUtils.h",
         "MemorySpace.h",
         "Passes.h",

--- a/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     LinalgToSPIRV
   HDRS
     "Attributes.h"
+    "CooperativeMatrixAnalysis.h"
     "MarkerUtils.h"
     "MemorySpace.h"
     "Passes.h"
@@ -26,6 +27,7 @@ iree_cc_library(
   SRCS
     "ConvertToGPUPass.cpp"
     "ConvertToSPIRVPass.cpp"
+    "CooperativeMatrixAnalysis.cpp"
     "LinalgTileAndFusePass.cpp"
     "MarkerUtils.cpp"
     "Passes.cpp"

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
@@ -21,6 +21,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.h"
 #include "iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
@@ -199,12 +200,17 @@ struct LinalgReshapeConverter final
 template <typename OpTy>
 class TransferToCoopMatLoadStore final : public SPIRVOpLowering<OpTy> {
  public:
-  using SPIRVOpLowering<OpTy>::SPIRVOpLowering;
+  TransferToCoopMatLoadStore(
+      MLIRContext *context, SPIRVTypeConverter &converter,
+      const CooperativeMatrixAnalysis &cooperativeMatrixAnalysis)
+      : SPIRVOpLowering<OpTy>(context, converter),
+        cooperativeMatrixAnalysis(cooperativeMatrixAnalysis) {}
 
   LogicalResult matchAndRewrite(
       OpTy op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    if (!hasCooperativeMatrixMarker(op)) return failure();
+    if (!cooperativeMatrixAnalysis.usesCooperativeMatrixType(op))
+      return failure();
     auto loc = op.getLoc();
     auto vecType = op.getVectorType();
     if (vecType.getRank() != 2) return failure();
@@ -236,11 +242,13 @@ class TransferToCoopMatLoadStore final : public SPIRVOpLowering<OpTy> {
     return success();
   }
 
+ private:
   /// Helper to generate the right load/store instruction and replace the
   /// transfer op.
   void replaceTransferOp(OpTy op, Location loc, Type matType, Value ptr,
                          Value strideValue, Value coloumnMajor,
                          ConversionPatternRewriter &rewriter) const;
+  const CooperativeMatrixAnalysis &cooperativeMatrixAnalysis;
 };
 
 template <>
@@ -269,14 +277,17 @@ void TransferToCoopMatLoadStore<vector::TransferWriteOp>::replaceTransferOp(
 class VectorContractToCoopMatmul final
     : public SPIRVOpLowering<vector::ContractionOp> {
  public:
-  using SPIRVOpLowering<vector::ContractionOp>::SPIRVOpLowering;
+  VectorContractToCoopMatmul(
+      MLIRContext *context, SPIRVTypeConverter &converter,
+      const CooperativeMatrixAnalysis &cooperativeMatrixAnalysis)
+      : SPIRVOpLowering<vector::ContractionOp>(context, converter),
+        cooperativeMatrixAnalysis(cooperativeMatrixAnalysis) {}
 
   LogicalResult matchAndRewrite(
       vector::ContractionOp contractOp, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    // TODO(thomasraoux): Check that the size of the matmul is supported by the
-    // target.
-    if (!hasCooperativeMatrixMarker(contractOp)) return failure();
+    if (!cooperativeMatrixAnalysis.usesCooperativeMatrixType(contractOp))
+      return failure();
     auto loc = contractOp.getLoc();
     // Check that all the operands are cooperative matrix.
     vector::ContractionOp::Adaptor adaptor(operands);
@@ -303,6 +314,9 @@ class VectorContractToCoopMatmul final
     rewriter.replaceOp(contractOp, matmul);
     return success();
   }
+
+ private:
+  const CooperativeMatrixAnalysis &cooperativeMatrixAnalysis;
 };
 
 /// A pass to perform the SPIR-V conversion.
@@ -371,12 +385,14 @@ LogicalResult IREEPlaceholderConverter::matchAndRewrite(
   return success();
 }
 
-static void populateVectorToSPIRVPatterns(MLIRContext *context,
-                                          SPIRVTypeConverter &typeConverter,
-                                          OwningRewritePatternList &patterns) {
+static void populateVectorToSPIRVPatterns(
+    MLIRContext *context, SPIRVTypeConverter &converter,
+    OwningRewritePatternList &patterns,
+    const CooperativeMatrixAnalysis &cooperativeMatrixAnalysis) {
   patterns.insert<TransferToCoopMatLoadStore<vector::TransferReadOp>,
                   TransferToCoopMatLoadStore<vector::TransferWriteOp>,
-                  VectorContractToCoopMatmul>(context, typeConverter);
+                  VectorContractToCoopMatmul>(context, converter,
+                                              cooperativeMatrixAnalysis);
 }
 
 void ConvertToSPIRVPass::runOnOperation() {
@@ -395,7 +411,9 @@ void ConvertToSPIRVPass::runOnOperation() {
   populateBuiltinFuncToSPIRVPatterns(context, typeConverter, patterns);
 
   if (useCooperativeMatrix) {
-    populateVectorToSPIRVPatterns(context, typeConverter, patterns);
+    auto &cooperativeMatrixAnalysis = getAnalysis<CooperativeMatrixAnalysis>();
+    populateVectorToSPIRVPatterns(context, typeConverter, patterns,
+                                  cooperativeMatrixAnalysis);
   }
   patterns.insert<HALInterfaceLoadConstantConverter, IREEPlaceholderConverter,
                   LinalgReshapeConverter>(context, typeConverter);

--- a/iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.cpp
@@ -1,0 +1,100 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.h"
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SPIRV/TargetAndABI.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+
+using namespace mlir;
+
+namespace {
+bool isLegalVectorContract(vector::ContractionOp contract) {
+  if (llvm::size(contract.masks()) != 0) return false;
+  VectorType lhsType = contract.lhs().getType().cast<VectorType>();
+  VectorType rhsType = contract.rhs().getType().cast<VectorType>();
+  VectorType accType = contract.acc().getType().cast<VectorType>();
+
+  std::tuple<int, int, int> dim(lhsType.getDimSize(0), rhsType.getDimSize(1),
+                                lhsType.getDimSize(1));
+  bool supportedType = false;
+  // Check if the mattrix type can be supported as a cooperative matrix.
+  // Currently we have hardcoded checks for what Turing hardware supports.
+  // TODO(thomasraoux): Add device information to be able to query what the
+  // device supports.
+  if (lhsType.getElementType().isInteger(8) &&
+      rhsType.getElementType().isInteger(8) &&
+      accType.getElementType().isInteger(32) &&
+      (dim == std::make_tuple(8, 8, 32) || dim == std::make_tuple(16, 16, 32) ||
+       dim == std::make_tuple(16, 8, 32)))
+    supportedType = true;
+
+  if (lhsType.getElementType().isF16() && rhsType.getElementType().isF16() &&
+      (accType.getElementType().isF16() || accType.getElementType().isF32()) &&
+      (dim == std::make_tuple(8, 8, 16) || dim == std::make_tuple(16, 16, 16) ||
+       dim == std::make_tuple(16, 8, 16)))
+    supportedType = true;
+
+  return supportedType;
+}
+
+bool supportsCooperativeMatrix(Operation* op) {
+  if (isa<vector::TransferReadOp>(op) || isa<vector::TransferWriteOp>(op))
+    return true;
+  if (isa<vector::ContractionOp>(op) &&
+      isLegalVectorContract(cast<vector::ContractionOp>(op)))
+    return true;
+  // We only support minimal set of operations right now. We can trivially
+  // extend to ALU instructions supporting Cooperative Matrix in SPIR-V spec.
+  // We also need to extend to control flow operations, Alloca, etc...
+  // TODO(thomasraoux): extend support to more complex chain of instructions.
+  return false;
+}
+}  // namespace
+namespace mlir {
+namespace iree_compiler {
+
+CooperativeMatrixAnalysis::CooperativeMatrixAnalysis(mlir::Operation* op) {
+  auto targetEnv = spirv::TargetEnv(spirv::lookupTargetEnv(op));
+  if (!targetEnv.allows(spirv::Capability::CooperativeMatrixNV) ||
+      !targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix))
+    return;
+
+  op->walk([&](Operation* op) {
+    auto contract = dyn_cast<vector::ContractionOp>(op);
+    if (contract == nullptr) return;
+    auto hasVectorDest = [](Operation* op) {
+      for (auto resultType : op->getResultTypes()) {
+        if (resultType.isa<VectorType>()) return true;
+      }
+      return false;
+    };
+    auto dependentOps = getSlice(op, hasVectorDest);
+    for (auto* dependeOp : dependentOps) {
+      // If any instruction cannot use cooperative matrix drop the whole chaine.
+      // In the future we can introduce "bitcast" type of conversion to allow
+      // the same value to be used as both cooperative matrix as well as an
+      // array.
+      if (!supportsCooperativeMatrix(dependeOp)) {
+        return;
+      }
+    }
+    // All the dependent instruction can use cooperative matrix type. We can
+    // mark the whole chain of operations as using cooperative matrix.
+    usesCooperativeMatrix.insert(op);
+    usesCooperativeMatrix.insert(dependentOps.begin(), dependentOps.end());
+  });
+}
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CooperativeMatrixAnalysis.h
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//===- CooperativeMatrixAnalysis.h - Analysis to help lowering of matmul---===//
+//
+// Analysis class to help decide whether a chain of operations can use
+// cooperative matrix extension.
+// Since cooperative matrix is a separate type it needs to be used consistently
+// across operations. This analyzes if a chain of operations can be fully
+// converted to cooperative matrix operations. It then provides a query lowering
+// passes can use to know whether an instruction should use cooperative matrix
+// or not.
+//
+//===----------------------------------------------------------------------===//
+#ifndef IREE_COMPILER_CONVERSION_LINALGTOSPIRV_COOPERATIVEMATRIXANALYSIS_H_
+#define IREE_COMPILER_CONVERSION_LINALGTOSPIRV_COOPERATIVEMATRIXANALYSIS_H_
+#include "llvm/ADT/DenseSet.h"
+
+namespace mlir {
+class Operation;
+
+namespace iree_compiler {
+
+class CooperativeMatrixAnalysis {
+ public:
+  explicit CooperativeMatrixAnalysis(mlir::Operation *);
+
+  // Return true if the operation should be lowered using operations on
+  // cooperative matrix type.
+  bool usesCooperativeMatrixType(mlir::Operation *op) const {
+    return usesCooperativeMatrix.count(op);
+  }
+
+ private:
+  llvm::DenseSet<mlir::Operation *> usesCooperativeMatrix;
+};
+}  // namespace iree_compiler
+}  // namespace mlir
+#endif  // IREE_COMPILER_CONVERSION_LINALGTOSPIRV_COOPERATIVEMATRIXANALYSIS_H_

--- a/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.cpp
@@ -38,8 +38,6 @@ StringRef getWorkGroupMarker() { return "workgroup"; }
 
 StringRef getWorkItemMarker() { return "workitem"; }
 
-StringRef getCooperativeMatrixMarker() { return "cooperative-matrix"; }
-
 bool hasMarker(Operation *op, StringRef marker) {
   return checkMarkerValue(op, marker);
 }
@@ -52,21 +50,11 @@ bool hasWorkItemMarker(Operation *op) {
   return checkMarkerValue(op, getWorkItemMarker());
 }
 
-bool hasCooperativeMatrixMarker(Operation *op) {
-  StringAttr attr =
-      op->getAttrOfType<StringAttr>(VectorTransforms::kVectorTransformMarker);
-  return attr && attr.getValue() == getCooperativeMatrixMarker();
-}
-
 void setMarker(Operation *op, StringRef marker) {
   op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker,
               StringAttr::get(marker, op->getContext()));
 }
 
-void setCooperativeMatrixMarker(Operation *op) {
-  op->setAttr(VectorTransforms::kVectorTransformMarker,
-              StringAttr::get(getCooperativeMatrixMarker(), op->getContext()));
-}
 void setWorkGroupMarker(Operation *op) { setMarker(op, getWorkGroupMarker()); }
 
 void setWorkItemMarker(Operation *op) { setMarker(op, getWorkItemMarker()); }

--- a/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
@@ -33,11 +33,6 @@ namespace iree_compiler {
 /// Marker to denote that a linalg operation is to be partitioned to workitems.
 StringRef getWorkItemMarker();
 
-/// Returns true if an operation has a marker to denote that it will be mapped
-/// to cooperative matrix operations. Markers need to be consistent as
-/// cooperative matrices have their own type and load/store operations.
-bool hasCooperativeMatrixMarker(Operation *);
-
 /// Returns true if an operation has the specified `marker`. When `marker` is
 /// empty, returns true if the operation has any marker.
 bool hasMarker(Operation *, StringRef marker = "");
@@ -45,10 +40,6 @@ bool hasMarker(Operation *, StringRef marker = "");
 /// Returns true if an operation has marker to denote that it is to be
 /// partitioned to workitems.
 bool hasWorkItemMarker(Operation *);
-
-/// Sets marker to denote that a vector operation is to be execute on a
-/// cooperative matrix.
-void setCooperativeMatrixMarker(Operation *);
 
 /// Sets a given marker on an operation.
 void setMarker(Operation *, StringRef);


### PR DESCRIPTION
The new analysis will be responsible to decide if a chain of
operations should use cooperative matrix extension or not. This allows
removing markers which were not the correct way to handle this. The
analysis is very basic and will be improved in future commits.