### PR TITLE
Adding missing distribution options for BatchMatmul in tile+distribute (#3010)

### DIFF
--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
@@ -788,6 +788,8 @@ void populateHLOToVMLAPatterns(MLIRContext *context,
       context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::XorOp, IREE::VMLA::XorOp>>(
       context, typeConverter);
+  patterns.insert<VMLAOpConversion<mhlo::NotOp, IREE::VMLA::NotOp>>(
+      context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::ExpOp, IREE::VMLA::ExpOp>>(
       context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::LogOp, IREE::VMLA::LogOp>>(

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/test/math_ops.mlir
@@ -45,3 +45,15 @@ func @finite(%arg0 : tensor<4xf32>) -> tensor<4xi1> attributes { sym_visibility 
   // CHECK-NEXT: return %[[BUF]]
   return %0 : tensor<4xi1>
 }
+
+// -----
+
+// CHECK-LABEL: @not
+func @not(%arg0 : tensor<4xi1>) -> tensor<4xi1> attributes { sym_visibility = "private" } {
+  // CHECK-NEXT: %[[BUF_SZ:.+]] = constant 4
+  // CHECK-NEXT: %[[BUF:.+]] = vmla.buffer.alloc byte_length = %[[BUF_SZ]] : !vmla.buffer
+  // CHECK-NEXT: vmla.not %arg0, out %[[BUF]] : i1
+  %0 = "mhlo.not"(%arg0) : (tensor<4xi1>) -> tensor<4xi1>
+  // CHECK-NEXT: return %[[BUF]]
+  return %0 : tensor<4xi1>
+}


### PR DESCRIPTION
The distribution needs to be specified since the downstream passes do
not distribute loops anymore.

Fixes #3000