### PR TITLE
Move hal.executable.entry_point ops into hal.executable.target.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -5,12 +5,12 @@ hal.executable @ex0 {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.entry_point @entry0 attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<128xf32>) -> tensor<128xf32>
-  }
   hal.executable.target "vmla" {
+    hal.executable.entry_point @entry0 attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<128xf32>) -> tensor<128xf32>
+    }
     module {}
   }
 }
@@ -79,12 +79,12 @@ hal.executable @ex0 {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.entry_point @entry0 attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<?x128xf32>, index) -> tensor<?x128xf32>
-  }
   hal.executable.target "vmla" {
+    hal.executable.entry_point @entry0 attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<?x128xf32>, index) -> tensor<?x128xf32>
+    }
     module {}
   }
 }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -62,9 +62,7 @@ class LLVMAOTTargetBackend final : public TargetBackend {
     }
 
     // Create invocation function an populate entry_points.
-    auto executableOp = cast<ExecutableOp>(targetOp.getParentOp());
-    auto entryPointOps =
-        executableOp.getBlock().getOps<ExecutableEntryPointOp>();
+    auto entryPointOps = targetOp.getBlock().getOps<ExecutableEntryPointOp>();
 
     for (auto entryPointOp : entryPointOps) {
       dyLibExecutableDef.entry_points.push_back(

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRTarget.cpp
@@ -58,9 +58,8 @@ class LLVMIRTargetBackend final : public TargetBackend {
 
     // Create invocation function an populate entry_points.
     iree::LLVMIRExecutableDefT llvmIrExecutableDef;
-    auto executableOp = cast<IREE::HAL::ExecutableOp>(targetOp.getParentOp());
     auto entryPointOps =
-        executableOp.getBlock().getOps<IREE::HAL::ExecutableEntryPointOp>();
+        targetOp.getBlock().getOps<IREE::HAL::ExecutableEntryPointOp>();
     for (auto entryPointOp : entryPointOps) {
       llvmIrExecutableDef.entry_points.push_back(
           std::string(entryPointOp.sym_name()));

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/binaryop_test.mlir
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/binaryop_test.mlir
@@ -12,7 +12,6 @@ flow.executable @simpleMath_ex_dispatch_0 {
 }
 
 // CHECK-LABEL: hal.executable @simpleMath_ex_dispatch_0
-// CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0
 // CHECK-DAG:   hal.executable.binary attributes {
 // CHECK-SAME:     data = dense
 // CHECK-SAME:     format = 1280071245 : i32} {

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/matmul_op.mlir
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/matmul_op.mlir
@@ -12,7 +12,6 @@ flow.executable @simpleMath_ex_dispatch_0 {
 }
 
 // CHECK-LABEL: hal.executable @simpleMath_ex_dispatch_0
-// CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0
 // CHECK-DAG:   hal.executable.binary attributes {
 // CHECK-SAME:     data = dense
 // CHECK-SAME:     format = 1280071245 : i32} {

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -70,13 +70,13 @@ bool TargetBackend::matchPattern(StringRef value, StringRef pattern) {
   return false;
 }
 
-void TargetBackend::constructTargetOps(IREE::Flow::ExecutableOp sourceOp,
-                                       IREE::HAL::ExecutableOp executableOp) {
+void TargetBackend::declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
+                                     IREE::HAL::ExecutableOp executableOp) {
   OpBuilder targetBuilder(&executableOp.getBlock().back());
   auto targetContainerOp = targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
       sourceOp.getLoc(), name());
   OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
-  containerBuilder.clone(*sourceOp.getInnerModule().getOperation());
+  containerBuilder.create<ModuleOp>(sourceOp.getLoc());
 }
 
 std::array<Value, 3> TargetBackend::calculateDispatchWorkgroupSize(

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
@@ -17,8 +17,8 @@ flow.executable @simpleMath_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:     hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.func @simpleMath_rgn_dispatch_0(%arg0: !vm.ref<!vmla.interface>, %arg1: i32, %arg2: i32, %arg3: i32) {
@@ -60,8 +60,8 @@ flow.executable @shaped_dispatch {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.entry_point @entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x?xf32>, index) -> tensor<4x?xf32>}
 //  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:     hal.executable.entry_point @entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x?xf32>, index) -> tensor<4x?xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.func @entry(%arg0: !vm.ref<!vmla.interface>, %arg1: i32, %arg2: i32, %arg3: i32) {
@@ -102,8 +102,8 @@ flow.executable @reduction_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.entry_point @reduction_ex_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x8xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:     hal.executable.entry_point @reduction_ex_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x8xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.rodata @reduction_ex_dispatch_0_const_0 dense<0.000000e+00> : tensor<f32>

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
@@ -17,7 +17,6 @@ flow.executable @simpleMath_ex_dispatch_0 {
 // VKSPV-DAG:      hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 // VKSPV-DAG:      hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 // VKSPV-NEXT:   }
-// VKSPV-NEXT:   hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>
 // VKSPV-NEXT:   hal.executable.binary attributes {
 // VKSPV-SAME:     data = dense
 // VKSPV-SAME:     format = 1397773893 : i32}
@@ -46,11 +45,6 @@ flow.executable @reduction_ex_reduce_0_dim_0 {
 // VKSPV-DAG:      hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
 // VKSPV-DAG:      hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
 // VKSPV-NEXT:   }
-// VKSPV-NEXT:   hal.executable.entry_point @reduction_rgn_reduce_0_dim_0_entry attributes {
-// VKSPV-SAME:     interface = @legacy_io,
-// VKSPV-SAME:     ordinal = 0 : i32,
-// VKSPV-SAME:     signature = (tensor<4x8xf32>, tensor<f32>) -> tensor<4xf32>
-// VKSPV-SAME:   }
 // VKSPV-NEXT:   hal.executable.binary attributes {
 // VKSPV-SAME:     data = dense
 // VKSPV-SAME:     format = 1397773893 : i32} {

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -130,22 +130,28 @@ static llvm::Optional<IREE::HAL::InterfaceOp> declareInterfaceIO(
 //     Such an ordering can be useful for downstream code generation because
 //     it can often be necessary to reference primitives in the materialization
 //     of binding-based loads (i.e. for size calculations, etc). For any
-//     stronger guarnatees or inter-load ordering constraints, downstream
+//     stronger guarantees or inter-load ordering constraints, downstream
 //     code generation must explicitly take non-determinism of argument
 //     ordering into account.
 static Optional<FuncOp> createDispatchEntryThunk(
-    FuncOp sourceFuncOp, IREE::HAL::InterfaceOp interfaceOp) {
+    FuncOp sourceFuncOp, IREE::HAL::InterfaceOp interfaceOp,
+    IREE::HAL::ExecutableTargetOp targetOp) {
+  // Clone the source FuncOp into the target then manipulate it into a
+  // dispatch entry thunk.
+  auto clonedFuncOp = sourceFuncOp.clone();
+  targetOp.getInnerModule().push_back(clonedFuncOp);
+
   // Functions take all I/O through the interface API.
-  auto sourceFuncType = sourceFuncOp.getType();
-  auto thunkFuncType = FunctionType::get({}, {}, sourceFuncOp.getContext());
-  auto thunkFuncOp = FuncOp::create(sourceFuncOp.getLoc(),
-                                    sourceFuncOp.getName(), thunkFuncType);
+  auto sourceFuncType = clonedFuncOp.getType();
+  auto thunkFuncType = FunctionType::get({}, {}, clonedFuncOp.getContext());
+  auto thunkFuncOp = FuncOp::create(clonedFuncOp.getLoc(),
+                                    clonedFuncOp.getName(), thunkFuncType);
   SymbolTable::setSymbolVisibility(thunkFuncOp,
                                    SymbolTable::Visibility::Public);
-  sourceFuncOp.setName((sourceFuncOp.getName() + "_impl").str());
-  SymbolTable::setSymbolVisibility(sourceFuncOp,
+  clonedFuncOp.setName((clonedFuncOp.getName() + "_impl").str());
+  SymbolTable::setSymbolVisibility(clonedFuncOp,
                                    SymbolTable::Visibility::Private);
-  sourceFuncOp.getParentRegion()->getBlocks().front().push_front(thunkFuncOp);
+  clonedFuncOp.getParentRegion()->getBlocks().front().push_front(thunkFuncOp);
 
   // For now we only support tensor types, so bindings are in order.
   // In the future we will want to provide N:M mappings (as well as the
@@ -194,7 +200,7 @@ static Optional<FuncOp> createDispatchEntryThunk(
       operands.push_back(loadOp.getResult());
       ++pushConstantOffset;
     } else {
-      sourceFuncOp.emitError() << "function argument type " << inputType
+      clonedFuncOp.emitError() << "function argument type " << inputType
                                << " is not valid for interface I/O";
       return llvm::None;
     }
@@ -203,7 +209,7 @@ static Optional<FuncOp> createDispatchEntryThunk(
 
   // Call the original entry function.
   auto callOp = thunkEntryBuilder.create<mlir::CallOp>(thunkFuncOp.getLoc(),
-                                                       sourceFuncOp, operands);
+                                                       clonedFuncOp, operands);
 
   // Push all results to the bindings.
   for (auto result : callOp.getResults()) {
@@ -222,38 +228,44 @@ static Optional<FuncOp> createDispatchEntryThunk(
 
 // Adds the entry point ops with assigned ordinals for each entry function.
 // The entry points will all use the provided |interfaceOp|.
-static LogicalResult declareEntryPointOps(IREE::Flow::ExecutableOp sourceOp,
-                                          IREE::HAL::ExecutableOp targetOp,
-                                          IREE::HAL::InterfaceOp interfaceOp) {
-  // Insert interface bindings into the flow module so that symbol references
-  // work. This hacks around our isolated module handling used by the legacy
-  // backend translation API needing the source in a specific state.
-  auto inlinedInterfaceOp = interfaceOp.clone();
-  SymbolTable::setSymbolVisibility(inlinedInterfaceOp,
-                                   SymbolTable::Visibility::Private);
-  sourceOp.getInnerModule().push_back(inlinedInterfaceOp);
+static LogicalResult declareEntryPointOps(
+    IREE::Flow::ExecutableOp sourceExecutableOp,
+    IREE::HAL::ExecutableOp targetExecutableOp,
+    IREE::HAL::InterfaceOp interfaceOp) {
+  auto targetOps =
+      targetExecutableOp.getBlock().getOps<IREE::HAL::ExecutableTargetOp>();
+  for (auto targetOp : targetOps) {
+    OpBuilder builder(&targetOp.getBlock().front());
 
-  OpBuilder builder(targetOp.getContext());
-  builder.setInsertionPointAfter(interfaceOp);
-  int nextOrdinal = 0;
-  for (auto &op : sourceOp.getBlock()) {
-    if (auto dispatchEntryOp = dyn_cast<IREE::Flow::DispatchEntryOp>(op)) {
-      auto sourceFuncOp = sourceOp.getInnerModule().lookupSymbol<FuncOp>(
-          dispatchEntryOp.function_ref());
-      auto thunkFuncOp = createDispatchEntryThunk(sourceFuncOp, interfaceOp);
-      if (!thunkFuncOp.hasValue()) {
-        return failure();
+    // For each Flow entry point, create a HAL entry point and dispatch thunk.
+    int nextOrdinal = 0;
+    for (auto &op : sourceExecutableOp.getBlock()) {
+      if (auto dispatchEntryOp = dyn_cast<IREE::Flow::DispatchEntryOp>(op)) {
+        auto sourceFuncOp =
+            sourceExecutableOp.getInnerModule().lookupSymbol<FuncOp>(
+                dispatchEntryOp.function_ref());
+        auto thunkFuncOp =
+            createDispatchEntryThunk(sourceFuncOp, interfaceOp, targetOp);
+        if (!thunkFuncOp.hasValue()) {
+          return failure();
+        }
+        dispatchEntryOp.setAttr(
+            "function_ref", builder.getSymbolRefAttr(thunkFuncOp.getValue()));
+
+        builder.create<IREE::HAL::ExecutableEntryPointOp>(
+            dispatchEntryOp.getLoc(),
+            builder.getStringAttr(thunkFuncOp->getName()),
+            builder.getI32IntegerAttr(nextOrdinal++),
+            builder.getSymbolRefAttr(interfaceOp),
+            TypeAttr::get(sourceFuncOp.getType()));
       }
-      dispatchEntryOp.setAttr("function_ref",
-                              builder.getSymbolRefAttr(thunkFuncOp.getValue()));
-
-      builder.create<IREE::HAL::ExecutableEntryPointOp>(
-          dispatchEntryOp.getLoc(),
-          builder.getStringAttr(thunkFuncOp->getName()),
-          builder.getI32IntegerAttr(nextOrdinal++),
-          builder.getSymbolRefAttr(interfaceOp),
-          TypeAttr::get(sourceFuncOp.getType()));
     }
+
+    // Copy interface bindings into the target module so symbol references work.
+    auto inlinedInterfaceOp = interfaceOp.clone();
+    SymbolTable::setSymbolVisibility(inlinedInterfaceOp,
+                                     SymbolTable::Visibility::Private);
+    targetOp.getInnerModule().push_back(inlinedInterfaceOp);
   }
   return success();
 }
@@ -261,9 +273,9 @@ static LogicalResult declareEntryPointOps(IREE::Flow::ExecutableOp sourceOp,
 // Creates zero or more hal.executable.target ops for each target backend.
 // The source op will contain the flow.executable contents and any attributes
 // the backend wants to carry along during transformation.
-static LogicalResult constructTargetOps(TargetOptions targetOptions,
-                                        IREE::Flow::ExecutableOp sourceOp,
-                                        IREE::HAL::ExecutableOp executableOp) {
+static LogicalResult declareTargetOps(TargetOptions targetOptions,
+                                      IREE::Flow::ExecutableOp sourceOp,
+                                      IREE::HAL::ExecutableOp executableOp) {
   // The user has specified what targets they want as a set of patterns. This
   // matches against those patterns so vulkan-* may match vulkan-v1.1 and
   // vulkan-v1.2.
@@ -288,7 +300,7 @@ static LogicalResult constructTargetOps(TargetOptions targetOptions,
   // Materialize all of the hal.executable.target ops for all backends we are
   // targeting. Note that each backend may create zero or more target ops.
   for (auto &targetBackend : targetBackends) {
-    targetBackend->constructTargetOps(sourceOp, executableOp);
+    targetBackend->declareTargetOps(sourceOp, executableOp);
   }
 
   // Ensure that at least one target op got created. If it didn't that means
@@ -335,15 +347,15 @@ class MaterializeInterfacesPass
         return signalPassFailure();
       }
 
+      // Embed the hal.executable.target ops for each source.
+      if (failed(declareTargetOps(targetOptions_, sourceOp, exectuableOp))) {
+        return signalPassFailure();
+      }
+
       // Annotate the entry points.
       // TODO(benvanik): allow entry points to use different interfaces.
       if (failed(declareEntryPointOps(sourceOp, exectuableOp,
                                       interfaceOp.getValue()))) {
-        return signalPassFailure();
-      }
-
-      // Embed the hal.executable.target ops for each source.
-      if (failed(constructTargetOps(targetOptions_, sourceOp, exectuableOp))) {
         return signalPassFailure();
       }
 

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -5,12 +5,12 @@
 //  CHECK-NEXT:   hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:   hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT: }
-//   CHECK-DAG: hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {
-//  CHECK-SAME:   interface = @legacy_io,
-//  CHECK-SAME:   ordinal = 0 : i32,
-//  CHECK-SAME:   signature = (tensor<4xf32>) -> tensor<4xf32>
-//  CHECK-SAME: }
 //   CHECK-DAG: hal.executable.target "vmla" {
+//   CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {
+//  CHECK-SAME:     interface = @legacy_io,
+//  CHECK-SAME:     ordinal = 0 : i32,
+//  CHECK-SAME:     signature = (tensor<4xf32>) -> tensor<4xf32>
+//  CHECK-SAME:   }
 flow.executable @simpleMath_ex_dispatch_0 {
   flow.dispatch.entry @simpleMath_rgn_dispatch_0 attributes {
     workload = 4 : index
@@ -40,11 +40,6 @@ flow.executable @simpleMath_ex_dispatch_0 {
 //  CHECK-NEXT:   hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:   hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT: }
-//  CHECK-NEXT: hal.executable.entry_point @entry attributes {
-//  CHECK-SAME:   interface = @legacy_io,
-//  CHECK-SAME:   ordinal = 0 : i32,
-//  CHECK-SAME:   signature = (tensor<?x7x10xf32>, index, index) -> tensor<7x?x10xf32>
-//  CHECK-SAME: }
 flow.executable @shaped_dispatch {
   flow.dispatch.entry @entry
   // CHECK: module {


### PR DESCRIPTION
The HAL transformation pass pipeline "materializes interfaces" then "translates executables" for each configured target ([source](https://github.com/google/iree/blob/d7f61a1510aeee066e34ebfadf13f7651aea4de4/iree/compiler/Dialect/HAL/Transforms/Passes.cpp#L46-L58)). As part of its executable translation, the VulkanSPIRV target "splits" dispatch functions using [SplitDispatchFunctionPass](https://github.com/google/iree/blob/d7f61a1510aeee066e34ebfadf13f7651aea4de4/iree/compiler/Conversion/LinalgToSPIRV/SplitDispatchFunctionPass.cpp), creating a schedule of `spv.EntryPoint` ops to dispatch in sequence when `recordDispatch()` is called ([source](https://github.com/google/iree/blob/d7f61a1510aeee066e34ebfadf13f7651aea4de4/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp#L321-L370)).

For https://github.com/google/iree/issues/1890, we want to change dispatch ops from using loose ordinals for entry points:
```
hal.command_buffer.dispatch %arg0, %arg1, entry_point = 0, workgroup_xyz = ...
```
to using nested references:
```
hal.command_buffer.dispatch %arg0, %arg1, entry_point = @MyExecutable::EntryPoint, workgroup_xyz = ...
```

To use references in that format, the VulkanSPIRV target should create new `hal.executable.entry_point` ops which can be referenced whenever it splits dispatch functions. However, entry points are currently placed on `hal.executable` ops, which can contain multiple `hal.executable.target` ops (e.g. several for "vulkan" and one for "vmla"). Thus, this PR moves entry points down into `hal.executable.target` ops so that each target can have more control over how it sets up its entry points.

---

I explored a few different ways to structure the passes involved as part of this work, each with some tradeoffs. Happy to make changes now that I have a better handle on how this all fits together.