### PR TITLE
VMLA support for mhlo.round_nearest_nfz

### DIFF
--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
@@ -803,6 +803,8 @@ void populateHLOToVMLAPatterns(MLIRContext *context,
       context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::FloorOp, IREE::VMLA::FloorOp>>(
       context, typeConverter);
+  patterns.insert<VMLAOpConversion<mhlo::RoundOp, IREE::VMLA::RoundOp>>(
+      context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::RsqrtOp, IREE::VMLA::RsqrtOp>>(
       context, typeConverter);
   patterns.insert<VMLAOpConversion<mhlo::SqrtOp, IREE::VMLA::SqrtOp>>(

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
@@ -320,6 +320,7 @@ void populateVMLAToVMPatterns(MLIRContext *context,
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::ClampOp, "vmla.clamp");
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::FloorOp, "vmla.floor");
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::CeilOp, "vmla.ceil");
+  VMLA_TYPED_IMPORT_OP(IREE::VMLA::RoundOp, "vmla.round");
 
   patterns.insert<VMLAConvertImportOpConversion>(context, importSymbols,
                                                  typeConverter, "vmla.convert");

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -395,6 +395,7 @@ def VMLA_MaxOp : VMLA_BinaryOp<"max", VMLA_AnyTypeAttr>;
 def VMLA_ClampOp : VMLA_TernaryOp<"clamp", VMLA_AnyTypeAttr>;
 def VMLA_FloorOp : VMLA_UnaryOp<"floor", VMLA_FloatTypeAttr>;
 def VMLA_CeilOp : VMLA_UnaryOp<"ceil", VMLA_FloatTypeAttr>;
+def VMLA_RoundOp : VMLA_UnaryOp<"round", VMLA_FloatTypeAttr>;
 
 //===----------------------------------------------------------------------===//
 // VMLA Ops: conversion

--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -331,6 +331,7 @@ vm.import @clamp.i32(%min : !vm.ref<!vmla.buffer>, %value : !vm.ref<!vmla.buffer
 vm.import @clamp.f32(%min : !vm.ref<!vmla.buffer>, %value : !vm.ref<!vmla.buffer>, %max : !vm.ref<!vmla.buffer>, %dst : !vm.ref<!vmla.buffer>)
 vm.import @floor.f32(%src : !vm.ref<!vmla.buffer>, %dst : !vm.ref<!vmla.buffer>)
 vm.import @ceil.f32(%src : !vm.ref<!vmla.buffer>, %dst : !vm.ref<!vmla.buffer>)
+vm.import @round.f32(%src : !vm.ref<!vmla.buffer>, %dst : !vm.ref<!vmla.buffer>)
 
 //===----------------------------------------------------------------------===//
 // VMLA Ops: conversion

--- a/iree/hal/vmla/op_kernels.h
+++ b/iree/hal/vmla/op_kernels.h
@@ -370,6 +370,12 @@ struct Ceil {
                         absl::Span<T> dst_buffer);
 };
 
+struct Round {
+  template <typename T>
+  static Status Execute(absl::Span<const T> src_buffer,
+                        absl::Span<T> dst_buffer);
+};
+
 struct Convert {
   template <typename SRC, typename DST>
   static Status Execute(absl::Span<const SRC> src_buffer,

--- a/iree/hal/vmla/op_kernels_generic.h
+++ b/iree/hal/vmla/op_kernels_generic.h
@@ -816,6 +816,14 @@ Status Ceil::Execute(absl::Span<const T> src_buffer, absl::Span<T> dst_buffer) {
   return OkStatus();
 }
 
+template <typename T>
+Status Round::Execute(absl::Span<const T> src_buffer, absl::Span<T> dst_buffer) {
+  for (size_t i = 0; i < dst_buffer.size(); ++i) {
+    dst_buffer[i] = std::round(src_buffer[i]);
+  }
+  return OkStatus();
+}
+
 template <typename SRC, typename DST>
 Status Convert::Execute(absl::Span<const SRC> src_buffer,
                         absl::Span<DST> dst_buffer) {

--- a/iree/hal/vmla/op_kernels_generic.h
+++ b/iree/hal/vmla/op_kernels_generic.h
@@ -817,7 +817,8 @@ Status Ceil::Execute(absl::Span<const T> src_buffer, absl::Span<T> dst_buffer) {
 }
 
 template <typename T>
-Status Round::Execute(absl::Span<const T> src_buffer, absl::Span<T> dst_buffer) {
+Status Round::Execute(absl::Span<const T> src_buffer,
+                      absl::Span<T> dst_buffer) {
   for (size_t i = 0; i < dst_buffer.size(); ++i) {
     dst_buffer[i] = std::round(src_buffer[i]);
   }

--- a/iree/hal/vmla/vmla_module.cc
+++ b/iree/hal/vmla/vmla_module.cc
@@ -640,6 +640,7 @@ class VMLAModuleState final {
   IREE_VMLA_TERNARY_OP(ClampF32, kernels::Clamp, float);
   IREE_VMLA_UNARY_OP(FloorF32, kernels::Floor, float);
   IREE_VMLA_UNARY_OP(CeilF32, kernels::Ceil, float);
+  IREE_VMLA_UNARY_OP(RoundF32, kernels::Round, float);
 
   //===--------------------------------------------------------------------===//
   // VMLA Ops: conversion
@@ -968,6 +969,7 @@ static const vm::NativeFunction<VMLAModuleState> kVMLAModuleFunctions[] = {
     vm::MakeNativeFunction("clamp.f32", &VMLAModuleState::ClampF32),
     vm::MakeNativeFunction("floor.f32", &VMLAModuleState::FloorF32),
     vm::MakeNativeFunction("ceil.f32", &VMLAModuleState::CeilF32),
+    vm::MakeNativeFunction("round.f32", &VMLAModuleState::RoundF32),
     vm::MakeNativeFunction("finite.f32", &VMLAModuleState::FiniteF32),
 
     vm::MakeNativeFunction("convert.i8.i16", &VMLAModuleState::ConvertI8I16),

--- a/iree/test/e2e/xla_ops/round.mlir
+++ b/iree/test/e2e/xla_ops/round.mlir
@@ -1,0 +1,7 @@
+func @tensor() attributes { iree.module.export } {
+  %input = iree.unfoldable_constant dense<[-0.7, -0.5, -0.2, 0.0, 0.2, 0.5, 0.7]> : tensor<7xf32>
+  %result = "mhlo.round_nearest_afz"(%input) : (tensor<7xf32>) -> tensor<7xf32>
+  check.expect_almost_eq_const(%result, dense<[-1.0, -1.0, 0.0, 0.0, 0.0, 1.0, 1.0]> : tensor<7xf32>) : tensor<7xf32>
+  return
+}
+


### PR DESCRIPTION
Adds a new vmla round operation mapping to mhlo's round operation.