### PR TITLE
[vulkan] Reset TimePointFence status when releasing back to pool

### DIFF
--- a/iree/hal/vulkan/timepoint_util.cc
+++ b/iree/hal/vulkan/timepoint_util.cc
@@ -29,6 +29,7 @@ namespace vulkan {
 
 // static
 void TimePointFence::Delete(TimePointFence* ptr) {
+  ptr->ResetStatus();
   ptr->pool()->ReleaseResolved(ptr);
 }
 
@@ -39,6 +40,11 @@ VkResult TimePointFence::GetStatus() {
     status_ = device->syms()->vkGetFenceStatus(*device, fence_);
   }
   return status_;
+}
+
+void TimePointFence::ResetStatus() {
+  absl::MutexLock lock(&status_mutex_);
+  status_ = VK_NOT_READY;
 }
 
 // static

--- a/iree/hal/vulkan/timepoint_util.h
+++ b/iree/hal/vulkan/timepoint_util.h
@@ -67,6 +67,9 @@ class TimePointFence final : public RefObject<TimePointFence>,
   // under the hood.
   VkResult GetStatus();
 
+  // Resets the status to unsignaled (VK_NOT_READY).
+  void ResetStatus();
+
   // Returns the pool from which this fence comes.
   TimePointFencePool* pool() const { return pool_; }
 


### PR DESCRIPTION
This obviously is required to make sure that when later we acquire
the same TimePointFence, it's not in signaled state to start.

This bug is revealed by a non-deterministic crash on SwiftShader
where a command buffer can be destroyed in the middle of being
executed. This is because in IREE after queue submission we wait
on the TimePointSemaphore to signal to a specific value. Under
the hood, TimePointFence is used to query the status from GPU.
But it's always signaled and it causes IREE side to progress and
delete the command buffer (given it's already submitted and
executed seen by IREE). This triggers command buffer deletion
in SwiftShader, while it's still executing it.