### PR TITLE
Enables `conv_test` on vulkan.

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -84,7 +84,6 @@ LLVM_FAILING = [
 VULKAN_FAILING = [
     "broadcasting_test.py",
     "control_flow_test.py",
-    "conv_test.py",
     "depth_conv_test.py",
     "dynamic_mlp_relu_test.py",
     "dynamic_mlp_test.py",
@@ -93,7 +92,6 @@ VULKAN_FAILING = [
     "matrix_ops_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
-    "sliding_window_test.py",  # TODO(#2659)
     "strings_test.py",
 ]
 

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -92,6 +92,7 @@ VULKAN_FAILING = [
     "matrix_ops_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
+    "sliding_window_test.py",  # TODO(#2659) Failing on nvidia, passing on swiftshader.
     "strings_test.py",
 ]
 


### PR DESCRIPTION
`conv_test` is passing locally with swiftshader, internally and in the CI on an Nvidia GPU. Also added a note that `sliding_window_test` passes on SwiftShader (but fails on an Nvidia GPU).