### PR TITLE
Fix compile issues for gcc 9.1.1.

### DIFF
--- a/iree/modules/tensorlist/native_module.cc
+++ b/iree/modules/tensorlist/native_module.cc
@@ -322,12 +322,14 @@ class TensorList final : public RefObject<TensorList> {
 static iree_vm_ref_type_descriptor_t iree_tensorlist_descriptor = {0};
 
 // Register our type with the vm::ref<T> static machinery.
+namespace vm {
 template <>
-struct ::iree::vm::ref_type_descriptor<TensorList> {
+struct ref_type_descriptor<TensorList> {
   static const iree_vm_ref_type_descriptor_t* get() {
     return &iree_tensorlist_descriptor;
   }
 };
+}  // namespace vm
 
 extern "C" iree_status_t iree_tensorlist_module_register_types() {
   static bool has_registered = false;


### PR DESCRIPTION
* Reworks some atomic syntactic things (I *think* what I did is legal, but this is skating pretty far into compiler specific territory).
* Other misc fixes.
* Passes most tests in debug builds (appears to be just GPU tests failing -- I don't have a GPU in this container).
* Saw some evidence that release builds are segfaulting in iree-translate. Not yet triaged.
* This makes iree building in dockcross manylinux2014-x64 (needed to build portable pips).

Fixes #1269