### PR TITLE
Avoid recompiling e2e modules with global variables

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -571,9 +571,21 @@ class TracedModuleTestCase(tf.test.TestCase):
     self._ref_module = self._compile(ref_backend_info)
 
     tar_backend_infos = get_target_backends()
-    self._tar_modules = [
-        self._compile(backend_info) for backend_info in tar_backend_infos
+    cls._tar_modules = [
+        cls._compile(backend_info) for backend_info in tar_backend_infos
     ]
+
+  @classmethod
+  def _reinitialize_modules(cls):
+    cls._ref_module.create_reinitialized()
+    cls._tar_modules = [
+        module.create_reinitialized() for module in cls._tar_modules
+    ]
+
+  def setUp(self) -> None:
+    # Ran before each unit test.
+    super().setUp()
+    self._reinitialize_modules()
 
   def compare_backends(self, trace_function: callable) -> None:
     """Run the reference and target backends on trace_function and compare them.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -538,8 +538,9 @@ def compile_module(
 # Will be initialized by TracedModuleTestCase.setUpClass
 # Global variables are used because storing the compiler context on the cls
 # causes cleaning up refcounts to fail, and tf.test.TestCase wipes the variables
-# on the class instance (self.*) before each unittest. See this for more info:
-# https://github.com/google/iree/issues/2900
+# on the class instance (self.*) before each unittest.
+# TODO(#2900): Move these back to class variables when we figure out issues with
+# refcounting.
 _global_ref_module = None
 _global_tar_modules = None
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -568,27 +568,27 @@ class TracedModuleTestCase(tf.test.TestCase):
     cls._artifacts_dir = _setup_artifacts_dir(cls._module_class.__name__)
 
     # Get the backend information for this test.
-    cls._ref_backend_info = tf_utils.BackendInfo(
+    ref_backend_info = tf_utils.BackendInfo(
         FLAGS.reference_backend, f"{FLAGS.reference_backend}_ref")
-    cls._tar_backend_infos = get_target_backends()
+    tar_backend_infos = get_target_backends()
+
+    global _global_ref_module
+    global _global_tar_modules
+    _global_ref_module = cls._compile(ref_backend_info)
+    _global_tar_modules = [
+        cls._compile(backend_info)
+        for backend_info in tar_backend_infos
+    ]
 
   def setUp(self) -> None:
     # Runs before each unit test.
     super().setUp()
     global _global_ref_module
     global _global_tar_modules
-    if _global_ref_module is None:
-      # Compile if this is the first unittest.
-      _global_ref_module = self._compile(self._ref_backend_info)
-      _global_tar_modules = [
-          self._compile(backend_info)
-          for backend_info in self._tar_backend_infos
-      ]
-    else:
-      _global_ref_module = _global_ref_module.create_reinitialized()
-      _global_tar_modules = [
-          module.create_reinitialized() for module in _global_tar_modules
-      ]
+    _global_ref_module = _global_ref_module.create_reinitialized()
+    _global_tar_modules = [
+        module.create_reinitialized() for module in _global_tar_modules
+    ]
 
   def compare_backends(self, trace_function: callable) -> None:
     """Run the reference and target backends on trace_function and compare them.
@@ -645,5 +645,5 @@ class TracedModuleTestCase(tf.test.TestCase):
 
   @classmethod
   def tearDownClass(cls) -> None:
-    # Ran after all unit tests are completed.
+    # Runs after all unit tests are completed.
     super().tearDownClass()


### PR DESCRIPTION
Follow-up to #2899. The global variables `_global_ref_module` and `_global_tar_modules` are used to store compiled IREE modules for the `TracedModuleTestCase`. Storing the variables on the `TracedModuleTestCase` `cls` causes the errors in #2900, and storing the variables on the `TracedModuleTestCase` instance (via `self`) doesn't work because `tf.test.TestCase` wipes these variables before each unittest.

This was tested by manually running an `x86-turing` presubmit, which [passed](https://source.cloud.google.com/results/invocations/53acf325-2a7a-4ed0-a607-1dfefec045c0/targets/iree%2Fgcp_ubuntu%2Fbazel%2Flinux%2Fx86-turing%2Fintegrations%2Fpresubmit/log).