### PR TITLE
Remove ModelBuilder dep from ModelRunner

### DIFF
--- a/experimental/ModelBuilder/BUILD
+++ b/experimental/ModelBuilder/BUILD
@@ -65,7 +65,6 @@ cc_library(
         "-ldl",
     ],
     deps = [
-        ":ModelBuilder",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ExecutionEngine",
         "@llvm-project//mlir:ExecutionEngineUtils",

--- a/experimental/ModelBuilder/ModelRunner.cpp
+++ b/experimental/ModelBuilder/ModelRunner.cpp
@@ -14,7 +14,6 @@
 
 #include "experimental/ModelBuilder/ModelRunner.h"
 
-#include "experimental/ModelBuilder/ModelBuilder.h"
 #include "llvm/Support/TargetSelect.h"
 #include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h"
 #include "mlir/Conversion/GPUToVulkan/ConvertGPUToVulkanPass.h"


### PR DESCRIPTION
This dep is not actually required.

Tested:
Removed from .bazelignore and ran all builds and tests.
No new failures.
Before: https://source.cloud.google.com/results/invocations/7acb7108-9f66-490b-a3d6-b6e57a3fe759/targets
After: https://source.cloud.google.com/results/invocations/0e9f5cd8-97c2-4f4c-8b51-545ceff0df65
