### PR TITLE
Remove references to TypeStorage subclass data

### DIFF
--- a/iree/compiler/Dialect/IREE/IR/IREETypes.cpp
+++ b/iree/compiler/Dialect/IREE/IR/IREETypes.cpp
@@ -29,8 +29,7 @@ namespace IREE {
 namespace detail {
 
 struct PtrTypeStorage : public TypeStorage {
-  PtrTypeStorage(Type targetType, unsigned subclassData = 0)
-      : TypeStorage(subclassData), targetType(targetType) {}
+  PtrTypeStorage(Type targetType) : targetType(targetType) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;

--- a/iree/compiler/Dialect/Sequence/IR/SequenceTypes.cpp
+++ b/iree/compiler/Dialect/Sequence/IR/SequenceTypes.cpp
@@ -24,8 +24,7 @@ namespace Sequence {
 namespace detail {
 
 struct SequenceTypeStorage : public TypeStorage {
-  SequenceTypeStorage(Type targetType, unsigned subclassData = 0)
-      : TypeStorage(subclassData), targetType(targetType) {}
+  SequenceTypeStorage(Type targetType) : targetType(targetType) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;

--- a/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -33,8 +33,7 @@ namespace VM {
 namespace detail {
 
 struct ListTypeStorage : public TypeStorage {
-  ListTypeStorage(Type elementType, unsigned subclassData = 0)
-      : TypeStorage(subclassData), elementType(elementType) {}
+  ListTypeStorage(Type elementType) : elementType(elementType) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;
@@ -81,8 +80,7 @@ Type ListType::getElementType() { return getImpl()->elementType; }
 namespace detail {
 
 struct RefTypeStorage : public TypeStorage {
-  RefTypeStorage(Type objectType, unsigned subclassData = 0)
-      : TypeStorage(subclassData), objectType(objectType.cast<Type>()) {}
+  RefTypeStorage(Type objectType) : objectType(objectType.cast<Type>()) {}
 
   /// The hash key used for uniquing.
   using KeyTy = Type;


### PR DESCRIPTION
Support for subclass data on the base mlir::TypeStorage class is being
removed. This revision removes all references to subclass data from IREE
types.
