### PR TITLE
Update Bazel version in docs workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Bazel
         uses: abhinavsingh/setup-bazel@v3
         with:
-          version: 2.1.0
+          version: 3.3.1
       - name: Checking out repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This was broken by the Bazel upgrade, but I didn't notice because it isn't covered by any presubmits. Sorry!

Part of https://github.com/google/iree/issues/2510