### PR TITLE
Add iota.mlir test to e2e/xla_ops/

### DIFF
--- a/iree/test/e2e/xla_ops/iota.mlir
+++ b/iree/test/e2e/xla_ops/iota.mlir
@@ -1,0 +1,16 @@
+func @iota_dim0() attributes { iree.module.export } {
+  %result = "mhlo.iota"() {iota_dimension = 0 : i64} : () -> tensor<2x3xf32>
+  check.expect_almost_eq_const(%result, dense<[
+    [0.0, 0.0, 0.0],
+    [1.0, 1.0, 1.0]]> : tensor<2x3xf32>) : tensor<2x3xf32>
+  return
+}
+
+
+func @iota_dim1() attributes { iree.module.export } {
+  %result = "mhlo.iota"() {iota_dimension = 1 : i64} : () -> tensor<2x3xf32>
+  check.expect_almost_eq_const(%result, dense<[
+    [0.0, 1.0, 2.0],
+    [0.0, 1.0, 2.0]]> : tensor<2x3xf32>) : tensor<2x3xf32>
+  return
+}


### PR DESCRIPTION
This op is supported in VMLA but doesn't have a test.