### PR TITLE
Fix depthwise_conv groupSize and groupCount

### DIFF
--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -57,6 +57,15 @@ class Conv2dModule(tf.Module):
         img, kernel, [1, 2, 2, 1], "SAME", name="result")
 
 
+  @tf.function(input_signature=[
+      tf.TensorSpec([2, 4, 5, 4], tf.float32),
+      tf.TensorSpec([2, 4, 4, 1], tf.float32),
+  ])
+  def conv2d_2453x2441_same_stride_1(self, img, kernel):
+    return tf.nn.depthwise_conv2d(
+        img, kernel, [1, 1, 1, 1], "SAME", name="result")
+
+
 @tf_test_utils.compile_module(Conv2dModule)
 class ConvTest(tf_test_utils.TracedModuleTestCase):
 
@@ -96,6 +105,16 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       module.conv2d_2452x2423_same_stride_2(i, k)
 
     self.compare_backends(batched_feature_padded_same_stride_2)
+
+  def test_batched_feature_padded_same_stride_1_output_1(self):
+
+    def batched_feature_padded_same_stride_1_output_1(module):
+      i = tf_utils.ndarange([2, 4, 5, 4])
+      k = tf_utils.ndarange([2, 4, 4, 1])
+      module.conv2d_2453x2441_same_stride_1(i, k)
+
+    self.compare_backends(batched_feature_padded_same_stride_1_output_1)
+
 
 
 if __name__ == "__main__":

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -180,23 +180,6 @@ iree_vision_test_suite(
         "cifar10",
         "imagenet",
     ],
-    failing_configurations = [
-        # TODO(b/150244105): Compiling fails with commands targeting IREE
-        # interpreter and vulkan backends for these tests.
-        {
-            "models": [
-                "MobileNet",
-                "MobileNetV2",
-            ],
-            "datasets": [
-                "imagenet",
-            ],
-            "backends": [
-                "iree_llvmjit",
-                "iree_vulkan",
-            ],
-        },
-    ],
     models = [
         "MobileNet",
         "MobileNetV2",


### PR DESCRIPTION
The code incorrectly fetching groupSize & groupCount indices instead of values. This PR fixes that, adds an extra test case for depthwise conv and enable MobileNetV{1,2} e2e integration tests.