### PR TITLE
Add Bazel 3.3.1 to docker images

### DIFF
--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get install -y unzip zip wget \
 # Install a newer version of Bazel. We don't need the full installation now.
 # Just need to provide a different version for the version-identification
 # wrapper script to find in /root/.bazel/bin
-ARG NEW_BAZEL_VERSION=3.1.0
+ARG NEW_BAZEL_VERSION=3.3.1
 RUN cd "/root/.bazel/bin" \
   && wget "https://releases.bazel.build/${NEW_BAZEL_VERSION?}/release/bazel-${NEW_BAZEL_VERSION?}-linux-x86_64" \
   && chmod +x "bazel-${NEW_BAZEL_VERSION?}-linux-x86_64"

--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -40,12 +40,19 @@ RUN apt-get install -y git
 
 # Install Bazel.
 # https://docs.bazel.build/versions/master/install-ubuntu.html
-ENV BAZEL_VERSION 2.1.0
+ARG BAZEL_VERSION=2.1.0
 RUN apt-get install -y unzip zip wget \
   && wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION?}/bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh" \
   && chmod +x "bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh" \
   && "./bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh" --user \
   && rm "bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh"
+ARG NEW_BAZEL_VERSION=3.1.0
+RUN apt-get install -y unzip zip wget \
+  && wget "https://github.com/bazelbuild/bazel/releases/download/${NEW_BAZEL_VERSION?}/bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" \
+  && chmod +x "bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" \
+  && "./bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" --user \
+  && rm "bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh"
+
 # ENV does not allow ${variable?} syntax.
 ENV PATH "/root/bin:${PATH}"
 

--- a/build_tools/docker/bazel/Dockerfile
+++ b/build_tools/docker/bazel/Dockerfile
@@ -46,13 +46,13 @@ RUN apt-get install -y unzip zip wget \
   && chmod +x "bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh" \
   && "./bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh" --user \
   && rm "bazel-${BAZEL_VERSION?}-installer-linux-x86_64.sh"
+# Install a newer version of Bazel. We don't need the full installation now.
+# Just need to provide a different version for the version-identification
+# wrapper script to find in /root/.bazel/bin
 ARG NEW_BAZEL_VERSION=3.1.0
-RUN apt-get install -y unzip zip wget \
-  && wget "https://github.com/bazelbuild/bazel/releases/download/${NEW_BAZEL_VERSION?}/bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" \
-  && chmod +x "bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" \
-  && "./bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh" --user \
-  && rm "bazel-${NEW_BAZEL_VERSION?}-installer-linux-x86_64.sh"
-
+RUN cd "/root/.bazel/bin" \
+  && wget "https://releases.bazel.build/${NEW_BAZEL_VERSION?}/release/bazel-${NEW_BAZEL_VERSION?}-linux-x86_64" \
+  && chmod +x "bazel-${NEW_BAZEL_VERSION?}-linux-x86_64"
 # ENV does not allow ${variable?} syntax.
 ENV PATH "/root/bin:${PATH}"
 

--- a/build_tools/docker/build_and_update_gcr.py
+++ b/build_tools/docker/build_and_update_gcr.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     images_to_update.extend(IMAGES_TO_DEPENDENT_IMAGES[args.image])
 
   for image in images_to_update:
-    print(f"Updating image {image}")
+    print(f'Updating image {image}')
     image_url = os.path.join(IREE_GCR_URL, f'{image}:{args.tag}')
     image_path = os.path.join(DOCKER_DIR, image.replace('-', '_'))
     subprocess.check_output(['docker', 'build', '--tag', image_url, image_path])

--- a/build_tools/docker/build_and_update_gcr.py
+++ b/build_tools/docker/build_and_update_gcr.py
@@ -89,6 +89,7 @@ if __name__ == '__main__':
     images_to_update.extend(IMAGES_TO_DEPENDENT_IMAGES[args.image])
 
   for image in images_to_update:
+    print(f"Updating image {image}")
     image_url = os.path.join(IREE_GCR_URL, f'{image}:{args.tag}')
     image_path = os.path.join(DOCKER_DIR, image.replace('-', '_'))
     subprocess.check_output(['docker', 'build', '--tag', image_url, image_path])


### PR DESCRIPTION
Part of https://github.com/google/iree/issues/2495

Tested:
Pushed images with the `latest` tag and updated Kokoro to point at
them in this PR:
- https://source.cloud.google.com/results/invocations/c88b58e2-a6e9-479e-bf97-fddcb93b0fb1
- https://source.cloud.google.com/results/invocations/2a8af5a3-0387-425d-9597-cf6cd04fa4ad
- https://source.cloud.google.com/results/invocations/d6336b85-30a2-4c78-b25a-3126a482bab8

Will drop the "latest" tag commit before merging and then push a
prod image update after.

Did an actual upgrade of the requested Bazel version in
https://github.com/google/iree/pull/2496 and ran Kokoro with the
new images on that as well.