### PR TITLE
Fixing incorrect use of iree_vm_list_deinitialize.

### DIFF
--- a/iree/samples/simple_embedding/simple_embedding_test.cc
+++ b/iree/samples/simple_embedding/simple_embedding_test.cc
@@ -183,8 +183,8 @@ TEST_P(SimpleEmbeddingTest, RunOnce) {
   ASSERT_API_OK(iree_hal_buffer_unmap(ret_buffer, &mapped_memory));
   LOG(INFO) << "Results match!";
 
-  iree_vm_list_deinitialize(inputs.get());
-  iree_vm_list_deinitialize(outputs.get());
+  inputs.reset();
+  outputs.reset();
   iree_hal_device_release(device);
   iree_vm_context_release(context);
   iree_vm_instance_release(instance);

--- a/iree/tools/run_module_main.cc
+++ b/iree/tools/run_module_main.cc
@@ -142,8 +142,8 @@ Status Run() {
   RETURN_IF_ERROR(PrintVariantList(output_descs, outputs.get()))
       << "printing results";
 
-  iree_vm_list_deinitialize(inputs.get());
-  iree_vm_list_deinitialize(outputs.get());
+  inputs.reset();
+  outputs.reset();
   iree_vm_module_release(hal_module);
   iree_vm_module_release(input_module);
   iree_hal_device_release(device);


### PR DESCRIPTION
As the docs state this is only valid for lists initialized with
iree_vm_list_initialize.