### PR TITLE
Avoid running docker builds as root

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86/integrations/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86/integrations/build_kokoro.sh
@@ -26,16 +26,10 @@ set -o pipefail
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-WORKDIR="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docker_common.sh"
 
-# TODO(#2653): Don't run docker as root
-DOCKER_RUN_ARGS=(
-      # Make the source repository available
-      --volume="${WORKDIR?}:${WORKDIR?}"
-      --workdir="${WORKDIR?}"
-      # Delete the container after
-      --rm
-)
+# Sets DOCKER_RUN_ARGS
+docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   gcr.io/iree-oss/bazel-tensorflow:prod \
@@ -43,8 +37,7 @@ docker run "${DOCKER_RUN_ARGS[@]?}" \
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.
-# TODO(#2653): Remove sudo when docker doesn't run as root
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
 
 # Print out artifacts dir contents after deleting them as a coherence check.
 ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/build_tools/kokoro/gcp_ubuntu/docker_common.sh
+++ b/build_tools/kokoro/gcp_ubuntu/docker_common.sh
@@ -22,15 +22,37 @@
 # Sets the environment variable DOCKER_RUN_ARGS to be used by subsequent
 # `docker run` invocations.
 function docker_setup() {
-    # Setup to run docker as the current user.
-    # Provide a place to mount files that would normally be under /etc/
+    # Make the source repository available and launch containers in that
+    # directory.
+    local workdir="${KOKORO_ARTIFACTS_DIR?}/github/iree"
+    DOCKER_RUN_ARGS=(
+      --volume="${workdir?}:${workdir?}"
+      --workdir="${workdir?}"
+    )
+
+    # Delete the container after the run is complete.
+    DOCKER_RUN_ARGS+=(--rm)
+
+
+    # Run as the current user and group. If only it were this simple.
+    DOCKER_RUN_ARGS+=(--user="$(id -u):$(id -g)")
+
+
+    # The Docker container doesn't know about the users and groups of the host
+    # system. We have to tell it. This is just a mapping of IDs to names though.
+    # The thing that really matters is the IDs, so the key thing is that Docker
+    # writes files as the same ID as the current user, which we set above, but
+    # without the group and passwd file, lots of things get upset because they
+    # don't recognize the current user ID (e.g. `whoami` fails).
+    # So we make the container share the host mapping, which guarantees that the
+    # current user is mapped. If there was any user or group in the container
+    # that we cared about, this wouldn't work, but luckily we don't.
     # We don't just mount the real /etc/passwd and /etc/group because Google
     # Linux workstations do some interesting stuff with user/group permissions
     # such that they don't contain the information about normal users and we
     # want these scripts to be runnable locally for debugging.
+    # Instead we dump the results of `getent` to some fake files.
     local fake_etc_dir="${KOKORO_ROOT?}/fake_etc"
-    # Bazel wants a home directory
-    # TODO: more explanation if this works
     mkdir -p "${fake_etc_dir?}"
 
     local fake_group="${fake_etc_dir?}/group"
@@ -39,26 +61,34 @@ function docker_setup() {
     getent group > "${fake_group?}"
     getent passwd > "${fake_passwd?}"
 
-    local fake_home="${KOKORO_ROOT?}/fake_home"
-    mkdir -p "${fake_home}"
-
-    local workdir="${KOKORO_ARTIFACTS_DIR?}/github/iree"
-
-    DOCKER_RUN_ARGS=(
-      # Run as the current user and group
-      --user="$(id -u):$(id -g)"
-      # Make the source repository available
-      --volume="${workdir?}:${workdir?}"
-      --workdir="${workdir?}"
-      # Tell docker about the host users and groups. Bazel needs this
-      # information, but it also makes some other things more pleasant.
+    DOCKER_RUN_ARGS+=(
       --volume="${fake_group?}:/etc/group:ro"
       --volume="${fake_passwd?}:/etc/passwd:ro"
-      --volume="${fake_home?}:${HOME?}"
-      # Make gcloud credentials available. This isn't necessary when running
-      # in GCE but enables using this script locally with RBE.
-      --volume="${HOME?}/.config/gcloud:${HOME?}/.config/gcloud:ro"
-      # Delete the container after
-      --rm
+    )
+
+
+    # Bazel stores its cache in the user home directory by default. It's
+    # possible to override this, but that would require changing our Bazel
+    # startup options, which means polluting all our scripts and making them not
+    # runnable locally. Instead, we give it a special home directory to write
+    # into. We don't just mount the user home directory (or some subset thereof)
+    # for two reasons:
+    #   1. We probably don't want to just implicitly share this between runs or
+    #      pollute a local directory when running locally.
+    #   2. When running with Kokoro, we mount a local scratch SSD to KOKORO_ROOT
+    #      whereas the home directory is on the persistent SSD boot disk. It
+    #      turns out that makes a huge difference for the Bazel cache directory.
+    local fake_home_dir="${KOKORO_ROOT?}/fake_home"
+    mkdir -p "${fake_home_dir}"
+
+    DOCKER_RUN_ARGS+=(
+      --env HOME="${fake_home_dir?}"
+      --volume="${fake_home_dir?}:${fake_home_dir?}"
+    )
+
+    # Make gcloud credentials available. This isn't necessary when running in
+    # GCE but enables using this script locally with RBE.
+    DOCKER_RUN_ARGS+=(
+      --volume="${HOME?}/.config/gcloud:${fake_home_dir?}/.config/gcloud:ro"
     )
 }

--- a/build_tools/kokoro/gcp_ubuntu/docker_common.sh
+++ b/build_tools/kokoro/gcp_ubuntu/docker_common.sh
@@ -29,6 +29,8 @@ function docker_setup() {
     # such that they don't contain the information about normal users and we
     # want these scripts to be runnable locally for debugging.
     local fake_etc_dir="${KOKORO_ROOT?}/fake_etc"
+    # Bazel wants a home directory
+    # TODO: more explanation if this works
     mkdir -p "${fake_etc_dir?}"
 
     local fake_group="${fake_etc_dir?}/group"
@@ -36,6 +38,9 @@ function docker_setup() {
 
     getent group > "${fake_group?}"
     getent passwd > "${fake_passwd?}"
+
+    local fake_home="${KOKORO_ROOT?}/fake_home"
+    mkdir -p "${fake_home}"
 
     local workdir="${KOKORO_ARTIFACTS_DIR?}/github/iree"
 
@@ -49,9 +54,7 @@ function docker_setup() {
       # information, but it also makes some other things more pleasant.
       --volume="${fake_group?}:/etc/group:ro"
       --volume="${fake_passwd?}:/etc/passwd:ro"
-      # Allow Bazel to write its special cache directories. This is the
-      # default path Bazel will write to.
-      --volume="${HOME?}/.cache/bazel:${HOME?}/.cache/bazel"
+      --volume="${fake_home?}:${HOME?}"
       # Make gcloud credentials available. This isn't necessary when running
       # in GCE but enables using this script locally with RBE.
       --volume="${HOME?}/.config/gcloud:${HOME?}/.config/gcloud:ro"

--- a/build_tools/kokoro/gcp_ubuntu/docker_common.sh
+++ b/build_tools/kokoro/gcp_ubuntu/docker_common.sh
@@ -82,13 +82,12 @@ function docker_setup() {
     mkdir -p "${fake_home_dir}"
 
     DOCKER_RUN_ARGS+=(
-      --env HOME="${fake_home_dir?}"
-      --volume="${fake_home_dir?}:${fake_home_dir?}"
+      --volume="${fake_home_dir?}:${HOME?}"
     )
 
     # Make gcloud credentials available. This isn't necessary when running in
     # GCE but enables using this script locally with RBE.
     DOCKER_RUN_ARGS+=(
-      --volume="${HOME?}/.config/gcloud:${fake_home_dir?}/.config/gcloud:ro"
+      --volume="${HOME?}/.config/gcloud:${HOME?}/.config/gcloud:ro"
     )
 }


### PR DESCRIPTION
Instead of mounting the user's existing Bazel cache, create a fake home
directory under the Kokoro root directory.

This is another attempt at https://github.com/google/iree/pull/2566
which had to be rolled back for the Bazel integrations build because it
made it three times slower. It turns out the root cause there is that
the docker container volumes are by default mounted in /tmpfs which on
Kokoro is a local-ssd. The home directory, on the other hand, is a
persistent SSD. The integrations job is running Bazel with 64 cores,
which means it's IO bound. The difference turns out to be substantial.

Fixes https://github.com/google/iree/issues/2653

Tested:
Ran simulate_kokoro on the core build locally to confirm this doesn't
break RBE cloud credentials.
The integrations presubmit on this PR takes 20 minutes, as before.