### PR TITLE
[android] Disable LLVM JIT HAL driver related tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,13 @@ set(IREE_ALL_HAL_DRIVERS
 if( IREE_HAL_DRIVERS_TO_BUILD STREQUAL "all" )
   set( IREE_HAL_DRIVERS_TO_BUILD ${IREE_ALL_HAL_DRIVERS} )
 endif()
+
+# For cross compilation towords Android, we don't want LLVM JIT HAL driver.
+if(ANDROID AND LLVM IN_LIST IREE_HAL_DRIVERS_TO_BUILD)
+  list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD LLVM)
+  message(STATUS "Removed LLVM JIT HAL driver for Android build")
+endif()
+
 message(STATUS "Building HAL drivers ${IREE_HAL_DRIVERS_TO_BUILD}")
 
 # Default every IREE_HAL_DRIVER_* to OFF
@@ -101,12 +108,6 @@ foreach(_backend ${IREE_ALL_HAL_DRIVERS})
   string(TOUPPER "${_backend}" uppercase_backend)
   set(IREE_HAL_DRIVER_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
-
-# For cross compilation towords Android, we don't want LLVM JIT HAL driver.
-if(ANDROID)
-  message(STATUS "Removed LLVM JIT HAL driver for Android build")
-  list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD LLVM)
-endif()
 
 # Set IREE_HAL_DRIVER_* based on configuration
 foreach(_backend ${IREE_HAL_DRIVERS_TO_BUILD})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,12 @@ foreach(_backend ${IREE_ALL_HAL_DRIVERS})
   set(IREE_HAL_DRIVER_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
 
+# For cross compilation towords Android, we don't want LLVM JIT HAL driver.
+if(ANDROID)
+  message(STATUS "Removed LLVM JIT HAL driver for Android build")
+  list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD LLVM)
+endif()
+
 # Set IREE_HAL_DRIVER_* based on configuration
 foreach(_backend ${IREE_HAL_DRIVERS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
@@ -112,8 +118,8 @@ endforeach()
 # List of all target backends to be built by default:
 set(IREE_ALL_TARGET_BACKENDS
   # TODO(scotttodd): LLVMAOT
-  LLVMIR
-  Vulkan_SPIRV
+  LLVM-IR
+  Vulkan-SPIRV
   VMLA
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,14 +93,11 @@ set(IREE_ALL_HAL_DRIVERS
 
 if( IREE_HAL_DRIVERS_TO_BUILD STREQUAL "all" )
   set( IREE_HAL_DRIVERS_TO_BUILD ${IREE_ALL_HAL_DRIVERS} )
+  # For cross compilation towords Android, we don't want LLVM JIT HAL driver.
+  if(ANDROID)
+    list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD LLVM)
+  endif()
 endif()
-
-# For cross compilation towords Android, we don't want LLVM JIT HAL driver.
-if(ANDROID AND LLVM IN_LIST IREE_HAL_DRIVERS_TO_BUILD)
-  list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD LLVM)
-  message(STATUS "Removed LLVM JIT HAL driver for Android build")
-endif()
-
 message(STATUS "Building HAL drivers ${IREE_HAL_DRIVERS_TO_BUILD}")
 
 # Default every IREE_HAL_DRIVER_* to OFF

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -173,6 +173,17 @@ function(iree_check_single_backend_test_suite)
     ${ARGN}
   )
 
+
+  string(TOUPPER ${_RULE_DRIVER} _UPPERCASE_DRIVER)
+  if(NOT IREE_HAL_DRIVER_${_UPPERCASE_DRIVER})
+    return()
+  endif()
+
+  string(TOUPPER ${_RULE_TARGET_BACKEND} _UPPERCASE_TARGET_BACKEND)
+  if(NOT IREE_TARGET_BACKEND_${_UPPERCASE_TARGET_BACKEND})
+    return()
+  endif()
+
   foreach(_SRC IN LISTS _RULE_SRCS)
     set(_TEST_NAME "${_RULE_NAME}_${_SRC}")
     iree_check_test(

--- a/docs/get_started/cmake_options_and_variables.md
+++ b/docs/get_started/cmake_options_and_variables.md
@@ -73,7 +73,7 @@ all HAL drivers. Case-insensitive. Defaults to `all`. Example:
 *This does not have any effect at the moment, but will be supported in the
 future!* Semicolon-separated list of HAL drivers to build, or `all` for building
 all HAL drivers. Case-insensitive. Defaults to `all`. Example:
-`-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan_SPIRV;VMLA"`.
+`-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan-SPIRV;VMLA"`.
 
 #### `IREE_ENABLE_LLD`:BOOL
 

--- a/docs/get_started/cmake_options_and_variables.md
+++ b/docs/get_started/cmake_options_and_variables.md
@@ -63,16 +63,20 @@ Builds experimental projects. Defaults to `OFF`.
 
 #### `IREE_HAL_DRIVERS_TO_BUILD`:STRING
 
-*This does not have any effect at the moment, but will be supported in the
-future!* Semicolon-separated list of HAL drivers to build, or `all` for building
-all HAL drivers. Case-insensitive. Defaults to `all`. Example:
+*Righ now this only affects whether tests are enabled when compiling for
+Android; it will be fully supported in the future!*
+
+Semicolon-separated list of HAL drivers to build, or `all` for building all HAL
+drivers. Case-insensitive. Defaults to `all`. Example:
 `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan;VMLA"`.
 
 #### `IREE_TARGET_BACKENDS_TO_BUILD`:STRING
 
-*This does not have any effect at the moment, but will be supported in the
-future!* Semicolon-separated list of HAL drivers to build, or `all` for building
-all HAL drivers. Case-insensitive. Defaults to `all`. Example:
+*Righ now this only affects whether tests are enabled when compiling for
+Android; it will be fully supported in the future!*
+
+Semicolon-separated list of HAL drivers to build, or `all` for building all
+compiler target backends. Case-insensitive. Defaults to `all`. Example:
 `-DIREE_HAL_DRIVERS_TO_BUILD="Vulkan-SPIRV;VMLA"`.
 
 #### `IREE_ENABLE_LLD`:BOOL


### PR DESCRIPTION
We don't want LLVM JIT as part of the IREE runtime when on Android.
This commit serves as the first step as disabling it by turning
off tests.

Along the way, made the compiler target backend names consistent
with what's used elsewhere.

Progress on https://github.com/google/iree/issues/2528