### PR TITLE
Fix Werror specification and fix unused variable.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ build:generic_clang --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build:generic_clang --copt=-UNDEBUG
 
 # Treat warnings in-workspace as errors.
-build:generic_clang --per_file_copt=-external/.*-Werror
+build:generic_clang --per_file_copt=-external/.*@-Werror
 # ...and silence them outside of the workspace.
 build:generic_clang --per_file_copt=external/.*@-w
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -89,6 +89,7 @@ build:generic_clang --copt=-Wno-unused-function
 build:generic_clang --copt=-Wno-unused-local-typedef
 build:generic_clang --copt=-Wno-unused-private-field
 build:generic_clang --copt=-Wno-user-defined-warnings
+build:generic_clang --copt=-Wno-macro-redefined # IREE and TensorFlow define some of the same macros
 
 # Explicitly enable some additional warnings.
 # Some of these aren't on by default, or under -Wall, or are subsets of warnings

--- a/.bazelrc
+++ b/.bazelrc
@@ -89,7 +89,7 @@ build:generic_clang --copt=-Wno-unused-function
 build:generic_clang --copt=-Wno-unused-local-typedef
 build:generic_clang --copt=-Wno-unused-private-field
 build:generic_clang --copt=-Wno-user-defined-warnings
-build:generic_clang --copt=-Wno-macro-redefined # IREE and TensorFlow define some of the same macros
+build:generic_clang --copt=-Wno-macro-redefined # TODO(GH-2556): Re-enable (IREE and TF both define LOG)
 
 # Explicitly enable some additional warnings.
 # Some of these aren't on by default, or under -Wall, or are subsets of warnings

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -80,7 +80,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unused-local-typedef"
     "-Wno-unused-private-field"
     "-Wno-user-defined-warnings"
-    "-Wno-macro-redefined" # IREE and TensorFlow define some of the same macros
+    "-Wno-macro-redefined" # TODO(GH-2556): Re-enable (IREE and TF both define LOG)
     # Explicitly enable some additional warnings.
     # Some of these aren't on by default, or under -Wall, or are subsets of
     # warnings turned off above.

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -80,6 +80,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unused-local-typedef"
     "-Wno-unused-private-field"
     "-Wno-user-defined-warnings"
+    "-Wno-macro-redefined" # IREE and TensorFlow define some of the same macros
     # Explicitly enable some additional warnings.
     # Some of these aren't on by default, or under -Wall, or are subsets of
     # warnings turned off above.

--- a/iree/tools/vm_util.cc
+++ b/iree/tools/vm_util.cc
@@ -98,8 +98,6 @@ StatusOr<iree_vm_variant_list_t*> ParseToVariantList(
     auto input_string = input_strings[i];
     auto desc = descs[i];
     std::string desc_str;
-    // TODO(laurenzo): Parse real element type once bindings code enforces it.
-    iree_hal_element_type_t hal_element_type = IREE_HAL_ELEMENT_TYPE_NONE;
     desc.ToString(desc_str);
     switch (desc.type) {
       case RawSignatureParser::Type::kScalar: {


### PR DESCRIPTION
Is there an equivalent of `--per_file_copt=-external/.*@-Werror` that we can use for CMake?