### PR TITLE
Revert "Revert "invoking cmake --build twice (#2501)""

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -55,4 +55,5 @@ cd build
   -DIREE_HOST_C_COMPILER=$(which clang) \
   -DIREE_HOST_CXX_COMPILER=$(which clang++)
 
-"$CMAKE_BIN" --build .
+# TODO(#2494): Invoke once after fixing the flaky build failure in GCP.
+"$CMAKE_BIN" --build . || "$CMAKE_BIN" --build .


### PR DESCRIPTION
Flakiness has returned/never left.
https://source.cloud.google.com/results/invocations/b1905e8b-ef34-42a5-8d57-4cce7dd994c9

Reverts google/iree#2772