### PR TITLE
Increase job count for RBE

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -187,7 +187,8 @@ build:rbe --remote_instance_name=projects/iree-oss/instances/default_instance
 # this higher can make builds faster by allowing more jobs to run in parallel.
 # Setting it too high can result in jobs that timeout, however, while waiting
 # for a remote machine to execute them.
-build:rbe --jobs=50
+# Our pool autoscales from 25 to 200 jobs
+build:rbe --jobs=150
 
 # Flags related to specifying the platform, toolchain and java properties.
 # These flags must be adapted to work with toolchain containers other than


### PR DESCRIPTION
I've turned on autoscaling for our pool. This should decrease the
upper bound on build times, especially with local builds. CI builds
are already dominated by VM setup and cloning time.
