### PR TITLE
Revert "invoking cmake --build twice (#2501)"

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -55,5 +55,4 @@ cd build
   -DIREE_HOST_C_COMPILER=$(which clang) \
   -DIREE_HOST_CXX_COMPILER=$(which clang++)
 
-# TODO(#2494): Invoke once after fixing the flaky build failure in GCP.
-"$CMAKE_BIN" --build . || "$CMAKE_BIN" --build .
+"$CMAKE_BIN" --build .


### PR DESCRIPTION
We are not seeing flakiness in cross compilation for a while. It seems
the issue was addressed somehow.

This reverts commit 028a883090f58129ae1dfaa67150f86bc1bc6ff6.