### PR TITLE
Fix fake group and passwd files for Docker

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/docker_common.sh
+++ b/build_tools/kokoro/gcp_ubuntu/docker_common.sh
@@ -32,13 +32,10 @@ function docker_setup() {
     mkdir -p "${fake_etc_dir?}"
 
     local fake_group="${fake_etc_dir?}/group"
-    local fake_passwd="${fake_etc_dir?}/group"
+    local fake_passwd="${fake_etc_dir?}/passwd"
 
-    cp /etc/passwd "${fake_group?}"
-    cp /etc/group "${fake_passwd?}"
-    getent group "$(id -g)" >> "${fake_group?}"
-    getent passwd "$(id -u)" >> "${fake_passwd?}"
-
+    getent group > "${fake_group?}"
+    getent passwd > "${fake_passwd?}"
 
     local workdir="${KOKORO_ARTIFACTS_DIR?}/github/iree"
 


### PR DESCRIPTION
I mixed up some paths here. These just happen to work right now because
/etc/group is also a valid /etc/passwd file, but that's not great. Also
I realized that `getent` already produces everything I need if invoked
without a specific group or user argument.

Tested:
Ran the simulate_kokoro script locally:
```shell
./build_tools/kokoro/gcp_ubuntu/simulate_kokoro.sh \
  build_tools/kokoro/gcp_ubuntu/bazel/linux/x86/core/build_kokoro.sh \
  "$PWD/.git"`
```