### PR TITLE
Removed duplicate per-backend tf and iree input mlir files.

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -17,6 +17,7 @@
 import os
 import tempfile
 
+from absl import logging
 from absl.testing import parameterized
 from pyiree.tf.support import tf_utils
 import tensorflow as tf
@@ -52,7 +53,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       },
       {
           'testcase_name': 'multiple_backends',
-          'target_backends': ['vmla', 'llvm'],
+          'target_backends': ['vmla', 'llvm-ir'],
       },
   ])
   def test_artifact_saving(self, target_backends):
@@ -64,13 +65,13 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
           artifacts_dir=artifacts_dir)
 
       artifacts_to_check = [
-          'saved_model',
-          f'tf_input__{"__".join(target_backends)}.mlir',
-          f'iree_input__{"__".join(target_backends)}.mlir',
-          f'compiled__{"__".join(target_backends)}.vmfb',
+          'saved_model', 'tf_input.mlir', 'iree_input.mlir',
+          f'compiled__{tf_utils.backends_to_str(target_backends)}.vmfb',
       ]
       for artifact in artifacts_to_check:
-        self.assertTrue(os.path.exists(os.path.join(artifacts_dir, artifact)))
+        artifact_path = os.path.join(artifacts_dir, artifact)
+        logging.info('Checking path: %s', artifact_path)
+        self.assertTrue(os.path.exists(artifact_path))
 
   @parameterized.named_parameters([
       {


### PR DESCRIPTION
The `iree_input__<backend>.mlir` files are all identical, and the `tf_input__<backend>.mlir` files are all identical up to constants in their function names. For example:
```mlir
<   func @__inference_simple_matmul_70(%arg0: tensor<128x3072xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<3072x256xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<128x256xf32> {tf_saved_model.index_path = []}) attributes {tf._input_shapes = [#tf.shape<128x3072>, #tf.shape<3072x256>], tf_saved_model.exported_names = ["simple_matmul"]} {
---
>   func @__inference_simple_matmul_670(%arg0: tensor<128x3072xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<3072x256xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<128x256xf32> {tf_saved_model.index_path = []}) attributes {tf._input_shapes = [#tf.shape<128x3072>, #tf.shape<3072x256>], tf_saved_model.exported_names = ["simple_matmul"]} {
```