### PR TITLE
Fix hyperlink to getting started docs on python page.

### DIFF
--- a/docs/get_started/getting_started_python.md
+++ b/docs/get_started/getting_started_python.md
@@ -10,7 +10,7 @@ Python bindings you must build from source.
 ## Prerequisites
 
 You should already have IREE cloned and building on your machine. See the other
-[getting started guides](.) for instructions.
+[getting started guides](../get-started) for instructions.
 
 > Note:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;Support is best with Bazel.


### PR DESCRIPTION
This link won't work on GitHub, but will on GitHub Pages. We have the same sort of half-broken link at [gh-pages/docs/developing_iree/index.md](https://github.com/google/iree/blob/gh-pages/docs/developing_iree/index.md).

Fixes https://github.com/google/iree/issues/2029
Fixes https://github.com/google/iree/issues/3014