### PR TITLE
Refactor TensorFlow CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 
 if(${IREE_BUILD_COMPILER})
+  add_subdirectory(build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo EXCLUDE_FROM_ALL)
   add_subdirectory(build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla EXCLUDE_FROM_ALL)
 endif()
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -180,5 +180,7 @@ iree_get_executable_path(IREE_TABLEGEN_EXE iree-tblgen)
 
 list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tensorflow
+  ${PROJECT_SOURCE_DIR}/third_party/tensorflow/tensorflow/compiler/mlir/hlo/include/
   ${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow
+  ${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/include/
 )

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -33,23 +33,22 @@ external_cc_library(
   ROOT
     ${TF_MLIR_HLO_SRC_ROOT}
   SRCS
-    "lib/Dialect/mhlo/IR/infer_fusibility_op_interface.cc"
-    "lib/utils/convert_op_folder.cc"
     "lib/Dialect/mhlo/IR/chlo_ops.cc"
+    "lib/Dialect/mhlo/IR/dialect_registration.cc"
     "lib/Dialect/mhlo/IR/hlo_ops.cc"
+    "lib/Dialect/mhlo/IR/infer_fusibility_op_interface.cc"
+    "lib/Dialect/mhlo/IR/lhlo_ops.cc"
+    "lib/utils/convert_op_folder.cc"
     "lib/utils/broadcast_utils.cc"
     "lib/utils/hlo_utils.cc"
-    "lib/Dialect/mhlo/IR/lhlo_ops.cc"
-    "lib/Dialect/mhlo/IR/dialect_registration.cc"
   HDRS
-    "include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.h"
-    "include/mlir-hlo/utils/convert_op_folder.h"
     "include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
     "include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+    "include/mlir-hlo/utils/convert_op_folder.h"
     "include/mlir-hlo/utils/broadcast_utils.h"
     "include/mlir-hlo/utils/hlo_utils.h"
-    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
-    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
   COPTS
     ${TF_MLIR_HLO_COPTS_BASE}
   INCLUDES
@@ -58,12 +57,12 @@ external_cc_library(
   DEPS
     absl::core_headers
     absl::flat_hash_set
-    tensorflow_mlir_hlo_xla_canonicalize_gen
     tensorflow_mlir_hlo_chlo_ops_gen
     tensorflow_mlir_hlo_hlo_ops_gen
     tensorflow_mlir_hlo_hlo_ops_base_gen
     tensorflow_mlir_hlo_infer_fusibility_op_interface_gen
     tensorflow_mlir_hlo_lhlo_ops_gen
+    tensorflow_mlir_hlo_xla_canonicalize_gen
     LLVMSupport
     MLIRAnalysis
     MLIRIR

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -1,0 +1,179 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(TF_MLIR_HLO_SRC_ROOT
+  "${IREE_ROOT_DIR}/third_party/tensorflow/tensorflow/compiler/mlir/hlo/"
+)
+
+set(TF_MLIR_HLO_COPTS_BASE
+  "-I${IREE_ROOT_DIR}/third_party/tensorflow/"
+  "-I${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/"
+)
+
+# Create directories in the build tree for external_tablegen_library targets to use.
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/")
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/")
+
+external_cc_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "lib/Dialect/mhlo/IR/infer_fusibility_op_interface.cc"
+    "lib/utils/convert_op_folder.cc"
+    "lib/Dialect/mhlo/IR/chlo_ops.cc"
+    "lib/Dialect/mhlo/IR/hlo_ops.cc"
+    "lib/utils/broadcast_utils.cc"
+    "lib/utils/hlo_utils.cc"
+    "lib/Dialect/mhlo/IR/lhlo_ops.cc"
+    "lib/Dialect/mhlo/IR/dialect_registration.cc"
+  HDRS
+    "include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.h"
+    "include/mlir-hlo/utils/convert_op_folder.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+    "include/mlir-hlo/utils/broadcast_utils.h"
+    "include/mlir-hlo/utils/hlo_utils.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+  COPTS
+    ${TF_MLIR_HLO_COPTS_BASE}
+  INCLUDES
+    ${IREE_ROOT_DIR}/third_party/tensorflow/
+    ${CMAKE_BINARY_DIR}/build_tools/third_party/tensorflow/
+  DEPS
+    absl::core_headers
+    absl::flat_hash_set
+    tensorflow_mlir_hlo_xla_canonicalize_gen
+    tensorflow_mlir_hlo_chlo_ops_gen
+    tensorflow_mlir_hlo_hlo_ops_gen
+    tensorflow_mlir_hlo_hlo_ops_base_gen
+    tensorflow_mlir_hlo_infer_fusibility_op_interface_gen
+    tensorflow_mlir_hlo_lhlo_ops_gen
+    LLVMSupport
+    MLIRAnalysis
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRPass
+    MLIRShape
+    MLIRSideEffectInterfaces
+    MLIRStandardOps
+    MLIRSupport
+    MLIRTransformUtils
+    MLIRTransforms
+    MLIRViewLikeInterface
+  PUBLIC
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_chlo_ops_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.td"
+  OUTS
+    -gen-op-decls include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.h.inc
+    -gen-op-defs include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.cc.inc
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_hlo_ops_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td"
+  OUTS
+    -gen-op-decls include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.h.inc
+    -gen-op-defs include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.cc.inc
+    -gen-struct-attr-decls include/mlir-hlo/Dialect/mhlo/IR/hlo_structs.h.inc
+    -gen-struct-attr-defs include/mlir-hlo/Dialect/mhlo/IR/hlo_structs.cc.inc
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_hlo_ops_base_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base.td"
+  OUTS
+    -gen-op-decls include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base.h.inc
+    -gen-op-defs include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base.cc.inc
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_lhlo_ops_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td"
+  OUTS
+    -gen-op-decls include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h.inc
+    -gen-op-defs include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.cc.inc
+    -gen-struct-attr-decls include/mlir-hlo/Dialect/mhlo/IR/lhlo_structs.h.inc
+    -gen-struct-attr-defs include/mlir-hlo/Dialect/mhlo/IR/lhlo_structs.cc.inc
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_xla_canonicalize_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "lib/Dialect/mhlo/transforms/canonicalize.td"
+  OUTS
+    -gen-rewriters lib/Dialect/mhlo/transforms/generated_canonicalize.inc
+)
+
+external_tablegen_library(
+  PACKAGE
+    tensorflow
+  NAME
+    mlir_hlo_infer_fusibility_op_interface_gen
+  TBLGEN
+    MLIR
+  ROOT
+    ${TF_MLIR_HLO_SRC_ROOT}
+  SRCS
+    "include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.td"
+  OUTS
+    -gen-op-interface-decls include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.h.inc
+    -gen-op-interface-defs include/mlir-hlo/Dialect/mhlo/IR/infer_fusibility_op_interface.cc.inc
+)

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
@@ -22,7 +22,6 @@ set(TF_MLIR_XLA_COPTS_BASE
 )
 
 # Create directories in the build tree for external_tablegen_library targets to use.
-file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/ir")
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/transforms")
 
 external_cc_library(

--- a/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
+++ b/build_tools/third_party/tensorflow/tensorflow/compiler/mlir/xla/CMakeLists.txt
@@ -33,14 +33,6 @@ external_cc_library(
   ROOT
     ${TF_MLIR_XLA_SRC_ROOT}
   SRCS
-    "convert_op_folder.cc"
-    "ir/broadcast_utils.cc"
-    "ir/chlo_ops.cc"
-    "ir/dialect_registration.cc"
-    "ir/hlo_ops.cc"
-    "ir/hlo_utils.cc"
-    "ir/infer_fusibility_op_interface.cc"
-    "ir/lhlo_ops.cc"
     "transforms/chlo_legalize_to_hlo.cc"
     "transforms/cycle_detector.cc"
     "transforms/legalize_control_flow.cc"
@@ -51,12 +43,6 @@ external_cc_library(
     "transforms/xla_hlo_fusion.cc"
     "transforms/xla_legalize_to_linalg.cc"
   HDRS
-    "convert_op_folder.h"
-    "ir/chlo_ops.h"
-    "ir/hlo_ops.h"
-    "ir/hlo_utils.h"
-    "ir/infer_fusibility_op_interface.h"
-    "ir/lhlo_ops.h"
     "transforms/cycle_detector.h"
     "transforms/map_xla_to_scalar_op.h"
     "transforms/passes.h"
@@ -69,103 +55,22 @@ external_cc_library(
   DEPS
     absl::core_headers
     absl::flat_hash_set
-    tensorflow_mlir_xla_canonicalize_gen
-    tensorflow_mlir_xla_chlo_ops_gen
-    tensorflow_mlir_xla_hlo_ops_gen
-    tensorflow_mlir_xla_hlo_ops_base_gen
-    tensorflow_mlir_xla_infer_fusibility_op_interface_gen
+    absl::memory
+    tensorflow_mlir_hlo
     tensorflow_mlir_xla_legalize_to_standard_patterns_gen
-    tensorflow_mlir_xla_lhlo_ops_gen
+    LLVMCore
     LLVMSupport
     MLIRAnalysis
+    MLIRDialect
     MLIRIR
     MLIRLinalgOps
     MLIRPass
     MLIRShape
-    MLIRShapeOpsTransforms
+    MLIRStandardOps
+    MLIRSupport
     MLIRTransformUtils
+    MLIRTransforms
   PUBLIC
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_canonicalize_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "transforms/canonicalize.td"
-  OUTS
-    -gen-rewriters transforms/generated_canonicalize.inc
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_hlo_ops_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "ir/hlo_ops.td"
-  OUTS
-    -gen-op-decls ir/hlo_ops.h.inc
-    -gen-op-defs ir/hlo_ops.cc.inc
-    -gen-struct-attr-decls ir/hlo_structs.h.inc
-    -gen-struct-attr-defs ir/hlo_structs.cc.inc
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_chlo_ops_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "ir/chlo_ops.td"
-  OUTS
-    -gen-op-decls ir/chlo_ops.h.inc
-    -gen-op-defs ir/chlo_ops.cc.inc
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_hlo_ops_base_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "ir/hlo_ops_base.td"
-  OUTS
-    -gen-op-decls ir/hlo_ops_base.h.inc
-    -gen-op-defs ir/hlo_ops_base.cc.inc
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_infer_fusibility_op_interface_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "ir/infer_fusibility_op_interface.td"
-  OUTS
-    -gen-op-interface-decls ir/infer_fusibility_op_interface.h.inc
-    -gen-op-interface-defs ir/infer_fusibility_op_interface.cc.inc
 )
 
 external_tablegen_library(
@@ -181,22 +86,4 @@ external_tablegen_library(
     "transforms/legalize_to_standard_patterns.td"
   OUTS
     -gen-rewriters transforms/generated_legalize_to_standard.inc
-)
-
-external_tablegen_library(
-  PACKAGE
-    tensorflow
-  NAME
-    mlir_xla_lhlo_ops_gen
-  TBLGEN
-    MLIR
-  ROOT
-    ${TF_MLIR_XLA_SRC_ROOT}
-  SRCS
-    "ir/lhlo_ops.td"
-  OUTS
-    -gen-op-decls ir/lhlo_ops.h.inc
-    -gen-op-defs ir/lhlo_ops.cc.inc
-    -gen-struct-attr-decls ir/lhlo_structs.h.inc
-    -gen-struct-attr-defs ir/lhlo_structs.cc.inc
 )


### PR DESCRIPTION
With https://github.com/tensorflow/tensorflow/commit/619cc68ce1f2c7b616091ad2b3d5e994cd59db16, the HLO/LHLO dialects were moved to a new directory. This patch updates the CMakeLists accordingly.