### PR TITLE
Adds python trace serialization and deserialization.

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -23,6 +23,7 @@
 #   tar: target - for one of the target CompiledModules
 
 import copy
+import glob
 import inspect
 import json
 import os
@@ -422,7 +423,7 @@ class Trace:
       _load_kwargs = json.load(f)
     calls = [ModuleCall.load(call_dir) for call_dir in glob.glob("call_*")]
     _load_kwargs['calls'] = calls
-    return Trace(module=None, function=None, _load_kwargs=load_kwargs)
+    return Trace(module=None, function=None, _load_kwargs=_load_kwargs)
 
 class TracedModule:
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -77,27 +77,24 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
   ])
   def test_recursive_check_same(self, array_c, array_d, array_e, tar_same):
 
+    # yapf: disable
     ref = {
-        'a':
-            1,
-        'b': [{
-            'c': np.array([0, 1, 2])
-        }, {
-            'd': np.array(['0', '1', '2'])
-        }, {
-            'e': np.array([0.0, 0.1, 0.2])
-        }],
+        'a': 1,
+        'b': [
+            {'c': np.array([0, 1, 2])},
+            {'d': np.array(['0', '1', '2'])},
+            {'e': np.array([0.0, 0.1, 0.2])}
+        ],
     }
     tar = {
         'a': 1,
-        'b': [{
-            'c': array_c
-        }, {
-            'd': array_d
-        }, {
-            'e': array_e
-        }],
+        'b': [
+            {'c': array_c},
+            {'d': array_d},
+            {'e': array_e}
+        ],
     }
+    # yapf: enable
     same = tf_test_utils.Trace._check_same(ref, tar, rtol=1e-6, atol=1e-6)
     self.assertEqual(tar_same, same)
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Tests for pyiree.tf.support.tf_test_utils."""
 
+import os
+import tempfile
+
 from absl.testing import parameterized
 import numpy as np
 from pyiree.tf.support import tf_test_utils
@@ -37,6 +40,12 @@ class StatefulCountingModule(tf.Module):
   @tf.function(input_signature=[tf.TensorSpec([1])])
   def increment_by(self, value):
     self.count.assign_add(value)
+
+  @tf.function(input_signature=[tf.TensorSpec([1]), tf.TensorSpec([1])])
+  def increment_by_max(self, a, b):
+    result = tf.maximum(a, b)
+    self.count.assign_add(result)
+    return result
 
   @tf.function(input_signature=[])
   def decrement(self):
@@ -101,7 +110,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
   def test_trace_inputs_and_outputs(self):
 
     def trace_function(module):
-      # No inputs or outpus
+      # No inputs or outputs
       module.increment()
       # Only inputs
       module.increment_by(np.array([81.], dtype=np.float32))
@@ -163,6 +172,34 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 
     self.assertFalse(tf_test_utils.Trace.compare_traces(tf_trace, vmla_trace))
+
+  def test_trace_serialize_and_load(self):
+
+    def trace_function(module):
+      module.increment()
+      module.increment_by(np.array([81.], dtype=np.float32))
+      module.increment_by_max(np.array([81], dtype=np.float32),
+                              np.array([92], dtype=np.float32))
+      module.get_count()
+
+    module = tf_utils.TfCompiledModule(StatefulCountingModule,
+                                       tf_utils.BackendInfo('tf'))
+    trace = tf_test_utils.Trace(module, trace_function)
+    trace_function(tf_test_utils.TracedModule(module, trace))
+
+    with tempfile.TemporaryDirectory() as artifacts_dir:
+      trace_function_dir = tf_test_utils._get_trace_dir(artifacts_dir, trace)
+      trace.serialize(trace_function_dir)
+      loaded_trace = tf_test_utils.Trace.load(trace_function_dir)
+
+      # Check all calls match.
+      self.assertTrue(tf_test_utils.Trace.compare_traces(trace, loaded_trace))
+
+      # Check all other metadata match.
+      self.assertAllEqual(trace.__dict__.keys(), loaded_trace.__dict__.keys())
+      for key in trace.__dict__.keys():
+        if key != 'calls':
+          self.assertEqual(trace.__dict__[key], loaded_trace.__dict__[key])
 
 
 if __name__ == '__main__':

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -159,32 +159,33 @@ for each module is as follows:
 
 ```
 /tmp/iree/modules/ModuleName
-├── tf_input.mlir           # MLIR for ModuleName in TF's input dialect
-├── iree_input.mlir         # tf_input.mlir translated to IREE MLIR
-├── backend_name            # e.g. iree_vmla, tf or tf_ref
-│   ├── compiled.vmfb       # flatbuffer of ModuleName compiled to this backend
-│   ├── saved_model
+├── tf_input.mlir        # MLIR for ModuleName in TF's input dialect
+├── iree_input.mlir      # tf_input.mlir translated to IREE MLIR
+├── backend_name_1       # e.g. iree_vmla, tf or tf_ref
+│   ├── compiled.vmfb    # flatbuffer of ModuleName compiled to this backend
+│   ├── saved_model      # Only created if --keep_saved_model is specified.
 │   └── traces
-│       ├── trace_function  # Directory storing logs and serialization for each trace.
-│       │   └── log.txt     # A more detailed version of the test logs
-│       └── trace_function
+│       ├── trace_1      # Directory storing logs and serialization for each trace.
+│       │   └── log.txt  # A more detailed version of the test logs
+│       └── trace_2
 │           └── log.txt
-└── backend_name
+└── backend_name_2
     └── ...
 ```
-
-The `saved_model` directory is only created if `--keep_saved_model` is
-specified.
 
 Traces for a particular test can be loaded via the `Trace.load(trace_dir)`
 method. For example:
 
 ```python
-ref_trace = Trace.load("/tmp/iree/modules/ModuleName/tf_ref/traces/trace_function/")
-tar_trace = Trace.load("/tmp/iree/modules/ModuleName/iree_vmla/traces/trace_function/")
+ref_trace = Trace.load("/tmp/iree/modules/ModuleName/tf_ref/traces/predict/")
+tar_trace = Trace.load("/tmp/iree/modules/ModuleName/iree_vmla/traces/predict/")
 abs_diff = np.abs(ref_trace.calls[0].outputs[0] - tar_trace.calls[0].outputs[0])
 print(np.mean(abs_diff))
 ```
+
+Traces are named after the trace functions defined in their unittests. So in the
+`SimpleArithmeticModule` example above, the `trace_dir` would be
+`/tmp/iree/modules/SimpleArithmeticModule/iree_vmla/traces/simple_mul/`.
 
 ## Debugging Tests
 

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -159,14 +159,14 @@ for each module is as follows:
 
 ```
 /tmp/iree/modules/ModuleName
-├── tf_input.mlir          # MLIR for ModuleName in TF's input dialect
-├── iree_input.mlir        # tf_input.mlir translated to IREE MLIR
-├── backend_name           # e.g. iree_vmla, tf or tf_ref
-│   ├── compiled.vmfb      # flatbuffer of ModuleName compiled to this backend
+├── tf_input.mlir           # MLIR for ModuleName in TF's input dialect
+├── iree_input.mlir         # tf_input.mlir translated to IREE MLIR
+├── backend_name            # e.g. iree_vmla, tf or tf_ref
+│   ├── compiled.vmfb       # flatbuffer of ModuleName compiled to this backend
 │   ├── saved_model
 │   └── traces
-│       ├── trace_function
-│       │   └── log.txt    # A more detailed version of the test logs
+│       ├── trace_function  # Directory storing logs and serialization for each trace.
+│       │   └── log.txt     # A more detailed version of the test logs
 │       └── trace_function
 │           └── log.txt
 └── backend_name
@@ -175,6 +175,16 @@ for each module is as follows:
 
 The `saved_model` directory is only created if `--keep_saved_model` is
 specified.
+
+Traces for a particular test can be loaded via the `Trace.load(trace_dir)`
+method. For example:
+
+```python
+ref_trace = Trace.load("/tmp/iree/modules/ModuleName/tf_ref/traces/trace_function/")
+tar_trace = Trace.load("/tmp/iree/modules/ModuleName/iree_vmla/traces/trace_function/")
+abs_diff = np.abs(ref_trace.calls[0].outputs[0] - tar_trace.calls[0].outputs[0])
+print(np.mean(abs_diff))
+```
 
 ## Debugging Tests
 


### PR DESCRIPTION
`Trace`s and `ModuleCall`s can be serialized to disk via a `serialize` method, and loaded via a static `load` method. These artifacts are saved under `.../ModuleName/backend_name/traces/trace_function/`.