### PR TITLE
[ci] Run cmake --build twice to temporary fix the flaky build

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -55,4 +55,5 @@ cd build
   -DIREE_HOST_C_COMPILER=$(which clang) \
   -DIREE_HOST_CXX_COMPILER=$(which clang++)
 
-"$CMAKE_BIN" --build .
+# TODO(#2494): Invoke once after fixing the flaky build failure in GCP.
+"$CMAKE_BIN" --build . || "$CMAKE_BIN" --build .


### PR DESCRIPTION
This can serve as a temporary solution to unblock development
until the root case for https://github.com/google/iree/issues/2494
is discovered and fixed.