### PR TITLE
  Implement linalg.conv -> img2col packing + matmul rewrite

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -21,6 +21,7 @@ package(
 cc_library(
     name = "LinalgToLLVM",
     srcs = [
+        "ConvImg2ColMatmulConversion.cpp",
         "ConvertToLLVM.cpp",
         "MatMulVectorization.cpp",
         "Passes.cpp",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "ConvImg2ColMatmulConversion.cpp"
     "ConvertToLLVM.cpp"
     "MatMulVectorization.cpp"
     "Passes.cpp"

--- a/iree/compiler/Conversion/LinalgToLLVM/ConvImg2ColMatmulConversion.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvImg2ColMatmulConversion.cpp
@@ -1,0 +1,215 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+// clang-format off
+// 
+// Convert linalg.conv op into img2col packing operation (linalg.generic) +
+// linalg.matmul. See details below:
+// A convolution operaton can be written as a matrix-matrix multiplication by
+// unfolding the cross corrolation between input and filter and explcitiy copy
+// overlaped sliding window inputs.
+// Consider 2D input X with single channel input and output and 2x2 filter W:
+// [x(0, 0)  , x(0, 1)  , ...,   x(0, n)  ]
+// [x(1, 0)  , x(1, 1)  , ...,   x(1, n)  ]
+// [.        ,  .       ,.   ,      .     ]            [w(0, 0), w(0, 1)]
+// [.        ,  .       , .  ,      .     ]    (conv)  [w(1, 0), w(1, 1)]
+// [.        ,  .       ,   .,      .     ]
+// [x(n-1, 0), x(n-1, 1), ..., x(n-1, n-1)]
+// The packed input data (img2col) is a matrix with |rows| = output spatial
+// size, |columns| = filter spatial size. To compute the output Y(i, j) we need
+// to calculate the dot product between filter window at input X(x, y)) and the
+// filter which will look like the following where r.h.s is the img2col matrix and 
+// l.h.s is the flattned filter:
+// [x(0, 0), x(0, 1), x(1, 0), x(1, 1)] 
+// [x(0, 1), x(1, 1), x(0, 2), x(1, 2)] (matmul) [w(0, 0), w(0, 1), w(1, 0), w(1, 1)] 
+// [x(0, 1), x(1, 1), x(0, 2), x(1, 2)]
+// [   .   ,    .   ,    .   ,    .   ]
+// In general for 2D case with (N, H, W, C) input and (Kh, Kw, C, D) filter 
+// and output (N, Ho, Wo, D) the convolutin is the following matrix-matrix multiplication
+// (Ho x Wo, Kh x Kw x C) * (Kh x Kw x C, D) for each input in the N input.
+// For the case where N > 1 its a batched matrxi-matrix multplication.
+//
+// clang-format on
+class ConvImg2ColMatmulConversion : public OpRewritePattern<linalg::ConvOp> {
+ public:
+  using OpRewritePattern<linalg::ConvOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::ConvOp op,
+                                PatternRewriter &rewriter) const override {
+    auto filterShapeType = op.filter().getType().dyn_cast_or_null<ShapedType>();
+    auto inputShapeType = op.input().getType().dyn_cast_or_null<ShapedType>();
+    auto outputShapeType = op.output().getType().dyn_cast_or_null<ShapedType>();
+    if (!filterShapeType || !inputShapeType) return failure();
+    if (!filterShapeType.hasStaticShape() || !inputShapeType.hasStaticShape())
+      return failure();
+
+    // TODO(ataei): Support for batched version.
+    if (inputShapeType.getShape()[0] > 1) return failure();
+
+    auto loc = op.getLoc();
+
+    auto inputFeatures =
+        filterShapeType.getShape()[filterShapeType.getRank() - 1];
+    auto outputFeatures = filterShapeType.getShape().back();
+
+    // Col buffer shape (n, d1, d1, d2, ...dn, k1, k2, k3, ...kn, ci)
+    SmallVector<int64_t, 4> colBufferShape;
+    int64_t spatialSize = 1, filterSpatialSize = 1;
+    colBufferShape.push_back(outputShapeType.getShape()[0]);
+    for (int i = 0; i < op.getNumSpatialDimensions(); ++i) {
+      auto dimSize = outputShapeType.getShape()[i + op.getNumBatchDimensions()];
+      colBufferShape.push_back(dimSize);
+      spatialSize *= dimSize;
+    }
+    for (int i = 0; i < op.getNumSpatialDimensions(); ++i) {
+      auto dimSize = filterShapeType.getShape()[i];
+      colBufferShape.push_back(dimSize);
+      filterSpatialSize *= dimSize;
+    }
+    colBufferShape.push_back(
+        filterShapeType.getShape()[op.getNumSpatialDimensions()]);
+
+    auto ColBufferMemrefType =
+        MemRefType::get(colBufferShape, filterShapeType.getElementType());
+
+    Value result = rewriter.create<AllocaOp>(loc, ColBufferMemrefType);
+
+    llvm::SmallVector<Value, 4> linalgOpArgs = {op.input(), result};
+
+    // (n, d1, d2, d3, ..., dn, k1, k2, k3, ...kn, ci) ->
+    // (n, d_1 * stride_1 + k_1, d_2 * stride_2 + k_2, ...d_n * stride_n + k_n,
+    // ci)
+    SmallVector<AffineExpr, 4> inputExprs;
+    inputExprs.push_back(rewriter.getAffineDimExpr(0));
+    int spatialDimsOffset = 1;
+    auto kernelDimsOffset = spatialDimsOffset + op.getNumSpatialDimensions();
+    for (int i = 0; i < op.getNumSpatialDimensions(); ++i) {
+      inputExprs.push_back(rewriter.getAffineDimExpr(i + spatialDimsOffset) *
+                               op.getStride(i) +
+                           rewriter.getAffineDimExpr(i + kernelDimsOffset));
+    }
+    inputExprs.push_back(rewriter.getAffineDimExpr(
+        kernelDimsOffset + op.getNumSpatialDimensions()));
+
+    auto nloops = colBufferShape.size();
+
+    SmallVector<StringRef, 3> loopAttributeTypes(nloops, "parallel");
+
+    SmallVector<AffineMap, 4> indexingMaps;
+    indexingMaps.emplace_back(
+        AffineMap::get(nloops, 0, inputExprs, rewriter.getContext()));
+    indexingMaps.emplace_back(AffineMap::getMultiDimIdentityMap(
+        ColBufferMemrefType.getRank(), rewriter.getContext()));
+
+    rewriter.create<linalg::GenericOp>(
+        loc, ArrayRef<Type>{}, linalgOpArgs,
+        1,  // args_in
+        1,  // args_out
+        indexingMaps, loopAttributeTypes,
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+          nestedBuilder.create<linalg::YieldOp>(nestedLoc, args[0]);
+        });
+
+    auto getIndicesVector = [](int start, int end) {
+      SmallVector<int64_t, 2> indices;
+      for (int i = start; i <= end; ++i) {
+        indices.push_back(i);
+      }
+      return indices;
+    };
+
+    // n, d1, d2,....dn
+    auto batchAndSpatialIndices =
+        getIndicesVector(0, op.getNumSpatialDimensions());
+    auto featureIndices = getIndicesVector(op.getNumSpatialDimensions() + 1,
+                                           op.getNumSpatialDimensions() + 3);
+
+    SmallVector<linalg::ReassociationIndices, 4> lhsCollapsedDimsList = {
+        batchAndSpatialIndices, featureIndices};
+    SmallVector<linalg::ReassociationIndices, 4> rhsCollapsedDimsList = {
+        batchAndSpatialIndices, {op.getNumSpatialDimensions() + 1}};
+
+    SmallVector<linalg::ReassociationIndices, 4> resultCollapsedDimsList = {
+        batchAndSpatialIndices, {op.getNumSpatialDimensions() + 1}};
+
+    auto reshapedColBufferType =
+        MemRefType::get({spatialSize, filterSpatialSize * inputFeatures},
+                        filterShapeType.getElementType());
+
+    auto reshapedfilterType =
+        MemRefType::get({filterSpatialSize * inputFeatures, outputFeatures},
+                        filterShapeType.getElementType());
+
+    auto reshapedOutputType = MemRefType::get({spatialSize, outputFeatures},
+                                              filterShapeType.getElementType());
+
+    Value reshapedLhs = rewriter.create<linalg::ReshapeOp>(
+        loc, reshapedColBufferType, result, lhsCollapsedDimsList);
+
+    Value reshapedRhs = rewriter.create<linalg::ReshapeOp>(
+        loc, reshapedfilterType, op.filter(), rhsCollapsedDimsList);
+
+    Value reshapedResult = rewriter.create<linalg::ReshapeOp>(
+        loc, reshapedOutputType, op.output(), resultCollapsedDimsList);
+
+    rewriter.create<linalg::MatmulOp>(
+        loc, ArrayRef<Value>{reshapedLhs, reshapedRhs}, reshapedResult);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvImg2ColMatmulConversionPass
+    : PassWrapper<ConvImg2ColMatmulConversionPass, FunctionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+  void runOnFunction() override;
+};
+}  // namespace
+
+void populateConvImg2ColMatmulConversionPatterns(
+    MLIRContext *context, OwningRewritePatternList &patterns) {
+  patterns.insert<ConvImg2ColMatmulConversion>(context);
+}
+
+void ConvImg2ColMatmulConversionPass::runOnFunction() {
+  auto funcOp = getOperation();
+  auto context = funcOp.getContext();
+  OwningRewritePatternList patterns;
+  populateConvImg2ColMatmulConversionPatterns(context, patterns);
+  applyPatternsAndFoldGreedily(funcOp, patterns);
+}
+
+std::unique_ptr<FunctionPass> createConvImg2ColMatmulConversionPass() {
+  return std::make_unique<ConvImg2ColMatmulConversionPass>();
+}
+
+static PassRegistration<ConvImg2ColMatmulConversionPass> pass(
+    "iree-codegen-linalg-to-llvm-conv-img2col-conversion-pass",
+    "Convert linalg.conv on to img2col followd by linalg.matmul.",
+    [] { return std::make_unique<ConvImg2ColMatmulConversionPass>(); });
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -25,7 +25,18 @@
 namespace mlir {
 namespace iree_compiler {
 
+static llvm::cl::opt<bool> convImg2ColConversion(
+    "iree-codegen-linalg-to-llvm-conv-img2col-conversion",
+    llvm::cl::desc("Enable rewriting linalg.conv linalg.generic that does "
+                   "img2col buffer packing + "
+                   "linag.matmul"),
+    llvm::cl::init(false));
+
 void addLinalgToLLVMPasses(OpPassManager &passManager) {
+  // Linalg.ConvOp -> (Img2Col packing + matmul)
+  if (convImg2ColConversion) {
+    passManager.addPass(createConvImg2ColMatmulConversionPass());
+  }
   // Linalg -> Vectors Ops.
   passManager.addPass(createMatMulTileAndVectorizePass());
   // Linalg -> SCF

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -23,6 +23,15 @@ namespace iree_compiler {
 /// Converts linalg::MatmulOp into LLVM dialect
 std::unique_ptr<FunctionPass> createMatMulTileAndVectorizePass();
 
+/// Converts linalg::ConvOp into packed img2col operation followed by
+/// linalg::MatmulOp.
+std::unique_ptr<FunctionPass> createConvImg2ColMatmulConversionPass();
+
+/// Populates patterns to rewrite linalg::ConvOp into packed img2col operation
+/// followed by linalg::MatmulOp.
+void populateConvImg2ColMatmulConversionPatterns(
+    MLIRContext *context, OwningRewritePatternList &patterns);
+
 /// Pass to perform final conversion to LLVM dialect.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass();
 

--- a/iree/compiler/Conversion/LinalgToLLVM/test/conv_img2col.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/conv_img2col.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-opt -iree-codegen-convert-to-llvm -split-input-file --iree-codegen-linalg-to-llvm-conv-img2col-conversion-pass %s | IreeFileCheck %s
+
+func @conv_16433136(%arg0: memref<1x16x16x4xf32>, %arg1: memref<3x3x4x16xf32>, %arg2: memref<1x14x14x16xf32>) {
+    linalg.conv(%arg1, %arg0, %arg2)  : memref<3x3x4x16xf32>, memref<1x16x16x4xf32>, memref<1x14x14x16xf32>
+    return
+}
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1 + d3, d2 + d4, d5)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG: #[[MAP5:.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK: func @conv_16433136(%[[INPUT:.+]]: memref<1x16x16x4xf32>, %[[FILTER:.+]]: memref<3x3x4x16xf32>, %[[OUTPUT:.+]]: memref<1x14x14x16xf32>)
+// CHECK: %[[COLBUFFER:.+]] =   alloca() : memref<1x14x14x3x3x4xf32>
+// CHECK: linalg.generic {args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#[[MAP0]], #[[MAP1]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} %[[INPUT]], %[[COLBUFFER]]
+// CHECK: %[[X:.+]] = linalg.reshape %[[COLBUFFER]] [#[[MAP2]], #[[MAP3]]] : memref<1x14x14x3x3x4xf32> into memref<196x36xf32>
+// CHECK: %[[W:.+]] = linalg.reshape %[[FILTER]] [#[[MAP4]], #[[MAP5]]] : memref<3x3x4x16xf32> into memref<36x16xf32>
+// CHECK: %[[Y:.+]] = linalg.reshape %[[OUTPUT]] [#[[MAP4]], #[[MAP5]]] : memref<1x14x14x16xf32> into memref<196x16xf32>
+// CHECK: linalg.matmul ins(%[[X]], %[[W]] : memref<196x36xf32>, memref<36x16xf32>) outs(%[[Y]] : memref<196x16xf32>

--- a/iree/test/e2e/llvmir_specific/BUILD
+++ b/iree/test/e2e/llvmir_specific/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for end-to-end IREE support specific to the vulkan-spirv lowering.
+# TODO(ravishankarm): Reorganize these tests.
+
+load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_llvm-ir-conv_img2col",
+    srcs = [
+        "conv.mlir",
+    ],
+    compiler_flags = ["-iree-codegen-linalg-to-llvm-conv-img2col-conversion"],
+    driver = "llvm",
+    target_backend = "llvm-ir",
+)

--- a/iree/test/e2e/llvmir_specific/CMakeLists.txt
+++ b/iree/test/e2e/llvmir_specific/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_llvm-ir-conv_img2col
+  SRCS
+    "conv.mlir"
+  TARGET_BACKEND
+    llvm-ir
+  DRIVER
+    llvm
+  COMPILER_FLAGS
+    "-iree-codegen-linalg-to-llvm-conv-img2col-conversion"
+)

--- a/iree/test/e2e/llvmir_specific/conv.mlir
+++ b/iree/test/e2e/llvmir_specific/conv.mlir
@@ -1,0 +1,207 @@
+func @conv2d_nopadding() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[[
+      [[ 1.0,  2.0], [ 3.0,  4.0], [ 5.0,  6.0], [ 7.0,  8.0], [ 9.0, 10.0]],
+      [[11.0, 12.0], [13.0, 14.0], [15.0, 16.0], [17.0, 18.0], [19.0, 20.0]],
+      [[21.0, 22.0], [23.0, 24.0], [25.0, 26.0], [27.0, 28.0], [29.0, 30.0]],
+      [[31.0, 32.0], [33.0, 34.0], [35.0, 36.0], [37.0, 38.0], [39.0, 40.0]]]]> : tensor<1x4x5x2xf32>
+  %weights = iree.unfoldable_constant dense<[
+      [[[ 1.0], [ 2.0]], [[ 3.0], [ 4.0]]],
+      [[[ 5.0], [ 6.0]], [[ 7.0], [ 8.0]]],
+      [[[ 9.0], [10.0]], [[11.0], [12.0]]]]> : tensor<3x2x2x1xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+        batch_group_count = 1 : i64,
+        dimension_numbers = {
+          input_batch_dimension = 0 : i64,
+          input_feature_dimension = 3 : i64,
+          input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+          kernel_input_feature_dimension = 2 : i64,
+          kernel_output_feature_dimension = 3 : i64,
+          kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+          output_batch_dimension = 0 : i64,
+          output_feature_dimension = 3 : i64,
+          output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+        feature_group_count = 1 : i64,
+        rhs_dilation = dense<1> : tensor<2xi64>,
+        window_strides = dense<1> : tensor<2xi64>} : (tensor<1x4x5x2xf32>, tensor<3x2x2x1xf32>) -> tensor<1x2x3x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[
+      [[1310.0],[1466.0],[1622.0]],
+      [[2090.0],[2246.0],[2402.0]]
+  ]]> : tensor<1x2x3x1xf32>) : tensor<1x2x3x1xf32>
+  return
+}
+
+func @conv2d_1452x3221_same() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[[
+      [[ 1.0,  2.0], [ 3.0,  4.0], [ 5.0,  6.0], [ 7.0,  8.0], [ 9.0, 10.0]],
+      [[11.0, 12.0], [13.0, 14.0], [15.0, 16.0], [17.0, 18.0], [19.0, 20.0]],
+      [[21.0, 22.0], [23.0, 24.0], [25.0, 26.0], [27.0, 28.0], [29.0, 30.0]],
+      [[31.0, 32.0], [33.0, 34.0], [35.0, 36.0], [37.0, 38.0], [39.0, 40.0]]]]> : tensor<1x4x5x2xf32>
+  %weights = iree.unfoldable_constant dense<[
+      [[[ 1.0], [ 2.0]], [[ 3.0], [ 4.0]]],
+      [[[ 5.0], [ 6.0]], [[ 7.0], [ 8.0]]],
+      [[[ 9.0], [10.0]], [[11.0], [12.0]]]]> : tensor<3x2x2x1xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+       batch_group_count = 1 : i64,
+       dimension_numbers = {
+         input_batch_dimension = 0 : i64,
+         input_feature_dimension = 3 : i64,
+         input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+         kernel_input_feature_dimension = 2 : i64,
+         kernel_output_feature_dimension = 3 : i64,
+         kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+         output_batch_dimension = 0 : i64,
+         output_feature_dimension = 3 : i64,
+         output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+       feature_group_count = 1 : i64,
+       padding = dense<[[1, 1], [0, 1]]> : tensor<2x2xi64>,
+       rhs_dilation = dense<1> : tensor<2xi64>,
+       window_strides = dense<1> : tensor<2xi64>} :
+       (tensor<1x4x5x2xf32>, tensor<3x2x2x1xf32>) -> tensor<1x4x5x1xf32>
+  check.expect_almost_eq_const(%res,  dense<[[
+    [[ 600.0], [ 736.0], [ 872.0], [1008.0], [ 476.0]],
+    [[1310.0], [1466.0], [1622.0], [1778.0], [ 805.0]],
+    [[2090.0], [2246.0], [2402.0], [2558.0], [1135.0]],
+    [[1080.0], [1152.0], [1224.0], [1296.0], [ 524.0]]]]> : tensor<1x4x5x1xf32>) : tensor<1x4x5x1xf32>
+  return
+}
+
+func @conv2d_2451x2311_same() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[
+      [[[ 1.0], [ 2.0], [ 3.0], [ 4.0], [ 5.0]],
+       [[ 6.0], [ 7.0], [ 8.0], [ 9.0], [10.0]],
+       [[11.0], [12.0], [13.0], [14.0], [15.0]],
+       [[16.0], [17.0], [18.0], [19.0], [20.0]]],
+      [[[21.0], [22.0], [23.0], [24.0], [25.0]],
+       [[26.0], [27.0], [28.0], [29.0], [30.0]],
+       [[31.0], [32.0], [33.0], [34.0], [35.0]],
+       [[36.0], [37.0], [38.0], [39.0], [40.0]]]]> : tensor <2x4x5x1xf32>
+  %weights = iree.unfoldable_constant dense<[
+      [[[1.0]], [[2.0]], [[3.0]]],
+      [[[4.0]], [[5.0]], [[6.0]]]]> : tensor <2x3x1x1xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+       batch_group_count = 1 : i64,
+       dimension_numbers = {
+         input_batch_dimension = 0 : i64,
+         input_feature_dimension = 3 : i64,
+         input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+         kernel_input_feature_dimension = 2 : i64,
+         kernel_output_feature_dimension = 3 : i64,
+         kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+         output_batch_dimension = 0 : i64,
+         output_feature_dimension = 3 : i64,
+         output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+       feature_group_count = 1 : i64,
+       padding = dense<[[0, 1], [1, 1]]> : tensor<2x2xi64>,
+       rhs_dilation = dense<1> : tensor<2xi64>,
+       window_strides = dense<1> : tensor<2xi64>} :
+       (tensor<2x4x5x1xf32>, tensor<2x3x1x1xf32>) -> tensor<2x4x5x1xf32>
+  check.expect_almost_eq_const(%res, dense<[
+    [[[ 80.0], [121.0], [142.0], [163.0], [100.0]],
+     [[160.0], [226.0], [247.0], [268.0], [160.0]],
+     [[240.0], [331.0], [352.0], [373.0], [220.0]],
+     [[ 83.0], [104.0], [110.0], [116.0], [ 59.0]]],
+    [[[400.0], [541.0], [562.0], [583.0], [340.0]],
+     [[480.0], [646.0], [667.0], [688.0], [400.0]],
+     [[560.0], [751.0], [772.0], [793.0], [460.0]],
+     [[183.0], [224.0], [230.0], [236.0], [119.0]]]]> : tensor<2x4x5x1xf32>) : tensor<2x4x5x1xf32>
+  return
+}
+
+func @conv2d_no_padding2() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[
+       [[[  1.0,   2.0,   3.0],
+         [  4.0,   5.0,   6.0],
+         [  7.0,   8.0,   9.0],
+         [ 10.0,  11.0,  12.0],
+         [ 13.0,  14.0,  15.0]],
+        [[ 16.0,  17.0,  18.0],
+         [ 19.0,  20.0,  21.0],
+         [ 22.0,  23.0,  24.0],
+         [ 25.0,  26.0,  27.0],
+         [ 28.0,  29.0,  30.0]],
+        [[ 31.0,  32.0,  33.0],
+         [ 34.0,  35.0,  36.0],
+         [ 37.0,  38.0,  39.0],
+         [ 40.0,  41.0,  42.0],
+         [ 43.0,  44.0,  45.0]],
+        [[ 46.0,  47.0,  48.0],
+         [ 49.0,  50.0,  51.0],
+         [ 52.0,  53.0,  54.0],
+         [ 55.0,  56.0,  57.0],
+         [ 58.0,  59.0,  60.0]]],
+       [[[ 61.0,  62.0,  63.0],
+         [ 64.0,  65.0,  66.0],
+         [ 67.0,  68.0,  69.0],
+         [ 70.0,  71.0,  72.0],
+         [ 73.0,  74.0,  75.0]],
+        [[ 76.0,  77.0,  78.0],
+         [ 79.0,  80.0,  81.0],
+         [ 82.0,  83.0,  84.0],
+         [ 85.0,  86.0,  87.0],
+         [ 88.0,  89.0,  90.0]],
+        [[ 91.0,  92.0,  93.0],
+         [ 94.0,  95.0,  96.0],
+         [ 97.0,  98.0,  99.0],
+         [100.0, 101.0, 102.0],
+         [103.0, 104.0, 105.0]],
+        [[106.0, 107.0, 108.0],
+         [109.0, 110.0, 111.0],
+         [112.0, 113.0, 114.0],
+         [115.0, 116.0, 117.0],
+         [118.0, 119.0, 120.0]]]]> : tensor<2x4x5x3xf32>
+  %weights = iree.unfoldable_constant dense<[
+      [[[  1.0,   2.0,   3.0,   4.0,   5.0,   6.0],
+        [  7.0,   8.0,   9.0,  10.0,  11.0,  12.0],
+        [ 13.0,  14.0,  15.0,  16.0,  17.0,  18.0]],
+       [[ 19.0,  20.0,  21.0,  22.0,  23.0,  24.0],
+        [ 25.0,  26.0,  27.0,  28.0,  29.0,  30.0],
+        [ 31.0,  32.0,  33.0,  34.0,  35.0,  36.0]],
+       [[ 37.0,  38.0,  39.0,  40.0,  41.0,  42.0],
+        [ 43.0,  44.0,  45.0,  46.0,  47.0,  48.0],
+        [ 49.0,  50.0,  51.0,  52.0,  53.0,  54.0]]],
+      [[[ 55.0,  56.0,  57.0,  58.0,  59.0,  60.0],
+        [ 61.0,  62.0,  63.0,  64.0,  65.0,  66.0],
+        [ 67.0,  68.0,  69.0,  70.0,  71.0,  72.0]],
+       [[ 73.0,  74.0,  75.0,  76.0,  77.0,  78.0],
+        [ 79.0,  80.0,  81.0,  82.0,  83.0,  84.0],
+        [ 85.0,  86.0,  87.0,  88.0,  89.0,  90.0]],
+       [[ 91.0,  92.0,  93.0,  94.0,  95.0,  96.0],
+        [ 97.0,  98.0,  99.0, 100.0, 101.0, 102.0],
+        [103.0, 104.0, 105.0, 106.0, 107.0, 108.0]]]]> : tensor<2x3x3x6xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+       batch_group_count = 1 : i64,
+       dimension_numbers = {
+         input_batch_dimension = 0 : i64,
+         input_feature_dimension = 3 : i64,
+         input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+         kernel_input_feature_dimension = 2 : i64,
+         kernel_output_feature_dimension = 3 : i64,
+         kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+         output_batch_dimension = 0 : i64,
+         output_feature_dimension = 3 : i64,
+         output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+       feature_group_count = 1 : i64,
+       rhs_dilation = dense<1> : tensor<2xi64>,
+       window_strides = dense<1> : tensor<2xi64>} :
+       (tensor<2x4x5x3xf32>, tensor<2x3x3x6xf32>) -> tensor<2x3x3x6xf32>
+  check.expect_almost_eq_const(%res, dense<[
+      [[[16065.0,  16290.0,  16515.0,  16740.0,  16965.0,  17190.0],
+        [18873.0,  19152.0,  19431.0,  19710.0,  19989.0,  20268.0],
+        [21681.0,  22014.0,  22347.0,  22680.0,  23013.0,  23346.0]],
+       [[30105.0,  30600.0,  31095.0,  31590.0,  32085.0,  32580.0],
+        [32913.0,  33462.0,  34011.0,  34560.0,  35109.0,  35658.0],
+        [35721.0,  36324.0,  36927.0,  37530.0,  38133.0,  38736.0]],
+       [[44145.0,  44910.0,  45675.0,  46440.0,  47205.0,  47970.0],
+        [46953.0,  47772.0,  48591.0,  49410.0,  50229.0,  51048.0],
+        [49761.0,  50634.0,  51507.0,  52380.0,  53253.0,  54126.0]]],
+      [[[72225.0,  73530.0,  74835.0,  76140.0,  77445.0,  78750.0],
+        [75033.0,  76392.0,  77751.0,  79110.0,  80469.0,  81828.0],
+        [77841.0,  79254.0,  80667.0,  82080.0,  83493.0,  84906.0]],
+       [[86265.0,  87840.0,  89415.0,  90990.0,  92565.0,  94140.0],
+        [89073.0,  90702.0,  92331.0,  93960.0,  95589.0,  97218.0],
+        [91881.0,  93564.0,  95247.0,  96930.0,  98613.0, 100296.0]],
+       [[100305.0, 102150.0, 103995.0, 105840.0, 107685.0, 109530.0],
+        [103113.0, 105012.0, 106911.0, 108810.0, 110709.0, 112608.0],
+        [105921.0, 107874.0, 109827.0, 111780.0, 113733.0, 115686.0]]]]> : tensor<2x3x3x6xf32>) : tensor<2x3x3x6xf32>
+  return
+}


### PR DESCRIPTION
Rewrites `linalg.conv -> linalg.generic + linalg.matmul` the `linalg.generic` packs input data into a layout `column-buffer` where the output of the convolution is just a matrix-matrix multiplication between this buffer and reshaped filter.

This is expected/planned to work for LLVM/CPU backends for now using stacked allocated buffer but will be generalized for Vulkan in future iterations.

