### PR TITLE
Enables newly passing `MobileNet` and `MobileNetV2` vision tests

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -185,11 +185,21 @@ iree_vision_test_suite(
         # interpreter and vulkan backends for these tests.
         {
             "models": [
-                "MobileNet",
                 "MobileNetV2",
             ],
             "datasets": [
                 "cifar10",
+            ],
+            "backends": [
+                "iree_vulkan",
+            ],
+        },
+        {
+            "models": [
+                "MobileNet",
+                "MobileNetV2",
+            ],
+            "datasets": [
                 "imagenet",
             ],
             "backends": [


### PR DESCRIPTION
This change enables the following previously failing configurations:
- `MobileNet, cifar10, iree_llvmjit`
- `MobileNet, cifar10, iree_vulkan`
- `MobileNetV2, cifar10, iree_llvmjit`

I tested that these are passing locally in OSS with `swiftshader` and internally.