### PR TITLE
Rename bundled LLVM FileCheck target

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -410,7 +410,7 @@ if(${IREE_ENABLE_MLIR})
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/IreeFileCheck.sh IreeFileCheck
   )
   if(${IREE_MLIR_DEP_MODE} STREQUAL "BUNDLED")
-    add_custom_target(LLVMFileCheck ALL
+    add_custom_target(BundledLLVMFileCheck ALL
       COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:FileCheck> FileCheck
       DEPENDS FileCheck
     )


### PR DESCRIPTION
Avoids a name conflict with the LLVMFileCheck lib introduced in
https://github.com/llvm/llvm-project/commit/5ffd940ac02a. AFAICT the
actual name here doesn't really matter. I decided to not give it the
LLVM prefix to avoid future conflicts.

Unbreaks the cmake build. The Bazel build is unbroken by
https://github.com/google/iree/commit/4e5f860d7822.