### PR TITLE
[cmake] Add options for enabling Clang sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,9 +261,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 # IREE compilation flags
 #-------------------------------------------------------------------------------
 
-string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
-string(JOIN " " CMAKE_C_FLAGS_DEBUG ${IREE_C_FLAGS_DEBUG_LIST})
-string(JOIN " " CMAKE_CXX_FLAGS_DEBUG ${IREE_CXX_FLAGS_DEBUG_LIST})
+iree_append_list_to_string(CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
+iree_append_list_to_string(CMAKE_C_FLAGS_DEBUG ${IREE_C_FLAGS_DEBUG_LIST})
+iree_append_list_to_string(CMAKE_CXX_FLAGS_DEBUG ${IREE_CXX_FLAGS_DEBUG_LIST})
 
 set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
 set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,17 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 
 #-------------------------------------------------------------------------------
+# IREE compilation toolchain configuration
+#-------------------------------------------------------------------------------
+
+# Enable using lld as the linker for C/C++ targets. This affects IREE and all
+# dependency projects.
+option(IREE_ENABLE_LLD "Use lld when linking" OFF)
+option(IREE_ENABLE_ASAN "Enable address sanitizer" OFF)
+option(IREE_ENABLE_MSAN "Enable memory sanitizer" OFF)
+option(IREE_ENABLE_TSAN "Enable thread sanitizer" OFF)
+
+#-------------------------------------------------------------------------------
 # IREE utility definitions
 #-------------------------------------------------------------------------------
 
@@ -247,14 +258,12 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 #-------------------------------------------------------------------------------
-# IREE compilation toolchain configuration
+# IREE compilation flags
 #-------------------------------------------------------------------------------
 
-# Enable using lld as the linker for C/C++ targets. This affects IREE and all
-# dependency projects.
-option(IREE_ENABLE_LLD "Use lld when linking" OFF)
-
 string(JOIN " " CMAKE_CXX_FLAGS ${IREE_DEFAULT_COPTS})
+string(JOIN " " CMAKE_C_FLAGS_DEBUG ${IREE_C_FLAGS_DEBUG_LIST})
+string(JOIN " " CMAKE_CXX_FLAGS_DEBUG ${IREE_CXX_FLAGS_DEBUG_LIST})
 
 set(CMAKE_CXX_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C++ compiler during fast builds." FORCE)
 set(CMAKE_C_FLAGS_FASTBUILD "-gmlt" CACHE STRING "Flags used by the C compiler during fast builds." FORCE)

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -133,6 +133,57 @@ set(IREE_DEFAULT_LINKOPTS "${ABSL_DEFAULT_LINKOPTS}")
 set(IREE_TEST_COPTS "${ABSL_TEST_COPTS}")
 
 #-------------------------------------------------------------------------------
+# Sanitizer configurations
+#-------------------------------------------------------------------------------
+
+include(CheckCXXCompilerFlag)
+if(${IREE_ENABLE_ASAN})
+  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(FATAL_ERROR "IREE_ENABLE_ASAN requires Debug build")
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
+  check_cxx_compiler_flag(-fsanitize=address COMPILER_SUPPORTS_ASAN)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(${COMPILER_SUPPORTS_ASAN})
+    list(APPEND IREE_C_FLAGS_DEBUG_LIST "-fsanitize=address")
+    list(APPEND IREE_CXX_FLAGS_DEBUG_LIST "-fsanitize=address")
+  else()
+    message(FATAL_ERROR "The compiler does not support address sanitizer "
+                        "or is missing configuration for address sanitizer")
+  endif()
+endif()
+if(${IREE_ENABLE_MSAN})
+  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(FATAL_ERROR "IREE_ENABLE_MSAN requires Debug build")
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=memory")
+  check_cxx_compiler_flag(-fsanitize=memory COMPILER_SUPPORTS_MSAN)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(${COMPILER_SUPPORTS_MSAN})
+    list(APPEND IREE_C_FLAGS_DEBUG_LIST "-fsanitize=memory")
+    list(APPEND IREE_CXX_FLAGS_DEBUG_LIST "-fsanitize=memory")
+  else()
+    message(FATAL_ERROR "The compiler does not support memory sanitizer "
+                        "or is missing configuration for address sanitizer")
+  endif()
+endif()
+if(${IREE_ENABLE_TSAN})
+  if(NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(FATAL_ERROR "IREE_ENABLE_TSAN requires Debug build")
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
+  check_cxx_compiler_flag(-fsanitize=thread COMPILER_SUPPORTS_TSAN)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(${COMPILER_SUPPORTS_TSAN})
+    list(APPEND IREE_C_FLAGS_DEBUG_LIST "-fsanitize=thread")
+    list(APPEND IREE_CXX_FLAGS_DEBUG_LIST "-fsanitize=thread")
+  else()
+    message(FATAL_ERROR "The compiler does not support thread sanitizer "
+                        "or is missing configuration for address sanitizer")
+  endif()
+endif()
+
+#-------------------------------------------------------------------------------
 # Size-optimized build flags
 #-------------------------------------------------------------------------------
 

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -42,6 +42,17 @@ function(iree_to_bool VARIABLE VALUE)
   endif()
 endfunction()
 
+# iree_append_list_to_string
+#
+# Joins ${ARGN} together as a string separated by " " and appends it to
+# ${VARIABLE}.
+function(iree_append_list_to_string VARIABLE)
+  if(NOT "${ARGN}" STREQUAL "")
+    string(JOIN " " _ARGN_STR ${ARGN})
+    set(${VARIABLE} "${${VARIABLE}} ${_ARGN_STR}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 
 #-------------------------------------------------------------------------------
 # Packages and Paths

--- a/docs/get_started/cmake_options_and_variables.md
+++ b/docs/get_started/cmake_options_and_variables.md
@@ -80,6 +80,21 @@ Use lld when linking. Defaults to `OFF`. This option is equivalent to
 `-DIREE_USE_LINKER=lld`. The option `IREE_ENABLE_LLD` and `IREE_USE_LINKER` can
 not be set at the same time.
 
+#### `IREE_ENABLE_ASAN`:BOOL
+
+Enable [address sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
+if the current build type is Debug and the compiler supports it.
+
+#### `IREE_ENABLE_MSAN`:BOOL
+
+Enable [memory sanitizer](https://clang.llvm.org/docs/MemorySanitizer.html)
+if the current build type is Debug and the compiler supports it.
+
+#### `IREE_ENABLE_TSAN`:BOOL
+
+Enable [thread sanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)
+if the current build type is Debug and the compiler supports it.
+
 #### `IREE_MLIR_DEP_MODE`:STRING
 
 Defines the MLIR dependency mode. Case-sensitive. Can be `BUNDLED`, `DISABLED`


### PR DESCRIPTION
This is re-landing #2832 by cherry-picking the previous commit
d87ecb7c97ee5ca9d01054367a60c6631163780b and fix the issue with it.

So only need to review the second commit.