### PR TITLE
Avoid unused result warning

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/LLVMAOTTargetLinker.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/LLVMAOTTargetLinker.cpp
@@ -31,7 +31,7 @@ iree::StatusOr<std::string> linkLLVMAOTObjects(
       linkerToolPath + " -shared " + archiveFile + " -o " + sharedLibFile;
   int systemRet = system(linkingCmd.c_str());
   if (systemRet != 0) {
-    return InternalErrorBuilder(IREE_LOC)
+    return iree::InternalErrorBuilder(IREE_LOC)
            << linkingCmd << " failed with exit code " << systemRet;
   }
   return iree::file_io::GetFileContents(sharedLibFile);

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/LLVMAOTTargetLinker.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/LLVMAOTTargetLinker.cpp
@@ -14,6 +14,8 @@
 
 #include "iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTargetLinker.h"
 
+#include "iree/base/status.h"
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
@@ -27,7 +29,11 @@ iree::StatusOr<std::string> linkLLVMAOTObjects(
   ASSIGN_OR_RETURN(sharedLibFile, iree::file_io::GetTempFile("dylibfile"));
   std::string linkingCmd =
       linkerToolPath + " -shared " + archiveFile + " -o " + sharedLibFile;
-  system(linkingCmd.c_str());
+  int systemRet = system(linkingCmd.c_str());
+  if (systemRet != 0) {
+    return InternalErrorBuilder(IREE_LOC)
+           << linkingCmd << " failed with exit code " << systemRet;
+  }
   return iree::file_io::GetFileContents(sharedLibFile);
 }
 


### PR DESCRIPTION
Check the return value of system and throw an error for non-zero to
avoid warnings about unused results.
