### PR TITLE
[cmake] Support running tests on Android device with ctest

### DIFF
--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -115,6 +115,7 @@ function(iree_cc_test)
     set(_ANDROID_ABS_DIR "/data/local/tmp/${_ANDROID_REL_DIR}")
 
     # Define a custom target for pushing and running the test on Android device.
+    set(_TEST_NAME ${_TEST_NAME}_on_android_device)
     add_test(
       NAME
         ${_TEST_NAME}

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -107,6 +107,7 @@ function(iree_cc_test)
   set_property(TARGET ${_NAME} PROPERTY DIRECT_DEPS ${_RULE_DEPS})
 
   string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
+  set(_TEST_NAME "${_PACKAGE_PATH}:${_RULE_NAME}")
 
   # Case for cross-compiling towards Android.
   if(ANDROID)
@@ -114,10 +115,9 @@ function(iree_cc_test)
     set(_ANDROID_ABS_DIR "/data/local/tmp/${_ANDROID_REL_DIR}")
 
     # Define a custom target for pushing and running the test on Android device.
-    set(_RUN_NAME "run_${_PACKAGE_NAME}_${_RULE_NAME}_on_android_device")
     add_test(
       NAME
-        ${_RUN_NAME}
+        ${_TEST_NAME}
       COMMAND
         "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_android_test.${IREE_HOST_SCRIPT_EXT}"
         "${_ANDROID_REL_DIR}/${_NAME}"
@@ -133,13 +133,11 @@ function(iree_cc_test)
         TEST_ARTIFACT_NAME=$<TARGET_FILE_NAME:${_NAME}>
         TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir
     )
-    set_property(TEST ${_RUN_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
-    set(_NAME_PATH ${_RUN_NAME})
+    set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
   else(ANDROID)
-    set(_NAME_PATH "${_PACKAGE_PATH}:${_RULE_NAME}")
     add_test(
       NAME
-        ${_NAME_PATH}
+        ${_TEST_NAME}
       COMMAND
         # We run all our tests through a custom test runner to allow temp
         # directory cleanup upon test completion.
@@ -148,9 +146,9 @@ function(iree_cc_test)
       WORKING_DIRECTORY
         "${CMAKE_BINARY_DIR}"
       )
-    set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_NAME}_test_tmpdir")
+    set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_NAME}_test_tmpdir")
   endif(ANDROID)
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
-  set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
+  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
 endfunction()

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -22,7 +22,7 @@ include(AbseilConfigureCopts)
 # we cannot run IREE binaries via command-line with proper options. Turn off
 # the stripping.
 # TODO: we might still want to strip when compiling IREE into Android Java apps.
-if(CMAKE_CROSSCOMPILING AND "${CMAKE_SYSTEM_NAME}" MATCHES "Android")
+if(ANDROID)
   add_definitions(-DABSL_FLAGS_STRIP_NAMES=0)
 endif()
 

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -43,6 +43,10 @@ function(iree_lit_test)
     ${ARGN}
   )
 
+  if(CMAKE_CROSSCOMPILING AND "hostonly" IN_LIST _RULE_LABELS)
+    return()
+  endif()
+
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 

--- a/build_tools/cmake/run_android_test.bat
+++ b/build_tools/cmake/run_android_test.bat
@@ -1,0 +1,18 @@
+@ECHO OFF
+REM Copyright 2020 Google LLC
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM      https://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+SET RUNNER_PATH=%~dp0
+powershell.exe -NoProfile -File "%RUNNER_PATH%\run_android_test.ps1" %*
+EXIT /B %ERRORLEVEL%

--- a/build_tools/cmake/run_android_test.ps1
+++ b/build_tools/cmake/run_android_test.ps1
@@ -12,43 +12,116 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Wrapper script to push build artifacts and run tests on an Android device.
+#
+# This script expects the following arguments:
+#   <test-binary> [<test-args>]..
+# Where <test-binary> should be a path relative to /data/local/tmp/ on device.
+#
+# This script reads the following environment variables:
+# - TEST_ANDROID_ABS_DIR: the absolute path on Android device for the build
+#   artifact.
+# - TEST_ARTIFACT: the build artifact to push to the Android device.
+# - TEST_ARTIFACT_IS_EXECUTABLE: whether the build artifact should be marked
+#   as executable on the Android device.
+# - TEST_ARTIFACT_NAME: the build artifact's filename.
+# - TEST_TMPDIR: optional; temporary directory on the Android device for
+#   running tests.
+#
+# This script pushes $env:TEST_ARTIFACT onto the device as
+# $env:TEST_ANDROID_ABS_DIR/$env:TEST_ARTIFACT_NAME before running
+# <test-binary> with all <test-args> under /data/local/tmp.
+
 param(
-  [Parameter(Position=0, Mandatory, ValueFromRemainingArguments=$true)]
+  [Parameter(Position=0, Mandatory)]
   [ValidateNotNullOrEmpty()]
+  [string]
+    $test_binary,
+  [Parameter(Position=1, ValueFromRemainingArguments=$true)]
   [string[]]
-    $adb_cmd
+    $test_args = @()
 )
 
 # NOTE: to debug first run `$DebugPreference = 'Continue'` in your shell.
 # $DebugPreference = "Continue"
 
-Write-Host -ForegroundColor Yellow "Requested adb command: $adb_cmd"
+# Composes arguments for adb to push `$data` to `$dest` on device.
+function Compose-AdbPushCommand {
+  param([string]$data, [string]$dest)
+
+  $adb_params = "push", $data, $dest
+  $adb_params = $adb_params -join " "
+
+  return $adb_params
+}
+
+# Composes arguments for adb to run the given `$adb_cmd` and returns a string:
+#   shell "cd /data/local/tmp && $adb_cmd"
+function Compose-AdbShellCommand {
+  param([string[]]$adb_cmd)
+
+  $adb_cmd_prefix = "cd", "/data/local/tmp", "&&"
+  $adb_params = $adb_cmd_prefix + $adb_cmd
+  $adb_params = $adb_params -join " "
+  $adb_params = ('"', $adb_params, '"') -join ""
+
+  $adb_params = "shell " + $adb_params
+  Write-Host -ForegroundColor Yellow "adb parameters: $adb_params"
+  return $adb_params
+}
+
+# Invokes adb at `$adb_path` with the given parameters `$adb_params`.
+function Invoke-Adb {
+  param([string]$adb_path, [string]$adb_params)
+
+  $process = Start-Process -FilePath $adb_path -ArgumentList $adb_params -NoNewWindow -PassThru
+  # HACK: Start-Process is broken... wow.
+  # https://stackoverflow.com/questions/10262231/obtaining-exitcode-using-start-process-and-waitforexit-instead-of-wait
+  $handle = $process.Handle
+  $exitcode = 1
+  $timeout_millis = 120 * 1000
+  if ($process.WaitForExit($timeout_millis) -eq $false) {
+    Write-Error "adb timed out after $timeout_millis millis"
+  } else {
+    $exitcode = $process.ExitCode
+    Write-Debug "adb returned in time with exit code $($exitcode)"
+  }
+
+  if ($process.ExitCode -ne 0) {
+    Write-Debug "adb exited with $exitcode"
+    exit $exitcode
+  }
+}
+
+Write-Host -ForegroundColor Yellow "Requested adb command: $test_binary $test_args"
 
 $adb_path = $(Get-Command adb -Type Application).Path
 Write-Host -ForegroundColor Yellow "Using adb executable: $adb_path"
 
-# Compose arguments to `adb shell`. It should be of the form:
-#   "cd /data/local/tmp && <requested-adb-command>"
-$adb_cmd_prefix = "cd", "/data/local/tmp", "&&"
-$adb_params = $adb_cmd_prefix + $adb_cmd
-$adb_params = $adb_params -join " "
-$adb_params = ('"', $adb_params, '"') -join ""
+# Push the artifact needed for testing to Android device.
+$adb_push_params = Compose-AdbPushCommand $env:TEST_ARTIFACT $env:TEST_ANDROID_ABS_DIR/$env:TEST_ARTIFACT_NAME
+Invoke-Adb $adb_path $adb_push_params
 
-$adb_params = "shell " + $adb_params
-Write-Host -ForegroundColor Yellow "Full adb arguments: $adb_params"
-
-$process = Start-Process -FilePath $adb_path -ArgumentList $adb_params -NoNewWindow -PassThru
-# HACK: Start-Process is broken... wow.
-# https://stackoverflow.com/questions/10262231/obtaining-exitcode-using-start-process-and-waitforexit-instead-of-wait
-$handle = $process.Handle
-$exitcode = 1
-$timeout_millis = 120 * 1000
-if ($process.WaitForExit($timeout_millis) -eq $false) {
-  Write-Error "Test timed out after $timeout_millis millis"
-} else {
-  $exitcode = $process.ExitCode
-  Write-Debug "Test returned in time with exit code $($process.ExitCode)"
+# Optionally mark it as executable.
+if ($env:TEST_ARTIFACT_IS_EXECUTABLE) {
+  $adb_mark_executable_params = Compose-AdbShellCommand "chmod","+x",$env:TEST_ANDROID_ABS_DIR/$env:TEST_ARTIFACT_NAME
+  Invoke-Adb $adb_path $adb_mark_executable_params
 }
 
-Write-Debug "Test exited with $exitcode"
-exit $exitcode
+if ($env:TEST_TMPDIR -ne $null) {
+  $adb_mkdir_params = Compose-AdbShellCommand "mkdir","-p",$env:TEST_TMPDIR
+  Invoke-Adb $adb_path $adb_mkdir_params
+  $tmpdir = "TEST_TMPDIR=" + $tmpdir
+} else {
+  $tmpdir = ""
+}
+
+$adb_shell_params = Compose-AdbShellCommand $tmpdir,$test_binary,$test_args
+Invoke-Adb $adb_path $adb_shell_params
+
+if ($env:TEST_TMPDIR -ne $null) {
+  $adb_rm_params = Compose-AdbShellCommand "rm","-rf",$env:TEST_TMPDIR
+  Invoke-Adb $adb_path $adb_rm_params
+}
+
+exit 0

--- a/build_tools/cmake/run_android_test.ps1
+++ b/build_tools/cmake/run_android_test.ps1
@@ -1,0 +1,54 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+param(
+  [Parameter(Position=0, Mandatory, ValueFromRemainingArguments=$true)]
+  [ValidateNotNullOrEmpty()]
+  [string[]]
+    $adb_cmd
+)
+
+# NOTE: to debug first run `$DebugPreference = 'Continue'` in your shell.
+# $DebugPreference = "Continue"
+
+Write-Host -ForegroundColor Yellow "Requested adb command: $adb_cmd"
+
+$adb_path = $(Get-Command adb -Type Application).Path
+Write-Host -ForegroundColor Yellow "Using adb executable: $adb_path"
+
+# Compose arguments to `adb shell`. It should be of the form:
+#   "cd /data/local/tmp && <requested-adb-command>"
+$adb_cmd_prefix = "cd", "/data/local/tmp", "&&"
+$adb_params = $adb_cmd_prefix + $adb_cmd
+$adb_params = $adb_params -join " "
+$adb_params = ('"', $adb_params, '"') -join ""
+
+$adb_params = "shell " + $adb_params
+Write-Host -ForegroundColor Yellow "Full adb arguments: $adb_params"
+
+$process = Start-Process -FilePath $adb_path -ArgumentList $adb_params -NoNewWindow -PassThru
+# HACK: Start-Process is broken... wow.
+# https://stackoverflow.com/questions/10262231/obtaining-exitcode-using-start-process-and-waitforexit-instead-of-wait
+$handle = $process.Handle
+$exitcode = 1
+$timeout_millis = 120 * 1000
+if ($process.WaitForExit($timeout_millis) -eq $false) {
+  Write-Error "Test timed out after $timeout_millis millis"
+} else {
+  $exitcode = $process.ExitCode
+  Write-Debug "Test returned in time with exit code $($process.ExitCode)"
+}
+
+Write-Debug "Test exited with $exitcode"
+exit $exitcode

--- a/build_tools/cmake/run_android_test.sh
+++ b/build_tools/cmake/run_android_test.sh
@@ -14,8 +14,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Wrapper script to push build artifacts and run tests on an Android device.
+#
+# This script expects the following arguments:
+#   <test-binary> [<test-args>]..
+# Where <test-binary> should be a path relative to /data/local/tmp/ on device.
+#
+# This script reads the following environment variables:
+# - TEST_ANDROID_ABS_DIR: the absolute path on Android device for the build
+#   artifact.
+# - TEST_ARTIFACT: the build artifact to push to the Android device.
+# - TEST_ARTIFACT_NAME: the build artifact's filename.
+# - TEST_TMPDIR: optional; temporary directory on the Android device for
+#   running tests.
+#
+# This script pushes $TEST_ARTIFACT onto the device as
+# $TEST_ANDROID_ABS_DIR/$TEST_ARTIFACT_NAME before running
+# <test-binary> with all <test-args> under /data/local/tmp.
+
 set -x
 set -e
 
-# Execute the command with `adb shell` under `/data/local/tmp`.
-adb shell "cd /data/local/tmp && $*"
+adb push $TEST_ARTIFACT $TEST_ANDROID_ABS_DIR/$TEST_ARTIFACT_NAME
+
+if [ -n "$TEST_TMPDIR" ]; then
+  adb shell "mkdir -p $TEST_TMPDIR"
+  tmpdir="TEST_TMPDIR=$TEST_TMPDIR"
+else
+  tmpdir=""
+fi
+
+adb shell "cd /data/local/tmp && $tmpdir $*"
+
+if [ -n "$TEST_TMPDIR" ]; then
+  adb shell "rm -rf $TEST_TMPDIR"
+fi

--- a/build_tools/cmake/run_android_test.sh
+++ b/build_tools/cmake/run_android_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A wrapper around a test command that performs setup and teardown. This is
+# appranetly not supported natively in ctest/cmake.
+
+set -x
+set -e
+
+# Execute the command with `adb shell` under `/data/local/tmp`.
+adb shell "cd /data/local/tmp && $*"

--- a/build_tools/cmake/run_android_test.sh
+++ b/build_tools/cmake/run_android_test.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A wrapper around a test command that performs setup and teardown. This is
-# appranetly not supported natively in ctest/cmake.
-
 set -x
 set -e
 


### PR DESCRIPTION
This commit adds test targets for pushing and running cross
compilation artifacts on Android devices. This makes testing
with Android devices easier: now we just need to run `ctest`
under the cross compilation build directory.