### PR TITLE
Only rewrite 1x1_conv -> dot only for unit strides & dilations

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -225,6 +225,18 @@ class Lower1x1ConvolutionToDotOp : public OpRewritePattern<mhlo::ConvOp> {
       if (filterShape[dim.getZExtValue()] != 1) return failure();
     }
 
+    // Check dilation & strides are ones.
+    if (op.window_strides()) {
+      for (auto stride : op.window_strides()->getValues<int64_t>()) {
+        if (stride != 1) return failure();
+      }
+    }
+    if (op.rhs_dilation()) {
+      for (auto dilation : op.rhs_dilation()->getValues<int64_t>()) {
+        if (dilation != 1) return failure();
+      }
+    }
+
     int64_t spatialSize = inputShape[0];
     for (auto dim : op.dimension_numbers().input_spatial_dimensions()) {
       spatialSize *= inputShape[dim.getZExtValue()];


### PR DESCRIPTION
Only rewrites 1x1 conv -> when strides and dilation are 1. Otherwise its not a correct rewrite 