### PR TITLE
Use a hierarchical directory structure for E2E test artifacts

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -314,7 +314,8 @@ class Trace:
     return True
 
   def _get_trace_dir(self, artifacts_dir):
-    trace_dir = os.path.join(artifacts_dir, "traces")
+    trace_dir = os.path.join(artifacts_dir, self.backend, "traces",
+                             self.function_name)
     if not os.path.exists(trace_dir):
       os.makedirs(trace_dir)
     return trace_dir
@@ -335,7 +336,7 @@ class Trace:
         edgeitems=10)  # Can show more items since they won't clutter the logs.
 
     trace_dir = self._get_trace_dir(artifacts_dir)
-    path = os.path.join(trace_dir, f"{self.function_name}__{self.backend}.txt")
+    path = os.path.join(trace_dir, "log.txt")
     with open(path, "w") as f:
       f.write(str(self))
       f.write("\n")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -107,16 +107,21 @@ def compile_tf_module(tf_module,
   that returns a module that can be called without any further steps.
 
   If artifacts_dir is provided then the following artifacts will be saved:
-    saved_model:
+    backend_name/saved_model:
       A TF SavedModel directory containing the files used translate the
-      tf.Module into an IREE module.
+      tf.Module into an IREE module. Only saved if '--keep_saved_model=True'.
     tf_input.mlir:
       MLIR for the module in TF's input dialect.
     iree_input.mlir:
       The MLIR above translated to IREE via compiler.TF_IMPORT_PASS_PIPELINE.
-    compiled__backends.vmfb:
+    backend_name/compiled.vmfb:
       A VM FlatBuffer compiled to the target backends from the IREE MLIR above.
-  Here 'backends' is a '__' delimited list of iree backends (e.g. vmla__llvm_ir)
+
+  If multiple backends are specified, then instead of saving the SavedModel and
+  compiled 'vmfb' under 'backend_name/', they will be saved as follows:
+    - 'saved_model__{backends}'
+    - 'compiled__{backends}.vmfb'
+  where 'backends' is a '__' delimited list (e.g. iree_vmla__iree_llvmjit).
 
   Args:
     tf_module: A tf.Module.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -49,36 +49,6 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
 
   @parameterized.named_parameters([
       {
-          'testcase_name': 'single_backend',
-          'backend_infos': [tf_utils.BackendInfo('iree_vmla')],
-      },
-      {
-          'testcase_name':
-              'multiple_backends',
-          'backend_infos': [
-              tf_utils.BackendInfo('iree_vmla'),
-              tf_utils.BackendInfo('iree_llvmjit')
-          ],
-      },
-  ])
-  def test_artifact_saving(self, backend_infos):
-    with tempfile.TemporaryDirectory() as artifacts_dir:
-      tf_module = ConstantModule()
-      iree_compiled_module = tf_utils.compile_tf_module(
-          tf_module, backend_infos=backend_infos, artifacts_dir=artifacts_dir)
-
-      artifacts_to_check = [
-          'tf_input.mlir',
-          'iree_input.mlir',
-          f'compiled__{tf_utils.backends_to_str(backend_infos)}.vmfb',
-      ]
-      for artifact in artifacts_to_check:
-        artifact_path = os.path.join(artifacts_dir, artifact)
-        logging.info('Checking path: %s', artifact_path)
-        self.assertTrue(os.path.exists(artifact_path))
-
-  @parameterized.named_parameters([
-      {
           'testcase_name': 'tensorflow',
           'backend_name': 'tf',
       },

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -13,7 +13,7 @@ that TensorFlow should be version 2.0+. This can be checked with
 See [Install TensorFlow with pip](https://www.tensorflow.org/install/pip) for
 instructions.
 
-## Vulkan setup
+## Vulkan Setup
 
 If you do not have your environment setup to use IREE with Vulkan (see
 [the doc](../../../docs/vulkan_and_spirv.md)), then you can run the manual test
@@ -48,7 +48,7 @@ vmla_module.predict(...)
 By default the TensorFlow SavedModels will not be kept. This can be overridden
 via the `--keep_saved_model` flag.
 
-## Running tests
+## Running Tests
 
 For locally running tests and iterating on backend development, `bazel run` is
 preferred.
@@ -150,7 +150,33 @@ bazel test :e2e_tests_failing
 bazel test :e2e_tests_failing_broadcasting_test__tf__iree_vulkan
 ```
 
-## Debugging tests
+## Generated Artifacts
+
+By default, running an E2E test generates a number of compilation, debugging and
+benchmarking artifacts in `/tmp/iree/modules/`. The location of these artifacts
+can be changed via the `--artifacts_dir` flag. The generated directory structure
+for each module is as follows:
+
+```
+/tmp/iree/modules/ModuleName
+├── iree_input.mlir        # tf_input.mlir translated to IREE MLIR
+├── backend_name_1         # e.g. iree_vmla, tf or tf_ref
+│   ├── compiled.vmfb      # flatbuffer of ModuleName compiled to this backend
+│   ├── saved_model
+│   └── traces
+│       ├── trace_function
+│       │   └── log.txt    # A more detailed version of the test logs
+│       └── simple_mul
+│           └── log.txt
+├── backend_name_2
+│   └── ...
+└── tf_input.mlir          # MLIR for ModuleName in TF's input dialect
+```
+
+The `saved_model` directory is only created if `--keep_saved_model` is
+specified.
+
+## Debugging Tests
 
 If the compiler fails to compile the program, then it will create a crash
 reproducer (see [MLIR documentation](https://mlir.llvm.org/docs/WritingAPass/)),
@@ -159,7 +185,7 @@ debugging iteration can happen in opt.
 
 TODO(silvasean): debugging miscompiles
 
-## Test harnesses
+## Test Harnesses
 
 ### Simple function tests
 

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -159,18 +159,18 @@ for each module is as follows:
 
 ```
 /tmp/iree/modules/ModuleName
+├── tf_input.mlir          # MLIR for ModuleName in TF's input dialect
 ├── iree_input.mlir        # tf_input.mlir translated to IREE MLIR
-├── backend_name_1         # e.g. iree_vmla, tf or tf_ref
+├── backend_name           # e.g. iree_vmla, tf or tf_ref
 │   ├── compiled.vmfb      # flatbuffer of ModuleName compiled to this backend
 │   ├── saved_model
 │   └── traces
 │       ├── trace_function
 │       │   └── log.txt    # A more detailed version of the test logs
-│       └── simple_mul
+│       └── trace_function
 │           └── log.txt
-├── backend_name_2
-│   └── ...
-└── tf_input.mlir          # MLIR for ModuleName in TF's input dialect
+└── backend_name
+    └── ...
 ```
 
 The `saved_model` directory is only created if `--keep_saved_model` is


### PR DESCRIPTION
- Store compiled modules in `/tmp/iree/modules/ModuleName/backend_name/compiled.vmfb`
  - Fall back to `compiled__backend_1__backend_2.vmfb` if `compile_tf_module` is called with multiple backends.
- Organize traces by their backend (e.g. `/tmp/iree/modules/ModuleName/backend_name/traces/trace_function/log.txt`).
- Add 'Generated Artifacts' section to E2E readme.