### PR TITLE
Split TargetBackend filter/name into two fields.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/AOT/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/AOT/LLVMAOTTarget.cpp
@@ -42,8 +42,9 @@ class LLVMAOTTargetBackend final : public TargetBackend {
   LLVMAOTTargetBackend(LLVMTargetOptions options)
       : options_(std::move(options)) {}
 
-  // NOTE: we could vary this based on the options, such as by arch/etc.
-  std::string name() const override { return "dylib*"; }
+  // NOTE: we could vary these based on the options, such as by arch/etc.
+  std::string name() const override { return "llvm_aot"; }
+  std::string filter_pattern() const override { return "dylib*"; }
 
   void getDependentDialects(DialectRegistry& registry) const override {
     // clang-format off
@@ -53,17 +54,6 @@ class LLVMAOTTargetBackend final : public TargetBackend {
                     scf::SCFDialect,
                     vector::VectorDialect>();
     // clang-format on
-  }
-
-  void declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
-                        IREE::HAL::ExecutableOp executableOp) override {
-    OpBuilder targetBuilder(&executableOp.getBlock().back());
-    auto targetContainerOp =
-        targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
-            sourceOp.getLoc(), /*name=*/"llvm_aot",
-            /*targetBackendFilter=*/name());
-    OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
-    containerBuilder.create<ModuleOp>(sourceOp.getLoc());
   }
 
   void buildTranslationPassPipeline(ExecutableTargetOp targetOp,

--- a/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
@@ -39,7 +39,6 @@ class LLVMIRTargetBackend final : public TargetBackend {
   LLVMIRTargetBackend(LLVMTargetOptions options)
       : options_(std::move(options)) {}
 
-
   // NOTE: we could vary these based on the options, such as by arch/etc.
   std::string name() const override { return "llvm_ir"; }
   std::string filter_pattern() const override { return "llvm-ir*"; }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
@@ -39,8 +39,10 @@ class LLVMIRTargetBackend final : public TargetBackend {
   LLVMIRTargetBackend(LLVMTargetOptions options)
       : options_(std::move(options)) {}
 
-  // NOTE: we could vary this based on the options, such as by arch/etc.
-  std::string name() const override { return "llvm-ir*"; }
+
+  // NOTE: we could vary these based on the options, such as by arch/etc.
+  std::string name() const override { return "llvm_ir"; }
+  std::string filter_pattern() const override { return "llvm-ir*"; }
 
   void getDependentDialects(DialectRegistry& registry) const override {
     // clang-format off
@@ -50,17 +52,6 @@ class LLVMIRTargetBackend final : public TargetBackend {
                     scf::SCFDialect,
                     vector::VectorDialect>();
     // clang-format on
-  }
-
-  void declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
-                        IREE::HAL::ExecutableOp executableOp) override {
-    OpBuilder targetBuilder(&executableOp.getBlock().back());
-    auto targetContainerOp =
-        targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
-            sourceOp.getLoc(), /*name=*/"llvm_ir",
-            /*targetBackendFilter=*/name());
-    OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
-    containerBuilder.create<ModuleOp>(sourceOp.getLoc());
   }
 
   void buildTranslationPassPipeline(ExecutableTargetOp targetOp,

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -75,7 +75,7 @@ void TargetBackend::declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
                                      IREE::HAL::ExecutableOp executableOp) {
   OpBuilder targetBuilder(&executableOp.getBlock().back());
   auto targetContainerOp = targetBuilder.create<IREE::HAL::ExecutableTargetOp>(
-      sourceOp.getLoc(), /*name=*/name(), /*targetBackendFilter=*/name());
+      sourceOp.getLoc(), name(), filter_pattern());
   OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
   containerBuilder.create<ModuleOp>(sourceOp.getLoc());
 }
@@ -135,7 +135,7 @@ LogicalResult TargetBackend::recordDispatch(
     Location loc, DispatchState dispatchState,
     DeviceSwitchBuilder &switchBuilder) {
   auto *region = switchBuilder.addConditionRegion(
-      IREE::HAL::DeviceMatchIDAttr::get(name(), loc.getContext()),
+      IREE::HAL::DeviceMatchIDAttr::get(filter_pattern(), loc.getContext()),
       {
           dispatchState.workload,
           dispatchState.commandBuffer,

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -118,9 +118,11 @@ class TargetBackend {
 
   virtual ~TargetBackend() = default;
 
-  // Returns the name of the backend as expected to be matched with a call to
-  // matchPattern. For example, 'vulkan-v1.1' or 'vmla*'.
+  // Returns a name for the backend used to differentiate between other targets.
   virtual std::string name() const = 0;
+  // Returns a filter pattern for the backend as expected to be matched with a
+  // call to matchPattern. For example, 'vulkan-v1.1' or 'vmla*'.
+  virtual std::string filter_pattern() const = 0;
 
   // Creates an interface representing the bindings and push constants required
   // to dispatch the executable. Interfaces used across backends and executables

--- a/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
@@ -48,6 +48,7 @@ class VMLATargetBackend final : public TargetBackend {
   VMLATargetBackend(VMLATargetOptions options) : options_(std::move(options)) {}
 
   std::string name() const override { return "vmla"; }
+  std::string filter_pattern() const override { return "vmla"; }
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<VM::VMDialect, VMLA::VMLADialect>();


### PR DESCRIPTION
Note: keeping these uses of `name()`:

https://github.com/google/iree/blob/45d971608fe91e119d7f9dbef5a0b6a1f9e0edd7/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp#L66-L68

https://github.com/google/iree/blob/45d971608fe91e119d7f9dbef5a0b6a1f9e0edd7/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp#L44-L47