### PR TITLE
Use !llvm<i32*> instead of !llvm<i64*> to pass push_constant

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
@@ -218,11 +218,11 @@ class ConvertFuncWithHALInterface : public ConvertToLLVMPattern {
 
     TypeConverter::SignatureConversion signatureConverter(/*numOrigInputs=*/0);
 
-    // func foo(%packed_buffer_args: !llvm<i8**>, %push_constant: !llvm<i64*>)
+    // func foo(%packed_buffer_args: !llvm<i8**>, %push_constant: !llvm<i32*>)
     auto packedBuffersArgsTy =
         LLVM::LLVMType::getInt8PtrTy(typeConverter.getDialect()).getPointerTo();
     auto pushConstantArgTy =
-        LLVM::LLVMType::getInt64Ty(typeConverter.getDialect()).getPointerTo();
+        LLVM::LLVMType::getInt32Ty(typeConverter.getDialect()).getPointerTo();
     signatureConverter.addInputs(packedBuffersArgsTy);
     signatureConverter.addInputs(pushConstantArgTy);
 
@@ -279,7 +279,9 @@ class ConvertFuncWithHALInterface : public ConvertToLLVMPattern {
                                                    newFuncOp.getArgument(1),
                                                    ArrayRef<Value>({offset}));
       Value dimConstant = builder.create<LLVM::LoadOp>(loc, constPtr);
-      rewriter.replaceOp(loadOp, dimConstant);
+      Value dimConstantCasted = builder.create<LLVM::ZExtOp>(
+          loc, typeConverter.convertType(loadOp.getType()), dimConstant);
+      rewriter.replaceOp(loadOp, dimConstantCasted);
     }
 
     rewriter.eraseOp(funcOp);

--- a/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
@@ -13,7 +13,7 @@ func @convert_dynamic_shape() -> f32 {
 hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 }
-// CHECK: llvm.func @convert_dynamic_shape(%[[ARG0:.+]]: !llvm<"i8**">, %[[ARG1:.+]]: !llvm<"i64*">)
+// CHECK: llvm.func @convert_dynamic_shape(%[[ARG0:.+]]: !llvm<"i8**">, %[[ARG1:.+]]: !llvm<"i32*">)
 // CHECK: %[[PACKED_ARGS_PTR:.+]] = llvm.bitcast %[[ARG0]] : !llvm<"i8**"> to !llvm<"{ float* }*">
 // CHECK: %[[PACKED_ARGS:.+]] = llvm.load %[[PACKED_ARGS_PTR]] : !llvm<"{ float* }*">
 // CHECK: %[[MEMREF0_DATA_PTR:.+]] = llvm.extractvalue %[[PACKED_ARGS]][0] : !llvm<"{ float* }">
@@ -21,13 +21,15 @@ hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = 
 // CHECK: %[[MEMREF0_0:.+]] = llvm.insertvalue %[[MEMREF0_DATA_PTR]], %[[MEMREF0]][0] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
 // CHECK: %[[MEMREF0_1:.+]] = llvm.insertvalue %[[MEMREF0_DATA_PTR]], %[[MEMREF0_0]][1] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
 // CHECK: %[[CONST0:.+]] = llvm.mlir.constant(0 : i64) : !llvm.i64
-// CHECK: %[[DIM0_PTR:.+]] = llvm.getelementptr %[[ARG1]][%[[CONST0]]] : (!llvm<"i64*">, !llvm.i64) -> !llvm<"i64*">
-// CHECK: %[[DIM0:.+]] = llvm.load %[[DIM0_PTR]] : !llvm<"i64*">
+// CHECK: %[[DIM0_PTR:.+]] = llvm.getelementptr %[[ARG1]][%[[CONST0]]] : (!llvm<"i32*">, !llvm.i64) -> !llvm<"i32*">
+// CHECK: %[[DIM0:.+]] = llvm.load %[[DIM0_PTR]] : !llvm<"i32*">
+// CHECK: %[[DIM0CASTED:.+]] = llvm.zext %[[DIM0]] : !llvm.i32 to !llvm.i64
 // CHECK: %[[CONST1:.+]] = llvm.mlir.constant(1 : i64) : !llvm.i64
-// CHECK: %[[DIM1_PTR:.+]] = llvm.getelementptr %[[ARG1]][%[[CONST1]]] : (!llvm<"i64*">, !llvm.i64) -> !llvm<"i64*">
-// CHECK: %[[DIM1:.+]] = llvm.load %[[DIM1_PTR]] : !llvm<"i64*">
-// CHECK: %[[MEMREF0_2:.+]] = llvm.insertvalue %[[DIM0]], %[[MEMREF0_1]][3, 0] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
-// CHECK: %[[MEMREF0_3:.+]] = llvm.insertvalue %[[DIM1]], %[[MEMREF0_2]][3, 1] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
+// CHECK: %[[DIM1_PTR:.+]] = llvm.getelementptr %[[ARG1]][%[[CONST1]]] : (!llvm<"i32*">, !llvm.i64) -> !llvm<"i32*">
+// CHECK: %[[DIM1:.+]] = llvm.load %[[DIM1_PTR]] : !llvm<"i32*">
+// CHECK: %[[DIM1CASTED:.+]] = llvm.zext %[[DIM1]] : !llvm.i32 to !llvm.i64
+// CHECK: %[[MEMREF0_2:.+]] = llvm.insertvalue %[[DIM0CASTED]], %[[MEMREF0_1]][3, 0] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
+// CHECK: %[[MEMREF0_3:.+]] = llvm.insertvalue %[[DIM1CASTED]], %[[MEMREF0_2]][3, 1] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
 // CHECK: %[[CONST1_STRIDE:.+]] = llvm.mlir.constant(1 : index) : !llvm.i64
 // CHECK: %[[MEMREF0_4:.+]] = llvm.insertvalue %[[CONST1_STRIDE]], %[[MEMREF0_3]][4, 1] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">
 // CHECK: %[[STRIDE_DIM1:.+]] = llvm.extractvalue %[[MEMREF0_4]][4, 1] : !llvm<"{ float*, float*, i64, [2 x i64], [2 x i64] }">

--- a/iree/hal/dylib/dylib_executable.cc
+++ b/iree/hal/dylib/dylib_executable.cc
@@ -97,7 +97,7 @@ struct DyLibDispatchState : public HostExecutable::DispatchState {
   DyLibDispatchState() = default;
   void* entry_function = nullptr;
   absl::InlinedVector<void*, 4> args;
-  absl::InlinedVector<int64_t, 4> push_constant;
+  absl::InlinedVector<int32_t, 4> push_constant;
 };
 
 StatusOr<ref_ptr<HostExecutable::DispatchState>>
@@ -124,7 +124,6 @@ DyLibExecutable::PrepareDispatch(const DispatchParams& params) {
       dispatch_state->args.push_back(data);
     }
   }
-  // TODO(ataei): Consider moving this casting to codegen side ?!
   for (int i = 0; i < params.push_constants->values.size(); ++i) {
     dispatch_state->push_constant.push_back(params.push_constants->values[i]);
   }
@@ -138,7 +137,7 @@ Status DyLibExecutable::DispatchTile(DispatchState* state,
   auto* dispatch_state = static_cast<DyLibDispatchState*>(state);
 
   auto entry_function =
-      (void (*)(void**, int64_t*))dispatch_state->entry_function;
+      (void (*)(void**, int32_t*))dispatch_state->entry_function;
   entry_function(dispatch_state->args.data(),
                  dispatch_state->push_constant.data());
 

--- a/iree/hal/llvmjit/llvmjit_executable.cc
+++ b/iree/hal/llvmjit/llvmjit_executable.cc
@@ -111,7 +111,7 @@ struct LLVMJITDispatchState : public HostExecutable::DispatchState {
 
   llvm::JITEvaluatedSymbol symbol;
   llvm::SmallVector<void*, 4> args;
-  llvm::SmallVector<int64_t, 4> push_constant;
+  llvm::SmallVector<int32_t, 4> push_constant;
 };
 
 StatusOr<ref_ptr<HostExecutable::DispatchState>>
@@ -151,7 +151,7 @@ Status LLVMJITExecutable::DispatchTile(DispatchState* state,
   auto* dispatch_state = static_cast<LLVMJITDispatchState*>(state);
 
   auto func_ptr =
-      (void (*)(void**, int64_t*))dispatch_state->symbol.getAddress();
+      (void (*)(void**, int32_t*))dispatch_state->symbol.getAddress();
   func_ptr(dispatch_state->args.data(), dispatch_state->push_constant.data());
 
   return OkStatus();


### PR DESCRIPTION
Pass push_constant as array of int32 values and zero-extend to int64 when filling indices.