### PR TITLE
Avoid docker running as root

### DIFF
--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -32,7 +32,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/bazel-bindings:latest \
+  gcr.io/iree-oss/bazel-bindings:prod \
   kokoro/gcp_ubuntu/bazel/bindings/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/bindings/build_kokoro.sh
@@ -16,28 +16,28 @@
 
 # Build and test IREE's bindings within the gcr.io/iree-oss/bazel-bindings
 # image using Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
 
-set -e
 set -x
+set -e
+set -o pipefail
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Kokoro checks out the repository here.
-WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 
-# Mount the checked out repository, make that the working directory and run the
-# tests in the bazel-bindings image.
-docker run \
-  --volume "${WORKDIR?}:${WORKDIR?}" \
-  --workdir="${WORKDIR?}" \
-  --rm \
-  gcr.io/iree-oss/bazel-bindings:prod \
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/bazel-bindings:latest \
   kokoro/gcp_ubuntu/bazel/bindings/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
@@ -32,7 +32,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/bazel:latest \
+  gcr.io/iree-oss/bazel:prod \
   kokoro/gcp_ubuntu/bazel/core/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/core/build_kokoro.sh
@@ -16,28 +16,28 @@
 
 # Build and test IREE's core within the gcr.io/iree-oss/bazel image using
 # Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
 
-set -e
 set -x
+set -e
+set -o pipefail
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Kokoro checks out the repository here.
-WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 
-# Mount the checked out repository, make that the working directory and run the
-# tests in the bazel image.
-docker run \
-  --volume "${WORKDIR?}:${WORKDIR?}" \
-  --workdir="${WORKDIR?}" \
-  --rm \
-  gcr.io/iree-oss/bazel:prod \
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/bazel:latest \
   kokoro/gcp_ubuntu/bazel/core/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
@@ -32,7 +32,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/bazel-tensorflow:latest \
+  gcr.io/iree-oss/bazel-tensorflow:prod \
   kokoro/gcp_ubuntu/bazel/integrations/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/bazel/integrations/build_kokoro.sh
@@ -16,28 +16,28 @@
 
 # Build and test IREE's integrations within the gcr.io/iree-oss/bazel-tensorflow
 # image using Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
 
-set -e
 set -x
+set -e
+set -o pipefail
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Kokoro checks out the repository here.
-WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 
-# Mount the checked out repository, make that the working directory and run the
-# tests in the bazel-tensorflow image.
-docker run \
-  --volume "${WORKDIR?}:${WORKDIR?}" \
-  --workdir="${WORKDIR?}" \
-  --rm \
-  gcr.io/iree-oss/bazel-tensorflow:prod \
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/bazel-tensorflow:latest \
   kokoro/gcp_ubuntu/bazel/integrations/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
@@ -16,28 +16,28 @@
 
 # Cross-compile the project towards Android arm64-v8a with the
 # gcr.io/iree-oss/cmake-android image using Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
 
-set -e
 set -x
+set -e
+set -o pipefail
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Kokoro checks out the repository here.
-WORKDIR=${KOKORO_ARTIFACTS_DIR?}/github/iree
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 
-# Mount the checked out repository, make that the working directory and run the
-# tests in the cmake-android image.
-docker run \
-  --volume "${WORKDIR?}:${WORKDIR?}" \
-  --workdir="${WORKDIR?}" \
-  --rm \
-  gcr.io/iree-oss/cmake-android:prod \
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/cmake-android:latest \
   kokoro/gcp_ubuntu/cmake/android/build.sh arm64-v8a
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/android/arm64-v8a/build_kokoro.sh
@@ -32,7 +32,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/cmake-android:latest \
+  gcr.io/iree-oss/cmake-android:prod \
   kokoro/gcp_ubuntu/cmake/android/build.sh arm64-v8a
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -31,7 +31,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/cmake:latest \
+  gcr.io/iree-oss/cmake:prod \
   kokoro/gcp_ubuntu/cmake/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/build_kokoro.sh
@@ -15,28 +15,28 @@
 # limitations under the License.
 
 # Build and test the project within the gcr.io/iree-oss/cmake using Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
 
-set -e
 set -x
+set -e
+set -o pipefail
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Kokoro checks out the repository here.
-WORKDIR=${KOKORO_ARTIFACTS_DIR?}/github/iree
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/kokoro/gcp_ubuntu/docker_common.sh"
 
-# Mount the checked out repository, make that the working directory and run the
-# tests in the cmake image.
-docker run \
-  --volume "${WORKDIR?}:${WORKDIR?}" \
-  --workdir="${WORKDIR?}" \
-  --rm \
-  gcr.io/iree-oss/cmake:prod \
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/cmake:latest \
   kokoro/gcp_ubuntu/cmake/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
+++ b/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
@@ -30,8 +30,8 @@ export CMAKE_BIN="$(which cmake)"
 python3 --version
 
 # Print Vulkan related information: SDK version and GPU ICD version
-vulkaninfo 2>/dev/null | grep "Vulkan Instance"
-vulkaninfo 2>/dev/null | grep -A7 "VkPhysicalDeviceProperties"
+vulkaninfo 2>/dev/null | grep "Vulkan Instance" || echo "Vulkan Instance not found!"
+vulkaninfo 2>/dev/null | grep -A7 "VkPhysicalDeviceProperties"  || echo "VkPhysicalDeviceProperties not found!"
 
 echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init

--- a/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build_kokoro.sh
+++ b/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build_kokoro.sh
@@ -34,7 +34,7 @@ docker_setup
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   --env IREE_VULKAN_DISABLE=0 \
   --gpus all \
-  gcr.io/iree-oss/cmake-nvidia:latest \
+  gcr.io/iree-oss/cmake-nvidia:prod \
   kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/kokoro/gcp_ubuntu/docker_common.sh
+++ b/kokoro/gcp_ubuntu/docker_common.sh
@@ -1,0 +1,64 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Functions for setting up Docker containers to run on Kokoro
+
+# Sets up files and environment to enable running all our Kokoro docker scripts.
+# In particular, does some shenanigans to enable running with the current user.
+# Some of this setup is only strictly necessary for Bazel, but it doesn't hurt
+# for anything else.
+# Requires that KOKORO_ROOT and KOKORO_ARTIFACTS_DIR have been set
+# Sets the environment variable DOCKER_RUN_ARGS to be used by subsequent
+# `docker run` invocations.
+function docker_setup() {
+    # Setup to run docker as the current user.
+    # Provide a place to mount files that would normally be under /etc/
+    # We don't just mount the real /etc/passwd and /etc/group because Google
+    # Linux workstations do some interesting stuff with user/group permissions
+    # such that they don't contain the information about normal users and we
+    # want these scripts to be runnable locally for debugging.
+    local fake_etc_dir="${KOKORO_ROOT?}/fake_etc"
+    mkdir -p "${fake_etc_dir?}"
+
+    local fake_group="${fake_etc_dir?}/group"
+    local fake_passwd="${fake_etc_dir?}/group"
+
+    cp /etc/passwd "${fake_group?}"
+    cp /etc/group "${fake_passwd?}"
+    getent group "$(id -g)" >> "${fake_group?}"
+    getent passwd "$(id -u)" >> "${fake_passwd?}"
+
+
+    local workdir="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+
+    DOCKER_RUN_ARGS=(
+      # Run as the current user and group
+      --user="$(id -u):$(id -g)"
+      # Make the source repository available
+      --volume="${workdir?}:${workdir?}"
+      --workdir="${workdir?}"
+      # Tell docker about the host users and groups. Bazel needs this
+      # information, but it also makes some other things more pleasant.
+      --volume="${fake_group?}:/etc/group:ro"
+      --volume="${fake_passwd?}:/etc/passwd:ro"
+      # Allow Bazel to write its special cache directories. This is the
+      # default path Bazel will write to.
+      --volume="${HOME?}/.cache/bazel:${HOME?}/.cache/bazel"
+      # Make gcloud credentials available. This isn't necessary when running
+      # in GCE but enables using this script locally with RBE.
+      --volume="${HOME?}/.config/gcloud:${HOME?}/.config/gcloud:ro"
+      # Delete the container after
+      --rm
+    )
+}


### PR DESCRIPTION
This avoids everything having root permissions, created files being
owned by root, and other nastiness. This is made slightly more
complicated by Google linux machine's...creative... setup for user
management. All these scripts can be run locally provided the appropriate
env variables are set, which can be done with the script provided in
https://github.com/google/iree/pull/2588.

This was the root cause for https://github.com/google/iree/issues/2565.
The image we're using for the GPU builds doesn't have passwordless sudo
so we couldn't delete the Kokoro artifacts directory.

Fixes https://github.com/google/iree/issues/2565