### PR TITLE
Enable simple.mlir test for iree-benchmark-module on vulkan

### DIFF
--- a/iree/tools/test/simple.mlir
+++ b/iree/tools/test/simple.mlir
@@ -6,8 +6,7 @@
 // iree-benchmark-module (only checking exit codes).
 // RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --entry_function=abs --inputs="i32=-2" --input_file=${TEST_TMPDIR?}/bc.module
 
-// TODO(#3007): Enable the test.
-// FAIL: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vulkan --entry_function=abs --inputs="i32=-2" --input_file=${TEST_TMPDIR?}/bc.module)
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vulkan --entry_function=abs --inputs="i32=-2" --input_file=${TEST_TMPDIR?}/bc.module)
 
 // iree-run-mlir
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmla --input-value="i32=-2" %s) | IreeFileCheck %s


### PR DESCRIPTION
With #2904 and #2800, the issue on SwiftShader is resolved.

Fixes https://github.com/google/iree/issues/3007