### PR TITLE
[ModelBuilder] Fix leak when using llvm::createLowerMatrixIntrinsicsPass

### DIFF
--- a/experimental/ModelBuilder/ModelRunner.cpp
+++ b/experimental/ModelBuilder/ModelRunner.cpp
@@ -81,8 +81,10 @@ void mlir::ModelRunner::compile(CompilationOptions compilationOptions,
   if (target == Target::CPUTarget) {
     // TODO(ntv): Looking up the pass by name fails quite surprisingly. Just
     // build the pass to get its ID to look up the PassInfo.
+    std::unique_ptr<llvm::Pass> owningLowerMatrixIntrinsicsPass(
+        llvm::createLowerMatrixIntrinsicsPass());
     const llvm::PassInfo* lowerMatrixIntrinsics = llvm::Pass::lookupPassInfo(
-        llvm::createLowerMatrixIntrinsicsPass()->getPassID());
+        owningLowerMatrixIntrinsicsPass->getPassID());
     assert(lowerMatrixIntrinsics);
     llvmPasses.push_back(lowerMatrixIntrinsics);
   }


### PR DESCRIPTION
Unlike MLIR, LLVM `createXXX` pass creation functions return a raw pointer.
Wraper this pointer into a unique_ptr to cleanup on scope exit.