### PR TITLE
Use persistent storage for SubmissionBatch in SerializingCommandQueue.

### DIFF
--- a/iree/hal/vulkan/serializing_command_queue.h
+++ b/iree/hal/vulkan/serializing_command_queue.h
@@ -72,14 +72,15 @@ class SerializingCommandQueue final : public CommandQueue {
   void AbortQueueSubmission();
 
  private:
+  struct PendingBatch {
+    absl::InlinedVector<SemaphoreValue, 4> wait_semaphores;
+    absl::InlinedVector<CommandBuffer*, 4> command_buffers;
+    absl::InlinedVector<SemaphoreValue, 4> signal_semaphores;
+  };
   // A submission batch together with the fence to singal its status.
-  struct FencedSubmission : IntrusiveLinkBase<void> {
-    SubmissionBatch batch;
+  struct FencedSubmission : public IntrusiveLinkBase<void> {
+    PendingBatch batch;
     ref_ptr<TimePointFence> fence;
-
-    FencedSubmission(const SubmissionBatch& batch,
-                     ref_ptr<TimePointFence> fence)
-        : batch(batch), fence(std::move(fence)) {}
   };
 
   // Processes deferred submissions in this queue and returns whether there are


### PR DESCRIPTION
SubmissionBatch contains `absl::Span<T>` members and thus must be copied if the data it wraps is expected to live beyond the scope of `CommandQueue::Submit()`: https://github.com/google/iree/blob/d7835cad52c4e74bc71f36a98567b144c92f3837/iree/hal/command_queue.h#L33-L48

https://github.com/google/iree/blob/d7835cad52c4e74bc71f36a98567b144c92f3837/iree/hal/command_queue.h#L82-L86

This was caught by ASAN's [`sanitize-address-use-after-scope`](https://github.com/google/sanitizers/wiki/AddressSanitizerUseAfterScope) running the tests in https://github.com/google/iree/pull/2196.