### PR TITLE
Mark mhlo.broadcast op as indexable to clone into its consumers.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -44,7 +44,7 @@ bool isIndexOp(Operation *op) {
   // TODO(laurenzo): Curate this list more specifically (or have a better
   // mechanism for determining).
   return isa<Shape::RankedBroadcastInDimOp>(op) ||
-         isa<mhlo::BroadcastInDimOp>(op) ||
+         isa<mhlo::BroadcastInDimOp>(op) || isa<mhlo::BroadcastOp>(op) ||
          isa<mhlo::DynamicBroadcastInDimOp>(op) ||
          isa<mhlo::DynamicReshapeOp>(op) || isa<mhlo::DynamicSliceOp>(op) ||
          isa<mhlo::ReshapeOp>(op) || isa<mhlo::SliceOp>(op) ||


### PR DESCRIPTION
This enforces broadcast to be cloned to their consumers  and prevents forming dispatch regions of only constant broadcast or regions with  broadcasted const outputs. 

Benchmark MobileNetV2 on Pixel4

Before:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       93.2 ms         92.6 ms            8
```
After:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       76.3 ms         75.8 ms            8
```