### PR TITLE
Add shape and dtype information to e2e logs

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -138,6 +138,12 @@ class ModuleCall:
     """Gets the floating point tolerances associated with this call."""
     return self.rtol, self.atol
 
+  def _get_shape_and_dtype(self, value):
+    if isinstance(value, np.ndarray):
+      return tf_utils.get_shape_and_dtype(value, allow_non_mlir_dtype=True)
+    else:
+      return str(type(value))
+
   def __str__(self):
     prior_printoptions = np.get_printoptions()
     np.set_printoptions(linewidth=NUMPY_LINEWIDTH)
@@ -145,11 +151,11 @@ class ModuleCall:
     header = f"Method: {self.method}"
     inputs = "\n".join(_indent(str(value)) for value in self.inputs)
     input_shapes = ", ".join(
-        tf_utils.get_mlir_shape_and_dtype(value) for value in self.inputs)
+        self._get_shape_and_dtype(value) for value in self.inputs)
 
     outputs = "\n".join(_indent(str(value)) for value in self.outputs)
     output_shapes = ", ".join(
-        tf_utils.get_mlir_shape_and_dtype(value) for value in self.outputs)
+        self._get_shape_and_dtype(value) for value in self.outputs)
 
     tolerances = _indent(f"rtol={self.rtol}, atol={self.atol}")
     body = (f"Inputs: {input_shapes}\n{inputs}\n"

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -144,9 +144,17 @@ class ModuleCall:
 
     header = f"Method: {self.method}"
     inputs = "\n".join(_indent(str(value)) for value in self.inputs)
+    input_shapes = ", ".join(
+        tf_utils.get_mlir_shape_and_dtype(value) for value in self.inputs)
+
     outputs = "\n".join(_indent(str(value)) for value in self.outputs)
+    output_shapes = ", ".join(
+        tf_utils.get_mlir_shape_and_dtype(value) for value in self.outputs)
+
     tolerances = _indent(f"rtol={self.rtol}, atol={self.atol}")
-    body = f"Inputs:\n{inputs}\nOutputs:\n{outputs}\nTolerances:\n{tolerances}"
+    body = (f"Inputs: {input_shapes}\n{inputs}\n"
+            f"Outputs: {output_shapes}\n{outputs}"
+            f"\nTolerances:\n{tolerances}")
     result = f"{header}\n{_indent(body)}"
 
     np.set_printoptions(**prior_printoptions)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -69,15 +69,19 @@ def to_mlir_type(dtype):
     raise TypeError(f"Expected integer or floating type, but got {dtype}")
 
 
+def get_mlir_shape_and_dtype(array):
+  shape_dtype = [str(dim) for dim in list(array.shape)]
+  shape_dtype.append(to_mlir_type(array.dtype))
+  return "x".join(shape_dtype)
+
+
 def save_input_values(inputs, artifacts_dir=None):
   """Saves input values with IREE tools format if `artifacts_dir` is set."""
   result = []
   for array in inputs:
-    shape = [str(dim) for dim in list(array.shape)]
-    shape.append(to_mlir_type(array.dtype))
-    shape = "x".join(shape)
+    shape_dtype = get_mlir_shape_and_dtype(array)
     values = " ".join([str(x) for x in array.flatten()])
-    result.append(f"{shape}={values}")
+    result.append(f"{shape_dtype}={values}")
   result = "\n".join(result)
   if artifacts_dir is not None:
     inputs_path = os.path.join(artifacts_dir, "inputs.txt")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -69,9 +69,14 @@ def to_mlir_type(dtype):
     raise TypeError(f"Expected integer or floating type, but got {dtype}")
 
 
-def get_mlir_shape_and_dtype(array):
+def get_shape_and_dtype(array, allow_non_mlir_dtype=False):
   shape_dtype = [str(dim) for dim in list(array.shape)]
-  shape_dtype.append(to_mlir_type(array.dtype))
+  if np.issubdtype(array.dtype, np.number):
+    shape_dtype.append(to_mlir_type(array.dtype))
+  elif allow_non_mlir_dtype:
+    shape_dtype.append(f"<dtype '{array.dtype}'>")
+  else:
+    raise TypeError(f"Expected integer or floating type, but got {dtype}")
   return "x".join(shape_dtype)
 
 
@@ -79,7 +84,7 @@ def save_input_values(inputs, artifacts_dir=None):
   """Saves input values with IREE tools format if `artifacts_dir` is set."""
   result = []
   for array in inputs:
-    shape_dtype = get_mlir_shape_and_dtype(array)
+    shape_dtype = get_shape_and_dtype(array)
     values = " ".join([str(x) for x in array.flatten()])
     result.append(f"{shape_dtype}={values}")
   result = "\n".join(result)
@@ -236,11 +241,10 @@ class IreeCompiledModule(CompiledModule):
 
     if _create_reinitialized_args is None:
       set_random_seed()
-      self._module_blob = compile_tf_module(
-          tf_module=module_class(),
-          backend_infos=[backend_info],
-          exported_names=exported_names,
-          artifacts_dir=artifacts_dir)
+      self._module_blob = compile_tf_module(tf_module=module_class(),
+                                            backend_infos=[backend_info],
+                                            exported_names=exported_names,
+                                            artifacts_dir=artifacts_dir)
       self._module = rt.VmModule.from_flatbuffer(self._module_blob)
       self._config = rt.Config(driver_name=backend_info.driver)
     else:
@@ -248,8 +252,8 @@ class IreeCompiledModule(CompiledModule):
       self._module_blob, self._module, self._config = _create_reinitialized_args
 
     # Holds all of the module's mutable state.
-    self._context = rt.SystemContext(
-        modules=[self._module], config=self._config)
+    self._context = rt.SystemContext(modules=[self._module],
+                                     config=self._config)
 
   def create_reinitialized(self):
     """Duplicates this module with its initial state without recompiling."""
@@ -345,8 +349,9 @@ class _TfFunctionWrapper(object):
     # which is sad).
     if not isinstance(results, tuple):
       results = (results,)
-    return tf.nest.map_structure(
-        self._convert_to_numpy, *results, check_types=False)
+    return tf.nest.map_structure(self._convert_to_numpy,
+                                 *results,
+                                 check_types=False)
 
 
 class BackendInfo:


### PR DESCRIPTION
Adds mlir style dtype and shape information to the e2e test logs. If there are multiple inputs or outputs then they will be displayed as a comma separated list.

```
  2. Method: calculate
    Inputs: <class 'float'>, <class 'float'>, <class 'float'>, <class 'int'>, <class 'int'>
      -0.743644786
      0.1318252536
      2.9336e-06
      400
      3000
    Outputs: 400x400xf32
      [[1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
       ...
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
       [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. ... 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]
    Tolerances:
      rtol=1e-06, atol=1e-06