### PR TITLE
Add flag to force timeline semaphore emulation enabled.

### DIFF
--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -460,6 +460,7 @@ cc_library(
         "//iree/hal:driver",
         "//iree/hal:semaphore",
         "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -517,6 +517,7 @@ iree_cc_library(
     ::serializing_command_queue
     ::status_util
     ::vma_allocator
+    absl::flags
     absl::inlined_vector
     absl::memory
     absl::strings


### PR DESCRIPTION
This will help with testing. If we wanted to enable/disable emulation based on device characteristics (on buggy drivers), we would want a different mechanism.