### PR TITLE
Handle multiple uses of a tensor_reshape before store.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -1481,11 +1481,11 @@ static LogicalResult createAndPropagateBufferUsedForResultTensor(
     }
     if (auto tensorReshapeOp =
             tensor.getDefiningOp<linalg::TensorReshapeOp>()) {
-      if (!tensorReshapeOp.result().hasOneUse()) break;
+      tensor = tensorReshapeOp.src();
+      if (resultTensorToBufferMap.count(tensor)) break;
       auto newReshapeOp = builder.create<linalg::ReshapeOp>(
           op.getLoc(), getMemrefTypeForTensor(tensorReshapeOp.getSrcType()),
           buffer, tensorReshapeOp.reassociation());
-      tensor = tensorReshapeOp.src();
       buffer = newReshapeOp.result();
       resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
       continue;


### PR DESCRIPTION
Generalize the reshape handling in TensorToBuffer Pass to remove
restriction of tensor_reshape -> hal.interface.store.tensor is
converted to buffer only if the tensor_reshape has a single use.

Fixes #2882