### PR TITLE
Update base:status_test to handle IREE_STATUS_FEATURE_ANNOTATIONS.

### DIFF
--- a/iree/base/status_test.cc
+++ b/iree/base/status_test.cc
@@ -23,29 +23,46 @@ namespace {
 using ::iree::testing::status::StatusIs;
 using ::testing::HasSubstr;
 
+#if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0
+#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
+  EXPECT_THAT(status.ToString(), HasSubstr(message_substr))
+#else
+#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
+  EXPECT_THAT(status.ToString(), HasSubstr(StatusCodeToString(status.code())));
+#endif
+
+#if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0
+#define CHECK_STREAM_SUBSTR(status, os, message_substr) \
+  EXPECT_THAT(os.str(), HasSubstr(message_substr));
+#else
+#define CHECK_STREAM_SUBSTR(status, os, message_substr) \
+  EXPECT_THAT(os.str(), HasSubstr(StatusCodeToString(status.code())));
+#endif
+
 TEST(Status, ConstructedWithMessage) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
-  EXPECT_THAT(status.ToString(), HasSubstr("message"));
+
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
 }
 
 TEST(Status, StreamInsertion) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
   std::ostringstream os;
   os << status;
-  EXPECT_THAT(os.str(), HasSubstr("message"));
+  CHECK_STREAM_SUBSTR(status, os, "message");
 }
 
 TEST(Status, StreamInsertionContinued) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
   std::ostringstream os;
   os << status << " annotation";
-  EXPECT_THAT(os.str(), HasSubstr("message"));
-  EXPECT_THAT(os.str(), HasSubstr("annotation"));
+  CHECK_STREAM_SUBSTR(status, os, "message");
+  CHECK_STREAM_SUBSTR(status, os, "annotation");
 }
 
 TEST(StatusBuilder, StreamInsertion) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
-  EXPECT_THAT(status.ToString(), HasSubstr("message"));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
 }
 
 TEST(StatusBuilder, StreamInsertionMultiple) {
@@ -53,13 +70,13 @@ TEST(StatusBuilder, StreamInsertionMultiple) {
                                                         << " goes"
                                                         << " like"
                                                         << " this.";
-  EXPECT_THAT(status.ToString(), HasSubstr("message goes like this."));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message goes like this.");
 }
 
 TEST(StatusBuilder, StreamInsertionFlag) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC)
                   << "message " << std::hex << 32;
-  EXPECT_THAT(status.ToString(), HasSubstr("message 20"));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message 20");
 }
 
 TEST(StatusMacro, ReturnIfError) {
@@ -70,8 +87,8 @@ TEST(StatusMacro, ReturnIfError) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
   status = returnIfError(std::move(status));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  EXPECT_THAT(status.ToString(), HasSubstr("message"));
-  EXPECT_THAT(status.ToString(), HasSubstr("annotation"));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation");
 
   IREE_EXPECT_OK(returnIfError(OkStatus()));
 }
@@ -85,9 +102,9 @@ TEST(StatusMacro, ReturnIfErrorFormat) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
   status = returnIfError(std::move(status));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  EXPECT_THAT(status.ToString(), HasSubstr("message"));
-  EXPECT_THAT(status.ToString(), HasSubstr("annotation 1 2 3"));
-  EXPECT_THAT(status.ToString(), HasSubstr("extra annotation"));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation 1 2 3");
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "extra annotation");
 
   IREE_EXPECT_OK(returnIfError(OkStatus()));
 }
@@ -102,8 +119,8 @@ TEST(StatusMacro, AssignOrReturn) {
                                    << "message";
   Status status = assignOrReturn(std::move(statusOr));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  EXPECT_THAT(status.ToString(), HasSubstr("message"));
-  EXPECT_THAT(status.ToString(), HasSubstr("annotation"));
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
+  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation");
 
   IREE_EXPECT_OK(assignOrReturn("foo"));
 }

--- a/iree/base/status_test.cc
+++ b/iree/base/status_test.cc
@@ -26,15 +26,11 @@ using ::testing::HasSubstr;
 #if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0
 #define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
   EXPECT_THAT(status.ToString(), HasSubstr(message_substr))
-#else
-#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
-  EXPECT_THAT(status.ToString(), HasSubstr(StatusCodeToString(status.code())));
-#endif
-
-#if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0
 #define CHECK_STREAM_SUBSTR(status, os, message_substr) \
   EXPECT_THAT(os.str(), HasSubstr(message_substr));
 #else
+#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
+  EXPECT_THAT(status.ToString(), HasSubstr(StatusCodeToString(status.code())));
 #define CHECK_STREAM_SUBSTR(status, os, message_substr) \
   EXPECT_THAT(os.str(), HasSubstr(StatusCodeToString(status.code())));
 #endif

--- a/iree/base/status_test.cc
+++ b/iree/base/status_test.cc
@@ -33,7 +33,7 @@ using ::testing::HasSubstr;
   EXPECT_THAT(status.ToString(), HasSubstr(StatusCodeToString(status.code())));
 #define CHECK_STREAM_SUBSTR(status, os, message_substr) \
   EXPECT_THAT(os.str(), HasSubstr(StatusCodeToString(status.code())));
-#endif
+#endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
 
 TEST(Status, ConstructedWithMessage) {
   Status status = Status(StatusCode::kInvalidArgument, "message");

--- a/iree/base/status_test.cc
+++ b/iree/base/status_test.cc
@@ -24,40 +24,43 @@ using ::iree::testing::status::StatusIs;
 using ::testing::HasSubstr;
 
 #if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) != 0
-#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
+#define CHECK_STATUS_MESSAGE(status, message_substr)         \
+  EXPECT_THAT(status.ToString(),                             \
+              HasSubstr(StatusCodeToString(status.code()))); \
   EXPECT_THAT(status.ToString(), HasSubstr(message_substr))
-#define CHECK_STREAM_SUBSTR(status, os, message_substr) \
-  EXPECT_THAT(os.str(), HasSubstr(message_substr));
+#define CHECK_STREAM_MESSAGE(status, os, message_substr)               \
+  EXPECT_THAT(os.str(), HasSubstr(StatusCodeToString(status.code()))); \
+  EXPECT_THAT(os.str(), HasSubstr(message_substr))
 #else
-#define CHECK_STATUS_MESSAGE_SUBSTR(status, message_substr) \
+#define CHECK_STATUS_MESSAGE(status, message_substr) \
   EXPECT_THAT(status.ToString(), HasSubstr(StatusCodeToString(status.code())));
-#define CHECK_STREAM_SUBSTR(status, os, message_substr) \
+#define CHECK_STREAM_MESSAGE(status, os, message_substr) \
   EXPECT_THAT(os.str(), HasSubstr(StatusCodeToString(status.code())));
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS
 
 TEST(Status, ConstructedWithMessage) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
+  CHECK_STATUS_MESSAGE(status, "message");
 }
 
 TEST(Status, StreamInsertion) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
   std::ostringstream os;
   os << status;
-  CHECK_STREAM_SUBSTR(status, os, "message");
+  CHECK_STREAM_MESSAGE(status, os, "message");
 }
 
 TEST(Status, StreamInsertionContinued) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
   std::ostringstream os;
   os << status << " annotation";
-  CHECK_STREAM_SUBSTR(status, os, "message");
-  CHECK_STREAM_SUBSTR(status, os, "annotation");
+  CHECK_STREAM_MESSAGE(status, os, "message");
+  CHECK_STREAM_MESSAGE(status, os, "annotation");
 }
 
 TEST(StatusBuilder, StreamInsertion) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
+  CHECK_STATUS_MESSAGE(status, "message");
 }
 
 TEST(StatusBuilder, StreamInsertionMultiple) {
@@ -65,13 +68,13 @@ TEST(StatusBuilder, StreamInsertionMultiple) {
                                                         << " goes"
                                                         << " like"
                                                         << " this.";
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message goes like this.");
+  CHECK_STATUS_MESSAGE(status, "message goes like this.");
 }
 
 TEST(StatusBuilder, StreamInsertionFlag) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC)
                   << "message " << std::hex << 32;
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message 20");
+  CHECK_STATUS_MESSAGE(status, "message 20");
 }
 
 TEST(StatusMacro, ReturnIfError) {
@@ -82,8 +85,8 @@ TEST(StatusMacro, ReturnIfError) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
   status = returnIfError(std::move(status));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation");
+  CHECK_STATUS_MESSAGE(status, "message");
+  CHECK_STATUS_MESSAGE(status, "annotation");
 
   IREE_EXPECT_OK(returnIfError(OkStatus()));
 }
@@ -97,9 +100,9 @@ TEST(StatusMacro, ReturnIfErrorFormat) {
   Status status = InvalidArgumentErrorBuilder(IREE_LOC) << "message";
   status = returnIfError(std::move(status));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation 1 2 3");
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "extra annotation");
+  CHECK_STATUS_MESSAGE(status, "message");
+  CHECK_STATUS_MESSAGE(status, "annotation 1 2 3");
+  CHECK_STATUS_MESSAGE(status, "extra annotation");
 
   IREE_EXPECT_OK(returnIfError(OkStatus()));
 }
@@ -114,8 +117,8 @@ TEST(StatusMacro, AssignOrReturn) {
                                    << "message";
   Status status = assignOrReturn(std::move(statusOr));
   EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
-  CHECK_STATUS_MESSAGE_SUBSTR(status, "annotation");
+  CHECK_STATUS_MESSAGE(status, "message");
+  CHECK_STATUS_MESSAGE(status, "annotation");
 
   IREE_EXPECT_OK(assignOrReturn("foo"));
 }

--- a/iree/base/status_test.cc
+++ b/iree/base/status_test.cc
@@ -37,7 +37,6 @@ using ::testing::HasSubstr;
 
 TEST(Status, ConstructedWithMessage) {
   Status status = Status(StatusCode::kInvalidArgument, "message");
-
   CHECK_STATUS_MESSAGE_SUBSTR(status, "message");
 }
 


### PR DESCRIPTION
Otherwise the test fails in optimized builds (or other builds which disable annotations).

I used macros instead of helper functions so we get line numbers for failed test checks.