### PR TITLE
Mark unanalyzable XLA target as manual

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/xla/compiler/BUILD
@@ -92,6 +92,7 @@ iree_py_test(
     srcs = ["xla_module_proto_test.py"],
     python_version = "PY3",
     tags = [
+        "manual",
         "nokokoro",
     ],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [


### PR DESCRIPTION
This cannot be built or analyzed in OSS due to a missing grpc
dependency. It causes wildcard builds to fail during analysis.


> ERROR: 
[snip]/external/org_tensorflow/tensorflow/compiler/xla/pjrt/distributed/BUILD:9:20:
no such target '//external:grpc_lib': target 'grpc_lib' not declared in
package 'external' defined by
[snip]/iree/WORKSPACE and referenced by
@org_tensorflow//tensorflow/compiler/xla/pjrt/distributed:protocol_proto_cc_impl'

TESTED=`bazel build --nobuild //...`