### PR TITLE
Enable ASAN test on iree/vm:vm:native_module_test

### DIFF
--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -246,9 +246,6 @@ cc_test(
 cc_test(
     name = "native_module_test",
     srcs = ["native_module_test.cc"],
-    tags = [
-        "noasan",  # TODO(#3122): Enable ASAN test.
-    ],
     deps = [
         ":context",
         ":instance",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -292,8 +292,6 @@ iree_cc_test(
     iree::base::status
     iree::testing::gtest
     iree::testing::gtest_main
-  LABELS
-    "noasan"
 )
 
 iree_cc_library(


### PR DESCRIPTION
Follow up on https://github.com/google/iree/pull/3130

The test was fixed, but forgot to enable.