### PR TITLE
Rewrites mhlo.conv -> mhlo.dot when convolution with 1x1x.. filters

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -30,9 +30,14 @@ namespace Flow {
 namespace {
 
 static llvm::cl::opt<bool> extractPadFromConv(
-    "iree-extract-pad-from-conv",
+    "iree-flow-extract-pad-from-conv",
     llvm::cl::desc("Extract padding attributes from conv op"),
     llvm::cl::init(true));
+
+static llvm::cl::opt<bool> conv1x1toDot(
+    "iree-flow-1x1-conv-to-dot",
+    llvm::cl::desc("Rewrites mhlo.conv with 1x1 filter into mhlo.dot"),
+    llvm::cl::init(false));
 
 static bool isAllZero(DenseIntElementsAttr attr) {
   if (!attr.isSplat()) return false;
@@ -168,6 +173,92 @@ class ExtractReduceWindowOpPaddingAttributes
   }
 };
 
+// Rewrites an n-d (n, d1, d2, d3, ..., ci) * (1, 1, 1, ..., ci, co)
+// as (n * d1 * d2 * d3, ..., ci) . (ci, co)
+class Lower1x1ConvolutionToDotOp : public OpRewritePattern<mhlo::ConvOp> {
+ public:
+  using OpRewritePattern<mhlo::ConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::ConvOp op,
+                                PatternRewriter &rewriter) const override {
+    // Only 1x1 convolution no groups will match.
+    if (op.feature_group_count() != 1) return failure();
+
+    Value input = op.lhs();
+    Value filter = op.rhs();
+    Value output = op.getResult();
+    auto inputShapeType = input.getType().dyn_cast_or_null<RankedTensorType>();
+    auto filterShapeType =
+        filter.getType().dyn_cast_or_null<RankedTensorType>();
+    auto outputShapeType =
+        output.getType().dyn_cast_or_null<RankedTensorType>();
+
+    if (!inputShapeType || !filterShapeType || !outputShapeType) {
+      return failure();
+    }
+
+    auto inputShape = inputShapeType.getShape();
+    auto filterShape = filterShapeType.getShape();
+
+    auto inputBatchDim =
+        op.dimension_numbers().input_batch_dimension().getInt();
+    auto inputFeatureDim =
+        op.dimension_numbers().input_feature_dimension().getInt();
+    auto kernelInputFeatureDim =
+        op.dimension_numbers().kernel_input_feature_dimension().getInt();
+    auto kernelOutputFeatureDim =
+        op.dimension_numbers().kernel_output_feature_dimension().getInt();
+
+    // Match input (n, d1, d2, ..., ci) format
+    if (inputFeatureDim != (inputShape.size() - 1) || inputBatchDim != 0) {
+      return failure();
+    }
+
+    // Match filter (k1, k2, ..., ci, co) format
+    if (kernelInputFeatureDim != (filterShape.size() - 2) ||
+        kernelOutputFeatureDim != (filterShape.size() - 1)) {
+      return failure();
+    }
+
+    // Check 1x1x... kernel spatial size.
+    for (auto dim : op.dimension_numbers().kernel_spatial_dimensions()) {
+      if (filterShape[dim.getZExtValue()] != 1) return failure();
+    }
+
+    int64_t spatialSize = inputShape[0];
+    for (auto dim : op.dimension_numbers().input_spatial_dimensions()) {
+      spatialSize *= inputShape[dim.getZExtValue()];
+    }
+
+    Type reshapedInputType =
+        RankedTensorType::get({spatialSize, inputShape[inputFeatureDim]},
+                              inputShapeType.getElementType());
+    Type reshapedFilterTYpe =
+        RankedTensorType::get({filterShape[kernelInputFeatureDim],
+                               filterShape[kernelOutputFeatureDim]},
+                              filterShapeType.getElementType());
+    Type dotResultType = RankedTensorType::get(
+        {spatialSize, filterShape[kernelOutputFeatureDim]},
+        outputShapeType.getElementType());
+
+    Value reshapedInput =
+        rewriter.create<mhlo::ReshapeOp>(op.getLoc(), reshapedInputType, input);
+    Value reshapedFilter = rewriter.create<mhlo::ReshapeOp>(
+        op.getLoc(), reshapedFilterTYpe, filter);
+
+    Value dotResult = rewriter.create<mhlo::DotOp>(
+        op.getLoc(), dotResultType, reshapedInput, reshapedFilter,
+        rewriter.getStrArrayAttr({"HIGHEST", "HIGHEST"}));
+
+    Value reshapedResult = rewriter.create<mhlo::ReshapeOp>(
+        op.getLoc(), outputShapeType, dotResult);
+
+    rewriter.replaceOp(op, reshapedResult);
+
+    return success();
+  }
+};
+
 // Adjust the shape of depthwise_conv filter where is applied by mhlo.
 class AdjustDepthwiseFilterShape : public OpRewritePattern<mhlo::ConvOp> {
  public:
@@ -218,6 +309,9 @@ struct HLOToHLOPreprocessing
                     AdjustDepthwiseFilterShape, DecomposeLog1PPattern>(context);
     if (extractPadFromConv) {
       patterns.insert<ExtractConvOpPaddingAttributes>(context);
+    }
+    if (conv1x1toDot) {
+      patterns.insert<Lower1x1ConvolutionToDotOp>(context);
     }
     applyPatternsAndFoldGreedily(getOperation(), patterns);
   }

--- a/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-hlo-to-hlo-preprocessing %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-hlo-to-hlo-preprocessing --iree-flow-1x1-conv-to-dot %s | IreeFileCheck %s
 
 // CHECK-LABEL: @batch_norm_inference
 // CHECK-SAME: %[[X:[^:[:space:]]+]]
@@ -85,3 +85,30 @@ func @log_plus_one(%input: tensor<4xf32>) -> tensor<4xf32> {
   %0 = "mhlo.log_plus_one"(%input) : (tensor<4xf32>) -> tensor<4xf32>
   return %0: tensor<4xf32>
 }
+
+// -----
+
+func @conv_1x1(%arg0: tensor<2x4x5x2xf32>, %arg1: tensor<1x1x2x7xf32>) -> tensor<2x4x5x7xf32> {
+    %0 = "mhlo.convolution"(%arg0, %arg1) {
+      batch_group_count = 1 : i64,
+      dimension_numbers = {
+        input_batch_dimension = 0 : i64,
+        input_feature_dimension = 3 : i64,
+        input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+        kernel_input_feature_dimension = 2 : i64,
+        kernel_output_feature_dimension = 3 : i64,
+        kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+        output_batch_dimension = 0 : i64,
+        output_feature_dimension = 3 : i64,
+        output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+     feature_group_count = 1 : i64,
+     padding = dense<0> : tensor<2x2xi64>,
+     rhs_dilation = dense<1> : tensor<2xi64>,
+     window_strides = dense<1> : tensor<2xi64>} : (tensor<2x4x5x2xf32>, tensor<1x1x2x7xf32>) -> tensor<2x4x5x7xf32>
+    return %0 : tensor<2x4x5x7xf32>
+}
+// CHECK: @conv_1x1(%[[INPUT:.+]]: tensor<2x4x5x2xf32>, %[[FILTER:.+]]: tensor<1x1x2x7xf32>) -> tensor<2x4x5x7xf32>
+// CHECK: %[[RESHAPED_INPUT:.+]] = "mhlo.reshape"(%[[INPUT]]) : (tensor<2x4x5x2xf32>) -> tensor<40x2xf32>
+// CHECK: %[[RESHAPED_FILTER:.+]] = "mhlo.reshape"(%[[FILTER]]) : (tensor<1x1x2x7xf32>) -> tensor<2x7xf32>
+// CHECK: %[[DOT_RESULT:.+]] = "mhlo.dot"(%[[RESHAPED_INPUT]], %[[RESHAPED_FILTER]]) {precision_config = ["HIGHEST", "HIGHEST"]} : (tensor<40x2xf32>, tensor<2x7xf32>) -> tensor<40x7xf32>
+// CEHCK: %[[RESULT:.+]] = "mhlo.reshape"(%[[DOT_RESULT]]) : (tensor<40x7xf32>) -> tensor<2x4x5x7xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing_extract_pad_from_conv.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing_extract_pad_from_conv.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -iree-flow-hlo-to-hlo-preprocessing -iree-extract-pad-from-conv %s | IreeFileCheck %s
+// RUN: iree-opt -iree-flow-hlo-to-hlo-preprocessing -iree-flow-extract-pad-from-conv %s | IreeFileCheck %s
 
 // CHECK-LABEL: @conv
 //       CHECK: mhlo.pad


### PR DESCRIPTION
It's better to handle rewrites like this at the top layers instead of specializing codegen or runtime for it. 

This PR:
- Rewrite 1x1 convolutions as matrix-matrix multiplication.
- Add a flat to enable/disable the rewrite.

Not enabled by default because of #2882 

Bencmarking MobileNet V1 on VMLA (host)

iree-1x1-conv-to-dot = false
```
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time       5956 ms         5956 ms            1
```

iree-1x1-conv-to-dot = true
```
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time       2131 ms         2131 ms            1
```