### PR TITLE
Treat warnings as errors and silence them in third party code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,13 +44,9 @@ test --define open_source_build=true
 ###############################################################################
 
 # Treat warnings in-workspace as errors.
-# The syntax is [+-]regex@option, where the regex matches against the label name,
-# so this is adding the copt for all labels that start with "//", whereas external
-# libraries start with "@repo_alias".
-# See https://docs.bazel.build/versions/master/user-manual.html#flag--per_file_copt
-build:generic_clang --per_file_copt=+^//@-Werror
+build:generic_clang --per_file_copt=-external/.*-Werror
 # ...and silence them outside of the workspace.
-build:generic_clang --per_file_copt=+.-^//@-w
+build:generic_clang --per_file_copt=external/.*@-w
 
 # Disable warnings we don't care about.
 build:generic_clang --copt=-Wno-unused-local-typedef

--- a/.bazelrc
+++ b/.bazelrc
@@ -50,7 +50,7 @@ test --define open_source_build=true
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--per_file_copt
 build:generic_clang --per_file_copt=+^//@-Werror
 # ...and silence them outside of the workspace.
-build:generic_clang --per_file_copt=-^//@-w
+build:generic_clang --per_file_copt=+.-^//@-w
 
 # Disable warnings we don't care about.
 build:generic_clang --copt=-Wno-unused-local-typedef

--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,15 @@ test --define open_source_build=true
 # either clang or gcc and are curated based on need.
 ###############################################################################
 
+# Treat warnings in-workspace as errors.
+# The syntax is [+-]regex@option, where the regex matches against the label name,
+# so this is adding the copt for all labels that start with "//", whereas external
+# libraries start with "@repo_alias".
+# See https://docs.bazel.build/versions/master/user-manual.html#flag--per_file_copt
+build:generic_clang --per_file_copt=+^//@-Werror
+# ...and silence them outside of the workspace.
+build:generic_clang --per_file_copt=-^//@-w
+
 # Disable warnings we don't care about.
 build:generic_clang --copt=-Wno-unused-local-typedef
 build:generic_clang --copt=-Wno-unused-private-field

--- a/iree/BUILD.bazel
+++ b/iree/BUILD.bazel
@@ -64,3 +64,9 @@ config_setting(
         "iree_is_msvc": "true",
     },
 )
+
+cc_library(
+    name = "test",
+    srcs = ["test.cc"],
+    deps = ["@zlib"],
+)

--- a/iree/BUILD.bazel
+++ b/iree/BUILD.bazel
@@ -64,9 +64,3 @@ config_setting(
         "iree_is_msvc": "true",
     },
 )
-
-cc_library(
-    name = "test",
-    srcs = ["test.cc"],
-    deps = ["@zlib"],
-)


### PR DESCRIPTION
We've been trying to figure out how to set this for a while and keep
running into warnings in third party code. I think this should take
care of it. We can add additional exclusions as necessary.

Closes #2389