### PR TITLE
Make DotGeneral op live in their own dispatch function.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -32,10 +32,9 @@ namespace {
 // TODO(laurenzo): Every one of these should have better support and removed
 // from this exclusion list eventually.
 bool isUnsupportedFusionOp(Operation *op) {
-  return isa<mhlo::DotOp>(op) || isa<mhlo::ConvOp>(op) ||
-         isa<mhlo::ReduceOp>(op) || isa<mhlo::PadOp>(op) ||
-         isa<mhlo::ReduceWindowOp>(op) || isa<mhlo::TorchIndexSelectOp>(op) ||
-         isa<mhlo::SliceOp>(op) || isa<mhlo::ConcatenateOp>(op);
+  return isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp, mhlo::DotOp,
+             mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp, mhlo::SliceOp,
+             mhlo::TorchIndexSelectOp>(op);
 }
 
 // Allowlist of ops that materialize to a an index-permuted copy of some kind

--- a/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
@@ -197,10 +197,9 @@ bool isDispatchRegionMergable(DispatchRegionOp &regionOp) {
   for (auto &block : regionOp.body().getBlocks()) {
     for (auto &op : block) {
       // TODO(b/144530470): replace with tablegen attributes/interfaces.
-      if (isa<mhlo::ReduceOp>(op) || isa<mhlo::DotOp>(op) ||
-          isa<mhlo::ConvOp>(op) || isa<mhlo::ReduceWindowOp>(op) ||
-          isa<mhlo::PadOp>(op) || isa<mhlo::TorchIndexSelectOp>(op) ||
-          isa<mhlo::SliceOp>(op) || isa<mhlo::ConcatenateOp>(op)) {
+      if (isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp,
+              mhlo::DotOp, mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp,
+              mhlo::SliceOp, mhlo::TorchIndexSelectOp>(op)) {
         return false;
       }
     }


### PR DESCRIPTION
Also group ops into one `isa<>` and sort them alphabetically.