### PR TITLE
Adds a class for tracing module calls and example tests.

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -645,12 +645,11 @@ class TracedModule:
     """Wraps a CompiledModule so that all inputs and outputs are traced.
 
     The TracedModule returned will have an API almost identical to that of the
-    passed CompiledModule. The only changes are:
-      - If the keywords `rtol` or `atol` are passed to one of the
-        CompiledModule's methods, then they will be used to set the tolerance
-        for comparing that call to the same call in another trace. So for
-        example, calling `traced_module.add(a, b rtol=1e-8)` would be the same
-        as calling `module.add(a, b)`.
+    passed CompiledModule. The only changes is that if the keywords `rtol` or
+    `atol` are passed to one of the CompiledModule's methods, then they will be
+    used to set the tolerance for comparing that call to the same call in
+    another trace. So for example, calling `traced_module.add(a, b rtol=1e-8)`
+    would be the same as calling `module.add(a, b)`.
 
     Args:
       module: the CompiledModule to trace.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -678,15 +678,15 @@ class TracedModule:
     return call
 
   def __getattr__(self, attr):
-    # Try to resolve it as an attr on self.module.
+    # Try to resolve it as an attr on self._module.
     if not hasattr(self._module, attr):
       raise AttributeError(f"The compiled module does not have attr '{attr}'")
     module_attr = getattr(self._module, attr)
     if not hasattr(module_attr, "__call__"):
-      # e.g. trace.backend
+      # e.g. traced_module.backend
       return module_attr
     else:
-      # e.g. trace.simple_mul(a, b)
+      # e.g. traced_module.simple_mul(a, b)
       return self._trace_call(module_attr, method_name=attr)
 
 
@@ -696,7 +696,7 @@ class TracedModuleTestCase(tf.test.TestCase):
   _module_class = None
   _exported_names = ()
 
-  # Will be initialized in setUpClass
+  # Will be initialized in setUpClass.
   _ref_module = None
   _tar_modules = None
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -19,8 +19,10 @@
 # pylint: disable=unsupported-assignment-operation
 
 import collections
+import copy
 import os
 import re
+import sys
 import tempfile
 
 from absl import flags
@@ -46,6 +48,7 @@ flags.DEFINE_bool(
     "summarize", True,
     "Summarize the inputs and outputs of each module trace logged to disk.")
 FLAGS = flags.FLAGS
+NUMPY_LINEWIDTH = 120
 
 
 def _setup_test_debug_dir(test_name):
@@ -429,6 +432,142 @@ def get_target_backends():
   return backends
 
 
+def _indent(input_str, indentation=2):
+  """Indents a string by the specified number of spaces, defaulting to 2."""
+  spaces = " " * indentation
+  lines = input_str.split("\n")
+  # Prepend spaces to each non-empty line.
+  lines = [f"{spaces}{line}" if len(line) else line for line in lines]
+  return "\n".join(lines)
+
+
+class ModuleCall:
+
+  def __init__(self, method_name, inputs, outputs, rtol=1e-6, atol=1e-6):
+    """Records the details of a call to a CompiledModule."""
+    self.method = method_name
+
+    # Deepcopy to safegard against mutation.
+    self.inputs = copy.deepcopy(inputs)
+    if outputs is not None:
+      outputs = copy.deepcopy(outputs)
+    else:
+      outputs = tuple()
+    self.outputs = outputs if isinstance(outputs, tuple) else (outputs,)
+
+    self.rtol = rtol
+    self.atol = atol
+
+  def get_tolerances(self):
+    """Gets the floating point tolerances associated with this call."""
+    return self.rtol, self.atol
+
+  def __str__(self):
+    prior_printoptions = np.get_printoptions()
+    np.set_printoptions(linewidth=NUMPY_LINEWIDTH)
+
+    header = f"Method: {self.method}"
+    inputs = "\n".join(_indent(str(value)) for value in self.inputs)
+    outputs = "\n".join(_indent(str(value)) for value in self.outputs)
+    tolerances = _indent(f"rtol={self.rtol}, atol={self.atol}")
+    body = f"Inputs:\n{inputs}\nOutputs:\n{outputs}\nTolerances:\n{tolerances}"
+    result = f"{header}\n{_indent(body)}"
+
+    np.set_printoptions(**prior_printoptions)
+    return result
+
+
+class TracedModule:
+
+  def __init__(self, module, trace_function=None):
+    """Wraps a CompiledModule so that all inputs and outputs are traced.
+
+    The TracedModule returned will have an API almost identical to that of the
+    passed CompiledModule. The only change is that if the keywords `rtol` or
+    `atol` are passed to one of the CompiledModule's functions, they will be
+    used to set the tolerance for comparing that call to the same call in
+    another trace. They will not be passed to the CompiledModule's method.
+    So for example, calling `trace.add(a, b, rtol=1e-8)` would be the same as
+    calling `module.add(a, b)`.
+
+    Args:
+      module: the CompiledModule to trace.
+      trace_function: an optional function accepting a TracedModule to run this
+        module through. Useful for comparing backends on the same set of calls.
+    """
+    self.module = module
+    self.trace_function = trace_function
+    self.trace_name = "unnamed_trace"  # Used for saving.
+    self.calls = []
+    if self.trace_function is not None:
+      self.trace_name = self.trace_function.__name__
+      self.trace_function(self)
+
+  def _trace_call(self, method, method_name):
+    """Decorates a CompiledModule method to capture its inputs and outputs."""
+
+    def call(*args, **kwargs):
+      # Pop manually specified tolerances from the kwargs (if any).
+      tolerances = {}
+      tolerances["rtol"] = kwargs.pop("rtol", None)
+      tolerances["atol"] = kwargs.pop("atol", None)
+      # Only pass these to ModuleCall if they were specified by the user.
+      tolerances = {k: v for k, v in tolerances.items() if v is not None}
+
+      # Run the method and record the details of the call.
+      outputs = method(*args, **kwargs)
+      self.calls.append(ModuleCall(method_name, args, outputs, **tolerances))
+      return outputs
+
+    return call
+
+  def __getattr__(self, attr):
+    # Try to resolve it as an attr on self.module.
+    if not hasattr(self.module, attr):
+      raise AttributeError(f"The compiled module does not have attr '{attr}'")
+    module_attr = getattr(self.module, attr)
+    if not hasattr(module_attr, "__call__"):
+      # e.g. trace.backend_name
+      return module_attr
+    else:
+      # e.g. trace.simple_mul(a, b)
+      return self._trace_call(module_attr, method_name=attr)
+
+  def __str__(self):
+    header = f"Trace of {self.module_name} compiled to '{self.backend}' "
+    if self.trace_name != "unnamed_trace":
+      header += f"on function '{self.trace_name}':"
+    # Give each call a number so it's easier to compare between multiple traces.
+    calls = [f"{i + 1}. {str(call)}" for i, call in enumerate(self.calls)]
+    calls = _indent("\n".join(calls))
+    return f"{header}\n{calls}"
+
+  def save_plaintext(self, trace_dir, summarize=True):
+    """Saves a human-readable string representation of this trace to disk.
+
+    Args:
+      trace_dir: the directory to save the trace in.
+      summarize: a bool controlling whether numpy should summarize the inputs
+        and outputs if they're large. Setting this to False is very slow for
+        large outputs.
+    """
+    prior_printoptions = np.get_printoptions()
+    np.set_printoptions(
+        linewidth=NUMPY_LINEWIDTH,
+        threshold=None if summarize else sys.maxsize,
+        edgeitems=10)  # Can show more items since they won't clutter the logs.
+
+    path = os.path.join(trace_dir, f"{self.trace_name}__{self.backend}.txt")
+    with open(path, "w") as f:
+      f.write(str(self))
+
+    np.set_printoptions(**prior_printoptions)
+
+  def __iter__(self):
+    for call in self.calls:
+      yield call
+
+
 class TracedModuleTestCase(tf.test.TestCase):
   """Compiles a tf.Module to multiple backends to test their correctness."""
   # This class uses the following abbreviations:
@@ -495,10 +634,9 @@ class TracedModuleTestCase(tf.test.TestCase):
       trace_function: a function accepting a TracedModule as its argument.
     """
     # Trace the test function for each backend.
-    ref_trace = tf_utils.TracedModule(self._ref_module, trace_function)
+    ref_trace = TracedModule(self._ref_module, trace_function)
     tar_traces = [
-        tf_utils.TracedModule(module, trace_function)
-        for module in self._tar_modules
+        TracedModule(module, trace_function) for module in self._tar_modules
     ]
 
     # Compare each target trace with the reference trace.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -573,18 +573,17 @@ class TracedModule:
       raise ValueError(
           "The reference and target traces have different call structures:\n"
           f"Reference: {ref_methods}\nTarget:    {tar_methods}")
-      return False
 
     for ref_call, tar_call in zip(ref_trace, tar_trace):
       logging.info("Comparing calls to '%s'", ref_call.method)
       rtol, atol = ref_call.get_tolerances()
 
-      inputs_match = TracedModule._check_same(
-          ref_call.inputs, tar_call.inputs, rtol, atol)
+      inputs_match = TracedModule._check_same(ref_call.inputs, tar_call.inputs,
+                                              rtol, atol)
       if not inputs_match:
         logging.error("Inputs did not match.")
-      outputs_match = TracedModule._check_same(
-          ref_call.outputs, tar_call.outputs, rtol, atol)
+      outputs_match = TracedModule._check_same(ref_call.outputs,
+                                               tar_call.outputs, rtol, atol)
       if not outputs_match:
         logging.error("Outputs did not match.")
       calls_match = inputs_match and outputs_match

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -596,8 +596,7 @@ class TracedModuleTestCase(tf.test.TestCase):
 
     # If outputs end up here then an extra branch for that type should be added.
     else:
-      logging.warning("Comparing an unexpected result type of %s", type(ref))
-      return ref == tar
+      raise TypeError(f"Encountered results with unexpected type {type(ref)}")
     return True
 
   @classmethod

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -116,10 +116,10 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     trace = tf_test_utils.Trace(module, trace_function)
     trace_function(tf_test_utils.TracedModule(module, trace))
 
-    self.assertTrue(isinstance(trace.calls[0].inputs, tuple))
-    self.assertTrue(len(trace.calls[0].inputs) == 0)
-    self.assertTrue(isinstance(trace.calls[0].outputs, tuple))
-    self.assertTrue(len(trace.calls[0].outputs) == 0)
+    self.assertIsInstance(trace.calls[0].inputs, tuple)
+    self.assertEmpty(trace.calls[0].inputs)
+    self.assertIsInstance(trace.calls[0].outputs, tuple)
+    self.assertEmpty(trace.calls[0].outputs)
 
     self.assertAllClose(trace.calls[1].inputs[0], [81.])
     self.assertAllClose(trace.calls[2].outputs[0], [82.])

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -17,9 +17,11 @@
 # pylint: disable=protected-access
 
 import collections
+import copy
 import os
 import random
 import re
+import sys
 import tempfile
 
 from absl import flags
@@ -30,6 +32,7 @@ from pyiree.tf import compiler
 import tensorflow.compat.v2 as tf
 
 FLAGS = flags.FLAGS
+NUMPY_LINEWIDTH = 120
 
 
 def set_random_seed(seed=0):
@@ -141,6 +144,10 @@ class CompiledModule(object):
     self._backend_info = backend_info
     self._exported_names = exported_names
     self._artifacts_dir = artifacts_dir
+
+    # Public attributes:
+    self.backend = self._backend_info.name
+    self.module_name = self._module_class.__name__
 
   def create_reinitialized(self):
     """Duplicates this module with its initial state without recompiling."""
@@ -317,3 +324,143 @@ BackendInfo.add(
     CompiledModule=IreeCompiledModule,
     iree_driver="llvm",
     iree_compiler_targets=["llvm-ir"])
+
+
+def _indent(input_str, indentation=2):
+  """Indents a string by the specified number of spaces, defaulting to 2."""
+  spaces = " " * indentation
+  lines = input_str.split("\n")
+  # Prepend spaces to each non-empty line.
+  lines = [f"{spaces}{line}" if len(line) else line for line in lines]
+  return "\n".join(lines)
+
+
+class ModuleCall:
+
+  def __init__(self, method_name, inputs, outputs, rtol=None, atol=None):
+    """Records the details of a call to a CompiledModule."""
+    self.method = method_name
+
+    # Deepcopy to safegard against mutation.
+    self.inputs = copy.deepcopy(inputs)
+    if outputs is not None:
+      outputs = copy.deepcopy(outputs)
+    else:
+      outputs = tuple()
+    self.outputs = outputs if isinstance(outputs, tuple) else (outputs,)
+
+    self.rtol = rtol
+    self.atol = atol
+
+  def record_tolerances_if_unset(self, rtol, atol):
+    """Record rtol or atol if they weren't specified for this call."""
+    if self.rtol is None:
+      self.rtol = rtol
+    if self.atol is None:
+      self.atol = atol
+
+  def get_tolerances(self):
+    """Gets the floating point tolerances associated with this call."""
+    return self.rtol, self.atol
+
+  def __str__(self):
+    prior_printoptions = np.get_printoptions()
+    np.set_printoptions(linewidth=NUMPY_LINEWIDTH)
+
+    header = f"Method: {self.method}"
+    inputs = "\n".join(_indent(str(value)) for value in self.inputs)
+    outputs = "\n".join(_indent(str(value)) for value in self.outputs)
+    tolerances = _indent(f"rtol={self.rtol}, atol={self.atol}")
+    body = f"Inputs:\n{inputs}\nOutputs:\n{outputs}\nTolerances:\n{tolerances}"
+    result = f"{header}\n{_indent(body)}"
+
+    np.set_printoptions(**prior_printoptions)
+    return result
+
+
+class TracedModule:
+
+  def __init__(self, module, trace_function=None):
+    """Wraps a CompiledModule so that all inputs and outputs are traced.
+
+    The TracedModule returned will have an API almost identical to that of the
+    passed CompiledModule. The only change is that if the keywords `rtol` or
+    `atol` are passed to one of the CompiledModule's functions, they will be
+    used to set the tolerance for comparing that call to the same call in
+    another trace. They will not be passed to the CompiledModule's method.
+    So for example, calling `trace.add(a, b, rtol=1e-8)` would be the same as
+    calling `module.add(a, b)`.
+
+    Args:
+      module: the CompiledModule to trace.
+      trace_function: an optional function accepting a TracedModule to run this
+        module through. Useful for comparing backends on the same set of calls.
+    """
+    self.module = module
+    self.trace_function = trace_function
+    self.trace_name = "unnamed_trace"  # Used for saving.
+    self.calls = []
+    if self.trace_function is not None:
+      self.trace_name = self.trace_function.__name__
+      self.trace_function(self)
+
+  def _trace_call(self, method, method_name):
+    """Decorates a CompiledModule method to capture its inputs and outputs."""
+
+    def call(*args, **kwargs):
+      # Pop manually specified tolerances from the kwargs (if any).
+      rtol = kwargs.pop("rtol", None)
+      atol = kwargs.pop("atol", None)
+
+      # Run the method and record the details of the call.
+      outputs = method(*args, **kwargs)
+      self.calls.append(ModuleCall(method_name, args, outputs, rtol, atol))
+      return outputs
+
+    return call
+
+  def __getattr__(self, attr):
+    # Try to resolve it as an attr on self.module.
+    if not hasattr(self.module, attr):
+      raise AttributeError(f"The compiled module does not have attr '{attr}'")
+    module_attr = getattr(self.module, attr)
+    if not hasattr(module_attr, "__call__"):
+      # e.g. trace.backend_name
+      return module_attr
+    else:
+      # e.g. trace.simple_mul(a, b)
+      return self._trace_call(module_attr, method_name=attr)
+
+  def __str__(self):
+    header = f"Trace of {self.module_name} compiled to '{self.backend}' "
+    if self.trace_name != "unnamed_trace":
+      header += f"on function '{self.trace_name}':"
+    # Give each call a number so it's easier to compare between multiple traces.
+    calls = [f"{i + 1}. {str(call)}" for i, call in enumerate(self.calls)]
+    calls = _indent("\n".join(calls))
+    return f"{header}\n{calls}"
+
+  def save_plaintext(self, trace_dir, summarize=True):
+    """Saves a human-readable string representation of this trace to disk.
+
+    Args:
+      trace_dir: the directory to save the trace in.
+      summarize: a bool controlling whether numpy should summarize the inputs
+        and outputs if they're large. Setting this to False is very slow for
+        large outputs.
+    """
+    prior_printoptions = np.get_printoptions()
+    np.set_printoptions(
+        linewidth=NUMPY_LINEWIDTH,
+        threshold=None if summarize else sys.maxsize,
+        edgeitems=10)  # Can show more items since they won't clutter the logs.
+
+    path = os.path.join(trace_dir, f"{self.trace_name}__{self.backend}.txt")
+    with open(path, "w") as f:
+      f.write(str(self))
+
+    np.set_printoptions(**prior_printoptions)
+
+  def __iter__(self):
+    for call in self.calls:
+      yield call

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -104,28 +104,6 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     # Test independent state.
     self.assertEqual([1.], module.get_count())
 
-  def test_trace_inputs_and_outputs(self):
-    backend_info = tf_utils.BackendInfo.ALL['tf']
-    module = backend_info.CompiledModule(StatefulCountingModule, backend_info)
-
-    def trace_function(trace):
-      # No inputs or outpus
-      trace.increment()
-      # Only inputs
-      trace.increment_by([81.])
-      # Only outputs
-      trace.get_count()
-
-    trace = tf_utils.TracedModule(module, trace_function)
-
-    self.assertTrue(isinstance(trace.calls[0].inputs, tuple))
-    self.assertTrue(len(trace.calls[0].inputs) == 0)
-    self.assertTrue(isinstance(trace.calls[0].outputs, tuple))
-    self.assertTrue(len(trace.calls[0].outputs) == 0)
-
-    self.assertAllClose(trace.calls[1].inputs[0], [81.])
-    self.assertAllClose(trace.calls[2].outputs[0], [82.])
-
 
 if __name__ == '__main__':
   tf.test.main()

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -43,6 +43,10 @@ class StatefulCountingModule(tf.Module):
   def get_count(self):
     return self.count
 
+  @tf.function(input_signature=[tf.TensorSpec([1])])
+  def increment_by(self, value):
+    self.count.assign_add(value)
+
 
 class UtilsTests(tf.test.TestCase, parameterized.TestCase):
 
@@ -99,6 +103,28 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     self.assertEqual([0.], reinitialized_module.get_count())
     # Test independent state.
     self.assertEqual([1.], module.get_count())
+
+  def test_trace_inputs_and_outputs(self):
+    backend_info = tf_utils.BackendInfo.ALL['tf']
+    module = backend_info.CompiledModule(StatefulCountingModule, backend_info)
+
+    def trace_function(trace):
+      # No inputs or outpus
+      trace.increment()
+      # Only inputs
+      trace.increment_by([81.])
+      # Only outputs
+      trace.get_count()
+
+    trace = tf_utils.TracedModule(module, trace_function)
+
+    self.assertTrue(isinstance(trace.calls[0].inputs, tuple))
+    self.assertTrue(len(trace.calls[0].inputs) == 0)
+    self.assertTrue(isinstance(trace.calls[0].outputs, tuple))
+    self.assertTrue(len(trace.calls[0].outputs) == 0)
+
+    self.assertAllClose(trace.calls[1].inputs[0], [81.])
+    self.assertAllClose(trace.calls[2].outputs[0], [82.])
 
 
 if __name__ == '__main__':

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -43,10 +43,6 @@ class StatefulCountingModule(tf.Module):
   def get_count(self):
     return self.count
 
-  @tf.function(input_signature=[tf.TensorSpec([1])])
-  def increment_by(self, value):
-    self.count.assign_add(value)
-
 
 class UtilsTests(tf.test.TestCase, parameterized.TestCase):
 

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -56,6 +56,8 @@ package(
 SPECIAL_CASES = [
     "explicit_backend_test.py",
     "linspace_test.py",
+    "simple_arithmetic_trace_test.py",
+    "strings_trace_test.py",
 ]
 
 # keep sorted
@@ -199,6 +201,41 @@ iree_py_test(
         "driver=vmla",
         "driver=vulkan",
     ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+# Traced tests – Temporarily separate from the rest of the testing infra while
+# prototyping a change.
+
+iree_py_test(
+    name = "simple_arithmetic_trace_test",
+    srcs = ["simple_arithmetic_trace_test.py"],
+    args = [
+        "--reference_backend=tf",
+        "--target_backends=tf,iree_vmla,iree_llvmjit",
+    ],
+    main = "simple_arithmetic_trace_test.py",
+    python_version = "PY3",
+    tags = [
+        "driver=llvm",
+        "driver=vmla",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+iree_py_test(
+    name = "strings_trace_test_tf",
+    srcs = ["strings_trace_test.py"],
+    args = [
+        "--reference_backend=tf",
+        "--target_backends=tf",
+    ],
+    main = "strings_trace_test.py",
+    python_version = "PY3",
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -23,6 +23,7 @@ load(
     "INTREE_TENSORFLOW_PY_DEPS",
     "NUMPY_DEPS",
     "iree_py_binary",
+    "iree_py_test",
 )
 load(
     "//integrations/tensorflow/e2e/keras:iree_vision_test_suite.bzl",
@@ -82,6 +83,7 @@ Command arguments description:
 
 SPECIAL_CASES = [
     "vision_model_test.py",
+    "lstm_static_trace_test.py",
 ]
 
 VMLA_FAILING = [
@@ -226,6 +228,26 @@ iree_py_binary(
     srcs = ["train_vision_models_on_cifar.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+# Traced tests – Temporarily separate from the rest of the testing infra while
+# prototyping a change.
+
+iree_py_test(
+    name = "lstm_static_trace_test_vmla",
+    srcs = ["lstm_static_trace_test.py"],
+    args = [
+        "--reference_backend=tf",
+        "--target_backends=tf,iree_vmla",
+    ],
+    main = "lstm_static_trace_test.py",
+    python_version = "PY3",
+    tags = [
+        "driver=vmla",
+    ],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/keras/lstm_static_trace_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_trace_test.py
@@ -1,0 +1,63 @@
+# Lint as: python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Temporary duplicate of `lstm_static_test.py` for prototyping.
+
+# This test is the same as keras_lstm_test, but all shapes are static.
+# This stresses the TensorList lowering more specifically.
+
+import numpy as np
+from pyiree.tf.support import tf_test_utils
+from pyiree.tf.support import tf_utils
+import tensorflow.compat.v2 as tf
+
+NUM_UNITS = 10
+NUM_TIMESTEPS = 24
+NUM_BATCH = 7
+INPUT_SHAPE = [NUM_BATCH, NUM_TIMESTEPS, NUM_UNITS]
+
+
+class LstmStatic(tf.Module):
+
+  def __init__(self):
+    super(LstmStatic, self).__init__()
+    tf_utils.set_random_seed()
+    inputs = tf.keras.layers.Input(batch_size=NUM_BATCH, shape=INPUT_SHAPE[1:])
+    outputs = tf.keras.layers.LSTM(
+        units=NUM_UNITS, return_sequences=True)(
+            inputs)
+    self.m = tf.keras.Model(inputs, outputs)
+    self.predict = tf.function(
+        input_signature=[tf.TensorSpec(INPUT_SHAPE, tf.float32)])(
+            self.m.call)
+
+
+@tf_test_utils.compile_module(LstmStatic, exported_names=["predict"])
+class LstmTest(tf_test_utils.TracedModuleTestCase):
+
+  def test_lstm(self):
+
+    def predict(trace):
+      inputs = np.arange(
+          np.prod(INPUT_SHAPE), dtype=np.float32).reshape(INPUT_SHAPE)
+      trace.predict(inputs, rtol=1e-5, atol=1e-5)
+
+    self.compare_backends(predict)
+
+
+if __name__ == "__main__":
+  if hasattr(tf, "enable_v2_behavior"):
+    tf.enable_v2_behavior()
+  tf.test.main()

--- a/integrations/tensorflow/e2e/keras/lstm_static_trace_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_trace_test.py
@@ -49,10 +49,10 @@ class LstmTest(tf_test_utils.TracedModuleTestCase):
 
   def test_lstm(self):
 
-    def predict(trace):
+    def predict(module):
       inputs = np.arange(
           np.prod(INPUT_SHAPE), dtype=np.float32).reshape(INPUT_SHAPE)
-      trace.predict(inputs, rtol=1e-5, atol=1e-5)
+      module.predict(inputs, rtol=1e-5, atol=1e-5)
 
     self.compare_backends(predict)
 

--- a/integrations/tensorflow/e2e/simple_arithmetic_trace_test.py
+++ b/integrations/tensorflow/e2e/simple_arithmetic_trace_test.py
@@ -1,0 +1,69 @@
+# Lint as: python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Several baseline e2e simple arithmetic tests."""
+
+# Temporary near duplicate of `simple_arithmetic_test.py` for prototyping.
+
+import numpy as np
+from pyiree.tf.support import tf_test_utils
+import tensorflow.compat.v2 as tf
+
+
+class SimpleArithmeticModule(tf.Module):
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([4], tf.float32),
+      tf.TensorSpec([4], tf.float32)
+  ])
+  def simple_mul(self, a, b):
+    return a * b
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([128, 3072], tf.float32),
+      tf.TensorSpec([3072, 256], tf.float32),
+  ])
+  def simple_matmul(self, a, b):
+    return tf.matmul(a, b)
+
+
+@tf_test_utils.compile_module(SimpleArithmeticModule)
+class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
+
+  def test_simple_mul(self):
+
+    def simple_mul(trace):
+      a = np.array([1., 2., 3., 4.], dtype=np.float32)
+      b = np.array([400., 5., 6., 7.], dtype=np.float32)
+      c = trace.simple_mul(a, b)
+      trace.simple_mul(a, c)
+
+    self.compare_backends(simple_mul)
+
+  def test_simple_matmul(self):
+
+    def simple_matmul(trace):
+      np.random.seed(12345)
+      # Note: scaling by a small value to increase numerical stability.
+      a = np.random.random((128, 3072)).astype(np.float32) * 1e-3
+      b = np.random.random((3072, 256)).astype(np.float32) * 1e-3
+      trace.simple_matmul(a, b)
+
+    self.compare_backends(simple_matmul)
+
+
+if __name__ == "__main__":
+  if hasattr(tf, "enable_v2_behavior"):
+    tf.enable_v2_behavior()
+  tf.test.main()

--- a/integrations/tensorflow/e2e/simple_arithmetic_trace_test.py
+++ b/integrations/tensorflow/e2e/simple_arithmetic_trace_test.py
@@ -43,22 +43,22 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 
   def test_simple_mul(self):
 
-    def simple_mul(trace):
+    def simple_mul(module):
       a = np.array([1., 2., 3., 4.], dtype=np.float32)
       b = np.array([400., 5., 6., 7.], dtype=np.float32)
-      c = trace.simple_mul(a, b)
-      trace.simple_mul(a, c)
+      c = module.simple_mul(a, b)
+      module.simple_mul(a, c)
 
     self.compare_backends(simple_mul)
 
   def test_simple_matmul(self):
 
-    def simple_matmul(trace):
+    def simple_matmul(module):
       np.random.seed(12345)
       # Note: scaling by a small value to increase numerical stability.
       a = np.random.random((128, 3072)).astype(np.float32) * 1e-3
       b = np.random.random((3072, 256)).astype(np.float32) * 1e-3
-      trace.simple_matmul(a, b)
+      module.simple_matmul(a, b)
 
     self.compare_backends(simple_matmul)
 

--- a/integrations/tensorflow/e2e/strings_trace_test.py
+++ b/integrations/tensorflow/e2e/strings_trace_test.py
@@ -47,21 +47,21 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
 
   def test_print_ids(self):
 
-    def print_ids(trace):
+    def print_ids(module):
       input_ids = np.asarray(
           [[12, 10, 29, 28, 94, 15, 24, 27, 94, 25, 21, 10, 34],
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
-      trace.print_ids(input_ids)
+      module.print_ids(input_ids)
 
     self.compare_backends(print_ids)
 
   def test_strings_to_ids(self):
 
-    def strings_to_ids(trace):
+    def strings_to_ids(module):
       input_ids = np.asarray(
           [[12, 10, 29, 28, 94, 15, 24, 27, 94, 25, 21, 10, 34],
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
-      trace.strings_to_ids(input_ids)
+      module.strings_to_ids(input_ids)
 
     self.compare_backends(strings_to_ids)
 

--- a/integrations/tensorflow/e2e/strings_trace_test.py
+++ b/integrations/tensorflow/e2e/strings_trace_test.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Temporary duplicate of `strings_test.py` for prototyping.
+
+import numpy as np
+from pyiree.tf.support import tf_test_utils
+import string
+import tensorflow.compat.v2 as tf
+
+
+class StringsModule(tf.Module):
+  """A Module for converting a set of ids to the concatenated string."""
+
+  def __init__(self):
+    wordparts = [str(c) for c in string.printable]
+    self.wordparts = tf.constant(wordparts, tf.string)
+
+  @tf.function(input_signature=[
+      tf.TensorSpec((None, None), dtype=tf.int32),
+  ])
+  def print_ids(self, ids):
+    string_tensor = tf.strings.as_string(ids)
+    tf.print(string_tensor)
+
+  @tf.function(input_signature=[
+      tf.TensorSpec((None, None), dtype=tf.int32),
+  ])
+  def strings_to_ids(self, ids):
+    wps = tf.gather(self.wordparts, ids)
+    return tf.strings.reduce_join(wps, 1)
+
+
+@tf_test_utils.compile_module(StringsModule)
+class StringsTest(tf_test_utils.TracedModuleTestCase):
+
+  def test_print_ids(self):
+
+    def print_ids(trace):
+      input_ids = np.asarray(
+          [[12, 10, 29, 28, 94, 15, 24, 27, 94, 25, 21, 10, 34],
+           [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
+      trace.print_ids(input_ids)
+
+    self.compare_backends(print_ids)
+
+  def test_strings_to_ids(self):
+
+    def strings_to_ids(trace):
+      input_ids = np.asarray(
+          [[12, 10, 29, 28, 94, 15, 24, 27, 94, 25, 21, 10, 34],
+           [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
+      trace.strings_to_ids(input_ids)
+
+    self.compare_backends(strings_to_ids)
+
+
+if __name__ == "__main__":
+  if hasattr(tf, "enable_v2_behavior"):
+    tf.enable_v2_behavior()
+  tf.test.main()


### PR DESCRIPTION
This is a part of a larger shift toward integrating our testing infrastructure with generating artifacts for benchmarking. Part of how we are planning to doing this is by tracing the inputs and outputs to our `CompiledModules` during our tests, and then using those traces as inputs to `iree-benchmark-module`. The aim is for these traces to tell the benchmark module which (series of) inputs to use, and what outputs to check for while the benchmark is warming up.

This change focuses on prototyping what that shift will look like for our testing infra. A class `TracedModule` is added to capture the data described above, and only the functionality that the testing infra needs of it is developed here.

Changes:

- Adds a class `TracedModule` which wraps a `CompiledModule` to capture the inputs and outputs of its method calls.
  - Another class `ModuleCall` is used to record this information and cleanly display it.
  - A method `save_plaintext` saves a human readable copy of the trace to disk (example shown below).
  - A method `save_pickle` which saves pickled copies of the inputs and outputs to each call to this module (controlled by `FLAGS.pickle_args`).
  - The API is written such that the trace object can be treated as if it were the `CompiledModule` it was passed.
- `CompiledModuleTestCase` is temporarily duplicated as `TracedModuleTestCase` to prototype testing using `TracedModule`s. Other notable differences include:
  - A flag `--reference_backend` to perform a one-to-many comparisons between backends.
  - A method `_check_same` that automatically handles comparing outputs of multiple types.
- Adds three example tests using `TracedModuleTestCase`:
  - `simple_arithmetic_traced_test.py` shows generic functionality
  - `strings_traced_test.py`  shows string comparison.
  - `lstm_static_traced_test.py` shows that comparison tolerances can be overridden for each call.

Example string representations of `TracedModule`s.

```
Trace of SimpleArithmeticModule compiled to 'iree_vmla' on function 'simple_mul':
  1. Method: simple_mul
    Inputs:
      [1. 2. 3. 4.]
      [400.   5.   6.   7.]
    Outputs:
      [400.  10.  18.  28.]
    Tolerances:
      rtol=1e-06, atol=1e-06
  2. Method: simple_mul
    Inputs:
      [1. 2. 3. 4.]
      [400.  10.  18.  28.]
    Outputs:
      [400.  20.  54. 112.]
    Tolerances:
      rtol=1e-06, atol=1e-06

Trace of StringsModule compiled to 'tf' on function 'strings_to_ids':
  1. Method: strings_to_ids
    Inputs:
      [[12 10 29 28 94 15 24 27 94 25 21 10 34]
       [13 24 16 28 94 15 24 27 94 28 29 10 34]]
    Outputs:
      [b'cats for play' b'dogs for stay']
    Tolerances:
      rtol=1e-06, atol=1e-06
```