### PR TITLE
Add support for trivial dot_general for vulkan-spirv backend.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -296,6 +296,64 @@ struct DotOpConversion
 }  // namespace
 
 //===----------------------------------------------------------------------===//
+// mhlo.dot_general conversion patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Converts mhlo.dot_general operation to linalg.batchmatmul op
+struct DotGeneralOpConversion
+    : public ConvertToLinalgBufferOp<DotGeneralOpConversion,
+                                     mhlo::DotGeneralOp> {
+  using ConvertToLinalgBufferOp<DotGeneralOpConversion,
+                                mhlo::DotGeneralOp>::ConvertToLinalgBufferOp;
+  LogicalResult apply(mhlo::DotGeneralOp op, ArrayRef<Value> inputBuffers,
+                      ArrayRef<Value> resultBuffers,
+                      ConversionPatternRewriter &rewriter) const {
+    auto extract1DVector = [](DenseIntElementsAttr elements) {
+      SmallVector<int64_t, 6> ret;
+      for (const APInt &element : elements) {
+        ret.push_back(element.getLimitedValue());
+      }
+      return ret;
+    };
+    mhlo::DotDimensionNumbers dimNumbers = op.dot_dimension_numbers();
+    auto lhsBatchingDims =
+        extract1DVector(dimNumbers.lhs_batching_dimensions());
+    auto rhsBatchingDims =
+        extract1DVector(dimNumbers.rhs_batching_dimensions());
+    auto lhsContractingDims =
+        extract1DVector(dimNumbers.lhs_contracting_dimensions());
+    auto rhsContractingDims =
+        extract1DVector(dimNumbers.rhs_contracting_dimensions());
+    if (lhsBatchingDims.size() != 1 || lhsBatchingDims[0] != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "expected lhs batching dimensions exactly {0}");
+    }
+    if (rhsBatchingDims.size() != 1 || rhsBatchingDims[0] != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "expected rhs batching dimensions exactly {0}");
+    }
+    if (lhsContractingDims.size() != 1 || lhsContractingDims[0] != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "expected lhs contracting dimensions exactly {2}");
+    }
+    if (rhsContractingDims.size() != 1 || rhsContractingDims[0] != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "expected rhs contracting dimensions exactly {1}");
+    }
+    if (failed(zeroFillBuffer(op.getLoc(), resultBuffers[0], rewriter))) {
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to zero fill result buffer");
+    }
+    rewriter.create<linalg::BatchMatmulOp>(
+        op.getLoc(), TypeRange{},
+        ValueRange{inputBuffers[0], inputBuffers[1], resultBuffers[0]});
+    return success();
+  }
+};
+}  // namespace
+
+//===----------------------------------------------------------------------===//
 // mhlo.convolution conversion patterns and utility functions.
 //===----------------------------------------------------------------------===//
 
@@ -1468,7 +1526,7 @@ void populateHLOToLinalgOnBuffersConversionPatterns(
   patterns.insert<
       ConvOpConversion, ConcatenateOpConversion,
       DotOpConversion<DotOperationType::MatrixMatrix, linalg::MatmulOp>,
-      LinalgOpOnTensorConversion<linalg::GenericOp>,
+      DotGeneralOpConversion, LinalgOpOnTensorConversion<linalg::GenericOp>,
       LinalgOpOnTensorConversion<linalg::IndexedGenericOp>, PadOpConversion,
       ReduceOpConversion, ReduceWindowOpConversion, SliceOpConversion,
       TensorReshapeOpConversion, TorchIndexSelectOpConversion>(

--- a/iree/compiler/Conversion/HLOToLinalg/test/dot_general.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/dot_general.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt -iree-codegen-hlo-to-linalg-on-buffers %s | IreeFileCheck %s
+
+module {
+  // CHECK: func @dot_general
+  func @dot_general() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2x3xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<2x3x4xf32>
+    // CHECK: linalg.batch_matmul %{{.+}}, %{{.+}}, %{{.+}} : (memref<2x2x3xf32>, memref<2x3x4xf32>, memref<2x2x4xf32>)
+    %result ="mhlo.dot_general"(%0, %1) {
+        dot_dimension_numbers = {
+            lhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
+            rhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            rhs_contracting_dimensions = dense<1> : tensor<1xi64>
+        },
+        precision_config = ["DEFAULT", "DEFAULT"]
+  } : (tensor<2x2x3xf32>, tensor<2x3x4xf32>) -> tensor<2x2x4xf32>
+    hal.interface.store.tensor %result, @legacy_io::@ret0, offset = %c0 : tensor<2x2x4xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -775,6 +775,7 @@ void ConvertToGPUPass::runOnFunction() {
                   MapLinalgOpToLocalInvocationId<linalg::ConvOp>,
                   MapLinalgOpToLocalInvocationId<linalg::CopyOp>,
                   MapLinalgOpToLocalInvocationId<linalg::MatmulOp>,
+                  MapLinalgOpToLocalInvocationId<linalg::BatchMatmulOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingMaxOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingMinOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingSumOp>,

--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -438,17 +438,16 @@ void LinalgTileAndFusePass::runOnFunction() {
   });
 
   OwningRewritePatternList tilingPatterns;
-  tilingPatterns.insert<TileConvPoolPattern<linalg::ConvOp>,
-                        TileMatmulPattern,
-                        TileBatchMatmulPattern,
-                        TileConvPoolPattern<linalg::PoolingMaxOp>,
-                        TileConvPoolPattern<linalg::PoolingMinOp>,
-                        TileConvPoolPattern<linalg::PoolingSumOp>>(
-      context,
-      linalg::LinalgTilingOptions()
-          .setTileSizes(tileSizeCalculator.getTileSizes())
-          .setLoopType(linalg::LinalgTilingLoopType::ParallelLoops),
-      tileSizeCalculator.getWorkgroupSize());
+  tilingPatterns
+      .insert<TileConvPoolPattern<linalg::ConvOp>, TileMatmulPattern,
+              TileBatchMatmulPattern, TileConvPoolPattern<linalg::PoolingMaxOp>,
+              TileConvPoolPattern<linalg::PoolingMinOp>,
+              TileConvPoolPattern<linalg::PoolingSumOp>>(
+          context,
+          linalg::LinalgTilingOptions()
+              .setTileSizes(tileSizeCalculator.getTileSizes())
+              .setLoopType(linalg::LinalgTilingLoopType::ParallelLoops),
+          tileSizeCalculator.getWorkgroupSize());
   applyPatternsAndFoldGreedily(getOperation(), tilingPatterns);
 
   if (useWorkgroupMemory) {

--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -173,7 +173,7 @@ LogicalResult TileSizeCalculator::inferTileAndWorkgroupSize(
   }
   if (opInfo & OpInfo::BatchMatmul) {
     tileSizes = {2, 8, 8, 4};
-    workgroupSize = {2, 8, 8};
+    workgroupSize = {8, 8, 2};
     return success();
   }
   if (opInfo & OpInfo::Pooling) {

--- a/iree/test/e2e/vulkan_specific/dot_general.mlir
+++ b/iree/test/e2e/vulkan_specific/dot_general.mlir
@@ -1,0 +1,49 @@
+func @dot_general_trivial_batching_dimension() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant  dense<[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]]> : tensor<1x2x3xf32>
+  %rhs = iree.unfoldable_constant dense<[[
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0]]]> : tensor<1x3x4xf32>
+  %res = "mhlo.dot_general"(%lhs, %rhs) {
+        dot_dimension_numbers = {
+            lhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
+            rhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            rhs_contracting_dimensions = dense<1> : tensor<1xi64>
+        },
+        precision_config = ["DEFAULT", "DEFAULT"]
+  } : (tensor<1x2x3xf32>, tensor<1x3x4xf32>) -> tensor<1x2x4xf32>
+  check.expect_almost_eq_const(%res, dense<[[[0.6, 1.2, 1.8, 2.4],[1.5, 3.0, 4.5, 6.0]]]> : tensor<1x2x4xf32>) : tensor<1x2x4xf32>
+  return
+}
+
+func @dot_general_nontrivial_batching_dimension() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[
+    [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+    [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<2x2x3xf32>
+  %rhs = iree.unfoldable_constant dense<[[
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0]
+  ], [
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0],
+    [1.0, 2.0, 3.0, 4.0]]]> : tensor<2x3x4xf32>
+  %res = "mhlo.dot_general"(%lhs, %rhs) {
+        dot_dimension_numbers = {
+            lhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
+            rhs_batching_dimensions = dense<0> : tensor<1xi64>,
+            rhs_contracting_dimensions = dense<1> : tensor<1xi64>
+        },
+        precision_config = ["DEFAULT", "DEFAULT"]
+  } : (tensor<2x2x3xf32>, tensor<2x3x4xf32>) -> tensor<2x2x4xf32>
+  check.expect_almost_eq_const(%res, dense<[
+      [
+          [0.6, 1.2, 1.8, 2.4],
+          [1.5, 3.0, 4.5, 6.0]
+      ], [
+          [6.0, 12.0, 18.0, 24.0],
+          [15.0, 30.0, 45.0, 60.0]]]> : tensor<2x2x4xf32>) : tensor<2x2x4xf32>
+  return
+}


### PR DESCRIPTION
It is not trivial to handle general cases because transpose op and
reshape op will be inserted before and after the linalg.batch_matmul.
Therefore, only the trivial case is handled, which is formed as the
definition of linalg.batch_matmul in the tc file.

Hit an issue in LinalgTileAndFusePass on BatchMatmulOp. It seems to be
the same bug as pool/conv op, so handle it as the same way as pool/conv
op.