### PR TITLE
Allow iree.placeholder as an op between splittable ops.

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/SplitDispatchFunctionPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/SplitDispatchFunctionPass.cpp
@@ -68,7 +68,8 @@ bool canSeparateOps(ArrayRef<Operation *> ops) {
   for (auto currOp = ops.begin(), nextOp = std::next(ops.begin());
        nextOp != ops.end(); ++currOp, ++nextOp) {
     Operation *iter = (*currOp)->getNextNode();
-    while (iter != *nextOp && MemoryEffectOpInterface::hasNoEffect(iter))
+    while (iter != *nextOp && (MemoryEffectOpInterface::hasNoEffect(iter) ||
+                               isa<IREE::PlaceholderOp>(iter)))
       iter = iter->getNextNode();
     if (iter != *nextOp) return false;
   }


### PR DESCRIPTION
iree.placeholder can be interspeesed with other operations that are to
be split within SplitDispatchFunctionPass.