### PR TITLE
Adding iree_vm_native_module to wrap up all the boilerplate for C modules.

### DIFF
--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -231,6 +231,62 @@ cc_library(
 )
 
 cc_library(
+    name = "native_module",
+    srcs = ["native_module.c"],
+    hdrs = ["native_module.h"],
+    deps = [
+        ":module",
+        ":stack",
+        "//iree/base:api",
+    ],
+)
+
+cc_test(
+    name = "native_module_benchmark",
+    srcs = ["native_module_benchmark.cc"],
+    deps = [
+        ":native_module_test_hdrs",
+        ":vm",
+        "//iree/base:api",
+        "//iree/base:logging",
+        "//iree/testing:benchmark_main",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
+cc_test(
+    name = "native_module_test",
+    srcs = ["native_module_test.cc"],
+    deps = [
+        ":context",
+        ":instance",
+        ":invocation",
+        ":list",
+        ":native_module_test_hdrs",
+        ":ref_cc",
+        "//iree/base:api",
+        "//iree/base:status",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "native_module_test_hdrs",
+    hdrs = [
+        "native_module_test.h",
+    ],
+    deps = [
+        ":context",
+        ":instance",
+        ":native_module",
+        ":ref",
+        ":stack",
+        "//iree/base:api",
+    ],
+)
+
+cc_library(
     name = "ref",
     srcs = ["ref.c"],
     hdrs = ["ref.h"],
@@ -314,6 +370,7 @@ cc_library(
         ":invocation",
         ":list",
         ":module",
+        ":native_module",
         ":ref",
         ":stack",
         ":type_def",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -261,6 +261,67 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    native_module
+  HDRS
+    "native_module.h"
+  SRCS
+    "native_module.c"
+  DEPS
+    ::module
+    ::stack
+    iree::base::api
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    native_module_benchmark
+  SRCS
+    "native_module_benchmark.cc"
+  DEPS
+    ::native_module_test_hdrs
+    ::vm
+    benchmark
+    iree::base::api
+    iree::base::logging
+    iree::testing::benchmark_main
+)
+
+iree_cc_test(
+  NAME
+    native_module_test
+  SRCS
+    "native_module_test.cc"
+  DEPS
+    ::context
+    ::instance
+    ::invocation
+    ::list
+    ::native_module_test_hdrs
+    ::ref_cc
+    iree::base::api
+    iree::base::status
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
+    native_module_test_hdrs
+  HDRS
+    "native_module_test.h"
+  DEPS
+    ::context
+    ::instance
+    ::native_module
+    ::ref
+    ::stack
+    iree::base::api
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     ref
   HDRS
     "ref.h"
@@ -358,6 +419,7 @@ iree_cc_library(
     ::invocation
     ::list
     ::module
+    ::native_module
     ::ref
     ::stack
     ::type_def

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -35,6 +35,12 @@ typedef struct iree_vm_stack_frame iree_vm_stack_frame_t;
 // to hash codes.
 typedef int64_t iree_vm_source_offset_t;
 
+// A key-value pair of module/function reflection information.
+typedef struct {
+  iree_string_view_t key;
+  iree_string_view_t value;
+} iree_vm_reflection_attr_t;
+
 // A variable-length list of registers.
 //
 // This structure is an overlay for the bytecode that is serialized in a

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -1,0 +1,376 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/vm/native_module.h"
+
+#include "iree/vm/stack.h"
+
+// Native module implementation allocated for all modules.
+typedef struct {
+  // Interface containing default function pointers.
+  // base_interface.self will be the self pointer to iree_vm_native_module_t.
+  //
+  // Must be first in the struct as we dereference the interface to find our
+  // members below.
+  iree_vm_module_t base_interface;
+
+  // Interface with optional user-provided function pointers.
+  // user_interface.self will contain the user's module pointer that must be
+  // passed to all functions.
+  iree_vm_module_t user_interface;
+
+  // Allocator this module was allocated with and must be freed with.
+  iree_allocator_t allocator;
+
+  // Module descriptor used for reflection.
+  const iree_vm_native_module_descriptor_t* descriptor;
+} iree_vm_native_module_t;
+
+#if defined(NDEBUG)
+static iree_status_t iree_vm_native_module_verify_descriptor(
+    const iree_vm_native_module_descriptor_t* module_descriptor) {}
+#else
+static iree_status_t iree_vm_native_module_verify_descriptor(
+    const iree_vm_native_module_descriptor_t* module_descriptor) {
+  // Verify the export table is sorted by name. This will help catch issues with
+  // people appending to tables instead of inserting in the proper order.
+  for (iree_host_size_t i = 1; i < module_descriptor->export_count; ++i) {
+    iree_string_view_t prev_export_name =
+        module_descriptor->exports[i - 1].local_name;
+    iree_string_view_t export_name = module_descriptor->exports[i].local_name;
+    int cmp = iree_string_view_compare(prev_export_name, export_name);
+    if (cmp >= 0) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "module export table is not sorted by name "
+                              "(export %zu ('%.*s') >= %zu ('%.*s'))",
+                              i - 1, (int)prev_export_name.size,
+                              prev_export_name.data, i, (int)export_name.size,
+                              export_name.data);
+    }
+  }
+  return iree_ok_status();
+}
+#endif  // NDEBUG
+
+static void IREE_API_PTR iree_vm_native_module_destroy(void* self) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+
+  // Destroy the optional user-provided self.
+  if (module->user_interface.destroy) {
+    module->user_interface.destroy(module->user_interface.self);
+  }
+
+  iree_allocator_free(module->allocator, module);
+}
+
+static iree_string_view_t IREE_API_PTR iree_vm_native_module_name(void* self) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.name) {
+    return module->user_interface.name(module->user_interface.self);
+  }
+  return module->descriptor->module_name;
+}
+
+static iree_vm_module_signature_t IREE_API_PTR
+iree_vm_native_module_signature(void* self) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.signature) {
+    return module->user_interface.signature(module->user_interface.self);
+  }
+  iree_vm_module_signature_t signature;
+  memset(&signature, 0, sizeof(signature));
+  signature.import_function_count = module->descriptor->import_count;
+  signature.export_function_count = module->descriptor->export_count;
+  signature.internal_function_count = 0;  // unused
+  return signature;
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_get_import_function(
+    iree_vm_native_module_t* module, iree_host_size_t ordinal,
+    iree_vm_function_t* out_function, iree_string_view_t* out_name,
+    iree_vm_function_signature_t* out_signature) {
+  if (ordinal >= module->descriptor->import_count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "import ordinal out of range (0 < %zu < %zu)",
+                            ordinal, module->descriptor->import_count);
+  }
+  const iree_vm_native_import_descriptor_t* import_descriptor =
+      &module->descriptor->imports[ordinal];
+  if (out_function) {
+    out_function->module = &module->base_interface;
+    out_function->linkage = IREE_VM_FUNCTION_LINKAGE_IMPORT;
+    out_function->ordinal = (uint16_t)ordinal;
+  }
+  if (out_name) {
+    *out_name = import_descriptor->full_name;
+  }
+  // TODO(#1979): signature queries when info is useful.
+  return iree_ok_status();
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_get_export_function(
+    iree_vm_native_module_t* module, iree_host_size_t ordinal,
+    iree_vm_function_t* out_function, iree_string_view_t* out_name,
+    iree_vm_function_signature_t* out_signature) {
+  if (ordinal >= module->descriptor->export_count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "export ordinal out of range (0 < %zu < %zu)",
+                            ordinal, module->descriptor->export_count);
+  }
+  const iree_vm_native_export_descriptor_t* export_descriptor =
+      &module->descriptor->exports[ordinal];
+  if (out_function) {
+    out_function->module = &module->base_interface;
+    out_function->linkage = IREE_VM_FUNCTION_LINKAGE_EXPORT;
+    out_function->ordinal = (uint16_t)ordinal;
+    out_function->i32_register_count = export_descriptor->i32_register_count;
+    out_function->ref_register_count = export_descriptor->ref_register_count;
+  }
+  if (out_name) {
+    *out_name = export_descriptor->local_name;
+  }
+  // TODO(#1979): signature queries when info is useful.
+  return iree_ok_status();
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_get_function(
+    void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
+    iree_vm_function_t* out_function, iree_string_view_t* out_name,
+    iree_vm_function_signature_t* out_signature) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (out_function) memset(out_function, 0, sizeof(*out_function));
+  if (out_name) memset(out_name, 0, sizeof(*out_name));
+  if (out_signature) memset(out_signature, 0, sizeof(*out_signature));
+  if (module->user_interface.get_function) {
+    return module->user_interface.get_function(module->user_interface.self,
+                                               linkage, ordinal, out_function,
+                                               out_name, out_signature);
+  }
+  switch (linkage) {
+    case IREE_VM_FUNCTION_LINKAGE_IMPORT:
+      return iree_vm_native_module_get_import_function(
+          module, ordinal, out_function, out_name, out_signature);
+    case IREE_VM_FUNCTION_LINKAGE_EXPORT:
+      return iree_vm_native_module_get_export_function(
+          module, ordinal, out_function, out_name, out_signature);
+    default:
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "native modules do not support internal function queries");
+  }
+}
+
+static iree_status_t IREE_API_PTR
+iree_vm_native_module_get_function_reflection_attr(
+    void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
+    iree_host_size_t index, iree_string_view_t* key,
+    iree_string_view_t* value) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.get_function_reflection_attr) {
+    return module->user_interface.get_function_reflection_attr(
+        module->user_interface.self, linkage, ordinal, index, key, value);
+  }
+  // TODO(benvanik): implement native module reflection.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "reflection not yet implemented");
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_lookup_function(
+    void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+    iree_vm_function_t* out_function) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  memset(out_function, 0, sizeof(*out_function));
+  if (module->user_interface.lookup_function) {
+    return module->user_interface.lookup_function(module->user_interface.self,
+                                                  linkage, name, out_function);
+  }
+
+  if (linkage != IREE_VM_FUNCTION_LINKAGE_EXPORT) {
+    // NOTE: we could support imports if required.
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "native modules do not support import/internal function queries");
+  }
+
+  // Binary search through the export descriptors.
+  ptrdiff_t min_ordinal = 0;
+  ptrdiff_t max_ordinal = module->descriptor->export_count - 1;
+  const iree_vm_native_export_descriptor_t* exports =
+      module->descriptor->exports;
+  while (min_ordinal <= max_ordinal) {
+    ptrdiff_t ordinal = (min_ordinal + max_ordinal) / 2;
+    int cmp = iree_string_view_compare(exports[ordinal].local_name, name);
+    if (cmp == 0) {
+      return iree_vm_native_module_get_function(self, linkage, ordinal,
+                                                out_function, NULL, NULL);
+    } else if (cmp < 0) {
+      min_ordinal = ordinal + 1;
+    } else {
+      max_ordinal = ordinal - 1;
+    }
+  }
+  return iree_make_status(
+      IREE_STATUS_NOT_FOUND, "no function %.*s.%.*s exported by module",
+      (int)module->descriptor->module_name.size,
+      module->descriptor->module_name.data, (int)name.size, name.data);
+}
+
+static iree_status_t IREE_API_PTR
+iree_vm_native_module_alloc_state(void* self, iree_allocator_t allocator,
+                                  iree_vm_module_state_t** out_module_state) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  *out_module_state = NULL;
+  if (module->user_interface.alloc_state) {
+    return module->user_interface.alloc_state(module->user_interface.self,
+                                              allocator, out_module_state);
+  }
+  // Default to no state.
+  return iree_ok_status();
+}
+
+static void IREE_API_PTR iree_vm_native_module_free_state(
+    void* self, iree_vm_module_state_t* module_state) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.free_state) {
+    module->user_interface.free_state(module->user_interface.self,
+                                      module_state);
+    return;
+  }
+  // No-op in the default implementation.
+  // TODO(#2843): IREE_DCHECK_EQ(NULL, module_state);
+  assert(!module_state);
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_resolve_import(
+    void* self, iree_vm_module_state_t* module_state, iree_host_size_t ordinal,
+    iree_vm_function_t function) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.resolve_import) {
+    return module->user_interface.resolve_import(
+        module->user_interface.self, module_state, ordinal, function);
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "native module does not support imports");
+}
+
+static iree_status_t IREE_API_PTR iree_vm_native_module_begin_call(
+    void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
+    iree_vm_execution_result_t* out_result) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (call->function.linkage != IREE_VM_FUNCTION_LINKAGE_EXPORT ||
+      call->function.ordinal >= module->descriptor->export_count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "function ordinal out of bounds: 0 < %u < %zu",
+                            call->function.ordinal,
+                            module->descriptor->export_count);
+  }
+  if (module->user_interface.begin_call) {
+    return module->user_interface.begin_call(module->user_interface.self, stack,
+                                             call, out_result);
+  }
+
+  iree_vm_module_state_t* module_state = NULL;
+  iree_vm_stack_frame_t* caller_frame = NULL;
+  IREE_RETURN_IF_ERROR(iree_vm_stack_native_enter(
+      stack, &call->function, &module_state, &caller_frame));
+
+  // Call the target function using the shim.
+  const iree_vm_native_function_ptr_t* function_ptr =
+      &module->descriptor->functions[call->function.ordinal];
+  iree_status_t status =
+      function_ptr->shim(module, module_state, stack, caller_frame, call,
+                         function_ptr->target, out_result);
+  if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+    iree_string_view_t module_name = iree_vm_native_module_name(module);
+    iree_string_view_t function_name = iree_string_view_empty();
+    iree_status_ignore(iree_vm_native_module_get_export_function(
+        module, call->function.ordinal, NULL, &function_name, NULL));
+    return iree_status_annotate_f(status,
+                                  "while invoking native function %.*s.%.*s",
+                                  (int)module_name.size, module_name.data,
+                                  (int)function_name.size, function_name.data);
+  }
+
+  return iree_vm_stack_native_leave(stack, call->result_registers);
+}
+
+static iree_status_t IREE_API_PTR
+iree_vm_native_module_resume_call(void* self, iree_vm_stack_t* stack,
+                                  iree_vm_execution_result_t* out_result) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.resume_call) {
+    return module->user_interface.resume_call(module->user_interface.self,
+                                              stack, out_result);
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "native module does not support resume");
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_native_module_create(
+    const iree_vm_module_t* interface,
+    const iree_vm_native_module_descriptor_t* module_descriptor,
+    iree_allocator_t allocator, iree_vm_module_t** out_module) {
+  IREE_ASSERT_ARGUMENT(out_module);
+  *out_module = NULL;
+
+  if (!interface->begin_call && !module_descriptor->functions) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "native modules must provide call support or function pointers");
+  } else if (!interface->begin_call && module_descriptor->export_count !=
+                                           module_descriptor->function_count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "native modules using the default call support "
+                            "must have 1:1 exports:function pointers");
+  }
+
+  // Perform some optional debug-only verification of the descriptor.
+  // Since native modules are designed to be compiled in we don't need to do
+  // this in release builds.
+  IREE_RETURN_IF_ERROR(
+      iree_vm_native_module_verify_descriptor(module_descriptor));
+
+  // TODO(benvanik): invert allocation such that caller allocates and we init.
+  // This would avoid the need for any dynamic memory allocation in the common
+  // case as the outer user module interface could nest us. Note that we'd need
+  // to expose this via a query_size function so that we could adjust the size
+  // of our storage independent of the definition of the user module.
+  iree_vm_native_module_t* module = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      allocator, sizeof(iree_vm_native_module_t), (void**)&module));
+  module->allocator = allocator;
+  module->descriptor = module_descriptor;
+
+  // TODO(benvanik): version interface and copy only valid bytes.
+  memcpy(&module->user_interface, interface, sizeof(*interface));
+
+  // Base interface that routes through our thunks.
+  iree_vm_module_initialize(&module->base_interface, module);
+  module->base_interface.destroy = iree_vm_native_module_destroy;
+  module->base_interface.name = iree_vm_native_module_name;
+  module->base_interface.signature = iree_vm_native_module_signature;
+  module->base_interface.get_function = iree_vm_native_module_get_function;
+  module->base_interface.get_function_reflection_attr =
+      iree_vm_native_module_get_function_reflection_attr;
+  module->base_interface.lookup_function =
+      iree_vm_native_module_lookup_function;
+  module->base_interface.alloc_state = iree_vm_native_module_alloc_state;
+  module->base_interface.free_state = iree_vm_native_module_free_state;
+  module->base_interface.resolve_import = iree_vm_native_module_resolve_import;
+  module->base_interface.begin_call = iree_vm_native_module_begin_call;
+  module->base_interface.resume_call = iree_vm_native_module_resume_call;
+
+  *out_module = &module->base_interface;
+  return iree_ok_status();
+}

--- a/iree/vm/native_module.h
+++ b/iree/vm/native_module.h
@@ -1,0 +1,128 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: native_module_test.h contains documented examples of how to use this!
+
+#ifndef IREE_VM_NATIVE_MODULE_H_
+#define IREE_VM_NATIVE_MODULE_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/vm/module.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Describes an imported native function in a native module.
+// All of this information is assumed read-only and will be referenced for the
+// lifetime of any module created with the descriptor.
+typedef struct {
+  // Fully-qualified function name (for example, 'other_module.foo').
+  iree_string_view_t full_name;
+} iree_vm_native_import_descriptor_t;
+
+// Describes an exported native function in a native module.
+// All of this information is assumed read-only and will be referenced for the
+// lifetime of any module created with the descriptor.
+typedef struct {
+  // Module-local function name (for example, 'foo' for function 'module.foo').
+  iree_string_view_t local_name;
+
+  // TODO(#1979): move register info to iree_vm_function_signature_t.
+  // Total number of valid i32 registers used by the function.
+  uint16_t i32_register_count;
+  // Total number of valid ref registers used by the function.
+  uint16_t ref_register_count;
+
+  // An optional list of function-level reflection attributes.
+  iree_host_size_t reflection_attr_count;
+  const iree_vm_reflection_attr_t* reflection_attrs;
+} iree_vm_native_export_descriptor_t;
+
+typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target_t)(
+    void* module, void* module_state, iree_vm_stack_t* stack);
+
+typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_shim_t)(
+    void* module, void* module_state, iree_vm_stack_t* stack,
+    iree_vm_stack_frame_t* caller_frame, const iree_vm_function_call_t* call,
+    iree_vm_native_function_target_t target_fn,
+    iree_vm_execution_result_t* out_result);
+
+// An entry in the function pointer table.
+typedef struct {
+  // A shim function that takes the VM ABI and maps it to the target ABI.
+  iree_vm_native_function_shim_t shim;
+  // Target function passed to the shim.
+  iree_vm_native_function_target_t target;
+} iree_vm_native_function_ptr_t;
+
+// Describes an native module implementation by way of descriptor tables.
+// All of this information is assumed read-only and will be referenced for the
+// lifetime of any module created with the descriptor.
+//
+// The common native module code will use this descriptor to return metadata on
+// query, lookup exported functions, and call module-provided implementation
+// functions for state and call management.
+typedef struct {
+  // Name of the module prefixed on all exported functions.
+  iree_string_view_t module_name;
+
+  // All imported function descriptors.
+  // interface.resolve_import will be called for each import.
+  // Imports must be in order sorted by name compatible with
+  // iree_string_view_compare.
+  iree_host_size_t import_count;
+  const iree_vm_native_import_descriptor_t* imports;
+
+  // All exported function descriptors.
+  // Exports must be in order sorted by name compatible with
+  // iree_string_view_compare.
+  iree_host_size_t export_count;
+  const iree_vm_native_export_descriptor_t* exports;
+
+  // All function shims and target function pointers.
+  // These must match 1:1 with the exports if using the default begin_call
+  // implementation and are optional if overriding begin_call.
+  iree_host_size_t function_count;
+  const iree_vm_native_function_ptr_t* functions;
+
+  // An optional list of module-level reflection attributes.
+  iree_host_size_t reflection_attr_count;
+  const iree_vm_reflection_attr_t* reflection_attrs;
+} iree_vm_native_module_descriptor_t;
+
+// Creates a new native module with the metadata tables in |descriptor|.
+// These tables will be used for reflection and function lookup, and the
+// provided function pointers will be called when state needs to be managed or
+// exported functions need to be called.
+//
+// An implementation |interface| providing functions for state management and
+// function calls can be provided to override default implementations of
+// functions. The structure will be copied and the self pointer will be passed
+// to all |interface| functions.
+//
+// The provided |descriptor| will be referenced by the created module and must
+// be kept live for the lifetime of the module.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_native_module_create(
+    const iree_vm_module_t* interface,
+    const iree_vm_native_module_descriptor_t* module_descriptor,
+    iree_allocator_t allocator, iree_vm_module_t** out_module);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_VM_NATIVE_MODULE_H_

--- a/iree/vm/native_module_benchmark.cc
+++ b/iree/vm/native_module_benchmark.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IREE_VM_API_H_
-#define IREE_VM_API_H_
-
+#include "benchmark/benchmark.h"
 #include "iree/base/api.h"
-#include "iree/vm/builtin_types.h"
-#include "iree/vm/context.h"
-#include "iree/vm/instance.h"
-#include "iree/vm/invocation.h"
-#include "iree/vm/list.h"
+#include "iree/base/logging.h"
 #include "iree/vm/module.h"
 #include "iree/vm/native_module.h"
-#include "iree/vm/ref.h"
+#include "iree/vm/native_module_test.h"
 #include "iree/vm/stack.h"
-#include "iree/vm/type_def.h"
-#include "iree/vm/value.h"
 
-#endif  // IREE_VM_API_H_
+namespace {
+
+// TODO(benvanik): native module benchmarks.
+
+}  // namespace

--- a/iree/vm/native_module_test.cc
+++ b/iree/vm/native_module_test.cc
@@ -1,0 +1,115 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/vm/native_module_test.h"
+
+#include "iree/base/status.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "iree/vm/context.h"
+#include "iree/vm/instance.h"
+#include "iree/vm/invocation.h"
+#include "iree/vm/list.h"
+#include "iree/vm/ref_cc.h"
+
+namespace iree {
+namespace {
+
+// Test suite that uses module_a and module_b defined in native_module_test.h.
+// Both modules are put in a context and the module_b.entry function can be
+// executed with RunFunction.
+class VMNativeModuleTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    IREE_CHECK_OK(iree_vm_instance_create(iree_allocator_system(), &instance_));
+
+    // Create both modules shared instances. These are generally immutable and
+    // can be shared by multiple contexts.
+    iree_vm_module_t* module_a = nullptr;
+    IREE_CHECK_OK(module_a_create(iree_allocator_system(), &module_a));
+    iree_vm_module_t* module_b = nullptr;
+    IREE_CHECK_OK(module_b_create(iree_allocator_system(), &module_b));
+
+    // Create the context with both modules and perform runtime linkage.
+    // Imports from module_a -> module_b will be resolved and per-context state
+    // will be allocated.
+    std::vector<iree_vm_module_t*> modules = {module_a, module_b};
+    IREE_CHECK_OK(iree_vm_context_create_with_modules(
+        instance_, modules.data(), modules.size(), iree_allocator_system(),
+        &context_));
+
+    // No longer need the modules as the context retains them.
+    iree_vm_module_release(module_a);
+    iree_vm_module_release(module_b);
+  }
+
+  virtual void TearDown() {
+    iree_vm_context_release(context_);
+    iree_vm_instance_release(instance_);
+  }
+
+  StatusOr<int32_t> RunFunction(iree_string_view_t function_name,
+                                int32_t arg0) {
+    // Lookup the entry function. This can be cached in an application if
+    // multiple calls will be made.
+    iree_vm_function_t function;
+    IREE_RETURN_IF_ERROR(
+        iree_vm_context_resolve_function(
+            context_, iree_make_cstring_view("module_b.entry"), &function),
+        "unable to resolve entry point");
+
+    // Setup I/O lists and pass in the argument. The result list will be
+    // populated upon return.
+    vm::ref<iree_vm_list_t> input_list;
+    IREE_RETURN_IF_ERROR(iree_vm_list_create(
+        /*element_type=*/nullptr, 1, iree_allocator_system(), &input_list));
+    auto arg0_value = iree_vm_value_make_i32(arg0);
+    IREE_RETURN_IF_ERROR(
+        iree_vm_list_push_value(input_list.get(), &arg0_value));
+    vm::ref<iree_vm_list_t> output_list;
+    IREE_RETURN_IF_ERROR(iree_vm_list_create(
+        /*element_type=*/nullptr, 1, iree_allocator_system(), &output_list));
+
+    // Invoke the entry function to do our work. Runs synchronously.
+    IREE_RETURN_IF_ERROR(iree_vm_invoke(context_, function,
+                                        /*policy=*/nullptr, input_list.get(),
+                                        output_list.get(),
+                                        iree_allocator_system()));
+
+    // Load the output result.
+    iree_vm_value_t ret0_value;
+    IREE_RETURN_IF_ERROR(
+        iree_vm_list_get_value(output_list.get(), 0, &ret0_value));
+    return ret0_value.i32;
+  }
+
+ private:
+  iree_vm_instance_t* instance_ = nullptr;
+  iree_vm_context_t* context_ = nullptr;
+};
+
+TEST_F(VMNativeModuleTest, Example) {
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t v0, RunFunction(iree_make_cstring_view("module_b.entry"), 1));
+  ASSERT_EQ(v0, 4);
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t v1, RunFunction(iree_make_cstring_view("module_b.entry"), 2));
+  ASSERT_EQ(v1, 4);
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t v2, RunFunction(iree_make_cstring_view("module_b.entry"), 3));
+  ASSERT_EQ(v2, 4);
+}
+
+}  // namespace
+}  // namespace iree

--- a/iree/vm/native_module_test.h
+++ b/iree/vm/native_module_test.h
@@ -1,0 +1,297 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/vm/context.h"
+#include "iree/vm/instance.h"
+#include "iree/vm/native_module.h"
+#include "iree/vm/ref.h"
+#include "iree/vm/stack.h"
+
+// Wrappers for calling the import functions with type (i32)->i32.
+// NOTE: we should have some common ones prebuilt or can generate and rely on
+// LTO to strip duplicates across the entire executable.
+// TODO(benvanik): generate/export these shims/call functions in stack.h.
+static iree_status_t call_import_i32_i32(iree_vm_stack_t* stack,
+                                         const iree_vm_function_t* import,
+                                         int32_t arg0, int32_t* out_ret0) {
+  // DO NOT SUBMIT
+  return 0;
+}
+
+typedef iree_status_t (*call_i32_i32_t)(void* module_ptr, void* module_state,
+                                        iree_vm_stack_t* stack, int32_t arg0,
+                                        int32_t* out_ret0);
+
+static iree_status_t call_shim_i32_i32(void* module, void* module_state,
+                                       iree_vm_stack_t* stack,
+                                       iree_vm_stack_frame_t* caller_frame,
+                                       const iree_vm_function_call_t* call,
+                                       call_i32_i32_t target_fn,
+                                       iree_vm_execution_result_t* out_result) {
+  const iree_vm_register_list_t* arg_list = call->argument_registers;
+  const iree_vm_register_list_t* ret_list = call->result_registers;
+  auto& regs = caller_frame->registers;
+
+  // TODO(benvanik): verify register counts/values and log nice errors.
+
+  // Grab I/O. Doing this here allows for a tail-call to the target_fn.
+  int32_t arg0 = regs.i32[arg_list->registers[0] & regs.i32_mask];
+  int32_t* out_ret0 = &regs.i32[ret_list->registers[0] & regs.i32_mask];
+
+  return target_fn(module, module_state, stack, arg0, out_ret0);
+}
+
+//===----------------------------------------------------------------------===//
+// module_a
+//===----------------------------------------------------------------------===//
+// This simple stateless module exports two functions that can be imported by
+// other modules or called directly by the user. When no imports, custom types,
+// or per-context state is required this simplifies module definitions.
+//
+// module_b below imports these functions and demonstrates a more complex module
+// with state.
+
+struct module_a_s;
+struct module_a_state_s;
+typedef struct module_a_s module_a_t;
+typedef struct module_a_state_s module_a_state_t;
+
+// vm.import @module_a.add_1(%arg0 : i32) -> i32
+static iree_status_t module_a_add_1(module_a_t* module,
+                                    module_a_state_t* module_state,
+                                    iree_vm_stack_t* stack, int32_t arg0,
+                                    int32_t* out_ret0) {
+  // Add 1 to arg0 and return.
+  *out_ret0 = arg0 + 1;
+  return iree_ok_status();
+}
+
+// vm.import @module_a.sub_1(%arg0 : i32) -> i32
+static iree_status_t module_a_sub_1(module_a_t* module,
+                                    module_a_state_t* module_state,
+                                    iree_vm_stack_t* stack, int32_t arg0,
+                                    int32_t* out_ret0) {
+  // Sub 1 to arg0 and return. Fail if < 0.
+  *out_ret0 = arg0 - 1;
+  return iree_ok_status();
+}
+
+static const iree_vm_native_export_descriptor_t module_a_exports_[] = {
+    {iree_make_cstring_view("add_1"), 0, 0, 0, NULL},
+    {iree_make_cstring_view("sub_1"), 0, 0, 0, NULL},
+};
+static const iree_vm_native_function_ptr_t module_a_funcs_[] = {
+    {(iree_vm_native_function_shim_t)call_shim_i32_i32,
+     (iree_vm_native_function_target_t)module_a_add_1},
+    {(iree_vm_native_function_shim_t)call_shim_i32_i32,
+     (iree_vm_native_function_target_t)module_a_sub_1},
+};
+static_assert(IREE_ARRAYSIZE(module_a_funcs_) ==
+                  IREE_ARRAYSIZE(module_a_exports_),
+              "function pointer table must be 1:1 with exports");
+static const iree_vm_native_module_descriptor_t module_a_descriptor_ = {
+    iree_make_cstring_view("module_a"),
+    0,
+    NULL,
+    IREE_ARRAYSIZE(module_a_exports_),
+    module_a_exports_,
+    IREE_ARRAYSIZE(module_a_funcs_),
+    module_a_funcs_,
+    0,
+    NULL,
+};
+
+static iree_status_t module_a_create(iree_allocator_t allocator,
+                                     iree_vm_module_t** out_module) {
+  // NOTE: this module has neither shared or per-context module state.
+  iree_vm_module_t interface;
+  IREE_RETURN_IF_ERROR(iree_vm_module_initialize(&interface, NULL));
+  return iree_vm_native_module_create(&interface, &module_a_descriptor_,
+                                      allocator, out_module);
+}
+
+//===----------------------------------------------------------------------===//
+// module_b
+//===----------------------------------------------------------------------===//
+// A more complex module that holds state for resolved types (shared across
+// all instances), imported functions (stored per-context), per-context user
+// data, and reflection metadata.
+
+struct module_b_s;
+struct module_b_state_s;
+typedef struct module_b_s module_b_t;
+typedef struct module_b_state_s module_b_state_t;
+
+// Stores shared state across all instances of the module.
+// This should generally be treated as read-only and if mutation is possible
+// then users must synchronize themselves.
+typedef struct module_b_s {
+  // Allocator the module must be freed with and that can be used for any other
+  // shared dynamic allocations.
+  iree_allocator_t allocator;
+  // Resolved types; these never change once queried and are safe to store on
+  // the shared structure to avoid needing to look them up again.
+  const iree_vm_ref_type_descriptor_t* types[1];
+} module_b_t;
+
+// Stores per-context state; at the minimum imports, but possibly other user
+// state data. No synchronization is required as the VM will not call functions
+// with the same state from multiple threads concurrently.
+typedef struct module_b_state_s {
+  // Allocator the state must be freed with and that can be used for any other
+  // per-context dynamic allocations.
+  iree_allocator_t allocator;
+  // Resolved import functions matching 1:1 with the module import descriptors.
+  iree_vm_function_t imports[2];
+  // Example user data stored per-state.
+  int counter;
+} module_b_state_t;
+
+// Frees the shared module; by this point all per-context states have been
+// freed and no more shared data is required.
+static void IREE_API_PTR module_b_destroy(void* self) {
+  module_b_t* module = (module_b_t*)self;
+  iree_allocator_free(module->allocator, module);
+}
+
+// Allocates per-context state, which stores resolved import functions and any
+// other non-shared user state.
+static iree_status_t IREE_API_PTR
+module_b_alloc_state(void* self, iree_allocator_t allocator,
+                     iree_vm_module_state_t** out_module_state) {
+  module_b_state_t* state = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, sizeof(*state), (void**)&state));
+  memset(state, 0, sizeof(*state));
+  *out_module_state = (iree_vm_module_state_t*)state;
+  return iree_ok_status();
+}
+
+// Frees the per-context state.
+static void IREE_API_PTR
+module_b_free_state(void* self, iree_vm_module_state_t* module_state) {
+  module_b_state_t* state = (module_b_state_t*)module_state;
+  iree_allocator_free(state->allocator, state);
+}
+
+// Called once per import function so the module can store the function ref.
+static iree_status_t IREE_API_PTR
+module_b_resolve_import(void* self, iree_vm_module_state_t* module_state,
+                        iree_host_size_t ordinal, iree_vm_function_t function) {
+  module_b_state_t* state = (module_b_state_t*)module_state;
+  state->imports[ordinal] = function;
+  return iree_ok_status();
+}
+
+// Our actual function. Here we directly access the registers but one could also
+// use this as a trampoline into user code with a native signature (such as
+// fetching the args, calling the function as a normal C function, and stashing
+// back the results).
+//
+// vm.import @module_b.entry(%arg0 : i32) -> i32
+static iree_status_t module_b_entry(module_b_t* module,
+                                    module_b_state_t* module_state,
+                                    iree_vm_stack_t* stack, int32_t arg0,
+                                    int32_t* out_ret0) {
+  // NOTE: if we needed to use ref types here we have them under module->types.
+  assert(module->types[0]);
+
+  // Call module_a.add_1.
+  IREE_RETURN_IF_ERROR(
+      call_import_i32_i32(stack, &module_state->imports[0], arg0, &arg0));
+
+  // Increment per-context state (persists across calls). No need for a mutex as
+  // only one thread can be using the per-context state at a time.
+  module_state->counter += arg0;
+  int32_t ret0 = module_state->counter;
+
+  // Call module_a.sub_1.
+  IREE_RETURN_IF_ERROR(
+      call_import_i32_i32(stack, &module_state->imports[1], ret0, &ret0));
+
+  *out_ret0 = ret0;
+  return iree_ok_status();
+}
+
+// Table of exported function pointers. Note that this table could be read-only
+// (like here) or shared/per-context to allow exposing different functions based
+// on versions, access rights, etc.
+static const iree_vm_native_function_ptr_t module_b_funcs_[] = {
+    {(iree_vm_native_function_shim_t)call_shim_i32_i32,
+     (iree_vm_native_function_target_t)module_b_entry},
+};
+
+static const iree_vm_native_import_descriptor_t module_b_imports_[] = {
+    {iree_make_cstring_view("module_a.add_1")},
+    {iree_make_cstring_view("module_a.sub_1")},
+};
+static_assert(IREE_ARRAYSIZE(module_b_state_t::imports) ==
+                  IREE_ARRAYSIZE(module_b_imports_),
+              "import storage must be able to hold all imports");
+static const iree_vm_reflection_attr_t module_b_entry_attrs_[] = {
+    {iree_make_cstring_view("key1"), iree_make_cstring_view("value1")},
+};
+static const iree_vm_native_export_descriptor_t module_b_exports_[] = {
+    {iree_make_cstring_view("entry"), 0, 0,
+     IREE_ARRAYSIZE(module_b_entry_attrs_), module_b_entry_attrs_},
+};
+static_assert(IREE_ARRAYSIZE(module_b_funcs_) ==
+                  IREE_ARRAYSIZE(module_b_exports_),
+              "function pointer table must be 1:1 with exports");
+static const iree_vm_native_module_descriptor_t module_b_descriptor_ = {
+    iree_make_cstring_view("module_b"),
+    IREE_ARRAYSIZE(module_b_imports_),
+    module_b_imports_,
+    IREE_ARRAYSIZE(module_b_exports_),
+    module_b_exports_,
+    IREE_ARRAYSIZE(module_b_funcs_),
+    module_b_funcs_,
+    0,
+    NULL,
+};
+
+static iree_status_t module_b_create(iree_allocator_t allocator,
+                                     iree_vm_module_t** out_module) {
+  // Allocate shared module state.
+  module_b_t* module = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, sizeof(*module), (void**)&module));
+  memset(module, 0, sizeof(*module));
+
+  // Resolve types used by the module once so that we can share it across all
+  // instances of the module.
+  module->types[0] = iree_vm_ref_lookup_registered_type(
+      iree_make_cstring_view("iree.byte_buffer"));
+  if (!module->types[0]) {
+    iree_allocator_free(allocator, module);
+    return iree_make_status(
+        IREE_STATUS_NOT_FOUND,
+        "required type iree.byte_buffer not registered with the type system");
+  }
+
+  // Setup the interface with the functions we implement ourselves. Any function
+  // we omit will be handled by the base native module.
+  iree_vm_module_t interface;
+  iree_status_t status = iree_vm_module_initialize(&interface, module);
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(allocator, module);
+    return status;
+  }
+  interface.destroy = module_b_destroy;
+  interface.alloc_state = module_b_alloc_state;
+  interface.free_state = module_b_free_state;
+  interface.resolve_import = module_b_resolve_import;
+  return iree_vm_native_module_create(&interface, &module_b_descriptor_,
+                                      allocator, out_module);
+}

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -216,6 +216,18 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_leave(
     iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers,
     iree_vm_stack_frame_t** out_caller_frame);
 
+// Enters into a `[native]` frame and returns the caller stack frame.
+// May invalidate any existing pointers to stack frames and the only pointer
+// that can be assumed valid after return is the one in |out_callee_frame|.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_native_enter(
+    iree_vm_stack_t* stack, const iree_vm_function_t* function,
+    iree_vm_module_state_t** out_module_state,
+    iree_vm_stack_frame_t** out_caller_frame);
+
+// Leaves the current native stack frame.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_native_leave(
+    iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers);
+
 // Enters into an `[external]` frame and returns the external stack frame.
 // May invalidate any existing pointers to stack frames and the only pointer
 // that can be assumed valid after return is the one in |out_callee_frame|.


### PR DESCRIPTION
native_module_test.h demonstrates usage (simple static functions, imported
functions, and statefullness).

Future changes will rebase module_abi_cc.h on top of this (so that all
modules share code), add a tool for generating .h/c marshaling code based
on vm.import files, and add some ABI register access helpers.