### PR TITLE
Use local instead of parameter comment

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -221,9 +221,10 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
 
     // Ordinals are fixed based on the precomputed schedule, so use
     // CommandBufferDispatchOp instead of CommandBufferDispatchSymbolOp.
+    int32_t entryPointOrdinal = it.index();
     builder.create<IREE::HAL::CommandBufferDispatchOp>(
         loc, commandBuffer, executable,
-        builder.getI32IntegerAttr(/*entryPointOrdinal=*/it.index()),
+        builder.getI32IntegerAttr(entryPointOrdinal),
         workgroupCount[0], workgroupCount[1], workgroupCount[2]);
     if (it.index() + 1 != spvEntryPointFns.size()) {
       recordFullExecutionBarrier(commandBuffer, loc, builder);

--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -224,8 +224,8 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
     int32_t entryPointOrdinal = it.index();
     builder.create<IREE::HAL::CommandBufferDispatchOp>(
         loc, commandBuffer, executable,
-        builder.getI32IntegerAttr(entryPointOrdinal),
-        workgroupCount[0], workgroupCount[1], workgroupCount[2]);
+        builder.getI32IntegerAttr(entryPointOrdinal), workgroupCount[0],
+        workgroupCount[1], workgroupCount[2]);
     if (it.index() + 1 != spvEntryPointFns.size()) {
       recordFullExecutionBarrier(commandBuffer, loc, builder);
     }


### PR DESCRIPTION
Parameter comments should match the name of the argument. See
http://clang.llvm.org/extra/clang-tidy/checks/bugprone-argument-comment.html