### PR TITLE
Enable MobileNet cifar10 test on vulkan-spirv.

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -185,17 +185,6 @@ iree_vision_test_suite(
         # interpreter and vulkan backends for these tests.
         {
             "models": [
-                "MobileNetV2",
-            ],
-            "datasets": [
-                "cifar10",
-            ],
-            "backends": [
-                "iree_vulkan",
-            ],
-        },
-        {
-            "models": [
                 "MobileNet",
                 "MobileNetV2",
             ],


### PR DESCRIPTION
Although this only tests compilation because the output values are too small to compare, it's worth to enable the test.