### PR TITLE
Enable while.test mlir on vulkan-spirv backend.

### DIFF
--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -82,9 +82,7 @@ iree_check_single_backend_test_suite(
         "tanh.mlir",
         "torch_index_select.mlir",
         "transpose.mlir",
-
-        # TODO(#2022): fails on real devices.
-        # "while.mlir",
+        "while.mlir",
     ],
     driver = "vulkan",
     target_backend = "vulkan-spirv",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_check_single_backend_test_suite(
     "tanh.mlir"
     "torch_index_select.mlir"
     "transpose.mlir"
+    "while.mlir"
   TARGET_BACKEND
     vulkan-spirv
   DRIVER


### PR DESCRIPTION
Also tested on Android, it's passing.