### PR TITLE
Use nested references in HAL command buffer dispatches.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -435,8 +435,8 @@ static LogicalResult recordDispatch(Value device, Value commandBuffer,
                                                device, rewriter);
   for (auto targetOp :
        executableOp.getBlock().getOps<IREE::HAL::ExecutableTargetOp>()) {
-    for (auto &targetBackend :
-         IREE::HAL::matchTargetBackends({targetOp.target_backend().str()})) {
+    for (auto &targetBackend : IREE::HAL::matchTargetBackends(
+             {targetOp.target_backend_filter().str()})) {
       auto entryPointOps =
           targetOp.getBlock().getOps<IREE::HAL::ExecutableEntryPointOp>();
       if (entryPointOps.empty()) {

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -5,7 +5,7 @@ hal.executable @ex0 {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.target "vmla" {
+  hal.executable.target @vmla, "vmla" {
     hal.executable.entry_point @entry0 attributes {
       interface = @interface,
       ordinal = 0 : i32,
@@ -79,7 +79,7 @@ hal.executable @ex0 {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.target "vmla" {
+  hal.executable.target @vmla, "vmla" {
     hal.executable.entry_point @entry0 attributes {
       interface = @interface,
       ordinal = 0 : i32,

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -30,11 +30,11 @@ func @multipleDispatches(%arg0: tensor<128xf32>) -> tensor<128xf32> {
     //  CHECK-DAG: %[[EXE:.+]] = hal.executable.lookup {{.+}}, @ex0 : !hal.executable
     //  CHECK-DAG: %[[EXE_LAYOUT:.+]] = hal.executable_layout.lookup
     //      CHECK: hal.command_buffer.push_descriptor_set %[[CMD]], %[[EXE_LAYOUT]], set=0, bindings=[0 = (%arg0, %c0, %sz_3), 1 = (%buffer_1, %c0, %sz_4)]
-    //      CHECK: hal.command_buffer.dispatch {{.+}}, entry_point = 0, workgroup_xyz
+    //      CHECK: hal.command_buffer.dispatch {{.+}}, entry_point = @ex0::@vmla::@entry0, workgroup_xyz
     //      CHECK: hal.command_buffer.execution_barrier
     %1 = flow.dispatch @ex0::@entry0[%arg1 : index](%arg2) : (tensor<128xf32>) -> tensor<128xf32>
     //      CHECK: hal.command_buffer.push_descriptor_set
-    //      CHECK: hal.command_buffer.dispatch {{.+}}, entry_point = 0, workgroup_xyz
+    //      CHECK: hal.command_buffer.dispatch {{.+}}, entry_point = @ex0::@vmla::@entry0, workgroup_xyz
     //      CHECK: hal.command_buffer.execution_barrier
     %2 = flow.dispatch @ex0::@entry0[%arg1 : index](%1) : (tensor<128xf32>) -> tensor<128xf32>
     flow.return %2 : tensor<128xf32>

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -194,12 +194,13 @@ void populateHALCommandBufferToVMPatterns(MLIRContext *context,
       VMImportOpConversion<IREE::HAL::CommandBufferBindDescriptorSetOp>>(
       context, importSymbols, typeConverter,
       "hal.command_buffer.bind_descriptor_set");
-  patterns.insert<VMImportOpConversion<IREE::HAL::CommandBufferDispatchOp>>(
-      context, importSymbols, typeConverter, "hal.command_buffer.dispatch");
   patterns
-      .insert<VMImportOpConversion<IREE::HAL::CommandBufferDispatchIndirectOp>>(
-          context, importSymbols, typeConverter,
-          "hal.command_buffer.dispatch.indirect");
+      .insert<VMImportOpConversion<IREE::HAL::CommandBufferDispatchOrdinalOp>>(
+          context, importSymbols, typeConverter, "hal.command_buffer.dispatch");
+  patterns.insert<
+      VMImportOpConversion<IREE::HAL::CommandBufferDispatchIndirectOrdinalOp>>(
+      context, importSymbols, typeConverter,
+      "hal.command_buffer.dispatch.indirect");
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -74,17 +74,29 @@ func @command_buffer_bind_descriptor_set(
 
 // -----
 
+hal.executable @ex {
+  hal.executable.target @target, "target*" {
+    hal.executable.entry_point @entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = () -> tensor<f32>}
+  }
+}
+
 // CHECK-LABEL: @command_buffer_dispatch
 func @command_buffer_dispatch(%arg0 : !hal.command_buffer, %arg1 : !hal.executable) {
   %c100 = constant 100 : index
   %c200 = constant 200 : index
   %c300 = constant 300 : index
   // CHECK: vm.call @hal.command_buffer.dispatch(%arg0, %arg1, %zero, %c100, %c200, %c300) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, i32, i32, i32) -> ()
-  hal.command_buffer.dispatch %arg0, %arg1, entry_point=0, workgroup_xyz=[%c100, %c200, %c300]
+  hal.command_buffer.dispatch.ordinal %arg0, %arg1, entry_point=0, workgroup_xyz=[%c100, %c200, %c300]
   return
 }
 
 // -----
+
+hal.executable @ex {
+  hal.executable.target @target, "target*" {
+    hal.executable.entry_point @entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = () -> tensor<f32>}
+  }
+}
 
 // CHECK-LABEL: @command_buffer_dispatch_indirect
 func @command_buffer_dispatch_indirect(
@@ -93,6 +105,6 @@ func @command_buffer_dispatch_indirect(
     %arg2 : !hal.buffer) {
   %c100 = constant 100 : index
   // CHECK: vm.call @hal.command_buffer.dispatch.indirect(%arg0, %arg1, %zero, %arg2, %c100) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.executable>, i32, !vm.ref<!hal.buffer>, i32) -> ()
-  hal.command_buffer.dispatch.indirect %arg0, %arg1, entry_point=0, workgroups=%arg2[%c100]
+  hal.command_buffer.dispatch.indirect.ordinal %arg0, %arg1, entry_point=0, workgroups=%arg2[%c100]
   return
 }

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
@@ -5,17 +5,19 @@ hal.executable @exe {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.entry_point @entry attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<4xf32>) -> tensor<4xf32>,
-    workgroup_size = [32 : index, 1 : index, 1 : index]
-  }
-  hal.executable.entry_point @entry_alias attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<4xf32>) -> tensor<4xf32>,
-    workgroup_size = [32 : index, 1 : index, 1 : index]
+  hal.executable.target @backend, "backend" {
+    hal.executable.entry_point @entry attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [32 : index, 1 : index, 1 : index]
+    }
+    hal.executable.entry_point @entry_alias attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [32 : index, 1 : index, 1 : index]
+    }
   }
   hal.executable.binary attributes {
     data = dense<[0, 1, 2, 3]> : vector<4xi8>,

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -855,20 +855,19 @@ void CommandBufferDispatchOp::build(
     OpBuilder &builder, OperationState &state, Value commandBuffer,
     Value executable, IREE::HAL::ExecutableEntryPointOp entryPoint,
     Value workgroupX, Value workgroupY, Value workgroupZ) {
-  build(builder, state, commandBuffer, executable,
-        entryPoint.ordinal().getZExtValue(), workgroupX, workgroupY,
-        workgroupZ);
-}
-
-void CommandBufferDispatchOp::build(Builder &builder, OperationState &state,
-                                    Value commandBuffer, Value executable,
-                                    unsigned entryPointOrdinal,
-                                    Value workgroupX, Value workgroupY,
-                                    Value workgroupZ) {
   state.addOperands(
       {commandBuffer, executable, workgroupX, workgroupY, workgroupZ});
+  // Construct Executable::Target::EntryPoint nested reference.
+  StringRef executableOpSymName =
+      entryPoint.getParentOp()
+          ->getParentOp()
+          ->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
   state.addAttribute("entry_point",
-                     builder.getI32IntegerAttr(entryPointOrdinal));
+                     builder.getSymbolRefAttr(
+                         executableOpSymName,
+                         {builder.getSymbolRefAttr(entryPoint.getParentOp()),
+                          builder.getSymbolRefAttr(entryPoint)}));
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1554,7 +1554,10 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
   let assemblyFormat = "attr-dict";
 }
 
-def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [Symbol]> {
+def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
+    Symbol,
+    HasParent<"IREE::HAL::ExecutableTargetOp">,
+  ]> {
   let summary = [{executable entry point declaration}];
   let description = [{
     An entry point exported by the executable with statically-available

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1573,6 +1573,8 @@ def HAL_ExecutableTargetOp : HAL_Op<"executable.target", [
     IsolatedFromAbove,
     HasParent<"IREE::HAL::ExecutableOp">,
     SingleBlockImplicitTerminator<"IREE::HAL::ExecutableTargetEndOp">,
+    Symbol,
+    SymbolTable,
   ]> {
   let summary = [{target executable IR}];
   let description = [{
@@ -1581,7 +1583,8 @@ def HAL_ExecutableTargetOp : HAL_Op<"executable.target", [
   }];
 
   let arguments = (ins
-    StrAttr:$target_backend
+    StrAttr:$sym_name,
+    StrAttr:$target_backend_filter
     // TODO(benvanik): add compatibility and versioning attributes.
   );
 
@@ -1590,7 +1593,8 @@ def HAL_ExecutableTargetOp : HAL_Op<"executable.target", [
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<[{
-      OpBuilder &builder, OperationState &state, StringRef targetBackend
+      OpBuilder &builder, OperationState &state, StringRef name,
+      StringRef targetBackendFilter
     }]>,
   ];
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1180,6 +1180,60 @@ def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch"> {
     %y = constant 32 : index
     %z = constant 1 : index
     hal.command_buffer.dispatch %cmd, %executable,
+                                entry_point = @executable::target::entry0,
+                                workgroup_xyz = [%x, %y, %z]
+    ```
+  }];
+
+  let arguments = (ins
+    HAL_CommandBuffer:$command_buffer,
+    HAL_Executable:$executable,  // TODO(scotttodd): remove this and extract from nested ref?
+    SymbolRefAttr:$entry_point,
+    HAL_Dim:$workgroup_x,
+    HAL_Dim:$workgroup_y,
+    HAL_Dim:$workgroup_z
+  );
+
+  let assemblyFormat = [{
+    $command_buffer `,` $executable `,` `entry_point` `=` $entry_point `,`
+    `workgroup_xyz` `=` `[` $workgroup_x `,` $workgroup_y `,` $workgroup_z `]`
+    attr-dict
+  }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<[{
+      OpBuilder &builder, OperationState &state, Value commandBuffer,
+      Value executable, IREE::HAL::ExecutableEntryPointOp entryPoint,
+      Value workgroupX, Value workgroupY, Value workgroupZ
+    }]>,
+  ];
+}
+
+// TODO(scotttodd): Re-evaluate naming
+//   Currently basic 'dispatch' is used during target backend compilation,
+//   then 'ordinal' is used just before serialization:
+//   - hal.command_buffer.dispatch, hal.command_buffer.dispatch.ordinal
+//
+//   But we could use something different during compilation and use
+//   unqualified 'dispatch' going forward:
+//   - hal.command_buffer.dispatch, hal.command_buffer.dispatch.symbolic
+//   - hal.command_buffer.dispatch, hal.command_buffer.dispatch.reference
+//
+//   Though what about command_buffer.dispatch.indirect?
+//
+//   Another option would be to make hal.command_buffer.dispatch take
+//   either OrdinalAttr OR SymbolRefAttr, then verify later...
+def HAL_CommandBufferDispatchOrdinalOp : HAL_Op<"command_buffer.dispatch.ordinal"> {
+  let summary = [{command buffer dispatch recording operation, using an entry point ordinal}];
+  let description = [{
+    Dispatches an execution request, using an entry point ordinal.
+
+    ```mlir
+    %x = constant 128 : index
+    %y = constant 32 : index
+    %z = constant 1 : index
+    hal.command_buffer.dispatch %cmd, %executable,
                                 entry_point = 0,
                                 workgroup_xyz = [%x, %y, %z]
     ```
@@ -1199,20 +1253,6 @@ def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch"> {
     `workgroup_xyz` `=` `[` $workgroup_x `,` $workgroup_y `,` $workgroup_z `]`
     attr-dict
   }];
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<[{
-      OpBuilder &builder, OperationState &state, Value commandBuffer,
-      Value executable, IREE::HAL::ExecutableEntryPointOp entryPoint,
-      Value workgroupX, Value workgroupY, Value workgroupZ
-    }]>,
-    OpBuilder<[{
-      Builder &builder, OperationState &state, Value commandBuffer,
-      Value executable, unsigned entryPointOrdinal,
-      Value workgroupX, Value workgroupY, Value workgroupZ
-    }]>,
-  ];
 }
 
 def HAL_CommandBufferDispatchIndirectOp : HAL_Op<"command_buffer.dispatch.indirect"> {
@@ -1223,8 +1263,35 @@ def HAL_CommandBufferDispatchIndirectOp : HAL_Op<"command_buffer.dispatch.indire
 
     ```mlir
     hal.command_buffer.dispatch.indirect %cmd, %executable,
-                                         entry_point = 0,
+                                         entry_point = @executable::target::entry0,
                                          workgroups = %buffer[%offset]
+    ```
+  }];
+
+  let arguments = (ins
+    HAL_CommandBuffer:$command_buffer,
+    HAL_Executable:$executable,  // TODO(scotttodd): remove this and extract from nested ref?
+    SymbolRefAttr:$entry_point,
+    HAL_Buffer:$workgroups_buffer,
+    HAL_DeviceSize:$workgroups_offset
+  );
+
+  let assemblyFormat = [{
+    $command_buffer `,` $executable `,` `entry_point` `=` $entry_point `,`
+    `workgroups` `=` $workgroups_buffer `[` $workgroups_offset `]` attr-dict
+  }];
+}
+
+def HAL_CommandBufferDispatchIndirectOrdinalOp : HAL_Op<"command_buffer.dispatch.indirect.ordinal"> {
+  let summary = [{command buffer indirect dispatch recording operation, using an entry point ordinal}];
+  let description = [{
+    Dispatches an execution request with the dispatch parameters loaded from the
+    given buffer, using an entry point ordinal.
+
+    ```mlir
+    hal.command_buffer.dispatch.indirect.ordinal %cmd, %executable,
+                                                 entry_point = 0,
+                                                 workgroups = %buffer[%offset]
     ```
   }];
 
@@ -1589,6 +1656,8 @@ def HAL_ExecutableTargetOp : HAL_Op<"executable.target", [
     StrAttr:$sym_name,
     StrAttr:$target_backend_filter
     // TODO(benvanik): add compatibility and versioning attributes.
+    // TODO(scotttodd): add linking / preserve_ordinals attribute(s) for targets
+    //                  with special linking requirements
   );
 
   let regions = (region SizedRegion<1>:$body);

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -108,12 +108,19 @@ func @command_buffer_bind_descriptor_set(%arg0 : !hal.command_buffer) {
 
 // CHECK-LABEL: @command_buffer_dispatch
 func @command_buffer_dispatch(%arg0 : !hal.command_buffer) {
+  hal.executable @ex {
+    hal.executable.target @backend, "backend" {
+      hal.executable.entry_point @entry0 attributes {
+        interface = @interface, ordinal = 0 : i32, signature = (tensor<f32>) -> tensor<f32>
+      }
+    }
+  }
   %0 = "test_hal.executable"() : () -> !hal.executable
   %1 = "test_hal.workgroup_x"() : () -> index
   %2 = "test_hal.workgroup_y"() : () -> index
   %3 = "test_hal.workgroup_z"() : () -> index
-  // CHECK: hal.command_buffer.dispatch %arg0, %0, entry_point = 0, workgroup_xyz = [%1, %2, %3]
-  hal.command_buffer.dispatch %arg0, %0, entry_point = 0, workgroup_xyz = [%1, %2, %3]
+  // CHECK: hal.command_buffer.dispatch %arg0, %0, entry_point = @ex::@backend::@entry0, workgroup_xyz = [%1, %2, %3]
+  hal.command_buffer.dispatch %arg0, %0, entry_point = @ex::@backend::@entry0, workgroup_xyz = [%1, %2, %3]
   return
 }
 
@@ -121,10 +128,17 @@ func @command_buffer_dispatch(%arg0 : !hal.command_buffer) {
 
 // CHECK-LABEL: @command_buffer_dispatch_indirect
 func @command_buffer_dispatch_indirect(%arg0 : !hal.command_buffer) {
+  hal.executable @ex {
+    hal.executable.target @backend, "backend" {
+      hal.executable.entry_point @entry0 attributes {
+        interface = @interface, ordinal = 0 : i32, signature = (tensor<f32>) -> tensor<f32>
+      }
+    }
+  }
   %0 = "test_hal.executable"() : () -> !hal.executable
   %1 = "test_hal.buffer"() : () -> !hal.buffer
   %2 = "test_hal.offset"() : () -> index
-  // CHECK: hal.command_buffer.dispatch.indirect %arg0, %0, entry_point = 0, workgroups = %1[%2]
-  hal.command_buffer.dispatch.indirect %arg0, %0, entry_point = 0, workgroups = %1[%2]
+  // CHECK: hal.command_buffer.dispatch.indirect %arg0, %0, entry_point = @ex::@backend::@entry0, workgroups = %1[%2]
+  hal.command_buffer.dispatch.indirect %arg0, %0, entry_point = @ex::@backend::@entry0, workgroups = %1[%2]
   return
 }

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -19,16 +19,19 @@ func @interface_io() {
 
 // CHECK-LABEL: @ex
 hal.executable @ex {
-  // CHECK-DAG: hal.executable.entry_point @entry0 attributes {
-  // CHECK-SAME:     interface = @interface
-  // CHECK-SAME:     ordinal = 0 : i32
-  // CHECK-SAME:     signature = (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-  hal.executable.entry_point @entry0 attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<4xf32>) -> tensor<4xf32>,
-    workgroup_size = [4 : index, 1 : index, 1 : index]
+  // CHECK: hal.executable.target @backend, "backend"
+  hal.executable.target @backend, "backend" {
+    // CHECK-DAG: hal.executable.entry_point @entry0 attributes {
+    // CHECK-SAME:     interface = @interface
+    // CHECK-SAME:     ordinal = 0 : i32
+    // CHECK-SAME:     signature = (tensor<4xf32>) -> tensor<4xf32>
+    // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
+    hal.executable.entry_point @entry0 attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [4 : index, 1 : index, 1 : index]
+    }
   }
   // CHECK-DAG: hal.interface @interface
   hal.interface @interface {

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -74,7 +74,7 @@ void TargetBackend::declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
                                      IREE::HAL::ExecutableOp executableOp) {
   OpBuilder targetBuilder(&executableOp.getBlock().back());
   auto targetContainerOp = targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
-      sourceOp.getLoc(), name());
+      sourceOp.getLoc(), /*name=*/name(), /*targetBackendFilter=*/name());
   OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
   containerBuilder.create<ModuleOp>(sourceOp.getLoc());
 }

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -69,26 +69,26 @@ TargetOptions getTargetOptionsFromFlags();
 //   -> flow.executable @my_exe
 //   [[-iree-hal-materialize-interfaces]]
 //   -> hal.executable @my_exe
-//      + hal.executable.target "vulkan-spirv-v1.1-mobile"
+//      + hal.executable.target @vulkan-spirv-v1.1-mobile "spirv-v1.1-mobile*"
 //          hal.executable.entry_point @my_entry
 //          module { ... }
-//      + hal.executable.target "vulkan-spirv-v1.1-desktop"
+//      + hal.executable.target @vulkan-spirv-v1.1-desktop "spirv-v1.1-desktop*"
 //          hal.executable.entry_point @my_entry
 //          module { ... }
-//      + hal.executable.target "vulkan-spirv-v1.2-desktop"
+//      + hal.executable.target @vulkan-spirv-v1.2-desktop "spirv-v1.2-desktop*"
 //          hal.executable.entry_point @my_entry
 //          module { ... }
 //   [[-iree-hal-translate-executables]]
 //   -> hal.executable @my_exe
-//      + hal.executable.target "vulkan-spirv-v1.1-mobile"
+//      + hal.executable.target @vulkan-spirv-v1.1-mobile "spirv-v1.1-mobile*"
 //          hal.executable.entry_point @my_entry_1
 //          hal.executable.entry_point @my_entry_2
 //          hal.executable.entry_point @my_entry_3
 //          module { spv.module { ... } }
-//      + hal.executable.target "vulkan-spirv-v1.1-desktop"
+//      + hal.executable.target @vulkan-spirv-v1.1-desktop "spirv-v1.1-desktop*"
 //          hal.executable.entry_point @my_entry
 //          module { spv.module { ... } }
-//      + hal.executable.target "vulkan-spirv-v1.2-desktop"
+//      + hal.executable.target @vulkan-spirv-v1.2-desktop "spirv-v1.2-desktop*"
 //          hal.executable.entry_point @my_entry
 //          module { spv.module { ... } }
 //   [[-iree-hal-link-executables]]

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
@@ -17,7 +17,7 @@ flow.executable @simpleMath_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:   hal.executable.target @vmla, "vmla" {
 //  CHECK-NEXT:     hal.executable.entry_point @simpleMath_rgn_dispatch_0_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
@@ -60,7 +60,7 @@ flow.executable @shaped_dispatch {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:   hal.executable.target @vmla, "vmla" {
 //  CHECK-NEXT:     hal.executable.entry_point @entry_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x?xf32>, index) -> tensor<4x?xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
@@ -102,7 +102,7 @@ flow.executable @reduction_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   hal.executable.target "vmla" {
+//  CHECK-NEXT:   hal.executable.target @vmla, "vmla" {
 //  CHECK-NEXT:     hal.executable.entry_point @reduction_ex_dispatch_0_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x8xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
@@ -18,7 +18,7 @@ flow.executable @simpleMath_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   hal.executable.target "vmla" {
-//  CHECK-NEXT:     hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
+//  CHECK-NEXT:     hal.executable.entry_point @simpleMath_rgn_dispatch_0_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.func @simpleMath_rgn_dispatch_0(%arg0: !vm.ref<!vmla.interface>, %arg1: i32, %arg2: i32, %arg3: i32) {
@@ -61,7 +61,7 @@ flow.executable @shaped_dispatch {
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   hal.executable.target "vmla" {
-//  CHECK-NEXT:     hal.executable.entry_point @entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x?xf32>, index) -> tensor<4x?xf32>}
+//  CHECK-NEXT:     hal.executable.entry_point @entry_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x?xf32>, index) -> tensor<4x?xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.func @entry(%arg0: !vm.ref<!vmla.interface>, %arg1: i32, %arg2: i32, %arg3: i32) {
@@ -103,7 +103,7 @@ flow.executable @reduction_ex_dispatch_0 {
 //  CHECK-NEXT:     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   hal.executable.target "vmla" {
-//  CHECK-NEXT:     hal.executable.entry_point @reduction_ex_dispatch_0 attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x8xf32>) -> tensor<4xf32>}
+//  CHECK-NEXT:     hal.executable.entry_point @reduction_ex_dispatch_0_entry attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (tensor<4x8xf32>) -> tensor<4xf32>}
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-NEXT:         vm.rodata @reduction_ex_dispatch_0_const_0 dense<0.000000e+00> : tensor<f32>

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -233,7 +233,8 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
                         IREE::HAL::ExecutableOp executableOp) override {
     OpBuilder targetBuilder(&executableOp.getBlock().back());
     auto targetOp = targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
-        sourceOp.getLoc(), name());
+        sourceOp.getLoc(), /*name=*/"vulkan_any",
+        /*targetBackendFilter=*/name());
     OpBuilder containerBuilder(&targetOp.getBlock().back());
 
     auto innerModuleOp = containerBuilder.create<ModuleOp>(sourceOp.getLoc());
@@ -261,7 +262,7 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     IREE::HAL::ExecutableOp executableOp = dispatchState.executableOp;
     for (auto executableTargetOp :
          executableOp.getBlock().getOps<IREE::HAL::ExecutableTargetOp>()) {
-      if (matchPattern(executableTargetOp.target_backend(), name())) {
+      if (matchPattern(executableTargetOp.target_backend_filter(), name())) {
         ModuleOp innerModuleOp = executableTargetOp.getInnerModule();
         auto spvModuleOps = innerModuleOp.getOps<spirv::ModuleOp>();
         assert(llvm::hasSingleElement(spvModuleOps));
@@ -387,7 +388,7 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     spirv::ModuleOp spvModuleOp;
     for (auto executableTargetOp :
          executableOp.getBlock().getOps<IREE::HAL::ExecutableTargetOp>()) {
-      if (matchPattern(executableTargetOp.target_backend(), name())) {
+      if (matchPattern(executableTargetOp.target_backend_filter(), name())) {
         ModuleOp innerModuleOp = executableTargetOp.getInnerModule();
         assert(!innerModuleOp.getAttr(
             iree_compiler::getEntryPointScheduleAttrName()));

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "MemoizeDeviceQueries.cpp",
         "Passes.cpp",
         "PublicAbiGeneration.cpp",
+        "ResolveEntryPointOrdinals.cpp",
         "SerializeExecutables.cpp",
         "TranslateExecutables.cpp",
     ],

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "MemoizeDeviceQueries.cpp"
     "Passes.cpp"
     "PublicAbiGeneration.cpp"
+    "ResolveEntryPointOrdinals.cpp"
     "SerializeExecutables.cpp"
     "TranslateExecutables.cpp"
   DEPS

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -253,9 +254,10 @@ static LogicalResult declareEntryPointOps(
         dispatchEntryOp.setAttr(
             "function_ref", builder.getSymbolRefAttr(thunkFuncOp.getValue()));
 
+        std::string entryName =
+            llvm::formatv("{0}_entry", thunkFuncOp->getName());
         builder.create<IREE::HAL::ExecutableEntryPointOp>(
-            dispatchEntryOp.getLoc(),
-            builder.getStringAttr(thunkFuncOp->getName()),
+            dispatchEntryOp.getLoc(), builder.getStringAttr(entryName),
             builder.getI32IntegerAttr(nextOrdinal++),
             builder.getSymbolRefAttr(interfaceOp),
             TypeAttr::get(sourceFuncOp.getType()));

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -85,6 +85,10 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createCSEPass());
 
+  // Resolve entry point ordinals from nested symbol references prior to
+  // serialization.
+  passManager.addPass(createResolveEntryPointOrdinalsPass());
+
   // TODO(#1036): run this once per hal.executable.target in a nested pass
   // manager so that we have as many passes as hal.executable.target ops.
   if (transformOptions.serializeExecutables) {

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -80,6 +80,9 @@ createTranslateExecutablesPass(TargetOptions executableOptions);
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkExecutablesPass(
     TargetOptions executableOptions);
 
+// Resolves hal.executable.entry_point references to ordinals.
+std::unique_ptr<OperationPass<ModuleOp>> createResolveEntryPointOrdinalsPass();
+
 // Converts hal.executable.target ops to hal.executable.binary ops.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createSerializeExecutablesPass(TargetOptions executableOptions);
@@ -111,6 +114,7 @@ inline void registerHALPasses() {
   createMaterializeInterfacesPass(executableOptions);
   createTranslateExecutablesPass(executableOptions);
   createLinkExecutablesPass(executableOptions);
+  createResolveEntryPointOrdinalsPass();
   createSerializeExecutablesPass(executableOptions);
   createPublicABIGenerationPass();
   createMaterializeResourceCachesPass(executableOptions);

--- a/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+
+// TODO(scotttodd): trim includes
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
+#include "llvm/ADT/StringSet.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+// TODO(scotttodd): rewrite as conversion from CommandBufferDispatchOp to
+//                  CommandBufferDispatchOrdinalOp?
+class ResolveEntryPointOrdinalsPass
+    : public PassWrapper<ResolveEntryPointOrdinalsPass,
+                         OperationPass<ModuleOp>> {
+ public:
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    SmallVector<IREE::HAL::CommandBufferDispatchOp, 4> dispatchOps;
+    moduleOp.walk([&](IREE::HAL::CommandBufferDispatchOp dispatchOp) {
+      dispatchOps.push_back(dispatchOp);
+    });
+    for (auto dispatchOp : dispatchOps) {
+      // Extract entry point ordinal from the nested symbol reference.
+      auto entryPointOp = dyn_cast_or_null<IREE::HAL::ExecutableEntryPointOp>(
+          SymbolTable::lookupNearestSymbolFrom(dispatchOp,
+                                               dispatchOp.entry_point()));
+      if (!entryPointOp) continue;
+      OpBuilder builder(dispatchOp);
+      builder.create<IREE::HAL::CommandBufferDispatchOrdinalOp>(
+          dispatchOp.getLoc(), dispatchOp.command_buffer(),
+          dispatchOp.executable(), entryPointOp.ordinalAttr(),
+          dispatchOp.workgroup_x(), dispatchOp.workgroup_y(),
+          dispatchOp.workgroup_z());
+      dispatchOp.erase();
+    }
+
+    SmallVector<IREE::HAL::CommandBufferDispatchIndirectOp, 4>
+        dispatchIndirectOps;
+    moduleOp.walk(
+        [&](IREE::HAL::CommandBufferDispatchIndirectOp dispatchIndirectOp) {
+          dispatchIndirectOps.push_back(dispatchIndirectOp);
+        });
+    for (auto dispatchIndirectOp : dispatchIndirectOps) {
+      // Extract entry point ordinal from the nested symbol reference.
+      auto entryPointOp = dyn_cast_or_null<IREE::HAL::ExecutableEntryPointOp>(
+          SymbolTable::lookupNearestSymbolFrom(
+              dispatchIndirectOp, dispatchIndirectOp.entry_point()));
+      if (!entryPointOp) continue;
+      OpBuilder builder(dispatchIndirectOp);
+      builder.create<IREE::HAL::CommandBufferDispatchIndirectOrdinalOp>(
+          dispatchIndirectOp.getLoc(), dispatchIndirectOp.command_buffer(),
+          dispatchIndirectOp.executable(), entryPointOp.ordinalAttr(),
+          dispatchIndirectOp.workgroups_buffer(),
+          dispatchIndirectOp.workgroups_offset());
+      dispatchIndirectOp.erase();
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createResolveEntryPointOrdinalsPass() {
+  return std::make_unique<ResolveEntryPointOrdinalsPass>();
+}
+
+static PassRegistration<ResolveEntryPointOrdinalsPass> pass(
+    "iree-hal-resolve-entry-point-ordinals",
+    "Resolves hal.executable.entry_point references to ordinals");
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
@@ -44,7 +44,7 @@ class SerializeExecutablesPass
         executableOp.getBlock().getOps<IREE::HAL::ExecutableTargetOp>());
     for (auto targetOp : targetOps) {
       for (auto &targetBackend :
-           matchTargetBackends({targetOp.target_backend().str()})) {
+           matchTargetBackends({targetOp.target_backend_filter().str()})) {
         // Ask the target backend to serialize the executable. Note that it may
         // create one or more hal.executable.binary ops in the case of
         // multi-architecture binaries.
@@ -52,7 +52,7 @@ class SerializeExecutablesPass
         if (failed(targetBackend->serializeExecutable(targetOp,
                                                       executableBuilder))) {
           targetOp.emitError() << "failed to serialize op to target backend "
-                               << targetOp.target_backend();
+                               << targetOp.target_backend_filter();
           return signalPassFailure();
         }
       }

--- a/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -45,9 +45,9 @@ class TranslateExecutablesPass
     for (auto targetOp : targetOps) {
       // TODO(#1036): this will be what we want the dynamic pass manager to
       // do for us: we want to nest all of the backend passes on a source op
-      // that matches their target_backend pattern.
+      // that matches their target_backend_filter pattern.
       for (auto &targetBackend :
-           matchTargetBackends({targetOp.target_backend().str()})) {
+           matchTargetBackends({targetOp.target_backend_filter().str()})) {
         // Run the nested pass manager. This is effectively the same as
         // launching a new iree-opt, and as such won't integrate well with the
         // logging/pass instrumentation of the parent pass manager.
@@ -58,7 +58,7 @@ class TranslateExecutablesPass
         if (failed(targetPassManager.run(targetOp.getInnerModule()))) {
           targetOp.emitError() << "failed to run translation of source "
                                   "executable to target executable for backend "
-                               << targetOp.target_backend();
+                               << targetOp.target_backend_filter();
           return signalPassFailure();
         }
       }

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -6,7 +6,7 @@
 //  CHECK-NEXT:   hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT: }
 //   CHECK-DAG: hal.executable.target "vmla" {
-//   CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0 attributes {
+//   CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0_entry attributes {
 //  CHECK-SAME:     interface = @legacy_io,
 //  CHECK-SAME:     ordinal = 0 : i32,
 //  CHECK-SAME:     signature = (tensor<4xf32>) -> tensor<4xf32>

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -5,7 +5,7 @@
 //  CHECK-NEXT:   hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 //  CHECK-NEXT:   hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
 //  CHECK-NEXT: }
-//   CHECK-DAG: hal.executable.target "vmla" {
+//   CHECK-DAG: hal.executable.target @vmla, "vmla" {
 //   CHECK-DAG:   hal.executable.entry_point @simpleMath_rgn_dispatch_0_entry attributes {
 //  CHECK-SAME:     interface = @legacy_io,
 //  CHECK-SAME:     ordinal = 0 : i32,

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -92,17 +92,19 @@ hal.executable @exe {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.entry_point @entry attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<4xf32>) -> tensor<4xf32>,
-    workgroup_size = [32 : index, 1 : index, 1 : index]
-  }
-  hal.executable.entry_point @entry_alias attributes {
-    interface = @interface,
-    ordinal = 0 : i32,
-    signature = (tensor<4xf32>) -> tensor<4xf32>,
-    workgroup_size = [32 : index, 1 : index, 1 : index]
+  hal.executable.target @target, "target" {
+    hal.executable.entry_point @entry attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [32 : index, 1 : index, 1 : index]
+    }
+    hal.executable.entry_point @entry_alias attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [32 : index, 1 : index, 1 : index]
+    }
   }
   hal.executable.binary attributes {
     data = dense<[0, 1, 2, 3]> : vector<4xi8>,

--- a/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
@@ -1,0 +1,121 @@
+// RUN: iree-opt -split-input-file -iree-hal-resolve-entry-point-ordinals %s | IreeFileCheck %s
+
+// CHECK: module {
+module {
+  hal.executable @exe {
+    hal.interface @interface {
+      hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+      hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+    }
+    hal.executable.target @target, "target" {
+      hal.executable.entry_point @entry attributes {
+        interface = @interface,
+        ordinal = 0 : i32,
+        signature = (tensor<4xf32>) -> tensor<4xf32>,
+        workgroup_size = [32 : index, 1 : index, 1 : index]
+      }
+    }
+  }
+
+  func @dispatch_with_nested_references() {
+    %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
+    %x = "test_hal.workgroup_x"() : () -> index
+    %y = "test_hal.workgroup_y"() : () -> index
+    %z = "test_hal.workgroup_z"() : () -> index
+    // CHECK: hal.command_buffer.dispatch.ordinal %0, %1, entry_point = 0, workgroup_xyz = [%2, %3, %4]
+    hal.command_buffer.dispatch %cmd, %exe, entry_point = @exe::@target::@entry, workgroup_xyz = [%x, %y, %z]
+    return
+  }
+}
+
+// -----
+
+// CHECK: module {
+module {
+  hal.executable @exe {
+    hal.interface @interface {
+      hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+      hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+    }
+    hal.executable.target @target, "target" {
+      hal.executable.entry_point @entry attributes {
+        interface = @interface,
+        ordinal = 0 : i32,
+        signature = (tensor<4xf32>) -> tensor<4xf32>,
+        workgroup_size = [32 : index, 1 : index, 1 : index]
+      }
+    }
+  }
+
+  func @dispatch_already_using_ordinals() {
+    %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
+    %x = "test_hal.workgroup_x"() : () -> index
+    %y = "test_hal.workgroup_y"() : () -> index
+    %z = "test_hal.workgroup_z"() : () -> index
+    // CHECK: hal.command_buffer.dispatch.ordinal %0, %1, entry_point = 2, workgroup_xyz = [%2, %3, %4]
+    hal.command_buffer.dispatch.ordinal %cmd, %exe, entry_point = 2, workgroup_xyz = [%x, %y, %z]
+    return
+  }
+}
+
+// -----
+
+// CHECK: module {
+module {
+  hal.executable @exe {
+    hal.interface @interface {
+      hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+      hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+    }
+    hal.executable.target @target, "target" {
+      hal.executable.entry_point @entry attributes {
+        interface = @interface,
+        ordinal = 0 : i32,
+        signature = (tensor<4xf32>) -> tensor<4xf32>,
+        workgroup_size = [32 : index, 1 : index, 1 : index]
+      }
+    }
+  }
+
+  func @dispatch_indirect_with_nested_references() {
+    %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
+    %buffer = "test_hal.buffer"() : () -> !hal.buffer
+    %offset = "test_hal.offset"() : () -> index
+    // CHECK: hal.command_buffer.dispatch.indirect.ordinal %0, %1, entry_point = 0, workgroups = %2[%3]
+    hal.command_buffer.dispatch.indirect %cmd, %exe, entry_point = @exe::@target::@entry, workgroups = %buffer[%offset]
+    return
+  }
+}
+
+// -----
+
+// CHECK: module {
+module {
+  hal.executable @exe {
+    hal.interface @interface {
+      hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+      hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+    }
+    hal.executable.target @target, "target" {
+      hal.executable.entry_point @entry attributes {
+        interface = @interface,
+        ordinal = 0 : i32,
+        signature = (tensor<4xf32>) -> tensor<4xf32>,
+        workgroup_size = [32 : index, 1 : index, 1 : index]
+      }
+    }
+  }
+
+  func @dispatch_indirect_already_using_ordinals() {
+    %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
+    %buffer = "test_hal.buffer"() : () -> !hal.buffer
+    %offset = "test_hal.offset"() : () -> index
+    // CHECK: hal.command_buffer.dispatch.indirect.ordinal %0, %1, entry_point = 0, workgroups = %2[%3]
+    hal.command_buffer.dispatch.indirect.ordinal %cmd, %exe, entry_point = 0, workgroups = %buffer[%offset]
+    return
+  }
+}


### PR DESCRIPTION
Progress on https://github.com/google/iree/issues/1890.

This splits 

* CommandBufferDispatchOp -> CommandBufferDispatchOp / CommandBufferDispatchOrdinalOp
* CommandBufferDispatchIndirectOp -> CommandBufferDispatchIndirectOp / CommandBufferDispatchIndirectOrdinalOp

A new `ResolveEntryPointOrdinalsPass` runs after linking but prior to serialization, converting the ops using references to ops using ordinals. Backends may choose to record with or without references. Since the VulkanSPIRV target may split dispatches, it uses ordinals directly and must solve linking in some specialized way (this will at least need more attention as we implement linking).