### PR TITLE
Add `tf_utils._makedirs` to address race condition.

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -58,14 +58,7 @@ def _setup_artifacts_dir(module_name):
     parent_dir = os.path.join(tempfile.gettempdir(), "iree", "modules")
   artifacts_dir = os.path.join(parent_dir, module_name)
   logging.info("Saving compilation artifacts and traces to '%s'", artifacts_dir)
-
-  # If the artifacts already exist then we overwrite/update them.
-  try:
-    # Use try/except instead of os.path.exists to address a race condition
-    # between multiple tests targets.
-    os.makedirs(artifacts_dir)
-  except IOError:
-    pass
+  tf_utils._makedirs(artifacts_dir)
   return artifacts_dir
 
 
@@ -316,8 +309,7 @@ class Trace:
   def _get_trace_dir(self, artifacts_dir):
     trace_dir = os.path.join(artifacts_dir, self.backend, "traces",
                              self.function_name)
-    if not os.path.exists(trace_dir):
-      os.makedirs(trace_dir)
+    tf_utils._makedirs(trace_dir)
     return trace_dir
 
   def save_plaintext(self, artifacts_dir, summarize=True):

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -102,11 +102,20 @@ def _get_backends_path(artifact_name, backend_infos, artifacts_dir):
   # Put the artifact in a directory if there's only one backend.
   if len(backend_infos) == 1:
     backend_dir = os.path.join(artifacts_dir, backends_string)
-    if not os.path.exists(backend_dir):
-      os.makedirs(backend_dir)
+    _makedirs(backend_dir)
     return os.path.join(artifacts_dir, backends_string, artifact_name)
   else:
     return os.path.join(artifacts_dir, f"{artifact_name}__{backends_string}")
+
+
+def _makedirs(path):
+  # If the artifacts already exist then we overwrite/update them.
+  try:
+    # Use try/except instead of os.path.exists to address any race conditions
+    # that might arise between multiple tests targets.
+    os.makedirs(path)
+  except IOError:
+    pass
 
 
 def compile_tf_module(tf_module,


### PR DESCRIPTION
Use `try`/`except` to to run `os.makedirs` to give it similar behavior to `mkdir -p`, which doesn't fail if the directory already exists.

This was the cause of this [post-submit failure](https://source.cloud.google.com/results/invocations/fdc5d110-9ddb-444a-8ab9-f151c6b17018/targets).