### PR TITLE
Refactor HAL driver filtering in command_queue_test.

### DIFF
--- a/iree/hal/cts/command_queue_test.cc
+++ b/iree/hal/cts/command_queue_test.cc
@@ -26,17 +26,7 @@ namespace {
 using ::iree::testing::status::IsOkAndHolds;
 using ::testing::Eq;
 
-class CommandQueueTest : public CtsTestBase {
- protected:
-  virtual void SetUp() {
-    CtsTestBase::SetUp();
-
-    // Disabled on Vulkan until tests pass with timeline semaphore emulation.
-    if (driver_->name() == "vulkan") {
-      GTEST_SKIP();
-    }
-  }
-};
+class CommandQueueTest : public CtsTestBase {};
 
 TEST_P(CommandQueueTest, EnumerateDeviceQueues) {
   // Log how many queues we have so future test cases have more context.
@@ -140,9 +130,22 @@ TEST_P(CommandQueueTest, WaitMultiple) {
   ASSERT_OK(command_queue->WaitIdle());
 }
 
+std::vector<std::string> GetSupportedDrivers() {
+  auto drivers = DriverRegistry::shared_registry()->EnumerateAvailableDrivers();
+  auto it = drivers.begin();
+  while (it != drivers.end()) {
+    // Disabled on Vulkan until tests pass with timeline semaphore emulation.
+    if (*it == "vulkan") {
+      it = drivers.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return drivers;
+}
+
 INSTANTIATE_TEST_SUITE_P(AllDrivers, CommandQueueTest,
-                         ::testing::ValuesIn(DriverRegistry::shared_registry()
-                                                 ->EnumerateAvailableDrivers()),
+                         ::testing::ValuesIn(GetSupportedDrivers()),
                          GenerateTestName());
 
 }  // namespace

--- a/iree/hal/cts/command_queue_test.cc
+++ b/iree/hal/cts/command_queue_test.cc
@@ -26,7 +26,17 @@ namespace {
 using ::iree::testing::status::IsOkAndHolds;
 using ::testing::Eq;
 
-class CommandQueueTest : public CtsTestBase {};
+class CommandQueueTest : public CtsTestBase {
+ protected:
+  virtual void SetUp() {
+    CtsTestBase::SetUp();
+
+    // Disabled on Vulkan until tests pass with timeline semaphore emulation.
+    if (driver_->name() == "vulkan") {
+      GTEST_SKIP();
+    }
+  }
+};
 
 TEST_P(CommandQueueTest, EnumerateDeviceQueues) {
   // Log how many queues we have so future test cases have more context.
@@ -130,9 +140,9 @@ TEST_P(CommandQueueTest, WaitMultiple) {
   ASSERT_OK(command_queue->WaitIdle());
 }
 
-// Disabled on Vulkan until tests pass when using timeline semaphore emulation.
 INSTANTIATE_TEST_SUITE_P(AllDrivers, CommandQueueTest,
-                         ::testing::Values("vmla", "llvm", "dylib"),
+                         ::testing::ValuesIn(DriverRegistry::shared_registry()
+                                                 ->EnumerateAvailableDrivers()),
                          GenerateTestName());
 
 }  // namespace


### PR DESCRIPTION
If one of the listed drivers is not available, this will correctly exclude it.

This should let us roll-forward https://github.com/google/iree/pull/2759