### PR TITLE
Fixed vulkan errors with not destroyed lists and incorrect error check on pybindings

### DIFF
--- a/bindings/python/pyiree/rt/vm.cc
+++ b/bindings/python/pyiree/rt/vm.cc
@@ -198,7 +198,7 @@ std::string VmVariantList::DebugString() const {
 
   for (iree_host_size_t i = 0, e = size(); i < e; ++i) {
     iree_vm_variant_t variant = iree_vm_variant_empty();
-    if (iree_status_is_ok(
+    if (!iree_status_is_ok(
             iree_vm_list_get_variant(mutable_this->raw_ptr(), i, &variant))) {
       absl::StrAppend(&s, "Error");
       continue;

--- a/iree/samples/simple_embedding/simple_embedding_test.cc
+++ b/iree/samples/simple_embedding/simple_embedding_test.cc
@@ -183,6 +183,8 @@ TEST_P(SimpleEmbeddingTest, RunOnce) {
   ASSERT_API_OK(iree_hal_buffer_unmap(ret_buffer, &mapped_memory));
   LOG(INFO) << "Results match!";
 
+  iree_vm_list_deinitialize(inputs.get());
+  iree_vm_list_deinitialize(outputs.get());
   iree_hal_device_release(device);
   iree_vm_context_release(context);
   iree_vm_instance_release(instance);

--- a/iree/tools/run_module_main.cc
+++ b/iree/tools/run_module_main.cc
@@ -142,6 +142,8 @@ Status Run() {
   RETURN_IF_ERROR(PrintVariantList(output_descs, outputs.get()))
       << "printing results";
 
+  iree_vm_list_deinitialize(inputs.get());
+  iree_vm_list_deinitialize(outputs.get());
   iree_vm_module_release(hal_module);
   iree_vm_module_release(input_module);
   iree_hal_device_release(device);


### PR DESCRIPTION
Lists were not being freed resulting in errors for some of our vulkan tests.