### PR TITLE
Remove uses of kind on derived mlir Attribute and Type classes

### DIFF
--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/dialect.cpp
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/dialect.cpp
@@ -54,13 +54,14 @@ Type TFStringsDialect::parseType(DialectAsmParser& parser) const {
 }
 
 void TFStringsDialect::printType(Type type, DialectAsmPrinter& os) const {
-  switch (type.getKind()) {
-    case TFStringsTypes::String:
-      os << "string";
-      break;
-    default:
-      llvm_unreachable("unhandled string type");
-  }
+  if (type.isa<tf_strings::StringType>())
+    os << "string";
+  else
+    llvm_unreachable("unhandled string type");
+}
+
+bool TFStringsType::classof(Type type) {
+  return llvm::isa<TFStringsDialect>(type.getDialect());
 }
 
 }  // namespace tf_strings

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/types.h
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/types.h
@@ -41,10 +41,7 @@ class TFStringsType : public Type {
  public:
   using Type::Type;
 
-  static bool classof(Type type) {
-    return type.getKind() >= TFStringsTypes::FIRST_USED_STRINGS_TYPE &&
-           type.getKind() <= TFStringsTypes::LAST_USED_STRINGS_TYPE;
-  }
+  static bool classof(Type type);
 };
 
 class StringType
@@ -54,8 +51,6 @@ class StringType
   static StringType get(MLIRContext* context) {
     return Base::get(context, TFStringsTypes::String);
   }
-
-  static bool kindof(unsigned kind) { return kind == TFStringsTypes::String; }
 };
 
 }  // namespace tf_strings

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_types.h
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_types.h
@@ -30,7 +30,6 @@ class TensorListType
     : public Type::TypeBase<TensorListType, Type, TypeStorage> {
  public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == TypeKind::kTensorList; }
   static TensorListType get(MLIRContext *context) {
     return Base::get(context, TypeKind::kTensorList);
   }

--- a/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -63,7 +63,6 @@ class AllocatorType : public Type::TypeBase<AllocatorType, Type, TypeStorage> {
   static AllocatorType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Allocator);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Allocator; }
 };
 
 class BufferType : public Type::TypeBase<BufferType, Type, TypeStorage> {
@@ -72,7 +71,6 @@ class BufferType : public Type::TypeBase<BufferType, Type, TypeStorage> {
   static BufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Buffer);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Buffer; }
 };
 
 class BufferViewType
@@ -82,7 +80,6 @@ class BufferViewType
   static BufferViewType get(MLIRContext *context) {
     return Base::get(context, TypeKind::BufferView);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::BufferView; }
 };
 
 class CommandBufferType
@@ -92,7 +89,6 @@ class CommandBufferType
   static CommandBufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::CommandBuffer);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::CommandBuffer; }
 };
 
 class DescriptorSetType
@@ -102,7 +98,6 @@ class DescriptorSetType
   static DescriptorSetType get(MLIRContext *context) {
     return Base::get(context, TypeKind::DescriptorSet);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::DescriptorSet; }
 };
 
 class DescriptorSetLayoutType
@@ -112,9 +107,6 @@ class DescriptorSetLayoutType
   static DescriptorSetLayoutType get(MLIRContext *context) {
     return Base::get(context, TypeKind::DescriptorSetLayout);
   }
-  static bool kindof(unsigned kind) {
-    return kind == TypeKind::DescriptorSetLayout;
-  }
 };
 
 class DeviceType : public Type::TypeBase<DeviceType, Type, TypeStorage> {
@@ -123,7 +115,6 @@ class DeviceType : public Type::TypeBase<DeviceType, Type, TypeStorage> {
   static DeviceType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Device);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Device; }
 };
 
 class EventType : public Type::TypeBase<EventType, Type, TypeStorage> {
@@ -132,7 +123,6 @@ class EventType : public Type::TypeBase<EventType, Type, TypeStorage> {
   static EventType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Event);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Event; }
 };
 
 class ExecutableType
@@ -142,7 +132,6 @@ class ExecutableType
   static ExecutableType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Executable);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Executable; }
 };
 
 class ExecutableCacheType
@@ -151,9 +140,6 @@ class ExecutableCacheType
   using Base::Base;
   static ExecutableCacheType get(MLIRContext *context) {
     return Base::get(context, TypeKind::ExecutableCache);
-  }
-  static bool kindof(unsigned kind) {
-    return kind == TypeKind::ExecutableCache;
   }
 };
 
@@ -164,9 +150,6 @@ class ExecutableLayoutType
   static ExecutableLayoutType get(MLIRContext *context) {
     return Base::get(context, TypeKind::ExecutableLayout);
   }
-  static bool kindof(unsigned kind) {
-    return kind == TypeKind::ExecutableLayout;
-  }
 };
 
 class RingBufferType
@@ -176,7 +159,6 @@ class RingBufferType
   static RingBufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::RingBuffer);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::RingBuffer; }
 };
 
 class SemaphoreType : public Type::TypeBase<SemaphoreType, Type, TypeStorage> {
@@ -185,7 +167,6 @@ class SemaphoreType : public Type::TypeBase<SemaphoreType, Type, TypeStorage> {
   static SemaphoreType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Semaphore);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Semaphore; }
 };
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/IREE/IR/IREEDialect.cpp
+++ b/iree/compiler/Dialect/IREE/IR/IREEDialect.cpp
@@ -65,21 +65,14 @@ Type IREEDialect::parseType(DialectAsmParser& parser) const {
 }
 
 void IREEDialect::printType(Type type, DialectAsmPrinter& os) const {
-  switch (type.getKind()) {
-    case IREE::TypeKind::Ptr: {
-      auto targetType = type.cast<IREE::PtrType>().getTargetType();
-      os << "ptr<" << targetType << ">";
-      break;
-    }
-    case IREE::TypeKind::ByteBuffer:
-      os << "byte_buffer";
-      break;
-    case IREE::TypeKind::MutableByteBuffer:
-      os << "mutable_byte_buffer";
-      break;
-    default:
-      llvm_unreachable("unhandled IREE type");
-  }
+  if (auto ptrType = type.dyn_cast<IREE::PtrType>())
+    os << "ptr<" << ptrType.getTargetType() << ">";
+  else if (type.isa<IREE::ByteBufferType>())
+    os << "byte_buffer";
+  else if (type.isa<IREE::MutableByteBufferType>())
+    os << "mutable_byte_buffer";
+  else
+    llvm_unreachable("unhandled IREE type");
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/IREE/IR/IREETypes.h
+++ b/iree/compiler/Dialect/IREE/IR/IREETypes.h
@@ -143,7 +143,6 @@ class PtrType : public Type::TypeBase<PtrType, Type, detail::PtrTypeStorage> {
  public:
   static PtrType get(Type targetType);
   static PtrType getChecked(Type targetType, Location location);
-  static bool kindof(unsigned kind) { return kind == TypeKind::Ptr; }
 
   using Base::Base;
 
@@ -156,8 +155,6 @@ class ByteBufferType
  public:
   using Base::Base;
 
-  static bool kindof(unsigned kind) { return kind == TypeKind::ByteBuffer; }
-
   static ByteBufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::ByteBuffer);
   }
@@ -168,10 +165,6 @@ class MutableByteBufferType
     : public Type::TypeBase<MutableByteBufferType, Type, TypeStorage> {
  public:
   using Base::Base;
-
-  static bool kindof(unsigned kind) {
-    return kind == TypeKind::MutableByteBuffer;
-  }
 
   static MutableByteBufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::MutableByteBuffer);

--- a/iree/compiler/Dialect/IREE/Tools/StructAttrGen.cpp
+++ b/iree/compiler/Dialect/IREE/Tools/StructAttrGen.cpp
@@ -106,7 +106,6 @@ class {1} : public mlir::Attribute::AttrBase<{1}, mlir::Attribute, {3}Storage> {
   using Base::Base;
 
   static StringRef getKindName() { return "{2}"; }
-  static bool kindof(unsigned kind) { return kind == AttrKind::{1}; }
 
 )",
                 structAttr.getDescription(), structAttr.getStructClassName(),

--- a/iree/compiler/Dialect/Modules/Strings/IR/Types.h
+++ b/iree/compiler/Dialect/Modules/Strings/IR/Types.h
@@ -30,7 +30,6 @@ class StringType : public Type::TypeBase<StringType, Type, TypeStorage> {
   static StringType get(MLIRContext *context) {
     return Base::get(context, TypeKind::String);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::String; }
 };
 
 class StringTensorType
@@ -40,7 +39,6 @@ class StringTensorType
   static StringTensorType get(MLIRContext *context) {
     return Base::get(context, TypeKind::StringTensor);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::StringTensor; }
 };
 
 }  // namespace Strings

--- a/iree/compiler/Dialect/Modules/TensorList/IR/TensorListTypes.h
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/TensorListTypes.h
@@ -37,7 +37,6 @@ class TensorListType
   static TensorListType get(MLIRContext *context) {
     return Base::get(context, TypeKind::kTensorList);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::kTensorList; }
 };
 
 }  // namespace TensorList

--- a/iree/compiler/Dialect/Sequence/IR/SequenceDialect.cpp
+++ b/iree/compiler/Dialect/Sequence/IR/SequenceDialect.cpp
@@ -53,17 +53,8 @@ Type SequenceDialect::parseType(DialectAsmParser& parser) const {
 }
 
 void SequenceDialect::printType(Type type, DialectAsmPrinter& os) const {
-  switch (type.getKind()) {
-    case TypeKind::Sequence: {
-      auto targetType = type.cast<SequenceType>().getTargetType();
-      os << "of<";
-      os.printType(targetType);
-      os << ">";
-      break;
-    }
-    default:
-      llvm_unreachable("unhandled sequence type");
-  }
+  if (auto sequenceType = type.dyn_cast<SequenceType>())
+    os << "of<" << sequenceType.getTargetType() << ">";
 }
 
 }  // namespace Sequence

--- a/iree/compiler/Dialect/Sequence/IR/SequenceTypes.h
+++ b/iree/compiler/Dialect/Sequence/IR/SequenceTypes.h
@@ -32,7 +32,6 @@ class SequenceType
  public:
   using Base::Base;
 
-  static bool kindof(unsigned kind) { return kind == TypeKind::Sequence; }
   static SequenceType get(Type targetType);
   static SequenceType getChecked(Type targetType, Location location);
 

--- a/iree/compiler/Dialect/Shape/IR/ShapeDialect.cpp
+++ b/iree/compiler/Dialect/Shape/IR/ShapeDialect.cpp
@@ -164,13 +164,9 @@ Type ShapeDialect::parseType(DialectAsmParser& parser) const {
 }
 
 void ShapeDialect::printType(Type type, DialectAsmPrinter& os) const {
-  switch (type.getKind()) {
-    case Shape::TypeKind::RankedShape:
-      printRankedShape(type.cast<Shape::RankedShapeType>(), os);
-      break;
-    default:
-      llvm_unreachable("unhandled Shape type");
-  }
+  if (auto rankedShapeTy = type.dyn_cast<Shape::RankedShapeType>())
+    return printRankedShape(type.cast<Shape::RankedShapeType>(), os);
+  llvm_unreachable("unhandled Shape type");
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Shape/IR/ShapeTypes.h
+++ b/iree/compiler/Dialect/Shape/IR/ShapeTypes.h
@@ -39,9 +39,6 @@ class RankedShapeType : public Type::TypeBase<RankedShapeType, Type,
  public:
   using Base::Base;
 
-  /// Support method to enable LLVM-style type casting.
-  static bool kindof(unsigned kind) { return kind == TypeKind::RankedShape; }
-
   // Gets an instance of a RankedShapeType given an array of dimensions.
   // Any dynamic dim should be -1.
   static RankedShapeType get(ArrayRef<int64_t> dims, MLIRContext *context);

--- a/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -246,26 +246,21 @@ Type VMDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void VMDialect::printType(Type type, DialectAsmPrinter &os) const {
-  switch (type.getKind()) {
-    case IREE::VM::TypeKind::Ref: {
-      auto objectType = type.cast<IREE::VM::RefType>().getObjectType();
-      if (auto listType = objectType.dyn_cast<IREE::VM::ListType>()) {
-        printType(listType, os);
-      } else if (objectType.isa<IREE::VM::OpaqueType>()) {
-        os << "ref<?>";
-      } else {
-        os << "ref<" << objectType << ">";
-      }
-      break;
+  if (auto refType = type.dyn_cast<IREE::VM::RefType>()) {
+    auto objectType = refType.getObjectType();
+    if (auto listType = objectType.dyn_cast<IREE::VM::ListType>()) {
+      printType(listType, os);
+    } else if (objectType.isa<IREE::VM::OpaqueType>()) {
+      os << "ref<?>";
+    } else {
+      os << "ref<" << objectType << ">";
     }
-    case IREE::VM::TypeKind::Opaque:
-      os << "opaque";
-      break;
-    case IREE::VM::TypeKind::List:
-      os << "list<" << type.cast<IREE::VM::ListType>().getElementType() << ">";
-      break;
-    default:
-      llvm_unreachable("unhandled VM type");
+  } else if (type.isa<IREE::VM::OpaqueType>()) {
+    os << "opaque";
+  } else if (auto listType = type.dyn_cast<IREE::VM::ListType>()) {
+    os << "list<" << listType.getElementType() << ">";
+  } else {
+    llvm_unreachable("unhandled VM type");
   }
 }
 

--- a/iree/compiler/Dialect/VM/IR/VMTypes.h
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.h
@@ -64,16 +64,12 @@ class ListType
   }
 
   Type getElementType();
-
-  static bool kindof(unsigned kind) { return kind == TypeKind::List; }
 };
 
 /// An opaque ref object that comes from an external source.
 class OpaqueType : public Type::TypeBase<OpaqueType, Type, TypeStorage> {
  public:
   using Base::Base;
-
-  static bool kindof(unsigned kind) { return kind == TypeKind::Opaque; }
 
   static OpaqueType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Opaque);
@@ -106,8 +102,6 @@ class RefType : public Type::TypeBase<RefType, Type, detail::RefTypeStorage> {
   }
 
   Type getObjectType();
-
-  static bool kindof(unsigned kind) { return kind == TypeKind::Ref; }
 };
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VMLA/IR/VMLATypes.h
+++ b/iree/compiler/Dialect/VMLA/IR/VMLATypes.h
@@ -49,7 +49,6 @@ class BufferType : public Type::TypeBase<BufferType, Type, TypeStorage> {
   static BufferType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Buffer);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Buffer; }
 };
 
 class InterfaceType : public Type::TypeBase<InterfaceType, Type, TypeStorage> {
@@ -58,7 +57,6 @@ class InterfaceType : public Type::TypeBase<InterfaceType, Type, TypeStorage> {
   static InterfaceType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Interface);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Interface; }
 };
 
 }  // namespace VMLA

--- a/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.h
+++ b/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.h
@@ -70,8 +70,6 @@ class TargetEnvAttr
   /// bits.
   CapabilitiesAttr getCapabilitiesAttr();
 
-  static bool kindof(unsigned kind) { return kind == AttrKind::TargetEnv; }
-
   static LogicalResult verifyConstructionInvariants(
       Location loc, IntegerAttr version, IntegerAttr revision,
       ArrayAttr extensions, DictionaryAttr capabilities);

--- a/iree/samples/custom_modules/dialect/custom_dialect.h
+++ b/iree/samples/custom_modules/dialect/custom_dialect.h
@@ -47,7 +47,6 @@ class MessageType : public Type::TypeBase<MessageType, Type, TypeStorage> {
   static MessageType get(MLIRContext *context) {
     return Base::get(context, TypeKind::Message);
   }
-  static bool kindof(unsigned kind) { return kind == TypeKind::Message; }
 };
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
The need/existence of these are being removed from upstream MLIR.
