### PR TITLE
Fix flatcc target name and binary path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,11 +368,14 @@ if(CMAKE_CROSSCOMPILING)
   add_custom_target(iree_host_flatcc_cli
     COMMAND
       "${CMAKE_COMMAND}" -E copy_if_different
-        "${IREE_HOST_BINARY_ROOT}/third_party/flatcc/flatcc${IREE_HOST_EXECUTABLE_SUFFIX}"
+        "${PROJECT_SOURCE_DIR}/third_party/flatcc/bin/flatcc${IREE_HOST_EXECUTABLE_SUFFIX}"
         "${IREE_HOST_BINARY_ROOT}/bin/flatcc_cli"
     DEPENDS iree_host_build_flatcc_cli
     COMMENT "Installing host flatcc..."
   )
+else()
+  # TODO: unify flatc and flatcc handling to the same mechanism.
+  add_executable(iree_host_flatcc_cli ALIAS flatcc_cli)
 endif()
 
 if(${IREE_BUILD_COMPILER})

--- a/build_tools/cmake/flatbuffer_c_library.cmake
+++ b/build_tools/cmake/flatbuffer_c_library.cmake
@@ -115,7 +115,7 @@ function(flatbuffer_c_library)
     MAIN_DEPENDENCY
       ${_RULE_SRCS}
     DEPENDS
-      ${_FLATCC_BIN}
+      iree_host_flatcc_cli
       ${_RULE_SRCS}
     COMMAND_EXPAND_LISTS
   )


### PR DESCRIPTION
This commit also defines iree_host_build_flatcc_cli when not
cross compiling so we can depend on it in iree_flatbuffer_c_library.

Also copy flatcc_cli from the proper place. They install it
in the source directory...