### PR TITLE
Add serialization for benchmarking e2e test modules with IREE

### DIFF
--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -504,9 +504,7 @@ std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
     iree_vm_variant_t variant = iree_vm_variant_empty();
     iree_status_t status =
         iree_vm_list_get_variant(vm_list.raw_ptr(), i, &variant);
-    if (!iree_status_is_ok(status)) {
-      RaiseValueError("Failed to get vm variant from list");
-    }
+    CheckApiStatus(status, "Failed to get vm variant from list");
 
     if (iree_vm_variant_is_value(variant)) {
       results.push_back("i32=" + std::to_string(variant.i32));

--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -495,8 +495,6 @@ void FunctionAbi::PackBuffer(const RawSignatureParser::Description& desc,
 }
 
 std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
-  LOG(INFO) << "SerializeVmVariantList: " << vm_list.DebugString();
-
   size_t size = vm_list.size();
   std::vector<std::string> results;
   results.reserve(size);
@@ -523,7 +521,7 @@ std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
                                              &result_str[0], &actual_length);
         result_str.resize(actual_length);
       } while (iree_status_is_out_of_range(status));
-      CheckApiStatus(status, 
+      CheckApiStatus(status,
           "Failed to create a string representation of the inputs");
 
       results.push_back(result_str);

--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -523,10 +523,8 @@ std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
                                              &result_str[0], &actual_length);
         result_str.resize(actual_length);
       } while (iree_status_is_out_of_range(status));
-      if (!iree_status_is_ok(status)) {
-        RaiseValueError(
-            "Failed to create a string representation of the inputs.");
-      }
+      CheckApiStatus(status, 
+          "Failed to create a string representation of the inputs");
 
       results.push_back(result_str);
     } else {

--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -497,8 +497,10 @@ void FunctionAbi::PackBuffer(const RawSignatureParser::Description& desc,
 std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
   LOG(INFO) << "SerializeVmVariantList: " << vm_list.DebugString();
 
+  size_t size = vm_list.size();
   std::vector<std::string> results;
-  for (iree_host_size_t i = 0, e = vm_list.size(); i < e; ++i) {
+  results.reserve(size);
+  for (iree_host_size_t i = 0; i < size; ++i) {
     iree_vm_variant_t variant = iree_vm_variant_empty();
     iree_status_t status =
         iree_vm_list_get_variant(vm_list.raw_ptr(), i, &variant);

--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -522,7 +522,7 @@ std::vector<std::string> SerializeVmVariantList(VmVariantList& vm_list) {
         result_str.resize(actual_length);
       } while (iree_status_is_out_of_range(status));
       CheckApiStatus(status,
-          "Failed to create a string representation of the inputs");
+                     "Failed to create a string representation of the inputs");
 
       results.push_back(result_str);
     } else {

--- a/bindings/python/pyiree/rt/system_api.py
+++ b/bindings/python/pyiree/rt/system_api.py
@@ -139,10 +139,10 @@ class BoundFunction:
     # this should default to async and potentially have some kind of policy
     # flag that can allow it to be overridden.
     inputs = self._abi.raw_pack_inputs(args)
-    self._serialized_inputs = self._abi.serialize_vm_list(inputs)
+    self._serialized_inputs = tuple(self._abi.serialize_vm_list(inputs))
     results = self._abi.allocate_results(inputs, static_alloc=False)
     self._context._vm_context.invoke(self._vm_function, inputs, results)
-    self._serialized_outputs = self._abi.serialize_vm_list(results)
+    self._serialized_outputs = tuple(self._abi.serialize_vm_list(results))
     unpacked_results = self._abi.raw_unpack_results(results)
     # TODO(laurenzo): When switching from 'raw' to structured pack/unpack,
     # the ABI should take care of this one-arg special case.
@@ -163,7 +163,7 @@ class BoundFunction:
     if self._serialized_inputs is None:
       raise RuntimeError("Attempted to call get_serialized_values() before "
                          "any values were passed.")
-    return tuple(self._serialized_inputs), tuple(self._serialized_outputs)
+    return self._serialized_inputs, self._serialized_outputs
 
 
 class BoundModule:

--- a/bindings/python/pyiree/rt/system_api_test.py
+++ b/bindings/python/pyiree/rt/system_api_test.py
@@ -93,6 +93,19 @@ class SystemApiTest(absltest.TestCase):
     results = f(arg0, arg1)
     np.testing.assert_allclose(results, [4., 10., 18., 28.])
 
+  def test_serialize_values(self):
+    ctx = rt.SystemContext()
+    self.assertTrue(ctx.is_dynamic)
+    ctx.add_module(create_simple_mul_module())
+    self.assertEqual(ctx.modules.arithmetic.name, "arithmetic")
+    f = ctx.modules.arithmetic["simple_mul"]
+    arg0 = np.array([1., 2., 3., 4.], dtype=np.float32)
+    arg1 = np.array([4., 5., 6., 7.], dtype=np.float32)
+    results = f(arg0, arg1)
+    inputs, outputs = f.get_serialized_values()
+    self.assertEqual(inputs, ("4xf32=1 2 3 4", "4xf32=4 5 6 7"))
+    self.assertEqual(outputs, ("4xf32=4 10 18 28",))
+
   def test_load_module(self):
     arithmetic = rt.load_module(create_simple_mul_module())
     arg0 = np.array([1., 2., 3., 4.], dtype=np.float32)

--- a/bindings/python/pyiree/rt/vm_test.py
+++ b/bindings/python/pyiree/rt/vm_test.py
@@ -126,6 +126,7 @@ class VmTest(absltest.TestCase):
     logging.info("abi: %s", abi)
 
     inputs = abi.raw_pack_inputs((5, 6))
+    logging.info("serialize_inputs: %s", abi.serialize_vm_list(inputs))
     logging.info("inputs: %s", inputs)
 
     allocated_results = abi.allocate_results(inputs, static_alloc=False)
@@ -148,6 +149,7 @@ class VmTest(absltest.TestCase):
 
     arg0 = np.array([[-1., 2.], [3., -4.]], dtype=np.float32)
     inputs = abi.raw_pack_inputs((arg0,))
+    logging.info("Serialized inputs: %s", abi.serialize_vm_list(inputs))
     logging.info("inputs: %s", inputs)
 
     allocated_results = abi.allocate_results(inputs, static_alloc=False)
@@ -171,6 +173,7 @@ class VmTest(absltest.TestCase):
     arg0 = np.array([1., 2., 3., 4.], dtype=np.float32)
     arg1 = np.array([4., 5., 6., 7.], dtype=np.float32)
     inputs = abi.raw_pack_inputs((arg0, arg1))
+    logging.info("Serialized inputs: %s", abi.serialize_vm_list(inputs))
     logging.info("inputs: %s", inputs)
 
     allocated_results = abi.allocate_results(inputs, static_alloc=False)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -448,7 +448,6 @@ class Trace:
 
     # C++ Serialization.
     if "tf" not in self.backend:
-    if "tf" not in self.backend:
       flaglines = []
       if self.compiled_path is not None:
         flaglines.append(f"--input_file={self.compiled_path}")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -261,8 +261,7 @@ class Trace:
       self.module_name = module.module_name
       self.compiled_path = module.compiled_path
       self.backend_name = module.backend
-      self.supports_cxx_serialization = isinstance(module,
-                                                   tf_utils.TfCompiledModule)
+      self.supports_cxx_serialization = module.supports_cxx_serialization()
       self.backend_driver = module.backend_driver
       self.function_name = function.__name__
       self.function_sourcefile = inspect.getsourcefile(function)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -451,7 +451,6 @@ class Trace:
     if "tf" not in self.backend:
       flaglines = []
       if self.compiled_path is not None:
-        # Can be overridden with another flag after the flagfile.
         flaglines.append(f"--input_file={self.compiled_path}")
       flaglines.append(f"--driver={self.backend_driver}")
       inputs_str = ", ".join(self.calls[0].serialized_inputs)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -448,19 +448,18 @@ class Trace:
 
     # C++ Serialization.
     if "tf" not in self.backend:
-      flagfile = []
+    if "tf" not in self.backend:
+      flaglines = []
       if self.compiled_path is not None:
         # Can be overridden with another flag after the flagfile.
-        flagfile.append(f"--input_file={self.compiled_path}")
-      flagfile.append(f"--driver={self.backend_driver}")
+        flaglines.append(f"--input_file={self.compiled_path}")
+      flaglines.append(f"--driver={self.backend_driver}")
       inputs_str = ", ".join(self.calls[0].serialized_inputs)
-      flagfile.append(f"--inputs={inputs_str}")
-      flagfile.append(f"--entry_function={self.calls[0].method}")
-      flagfile = "\n".join(flagfile)
+      flaglines.append(f"--inputs={inputs_str}")
+      flaglines.append(f"--entry_function={self.calls[0].method}")
 
       with open(os.path.join(trace_dir, "flagfile"), "w") as f:
-        f.write(flagfile)
-        f.write("\n")
+        f.writelines(line + '\n' for line in flaglines)
 
   @staticmethod
   def load(trace_dir: str) -> "Trace":

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -261,7 +261,8 @@ class Trace:
       self.module_name = module.module_name
       self.compiled_path = module.compiled_path
       self.backend_name = module.backend
-      self.backend_is_tf = isinstance(module, tf_utils.TfCompiledModule)
+      self.supports_cxx_serialization = isinstance(module,
+                                                   tf_utils.TfCompiledModule)
       self.backend_driver = module.backend_driver
       self.function_name = function.__name__
       self.function_sourcefile = inspect.getsourcefile(function)
@@ -274,7 +275,7 @@ class Trace:
       self.module_name = _load_dict["module_name"]
       self.compiled_path = _load_dict["compiled_path"]
       self.backend_name = _load_dict["backend_name"]
-      self.backend_is_tf = _load_dict["backend_is_tf"]
+      self.supports_cxx_serialization = _load_dict["supports_cxx_serialization"]
       self.backend_driver = _load_dict["backend_driver"]
       self.function_name = _load_dict["function_name"]
       self.function_sourcefile = _load_dict["function_sourcefile"]
@@ -436,7 +437,7 @@ class Trace:
         "module_name": self.module_name,
         "compiled_path": self.compiled_path,
         "backend_name": self.backend_name,
-        "backend_is_tf": self.backend_is_tf,
+        "supports_cxx_serialization": self.supports_cxx_serialization,
         "backend_driver": self.backend_driver,
         "function_name": self.function_name,
         "function_sourcefile": self.function_sourcefile,
@@ -452,7 +453,7 @@ class Trace:
       call.serialize(call_dir)
 
     # C++ Serialization.
-    if not self.backend_is_tf:
+    if not self.supports_cxx_serialization:
       flaglines = []
       if self.compiled_path is not None:
         flaglines.append(f"--input_file={self.compiled_path}")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -182,8 +182,8 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
           np.array([81], dtype=np.float32), np.array([92], dtype=np.float32))
       module.get_count()
 
-    module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                       tf_utils.BackendInfo('tf'))
+    module = tf_utils.IreeCompiledModule(StatefulCountingModule,
+                                         tf_utils.BackendInfo('iree_vmla'))
     trace = tf_test_utils.Trace(module, trace_function)
     trace_function(tf_test_utils.TracedModule(module, trace))
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -245,6 +245,10 @@ class CompiledModule(object):
     """Duplicates this module with its initial state without recompiling."""
     raise NotImplementedError()
 
+  @staticmethod
+  def supports_cxx_serialization():
+    raise NotImplementedError()
+
 
 class _IreeFunctionWrapper(object):
   """Wraps an IREE function, making it callable."""
@@ -323,6 +327,10 @@ class IreeCompiledModule(CompiledModule):
     f = m[attr]
     return _IreeFunctionWrapper(self._context, f)
 
+  @staticmethod
+  def supports_cxx_serialization() -> bool:
+    return True
+
 
 class _TfFunctionWrapper(object):
   """Wraps a TF function, normalizing it to numpy."""
@@ -398,6 +406,10 @@ class TfCompiledModule(CompiledModule):
       raise AttributeError(
           f"The TensorFlow module does not have a callable attr '{attr}'")
     return _TfFunctionWrapper(f)
+
+  @staticmethod
+  def supports_cxx_serialization() -> bool:
+    return False
 
 
 class BackendInfo:

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -20,7 +20,7 @@ import os
 import random
 import re
 import tempfile
-from typing import Any, Callable, Sequence, Type
+from typing import Any, Callable, Dict, Sequence, Tuple, Type, Union
 
 from absl import flags
 from absl import logging
@@ -89,7 +89,6 @@ def save_input_values(inputs: Sequence[np.ndarray],
       f.write("\n")
   return result
 
-
 def backends_to_str(backend_infos: Sequence["BackendInfo"]) -> str:
   """Creates a normalized string representing the provided backends."""
   normalized_names = []
@@ -114,10 +113,12 @@ def _get_backends_path(artifact_name: str,
     return os.path.join(artifacts_dir, f"{artifact_name}__{backends_string}")
 
 
-def compile_tf_module(tf_module: Type[tf.Module],
-                      backend_infos: Sequence["BackendInfo"] = (),
-                      exported_names: Sequence[str] = (),
-                      artifacts_dir: str = None) -> compiler.binding.OpaqueBlob:
+def compile_tf_module(
+    tf_module: Type[tf.Module],
+    backend_infos: Sequence["BackendInfo"] = (),
+    exported_names: Sequence[str] = (),
+    artifacts_dir: str = None
+) -> Tuple[compiler.binding.OpaqueBlob, Union[str, None]]:
   """Compiles a TensorFlow tf.Module and optionally saves compilation artifacts.
 
   The artifact this creates is not callable. See IreeCompiledModule for an API
@@ -149,7 +150,8 @@ def compile_tf_module(tf_module: Type[tf.Module],
       should be saved.
 
   Returns:
-    A compiled IREE module blob.
+    A compiled IREE module blob and the path to the compiled VM FlatBuffer if
+    artifacts_dir is provided.
   """
 
   def _compile_from_path(sm_path: str) -> compiler.binding.OpaqueBlob:
@@ -189,6 +191,7 @@ def compile_tf_module(tf_module: Type[tf.Module],
         target_backends.extend(backend_info.compiler_targets)
       compiled_module = compiler_module.compile(target_backends=target_backends)
 
+      compiled_path = None
       if artifacts_dir is not None:
         compiled_path = _get_backends_path("compiled", backend_infos,
                                            artifacts_dir)
@@ -197,7 +200,7 @@ def compile_tf_module(tf_module: Type[tf.Module],
         with open(compiled_path, "wb") as f:
           f.write(compiled_module)
 
-      return compiled_module
+      return compiled_module, compiled_path
     except Exception:  # pylint: disable=broad-except
       if artifacts_dir is not None:
         # Disable the crash reproducer (to avoid inadvertently overwriting it).
@@ -233,7 +236,9 @@ class CompiledModule(object):
 
     # Public attributes:
     self.backend = self._backend_info.name
+    self.backend_driver = self._backend_info.driver
     self.module_name = self._module_class.__name__
+    self.compiled_path = None
 
   def create_reinitialized(self):
     """Duplicates this module with its initial state without recompiling."""
@@ -259,7 +264,7 @@ class IreeCompiledModule(CompiledModule):
                backend_info: "BackendInfo",
                exported_names: Sequence[str] = (),
                artifacts_dir: str = None,
-               _create_reinitialized_args: Sequence[Any] = None):
+               _create_reinitialized_dict: Dict[str, Any] = None):
     """Compile a tf.Module to the target backend in backend_info.
 
     Args:
@@ -270,13 +275,13 @@ class IreeCompiledModule(CompiledModule):
         module_class's functions to compile. If exported_names is empty all
         functions will be compiled.
       artifacts_dir: an optional path to save compilation artifacts to.
-      _create_reinitialized_args: used internally.
+      _create_reinitialized_dict: used internally.
     """
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
 
-    if _create_reinitialized_args is None:
+    if _create_reinitialized_dict is None:
       set_random_seed()
-      self._module_blob = compile_tf_module(
+      self._module_blob, self.compiled_path = compile_tf_module(
           tf_module=module_class(),
           backend_infos=[backend_info],
           exported_names=exported_names,
@@ -285,7 +290,10 @@ class IreeCompiledModule(CompiledModule):
       self._config = rt.Config(driver_name=backend_info.driver)
     else:
       # Called from self.create_reinitialized()
-      self._module_blob, self._module, self._config = _create_reinitialized_args
+      self._module_blob = _create_reinitialized_dict["_module_blob"]
+      self._module = _create_reinitialized_dict["_module"]
+      self._config = _create_reinitialized_dict["_config"]
+      self.compiled_path = _create_reinitialized_dict["compiled_path"]
 
     # Holds all of the module's mutable state.
     self._context = rt.SystemContext(
@@ -297,8 +305,13 @@ class IreeCompiledModule(CompiledModule):
         self._module_class, self._backend_info, self._exported_names,
         self._artifacts_dir
     ]
-    create_reinitialized_args = [self._module_blob, self._module, self._config]
-    return IreeCompiledModule(*default_args, create_reinitialized_args)
+    create_reinitialized_dict = {
+        "_module_blob": self._module_blob,
+        "_module": self._module,
+        "_config": self._config,
+        "compiled_path": self.compiled_path
+    }
+    return IreeCompiledModule(*default_args, create_reinitialized_dict)
 
   def __getattr__(self, attr: str) -> _IreeFunctionWrapper:
     # Try to resolve it as a function.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -64,12 +64,9 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
   def test_artifact_saving(self, backend_infos):
     with tempfile.TemporaryDirectory() as artifacts_dir:
       tf_module = ConstantModule()
-      iree_compiled_module = tf_utils.compile_tf_module(
+      iree_compiled_module, compiled_path = tf_utils.compile_tf_module(
           tf_module, backend_infos=backend_infos, artifacts_dir=artifacts_dir)
 
-      compiled_path = tf_utils._get_backends_path('compiled', backend_infos,
-                                                  artifacts_dir)
-      compiled_path = f'{compiled_path}.vmfb'
       artifacts_to_check = [
           'tf_input.mlir',
           'iree_input.mlir',

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -187,6 +187,39 @@ Traces are named after the trace functions defined in their unittests. So in the
 `SimpleArithmeticModule` example above, the `trace_dir` would be
 `/tmp/iree/modules/SimpleArithmeticModule/iree_vmla/traces/simple_mul/`.
 
+## Benchmarking E2E Modules
+
+Abseil flagfiles containing all of the data that `iree-benchmark-module` needs
+to run are generated for each `Trace` in our E2E tests. This allows for any
+module we test to be easily benchmarked on valid inputs. The process for
+benchmarking a vision model can thus be reduced to the following:
+
+```shell
+# Generate benchmarking artifacts for all vision models:
+bazel test integrations/tensorflow/e2e/keras:vision_external_tests
+
+# Benchmark ResNet50 with cifar10 weights on vmla:
+bazel run iree/tools:iree-benchmark-module -- \
+  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_vmla/traces/predict/flagfile
+
+# Benchmark ResNet50 with cifar10 weights on llvmjit:
+bazel run iree/tools:iree-benchmark-module -- \
+  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_llvmjit/traces/predict/flagfile
+```
+
+Duplicate flags provided after the flagfile will take precedence. For example:
+
+```shell
+bazel run iree/tools:iree-benchmark-module -- \
+  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_llvmjit/traces/predict/flagfile  \
+  --input_file=/path/to/custom/compiled.vmfb
+```
+
+Currently, this only supports benchmarking the first module call in a trace.
+We plan to extend this to support benchmarking all of the calls in the trace,
+and also plan to support verifying outputs during the warm-up phase of the
+benchmark.
+
 ## Debugging Tests
 
 If the compiler fails to compile the program, then it will create a crash


### PR DESCRIPTION
Abseil flagfiles containing all of the data that `iree-benchmark-module` needs to run are generated for each `Trace` in our E2E tests. This allows for any module we test to be easily benchmarked on valid inputs. The process for benchmarking a vision model can thus be reduced to the following:

```shell
# Generate benchmarking artifacts for all vision models:
bazel test integrations/tensorflow/e2e/keras:vision_external_tests

# Benchmark ResNet50 with cifar10 weights on vmla:
bazel run iree/tools:iree-benchmark-module -- \
  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_vmla/traces/predict/flagfile 

# Benchmark ResNet50 with cifar10 weights on llvmjit:
bazel run iree/tools:iree-benchmark-module -- \
  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_llvmjit/traces/predict/flagfile 
```

Duplicate flags provided after the flagfile will take precedence. For example:

```shell
bazel run iree/tools:iree-benchmark-module -- \
  --flagfile=/tmp/iree/modules/ResNet50/cifar10/iree_llvmjit/traces/predict/flagfile  \
  --input_file=/path/to/custom/compiled.vmfb
```

Currently, this only supports benchmarking the first module call in a trace. We plan to extend this to support benchmarking all of the calls in the trace, and also plan to support verifying outputs during the warm-up phase of the benchmark.