### PR TITLE
Removes non-standard constructors from `CompiledModule`

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -264,8 +264,7 @@ def _instantiate_backends(compiled_backends):
       return self.multi()
 
   reinitialized_modules = [
-      tf_utils.CompiledModule.from_existing(module)
-      for module in compiled_backends.values()
+      module.create_reinitialized() for module in compiled_backends.values()
   ]
   return VirtualBackendsClass(*reinitialized_modules)
 
@@ -366,10 +365,12 @@ class CompiledModuleTestCase(tf.test.TestCase):
     try:
       backends = get_backends()
       cls._compiled_backends_dict = {}
-      for backend in backends:
-        compiled_backend = tf_utils.CompiledModule.compile(
-            cls._module_class, backend, cls._exported_names, global_debug_dir)
-        cls._compiled_backends_dict[backend.name] = compiled_backend
+      for backend_info in backends:
+        compiled_backend = backend_info.CompiledModule(cls._module_class,
+                                                       backend_info,
+                                                       cls._exported_names,
+                                                       global_debug_dir)
+        cls._compiled_backends_dict[backend_info.name] = compiled_backend
     finally:
       # Disable crash reproducer (to avoid inadvertently overwriting this
       # path on a subsequent interaction).

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -45,8 +45,8 @@ def compile_tf_module(tf_module,
                       artifacts_dir=None):
   """Compiles a TensorFlow tf.Module and optionally saves compilation artifacts.
 
-  The artifact this creates is not callable. See IreeCompiledModule.compile(...)
-  for an API that returns a module that can be called without any further steps.
+  The artifact this creates is not callable. See IreeCompiledModule for an API
+  that returns a module that can be called without any further steps.
 
   If artifacts_dir is provided then the following artifacts will be saved:
     saved_model:
@@ -133,51 +133,29 @@ def compile_tf_module(tf_module,
 
 
 class CompiledModule(object):
-  """Base class for the TF and IREE compiled module facades."""
-
-  @staticmethod
-  def compile(module_class,
-              backend_info,
-              exported_names=(),
-              artifacts_dir=None):
-    """Compile a tf.Module using the CompiledModule subclass in backend_info.
-
-    Args:
-      module_class: the tf.Module subclass to compile.
-      backend_info: an element of BackendInfo corresponding to the backend to
-        compile to. If a TF 'backend' is provided then the module is wrapped in
-        a TfCompiledModule.
-      exported_names: an optional iterable of strings representing which of the
-        module_class's functions to compile. If exported_names is empty all
-        functions will be compiled.
-      artifacts_dir: an optional path to save compilation artifacts to.
-    """
-    compile = backend_info.CompiledModule.compile
-    return compile(module_class, backend_info, exported_names, artifacts_dir)
-
-  @staticmethod
-  def from_existing(module):
-    """Duplicates 'module' with the tf.Module's state without recompiling."""
-    # Use the backend_info attr to determine which subclass' constructor to use.
-    from_existing = module._backend_info.CompiledModule.from_existing
-    return from_existing(module)
+  """Base class for the TF and IREE compiled modules."""
 
   def __init__(self, module_class, backend_info, exported_names, artifacts_dir):
-    """Default constructor – use `compile` or `from_existing` instead."""
+    """Shared base constructor – not useful on its own."""
     self._module_class = module_class
     self._backend_info = backend_info
     self._exported_names = exported_names
     self._artifacts_dir = artifacts_dir
 
+  def create_reinitialized(self):
+    """Duplicates this module with its initial state without recompiling."""
+    raise NotImplementedError()
+
 
 class IreeCompiledModule(CompiledModule):
   """Iree compiled module."""
 
-  @staticmethod
-  def compile(module_class,
-              backend_info,
-              exported_names=(),
-              artifacts_dir=None):
+  def __init__(self,
+               module_class,
+               backend_info,
+               exported_names=[],
+               artifacts_dir=None,
+               _create_reinitialized_args=None):
     """Compile a tf.Module to the target backend in backend_info.
 
     Args:
@@ -189,30 +167,9 @@ class IreeCompiledModule(CompiledModule):
         functions will be compiled.
       artifacts_dir: an optional path to save compilation artifacts to.
     """
-    return IreeCompiledModule(module_class, backend_info, exported_names,
-                              artifacts_dir)
-
-  @staticmethod
-  def from_existing(module):
-    """Duplicates 'module' with the tf.Module's state without recompiling."""
-    default_args = [
-        module._module_class, module._backend_info, module._exported_names,
-        module._artifacts_dir
-    ]
-    from_existing_args = [module._module_blob, module._module, module._config]
-    return IreeCompiledModule(*default_args, from_existing_args)
-
-  def __init__(self,
-               module_class,
-               backend_info,
-               exported_names,
-               artifacts_dir,
-               _from_existing_args=None):
-    """Default constructor – use `compile` or `from_existing` instead."""
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
 
-    if _from_existing_args is None:
-      # Called from IreeCompiledModule.compile(...)
+    if _create_reinitialized_args is None:
       self._module_blob = compile_tf_module(
           tf_module=module_class(),
           target_backends=backend_info.iree_compiler_targets,
@@ -221,12 +178,21 @@ class IreeCompiledModule(CompiledModule):
       self._module = rt.VmModule.from_flatbuffer(self._module_blob)
       self._config = rt.Config(driver_name=backend_info.iree_driver)
     else:
-      # Called from IreeCompiledModule.from_existing(module)
-      self._module_blob, self._module, self._config = _from_existing_args
+      # Called from self.create_reinitialized()
+      self._module_blob, self._module, self._config = _create_reinitialized_args
 
     # Holds all of the module's mutable state.
     self._context = rt.SystemContext(
         modules=[self._module], config=self._config)
+
+  def create_reinitialized(self):
+    """Duplicates this module with its initial state without recompiling."""
+    default_args = [
+        self._module_class, self._backend_info, self._exported_names,
+        self._artifacts_dir
+    ]
+    create_reinitialized_args = [self._module_blob, self._module, self._config]
+    return IreeCompiledModule(*default_args, create_reinitialized_args)
 
   def __getattr__(self, attr):
     # Try to resolve it as a function.
@@ -253,11 +219,11 @@ class TfCompiledModule(CompiledModule):
   normalize TensorFlow's output to Numpy.
   """
 
-  @staticmethod
-  def compile(module_class,
-              backend_info,
-              exported_names=(),
-              artifacts_dir=None):
+  def __init__(self,
+               module_class,
+               backend_info,
+               exported_names=[],
+               artifacts_dir=None):
     """Wrap a tf.Module in a TFCompiledModule facade.
 
     Args:
@@ -269,22 +235,13 @@ class TfCompiledModule(CompiledModule):
       artifacts_dir: an optional path to save compilation artifacts to. Has no
         effect for this subclass as nothing is compiled.
     """
-    return TfCompiledModule(module_class, backend_info, exported_names,
-                            artifacts_dir)
-
-  @staticmethod
-  def from_existing(module):
-    """Duplicates 'module's facade with the starting state of module_class."""
-    duplicate_module = TfCompiledModule(module._module_class,
-                                        module._backend_info,
-                                        module._exported_names,
-                                        module._artifacts_dir)
-    return duplicate_module
-
-  def __init__(self, module_class, backend_info, exported_names, artifacts_dir):
-    """Default constructor – use `compile` or `from_existing` instead."""
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
     self._tf_module = module_class()
+
+  def create_reinitialized(self):
+    """Duplicates this module with the starting state of module_class."""
+    return TfCompiledModule(self._module_class, self._backend_info,
+                            self._exported_names, self._artifacts_dir)
 
   def __getattr__(self, attr):
     # Try to resolve it as a function.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -83,15 +83,15 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       },
   ])
   def test_unaltered_state(self, backend_name):
-    info = tf_utils.BackendInfo.ALL[backend_name]
-    module = tf_utils.CompiledModule.compile(StatefulCountingModule, info)
+    backend_info = tf_utils.BackendInfo.ALL[backend_name]
+    module = backend_info.CompiledModule(StatefulCountingModule, backend_info)
 
     # Test that incrementing works properly.
     self.assertEqual([0.], module.get_count())
     module.increment()
     self.assertEqual([1.], module.get_count())
 
-    reinitialized_module = tf_utils.CompiledModule.from_existing(module)
+    reinitialized_module = module.create_reinitialized()
     # Test reinitialization.
     self.assertEqual([0.], reinitialized_module.get_count())
     # Test independent state.

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -26,10 +26,10 @@ The test suites can be run excluding Vulkan by specifying
 ## Compiling `tf.Module`s
 
 Compatible TensorFlow modules can be compiled to specific IREE backends using
-`IreeCompiledModule.compile(...)`. This also optionally saves compilation
-artifacts to a specified directory. These artifacts include: MLIR across various
-lowerings, a TensorFlow SavedModel, and the compiled VM FlatBuffer. A basic
-example of creating and calling an `IreeCompiledModule` can be found in
+`IreeCompiledModule`. This also optionally saves compilation artifacts to a
+specified directory. These artifacts include: MLIR across various lowerings, a
+TensorFlow SavedModel, and the compiled VM FlatBuffer. A basic example of
+creating and calling an `IreeCompiledModule` can be found in
 [`tf_utils_test.py`](https://github.com/google/iree/blob/main/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py)
 
 When using Keras models or tf.Modules with functions that IREE can't compile,
@@ -38,7 +38,7 @@ When using Keras models or tf.Modules with functions that IREE can't compile,
 ```python
 from pyiree.tf.support import tf_utils
 vmla_module = tf_utils.IreeCompiledModule(
-    constructor=KerasTFModuleClass,
+    module_class=KerasTFModuleClass,
     backend_info=tf_utils.BackendInfo.ALL['iree_vmla'],
     exported_names=['predict'])
 vmla_module.predict(...)


### PR DESCRIPTION
`CompiledModule` used to use a static `create` method to dynamically create `CompiledModule` subclasses of the correct type. This can be done just as well using the class on a `BackendInfo` value, and avoids using non-standard constructors.

`compile` and `from_existing` were spiritual successors of this method, and have been removed in favor of using the default constructor and a `create_reinitialized` method that passes `__init__` a `_` prefixed arg.