### PR TITLE
Working around duplicate func->llvm.func rewrites.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
@@ -144,8 +144,9 @@ class ConvertFuncWithHALInterface : public ConvertToLLVMPattern {
  public:
   explicit ConvertFuncWithHALInterface(MLIRContext *context,
                                        LLVMTypeConverter &typeconverter)
-      : ConvertToLLVMPattern(FuncOp::getOperationName(), context,
-                             typeconverter) {}
+      : ConvertToLLVMPattern(
+            mlir::FuncOp::getOperationName(), context, typeconverter,
+            LowerToLLVMOptions::getDefaultOptions(), 65535 - 1) {}
 
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,
@@ -345,8 +346,15 @@ void ConvertToLLVMPass::runOnOperation() {
                   RemoveInterfaceOpPattern>(&getContext(), converter);
   LLVMConversionTarget target(getContext());
   target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
-  if (failed(applyPartialConversion(module, target, patterns)))
+  target.addIllegalOp<IREE::PlaceholderOp>();
+  target.addDynamicallyLegalOp<FuncOp>([](FuncOp funcOp) {
+    bool any = false;
+    funcOp.walk([&](IREE::PlaceholderOp placeholderOp) { any = true; });
+    return any ? false : true;
+  });
+  if (failed(applyPartialConversion(module, target, patterns))) {
     signalPassFailure();
+  }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass() {

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRTarget.cpp
@@ -52,6 +52,9 @@ class LLVMIRTargetBackend final : public TargetBackend {
     // At this moment we are leaving MLIR LLVM dialect land translating module
     // into target independent LLVMIR.
     auto llvmModule = mlir::translateModuleToLLVMIR(targetOp.getInnerModule());
+    if (!llvmModule) {
+      return targetOp.emitError("Failed to translate executable to LLVM IR");
+    }
 
     // Create invocation function an populate entry_points.
     iree::LLVMIRExecutableDefT llvmIrExecutableDef;


### PR DESCRIPTION
This makes builds with MSVC pass; hopefully it isn't whackamole with clang.