### PR TITLE
Use new registration for MLIR passes

### DIFF
--- a/iree/tools/init_mlir_passes.h
+++ b/iree/tools/init_mlir_passes.h
@@ -22,12 +22,7 @@
 
 #include <cstdlib>
 
-#include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h"
-#include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
-#include "mlir/Conversion/LinalgToSPIRV/LinalgToSPIRVPass.h"
 #include "mlir/Conversion/Passes.h"
-#include "mlir/Conversion/SCFToGPU/SCFToGPUPass.h"
-#include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/GPU/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -35,7 +30,6 @@
 #include "mlir/Dialect/SCF/Passes.h"
 #include "mlir/Dialect/SPIRV/Passes.h"
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
-#include "mlir/Transforms/LocationSnapshot.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {

--- a/iree/tools/init_mlir_passes.h
+++ b/iree/tools/init_mlir_passes.h
@@ -25,6 +25,7 @@
 #include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRVPass.h"
 #include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
 #include "mlir/Conversion/LinalgToSPIRV/LinalgToSPIRVPass.h"
+#include "mlir/Conversion/Passes.h"
 #include "mlir/Conversion/SCFToGPU/SCFToGPUPass.h"
 #include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRVPass.h"
 #include "mlir/Dialect/Affine/Passes.h"
@@ -39,65 +40,52 @@
 
 namespace mlir {
 
-// This function may be called to register the MLIR passes with the
-// global registry.
+// This function may be called to register the MLIR passes with the global
+// registry.
 // If you're building a compiler, you likely don't need this: you would build a
 // pipeline programmatically without the need to register with the global
 // registry, since it would already be calling the creation routine of the
 // individual passes.
 // The global registry is interesting to interact with the command-line tools.
 inline void registerMlirPasses() {
-  // A local workaround until we can use individual pass registration from
-  // https://reviews.llvm.org/D77322
-  ::mlir::registerAffineLoopFusionPass();
-  ::mlir::registerAffinePipelineDataTransferPass();
-  ::mlir::registerCSEPass();
-  ::mlir::registerCanonicalizerPass();
-  ::mlir::registerInlinerPass();
-  ::mlir::registerLocationSnapshotPass();
-  ::mlir::registerLoopCoalescingPass();
-  ::mlir::registerLoopInvariantCodeMotionPass();
-  ::mlir::registerMemRefDataFlowOptPass();
-  ::mlir::registerParallelLoopCollapsingPass();
-  ::mlir::registerPrintOpStatsPass();
-  ::mlir::registerStripDebugInfoPass();
-  ::mlir::registerSymbolDCEPass();
+  // Core Transforms
+  registerCanonicalizerPass();
+  registerCSEPass();
+  registerInlinerPass();
+  registerLocationSnapshotPass();
+  registerLoopCoalescingPass();
+  registerLoopInvariantCodeMotionPass();
+  registerMemRefDataFlowOptPass();
+  registerParallelLoopCollapsingPass();
+  registerPrintOpStatsPass();
+  registerStripDebugInfoPass();
+  registerSymbolDCEPass();
 
-  createCanonicalizerPass();
-  createCSEPass();
-  createSuperVectorizePass({});
-  createLoopUnrollPass();
-  createLoopUnrollAndJamPass();
-  createSimplifyAffineStructuresPass();
-  createLoopFusionPass();
-  createLoopInvariantCodeMotionPass();
-  createAffineLoopInvariantCodeMotionPass();
-  createPipelineDataTransferPass();
-  createLowerAffinePass();
-  createLoopTilingPass(0);
-  createLoopCoalescingPass();
-  createAffineDataCopyGenerationPass(0, 0);
+  // Affine
+  registerAffinePasses();
+  registerAffineLoopFusionPass();
+  registerAffinePipelineDataTransferPass();
+  registerConvertAffineToStandardPass();
 
   // Linalg
-  mlir::registerLinalgPasses();
+  registerLinalgPasses();
 
-  // Loop
-  createParallelLoopFusionPass();
-  createParallelLoopTilingPass();
+  // SCF
+  registerSCFParallelLoopFusionPass();
+  registerSCFParallelLoopTilingPass();
 
   // Quant
-  quant::createConvertSimulatedQuantPass();
-  quant::createConvertConstPass();
+  quant::registerQuantPasses();
 
   // Shape
-  mlir::registerShapePasses();
+  registerShapePasses();
 
   // SPIR-V
-  spirv::createLowerABIAttributesPass();
-  createConvertGPUToSPIRVPass();
-  createConvertStandardToSPIRVPass();
-  createLegalizeStdOpsForSPIRVLoweringPass();
-  createLinalgToSPIRVPass();
+  spirv::registerSPIRVLowerABIAttributesPass();
+  registerConvertGPUToSPIRVPass();
+  registerConvertStandardToSPIRVPass();
+  registerLegalizeStandardForSPIRVPass();
+  registerConvertLinalgToSPIRVPass();
 }
 
 }  // namespace mlir


### PR DESCRIPTION
These create callls don't actually do anything anymore (if they ever
did). We have a new registration mechanism in MLIR thanks to
https://github.com/llvm/llvm-project/commit/2a6c8b2e9581.

This actually adds registration for a single affine pass we didn't
have before `AffineParallelizePass` because it uses the registration
for all Affine passes.

A diff of the sorted help text from iree-opt:
https://gist.githubusercontent.com/GMNGeoffrey/db6add0ca60759c2dcde0c3fa83ca1b9/raw/c5dd07006a1d36b459bf5e25edb65759ac5bd6f0/iree-opt%2520diff
