### PR TITLE
Use hidden visibility for all symbols by default

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -117,6 +117,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
   CLANG_OR_GCC
     "-Wno-unused-parameter"
     "-Wno-undef"
+    "-fvisibility=hidden"
   MSVC_OR_CLANG_CL
     "/DWIN32_LEAN_AND_MEAN"
     "/wd4624"

--- a/iree/base/dynamic_library_test_library.cc
+++ b/iree/base/dynamic_library_test_library.cc
@@ -21,7 +21,7 @@
 #if defined(_WIN32)
 #define IREE_SYM_EXPORT __declspec(dllexport)
 #else
-#define IREE_SYM_EXPORT
+#define IREE_SYM_EXPORT __attribute__ ((visibility ("default")))
 #endif  // _WIN32
 
 IREE_API_EXPORT int IREE_SYM_EXPORT times_two(int value) { return value * 2; }

--- a/iree/base/dynamic_library_test_library.cc
+++ b/iree/base/dynamic_library_test_library.cc
@@ -21,7 +21,7 @@
 #if defined(_WIN32)
 #define IREE_SYM_EXPORT __declspec(dllexport)
 #else
-#define IREE_SYM_EXPORT __attribute__ ((visibility ("default")))
+#define IREE_SYM_EXPORT __attribute__((visibility("default")))
 #endif  // _WIN32
 
 IREE_API_EXPORT int IREE_SYM_EXPORT times_two(int value) { return value * 2; }


### PR DESCRIPTION
This addresses pages of pages of warnings on macOS like:

ld: warning: direct access in function 'foo' from file 'foo.file' to
global weak symbol 'bar' from file 'bar.file' means the weak symbol
cannot be overridden at runtime. This was likely caused by different
translation units being compiled with different visibility settings.

Besides, this has many benefits like avoiding symbol collision,
reducing library size, improving optimization, etc.