### PR TITLE
Fix time bug with new tests, re-enable SemaphoreTest cases.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -435,6 +435,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "time_test",
+    srcs = ["time_test.cc"],
+    deps = [
+        ":time",
+        "//iree/testing:gtest_main",
+    ],
+)
+
 cc_library(
     name = "tracing",
     hdrs = ["tracing.h"],

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -524,6 +524,16 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    time_test
+  SRCS
+    "time_test.cc"
+  DEPS
+    ::time
+    iree::testing::gtest_main
+)
+
 if(${IREE_ENABLE_RUNTIME_TRACING})
   iree_cc_library(
     NAME

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -374,7 +374,7 @@ typedef int64_t iree_time_t;
 // Like absl::Duration, represented as relative nanoseconds.
 typedef int64_t iree_duration_t;
 // Like absl::InfiniteDuration.
-#define IREE_DURATION_INFINITE INT64_MIN
+#define IREE_DURATION_INFINITE INT64_MAX
 // Like absl::ZeroDuration.
 #define IREE_DURATION_ZERO 0
 

--- a/iree/base/time.h
+++ b/iree/base/time.h
@@ -43,7 +43,7 @@ class ChronoType {
     return !(lhs == rhs);
   }
   friend inline bool operator<(const ChronoType& lhs, const ChronoType& rhs) {
-    return rhs.value_ < lhs.value_;
+    return lhs.value_ < rhs.value_;
   }
   friend inline bool operator>(const ChronoType& lhs, const ChronoType& rhs) {
     return rhs < lhs;

--- a/iree/base/time.h
+++ b/iree/base/time.h
@@ -15,6 +15,9 @@
 #ifndef IREE_BASE_TIME_H_
 #define IREE_BASE_TIME_H_
 
+#include <type_traits>
+#include <utility>
+
 #include "iree/base/api.h"
 
 namespace iree {

--- a/iree/base/time_test.cc
+++ b/iree/base/time_test.cc
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/time.h"
+
+#include "iree/testing/gtest.h"
+
+namespace iree {
+namespace {
+
+TEST(Time, DurationComparisons) {
+  EXPECT_TRUE(Milliseconds(123) == Milliseconds(123));
+  EXPECT_FALSE(Milliseconds(123) == Milliseconds(456));
+  EXPECT_FALSE(Milliseconds(123) != Milliseconds(123));
+  EXPECT_TRUE(Milliseconds(123) != Milliseconds(456));
+
+  EXPECT_TRUE(Milliseconds(123) < Milliseconds(456));
+  EXPECT_FALSE(Milliseconds(123) > Milliseconds(456));
+  EXPECT_FALSE(Milliseconds(123) > Milliseconds(123));
+  EXPECT_FALSE(Milliseconds(123) < Milliseconds(123));
+
+  EXPECT_TRUE(Milliseconds(123) <= Milliseconds(123));
+  EXPECT_TRUE(Milliseconds(123) >= Milliseconds(123));
+  EXPECT_TRUE(Milliseconds(123) <= Milliseconds(456));
+  EXPECT_FALSE(Milliseconds(123) >= Milliseconds(456));
+}
+
+TEST(Time, DurationArithmetic) {
+  EXPECT_EQ(Milliseconds(150), Milliseconds(100) + Milliseconds(50));
+  EXPECT_EQ(Milliseconds(50), Milliseconds(100) - Milliseconds(50));
+}
+
+}  // namespace
+}  // namespace iree

--- a/iree/hal/cts/semaphore_test.cc
+++ b/iree/hal/cts/semaphore_test.cc
@@ -76,7 +76,7 @@ TEST_P(SemaphoreTest, WaitAlreadySignaled) {
 }
 
 // Tests waiting on a semaphore that has not been signaled.
-TEST_P(SemaphoreTest, DISABLED_WaitUnsignaled) {
+TEST_P(SemaphoreTest, WaitUnsignaled) {
   ASSERT_OK_AND_ASSIGN(auto semaphore, device_->CreateSemaphore(2u));
   // NOTE: we don't actually block here because otherwise we'd lock up.
   // Result status is undefined - some backends may return DeadlineExceededError
@@ -90,7 +90,7 @@ TEST_P(SemaphoreTest, DISABLED_WaitUnsignaled) {
 
 // Tests threading behavior by ping-ponging between the test main thread and
 // a little thread.
-TEST_P(SemaphoreTest, DISABLED_PingPong) {
+TEST_P(SemaphoreTest, PingPong) {
   ASSERT_OK_AND_ASSIGN(auto a2b, device_->CreateSemaphore(0u));
   ASSERT_OK_AND_ASSIGN(auto b2a, device_->CreateSemaphore(0u));
   std::thread thread([&]() {


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/2604

This loop in emulated timeline semaphores was never terminating with `deadline_ns == InfinitePast()`: https://github.com/google/iree/blob/7dd38828dae845aa2f48da76811e009781812944/iree/hal/vulkan/emulated_timeline_semaphore.cc#L115