### PR TITLE
Avoid confusing error message in TF tests

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -504,13 +504,10 @@ class TracedModuleTestCase(tf.test.TestCase):
     if failed_backend_indices:
       # Extract info for logging.
       failed_backends = [tar_traces[i].backend for i in failed_backend_indices]
-      failure_info = (
+      self.fail(
           "Comparision between the reference backend and the following targets "
           f"failed: {failed_backends}. The errors above show the inputs and "
           "outputs the non-matching calls.")
-
-      # This condition is always True, but is useful for context in the logs.
-      self.assertEmpty(failed_backends, failure_info)
 
   @classmethod
   def tearDownClass(cls):

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -507,7 +507,7 @@ class TracedModuleTestCase(tf.test.TestCase):
       self.fail(
           "Comparision between the reference backend and the following targets "
           f"failed: {failed_backends}. The errors above show the inputs and "
-          "outputs the non-matching calls.")
+          "outputs of the non-matching calls.")
 
   @classmethod
   def tearDownClass(cls):


### PR DESCRIPTION
This currently prints a misleading error message
`AssertionError: ['tf'] has length of 1`, which suggests that somehow
the lenght of this variable is the problem. We can just fail directly
without this.