### PR TITLE
Adding missing distribution options for BatchMatmul in tile+distribute

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -276,7 +276,7 @@ struct TileBatchMatmulPattern
                          linalg::LinalgTilingOptions options,
                          ArrayRef<int64_t> workgroupSize,
                          PatternBenefit benefit = 1)
-      : Base(context, options,
+      : Base(context, options.setDistributionOptions(matmulDistributionOptions),
              linalg::LinalgMarker(
                  ArrayRef<Identifier>(),
                  Identifier::get(getWorkgroupMarker(), context)),

--- a/iree/test/e2e/xla_ops/dot_general.mlir
+++ b/iree/test/e2e/xla_ops/dot_general.mlir
@@ -79,3 +79,19 @@ func @dot_general_nontrivial_batching_dimension() attributes { iree.module.expor
           [15.0, 30.0, 45.0, 60.0]]]> : tensor<2x2x4xf32>) : tensor<2x2x4xf32>
   return
 }
+
+func @large_dot_general() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1.0> : tensor<4x32x1024xf32>
+  %rhs = iree.unfoldable_constant dense<0.4> : tensor<4x1024x64xf32>
+  %res = "mhlo.dot_general"(%lhs, %rhs) {
+           dot_dimension_numbers = {
+             lhs_batching_dimensions = dense<0> : tensor<1xi64>,
+             lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
+             rhs_batching_dimensions = dense<0> : tensor<1xi64>,
+             rhs_contracting_dimensions = dense<1> : tensor<1xi64>
+           },
+           precision_config = ["DEFAULT", "DEFAULT"]
+         } : (tensor<4x32x1024xf32>, tensor<4x1024x64xf32>) -> tensor<4x32x64xf32>
+  check.expect_almost_eq_const(%res, dense<409.596> : tensor<4x32x64xf32>) : tensor<4x32x64xf32>
+  return
+}


### PR DESCRIPTION
The distribution needs to be specified since the downstream passes do
not distribute loops anymore.