### PR TITLE
Expand the tf_module_to_compiler_module API

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_driver.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_driver.py
@@ -45,11 +45,10 @@ def _run_test(test_dict):
   """Runs an individual test dict."""
   tf_module_builder_lambda = test_dict["tf_module_builder"]
   tf_module = tf_module_builder_lambda()
-  ctx = compiler.Context()
   with tempfile.TemporaryDirectory() as sm_path:
     options = tf.saved_model.SaveOptions(save_debug_info=True)
     tf.saved_model.save(tf_module, sm_path, options=options)
-    input_module = compiler.tf_load_saved_model(sm_path, ctx, pass_pipeline=())
+    input_module = compiler.tf_load_saved_model(sm_path, pass_pipeline=())
 
   passes = test_dict.get("passes")
   expect_pass_failure = test_dict.get("expect_pass_failure")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_driver.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_driver.py
@@ -45,10 +45,8 @@ def _run_test(test_dict):
   """Runs an individual test dict."""
   tf_module_builder_lambda = test_dict["tf_module_builder"]
   tf_module = tf_module_builder_lambda()
-  with tempfile.TemporaryDirectory() as sm_path:
-    options = tf.saved_model.SaveOptions(save_debug_info=True)
-    tf.saved_model.save(tf_module, sm_path, options=options)
-    input_module = compiler.tf_load_saved_model(sm_path, pass_pipeline=())
+  input_module = compiler.tf_module_to_compiler_module(tf_module,
+                                                       pass_pipeline=())
 
   passes = test_dict.get("passes")
   expect_pass_failure = test_dict.get("expect_pass_failure")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -171,7 +171,7 @@ def compile_tf_module(
   try:
     # Convert the tf_module into raw TF input MLIR.
     compiler_module = compiler.tf_module_to_compiler_module(
-      tf_module, exported_names, sm_path)
+      tf_module, exported_names, sm_path, pass_pipeline=())
 
     if artifacts_dir is not None:
       tf_mlir_path = os.path.join(artifacts_dir, "tf_input.mlir")
@@ -179,7 +179,8 @@ def compile_tf_module(
       with open(tf_mlir_path, "w") as f:
         f.write(compiler_module.to_asm())
 
-    # Now run the passes manually that tf_load_saved_model would usually do.
+    # Now run the passes manually that tf_module_to_compiler_module would
+    # usually do.
     compiler_module.run_pass_pipeline(compiler.TF_IMPORT_PASS_PIPELINE)
 
     if artifacts_dir is not None:


### PR DESCRIPTION
Allows for specification of a `pass_pipeline` and `compiler_context`. Also moved the compiler context arg to the last position in the `tf.compiler` functions, since it is largely unused, and calls can be simplified when it can be omitted.