### PR TITLE
Force Python to garbage collect target modules in TracedModuleTestCase

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -23,6 +23,7 @@
 #   tar: target - for one of the target CompiledModules
 
 import copy
+import gc
 import glob
 import inspect
 import os
@@ -634,3 +635,9 @@ class TracedModuleTestCase(tf.test.TestCase):
   def tearDownClass(cls) -> None:
     # Ran after all unit tests are completed.
     super().tearDownClass()
+    # For each test case, we are actually holding two contexts alive:
+    # one in cls._tar_modules (via setUpClass()) and one in self._tar_modules
+    # (via setUp()). The class one somehow is not properly released and
+    # that causes issues with Vulkan driver DSO deallocation.
+    cls._tar_modules = None
+    gc.collect()

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -88,7 +88,6 @@ VULKAN_FAILING = [
     "matrix_ops_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
-    "sliding_window_test.py",  # TODO(#2659) Failing on nvidia, passing on swiftshader.
     "strings_test.py",
 ]
 


### PR DESCRIPTION
For each test case, we are actually holding two contexts alive:
one in cls._tar_modules (via setUpClass()) and one in self._tar_modules
(via setUp()). The class one somehow is not properly released and
that causes issues with Vulkan driver DSO deallocation.