### PR TITLE
Set `-Werror` on generic_clang Bazel config.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,9 @@ test --define open_source_build=true
 # either clang or gcc and are curated based on need.
 ###############################################################################
 
+# Treat warnings as errors.
+build:generic_clang --copt=-Werror
+
 # Disable warnings we don't care about.
 build:generic_clang --copt=-Wno-unused-local-typedef
 build:generic_clang --copt=-Wno-unused-private-field


### PR DESCRIPTION
Otherwise `-Wimplicit-fallthrough` and `-Wthread-safety-analysis` warnings will go unnoticed.