### PR TITLE
Use the actual versioned extension suffix when building wheels.

### DIFF
--- a/packaging/python/common_setup.py
+++ b/packaging/python/common_setup.py
@@ -16,6 +16,7 @@ import os
 import platform
 import setuptools
 import sys
+import sysconfig
 from datetime import date
 
 
@@ -99,15 +100,6 @@ def get_setup_defaults(sub_project, description, package_dir=None):
   }
 
 
-def get_native_file_extension():
-  if platform.system() == "Windows":
-    return "pyd"
-  elif platform.system() == "Darwin":
-    return "dylib"
-  else:
-    return "so"
-
-
 def setup(**kwargs):
   # See: https://stackoverflow.com/q/45150304
   try:
@@ -128,7 +120,7 @@ def setup(**kwargs):
   # Unfortunately, bazel is imprecise and scatters .so files around, so
   # need to be specific.
   package_data = {
-      "": ["*.%s" % (get_native_file_extension(),)],
+      "": ["*%s" % (sysconfig.get_config_var("EXT_SUFFIX"),)],
   }
   setuptools.setup(
       package_data=package_data,

--- a/packaging/python/setup_compiler.py
+++ b/packaging/python/setup_compiler.py
@@ -39,7 +39,12 @@ def run():
   print("Found packages:", packages)
   setup_kwargs = common_setup.get_setup_defaults(
       sub_project="compiler", description="IREE Generic Compiler")
-  common_setup.setup(packages=packages, **setup_kwargs)
+  common_setup.setup(packages=packages,
+                     ext_modules=[
+                         setuptools.Extension(name="pyiree.compiler.binding",
+                                              sources=[]),
+                     ],
+                     **setup_kwargs)
 
 
 if __name__ == "__main__":

--- a/packaging/python/setup_rt.py
+++ b/packaging/python/setup_rt.py
@@ -35,7 +35,12 @@ def run():
   setup_kwargs = common_setup.get_setup_defaults(
       sub_project="rt",
       description="IREE Runtime Components (for executing compiled programs)")
-  common_setup.setup(packages=packages, **setup_kwargs)
+  common_setup.setup(packages=packages,
+                     ext_modules=[
+                         setuptools.Extension(name="pyiree.rt.binding",
+                                              sources=[]),
+                     ],
+                     **setup_kwargs)
 
 
 if __name__ == "__main__":

--- a/packaging/python/setup_tf.py
+++ b/packaging/python/setup_tf.py
@@ -28,15 +28,17 @@ import common_setup
 
 
 def run():
-  package_dir = common_setup.get_package_dir(
-      prefix=("integrations", "tensorflow", "bindings", "python"))
-  packages = setuptools.find_namespace_packages(
-      package_dir,
-      include=[
-          "pyiree.tf.compiler", "pyiree.tf.compiler.*", "pyiree.tf.support",
-          "pyiree.tf.support.*"
-      ],
-      exclude=["*.CMakeFiles"])
+  package_dir = common_setup.get_package_dir(prefix=("integrations",
+                                                     "tensorflow", "bindings",
+                                                     "python"))
+  packages = setuptools.find_namespace_packages(package_dir,
+                                                include=[
+                                                    "pyiree.tf.compiler",
+                                                    "pyiree.tf.compiler.*",
+                                                    "pyiree.tf.support",
+                                                    "pyiree.tf.support.*"
+                                                ],
+                                                exclude=["*.CMakeFiles"])
   print("Found packages:", packages)
   if not packages:
     print("ERROR: Did not find packages under", package_dir)
@@ -45,7 +47,12 @@ def run():
       sub_project="tf",
       description="IREE TensorFlow Compiler",
       package_dir=package_dir)
-  common_setup.setup(packages=packages, **setup_kwargs)
+  common_setup.setup(packages=packages,
+                     ext_modules=[
+                         setuptools.Extension(name="pyiree.tf.compiler.binding",
+                                              sources=[]),
+                     ],
+                     **setup_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* This will do the right thing when building from a directory that contains multiple version/platform specific extension modules.