### PR TITLE
Stop always sending TF update PRs to gcmn

### DIFF
--- a/.github/workflows/update_tf.yml
+++ b/.github/workflows/update_tf.yml
@@ -54,6 +54,4 @@ jobs:
 
             Automated submodule bump from .github/workflows/update_tf.yml
           committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
-          # TODO(gcmn): Figure out a way to assign this to someone dynamically.
-          reviewers: gmngeoffrey
           branch: "auto_submodule_update"


### PR DESCRIPTION
This sends me a lot of email and doesn't add much value, I think.

There is the option to use team reviewers. We could look at creating a
team for the build cops. It would be really nice to request review from
or tag someone dynamically based on our build cop rotation, but not sure
how to do that.
