### PR TITLE
Extract commit summarization into a script

### DIFF
--- a/scripts/git/google_to_main.sh
+++ b/scripts/git/google_to_main.sh
@@ -46,7 +46,7 @@ git push -f "${FORK_REMOTE?}" "${PR_BRANCH?}"
 TITLE="Merge google -> main"
 
 git fetch "${UPSTREAM_REMOTE?}" main
-BODY="$(git log ${UPSTREAM_REMOTE?}/main.. --decorate=no --pretty='format:* %h %<(80,trunc)%s')"
+BODY="$(./scripts/git/summarize_changes.sh ${UPSTREAM_REMOTE?}/main"
 
 if [[ -z "$(which gh)" ]]; then
   echo "gh not found on path."

--- a/scripts/git/main_to_google.sh
+++ b/scripts/git/main_to_google.sh
@@ -46,7 +46,7 @@ git push -f "${FORK_REMOTE?}" "${PR_BRANCH?}"
 TITLE="Merge main -> google"
 
 git fetch "${UPSTREAM_REMOTE?}" google
-BODY="$(git log ${UPSTREAM_REMOTE?}/google.. --decorate=no --pretty='format:* %h %<(80,trunc)%s')"
+BODY="$(./scripts/git/summarize_changes.sh ${UPSTREAM_REMOTE?}/google"
 
 if [[ -z "$(which gh)" ]]; then
   echo "gh not found on path."

--- a/scripts/git/summarize_changes.sh
+++ b/scripts/git/summarize_changes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a commit summary of commits between the specified refs.
+#
+# Get changes between the current HEAD commit and the latest fetch of the
+# upstream repository main branch:
+#   summarize_changes.sh upstream/main
+#   summarize_changes.sh upstream/main HEAD
+#
+# Summarize commits between the local main-to-google branch and the latest fetch
+# of the upstream repository main branch
+#   summarize_changes.sh upstream/main main-to-google
+
+set -e
+set -o pipefail
+
+BASE_REF="${1}"
+NEW_REF="${2:-HEAD}"
+
+# Print commits with their short hash and the first 80 characters of their
+# commit title. Use awk to trim the trailing whitespace introduced by git log
+
+git log \
+  "${BASE_REF?}..${NEW_REF?}"
+  --decorate=no \
+  --pretty='format:* %h %<(80,trunc)%s' \
+  | awk '{$1=$1;print}'

--- a/scripts/git/summarize_changes.sh
+++ b/scripts/git/summarize_changes.sh
@@ -35,7 +35,7 @@ NEW_REF="${2:-HEAD}"
 # commit title. Use awk to trim the trailing whitespace introduced by git log
 
 git log \
-  "${BASE_REF?}..${NEW_REF?}"
+  "${BASE_REF?}..${NEW_REF?}" \
   --decorate=no \
   --pretty='format:* %h %<(80,trunc)%s' \
   | awk '{$1=$1;print}'


### PR DESCRIPTION
This is getting complex enough for a wrapper.

This change also includes a pipe to awk to strip the trailing whitespace
that `git log` insists on creating. I couldn't find any way to get git
log to truncate without padding (See
https://git-scm.com/docs/git-log#Documentation/git-log.txt-emltltNgttruncltruncmtruncem)
