### PR TITLE
Enable -Wunused-variable warning.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,7 @@ build:generic_clang --copt=-Wno-unused-function
 # Enable warnings we do care about.
 build:generic_clang --copt=-Wimplicit-fallthrough
 build:generic_clang --copt=-Wthread-safety-analysis
+build:generic_clang --copt=-Wunused-variable
 
 # C++14 standard version is required.
 build:generic_clang --cxxopt=-std=c++14 --host_cxxopt=-std=c++14

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -57,6 +57,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # Enable some warnings
     "-Wimplicit-fallthrough"
     "-Wthread-safety-analysis"
+    "-Wunused-variable"
   CLANG_OR_GCC
     "-Wno-unused-parameter"
     "-Wno-undef"

--- a/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
@@ -218,7 +218,6 @@ LogicalResult generateSynchronousBody(
 
 LogicalResult generateAsynchronousBody(FuncOp funcOp, FuncOp syncFuncOp,
                                        OpBuilder moduleBuilder) {
-  auto *ctx = funcOp.getContext();
   auto loc = funcOp.getLoc();
   Block *entryBlock = funcOp.addEntryBlock();
   OpBuilder builder = OpBuilder::atBlockEnd(entryBlock);
@@ -228,8 +227,8 @@ LogicalResult generateAsynchronousBody(FuncOp funcOp, FuncOp syncFuncOp,
   auto waitValue = entryBlock->getArgument(1);
   auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
       loc, builder.getIntegerType(32), waitSemaphore, waitValue);
-  auto checkSuccessOp = builder.create<HAL::CheckSuccessOp>(
-      loc, waitOp.getResult(), "semaphore wait failed");
+  builder.create<HAL::CheckSuccessOp>(loc, waitOp.getResult(),
+                                      "semaphore wait failed");
 
   // Trim the first (wait semaphore/value) and last (signal semaphore/value)
   // two arguments.


### PR DESCRIPTION
We've been passing with this enabled before, but were not enforcing it in open source builds.