### PR TITLE
Add linker scripts to cmake pyiree builds to hide symbols.

### DIFF
--- a/bindings/python/pyiree/compiler/CMakeLists.txt
+++ b/bindings/python/pyiree/compiler/CMakeLists.txt
@@ -26,6 +26,8 @@ iree_pyext_module(
     PyExtCompiler
   MODULE_NAME
     binding
+  UNIX_LINKER_SCRIPT
+    "unix_version.lds"
   SRCS
     "initialize_module.cc"
   PYEXT_DEPS

--- a/bindings/python/pyiree/compiler/unix_version.lds
+++ b/bindings/python/pyiree/compiler/unix_version.lds
@@ -1,0 +1,4 @@
+{
+  global: PyInit_binding;
+  local: *;
+};

--- a/bindings/python/pyiree/rt/CMakeLists.txt
+++ b/bindings/python/pyiree/rt/CMakeLists.txt
@@ -50,6 +50,8 @@ iree_pyext_module(
   MODULE_NAME binding
   SRCS
     "initialize_module.cc"
+  UNIX_LINKER_SCRIPT
+    "unix_version.lds"
   PYEXT_DEPS
     ::PyExtRtLib
     bindings::python::pyiree::common::PyextCommonLib

--- a/bindings/python/pyiree/rt/unix_version.lds
+++ b/bindings/python/pyiree/rt/unix_version.lds
@@ -1,0 +1,4 @@
+{
+  global: PyInit_binding;
+  local: *;
+};

--- a/build_tools/cmake/iree_multipy.cmake
+++ b/build_tools/cmake/iree_multipy.cmake
@@ -98,7 +98,7 @@ endmacro()
 function(iree_pyext_module)
   cmake_parse_arguments(ARG
     ""
-    "NAME;MODULE_NAME"
+    "NAME;MODULE_NAME;UNIX_LINKER_SCRIPT"
     "SRCS;COPTS;DEPS;PYEXT_DEPS"
     ${ARGN})
   _setup_iree_pyext_names()
@@ -126,6 +126,14 @@ function(iree_pyext_module)
         PREFIX "${IREE_MULTIPY_${V}_PREFIX}"
         SUFFIX "${IREE_MULTIPY_${V}_SUFFIX}${IREE_MULTIPY_${V}_EXTENSION}"
     )
+
+    # Link flags.
+    if(UNIX AND NOT APPLE)  # Apple does not support linker scripts.
+      if(ARG_UNIX_LINKER_SCRIPT)
+        set_target_properties(${VER_NAME} PROPERTIES LINK_FLAGS
+          "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${ARG_UNIX_LINKER_SCRIPT}")
+      endif()
+    endif()
 
     iree_pyext_pybind11_options(${VER_NAME})
     target_include_directories(${VER_NAME}


### PR DESCRIPTION
* Keeps multiple extensions in the same process from interfering with each other.
* This was dropped at some point when porting and is required.

Fixes #2706