### PR TITLE
Replace `create_reinitialized` with `reinitialize` in tf_utils

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -624,10 +624,9 @@ class TracedModuleTestCase(tf.test.TestCase):
     super().setUp()
     global _global_ref_module
     global _global_tar_modules
-    _global_ref_module = _global_ref_module.create_reinitialized()
-    _global_tar_modules = [
-        module.create_reinitialized() for module in _global_tar_modules
-    ]
+    _global_ref_module.reinitialize()
+    for module in _global_tar_modules:
+      module.reinitialize()
 
   def compare_backends(self, trace_function: Callable[[TracedModule],
                                                       None]) -> None:

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -229,8 +229,7 @@ class CompiledModule(object):
     self.module_name = self._module_class.__name__
     self.compiled_path = None
 
-  def create_reinitialized(self):
-    """Duplicates this module with its initial state without recompiling."""
+  def reinitialize(self):
     raise NotImplementedError()
 
   @staticmethod
@@ -259,8 +258,7 @@ class IreeCompiledModule(CompiledModule):
                module_class: Type[tf.Module],
                backend_info: "BackendInfo",
                exported_names: Sequence[str] = (),
-               artifacts_dir: str = None,
-               _create_reinitialized_dict: Dict[str, Any] = None):
+               artifacts_dir: str = None):
     """Compile a tf.Module to the target backend in backend_info.
 
     Args:
@@ -271,43 +269,23 @@ class IreeCompiledModule(CompiledModule):
         module_class's functions to compile. If exported_names is empty all
         functions will be compiled.
       artifacts_dir: an optional path to save compilation artifacts to.
-      _create_reinitialized_dict: used internally.
     """
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
 
-    if _create_reinitialized_dict is None:
-      set_random_seed()
-      self._module_blob, self.compiled_path = compile_tf_module(
-          tf_module=module_class(),
-          backend_infos=[backend_info],
-          exported_names=exported_names,
-          artifacts_dir=artifacts_dir)
-      self._module = rt.VmModule.from_flatbuffer(self._module_blob)
-      self._config = rt.Config(driver_name=backend_info.driver)
-    else:
-      # Called from self.create_reinitialized()
-      self._module_blob = _create_reinitialized_dict["_module_blob"]
-      self._module = _create_reinitialized_dict["_module"]
-      self._config = _create_reinitialized_dict["_config"]
-      self.compiled_path = _create_reinitialized_dict["compiled_path"]
+    set_random_seed()
+    self._module_blob, self.compiled_path = compile_tf_module(
+        tf_module=module_class(),
+        backend_infos=[backend_info],
+        exported_names=exported_names,
+        artifacts_dir=artifacts_dir)
+    self._module = rt.VmModule.from_flatbuffer(self._module_blob)
+    self._config = rt.Config(driver_name=backend_info.driver)
 
-    # Holds all of the module's mutable state.
+    self.reinitialize()
+
+  def reinitialize(self):
     self._context = rt.SystemContext(
         modules=[self._module], config=self._config)
-
-  def create_reinitialized(self) -> "IreeCompiledModule":
-    """Duplicates this module with its initial state without recompiling."""
-    default_args = [
-        self._module_class, self._backend_info, self._exported_names,
-        self._artifacts_dir
-    ]
-    create_reinitialized_dict = {
-        "_module_blob": self._module_blob,
-        "_module": self._module,
-        "_config": self._config,
-        "compiled_path": self.compiled_path
-    }
-    return IreeCompiledModule(*default_args, create_reinitialized_dict)
 
   def __getattr__(self, attr: str) -> _IreeFunctionWrapper:
     # Try to resolve it as a function.
@@ -379,12 +357,10 @@ class TfCompiledModule(CompiledModule):
     """
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
     set_random_seed()
-    self._tf_module = module_class()
+    self.reinitialize()
 
-  def create_reinitialized(self) -> "TfCompiledModule":
-    """Duplicates this module with the starting state of module_class."""
-    return TfCompiledModule(self._module_class, self._backend_info,
-                            self._exported_names, self._artifacts_dir)
+  def reinitialize(self):
+    self._tf_module = self._module_class()
 
   def __getattr__(self, attr: str) -> _TfFunctionWrapper:
     # Try to resolve it as a function.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -230,6 +230,7 @@ class CompiledModule(object):
     self.compiled_path = None
 
   def reinitialize(self):
+    """Reinitializes to the initial state of the passed module_class."""
     raise NotImplementedError()
 
   @staticmethod
@@ -284,6 +285,7 @@ class IreeCompiledModule(CompiledModule):
     self.reinitialize()
 
   def reinitialize(self):
+    """Reinitializes to the initial state of the passed module_class."""
     self._context = rt.SystemContext(
         modules=[self._module], config=self._config)
 
@@ -360,6 +362,7 @@ class TfCompiledModule(CompiledModule):
     self.reinitialize()
 
   def reinitialize(self):
+    """Reinitializes to the initial state of the passed module_class."""
     self._tf_module = self._module_class()
 
   def __getattr__(self, attr: str) -> _TfFunctionWrapper:

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -96,11 +96,9 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     module.increment()
     self.assertEqual([1.], module.get_count())
 
-    reinitialized_module = module.create_reinitialized()
+    module.reinitialize()
     # Test reinitialization.
-    self.assertEqual([0.], reinitialized_module.get_count())
-    # Test independent state.
-    self.assertEqual([1.], module.get_count())
+    self.assertEqual([0.], module.get_count())
 
   def test_to_mlir_type(self):
     self.assertEqual('i8', tf_utils.to_mlir_type(np.dtype('int8')))


### PR DESCRIPTION
This removes the unused functionality of creating a reinitialized copy of a `CompiledModule` it in favor of just reinitializing the module itself without copying.