### PR TITLE
Refactor BackendInfo, remove tf_also, fully support duplicate backends

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -427,26 +427,15 @@ class TracedModuleTestCase(tf.test.TestCase):
     # Setup the directory for saving compilation artifacts and traces.
     cls._artifacts_dir = _setup_artifacts_dir(cls._module_class.__name__)
 
-    # Setup crash reproducer for the test.
-    crash_reproducer_path = os.path.join(cls._artifacts_dir, "reproducer.mlir")
-    compiler.Context.default_crash_reproducer_path = crash_reproducer_path
-
     # Create a CompiledModule for the reference backend and each target backend.
-    try:
-      ref_backend_info = tf_utils.BackendInfo(FLAGS.reference_backend,
-                                              f"{FLAGS.reference_backend}_ref")
-      cls._ref_module = cls._compile(ref_backend_info)
+    ref_backend_info = tf_utils.BackendInfo(FLAGS.reference_backend,
+                                            f"{FLAGS.reference_backend}_ref")
+    cls._ref_module = cls._compile(ref_backend_info)
 
-      tar_backend_infos = get_target_backends()
-      cls._tar_modules = [
-          cls._compile(backend_info) for backend_info in tar_backend_infos
-      ]
-    finally:
-      # TODO(meadowlark): Move this into tf_util.compile_tf_module to prevent
-      # overwritting `reproducer.mlir`.
-      # Disable crash reproducer (to avoid inadvertently overwriting this
-      # path if there are multiple TestCases in the same file).
-      compiler.Context.default_crash_reproducer_path = None
+    tar_backend_infos = get_target_backends()
+    cls._tar_modules = [
+        cls._compile(backend_info) for backend_info in tar_backend_infos
+    ]
 
   def setUp(self):
     # Ran before each unit test.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -112,7 +112,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       module.get_count()
 
     module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                       tf_utils.BackendInfo.ALL['tf'])
+                                       tf_utils.BackendInfo('tf'))
     trace = tf_test_utils.Trace(module, trace_function)
     trace_function(tf_test_utils.TracedModule(module, trace))
 
@@ -135,12 +135,12 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       module.decrement()
 
     tf_module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                          tf_utils.BackendInfo.ALL['tf'])
+                                          tf_utils.BackendInfo('tf'))
     tf_trace = tf_test_utils.Trace(tf_module, tf_function)
     tf_function(tf_test_utils.TracedModule(tf_module, tf_trace))
 
     vmla_module = tf_utils.IreeCompiledModule(
-        StatefulCountingModule, tf_utils.BackendInfo.ALL['iree_vmla'])
+        StatefulCountingModule, tf_utils.BackendInfo('iree_vmla'))
     vmla_trace = tf_test_utils.Trace(vmla_module, vmla_function)
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 
@@ -156,12 +156,12 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       module.increment_by(np.array([22.], dtype=np.float32))
 
     tf_module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                          tf_utils.BackendInfo.ALL['tf'])
+                                          tf_utils.BackendInfo('tf'))
     tf_trace = tf_test_utils.Trace(tf_module, tf_function)
     tf_function(tf_test_utils.TracedModule(tf_module, tf_trace))
 
     vmla_module = tf_utils.IreeCompiledModule(
-        StatefulCountingModule, tf_utils.BackendInfo.ALL['iree_vmla'])
+        StatefulCountingModule, tf_utils.BackendInfo('iree_vmla'))
     vmla_trace = tf_test_utils.Trace(vmla_module, vmla_function)
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -397,4 +397,4 @@ class BackendInfo:
   @staticmethod
   def get_all_backends():
     """Returns a list of all BackendInfo configurations."""
-    return [BackendInfo(backend_name) for backend_name in _BACKEND_NAME_TO_INFO]
+    return [BackendInfo(backend_name) for backend_name in self._NAME_TO_INFO]

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -117,7 +117,7 @@ VULKAN_PASSING = glob(
 iree_e2e_test_suite(
     name = "e2e_tests",
     backends_to_srcs = {
-        "tf_also": TF_PASSING,
+        "tf": TF_PASSING,
         "iree_vmla": VMLA_PASSING,
         "iree_llvmjit": LLVM_PASSING,
         "iree_vulkan": VULKAN_PASSING,
@@ -154,7 +154,7 @@ iree_e2e_test_suite(
     # TODO(#2082): `linspace_test.py` fails in the `bazel-tensorflow` image.
     name = "linspace_tests",
     backends_to_srcs = {
-        "tf_also": ["linspace_test.py"],
+        "tf": ["linspace_test.py"],
         "iree_vmla": ["linspace_test.py"],
     },
     reference_backend = "tf",

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -40,7 +40,7 @@ When using Keras models or tf.Modules with functions that IREE can't compile,
 from pyiree.tf.support import tf_utils
 vmla_module = tf_utils.IreeCompiledModule(
     module_class=KerasTFModuleClass,
-    backend_info=tf_utils.BackendInfo.ALL['iree_vmla'],
+    backend_info=tf_utils.BackendInfo('iree_vmla'),
     exported_names=['predict'])
 vmla_module.predict(...)
 ```

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -122,7 +122,7 @@ VULKAN_PASSING = glob(
 iree_e2e_test_suite(
     name = "keras_tests",
     backends_to_srcs = {
-        "tf_also": TF_PASSING,
+        "tf": TF_PASSING,
         "iree_vmla": VMLA_PASSING,
         "iree_llvmjit": LLVM_PASSING,
         "iree_vulkan": VULKAN_PASSING,
@@ -154,7 +154,7 @@ iree_e2e_test_suite(
 iree_vision_test_suite(
     name = "vision_internal_tests",
     backends = [
-        "tf_also",
+        "tf",
         "iree_vmla",
         "iree_llvmjit",
         "iree_vulkan",
@@ -171,7 +171,7 @@ iree_vision_test_suite(
 iree_vision_test_suite(
     name = "vision_external_tests",
     backends = [
-        "tf_also",
+        "tf",
         "iree_vmla",
         "iree_llvmjit",
         "iree_vulkan",

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -24,10 +24,10 @@ import os
 import subprocess
 
 REFERENCE_BACKEND = 'tf'
-# Assumes that tests are expanded for the tf_also, iree_vmla, iree_llvmjit and
+# Assumes that tests are expanded for the tf, iree_vmla, iree_llvmjit and
 # iree_vulkan backends.
 BACKENDS_TO_TITLES = collections.OrderedDict([
-    ('tf_also', 'tensorflow'),
+    ('tf', 'tensorflow'),
     ('iree_vmla', 'vmla'),
     ('iree_llvmjit', 'llvm-ir'),
     ('iree_vulkan', 'vulkan-spirv'),


### PR DESCRIPTION
`BackendInfo` is refactored from a wrapper around a set of `NamedTuple`s into it's own class. This allows for the name attribute to be overridden, which is necessary for supporting saving artifacts for duplicate backends (e.g. two copies of `"iree_vmla"`). It also provides a cleaner API for compiling modules and getting all `BackendInfo` configurations.

Changes this allows:

- Compilation artifacts and traces from duplicate target backends will not overwrite each other. Instead artifacts for each backend are saved with an index (e.g. `trace__iree_vmla_0.txt`, `trace__iree_vmla_1.txt` and so on).
- The reference backend will have `_ref` appended to it's name (e.g. `trace__tf_ref.txt` or `trace__iree_vmla_ref.txt`).
- `tf_also` is removed.


Example artifacts:

```
SimpleArithmeticModule
├── compiled__iree_llvmjit.vmfb
├── compiled__iree_vmla.vmfb
├── compiled__iree_vulkan.vmfb
├── iree_input.mlir
├── tf_input.mlir
└── traces
    ├── simple_matmul__iree_llvmjit.txt
    ├── simple_matmul__iree_vmla.txt
    ├── simple_matmul__iree_vulkan.txt
    ├── simple_matmul__tf_ref.txt
    ├── simple_matmul__tf.txt
    ├── simple_mul__iree_llvmjit.txt
    ├── simple_mul__iree_vmla.txt
    ├── simple_mul__iree_vulkan.txt
    ├── simple_mul__tf_ref.txt
    └── simple_mul__tf.txt
```