### PR TITLE
Fixes a bug where Kokoro's artifacts directory wasn't being deleted.

### DIFF
--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -37,7 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -37,4 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
@@ -37,7 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
@@ -37,4 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
@@ -37,7 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
@@ -37,4 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
@@ -37,7 +37,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
@@ -36,5 +36,8 @@ docker run \
   kokoro/gcp_ubuntu/cmake/android/build.sh arm64-v8a
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
-# build which takes forever and is totally useless. 
-rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+# build which takes forever and is totally useless.
+sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -34,12 +34,9 @@ docker run \
   gcr.io/iree-oss/cmake:prod \
   kokoro/gcp_ubuntu/cmake/build.sh
 
-# Print out artifacts dir contents before deleting them.
-ls -1a "${KOKORO_ARTIFACTS_DIR?}/"
-
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
 sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
 
-# Print out artifacts dir contents after deleting them.
+# Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -34,6 +34,12 @@ docker run \
   gcr.io/iree-oss/cmake:prod \
   kokoro/gcp_ubuntu/cmake/build.sh
 
+# Print out artifacts dir contents before deleting them.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"
+
 # Kokoro will rsync this entire directory back to the executor orchestrating the
-# build which takes forever and is totally useless. 
+# build which takes forever and is totally useless.
 rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+
+# Print out artifacts dir contents after deleting them.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -39,7 +39,7 @@ ls -1a "${KOKORO_ARTIFACTS_DIR?}/"
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
 
 # Print out artifacts dir contents after deleting them.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -39,7 +39,7 @@ ls -1a "${KOKORO_ARTIFACTS_DIR?}/"
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"
+rm -r ${KOKORO_ARTIFACTS_DIR?}/*
 
 # Print out artifacts dir contents after deleting them.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -36,7 +36,7 @@ docker run \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -39,7 +39,7 @@ ls -1a "${KOKORO_ARTIFACTS_DIR?}/"
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-rm -r ${KOKORO_ARTIFACTS_DIR?}/*
+rm -rf ${KOKORO_ARTIFACTS_DIR?}/*
 
 # Print out artifacts dir contents after deleting them.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"


### PR DESCRIPTION
This should fix the issue where our CMake presubmits would sometimes take twice as long as they should.

Explanation:
The problem was that (for some reason) `bash` was evaluating `rm -rf "${KOKORO_ARTIFACTS_DIR?}/*"` to `rm -rf '/tmpfs/src/*'`. The additional single quotes would cause `rm` to fail with a directory not found error, which would be swallowed by the `-f` flag.

Removing the double quotes around the `/*` expansion removes the single quotes that appear when `bash` + `rm` evaluates it. This gives a permission denied error, which we fix by adding `sudo`.