### PR TITLE
Switch from absl::GetCurrentTimeNanos() to std::chrono.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -43,7 +43,6 @@ cc_library(
         ":file_mapping",
         ":init",
         ":tracing",
-        "@com_google_absl//absl/time",
     ],
 )
 

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -38,7 +38,6 @@ iree_cc_library(
     ::file_mapping
     ::init
     ::tracing
-    absl::time
   PUBLIC
 )
 
@@ -61,7 +60,6 @@ iree_cc_library(
     ::status
     absl::core_headers
     absl::inlined_vector
-    absl::time
   PUBLIC
 )
 

--- a/iree/base/api.cc
+++ b/iree/base/api.cc
@@ -14,11 +14,11 @@
 
 #include "iree/base/api.h"
 
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
-#include "absl/time/clock.h"
 #include "iree/base/api_util.h"
 #include "iree/base/file_mapping.h"
 #include "iree/base/init.h"
@@ -96,7 +96,10 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_api_init(int* argc,
 //===----------------------------------------------------------------------===//
 
 IREE_API_EXPORT iree_time_t iree_time_now() {
-  return absl::GetCurrentTimeNanos();
+  auto now = std::chrono::system_clock::now();
+  auto now_nanos = std::chrono::time_point_cast<std::chrono::nanoseconds>(now);
+  auto now_nanos_since_epoch = now_nanos.time_since_epoch();
+  return now_nanos_since_epoch.count();
 }
 
 IREE_API_EXPORT iree_time_t


### PR DESCRIPTION
Intermediate fix for https://github.com/google/iree/issues/2801

Documentation for std::chrono: https://en.cppreference.com/w/cpp/header/chrono, which is standard since C++11. I tested that this builds on Windows/MSVC and Linux/Clang.