### PR TITLE
Update Linux docs to include an LLVM AOT example

### DIFF
--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -107,9 +107,9 @@ $ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
     -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
-### Dylib LLVM AOT backend
+### LLVM Ahead-of-Time (AOT) backend
 
-To compile IREE LLVM AOT module we need to set the AOT linker path environment variable (eg: for lld-10):
+To compile IREE LLVM AOT (vs JIT) module we need to set the AOT linker path environment variable:
 
 ```shell
 $ export IREE_LLVMAOT_LINKER_PATH=ld.lld-10

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -107,6 +107,39 @@ $ ./build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
     -input-value="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
+### Dylib LLVM AOT backend
+
+To compile IREE LLVM AOT module we need to set the AOT linker path environment variable (eg: for lld-10):
+
+```shell
+$ export IREE_LLVMAOT_LINKER_PATH=ld.lld-10
+```
+
+Translate a source MLIR into an IREE module:
+
+```shell
+# Assuming in IREE source root
+$ ./build/iree/tools/iree-translate \
+    -iree-mlir-to-vm-bytecode-module \
+    -iree-llvm-target-triple=x86_64-linux-gnu \
+    -iree-hal-target-backends=dylib-llvm-aot \
+    iree/tools/test/simple.mlir \
+    -o /tmp/simple-llvm_aot.vmfb
+```
+
+Then push the IREE runtime executable and module to the device:
+
+```shell
+$ ./build/iree/tools/iree-run-module -driver=dylib \
+          -input_file=/tmp/simple-llvm_aot.vmfb \
+          -entry_function=abs \
+          -inputs="i32=-5"
+
+EXEC @abs
+i32=5
+```
+
+
 ### Further Reading
 
 *   For an introduction to IREE's project structure and developer tools, see

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -127,7 +127,7 @@ $ ./build/iree/tools/iree-translate \
     -o /tmp/simple-llvm_aot.vmfb
 ```
 
-Then push the IREE runtime executable and module to the device:
+Then run the compiled module using the `dylib` HAL driver:
 
 ```shell
 $ ./build/iree/tools/iree-run-module -driver=dylib \


### PR DESCRIPTION
Update Linux CMake to also include an LLVM AOT example (based on the Android example)