### PR TITLE
Refactor semaphore use in async and sync public ABI functions.

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
@@ -96,7 +96,7 @@ LogicalResult mapRawAbiTypes(
   return success();
 }
 
-LogicalResult generateSynchronousBody(
+LogicalResult generateAsynchronousBody(
     FuncOp rawCalleeFuncOp, FuncOp funcOp, OpBuilder moduleBuilder,
     SmallVectorImpl<Type> &inputTypes,
     SmallVectorImpl<RawSignatureParser::Description> &inputDescs,
@@ -107,10 +107,20 @@ LogicalResult generateSynchronousBody(
   Block *entryBlock = funcOp.addEntryBlock();
   OpBuilder builder = OpBuilder::atBlockEnd(entryBlock);
 
+  // TODO(#1285): Pass semaphores into raw function so modules can run async
+  // Wait until the wait semaphore reaches the wait value.
+  auto waitSemaphore = entryBlock->getArgument(0);
+  auto waitValue = entryBlock->getArgument(1);
+  auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
+      loc, builder.getIntegerType(32), waitSemaphore, waitValue);
+  builder.create<HAL::CheckSuccessOp>(loc, waitOp.getResult(),
+                                      "semaphore wait failed");
+
   // Build call operands.
   SmallVector<Value, 4> callOperands;
   for (const auto &input : llvm::enumerate(inputDescs)) {
-    auto blockArg = entryBlock->getArgument(input.index());
+    // Skip first two arguments (wait semaphore, wait value).
+    auto blockArg = entryBlock->getArgument(input.index() + 2);
     switch (input.value().type) {
       case RawSignatureParser::Type::kBuffer: {
         // Pass the backing buffer.
@@ -211,42 +221,53 @@ LogicalResult generateSynchronousBody(
     }
   }
 
-  // Add the return.
-  builder.create<mlir::ReturnOp>(loc, funcResults);
-  return success();
-}
-
-LogicalResult generateAsynchronousBody(FuncOp funcOp, FuncOp syncFuncOp,
-                                       OpBuilder moduleBuilder) {
-  auto loc = funcOp.getLoc();
-  Block *entryBlock = funcOp.addEntryBlock();
-  OpBuilder builder = OpBuilder::atBlockEnd(entryBlock);
-
-  // Wait until the wait semaphore reaches the wait value.
-  auto waitSemaphore = entryBlock->getArgument(0);
-  auto waitValue = entryBlock->getArgument(1);
-  auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
-      loc, builder.getIntegerType(32), waitSemaphore, waitValue);
-  builder.create<HAL::CheckSuccessOp>(loc, waitOp.getResult(),
-                                      "semaphore wait failed");
-
-  // Trim the first (wait semaphore/value) and last (signal semaphore/value)
-  // two arguments.
-  SmallVector<Value, 4> callSyncArguments;
-  for (int i = 2; i < entryBlock->getNumArguments() - 2; ++i) {
-    callSyncArguments.push_back(entryBlock->getArguments()[i]);
-  }
-  // Call the sync op, passing through our arguments.
-  auto callSyncOp = builder.create<CallOp>(loc, syncFuncOp, callSyncArguments);
-
+  // TODO(#1285): Pass semaphores into raw function so modules can run async
   // Signal the signal semaphore to its signal value.
   auto signalSemaphore =
       entryBlock->getArgument(entryBlock->getNumArguments() - 2);
   auto signalValue = entryBlock->getArgument(entryBlock->getNumArguments() - 1);
   builder.create<HAL::SemaphoreSignalOp>(loc, signalSemaphore, signalValue);
 
-  // Return results of the sync op.
-  builder.create<mlir::ReturnOp>(loc, callSyncOp.getResults());
+  // Add the return.
+  builder.create<mlir::ReturnOp>(loc, funcResults);
+  return success();
+}
+
+LogicalResult generateSynchronousBody(FuncOp funcOp, FuncOp asyncFuncOp,
+                                      OpBuilder moduleBuilder) {
+  auto loc = funcOp.getLoc();
+  Block *entryBlock = funcOp.addEntryBlock();
+  OpBuilder builder = OpBuilder::atBlockEnd(entryBlock);
+
+  Value zero = builder.createOrFold<ConstantOp>(loc, builder.getIndexAttr(0));
+  Value one = builder.createOrFold<ConstantOp>(loc, builder.getIndexAttr(1));
+
+  auto device = builder.create<IREE::HAL::ExSharedDeviceOp>(loc);
+  auto semaphore = builder.create<IREE::HAL::SemaphoreCreateOp>(
+      loc, IREE::HAL::SemaphoreType::get(builder.getContext()),
+      device.getResult(), zero);
+
+  // Construct async arguments:
+  //     wait_semaphore, wait_value, args, signal_semaphore, signal_value
+  SmallVector<Value, 4> callAsyncArguments;
+  callAsyncArguments.push_back(semaphore);
+  callAsyncArguments.push_back(zero);
+  for (const auto &arg : entryBlock->getArguments()) {
+    callAsyncArguments.push_back(arg);
+  }
+  callAsyncArguments.push_back(semaphore);
+  callAsyncArguments.push_back(one);
+  auto callAsyncOp =
+      builder.create<CallOp>(loc, asyncFuncOp, callAsyncArguments);
+
+  // Wait until the semaphore reaches the signal value.
+  auto waitOp = builder.create<HAL::SemaphoreAwaitOp>(
+      loc, builder.getIntegerType(32), semaphore, one);
+  builder.create<HAL::CheckSuccessOp>(loc, waitOp.getResult(),
+                                      "semaphore wait failed");
+
+  // Return results of the async op.
+  builder.create<mlir::ReturnOp>(loc, callAsyncOp.getResults());
 
   return success();
 }
@@ -289,26 +310,6 @@ LogicalResult generateRawAbiFunctions(OpBuilder &moduleBuilder,
   }
   assert(resultTypes.size() == resultDescs.size());
 
-  // Create the new synchronous function export.
-  SmallVector<NamedAttribute, 1> syncExportAttrs;
-  syncExportAttrs.push_back(moduleBuilder.getNamedAttr(
-      "iree.module.export", moduleBuilder.getStringAttr(exportName)));
-  syncExportAttrs.push_back(
-      moduleBuilder.getNamedAttr("iree.reflection", reflection));
-  syncExportAttrs.push_back(
-      moduleBuilder.getNamedAttr("iree.abi.stub", UnitAttr::get(ctx)));
-
-  auto syncType = FunctionType::get(inputTypes, resultTypes, ctx);
-  auto syncName = (rawCalleeFuncOp.getName() + "$sync").str();
-  auto syncFuncOp =
-      moduleBuilder.create<FuncOp>(loc, syncName, syncType, syncExportAttrs);
-
-  if (failed(generateSynchronousBody(rawCalleeFuncOp, syncFuncOp, moduleBuilder,
-                                     inputTypes, inputDescs, resultTypes,
-                                     resultDescs))) {
-    return failure();
-  }
-
   // Create the new asynchronous function export.
   SmallVector<Type, 4> asyncInputTypes;
   // Prefix with wait semaphore and its value.
@@ -336,8 +337,27 @@ LogicalResult generateRawAbiFunctions(OpBuilder &moduleBuilder,
   auto asyncFuncOp =
       moduleBuilder.create<FuncOp>(loc, asyncName, asyncType, asyncExportAttrs);
 
-  if (failed(
-          generateAsynchronousBody(asyncFuncOp, syncFuncOp, moduleBuilder))) {
+  if (failed(generateAsynchronousBody(rawCalleeFuncOp, asyncFuncOp,
+                                      moduleBuilder, inputTypes, inputDescs,
+                                      resultTypes, resultDescs))) {
+    return failure();
+  }
+
+  // Create the new synchronous function export.
+  SmallVector<NamedAttribute, 1> syncExportAttrs;
+  syncExportAttrs.push_back(moduleBuilder.getNamedAttr(
+      "iree.module.export", moduleBuilder.getStringAttr(exportName)));
+  syncExportAttrs.push_back(
+      moduleBuilder.getNamedAttr("iree.reflection", reflection));
+  syncExportAttrs.push_back(
+      moduleBuilder.getNamedAttr("iree.abi.stub", UnitAttr::get(ctx)));
+
+  auto syncType = FunctionType::get(inputTypes, resultTypes, ctx);
+  auto syncName = (rawCalleeFuncOp.getName() + "$sync").str();
+  auto syncFuncOp =
+      moduleBuilder.create<FuncOp>(loc, syncName, syncType, syncExportAttrs);
+
+  if (failed(generateSynchronousBody(syncFuncOp, asyncFuncOp, moduleBuilder))) {
     return failure();
   }
 

--- a/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
@@ -8,66 +8,86 @@ func @noReflectionExport(%arg0 : tensor<4xf32>) -> tensor<4xf32>
 }
 
 // -----
+
 // CHECK-LABEL: @staticTwoArg
 // Note: reflection matches signature:
 //   (%arg0 : tensor<4x4xi64>, %arg1 : tensor<5x6xi64>) -> tensor<5x6xi64>
 // Original func should be rewritten to export with $raw suffix with no
 // reflection metadata.
 // CHECK-SAME: {iree.module.export = "staticTwoArg$raw"}
+// A new function with $async suffix based on buffer_view with wait and signal
+// semaphore arguments should be generated.
+// CHECK: func @staticTwoArg$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.buffer_view, %[[ARG4:.+]]: !hal.semaphore, %[[ARG5:.+]]: index)
+// CHECK-SAME: attributes
+// CHECK-SAME:   iree.module.export = "staticTwoArg$async"
+func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
+    attributes {iree.module.export,
+      iree.reflection = {f = "I19!B7!t7d4d4B7!t7d5d6R10!B7!t7d5d6", fv = "1"}}
+{
+  // CHECK-DAG: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+  // CHECK-DAG: hal.check_success %[[WAITRESULT]]
+  // CHECK-DAG: %[[BUFFER0:.+]] = hal.buffer_view.buffer %[[ARG2]] : !hal.buffer
+  // CHECK-DAG: %[[BUFFER1:.+]] = hal.buffer_view.buffer %[[ARG3]] : !hal.buffer
+  // CHECK-DAG: %[[R0:.+]] = call @staticTwoArg(%[[BUFFER0]], %[[BUFFER1]])
+  // CHECK-DAG: %[[C5:.+]] = constant 5 : index
+  // CHECK-DAG: %[[C6:.+]] = constant 6 : index
+  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], shape = [%[[C5]], %[[C6]]], element_type = 16777280 : !hal.buffer_view
+  // CHECK-DAG: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
+  // CHECK: return %[[VIEW]]
+  return %arg1 : !hal.buffer
+}
 // A new function with $sync suffix based on buffer_view should be generated.
+// It should wrap the $async function.
 // CHECK: func @staticTwoArg$sync(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view)
 // CHECK-SAME: attributes
 // CHECK-SAME:   iree.abi.stub
 // CHECK-SAME:   iree.module.export = "staticTwoArg"
 // CHECK-SAME:   iree.reflection = {f = "I19!B7!t7d4d4B7!t7d5d6R10!B7!t7d5d6", fv = "1"}
-func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
-    attributes {iree.module.export,
-      iree.reflection = {f = "I19!B7!t7d4d4B7!t7d5d6R10!B7!t7d5d6", fv = "1"}}
-{
-  // CHECK-DAG: %[[BUFFER0:.+]] = hal.buffer_view.buffer %[[ARG0]] : !hal.buffer
-  // CHECK-DAG: %[[BUFFER1:.+]] = hal.buffer_view.buffer %[[ARG1]] : !hal.buffer
-  // CHECK-DAG: %[[R0:.+]] = call @staticTwoArg(%[[BUFFER0]], %[[BUFFER1]])
-  // CHECK-DAG: %[[C5:.+]] = constant 5 : index
-  // CHECK-DAG: %[[C6:.+]] = constant 6 : index
-  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], shape = [%[[C5]], %[[C6]]], element_type = 16777280 : !hal.buffer_view
-  // CHECK: return %[[VIEW]]
-  return %arg1 : !hal.buffer
-}
-// A new function with $async suffix based on buffer_view with wait and signal
-// semaphore arguments should be generated. For now, it should just wrap $sync.
-// CHECK: func @staticTwoArg$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.buffer_view, %[[ARG4:.+]]: !hal.semaphore, %[[ARG5:.+]]: index)
-// CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
-// CHECK: hal.check_success %[[WAITRESULT]]
-// CHECK: %[[RESULT:.+]] = call @staticTwoArg$sync(%[[ARG2]], %[[ARG3]]) : (!hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
-// CHECK: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
+// CHECK-DAG: %[[C0:.+]] = constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = constant 1 : index
+// CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+// CHECK-DAG: %[[SEMAPHORE:.+]] = hal.semaphore.create %[[DEVICE]], initial_value = %[[C0]] : !hal.semaphore
+// CHECK-DAG: %[[RESULT:.+]] = call @staticTwoArg$async(%[[SEMAPHORE]], %[[C0]], %[[ARG0]], %[[ARG1]], %[[SEMAPHORE]], %[[C1]]) : (!hal.semaphore, index, !hal.buffer_view, !hal.buffer_view, !hal.semaphore, index) -> !hal.buffer_view
+// CHECK-DAG: %[[WAITRESULT:.+]] = hal.semaphore.await %[[SEMAPHORE]], min_value = %[[C1]] : i32
+// CHECK-DAG: hal.check_success %[[WAITRESULT]]
 // CHECK: return %[[RESULT]] : !hal.buffer_view
 
 // -----
+
 // CHECK-LABEL: @dynamicTwoDims
 // Note: reflection matches signature:
 //   (%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32>
 // Original func should be rewritten to export with $raw suffix with no
 // reflection metadata.
 // CHECK-SAME: {iree.module.export = "dynamicTwoDims$raw"}
+// A new function with $async suffix based on buffer_view with wait and signal
+// semaphore arguments should be generated.
+// CHECK: func @dynamicTwoDims$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.semaphore, %[[ARG4:.+]]: index)
+// CHECK-SAME: attributes
+// CHECK-SAME:   iree.module.export = "dynamicTwoDims$async"
+// CHECK-DAG: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
+// CHECK-DAG: hal.check_success %[[WAITRESULT]]
+// CHECK-DAG: %[[BUFFER:.+]] = hal.buffer_view.buffer %[[ARG2]] : !hal.buffer
+// CHECK-DAG: %[[DIM0:.+]] = hal.buffer_view.dim %[[ARG2]], 0 : index
+// CHECK-DAG: %[[DIM1:.+]] = hal.buffer_view.dim %[[ARG2]], 1 : index
+// CHECK-DAG: %[[RESULT:.+]]:3 = call @dynamicTwoDims(%[[BUFFER]], %[[DIM0]], %[[DIM1]])
+// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, shape = [%[[RESULT]]#1, %[[RESULT]]#2], element_type = 50331680 : !hal.buffer_view
+// CHECK-DAG: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
+// CHECK: return %[[RESULT_VIEW]]
 // A new function with $sync suffix based on buffer_view should be generated.
+// It should wrap the $async function.
 // CHECK: func @dynamicTwoDims$sync(%[[ARG0:.+]]: !hal.buffer_view)
 // CHECK-SAME: attributes
 // CHECK-SAME:   iree.abi.stub
 // CHECK-SAME:   iree.module.export = "dynamicTwoDims"
 // CHECK-SAME:   iree.reflection = {f = "I10!B7!d-1d-1R10!B7!d-1d-1", fv = "1"}
-// CHECK-DAG: %[[BUFFER:.+]] = hal.buffer_view.buffer %[[ARG0]] : !hal.buffer
-// CHECK-DAG: %[[DIM0:.+]] = hal.buffer_view.dim %[[ARG0]], 0 : index
-// CHECK-DAG: %[[DIM1:.+]] = hal.buffer_view.dim %[[ARG0]], 1 : index
-// CHECK-DAG: %[[RESULT:.+]]:3 = call @dynamicTwoDims(%[[BUFFER]], %[[DIM0]], %[[DIM1]])
-// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, shape = [%[[RESULT]]#1, %[[RESULT]]#2], element_type = 50331680 : !hal.buffer_view
-// CHECK: return %[[RESULT_VIEW]]
-// A new function with $async suffix based on buffer_view with wait and signal
-// semaphore arguments should be generated. For now, it should just wrap $sync.
-// CHECK: func @dynamicTwoDims$async(%[[ARG0:.+]]: !hal.semaphore, %[[ARG1:.+]]: index, %[[ARG2:.+]]: !hal.buffer_view, %[[ARG3:.+]]: !hal.semaphore, %[[ARG4:.+]]: index)
-// CHECK: %[[WAITRESULT:.+]] = hal.semaphore.await %[[ARG0]], min_value = %[[ARG1]] : i32
-// CHECK: hal.check_success %[[WAITRESULT]]
-// CHECK: %[[RESULT:.+]] = call @dynamicTwoDims$sync(%[[ARG2]]) : (!hal.buffer_view) -> !hal.buffer_view
-// CHECK: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
+// CHECK-DAG: %[[C0:.+]] = constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = constant 1 : index
+// CHECK-DAG: %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+// CHECK-DAG: %[[SEMAPHORE:.+]] = hal.semaphore.create %[[DEVICE]], initial_value = %[[C0]] : !hal.semaphore
+// CHECK-DAG: %[[RESULT:.+]] = call @dynamicTwoDims$async(%[[SEMAPHORE]], %[[C0]], %[[ARG0]], %[[SEMAPHORE]], %[[C1]]) : (!hal.semaphore, index, !hal.buffer_view, !hal.semaphore, index) -> !hal.buffer_view
+// CHECK-DAG: %[[WAITRESULT:.+]] = hal.semaphore.await %[[SEMAPHORE]], min_value = %[[C1]] : i32
+// CHECK-DAG: hal.check_success %[[WAITRESULT]]
 // CHECK: return %[[RESULT]] : !hal.buffer_view
 func @dynamicTwoDims(%arg0 : !hal.buffer, %arg1 : index, %arg2 : index) -> (!hal.buffer, index, index)
     attributes {iree.module.export,


### PR DESCRIPTION
This makes async the "default", with sync wrapping async, instead of the other way around. Now we can push semaphores down further into the compiler (e.g. to remove hal.ex.submit_and_wait).

Progress on https://github.com/google/iree/issues/1285

---

If the test is hard to read, here's a sample from simple.mlir's translation:
* Note how the `$sync` function creates a semaphore to pass into the `$async` function and waits for it to be incremented from `0` to `1` before returning. The `$async` function still waits and signals, but could instead pass the semaphores into the raw function for a `hal.submit`, removing the need for `hal.ex.submit_and_wait`.

Before:
```mlir
  func @abs$sync(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.module.export = "abs", iree.reflection = {f = "I6!B3!t6R6!B3!t6", fv = "1"}} {
    %buffer = hal.buffer_view.buffer %arg0 : !hal.buffer
    %0 = call @abs(%buffer) : (!hal.buffer) -> !hal.buffer
    %view = hal.buffer_view.create %0, shape = [], element_type = 16777248 : !hal.buffer_view
    return %view : !hal.buffer_view
  }
  func @abs$async(%arg0: !hal.semaphore, %arg1: index, %arg2: !hal.buffer_view, %arg3: !hal.semaphore, %arg4: index) -> !hal.buffer_view attributes {iree.module.export = "abs$async"} {
    %0 = hal.semaphore.await %arg0, min_value = %arg1 : i32
    hal.check_success %0, "semaphore wait failed"
    %1 = call @abs$sync(%arg2) : (!hal.buffer_view) -> !hal.buffer_view
    hal.semaphore.signal %arg3, value = %arg4
    return %1 : !hal.buffer_view
  }
```

After:
```mlir
  func @abs$async(%arg0: !hal.semaphore, %arg1: index, %arg2: !hal.buffer_view, %arg3: !hal.semaphore, %arg4: index) -> !hal.buffer_view attributes {iree.module.export = "abs$async"} {
    %0 = hal.semaphore.await %arg0, min_value = %arg1 : i32
    hal.check_success %0, "semaphore wait failed"
    %buffer = hal.buffer_view.buffer %arg2 : !hal.buffer
    %1 = call @abs(%buffer) : (!hal.buffer) -> !hal.buffer
    %view = hal.buffer_view.create %1, shape = [], element_type = 16777248 : !hal.buffer_view
    hal.semaphore.signal %arg3, value = %arg4
    return %view : !hal.buffer_view
  }
  func @abs$sync(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.module.export = "abs", iree.reflection = {f = "I6!B3!t6R6!B3!t6", fv = "1"}} {
    %c0 = constant 0 : index
    %c1 = constant 1 : index
    %dev = hal.ex.shared_device : !hal.device
    %semaphore = hal.semaphore.create %dev, initial_value = %c0 : !hal.semaphore
    %0 = call @abs$async(%semaphore, %c0, %arg0, %semaphore, %c1) : (!hal.semaphore, index, !hal.buffer_view, !hal.semaphore, index) -> !hal.buffer_view
    %1 = hal.semaphore.await %semaphore, min_value = %c1 : i32
    hal.check_success %1, "semaphore wait failed"
    return %0 : !hal.buffer_view
  }
```