### PR TITLE
Include python headers even if nested.

### DIFF
--- a/bindings/python/build_tools/python/generate_build.py
+++ b/bindings/python/build_tools/python/generate_build.py
@@ -64,7 +64,7 @@ config_setting(
 
 cc_library(
     name = "python_headers",
-    hdrs = glob(["include/*.h"]),
+    hdrs = glob(["include/**/*.h"]),
     srcs = [{extra_srcs}],
     includes = ["include"],
     linkopts = [],


### PR DESCRIPTION
* Some python versions/installations use trampoline headers at the root.