### PR TITLE
[vulkan] Do not request timeline semaphore if not available

### DIFF
--- a/iree/hal/vulkan/extensibility_util.cc
+++ b/iree/hal/vulkan/extensibility_util.cc
@@ -194,6 +194,9 @@ DeviceExtensions PopulateEnabledDeviceExtensions(
     if (std::strcmp(extension_name, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME) ==
         0) {
       extensions.push_descriptors = true;
+    } else if (std::strcmp(extension_name,
+                           VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME) == 0) {
+      extensions.timeline_semaphore = true;
     }
   }
   return extensions;

--- a/iree/hal/vulkan/extensibility_util.h
+++ b/iree/hal/vulkan/extensibility_util.h
@@ -81,6 +81,8 @@ InstanceExtensions PopulateEnabledInstanceExtensions(
 struct DeviceExtensions {
   // VK_KHR_push_descriptor is enabled and vkCmdPushDescriptorSetKHR is valid.
   bool push_descriptors : 1;
+  // VK_KHR_timeline_semaphore is enabled.
+  bool timeline_semaphore : 1;
 };
 
 // Returns a bitfield with all of the provided extension names.

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -311,6 +311,7 @@ StatusOr<ref_ptr<VulkanDevice>> VulkanDevice::Create(
   device_create_info.ppEnabledExtensionNames = enabled_extension_names.data();
   device_create_info.queueCreateInfoCount = queue_create_info.size();
   device_create_info.pQueueCreateInfos = queue_create_info.data();
+  device_create_info.pEnabledFeatures = nullptr;
 
   VkPhysicalDeviceTimelineSemaphoreFeatures semaphore_features;
   std::memset(&semaphore_features, 0, sizeof(semaphore_features));
@@ -321,11 +322,13 @@ StatusOr<ref_ptr<VulkanDevice>> VulkanDevice::Create(
   std::memset(&features2, 0, sizeof(features2));
   features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
   features2.pNext = &semaphore_features;
-  VkPhysicalDeviceFeatures features;
-  std::memset(&features, 0, sizeof(features));
 
-  device_create_info.pNext = &features2;
-  device_create_info.pEnabledFeatures = nullptr;
+  if (!enabled_device_extensions.timeline_semaphore ||
+      absl::GetFlag(FLAGS_vulkan_force_timeline_semaphore_emulation)) {
+    device_create_info.pNext = nullptr;
+  } else {
+    device_create_info.pNext = &features2;
+  }
 
   auto logical_device =
       make_ref<VkDeviceHandle>(syms, enabled_device_extensions,


### PR DESCRIPTION
If we know that the extension is not available, avoid filling in
VkPhysicalDeviceTimelineSemaphoreFeatures and attach it to pNext
when creating the Vulkan device.