### PR TITLE
Start creating $async functions as part of public ABI generation.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "ConvertBufferOps.cpp",
         "ConvertBufferViewOps.cpp",
         "ConvertCommandBufferOps.cpp",
+        "ConvertControlFlowOps.cpp",
         "ConvertDeviceOps.cpp",
         "ConvertExecutableOps.cpp",
         "ConvertExperimentalOps.cpp",

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     "ConvertBufferOps.cpp"
     "ConvertBufferViewOps.cpp"
     "ConvertCommandBufferOps.cpp"
+    "ConvertControlFlowOps.cpp"
     "ConvertDeviceOps.cpp"
     "ConvertExecutableOps.cpp"
     "ConvertExperimentalOps.cpp"

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertControlFlowOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertControlFlowOps.cpp
@@ -31,7 +31,7 @@ class CheckSuccessOpConversion
       ConversionPatternRewriter &rewriter) const override {
     // If status value is non-zero, fail.
     rewriter.replaceOpWithNewOp<IREE::VM::CondFailOp>(
-        op, op.status(), op.status(), op.messageAttr());
+        op, op.status(), op.message().getValueOr(""));
     return success();
   }
 };

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertControlFlowOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertControlFlowOps.cpp
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+class CheckSuccessOpConversion
+    : public OpConversionPattern<IREE::HAL::CheckSuccessOp> {
+ public:
+  CheckSuccessOpConversion(MLIRContext *context, SymbolTable &importSymbols,
+                           TypeConverter &typeConverter, StringRef importName)
+      : OpConversionPattern(context) {}
+
+  LogicalResult matchAndRewrite(
+      IREE::HAL::CheckSuccessOp op, llvm::ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    // If status value is non-zero, fail.
+    rewriter.replaceOpWithNewOp<IREE::VM::CondFailOp>(
+        op, op.status(), op.status(), op.messageAttr());
+    return success();
+  }
+};
+
+void populateHALControlFlowToVMPatterns(MLIRContext *context,
+                                        SymbolTable &importSymbols,
+                                        TypeConverter &typeConverter,
+                                        OwningRewritePatternList &patterns) {
+  patterns.insert<CheckSuccessOpConversion>(context, importSymbols,
+                                            typeConverter, "hal.check_success");
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
@@ -48,6 +48,9 @@ extern void populateHALBufferViewToVMPatterns(
 extern void populateHALCommandBufferToVMPatterns(
     MLIRContext *context, SymbolTable &importSymbols,
     TypeConverter &typeConverter, OwningRewritePatternList &patterns);
+extern void populateHALControlFlowToVMPatterns(
+    MLIRContext *context, SymbolTable &importSymbols,
+    TypeConverter &typeConverter, OwningRewritePatternList &patterns);
 extern void populateHALDeviceToVMPatterns(MLIRContext *context,
                                           SymbolTable &importSymbols,
                                           TypeConverter &typeConverter,
@@ -77,6 +80,8 @@ void populateHALToVMPatterns(MLIRContext *context, SymbolTable &importSymbols,
                                     patterns);
   populateHALCommandBufferToVMPatterns(context, importSymbols, typeConverter,
                                        patterns);
+  populateHALControlFlowToVMPatterns(context, importSymbols, typeConverter,
+                                     patterns);
   populateHALDeviceToVMPatterns(context, importSymbols, typeConverter,
                                 patterns);
   populateHALExecutableToVMPatterns(context, importSymbols, typeConverter,

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
@@ -4,7 +4,7 @@
 func @check_success() {
     // CHECK: %[[CODE:.+]] =
     %statusCode = constant 1 : i32
-    // CHECK: vm.cond_fail %[[CODE]], %[[CODE]]
+    // CHECK: vm.cond_fail %[[CODE]]
     hal.check_success %statusCode
     return
 }
@@ -15,7 +15,7 @@ func @check_success() {
 func @check_success_with_message() {
     // CHECK: %[[CODE:.+]] =
     %statusCode = constant 1 : i32
-    // CHECK: vm.cond_fail %[[CODE]], %[[CODE]], "failure message"
+    // CHECK: vm.cond_fail %[[CODE]], "failure message"
     hal.check_success %statusCode, "failure message"
     return
 }

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
+
+// CHECK-LABEL: func @check_success
+func @check_success() {
+    // CHECK: %[[CODE:.+]] =
+    %statusCode = constant 1 : i32
+    // CHECK: vm.cond_fail %[[CODE]], %[[CODE]]
+    hal.check_success %statusCode
+    return
+}
+
+// -----
+
+// CHECK-LABEL: func @check_success_with_message
+func @check_success_with_message() {
+    // CHECK: %[[CODE:.+]] =
+    %statusCode = constant 1 : i32
+    // CHECK: vm.cond_fail %[[CODE]], %[[CODE]], "failure message"
+    hal.check_success %statusCode, "failure message"
+    return
+}

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -284,6 +284,46 @@ def HAL_VariableStoreIndirectOp : HAL_Op<"variable.store.indirect"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Control flow
+//===----------------------------------------------------------------------===//
+
+def HAL_CheckSuccessOp : HAL_Op<"check_success"> {
+  let summary = [{raises a global failure if a status is not 'ok'}];
+  let description = [{
+    When the status is not 'ok' this signals a runtime failure that causes the
+    entire active invocation - and possibly *all* in-flight and pending
+    invocations - to fail with the given status. The status will be propagated
+    back via the available runtime error handling mechanisms such as semaphores
+    or synchronous invocation results.
+
+    As the IREE execution model is deeply pipelined it's possible that failures
+    have a latency between when they are emitted and when the application can
+    observe the failure. It's also possible that other work that is in-flight
+    or pending when the failure occurs will complete.
+  }];
+
+  let arguments = (ins
+    IREE_Status:$status,
+    OptionalAttr<StrAttr>:$message
+  );
+
+  let assemblyFormat = [{
+    $status (`,` $message^)? attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<[{
+      OpBuilder &builder, OperationState &result,
+      Value status, StringRef message = ""
+    }], [{
+      build(
+        builder, result, status,
+        message.empty() ? StringAttr{} : builder.getStringAttr(message));
+    }]>,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // iree::hal::Allocator
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
@@ -216,6 +216,44 @@ LogicalResult generateSynchronousBody(
   return success();
 }
 
+LogicalResult generateAsynchronousBody(FuncOp funcOp, FuncOp syncFuncOp,
+                                       OpBuilder moduleBuilder) {
+  auto *ctx = funcOp.getContext();
+  auto loc = funcOp.getLoc();
+  Block *entryBlock = funcOp.addEntryBlock();
+  OpBuilder builder = OpBuilder::atBlockEnd(entryBlock);
+
+  // Wait until the wait semaphore reaches the wait value.
+  auto waitSemaphore = entryBlock->getArgument(0);
+  auto waitValue = entryBlock->getArgument(1);
+  auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
+      loc, builder.getIntegerType(32), waitSemaphore, waitValue);
+  // TODO(scotttodd): if waitOp's result is not 0 (ok), fail
+  // VM::CondFailOp (are VM ops allowed in this pass?):
+  //   %nz = vm.cmp.nz.i32 %value : i32
+  //   vm.cond_fail %nz, %waitOp, "expected non-zero"
+
+  // Trim the first (wait semaphore/value) and last (signal semaphore/value)
+  // two arguments.
+  SmallVector<Value, 4> callSyncArguments;
+  for (int i = 2; i < entryBlock->getNumArguments() - 2; ++i) {
+    callSyncArguments.push_back(entryBlock->getArguments()[i]);
+  }
+  // Call the sync op, passing through our arguments.
+  auto callSyncOp = builder.create<CallOp>(loc, syncFuncOp, callSyncArguments);
+
+  // Signal the signal semaphore to its signal value.
+  auto signalSemaphore =
+      entryBlock->getArgument(entryBlock->getNumArguments() - 2);
+  auto signalValue = entryBlock->getArgument(entryBlock->getNumArguments() - 1);
+  builder.create<HAL::SemaphoreSignalOp>(loc, signalSemaphore, signalValue);
+
+  // Return results of the sync op.
+  builder.create<mlir::ReturnOp>(loc, callSyncOp.getResults());
+
+  return success();
+}
+
 LogicalResult generateRawAbiFunctions(OpBuilder &moduleBuilder,
                                       FuncOp rawCalleeFuncOp,
                                       StringRef exportName,
@@ -254,23 +292,52 @@ LogicalResult generateRawAbiFunctions(OpBuilder &moduleBuilder,
   }
   assert(resultTypes.size() == resultDescs.size());
 
-  // Create the new synchronus function export.
-  SmallVector<NamedAttribute, 1> exportAttrs;
-  exportAttrs.push_back(moduleBuilder.getNamedAttr(
+  // Create the new synchronous function export.
+  SmallVector<NamedAttribute, 1> syncExportAttrs;
+  syncExportAttrs.push_back(moduleBuilder.getNamedAttr(
       "iree.module.export", moduleBuilder.getStringAttr(exportName)));
-  exportAttrs.push_back(
+  syncExportAttrs.push_back(
       moduleBuilder.getNamedAttr("iree.reflection", reflection));
-  exportAttrs.push_back(
+  syncExportAttrs.push_back(
       moduleBuilder.getNamedAttr("iree.abi.stub", UnitAttr::get(ctx)));
 
   auto syncType = FunctionType::get(inputTypes, resultTypes, ctx);
   auto syncName = (rawCalleeFuncOp.getName() + "$sync").str();
   auto syncFuncOp =
-      moduleBuilder.create<FuncOp>(loc, syncName, syncType, exportAttrs);
+      moduleBuilder.create<FuncOp>(loc, syncName, syncType, syncExportAttrs);
 
   if (failed(generateSynchronousBody(rawCalleeFuncOp, syncFuncOp, moduleBuilder,
                                      inputTypes, inputDescs, resultTypes,
                                      resultDescs))) {
+    return failure();
+  }
+
+  // Create the new asynchronous function export.
+  SmallVector<Type, 4> asyncInputTypes;
+  // Prefix with wait semaphore and its value.
+  // TODO(scotttodd): SemaphoreValue wrapper for single {semaphore, value}
+  // TODO(scotttodd): SemaphoreList wrapper for list of SemaphoreValues
+  asyncInputTypes.push_back(HAL::SemaphoreType::get(ctx));
+  asyncInputTypes.push_back(moduleBuilder.getIndexType());
+  for (const auto &inputType : inputTypes) {
+    asyncInputTypes.push_back(inputType);
+  }
+  // Postfix with signal semaphore and its value.
+  asyncInputTypes.push_back(HAL::SemaphoreType::get(ctx));
+  asyncInputTypes.push_back(moduleBuilder.getIndexType());
+  // TODO(scotttodd): populate async export attributes
+  //   * iree.module.export with a name
+  //   * iree.reflection (considering new args?)
+  //   * iree.abi.stub
+  SmallVector<NamedAttribute, 1> asyncExportAttrs;
+
+  auto asyncType = FunctionType::get(asyncInputTypes, resultTypes, ctx);
+  auto asyncName = (rawCalleeFuncOp.getName() + "$async").str();
+  auto asyncFuncOp =
+      moduleBuilder.create<FuncOp>(loc, asyncName, asyncType, asyncExportAttrs);
+
+  if (failed(
+          generateAsynchronousBody(asyncFuncOp, syncFuncOp, moduleBuilder))) {
     return failure();
   }
 

--- a/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
@@ -228,10 +228,8 @@ LogicalResult generateAsynchronousBody(FuncOp funcOp, FuncOp syncFuncOp,
   auto waitValue = entryBlock->getArgument(1);
   auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
       loc, builder.getIntegerType(32), waitSemaphore, waitValue);
-  // TODO(scotttodd): if waitOp's result is not 0 (ok), fail
-  // VM::CondFailOp (are VM ops allowed in this pass?):
-  //   %nz = vm.cmp.nz.i32 %value : i32
-  //   vm.cond_fail %nz, %waitOp, "expected non-zero"
+  auto checkSuccessOp = builder.create<HAL::CheckSuccessOp>(
+      loc, waitOp.getResult(), "semaphore wait failed");
 
   // Trim the first (wait semaphore/value) and last (signal semaphore/value)
   // two arguments.

--- a/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
@@ -37,6 +37,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
 // semaphore arguments should be generated. For now, it should just wrap $sync.
 // CHECK: func @staticTwoArg$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.buffer_view, %[[ARG4:.+]]: !hal.semaphore, %[[ARG5:.+]]: index)
 // CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+// CHECK: hal.check_success %[[WAITRESULT]]
 // CHECK: %[[RESULT:.+]] = call @staticTwoArg$sync(%[[ARG2]], %[[ARG3]]) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
 // CHECK: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
 // CHECK: return %[[RESULT]] : !hal.buffer_view
@@ -64,6 +65,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
 // semaphore arguments should be generated. For now, it should just wrap $sync.
 // CHECK: func @dynamicTwoDims$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.semaphore, %[[ARG4:.+]]: index)
 // CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+// CHECK: hal.check_success %[[WAITRESULT]]
 // CHECK: %[[RESULT:.+]] = call @dynamicTwoDims$sync(%[[ARG2]]) : (!hal.buffer_view) -> !hal.buffer_view
 // CHECK: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
 // CHECK: return %[[RESULT]] : !hal.buffer_view

--- a/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
@@ -33,6 +33,13 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
   // CHECK: return %[[VIEW]]
   return %arg1 : !hal.buffer
 }
+// A new function with $async suffix based on buffer_view with wait and signal
+// semaphore arguments should be generated. For now, it should just wrap $sync.
+// CHECK: func @staticTwoArg$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.buffer_view, %[[ARG4:.+]]: !hal.semaphore, %[[ARG5:.+]]: index)
+// CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+// CHECK: %[[RESULT:.+]] = call @staticTwoArg$sync(%[[ARG2]], %[[ARG3]]) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+// CHECK: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
+// CHECK: return %[[RESULT]] : !hal.buffer_view
 
 // -----
 // CHECK-LABEL: @dynamicTwoDims
@@ -53,6 +60,13 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
 // CHECK-DAG: %[[RESULT:.+]]:3 = call @dynamicTwoDims(%[[BUFFER]], %[[DIM0]], %[[DIM1]])
 // CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, shape = [%[[RESULT]]#1, %[[RESULT]]#2], element_type = 50331680 : !hal.buffer_view
 // CHECK: return %[[RESULT_VIEW]]
+// A new function with $async suffix based on buffer_view with wait and signal
+// semaphore arguments should be generated. For now, it should just wrap $sync.
+// CHECK: func @dynamicTwoDims$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.semaphore, %[[ARG4:.+]]: index)
+// CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+// CHECK: %[[RESULT:.+]] = call @dynamicTwoDims$sync(%[[ARG2]]) : (!hal.buffer_view) -> !hal.buffer_view
+// CHECK: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
+// CHECK: return %[[RESULT]] : !hal.buffer_view
 func @dynamicTwoDims(%arg0 : !hal.buffer, %arg1 : index, %arg2 : index) -> (!hal.buffer, index, index)
     attributes {iree.module.export,
       iree.reflection = {f = "I10!B7!d-1d-1R10!B7!d-1d-1", fv = "1"}}

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1905,10 +1905,6 @@ def VM_CondFailOp : VM_Op<"cond_fail", [
     OptionalAttr<StrAttr>:$message
   );
 
-  let assemblyFormat = [{
-    $condition `,` $status (`,` $message^)? attr-dict
-  }];
-
   let builders = [
     OpBuilder<[{
       OpBuilder &builder, OperationState &result,
@@ -1917,6 +1913,12 @@ def VM_CondFailOp : VM_Op<"cond_fail", [
       build(
           builder, result, condition, status,
           message.empty() ? StringAttr{} : builder.getStringAttr(message));
+    }]>,
+    OpBuilder<[{
+      OpBuilder &builder, OperationState &result,
+      Value status, StringRef message = ""
+    }], [{
+      build(builder, result, status, status, message);
     }]>,
   ];
 

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
@@ -196,6 +196,22 @@ vm.module @my_module {
     vm.cond_fail %cond, %code2, "message"
     vm.return
   }
+  // CHECK-LABEL: @cond_fail_no_condition
+  vm.func @cond_fail_no_condition() {
+    // CHECK-DAG: %[[CODE3:.+]] = constant 3
+    %code3 = constant 3 : i32
+    // CHECK: vm.cond_fail %[[CODE3]]
+    vm.cond_fail %code3
+    vm.return
+  }
+  // CHECK-LABEL: @cond_fail_no_condition_with_message
+  vm.func @cond_fail_no_condition_with_message() {
+    // CHECK-DAG: %[[CODE4:.+]] = constant 4
+    %code4 = constant 4 : i32
+    // CHECK: vm.cond_fail %[[CODE4]]
+    vm.cond_fail %code4, "message"
+    vm.return
+  }
 }
 
 // -----


### PR DESCRIPTION
Progress on exposing semaphores for bindings to use, per discussions relating to https://github.com/google/iree/issues/1285.

At the moment these `$async` functions just wrap the `$sync` functions and include wait/signal semaphore arguments. A future change can go through and invert this (`$sync` wrap `$async` and wait/signal local semaphores).

IR looks roughly like:
```mlir
func main$sync(buffer_view_args...) -> hal.buffer_view attributes { ... } {
  // buffer_view handling
 call @main
  // buffer_view handling
}
func main$async(wait_semaphore, wait_value, buffer_view_args..., signal_semaphore, signal_value) -> hal.buffer_view {
  hal.semaphore.await wait_semaphore, wait_value
  call @main$sync
  hal.semaphore.signal signal_semaphore, signal_value
}
```

Here is a more complete snippet: [async_dynamic_add.mlir](https://gist.github.com/ScottTodd/84b2fb346ee157c643d7f5c1703414c1).

Specifically looking for feedback on:

1) How to populate attributes and reflection metadata in service of getting some C code calling these functions with `iree_hal_semaphore_create`, then Python bindings etc.
2) Argument ergonomics. Do we want some sort of `SemaphoreList` supporting 0+ or 1+ pairs of `[semaphore, value]`?