### PR TITLE
[vulkan] Avoid querying instanceless symbols with non-null instance

### DIFF
--- a/iree/hal/vulkan/dynamic_symbol_tables.h
+++ b/iree/hal/vulkan/dynamic_symbol_tables.h
@@ -38,11 +38,18 @@ namespace iree {
 namespace hal {
 namespace vulkan {
 
+// Defines the list of symbols that can be queried from vkGetInstanceProcAddr
+// before Vulkan instance creation.
+#define IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCELESS_TABLE(INS_PFN) \
+  INS_PFN(REQUIRED, vkCreateInstance)                          \
+  INS_PFN(REQUIRED, vkEnumerateInstanceExtensionProperties)    \
+  INS_PFN(REQUIRED, vkEnumerateInstanceLayerProperties)        \
+  INS_PFN(OPTIONAL, vkEnumerateInstanceVersion)
+
+// Defines the list of instance/device symbols that are queried from
+// vkGetInstanceProcAddr/vkGetDeviceProcAddr after Vulkan instance/device
+// creation.
 #define IREE_VULKAN_DYNAMIC_SYMBOL_COMMON_TABLE(INS_PFN, DEV_PFN)       \
-  INS_PFN(REQUIRED, vkCreateInstance)                                   \
-  INS_PFN(REQUIRED, vkEnumerateInstanceExtensionProperties)             \
-  INS_PFN(REQUIRED, vkEnumerateInstanceLayerProperties)                 \
-  INS_PFN(REQUIRED, vkEnumerateInstanceVersion)                         \
   DEV_PFN(REQUIRED, vkBeginCommandBuffer)                               \
   DEV_PFN(EXCLUDED, vkCmdBeginConditionalRenderingEXT)                  \
   DEV_PFN(OPTIONAL, vkCmdBeginDebugUtilsLabelEXT)                       \
@@ -485,7 +492,12 @@ namespace vulkan {
   IREE_VULKAN_DYNAMIC_SYMBOL_TABLE_XLIB_KHR(INS_PFN, DEV_PFN)        \
   IREE_VULKAN_DYNAMIC_SYMBOL_TABLE_XLIB_XRANDR_EXT(INS_PFN, DEV_PFN)
 
+#define IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCE_DEVICE_TABLES(INS_PFN, DEV_PFN) \
+  IREE_VULKAN_DYNAMIC_SYMBOL_COMMON_TABLE(INS_PFN, DEV_PFN)                 \
+  IREE_VULKAN_DYNAMIC_SYMBOL_PLATFORM_TABLES(INS_PFN, DEV_PFN)
+
 #define IREE_VULKAN_DYNAMIC_SYMBOL_TABLES(INS_PFN, DEV_PFN) \
+  IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCELESS_TABLE(INS_PFN)    \
   IREE_VULKAN_DYNAMIC_SYMBOL_COMMON_TABLE(INS_PFN, DEV_PFN) \
   IREE_VULKAN_DYNAMIC_SYMBOL_PLATFORM_TABLES(INS_PFN, DEV_PFN)
 

--- a/iree/hal/vulkan/dynamic_symbols.cc
+++ b/iree/hal/vulkan/dynamic_symbols.cc
@@ -61,16 +61,13 @@ namespace {
 // creation. These are safe to call with no instance parameter and should be
 // exported by all loaders/ICDs.
 static constexpr const FunctionPtrInfo kInstancelessFunctionPtrInfos[] = {
-    REQUIRED_PFN_FUNCTION_PTR(vkCreateInstance, false)                        //
-    REQUIRED_PFN_FUNCTION_PTR(vkEnumerateInstanceLayerProperties, false)      //
-    REQUIRED_PFN_FUNCTION_PTR(vkEnumerateInstanceExtensionProperties, false)  //
-};
+    IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCELESS_TABLE(INS_PFN_FUNCTION_PTR)};
 
 // Defines the table of FunctionPtrInfos for dynamic loading that must wait
 // until an instance has been created to be resolved.
 static constexpr const FunctionPtrInfo kDynamicFunctionPtrInfos[] = {
-    IREE_VULKAN_DYNAMIC_SYMBOL_TABLES(INS_PFN_FUNCTION_PTR,
-                                      DEV_PFN_FUNCTION_PTR)};
+    IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCE_DEVICE_TABLES(INS_PFN_FUNCTION_PTR,
+                                                      DEV_PFN_FUNCTION_PTR)};
 
 static const char* kVulkanLoaderSearchNames[] = {
 #if defined(IREE_PLATFORM_ANDROID)


### PR DESCRIPTION
When querying dynamic symbols that are not attached to any Vulkan
instance, i.e., vkCreateInstance, vkEnumerateInstanceLayerProperties,
vkEnumerateInstanceExtensionProperties, and vkEnumerateInstanceVersion,
vkGetInstanceProcAddr are expecting a null instance as per the spec.
But at the moment we are trying to query these symbols with non-null
instance when DynamicSymbols::LoadFrom{Instance|Device}. The behavior
of that is not specified in the spec; and on certain Vulkan loaders/ICDs
(i.e., Android) they might not be supported well.

Also turned vkEnumerateInstanceVersion as optional given we are not
using it for anything at the moment.