### PR TITLE
Fix doc generation on Windows.

### DIFF
--- a/build_tools/cmake/build_docs.sh
+++ b/build_tools/cmake/build_docs.sh
@@ -46,7 +46,7 @@ cd ${BUILD_DIR}
                 -DIREE_BUILD_PYTHON_BINDINGS=OFF \
                 -G Ninja
 # Generate docs and also build iree-opt for generating more docs :)
-ninja iree-doc iree-opt
+ninja iree-doc iree_tools_iree-opt
 
 cd ${ROOT_DIR}
 # Copy docs in source tree over

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -105,7 +105,7 @@ def get_test_targets(test_suite_path):
 
   query = ['bazel', 'query', f'tests({test_suite_path})']
   tests = subprocess.check_output(query)
-  tests = tests.decode('ascii').split('\n')
+  tests = tests.decode('ascii').split(os.linesep)
   tests = list(filter(lambda s: s.startswith(f'{test_suite_path}_'), tests))
   tests = [test.replace(f'{test_suite_path}_', '') for test in tests]
   return tests


### PR DESCRIPTION
There are some formatting differences between generating on Linux and generating on Windows, but this at least lets us run generation locally on Windows again for testing.