### PR TITLE
[vulkan] Fix VmaBuffer fill and copy

### DIFF
--- a/iree/hal/cts/buffer_test.cc
+++ b/iree/hal/cts/buffer_test.cc
@@ -58,9 +58,6 @@ TEST_P(BufferTest, AllocateZeroLength) {
 }
 
 TEST_P(BufferTest, Fill8) {
-  // TODO: fix this.
-  if (driver_->name() == "vulkan") GTEST_SKIP();
-
   IREE_ASSERT_OK_AND_ASSIGN(
       auto buffer, device_->allocator()->Allocate(
                        MemoryType::kHostLocal | MemoryType::kDeviceVisible,
@@ -95,9 +92,6 @@ TEST_P(BufferTest, Fill8) {
 }
 
 TEST_P(BufferTest, Fill16) {
-  // TODO: fix this.
-  if (driver_->name() == "vulkan") GTEST_SKIP();
-
   IREE_ASSERT_OK_AND_ASSIGN(
       auto buffer, device_->allocator()->Allocate(
                        MemoryType::kHostLocal | MemoryType::kDeviceVisible,
@@ -137,9 +131,6 @@ TEST_P(BufferTest, Fill16) {
 }
 
 TEST_P(BufferTest, Fill32) {
-  // TODO: fix this.
-  if (driver_->name() == "vulkan") GTEST_SKIP();
-
   IREE_ASSERT_OK_AND_ASSIGN(
       auto buffer, device_->allocator()->Allocate(
                        MemoryType::kHostLocal | MemoryType::kDeviceVisible,
@@ -209,9 +200,6 @@ TEST_P(BufferTest, ReadWriteData) {
 }
 
 TEST_P(BufferTest, CopyData) {
-  // TODO: fix this.
-  if (driver_->name() == "vulkan") GTEST_SKIP();
-
   std::vector<uint8_t> src_data = {0, 1, 2, 3};
   IREE_ASSERT_OK_AND_ASSIGN(
       auto src_buffer,

--- a/iree/hal/vulkan/vma_buffer.cc
+++ b/iree/hal/vulkan/vma_buffer.cc
@@ -55,21 +55,19 @@ Status VmaBuffer::FillImpl(device_size_t byte_offset, device_size_t byte_length,
     case 1: {
       uint8_t* data = static_cast<uint8_t*>(data_ptr);
       uint8_t value_bits = *static_cast<const uint8_t*>(pattern);
-      std::fill_n(data + byte_offset, byte_length, value_bits);
+      std::fill_n(data, byte_length, value_bits);
       break;
     }
     case 2: {
       uint16_t* data = static_cast<uint16_t*>(data_ptr);
       uint16_t value_bits = *static_cast<const uint16_t*>(pattern);
-      std::fill_n(data + byte_offset / sizeof(uint16_t),
-                  byte_length / sizeof(uint16_t), value_bits);
+      std::fill_n(data, byte_length / sizeof(uint16_t), value_bits);
       break;
     }
     case 4: {
       uint32_t* data = static_cast<uint32_t*>(data_ptr);
       uint32_t value_bits = *static_cast<const uint32_t*>(pattern);
-      std::fill_n(data + byte_offset / sizeof(uint32_t),
-                  byte_length / sizeof(uint32_t), value_bits);
+      std::fill_n(data, byte_length / sizeof(uint32_t), value_bits);
       break;
     }
     default:
@@ -111,8 +109,8 @@ Status VmaBuffer::CopyDataImpl(device_size_t target_offset,
                         MapMemory<uint8_t>(MemoryAccess::kDiscardWrite,
                                            target_offset, data_length));
   CHECK_EQ(data_length, target_mapping.size());
-  std::memcpy(target_mapping.mutable_data() + target_offset,
-              source_mapping.data(), data_length);
+  std::memcpy(target_mapping.mutable_data(), source_mapping.data(),
+              data_length);
   return OkStatus();
 }
 


### PR DESCRIPTION
MapMemory() already handles the offset. There is no need to
add the offset again when filling or copying.