### PR TITLE
[Model Runner] Fix error when using model runner with asserts off

### DIFF
--- a/experimental/ModelBuilder/ModelRunner.cpp
+++ b/experimental/ModelBuilder/ModelRunner.cpp
@@ -70,11 +70,16 @@ void mlir::ModelRunner::compile(CompilationOptions compilationOptions,
   // Make sure the execution engine runs LLVM passes for the specified
   // optimization level.
   auto tmBuilderOrError = llvm::orc::JITTargetMachineBuilder::detectHost();
+  if (!tmBuilderOrError) {
+    llvm::errs() << tmBuilderOrError.takeError() << "\n";
+    return;
+  }
   auto t = tmBuilderOrError->getTargetTriple().getTriple();
-  assert(tmBuilderOrError);
   auto tmOrError = tmBuilderOrError->createTargetMachine();
-  if (!tmOrError) llvm::errs() << tmOrError.takeError() << "\n";
-  assert(tmOrError);
+  if (!tmOrError) {
+    llvm::errs() << tmOrError.takeError() << "\n";
+    return;
+  }
   targetMachine = std::move(tmOrError.get());
   SmallVector<const llvm::PassInfo*, 4> llvmPasses;
   if (target == Target::CPUTarget) {


### PR DESCRIPTION
Bug found by Hanhan, when running with NDEBUG set we get an error
because Expected<> type is not checked before being used.