### PR TITLE
Disable Vulkan tests which are now failing.

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -82,6 +82,8 @@ LLVM_FAILING = [
 # keep sorted
 VULKAN_FAILING = [
     "broadcasting_test.py",
+    "control_flow_test.py",
+    "conv_test.py",
     "depth_conv_test.py",
     "dynamic_mlp_relu_test.py",
     "dynamic_mlp_test.py",


### PR DESCRIPTION
These tests are blocking https://github.com/google/iree/pull/2512. Looks like they started failing with https://github.com/google/iree/pull/2509.