### PR TITLE
Add pass to convert memref to memref of vector.

### DIFF
--- a/experimental/ModelBuilder/test/BenchMatMulVectorGPU.cpp
+++ b/experimental/ModelBuilder/test/BenchMatMulVectorGPU.cpp
@@ -82,6 +82,9 @@ static void addLoweringPasses(mlir::PassManager &pm,
   pm.addPass(mlir::createLegalizeStdOpsForSPIRVLoweringPass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
+  pm.addPass(mlir::iree_compiler::createVectorizeMemref());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
   pm.addPass(mlir::iree_compiler::createConvertToSPIRVPass());
 
   auto &spirvModulePM = pm.nest<mlir::spirv::ModuleOp>();

--- a/iree/compiler/Conversion/LinalgToSPIRV/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "SplitDispatchFunctionPass.cpp",
         "Utils.cpp",
         "VectorToGPUPass.cpp",
+        "VectorizeMemref.cpp",
     ],
     hdrs = [
         "Attributes.h",

--- a/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
     "SplitDispatchFunctionPass.cpp"
     "Utils.cpp"
     "VectorToGPUPass.cpp"
+    "VectorizeMemref.cpp"
   DEPS
     LLVMSupport
     MLIRAffineOps

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
@@ -65,6 +65,11 @@ std::unique_ptr<OperationPass<FuncOp>> createVectorToGPUPass();
 /// Pass to apply tiling and vectorization transformations on linagl::MatMulOp.
 std::unique_ptr<FunctionPass> createMatMulTileAndVectorizeGPUPass();
 
+/// Convert memref of scalar to memref of vector of efficent size. This will
+/// allow to convert memory accesses to vector load/store in SPIR-V without
+/// having pointer bitcast.
+std::unique_ptr<OperationPass<ModuleOp>> createVectorizeMemref();
+
 /// Populates passes needed to lower a XLA HLO op to SPIR-V dialect via the
 /// structured ops path. The pass manager `pm` in here operate on the module
 /// within the IREE::HAL::ExecutableOp. The `workGroupSize` can be used to

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
@@ -8,38 +8,32 @@
 //       CHECK: %[[MAT:.+]] = vector.transfer_read %[[ARG0]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
 //       CHECK: vector.transfer_write %[[MAT]], %[[ALLOC]][%{{.*}}, %{{.*}}] : vector<32x8xf32>, memref<128x8xvector<4xf32>, 3>
 //       CHECK: dealloc %[[ALLOC]] : memref<128x8xvector<4xf32>, 3>
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
-    %cst = constant 0.000000e+00 : f32
-    %0 = alloc() : memref<128x32xf32, 3>
-    %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<1x4xf32>
-    vector.transfer_write %v, %0[%x, %y] : vector<1x4xf32>, memref<128x32xf32, 3>
-    %mat = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<32x8xf32>
-    vector.transfer_write %mat, %0[%x, %y] : vector<32x8xf32>, memref<128x32xf32, 3>
-    dealloc %0 : memref<128x32xf32, 3>
-    return
-  }
+func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+  %cst = constant 0.000000e+00 : f32
+  %0 = alloc() : memref<128x32xf32, 3>
+  %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<1x4xf32>
+  vector.transfer_write %v, %0[%x, %y] : vector<1x4xf32>, memref<128x32xf32, 3>
+  %mat = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<32x8xf32>
+  vector.transfer_write %mat, %0[%x, %y] : vector<32x8xf32>, memref<128x32xf32, 3>
+  dealloc %0 : memref<128x32xf32, 3>
+  return
 }
 
 // -----
 
 // Test that the memref is not vectorized if used by scalar load or store.
 // CHECK-LABEL: func @copy
-//  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x4096xf32>
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
-    %cst = constant 0.000000e+00 : f32
-    %0 = alloc() : memref<128x32xf32, 3>
-    %s = load %arg0[%x, %y] : memref<4096x4096xf32>
-    store %s, %0[%x, %y] : memref<128x32xf32, 3>
-    dealloc %0 : memref<128x32xf32, 3>
-    return
-  }
+//  CHECK-SAME: %[[ARG0:.+]]: memref<4096x4096xf32>
+func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+  %cst = constant 0.000000e+00 : f32
+  %0 = alloc() : memref<128x32xf32, 3>
+  %s = load %arg0[%x, %y] : memref<4096x4096xf32>
+  store %s, %0[%x, %y] : memref<128x32xf32, 3>
+  dealloc %0 : memref<128x32xf32, 3>
+  return
 }
 
 // -----
-
-module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
 
 // CHECK-LABEL: func @resource_copy
 //     CHECK: %[[A:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4096x1024xvector<4xf32>>
@@ -48,21 +42,20 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SP
 //     CHECK: store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
 //     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
 //     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf32>, memref<4096x1024xvector<4xf32>>
-  func @resource_copy() {
-    %cst = constant 0.000000e+00 : f32
-    %c0 = constant 0 : index
-    %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4096x4096xf32>
-    %1 = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<4096x4096xf32>
-    %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<1x4xf32>
-    vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
-    %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
-    vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
-    return
-  }
+func @resource_copy() {
+  %cst = constant 0.000000e+00 : f32
+  %c0 = constant 0 : index
+  %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4096x4096xf32>
+  %1 = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<4096x4096xf32>
+  %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<1x4xf32>
+  vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
+  %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
+  vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
+  return
+}
 
-  hal.interface @legacy_io attributes {push_constants = 5 : i32, sym_visibility = "private"} {
-    hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
-    hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
-  }
+hal.interface @legacy_io attributes {push_constants = 5 : i32, sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
 }
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
@@ -8,7 +8,7 @@
 //       CHECK: %[[MAT:.+]] = vector.transfer_read %[[ARG0]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
 //       CHECK: vector.transfer_write %[[MAT]], %[[ALLOC]][%{{.*}}, %{{.*}}] : vector<32x8xf32>, memref<128x8xvector<4xf32>, 3>
 //       CHECK: dealloc %[[ALLOC]] : memref<128x8xvector<4xf32>, 3>
-func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
   %cst = constant 0.000000e+00 : f32
   %0 = alloc() : memref<128x32xf32, 3>
   %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<1x4xf32>
@@ -24,7 +24,7 @@ func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.e
 // Test that the memref is not vectorized if used by scalar load or store.
 // CHECK-LABEL: func @copy
 //  CHECK-SAME: %[[ARG0:.+]]: memref<4096x4096xf32>
-func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
   %cst = constant 0.000000e+00 : f32
   %0 = alloc() : memref<128x32xf32, 3>
   %s = load %arg0[%x, %y] : memref<4096x4096xf32>

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/memref_vecrotization.mlir
@@ -1,0 +1,68 @@
+// RUN: iree-opt -split-input-file -iree-spirv-vectorize-memref -canonicalize %s | IreeFileCheck %s
+
+// CHECK-LABEL: func @copy
+//  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x1024xvector<4xf32>>
+//       CHECK: %[[ALLOC:.+]] = alloc() : memref<128x8xvector<4xf32>, 3>
+//       CHECK: %[[V:.+]] = load %[[ARG0]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
+//       CHECK: store %[[V]], %[[ALLOC]][%{{.*}}, %{{.*}}] : memref<128x8xvector<4xf32>, 3>
+//       CHECK: %[[MAT:.+]] = vector.transfer_read %[[ARG0]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
+//       CHECK: vector.transfer_write %[[MAT]], %[[ALLOC]][%{{.*}}, %{{.*}}] : vector<32x8xf32>, memref<128x8xvector<4xf32>, 3>
+//       CHECK: dealloc %[[ALLOC]] : memref<128x8xvector<4xf32>, 3>
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+    %cst = constant 0.000000e+00 : f32
+    %0 = alloc() : memref<128x32xf32, 3>
+    %v = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<1x4xf32>
+    vector.transfer_write %v, %0[%x, %y] : vector<1x4xf32>, memref<128x32xf32, 3>
+    %mat = vector.transfer_read %arg0[%x, %y], %cst : memref<4096x4096xf32>, vector<32x8xf32>
+    vector.transfer_write %mat, %0[%x, %y] : vector<32x8xf32>, memref<128x32xf32, 3>
+    dealloc %0 : memref<128x32xf32, 3>
+    return
+  }
+}
+
+// -----
+
+// Test that the memref is not vectorized if used by scalar load or store.
+// CHECK-LABEL: func @copy
+//  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x4096xf32>
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
+    %cst = constant 0.000000e+00 : f32
+    %0 = alloc() : memref<128x32xf32, 3>
+    %s = load %arg0[%x, %y] : memref<4096x4096xf32>
+    store %s, %0[%x, %y] : memref<128x32xf32, 3>
+    dealloc %0 : memref<128x32xf32, 3>
+    return
+  }
+}
+
+// -----
+
+module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+
+// CHECK-LABEL: func @resource_copy
+//     CHECK: %[[A:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4096x1024xvector<4xf32>>
+//     CHECK: %[[B:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<4096x1024xvector<4xf32>>
+//     CHECK: %[[V:.+]] = load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
+//     CHECK: store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
+//     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
+//     CHECK: vector.transfer_write %[[MAT]], %[[B]][%{{.*}}, %{{.*}}] {{.*}} : vector<32x8xf32>, memref<4096x1024xvector<4xf32>>
+  func @resource_copy() {
+    %cst = constant 0.000000e+00 : f32
+    %c0 = constant 0 : index
+    %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4096x4096xf32>
+    %1 = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<4096x4096xf32>
+    %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<1x4xf32>
+    vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
+    %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
+    vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
+    return
+  }
+
+  hal.interface @legacy_io attributes {push_constants = 5 : i32, sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
+  }
+}
+

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -41,6 +41,7 @@ inline void registerLinalgToSPIRVPasses() {
     createSplitDispatchFunctionPass();
     createVectorToGPUPass();
     createMatMulTileAndVectorizeGPUPass();
+    createVectorizeMemref();
     return true;
   }();
   (void)init_once;


### PR DESCRIPTION
For memref accessed by vectortransfer op try to convert them to memref
of vector so that it can be accessed with vector load/store.