### PR TITLE
Add more type support to model builder matmul benchmark.

### DIFF
--- a/experimental/ModelBuilder/ModelBuilder.cpp
+++ b/experimental/ModelBuilder/ModelBuilder.cpp
@@ -94,6 +94,7 @@ static spirv::TargetEnvAttr getTargetEnv(MLIRContext *context) {
       spirv::Version::V_1_0,
       {spirv::Capability::Shader, spirv::Capability::CooperativeMatrixNV,
        spirv::Capability::Int8, spirv::Capability::Float16,
+       spirv::Capability::StorageUniform16,
        spirv::Capability::StorageBuffer8BitAccess,
        spirv::Capability::Float16Buffer},
       {spirv::Extension::SPV_KHR_storage_buffer_storage_class,


### PR DESCRIPTION
Add fp16, and fp32 support in the matmul benchmark. Also prepare a fp32xfp32xfp32 mode that will not use cooperative matrix.