### PR TITLE
Set USE_MATH_DEFINES for Windows CMake builds.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -120,6 +120,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-fvisibility=hidden"
   MSVC_OR_CLANG_CL
     "/DWIN32_LEAN_AND_MEAN"
+    "/DUSE_MATH_DEFINES"
     "/wd4624"
     # 'inline': used more than once
     "/wd4141"

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -120,7 +120,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-fvisibility=hidden"
   MSVC_OR_CLANG_CL
     "/DWIN32_LEAN_AND_MEAN"
-    "/DUSE_MATH_DEFINES"
+    "/D_USE_MATH_DEFINES"
     "/wd4624"
     # 'inline': used more than once
     "/wd4141"


### PR DESCRIPTION
Generally useful, and TF/MHLO now requires it for M_PI in a .td file.