### PR TITLE
Filter out deleted files in tabs check

### DIFF
--- a/scripts/check_tabs.sh
+++ b/scripts/check_tabs.sh
@@ -31,7 +31,7 @@ declare -a excluded_files_patterns=(
 excluded_files_pattern="$(IFS="|" ; echo "${excluded_files_patterns[*]?}")"
 
 readarray -t files < <(\
-  (git diff --name-only "${BASE_REF}" || kill $$) \
+  (git diff --name-only --diff-filter=d "${BASE_REF}" || kill $$) \
     | grep -v -E "${excluded_files_pattern?}")
 
 diff="$(grep --with-filename --line-number --perl-regexp '\t' "${files[@]}")"


### PR DESCRIPTION
Otherwise the diff will list deleted files and then grep will fail
because the files don't exist, e.g.
https://github.com/google/iree/pull/3065/checks?check_run_id=1068022415

Tested:
Ran the script before (failing) and after (succeeding) on
https://github.com/google/iree/pull/3065, which deletes files.
