### PR TITLE
Clean up HAL dispatch ops to not track redundant state.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -27,7 +27,6 @@ func @multipleDispatches(%arg0: tensor<128xf32>) -> tensor<128xf32> {
   // CHECK: %[[CMD:.+]] = hal.command_buffer.create {{.+}}, "OneShot", "Transfer|Dispatch"
   // CHECK-NEXT: hal.command_buffer.begin %[[CMD]]
   %0 = flow.ex.stream.fragment(%arg1 = %cst : index, %arg2 = %arg0 : tensor<128xf32>) -> tensor<128xf32> {
-    //  CHECK-DAG: %[[EXE:.+]] = hal.executable.lookup {{.+}}, @ex0 : !hal.executable
     //  CHECK-DAG: %[[EXE_LAYOUT:.+]] = hal.executable_layout.lookup
     //      CHECK: hal.command_buffer.push_descriptor_set %[[CMD]], %[[EXE_LAYOUT]], set=0, bindings=[0 = (%arg0, %c0, %sz_3), 1 = (%buffer_1, %c0, %sz_4)]
     //      CHECK: hal.command_buffer.dispatch.symbol {{.+}}, @ex0::@vmla::@entry0, workgroup_xyz

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -30,11 +30,11 @@ func @multipleDispatches(%arg0: tensor<128xf32>) -> tensor<128xf32> {
     //  CHECK-DAG: %[[EXE:.+]] = hal.executable.lookup {{.+}}, @ex0 : !hal.executable
     //  CHECK-DAG: %[[EXE_LAYOUT:.+]] = hal.executable_layout.lookup
     //      CHECK: hal.command_buffer.push_descriptor_set %[[CMD]], %[[EXE_LAYOUT]], set=0, bindings=[0 = (%arg0, %c0, %sz_3), 1 = (%buffer_1, %c0, %sz_4)]
-    //      CHECK: hal.command_buffer.dispatch.symbol {{.+}}, entry_point = @ex0::@vmla::@entry0, workgroup_xyz
+    //      CHECK: hal.command_buffer.dispatch.symbol {{.+}}, @ex0::@vmla::@entry0, workgroup_xyz
     //      CHECK: hal.command_buffer.execution_barrier
     %1 = flow.dispatch @ex0::@entry0[%arg1 : index](%arg2) : (tensor<128xf32>) -> tensor<128xf32>
     //      CHECK: hal.command_buffer.push_descriptor_set
-    //      CHECK: hal.command_buffer.dispatch.symbol {{.+}}, entry_point = @ex0::@vmla::@entry0, workgroup_xyz
+    //      CHECK: hal.command_buffer.dispatch.symbol {{.+}}, @ex0::@vmla::@entry0, workgroup_xyz
     //      CHECK: hal.command_buffer.execution_barrier
     %2 = flow.dispatch @ex0::@entry0[%arg1 : index](%1) : (tensor<128xf32>) -> tensor<128xf32>
     flow.return %2 : tensor<128xf32>

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -853,10 +853,9 @@ void CommandBufferBindDescriptorSetOp::build(OpBuilder &builder,
 
 void CommandBufferDispatchSymbolOp::build(
     OpBuilder &builder, OperationState &state, Value commandBuffer,
-    Value executable, IREE::HAL::ExecutableEntryPointOp entryPoint,
-    Value workgroupX, Value workgroupY, Value workgroupZ) {
-  state.addOperands(
-      {commandBuffer, executable, workgroupX, workgroupY, workgroupZ});
+    IREE::HAL::ExecutableEntryPointOp entryPoint, Value workgroupX,
+    Value workgroupY, Value workgroupZ) {
+  state.addOperands({commandBuffer, workgroupX, workgroupY, workgroupZ});
   // Construct Executable::Target::EntryPoint nested reference.
   StringRef executableOpSymName =
       entryPoint.getParentOp()

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1001,6 +1001,24 @@ def HAL_CommandBufferEndOp : HAL_Op<"command_buffer.end"> {
   let assemblyFormat = "$command_buffer attr-dict";
 }
 
+def HAL_CommandBufferDeviceOp : HAL_PureOp<"command_buffer.device"> {
+  let summary = [{command buffer device query pseudo-op}];
+  let description = [{
+    Used during conversion to access the device used to create a command buffer.
+  }];
+
+  let arguments = (ins
+    HAL_CommandBuffer:$command_buffer
+  );
+  let results = (outs
+    HAL_Device:$device
+  );
+
+  let assemblyFormat = "$command_buffer attr-dict `:` type($device)";
+
+  let hasCanonicalizer = 1;
+}
+
 def HAL_CommandBufferExecutionBarrierOp : HAL_Op<"command_buffer.execution_barrier", [
     AttrSizedOperandSegments,
   ]> {
@@ -1179,15 +1197,13 @@ def HAL_CommandBufferDispatchSymbolOp : HAL_Op<"command_buffer.dispatch.symbol">
     %x = constant 128 : index
     %y = constant 32 : index
     %z = constant 1 : index
-    hal.command_buffer.dispatch.symbol %cmd, %executable,
-                                       entry_point = @executable::@target::@entry0,
+    hal.command_buffer.dispatch.symbol %cmd, @executable::@target::@entry,
                                        workgroup_xyz = [%x, %y, %z]
     ```
   }];
 
   let arguments = (ins
     HAL_CommandBuffer:$command_buffer,
-    HAL_Executable:$executable,  // TODO(scotttodd): remove this and extract from nested ref?
     SymbolRefAttr:$entry_point,
     HAL_Dim:$workgroup_x,
     HAL_Dim:$workgroup_y,
@@ -1195,7 +1211,7 @@ def HAL_CommandBufferDispatchSymbolOp : HAL_Op<"command_buffer.dispatch.symbol">
   );
 
   let assemblyFormat = [{
-    $command_buffer `,` $executable `,` `entry_point` `=` $entry_point `,`
+    $command_buffer `,` $entry_point `,`
     `workgroup_xyz` `=` `[` $workgroup_x `,` $workgroup_y `,` $workgroup_z `]`
     attr-dict
   }];
@@ -1204,7 +1220,7 @@ def HAL_CommandBufferDispatchSymbolOp : HAL_Op<"command_buffer.dispatch.symbol">
   let builders = [
     OpBuilder<[{
       OpBuilder &builder, OperationState &state, Value commandBuffer,
-      Value executable, IREE::HAL::ExecutableEntryPointOp entryPoint,
+      IREE::HAL::ExecutableEntryPointOp entryPoint,
       Value workgroupX, Value workgroupY, Value workgroupZ
     }]>,
   ];
@@ -1248,22 +1264,20 @@ def HAL_CommandBufferDispatchIndirectSymbolOp : HAL_Op<"command_buffer.dispatch.
     given buffer, using using a nested symbol reference to the entry point.
 
     ```mlir
-    hal.command_buffer.dispatch.indirect.symbol %cmd, %executable,
-                                                entry_point = @executable::@target::@entry0,
+    hal.command_buffer.dispatch.indirect.symbol %cmd, @executable::@target::@entry,
                                                 workgroups = %buffer[%offset]
     ```
   }];
 
   let arguments = (ins
     HAL_CommandBuffer:$command_buffer,
-    HAL_Executable:$executable,  // TODO(scotttodd): remove this and extract from nested ref?
     SymbolRefAttr:$entry_point,
     HAL_Buffer:$workgroups_buffer,
     HAL_DeviceSize:$workgroups_offset
   );
 
   let assemblyFormat = [{
-    $command_buffer `,` $executable `,` `entry_point` `=` $entry_point `,`
+    $command_buffer `,` $entry_point `,`
     `workgroups` `=` $workgroups_buffer `[` $workgroups_offset `]` attr-dict
   }];
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1002,7 +1002,7 @@ def HAL_CommandBufferEndOp : HAL_Op<"command_buffer.end"> {
 }
 
 def HAL_CommandBufferDeviceOp : HAL_PureOp<"command_buffer.device"> {
-  let summary = [{command buffer device query pseudo-op}];
+  let summary = [{command buffer device query operation}];
   let description = [{
     Used during conversion to access the device used to create a command buffer.
   }];

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
@@ -1,0 +1,15 @@
+// Tests folding and canonicalization of HAL command buffer ops.
+
+// RUN: iree-opt -split-input-file -canonicalize %s | iree-opt -split-input-file | IreeFileCheck %s
+
+// CHECK-LABEL: @skip_command_buffer_device
+func @skip_command_buffer_device() -> !hal.executable {
+  %dev = hal.ex.shared_device : !hal.device
+  %cmd = hal.command_buffer.create %dev, "OneShot", "Transfer|Dispatch" : !hal.command_buffer
+
+  // CHECK: %[[EXECUTABLE:.+]] = hal.executable.lookup %dev, @executable_name : !hal.executable
+  %0 = hal.command_buffer.device %cmd : !hal.device
+  %exe = hal.executable.lookup %0, @executable_name : !hal.executable
+
+  return %exe : !hal.executable
+}

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
@@ -7,6 +7,7 @@ func @skip_command_buffer_device() -> !hal.executable {
   %dev = hal.ex.shared_device : !hal.device
   %cmd = hal.command_buffer.create %dev, "OneShot", "Transfer|Dispatch" : !hal.command_buffer
 
+  // CHECK-NOT: hal.command_buffer.device
   // CHECK: %[[EXECUTABLE:.+]] = hal.executable.lookup %dev, @executable_name : !hal.executable
   %0 = hal.command_buffer.device %cmd : !hal.device
   %exe = hal.executable.lookup %0, @executable_name : !hal.executable

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -44,8 +44,8 @@ func @command_buffer_begin_end(%arg0 : !hal.command_buffer) {
 
 // CHECK-LABEL: @command_buffer_device
 func @command_buffer_device(%arg0 : !hal.command_buffer) {
-  // CHECK: %device = hal.command_buffer.device %arg0 : !hal.device
-  %device = hal.command_buffer.device %arg0 : !hal.device
+  // CHECK: %0 = hal.command_buffer.device %arg0 : !hal.device
+  %0 = hal.command_buffer.device %arg0 : !hal.device
   return
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -42,6 +42,15 @@ func @command_buffer_begin_end(%arg0 : !hal.command_buffer) {
 
 // -----
 
+// CHECK-LABEL: @command_buffer_device
+func @command_buffer_device(%arg0 : !hal.command_buffer) {
+  // CHECK: %device = hal.command_buffer.device %arg0 : !hal.device
+  %device = hal.command_buffer.device %arg0 : !hal.device
+  return
+}
+
+// -----
+
 // CHECK-LABEL: @command_buffer_execution_barrier
 func @command_buffer_execution_barrier(%arg0 : !hal.command_buffer) {
   %0 = "test_hal.buffer"() : () -> !hal.buffer
@@ -115,12 +124,11 @@ func @command_buffer_dispatch(%arg0 : !hal.command_buffer) {
       }
     }
   }
-  %0 = "test_hal.executable"() : () -> !hal.executable
-  %1 = "test_hal.workgroup_x"() : () -> index
-  %2 = "test_hal.workgroup_y"() : () -> index
-  %3 = "test_hal.workgroup_z"() : () -> index
-  // CHECK: hal.command_buffer.dispatch.symbol %arg0, %0, entry_point = @ex::@backend::@entry0, workgroup_xyz = [%1, %2, %3]
-  hal.command_buffer.dispatch.symbol %arg0, %0, entry_point = @ex::@backend::@entry0, workgroup_xyz = [%1, %2, %3]
+  %0 = "test_hal.workgroup_x"() : () -> index
+  %1 = "test_hal.workgroup_y"() : () -> index
+  %2 = "test_hal.workgroup_z"() : () -> index
+  // CHECK: hal.command_buffer.dispatch.symbol %arg0, @ex::@backend::@entry0, workgroup_xyz = [%0, %1, %2]
+  hal.command_buffer.dispatch.symbol %arg0, @ex::@backend::@entry0, workgroup_xyz = [%0, %1, %2]
   return
 }
 
@@ -135,10 +143,9 @@ func @command_buffer_dispatch_indirect(%arg0 : !hal.command_buffer) {
       }
     }
   }
-  %0 = "test_hal.executable"() : () -> !hal.executable
-  %1 = "test_hal.buffer"() : () -> !hal.buffer
-  %2 = "test_hal.offset"() : () -> index
-  // CHECK: hal.command_buffer.dispatch.indirect.symbol %arg0, %0, entry_point = @ex::@backend::@entry0, workgroups = %1[%2]
-  hal.command_buffer.dispatch.indirect.symbol %arg0, %0, entry_point = @ex::@backend::@entry0, workgroups = %1[%2]
+  %0 = "test_hal.buffer"() : () -> !hal.buffer
+  %1 = "test_hal.offset"() : () -> index
+  // CHECK: hal.command_buffer.dispatch.indirect.symbol %arg0, @ex::@backend::@entry0, workgroups = %0[%1]
+  hal.command_buffer.dispatch.indirect.symbol %arg0, @ex::@backend::@entry0, workgroups = %0[%1]
   return
 }

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -139,20 +139,18 @@ LogicalResult TargetBackend::recordDispatch(
       {
           dispatchState.workload,
           dispatchState.commandBuffer,
-          dispatchState.executable,
       });
   auto &entryBlock = region->front();
   auto workload = entryBlock.getArgument(0);
   auto commandBuffer = entryBlock.getArgument(1);
-  auto executable = entryBlock.getArgument(2);
 
   auto builder = OpBuilder::atBlockBegin(&entryBlock);
   auto workgroupCount = calculateDispatchWorkgroupCount(
       loc, dispatchState.executableOp, dispatchState.entryPointOp, workload,
       builder);
   builder.create<IREE::HAL::CommandBufferDispatchSymbolOp>(
-      loc, commandBuffer, executable, dispatchState.entryPointOp,
-      workgroupCount[0], workgroupCount[1], workgroupCount[2]);
+      loc, commandBuffer, dispatchState.entryPointOp, workgroupCount[0],
+      workgroupCount[1], workgroupCount[2]);
 
   builder.create<IREE::HAL::ReturnOp>(loc);
   return success();

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -65,7 +65,7 @@ class MaterializeResourceCachesPass
     // loads from variables.
     for (auto funcOp : moduleOp.getOps<FuncOp>()) {
       for (auto &block : funcOp) {
-        for (auto &op : llvm::make_early_inc_range(block)) {
+        block.walk([&](Operation *op) {
           if (auto lookupOp = dyn_cast<DescriptorSetLayoutLookupOp>(op)) {
             replaceDescriptorSetLayoutLookupOp(lookupOp);
           } else if (auto lookupOp = dyn_cast<ExecutableLayoutLookupOp>(op)) {
@@ -73,7 +73,7 @@ class MaterializeResourceCachesPass
           } else if (auto lookupOp = dyn_cast<ExecutableLookupOp>(op)) {
             replaceExecutableLookupOp(lookupOp);
           }
-        }
+        });
       }
     }
 

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -75,6 +75,13 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // been expanded to primitives.
   passManager.addPass(createPublicABIGenerationPass());
 
+  // Resolve entry point ordinals from nested symbol references prior to
+  // serialization. As this pass creates lookup ops it should run before
+  // MaterializeResourceCachesPass.
+  passManager.addPass(createResolveEntryPointOrdinalsPass());
+  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
+  passManager.addNestedPass<FuncOp>(createCSEPass());
+
   // Gather cachable resources such as executables and descriptor sets and
   // cache them at initialization-time.
   passManager.addPass(createMaterializeResourceCachesPass(targetOptions));
@@ -85,10 +92,6 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createMemoizeDeviceQueriesPass());
   passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createCSEPass());
-
-  // Resolve entry point ordinals from nested symbol references prior to
-  // serialization.
-  passManager.addPass(createResolveEntryPointOrdinalsPass());
 
   // TODO(#1036): run this once per hal.executable.target in a nested pass
   // manager so that we have as many passes as hal.executable.target ops.

--- a/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
@@ -31,8 +31,19 @@ class ResolveCommandBufferDispatchOrdinals
                                 PatternRewriter &rewriter) const override {
     auto entryPointOp = dyn_cast<IREE::HAL::ExecutableEntryPointOp>(
         SymbolTable::lookupNearestSymbolFrom(op, op.entry_point()));
+
+    // Lookup the device for our command buffer, then the executable from the
+    // entry point's nested reference.
+    auto device = rewriter.createOrFold<IREE::HAL::CommandBufferDeviceOp>(
+        op.getLoc(), IREE::HAL::DeviceType::get(rewriter.getContext()),
+        op.command_buffer());
+    auto executableOp = dyn_cast<IREE::HAL::ExecutableOp>(
+        entryPointOp.getParentOp()->getParentOp());
+    auto executable = rewriter.createOrFold<IREE::HAL::ExecutableLookupOp>(
+        op.getLoc(), device, executableOp.sym_name());
+
     rewriter.replaceOpWithNewOp<IREE::HAL::CommandBufferDispatchOp>(
-        op, op.command_buffer(), op.executable(), entryPointOp.ordinalAttr(),
+        op, op.command_buffer(), executable, entryPointOp.ordinalAttr(),
         op.workgroup_x(), op.workgroup_y(), op.workgroup_z());
     return success();
   }
@@ -49,8 +60,19 @@ class ResolveCommandBufferDispatchIndirectOrdinals
       PatternRewriter &rewriter) const override {
     auto entryPointOp = dyn_cast<IREE::HAL::ExecutableEntryPointOp>(
         SymbolTable::lookupNearestSymbolFrom(op, op.entry_point()));
+
+    // Lookup the device for our command buffer, then the executable from the
+    // entry point's nested reference.
+    auto device = rewriter.createOrFold<IREE::HAL::CommandBufferDeviceOp>(
+        op.getLoc(), IREE::HAL::DeviceType::get(rewriter.getContext()),
+        op.command_buffer());
+    auto executableOp = dyn_cast<IREE::HAL::ExecutableOp>(
+        entryPointOp.getParentOp()->getParentOp());
+    auto executable = rewriter.createOrFold<IREE::HAL::ExecutableLookupOp>(
+        op.getLoc(), device, executableOp.sym_name());
+
     rewriter.replaceOpWithNewOp<IREE::HAL::CommandBufferDispatchIndirectOp>(
-        op, op.command_buffer(), op.executable(), entryPointOp.ordinalAttr(),
+        op, op.command_buffer(), executable, entryPointOp.ordinalAttr(),
         op.workgroups_buffer(), op.workgroups_offset());
     return success();
   }

--- a/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
@@ -19,12 +19,11 @@ module {
 
   func @dispatch_with_nested_references() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
-    %exe = "test_hal.executable"() : () -> !hal.executable
     %x = "test_hal.workgroup_x"() : () -> index
     %y = "test_hal.workgroup_y"() : () -> index
     %z = "test_hal.workgroup_z"() : () -> index
     // CHECK: hal.command_buffer.dispatch %0, %1, entry_point = 0, workgroup_xyz = [%2, %3, %4]
-    hal.command_buffer.dispatch.symbol %cmd, %exe, entry_point = @exe::@target::@entry, workgroup_xyz = [%x, %y, %z]
+    hal.command_buffer.dispatch.symbol %cmd, @exe::@target::@entry, workgroup_xyz = [%x, %y, %z]
     return
   }
 }
@@ -35,12 +34,11 @@ module {
 module {
   func @dispatch_already_using_ordinals() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
-    %exe = "test_hal.executable"() : () -> !hal.executable
     %x = "test_hal.workgroup_x"() : () -> index
     %y = "test_hal.workgroup_y"() : () -> index
     %z = "test_hal.workgroup_z"() : () -> index
     // CHECK: hal.command_buffer.dispatch %0, %1, entry_point = 2, workgroup_xyz = [%2, %3, %4]
-    hal.command_buffer.dispatch %cmd, %exe, entry_point = 2, workgroup_xyz = [%x, %y, %z]
+    hal.command_buffer.dispatch %cmd, 2, workgroup_xyz = [%x, %y, %z]
     return
   }
 }
@@ -66,11 +64,10 @@ module {
 
   func @dispatch_indirect_with_nested_references() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
-    %exe = "test_hal.executable"() : () -> !hal.executable
     %buffer = "test_hal.buffer"() : () -> !hal.buffer
     %offset = "test_hal.offset"() : () -> index
     // CHECK: hal.command_buffer.dispatch.indirect %0, %1, entry_point = 0, workgroups = %2[%3]
-    hal.command_buffer.dispatch.indirect.symbol %cmd, %exe, entry_point = @exe::@target::@entry, workgroups = %buffer[%offset]
+    hal.command_buffer.dispatch.indirect.symbol %cmd, @exe::@target::@entry, workgroups = %buffer[%offset]
     return
   }
 }
@@ -81,11 +78,10 @@ module {
 module {
   func @dispatch_indirect_already_using_ordinals() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
-    %exe = "test_hal.executable"() : () -> !hal.executable
     %buffer = "test_hal.buffer"() : () -> !hal.buffer
     %offset = "test_hal.offset"() : () -> index
     // CHECK: hal.command_buffer.dispatch.indirect %0, %1, entry_point = 0, workgroups = %2[%3]
-    hal.command_buffer.dispatch.indirect %cmd, %exe, entry_point = 0, workgroups = %buffer[%offset]
+    hal.command_buffer.dispatch.indirect %cmd, 0, workgroups = %buffer[%offset]
     return
   }
 }

--- a/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
@@ -22,7 +22,9 @@ module {
     %x = "test_hal.workgroup_x"() : () -> index
     %y = "test_hal.workgroup_y"() : () -> index
     %z = "test_hal.workgroup_z"() : () -> index
-    // CHECK: hal.command_buffer.dispatch %0, %1, entry_point = 0, workgroup_xyz = [%2, %3, %4]
+    // CHECK: %[[DEVICE:.+]] = hal.command_buffer.device %0
+    // CHECK: %[[EXE:.+]] = hal.executable.lookup %[[DEVICE]], @exe
+    // CHECK: hal.command_buffer.dispatch %0, %[[EXE]], entry_point = 0, workgroup_xyz = [%1, %2, %3]
     hal.command_buffer.dispatch.symbol %cmd, @exe::@target::@entry, workgroup_xyz = [%x, %y, %z]
     return
   }
@@ -34,11 +36,12 @@ module {
 module {
   func @dispatch_already_using_ordinals() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
     %x = "test_hal.workgroup_x"() : () -> index
     %y = "test_hal.workgroup_y"() : () -> index
     %z = "test_hal.workgroup_z"() : () -> index
     // CHECK: hal.command_buffer.dispatch %0, %1, entry_point = 2, workgroup_xyz = [%2, %3, %4]
-    hal.command_buffer.dispatch %cmd, 2, workgroup_xyz = [%x, %y, %z]
+    hal.command_buffer.dispatch %cmd, %exe, entry_point = 2, workgroup_xyz = [%x, %y, %z]
     return
   }
 }
@@ -66,7 +69,9 @@ module {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
     %buffer = "test_hal.buffer"() : () -> !hal.buffer
     %offset = "test_hal.offset"() : () -> index
-    // CHECK: hal.command_buffer.dispatch.indirect %0, %1, entry_point = 0, workgroups = %2[%3]
+    // CHECK: %[[DEVICE:.+]] = hal.command_buffer.device %0
+    // CHECK: %[[EXE:.+]] = hal.executable.lookup %[[DEVICE]], @exe
+    // CHECK: hal.command_buffer.dispatch.indirect %0, %[[EXE]], entry_point = 0, workgroups = %1[%2]
     hal.command_buffer.dispatch.indirect.symbol %cmd, @exe::@target::@entry, workgroups = %buffer[%offset]
     return
   }
@@ -78,10 +83,11 @@ module {
 module {
   func @dispatch_indirect_already_using_ordinals() {
     %cmd = "test_hal.command_buffer"() : () -> !hal.command_buffer
+    %exe = "test_hal.executable"() : () -> !hal.executable
     %buffer = "test_hal.buffer"() : () -> !hal.buffer
     %offset = "test_hal.offset"() : () -> index
     // CHECK: hal.command_buffer.dispatch.indirect %0, %1, entry_point = 0, workgroups = %2[%3]
-    hal.command_buffer.dispatch.indirect %cmd, 0, workgroups = %buffer[%offset]
+    hal.command_buffer.dispatch.indirect %cmd, %exe, entry_point = 0, workgroups = %buffer[%offset]
     return
   }
 }


### PR DESCRIPTION
* `hal.device` can be retrieved from `hal.command_buffer`
* `hal.executable` can be retrieved from `@executable::@target::@entry_point` nested references

This adds a new `hal.command_buffer.device` op to help keep the IR tidy, with a new canonicalization pattern for when it refers to a device that was created in the same scope.

Since the new op is created within a `hal.device.switch`, the canonicalization is not used. However, since `MaterializeResourceCachesPass` does not yet support multiple devices, the lowerings still "work" as written today, without needing to add a runtime op for the device query.

Progress on https://github.com/google/iree/issues/1890