### PR TITLE
Add hint for some vm context function resolution errors.

### DIFF
--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -106,7 +106,7 @@ static iree_status_t iree_vm_context_resolve_module_imports(
       for (size_t i = 0; i < full_name.size; i++) {
         fputc(full_name.data[i], stderr);
       }
-      fprintf(stderr, "'. Are all necessary modules registered?\n");
+      fprintf(stderr, "'. Ensure modules are registered with the context.\n");
       return status;
     }
     IREE_RETURN_IF_ERROR(

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -102,11 +102,11 @@ static iree_status_t iree_vm_context_resolve_module_imports(
         iree_vm_context_resolve_function(context, full_name, &import_function);
     if (!iree_status_is_ok(status)) {
       // iree_string_view_t is not NUL-terminated, so this is a bit awkward.
-      fprintf(stderr, "unable to resolve VM function '");
+      fprintf(stderr, "Unable to resolve VM function '");
       for (size_t i = 0; i < full_name.size; i++) {
         fputc(full_name.data[i], stderr);
       }
-      fprintf(stderr, "'\n");
+      fprintf(stderr, "'. Are all necessary modules registered?\n");
       return status;
     }
     IREE_RETURN_IF_ERROR(


### PR DESCRIPTION
If you just pass a VM bytecode module with no HAL module to `iree_vm_context_create_with_modules`, now the error message is:

```
Unable to resolve VM function 'hal.ex.shared_device'. Are all necessary modules registered?
```

(Encountered while setting up Java bindings)