### PR TITLE
Use ${IREE_HOST_SCRIPT_EXT} in CMake iree_py_test.

### DIFF
--- a/build_tools/cmake/iree_multipy.cmake
+++ b/build_tools/cmake/iree_multipy.cmake
@@ -292,7 +292,10 @@ function(iree_py_test)
     set(VER_NAME "${_NAME_PATH}__${V}")
     add_test(
       NAME ${VER_NAME}
-      COMMAND ${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.sh "${IREE_MULTIPY_${V}_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRCS}"
+      COMMAND
+        "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
+        "${IREE_MULTIPY_${V}_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRCS}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 


### PR DESCRIPTION
This gets the CMake Python tests closer to running/passing on Windows. There was no regression in https://github.com/google/iree/pull/2590, the old `iree_py_test.cmake` also had this issue.

`ctest -L bindings/python -V` output before:

```
353: Test command: D:\dev\projects\iree\build_tools\cmake\run_test.sh "C:/Users/Scott/scoop/shims/python3.exe" "D:/dev/projects/iree/bindings/python/pyiree/compiler/compiler_test.py"
353: Environment variables:
353:  PYTHONPATH=D:/dev/projects/iree-build-py/bindings/python:
353:  TEST_TMPDIR=bindings_python_pyiree_compiler_compiler_test_DEFAULT_test_tmpdir
353: Test timeout computed to be: 10000000
Process not started
 D:/dev/projects/iree/build_tools/cmake/run_test.sh
[unknown error]
5/5 Test #353: bindings/python/pyiree/compiler:compiler_test__DEFAULT ...***Not Run   0.00 sec
```

`ctest -L bindings/python -V` output after:

```
353: Test command: D:\dev\projects\iree\build_tools\cmake\run_test.bat "C:/Users/Scott/scoop/shims/python3.exe" "D:/dev/projects/iree/bindings/python/pyiree/compiler/compiler_test.py"
353: Environment variables:
353:  PYTHONPATH=D:/dev/projects/iree-build-py/bindings/python:
353:  TEST_TMPDIR=bindings_python_pyiree_compiler_compiler_test_DEFAULT_test_tmpdir
353: Test timeout computed to be: 10000000
353: Running test:
353: C:/Users/Scott/scoop/shims/python3.exe D:/dev/projects/iree/bindings/python/pyiree/compiler/compiler_test.py
353: Traceback (most recent call last):
353:   File "D:/dev/projects/iree/bindings/python/pyiree/compiler/compiler_test.py", line 17, in <module>
353:     from pyiree import compiler
353: ModuleNotFoundError: No module named 'pyiree'
5/5 Test #353: bindings/python/pyiree/compiler:compiler_test__DEFAULT ...***Failed    0.44 sec
```