### PR TITLE
Disable command_queue_test on Vulkan again.

### DIFF
--- a/iree/hal/cts/command_queue_test.cc
+++ b/iree/hal/cts/command_queue_test.cc
@@ -130,9 +130,22 @@ TEST_P(CommandQueueTest, WaitMultiple) {
   ASSERT_OK(command_queue->WaitIdle());
 }
 
+std::vector<std::string> GetSupportedDrivers() {
+  auto drivers = DriverRegistry::shared_registry()->EnumerateAvailableDrivers();
+  auto it = drivers.begin();
+  while (it != drivers.end()) {
+    // Disabled on Vulkan until tests pass with timeline semaphore emulation.
+    if (*it == "vulkan") {
+      it = drivers.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return drivers;
+}
+
 INSTANTIATE_TEST_SUITE_P(AllDrivers, CommandQueueTest,
-                         ::testing::ValuesIn(DriverRegistry::shared_registry()
-                                                 ->EnumerateAvailableDrivers()),
+                         ::testing::ValuesIn(GetSupportedDrivers()),
                          GenerateTestName());
 
 }  // namespace


### PR DESCRIPTION
It's still timing out when using timeline semaphore emulation.

This reverts part of https://github.com/google/iree/pull/2902 and covers all platforms, unlike https://github.com/google/iree/pull/2908.