### PR TITLE
Enables `tensorlist_test` on `vulkan`.

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -91,7 +91,6 @@ VULKAN_FAILING = [
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
     "strings_test.py",
-    "tensorlist_test.py",  # TODO(b/146900329): Triage op coverage for vulkan backend.
 ]
 
 TF_PASSING = glob(


### PR DESCRIPTION
This test is now passing internally on Vulkan and @ScottTodd has tested it locally in OSS.