### PR TITLE
Disable SDL sensor support on Windows.

### DIFF
--- a/build_tools/third_party/sdl2/SDL_config_windows.h
+++ b/build_tools/third_party/sdl2/SDL_config_windows.h
@@ -227,6 +227,9 @@ typedef unsigned int uintptr_t;
 /* Enable filesystem support */
 #define SDL_FILESYSTEM_WINDOWS 1
 
+/* Disable sensor support */
+#define SDL_SENSOR_DISABLED 1
+
 /* Enable assembly routines (Win64 doesn't have inline asm) */
 #ifndef _WIN64
 #define SDL_ASSEMBLY_ROUTINES 1


### PR DESCRIPTION
It wasn't building cleanly with our existing Bazel overlay files and MSVC.

Fixes https://github.com/google/iree/issues/2456