### PR TITLE
Add fused_dispatch_region test.

### DIFF
--- a/iree/test/e2e/structural/BUILD
+++ b/iree/test/e2e/structural/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+# TODO(#2395): This fails on conversion to buffers for both LLVM-ir and SPIR-V.
+iree_check_single_backend_test_suite(
+    name = "check_vmla-reference",
+    srcs = [
+        "fused_dispatch_region.mlir",
+    ],
+    driver = "vmla",
+    target_backend = "vmla",
+)

--- a/iree/test/e2e/structural/CMakeLists.txt
+++ b/iree/test/e2e/structural/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_vmla-reference
+  SRCS
+    "fused_dispatch_region.mlir"
+  TARGET_BACKEND
+    vmla
+  DRIVER
+    vmla
+)

--- a/iree/test/e2e/structural/fused_dispatch_region.mlir
+++ b/iree/test/e2e/structural/fused_dispatch_region.mlir
@@ -1,0 +1,21 @@
+func @fused_add_transpose_dot_tanh() attributes { iree.module.export } {
+  %term0 = iree.unfoldable_constant dense<[0.1, 0.2, 0.3, 0.4]> : tensor<4xf32>
+  %term1 = iree.unfoldable_constant dense<[
+    [0.1, 0.0, 0.0, 0.0],
+    [0.0, 0.3, 0.0, 0.0],
+    [0.0, 0.0, 0.4, 0.5]
+  ]> : tensor<3x4xf32>
+  %workload = constant 9 : index
+  %dr0 = flow.dispatch.region[%workload: index](%arg0 = %term0 : tensor<4xf32>, %arg1 = %term1 : tensor<3x4xf32>) -> tensor<3x3xf32> {
+    %0 = xla_chlo.broadcast_add %arg0, %arg1 : (tensor<4xf32>, tensor<3x4xf32>) -> tensor<3x4xf32>
+    %1 = "xla_hlo.transpose"(%0) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<3x4xf32>) -> tensor<4x3xf32>
+    %2 = "xla_hlo.dot"(%arg1, %1) {precision_config = ["DEFAULT", "DEFAULT"]} : (tensor<3x4xf32>, tensor<4x3xf32>) -> tensor<3x3xf32>
+    %3 = "xla_hlo.tanh"(%2) : (tensor<3x3xf32>) -> (tensor<3x3xf32>)
+    flow.return %3 : tensor<3x3xf32>
+  }
+  check.expect_almost_eq_const(%dr0,
+    dense<[[0.0199973, 0.00999967, 0.00999967],
+           [0.0599281, 0.148885, 0.0599281],
+           [0.309507, 0.309507, 0.623065]]> : tensor<3x3xf32>) : tensor<3x3xf32>
+  return
+}


### PR DESCRIPTION
* Since we are missing an easy way to generate such fusions, this solves the chicken and egg problem of getting something that we can iterate on.
* I specifically wrote this as a sequence that we are unlikely to ever see/fuse at the lowest levels in practice as a test of the infra.
* Also verifies that we can in fact send dispatch regions in to the frontend and everything works (up to codegen).
* Fails for llvm-ir when attempting to lower to buffers.
* Gives us something to progress towards on #2395.