### PR TITLE
Fix layering and turn on layering_check

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/bindings/python/BUILD
+++ b/bindings/python/BUILD
@@ -16,6 +16,7 @@ load(":build_defs.oss.bzl", "iree_py_library")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/bindings/python/build_tools/python/BUILD.bazel
+++ b/bindings/python/build_tools/python/BUILD.bazel
@@ -13,3 +13,8 @@
 # limitations under the License.
 
 # Intentionally empty.
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)

--- a/bindings/python/pyiree/BUILD
+++ b/bindings/python/pyiree/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/bindings/python/pyiree/common/BUILD
+++ b/bindings/python/pyiree/common/BUILD
@@ -19,6 +19,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/bindings/python/pyiree/compiler/BUILD
+++ b/bindings/python/pyiree/compiler/BUILD
@@ -28,6 +28,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/bindings/python/pyiree/rt/BUILD
+++ b/bindings/python/pyiree/rt/BUILD
@@ -27,6 +27,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/build_tools/bazel/BUILD
+++ b/build_tools/bazel/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/build_tools/embed_data/BUILD
+++ b/build_tools/embed_data/BUILD
@@ -18,6 +18,7 @@ load(":build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/colab/BUILD.bazel
+++ b/colab/BUILD.bazel
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
+
 py_binary(
     name = "everything_for_colab",
     srcs = ["dummy.py"],

--- a/experimental/BUILD
+++ b/experimental/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/experimental/ModelBuilder/BUILD
+++ b/experimental/ModelBuilder/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/experimental/ModelBuilder/test/BUILD
+++ b/experimental/ModelBuilder/test/BUILD
@@ -19,6 +19,7 @@ load("//iree:build_defs.oss.bzl", "IREE_DRIVER_MODULES", "PLATFORM_VULKAN_DEPS")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/bindings/python/BUILD
+++ b/integrations/tensorflow/bindings/python/BUILD
@@ -16,6 +16,7 @@ load("//bindings/python:build_defs.oss.bzl", "iree_py_library")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -27,6 +27,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/BUILD
@@ -21,6 +21,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
@@ -27,6 +27,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/BUILD
@@ -18,6 +18,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/test/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/compiler/test/BUILD
+++ b/integrations/tensorflow/compiler/test/BUILD
@@ -25,6 +25,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -32,6 +32,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -35,6 +35,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/integrations/tensorflow/e2e/keras/train/BUILD
+++ b/integrations/tensorflow/e2e/keras/train/BUILD
@@ -24,6 +24,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/BUILD.bazel
+++ b/iree/BUILD.bazel
@@ -30,9 +30,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
-    features = [
-        "-layering_check",  # buildozer: disable=no-layering-check, TODO(b/153880171): Enable when Bazel supports layering_check
-    ],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/BUILD.bazel
+++ b/iree/BUILD.bazel
@@ -30,6 +30,9 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = [
+        "-layering_check",  # buildozer: disable=no-layering-check, TODO(b/153880171): Enable when Bazel supports layering_check
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -19,6 +19,7 @@ load("//iree:build_defs.oss.bzl", "platform_trampoline_deps")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -18,6 +18,7 @@ load("//iree:build_defs.oss.bzl", "iree_build_test")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/BUILD
+++ b/iree/compiler/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Conversion/BUILD
+++ b/iree/compiler/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/CodegenUtils/BUILD
+++ b/iree/compiler/Conversion/CodegenUtils/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/HLOToLinalg/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/HLOToLinalg/test/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -48,6 +49,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Affine",
         "@llvm-project//mlir:AffineToStandardTransforms",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:GPUToSPIRVTransforms",
         "@llvm-project//mlir:GPUTransforms",
@@ -57,6 +59,7 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFToGPUPass",
+        "@llvm-project//mlir:SCFToSPIRV",
         "@llvm-project//mlir:SPIRVDialect",
         "@llvm-project//mlir:SPIRVLowering",
         "@llvm-project//mlir:StandardOps",

--- a/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     LLVMSupport
     MLIRAffineOps
     MLIRAffineToStandard
+    MLIRAnalysis
     MLIRGPU
     MLIRGPUToSPIRVTransforms
     MLIRIR
@@ -46,6 +47,7 @@ iree_cc_library(
     MLIRPass
     MLIRSCF
     MLIRSCFToGPU
+    MLIRSCFToSPIRV
     MLIRSPIRV
     MLIRSPIRVTransforms
     MLIRStandardOps

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/BUILD
+++ b/iree/compiler/Dialect/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Flow/Analysis/BUILD
+++ b/iree/compiler/Dialect/Flow/Analysis/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Analysis/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Analysis/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/BUILD
+++ b/iree/compiler/Dialect/Flow/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Flow/Conversion/BUILD
+++ b/iree/compiler/Dialect/Flow/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/BUILD
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Conversion/HLOToFlow/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/BUILD
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/IR/test/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Flow/Utils/BUILD
+++ b/iree/compiler/Dialect/Flow/Utils/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/BUILD
+++ b/iree/compiler/Dialect/HAL/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Conversion/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/IR/BUILD
+++ b/iree/compiler/Dialect/HAL/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/IR/test/BUILD
+++ b/iree/compiler/Dialect/HAL/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -16,6 +16,7 @@ load("//iree:build_defs.oss.bzl", "platform_trampoline_deps")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -21,7 +22,7 @@ cc_library(
     name = "LLVMAOTTargetLinker_internal",
     srcs = ["LLVMAOTTargetLinker.cpp"],
     deps = [
-        "//iree/base:file_io",
+        "//iree/base:status",
         "//iree/compiler/Dialect/HAL/Target/LLVM:LLVMAOTTargetLinker_hdrs",
     ],
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
@@ -20,7 +20,7 @@ iree_cc_library(
   SRCS
     "LLVMAOTTargetLinker.cpp"
   DEPS
-    iree::base::file_io
+    iree::base::status
     iree::compiler::Dialect::HAL::Target::LLVM::LLVMAOTTargetLinker_hdrs
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/VMLA/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Target/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/HAL/Utils/BUILD
+++ b/iree/compiler/Dialect/HAL/Utils/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/BUILD
+++ b/iree/compiler/Dialect/IREE/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/IREE/Conversion/BUILD
+++ b/iree/compiler/Dialect/IREE/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/Conversion/test/BUILD
+++ b/iree/compiler/Dialect/IREE/Conversion/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/IR/BUILD
+++ b/iree/compiler/Dialect/IREE/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/IR/test/BUILD
+++ b/iree/compiler/Dialect/IREE/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/Tools/BUILD
+++ b/iree/compiler/Dialect/IREE/Tools/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/Transforms/BUILD
+++ b/iree/compiler/Dialect/IREE/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/IREE/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/IREE/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/BUILD
+++ b/iree/compiler/Dialect/Modules/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Modules/Check/BUILD
+++ b/iree/compiler/Dialect/Modules/Check/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Check/Conversion/BUILD
+++ b/iree/compiler/Dialect/Modules/Check/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Check/IR/BUILD
+++ b/iree/compiler/Dialect/Modules/Check/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Check/test/BUILD
+++ b/iree/compiler/Dialect/Modules/Check/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/Conversion/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/IR/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/Strings/IR/test/BUILD
+++ b/iree/compiler/Dialect/Modules/Strings/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/test/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/IR/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Modules/TensorList/IR/test/BUILD
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Sequence/IR/BUILD
+++ b/iree/compiler/Dialect/Sequence/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -51,6 +52,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/iree/compiler/Dialect/Sequence/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Sequence/IR/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     LLVMSupport
     MLIRIR
     MLIRParser
+    MLIRSupport
     iree::compiler::Dialect::IREE::IR
   PUBLIC
 )

--- a/iree/compiler/Dialect/Sequence/IR/test/BUILD
+++ b/iree/compiler/Dialect/Sequence/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/BUILD
+++ b/iree/compiler/Dialect/Shape/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Shape/Conversion/BUILD
+++ b/iree/compiler/Dialect/Shape/Conversion/BUILD
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Conversion/test/BUILD
+++ b/iree/compiler/Dialect/Shape/Conversion/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/IR/BUILD
+++ b/iree/compiler/Dialect/Shape/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/IR/test/BUILD
+++ b/iree/compiler/Dialect/Shape/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Plugins/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Shape/Plugins/VMLA/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/VMLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Plugins/VMLA/test/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/VMLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/test/BUILD
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Transforms/BUILD
+++ b/iree/compiler/Dialect/Shape/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Shape/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Shape/Utils/BUILD
+++ b/iree/compiler/Dialect/Shape/Utils/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Analysis/BUILD
+++ b/iree/compiler/Dialect/VM/Analysis/BUILD
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Analysis/test/BUILD
+++ b/iree/compiler/Dialect/VM/Analysis/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/BUILD
+++ b/iree/compiler/Dialect/VM/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/VM/Conversion/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/BUILD
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/BUILD
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/IR/BUILD
+++ b/iree/compiler/Dialect/VM/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/IR/test/BUILD
+++ b/iree/compiler/Dialect/VM/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Target/BUILD
+++ b/iree/compiler/Dialect/VM/Target/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BUILD
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BUILD
@@ -1,5 +1,6 @@
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Tools/BUILD
+++ b/iree/compiler/Dialect/VM/Tools/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Transforms/BUILD
+++ b/iree/compiler/Dialect/VM/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VM/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/VM/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/BUILD
+++ b/iree/compiler/Dialect/VMLA/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/HALToVMLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -39,6 +40,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:legalize_to_linalg",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo:legalize_to_standard",
     ],
 )

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/IR/BUILD
+++ b/iree/compiler/Dialect/VMLA/IR/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/IR/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/VMLA/Transforms/BUILD
+++ b/iree/compiler/Dialect/VMLA/Transforms/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -46,5 +47,6 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:lhlo_fuse_linalg",
     ],
 )

--- a/iree/compiler/Dialect/VMLA/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Vulkan/BUILD
+++ b/iree/compiler/Dialect/Vulkan/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/compiler/Dialect/Vulkan/IR/BUILD
+++ b/iree/compiler/Dialect/Vulkan/IR/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Vulkan/IR/test/BUILD
+++ b/iree/compiler/Dialect/Vulkan/IR/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Vulkan/Utils/BUILD
+++ b/iree/compiler/Dialect/Vulkan/Utils/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Dialect/Vulkan/Utils/test/BUILD
+++ b/iree/compiler/Dialect/Vulkan/Utils/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Translation/BUILD
+++ b/iree/compiler/Translation/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Translation/test/BUILD
+++ b/iree/compiler/Translation/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/compiler/Utils/BUILD
+++ b/iree/compiler/Utils/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/BUILD
+++ b/iree/hal/BUILD
@@ -18,6 +18,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/cts/BUILD
+++ b/iree/hal/cts/BUILD
@@ -18,6 +18,7 @@ load("//iree:build_defs.oss.bzl", "PLATFORM_VULKAN_TEST_DEPS")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/dawn/BUILD
+++ b/iree/hal/dawn/BUILD
@@ -17,6 +17,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/dylib/BUILD
+++ b/iree/hal/dylib/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/host/BUILD
+++ b/iree/hal/host/BUILD
@@ -17,6 +17,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/host/serial/BUILD
+++ b/iree/hal/host/serial/BUILD
@@ -17,6 +17,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/llvmjit/BUILD
+++ b/iree/hal/llvmjit/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/testing/BUILD
+++ b/iree/hal/testing/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -16,6 +16,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -18,6 +18,7 @@ load("//iree:build_defs.oss.bzl", "PLATFORM_VULKAN_TEST_DEPS")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -189,16 +190,20 @@ cc_library(
     srcs = ["emulated_timeline_semaphore.cc"],
     hdrs = ["emulated_timeline_semaphore.h"],
     deps = [
+        ":dynamic_symbols",
         ":handle_util",
         ":status_util",
         ":timepoint_util",
         "//iree/base:intrusive_list",
+        "//iree/base:ref_ptr",
         "//iree/base:status",
         "//iree/base:tracing",
         "//iree/hal:semaphore",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/utility",
         "@iree_vulkan_headers//:vulkan_headers_no_prototypes",
     ],
 )
@@ -348,15 +353,25 @@ cc_library(
     hdrs = ["serializing_command_queue.h"],
     deps = [
         ":direct_command_buffer",
+        ":dynamic_symbols",
         ":emulated_timeline_semaphore",
         ":handle_util",
         ":status_util",
         ":timepoint_util",
+        "//iree/base:intrusive_list",
+        "//iree/base:memory",
+        "//iree/base:ref_ptr",
+        "//iree/base:source_location",
         "//iree/base:status",
         "//iree/base:tracing",
+        "//iree/hal:command_buffer",
         "//iree/hal:command_queue",
+        "//iree/hal:semaphore",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -375,12 +390,17 @@ cc_library(
     srcs = ["timepoint_util.cc"],
     hdrs = ["timepoint_util.h"],
     deps = [
+        ":dynamic_symbols",
         ":handle_util",
+        ":status_util",
         "//iree/base:intrusive_list",
         "//iree/base:ref_ptr",
         "//iree/base:status",
         "//iree/base:tracing",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/utility",
         "@iree_vulkan_headers//:vulkan_headers_no_prototypes",
     ],
 )

--- a/iree/modules/BUILD
+++ b/iree/modules/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/modules/check/BUILD
+++ b/iree/modules/check/BUILD
@@ -21,6 +21,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/modules/check/test/BUILD
+++ b/iree/modules/check/test/BUILD
@@ -17,6 +17,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/modules/hal/BUILD
+++ b/iree/modules/hal/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -2,6 +2,7 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -16,6 +16,7 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/BUILD
+++ b/iree/samples/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/samples/custom_modules/BUILD
+++ b/iree/samples/custom_modules/BUILD
@@ -16,6 +16,7 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/custom_modules/dialect/BUILD
+++ b/iree/samples/custom_modules/dialect/BUILD
@@ -18,6 +18,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/custom_modules/dialect/test/BUILD
+++ b/iree/samples/custom_modules/dialect/test/BUILD
@@ -16,6 +16,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -17,6 +17,7 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/vulkan/BUILD
+++ b/iree/samples/vulkan/BUILD
@@ -18,6 +18,9 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = [
+        "-layering_check",  # buildozer: disable=no-layering-check, TODO(b/153880171): Enable when Bazel supports layering_check
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/samples/vulkan/BUILD
+++ b/iree/samples/vulkan/BUILD
@@ -18,9 +18,7 @@ load("//iree/tools:compilation.bzl", "iree_bytecode_module")
 
 package(
     default_visibility = ["//visibility:public"],
-    features = [
-        "-layering_check",  # buildozer: disable=no-layering-check, TODO(b/153880171): Enable when Bazel supports layering_check
-    ],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/schemas/BUILD
+++ b/iree/schemas/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/test/BUILD
+++ b/iree/test/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/test/e2e/BUILD
+++ b/iree/test/e2e/BUILD
@@ -14,5 +14,6 @@
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/iree/test/e2e/models/BUILD
+++ b/iree/test/e2e/models/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -20,6 +20,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/test/e2e/structural/BUILD
+++ b/iree/test/e2e/structural/BUILD
@@ -16,6 +16,7 @@ load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/test/e2e/vulkan_specific/BUILD
+++ b/iree/test/e2e/vulkan_specific/BUILD
@@ -19,6 +19,7 @@ load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -23,6 +23,7 @@ load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/testing/BUILD
+++ b/iree/testing/BUILD
@@ -18,6 +18,7 @@ load("//iree:build_defs.oss.bzl", "platform_trampoline_deps")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/testing/internal/BUILD
+++ b/iree/testing/internal/BUILD
@@ -18,6 +18,7 @@ load("//iree:build_defs.oss.bzl", "iree_build_test")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -24,6 +24,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/tools/test/BUILD
+++ b/iree/tools/test/BUILD
@@ -18,6 +18,7 @@ load("//iree:lit_test.bzl", "iree_lit_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -5,6 +5,7 @@ load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -17,6 +17,7 @@ load("//build_tools/embed_data:build_defs.bzl", "cc_embed_data")
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/packaging/python/BUILD.bazel
+++ b/packaging/python/BUILD.bazel
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
+
 # This is a dummy binary that has the side-effect of building all of the TF
 # python bindings. It is used to build wheel files.
 py_binary(


### PR DESCRIPTION
This is a new feature in OSS Bazel (which has been available internally
for a while) that checks layering. That is, cc_* BUILD rules should
directly depend on a rule that exports each header that is `#include`'ed
in the rule's sources.

This is now available since we upgraded to Bazel 3.3.1 (#2495).

Unfortunately we can't just enable this in the .bazelrc with
`--features=layering_check` because that would enable it for all our
dependencies as well, which we are not interested in enforcing. I'm not
aware of an equivalent to `--per_file_copt` for features.

Includes adding package and license declarations to some packages that
were missing them.