### PR TITLE
Fuse linalg.tensor_reshape operations with hal.interface* operations.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/BUILD
@@ -21,6 +21,7 @@ package(
 cc_library(
     name = "HLOToLinalg",
     srcs = [
+        "FusionOfTensorOps.cpp",
         "HLOToLinalgOnBuffers.cpp",
         "HLOToLinalgOnTensors.cpp",
         "Passes.cpp",

--- a/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "FusionOfTensorOps.cpp"
     "HLOToLinalgOnBuffers.cpp"
     "HLOToLinalgOnTensors.cpp"
     "Passes.cpp"

--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -16,7 +16,7 @@
 //
 // Pass to fuse operations on tensors after conversion to Linalg. Uses the
 // patterns from MLIR for fusion linalg operations on tensors, and a few
-// patterns to fuse these with IREE specific operations
+// patterns to fuse these with IREE specific operations.
 //
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -1,0 +1,87 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//===--- FusionOfTensorsOps.cpp - Pass to fuse operations on tensors-------===//
+//
+// Pass to fuse operations on tensors after conversion to Linalg. Uses the
+// patterns from MLIR for fusion linalg operations on tensors, and a few
+// patterns to fuse these with IREE specific operations
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Conversion/HLOToLinalg/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Pattern to fuse hal.interface.load.tensor -> linalg.tensor_reshape
+struct FuseWithHALInterfaceLoadTensor
+    : public OpRewritePattern<linalg::TensorReshapeOp> {
+  using OpRewritePattern<linalg::TensorReshapeOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(linalg::TensorReshapeOp reshapeOp,
+                                PatternRewriter &rewriter) const override {
+    auto loadOp =
+        reshapeOp.src().getDefiningOp<IREE::HAL::InterfaceLoadTensorOp>();
+    if (!loadOp) return failure();
+    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceLoadTensorOp>(
+        reshapeOp, reshapeOp.getResultType(), loadOp.binding(),
+        loadOp.offset());
+    return success();
+  }
+};
+
+/// Pattern to fuse linalg.tensor_reshape -> hal.interface.store.tensor
+struct FuseWithHALInterfaceStoreTensor
+    : public OpRewritePattern<IREE::HAL::InterfaceStoreTensorOp> {
+  using OpRewritePattern<IREE::HAL::InterfaceStoreTensorOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(IREE::HAL::InterfaceStoreTensorOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    auto reshapeOp = storeOp.operand().getDefiningOp<linalg::TensorReshapeOp>();
+    if (!reshapeOp) return failure();
+    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceStoreTensorOp>(
+        storeOp, reshapeOp.src(), storeOp.binding(), storeOp.offset());
+    return success();
+  }
+};
+
+/// Pass to fuse linalg on tensor operations as well as fusion of hal.interface*
+/// operations with linalg.tensor_reshape operation.
+struct FusionOfTensorOpsPass
+    : public PassWrapper<FusionOfTensorOpsPass, OperationPass<>> {
+  void runOnOperation() override {
+    OwningRewritePatternList patterns;
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    populateLinalgTensorOpsFusionPatterns(context, patterns);
+    patterns.insert<FuseWithHALInterfaceLoadTensor,
+                    FuseWithHALInterfaceStoreTensor>(context);
+    applyPatternsAndFoldGreedily(op->getRegions(), patterns);
+  }
+};
+}  // namespace
+
+std::unique_ptr<Pass> createFusionOfTensorOpsPass() {
+  return std::make_unique<FusionOfTensorOpsPass>();
+}
+
+static PassRegistration<FusionOfTensorOpsPass> pass(
+    "iree-codegen-fusion-of-tensor-ops", "Fuse operations on tensors");
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
@@ -26,7 +26,7 @@ void addHLOToLinalgOnBuffersPasses(OpPassManager &pm) {
   pm.addPass(createHLOToLinalgOnTensorsPass());
   pm.addPass(createLinalgFoldUnitExtentDimsPass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createLinalgFusionOfTensorOpsPass());
+  pm.addPass(createFusionOfTensorOpsPass());
   pm.addPass(createHLOToLinalgOnBuffersPass());
 }
 

--- a/iree/compiler/Conversion/HLOToLinalg/Passes.h
+++ b/iree/compiler/Conversion/HLOToLinalg/Passes.h
@@ -27,6 +27,9 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Creates a pass to fuse operations on tensors.
+std::unique_ptr<Pass> createFusionOfTensorOpsPass();
+
 /// Creates XLA-HLO to Linalg on buffers transformation pass.
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnBuffersPass();
 

--- a/iree/compiler/Conversion/HLOToLinalg/test/fusion.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/fusion.mlir
@@ -1,0 +1,131 @@
+// RUN: iree-opt -iree-codegen-fusion-of-tensor-ops -split-input-file %s | FileCheck %s
+
+#map0 = affine_map<(d0) -> (d0)>
+module {
+  func @fuse_load_reshape() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<4x25xf32>
+    %1 = linalg.tensor_reshape %0 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<4x25xf32> into tensor<100xf32>
+    %2 = linalg.generic {
+           args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#map0, #map0],
+           iterator_types = ["parallel"]} %1 {
+    ^bb0(%arg0: f32):
+       linalg.yield %arg0 : f32
+    } : tensor<100xf32> -> tensor<100xf32>
+    hal.interface.store.tensor %2, @legacy_io::@ret0, offset = %c0 : tensor<100xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visiblity = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: func @fuse_load_reshape
+//       CHECK:   %[[LOAD:.+]] = hal.interface.load.tensor
+//  CHECK-SAME:     tensor<100xf32>
+//   CHECK-NOT:   linalg.reshape
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     %[[LOAD]]
+
+// -----
+
+module {
+  func @fuse_store_reshape() {
+    %c0 = constant 0 : index
+    %c42 = constant dense<42> : tensor<100xi32>
+    %0 = linalg.tensor_reshape %c42 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<100xi32> into tensor<4x25xi32>
+    hal.interface.store.tensor %0, @legacy_io::@ret0, offset = %c0 : tensor<4x25xi32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visiblity = "private"} {
+    hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer", access="Read"
+  }
+}
+
+// CHECK-LABEL: func @fuse_store_reshape
+//       CHECK:   %[[C42:.+]] = constant dense<{{.+}}> : tensor<100xi32>
+//       CHECK:   hal.interface.store.tensor %[[C42]]
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d2)>
+module {
+  func @example1() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<10xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<5xf32>
+    %2 = linalg.tensor_reshape %0 [#map0] : tensor<10xf32> into tensor<1x2x5xf32>
+    %3 = linalg.generic {args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} %1 {
+    ^bb0(%arg0: f32):  // no predecessors
+      linalg.yield %arg0 : f32
+    }: tensor<5xf32> -> tensor<2x5xf32>
+    %4 = linalg.tensor_reshape %2 [#map3, #map4] : tensor<1x2x5xf32> into tensor<2x5xf32>
+    %5 = linalg.generic {args_in = 2 : i64, args_out = 1 : i64, indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} %4, %3 {
+    ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+      %8 = addf %arg0, %arg1 : f32
+      linalg.yield %8 : f32
+    }: tensor<2x5xf32>, tensor<2x5xf32> -> tensor<2x5xf32>
+    %6 = linalg.tensor_reshape %5 [#map3, #map4] : tensor<2x5xf32> into tensor<1x2x5xf32>
+    %7 = linalg.tensor_reshape %6 [#map0] : tensor<1x2x5xf32> into tensor<10xf32>
+    hal.interface.store.tensor %7, @legacy_io::@ret0, offset = %c0 : tensor<10xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: func @example1
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.load.tensor @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.load.tensor @legacy_io::@arg1
+//       CHECK:   %[[STORE:.+]] = linalg.generic
+//  CHECK-SAME:     %[[ARG0]], %[[ARG1]]
+//       CHECK:   hal.interface.store.tensor %[[STORE]]
+
+// -----
+
+
+#map0 = affine_map<(d0) -> (d0)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d3)>
+module {
+  func @example2() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<1x1x1x1000xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<1000xf32>
+    %2 = linalg.generic {args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#map0, #map0], iterator_types = ["parallel"]} %1 {
+    ^bb0(%arg0: f32):  // no predecessors
+      linalg.yield %arg0 : f32
+    }: tensor<1000xf32> -> tensor<1000xf32>
+    %3 = linalg.tensor_reshape %0 [#map1] : tensor<1x1x1x1000xf32> into tensor<1000xf32>
+    %4 = linalg.generic {args_in = 2 : i64, args_out = 1 : i64, indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel"]} %3, %2 {
+    ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+      %7 = addf %arg0, %arg1 : f32
+      linalg.yield %7 : f32
+    }: tensor<1000xf32>, tensor<1000xf32> -> tensor<1000xf32>
+    %5 = linalg.tensor_reshape %4 [#map1] : tensor<1000xf32> into tensor<1x1x1x1000xf32>
+    %6 = linalg.tensor_reshape %5 [#map2, #map3] : tensor<1x1x1x1000xf32> into tensor<1x1000xf32>
+    hal.interface.store.tensor %5, @legacy_io::@ret0, offset = %c0 : tensor<1x1x1x1000xf32>
+    hal.interface.store.tensor %6, @legacy_io::@ret1, offset = %c0 : tensor<1x1000xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+    hal.interface.binding @ret1, set=0, binding=3, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: func @example2
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.load.tensor @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.load.tensor @legacy_io::@arg1
+//       CHECK:   %[[RES:.+]] = linalg.generic
+//  CHECK-SAME:     %[[ARG0]], %[[ARG1]]
+//   CHECK-DAG:   hal.interface.store.tensor %[[RES]]
+//   CHECK-DAG:   hal.interface.store.tensor %[[RES]]

--- a/iree/compiler/Conversion/HLOToLinalg/test/pipeline_test.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pipeline_test.mlir
@@ -23,3 +23,37 @@ module {
 //       CHECK:   linalg.generic
 //   CHECK-NOT:   linalg.generic
 //       CHECK:   return
+
+// -----
+
+module {
+  func @bug_2882_repro2() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<1x1x1x1000xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<1000xf32>
+    %2 = "mhlo.broadcast_in_dim"(%1) {broadcast_dimensions = dense<3> : tensor<1xi64>} : (tensor<1000xf32>) -> tensor<1x1x1x1000xf32>
+    %3 = mhlo.add %0, %2 : tensor<1x1x1x1000xf32>
+    %4 = "mhlo.reshape"(%3) : (tensor<1x1x1x1000xf32>) -> tensor<1x1000xf32>
+    hal.interface.store.tensor %3, @legacy_io::@ret0, offset = %c0 : tensor<1x1x1x1000xf32>
+    hal.interface.store.tensor %4, @legacy_io::@ret1, offset = %c0 : tensor<1x1000xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+    hal.interface.binding @ret1, set=0, binding=3, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: func @bug_2882_repro2
+//       CHECK:   %[[RET0:.+]] = iree.placeholder
+//  CHECK-SAME:     binding = @legacy_io::@ret0
+//       CHECK:   %[[RET1:.+]] = iree.placeholder
+//  CHECK-SAME:     binding = @legacy_io::@ret1
+//       CHECK:   %[[ARG1:.+]] = iree.placeholder
+//  CHECK-SAME:     binding = @legacy_io::@arg1
+//       CHECK:   %[[ARG0:.+]] = iree.placeholder
+//  CHECK-SAME:     binding = @legacy_io::@arg0
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     %[[ARG0]], %[[ARG1]], %[[RET0]]
+//       CHECK:   linalg.copy(%[[RET0]], %[[RET1]])


### PR DESCRIPTION
To reduce complexity of passes downstream, the linalg.tensor_reshape
operations can be fused with the hal.interface.load.tensor and
hal.interface.store.tensor operations. Add these patterns and the
patterns to fuse Linalg operations on tensors into a single pass.