### PR TITLE
Move LICM and hoisting after staged transforms in matmul strategy

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "CooperativeMatrixAnalysis.cpp",
         "LinalgTileAndFusePass.cpp",
         "MarkerUtils.cpp",
+        "MatMulVectorizationTest.cpp",
         "Passes.cpp",
         "SplitDispatchFunctionPass.cpp",
         "Utils.cpp",

--- a/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "CooperativeMatrixAnalysis.cpp"
     "LinalgTileAndFusePass.cpp"
     "MarkerUtils.cpp"
+    "MatMulVectorizationTest.cpp"
     "Passes.cpp"
     "SplitDispatchFunctionPass.cpp"
     "Utils.cpp"

--- a/iree/compiler/Conversion/LinalgToSPIRV/MatMulVectorizationTest.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MatMulVectorizationTest.cpp
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "iree/compiler/Conversion/CodegenUtils/MatmulCodegenStrategy.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+static llvm::cl::opt<int> wgTileSize(
+    "iree-codegen-linalg-to-gpu-wg-tile-size",
+    llvm::cl::desc(
+        "Specify the size of workgroup tile for matmul vector lowering"),
+    llvm::cl::init(32));
+
+static llvm::cl::list<uint32_t> unrollSize(
+    "iree-codegen-linalg-to-gpu-unroll-size",
+    llvm::cl::desc("Specify the size of the "), llvm::cl::CommaSeparated);
+
+static llvm::cl::opt<bool> enableLICM(
+    "iree-codegen-linalg-to-gpu-matmul-licm",
+    llvm::cl::desc(
+        "If true run LICM and hoisting passes after the staged transforms"),
+    llvm::cl::init(true));
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct MatMulTileAndVectorizeGPUPass
+    : PassWrapper<MatMulTileAndVectorizeGPUPass, FunctionPass> {
+  void runOnFunction() override;
+};
+}  // namespace
+
+void MatMulTileAndVectorizeGPUPass::runOnFunction() {
+  FuncOp fn = getFunction();
+  SmallVector<uint32_t, 3> vUnrollSize(unrollSize.begin(), unrollSize.end());
+  if (vUnrollSize.size() != 3) signalPassFailure();
+  MatmulCodegenStrategy strategy;
+  strategy
+      .tile<linalg::MatmulOp>(
+          linalg::LinalgTilingOptions()
+              // TODO(thomasraoux): Enable parallel loops once affine.min
+              // canonicalize supports it.
+              //.setLoopType(linalg::LinalgTilingLoopType::ParallelLoops)
+              .setTileSizes({wgTileSize, wgTileSize, wgTileSize}))
+      .setHoistInvariantCode(enableLICM)
+      .vectorize<linalg::MatmulOp>()
+      .unrollVector<vector::ContractionOp>(
+          {vUnrollSize[0], vUnrollSize[1], vUnrollSize[2]});
+  strategy.transform(fn);
+}
+
+std::unique_ptr<FunctionPass> createMatMulTileAndVectorizeGPUPass() {
+  return std::make_unique<MatMulTileAndVectorizeGPUPass>();
+}
+
+static PassRegistration<MatMulTileAndVectorizeGPUPass> pass(
+    "iree-codegen-linalg-to-gpu-matmul-vectorization-pass",
+    "Tile and vectorize linalg.matmul operation",
+    [] { return std::make_unique<MatMulTileAndVectorizeGPUPass>(); });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
@@ -60,6 +60,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createSplitDispatchFunctionPass();
 /// vector size equal to subgroup size are distributed across the subgroup.
 std::unique_ptr<OperationPass<FuncOp>> createVectorToGPUPass();
 
+/// Pass to apply tiling and vectorization transformations on linagl::MatMulOp.
+std::unique_ptr<FunctionPass> createMatMulTileAndVectorizeGPUPass();
+
 /// Populates passes needed to lower a XLA HLO op to SPIR-V dialect via the
 /// structured ops path. The pass manager `pm` in here operate on the module
 /// within the IREE::HAL::ExecutableOp. The `workGroupSize` can be used to

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/matmul_vectorization.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --iree-codegen-linalg-to-gpu-matmul-vectorization-pass
+// RUN: -split-input-file %s --iree-codegen-linalg-to-gpu-unroll-size=8,8,32 \
+// RUN: -iree-codegen-linalg-to-gpu-matmul-licm | IreeFileCheck %s
+
+// CHECK-LABEL: func @matmul_128x128x128
+// CHECK-SAME: (%[[ARG0:.+]]: memref<128x128xf32>, %[[ARG1:.+]]: memref<128x128xf32>, %[[ARG2:.+]]: memref<128x128xf32>)
+func @matmul_128x128x128(%arg0 : memref<128x128xf32>, %arg1: memref<128x128xf32>, %arg2: memref<128x128xf32>) {
+    linalg.matmul %arg0, %arg1, %arg2 : (memref<128x128xf32>, memref<128x128xf32>, memref<128x128xf32>)
+    return
+}
+
+// CHECK: %[[TILESIZE:.+]] = constant 32 : index
+// CHECK: %[[MATSIZE:.+]] = constant 128 : index
+// CHECK: %[[START:.+]] = constant 0 : index
+// CHECK: scf.for %[[IL:.+]] = %[[START]] to %[[MATSIZE]] step %[[TILESIZE]]
+// CHECK: scf.for %[[JL:.+]] = %[[START]] to %[[MATSIZE]] step %[[TILESIZE]]
+// CHECK: %[[SUBVVIEWC:.+]] = subview %[[ARG2]][%[[IL]], %[[JL]]] [32, 32] [1, 1] : memref<128x128xf32> to memref<32x32xf32
+// CHECK: scf.for %[[KL:.+]] = %[[START]] to %[[MATSIZE]] step %[[TILESIZE]]
+// CHECK: %[[SUBVVIEWA:.+]] = subview %[[ARG0]][%[[IL]], %[[KL]]] [32, 32] [1, 1] : memref<128x128xf32> to memref<32x32xf32
+// CHECK: %[[SUBVVIEWB:.+]] = subview %[[ARG1]][%[[KL]], %[[JL]]] [32, 32] [1, 1] : memref<128x128xf32> to memref<32x32xf32
+

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -40,6 +40,7 @@ inline void registerLinalgToSPIRVPasses() {
     createLinalgTileAndFusePass();
     createSplitDispatchFunctionPass();
     createVectorToGPUPass();
+    createMatMulTileAndVectorizeGPUPass();
     return true;
   }();
   (void)init_once;


### PR DESCRIPTION
Move the transformation doing LICM and transfer_op hoisting as we want
those to happen after unroll transformation. Also add a test file to be
able to unit test matmul vector lowering strategy for GPU.