### PR TITLE
[doc] Change doc publication from every commit to every day

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,9 +15,9 @@
 name: Publish Documentation
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every working day at 12pm UTC
+    - cron: '0 12 * * 1-5'
 
 jobs:
   linux:


### PR DESCRIPTION
There is little benefit to have the doc refreshed on every commit;
we aren't gonna chnage them that frequently. Also because now we
use iree-opt to dump IR conversion examples, we need more cycles
for compilation. This reduces the burden of that.