### PR TITLE
Lower a mhlo.concatenate op to subview + linalg.fill/copy

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
@@ -1,16 +1,15 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
 
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1 + 2)>
+// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<2x5xi32>
+// CHECK-DAG: %[[IN0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
+// CHECK-DAG: %[[IN1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<2x3xi32>
+//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<2x5xi32> to memref<2x2xi32, #[[MAP0]]>
+//     CHECK: linalg.copy(%[[IN0]], %[[SUB0]])
+//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][0, 2] [2, 3] [1, 1]  : memref<2x5xi32> to memref<2x3xi32, #[[MAP1]]>
+//     CHECK: linalg.copy(%[[IN1]], %[[SUB1]])
 module {
-  //  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
-  //  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
-  //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
-  //      CHECK: @concatenate
-  //      CHECK: linalg.indexed_generic {
-  // CHECK-SAME:   args_in = 2
-  // CHECK-SAME:   args_out = 1
-  // CHECK-SAME:   indexing_maps
-  // CHECK-SAME:   #[[MAP0]], #[[MAP1]], #[[MAP2]]
-  // CHECK-SAME:   iterator_types = ["parallel", "reduction", "reduction", "reduction"]
   func @concatenate() {
     %c0 = constant 0 : index
     %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
@@ -30,21 +29,20 @@ module {
 
 // -----
 
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d0)>
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d0)>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d0)>
-//      CHECK: @concatenate
-//      CHECK: linalg.indexed_generic {
-// CHECK-SAME:   args_in = 2
-// CHECK-SAME:   args_out = 1
-// CHECK-SAME:   indexing_maps
-// CHECK-SAME:   #[[MAP0]], #[[MAP1]], #[[MAP2]]
-// CHECK-SAME:   iterator_types = ["parallel", "reduction", "reduction", "reduction"]
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1 + 4)>
+// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<5x2xi32>
+// CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
+// CHECK-DAG: %[[CST:.+]] = constant 42 : i32
+//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<5x2xi32> to memref<2x2xi32, #[[MAP0]]>
+//     CHECK: linalg.copy(%[[IN]], %[[SUB0]])
+//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][2, 0] [3, 2] [1, 1]  : memref<5x2xi32> to memref<3x2xi32, #[[MAP1]]>
+//     CHECK: linalg.fill(%[[SUB1]], %[[CST]])
 module {
   func @concatenate() {
     %c0 = constant 0 : index
     %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
-    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<3x2xi32>
+    %1 = constant dense<42> : tensor<3x2xi32>
     %2 = "mhlo.concatenate"(%0, %1) {
       dimension = 0
     } : (tensor<2x2xi32>, tensor<3x2xi32>) -> tensor<5x2xi32>
@@ -53,7 +51,6 @@ module {
   }
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
-    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
-    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
   }
 }

--- a/iree/test/e2e/xla_ops/concatenate.mlir
+++ b/iree/test/e2e/xla_ops/concatenate.mlir
@@ -16,3 +16,11 @@ func @xla_concatenate() attributes { iree.module.export } {
   check.expect_eq_const(%3, dense<[[1, 2], [3, 4], [11, 12], [13, 14]]> : tensor<4x2xi32>) : tensor<4x2xi32>
   return
 }
+
+func @concatenate_cst() attributes { iree.module.export } {
+  %c0 = iree.unfoldable_constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
+  %c1 = mhlo.constant dense<0> : tensor<2x3xi32>
+  %0 = "mhlo.concatenate"(%c0, %c1) {dimension = 1} : (tensor<2x2xi32>, tensor<2x3xi32>) -> tensor<2x5xi32>
+  check.expect_eq_const(%0, dense<[[1, 2, 0, 0, 0], [3, 4, 0, 0, 0]]> : tensor<2x5xi32>) : tensor<2x5xi32>
+  return
+}


### PR DESCRIPTION
This drops inefficient loops and can handle constants as input.