### PR TITLE
Adds `TfLiteCompiledModule` and tests it in our integrations

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -298,9 +298,8 @@ class IreeCompiledModule(CompiledModule):
 
 
 def _normalize_numpy(result: np.ndarray):
-  """Normalizes TF/Lite's output to match IREE's"""
+  """Normalizes TF and TFLite's outputs to match IREE's"""
   if np.isscalar(result):
-    # convert_to_tensor isn't reversible via .numpy()
     result = np.array(result)
   if result.dtype == np.bool:
     # IREE interprets bools as int8s, so we modify this for comparison.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -378,8 +378,8 @@ class TfCompiledModule(CompiledModule):
     return False
 
 
-def get_added_function_names(cls):
-  """Gets all methods that cls has that its parent doesn't have."""
+def get_non_inhereted_function_names(cls):
+  """Gets all methods that cls has that its parents don't have."""
   names = set(dir(cls))
   for parent in cls.__bases__:
     names -= set(dir(parent))
@@ -391,7 +391,7 @@ def get_concrete_functions(module_class: Type[tf.Module],
   """Get concrete functions from non-inherited methods or exported_names."""
   if not len(exported_names):
     # Get all method names on 'module_class' that aren't on 'tf.Module'.
-    exported_names = get_added_function_names(module_class)
+    exported_names = get_non_inhereted_function_names(module_class)
   instance = module_class()
   functions = []
   for name in exported_names:

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -56,6 +56,24 @@ SPECIAL_CASES = [
     "linspace_test.py",
 ]
 
+TFLITE_FAILING = [
+    "broadcasting_test.py",
+    "complex_test.py",
+    "concat_test.py",
+    "dynamic_mlp_relu_test.py",
+    "dynamic_mlp_test.py",
+    "finite_test.py",
+    "gather_test.py",
+    "mandelbrot_test.py",
+    "matrix_ops_test.py",
+    "resource_ops_test.py",
+    "ring_buffer_test.py",
+    "scatter_update_test.py",
+    "simple_stateful_test.py",
+    "sliding_window_test.py",
+    "strings_test.py",
+]
+
 # keep sorted
 VMLA_FAILING = [
     "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
@@ -101,6 +119,11 @@ TF_PASSING = glob(
     exclude = SPECIAL_CASES,
 )
 
+TFLITE_PASSING = glob(
+    ["*_test.py"],
+    exclude = TFLITE_FAILING + SPECIAL_CASES,
+)
+
 VMLA_PASSING = glob(
     ["*_test.py"],
     exclude = VMLA_FAILING + SPECIAL_CASES,
@@ -120,6 +143,7 @@ iree_e2e_test_suite(
     name = "e2e_tests",
     backends_to_srcs = {
         "tf": TF_PASSING,
+        "tflite": TFLITE_PASSING,
         "iree_vmla": VMLA_PASSING,
         "iree_llvmjit": LLVM_PASSING,
         "iree_vulkan": VULKAN_PASSING,
@@ -133,6 +157,7 @@ iree_e2e_test_suite(
 iree_e2e_test_suite(
     name = "e2e_tests_failing",
     backends_to_srcs = {
+        "tflite": TFLITE_FAILING,
         "iree_vmla": VMLA_FAILING,
         "iree_llvmjit": LLVM_FAILING,
         "iree_vulkan": VULKAN_FAILING,

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -1,7 +1,7 @@
 # TensorFlow e2e tests
 
-This is a collection of e2e tests that save a TensorFlow model, compile it with
-IREE, run it on multiple backends and crosscheck the results.
+This is a collection of e2e tests that compile a TensorFlow model with IREE (and
+potentially TFLite), run it on multiple backends, and crosscheck the results.
 
 ## Pre-Requisites
 
@@ -28,9 +28,9 @@ adding `test --test_tag_filters="-driver=vulkan"` to your `user.bazelrc`.
 
 Compatible TensorFlow modules can be compiled to specific IREE backends using
 `IreeCompiledModule`. This also optionally saves compilation artifacts to a
-specified directory. These artifacts include: MLIR across various lowerings, a
-TensorFlow SavedModel, and the compiled VM FlatBuffer. A basic example of
-creating and calling an `IreeCompiledModule` can be found in
+specified directory. These artifacts include MLIR across various lowerings and
+the compiled VM FlatBuffer. A basic example of creating and calling an
+`IreeCompiledModule` can be found in
 [`tf_utils_test.py`](https://github.com/google/iree/blob/main/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py)
 
 When using Keras models or tf.Modules with functions that IREE can't compile,
@@ -44,9 +44,6 @@ vmla_module = tf_utils.IreeCompiledModule(
     exported_names=['predict'])
 vmla_module.predict(...)
 ```
-
-By default the TensorFlow SavedModels will not be kept. This can be overridden
-via the `--keep_saved_model` flag.
 
 ## Running Tests
 
@@ -161,16 +158,21 @@ for each module is as follows:
 /tmp/iree/modules/ModuleName
 ├── tf_input.mlir        # MLIR for ModuleName in TF's input dialect
 ├── iree_input.mlir      # tf_input.mlir translated to IREE MLIR
-├── backend_name_1       # e.g. iree_vmla, tf or tf_ref
+├── iree_backend_name    # e.g. iree_vmla, iree_llvmjit or iree_vulkan
 │   ├── compiled.vmfb    # flatbuffer of ModuleName compiled to this backend
-│   ├── saved_model      # Only created if --keep_saved_model is specified.
 │   └── traces
-│       ├── trace_1      # Directory storing logs and serialization for each trace.
+│       ├── trace_1      # Directory storing logs and serialization for each trace
 │       │   └── log.txt  # A more detailed version of the test logs
 │       └── trace_2
 │           └── log.txt
-└── backend_name_2
-    └── ...
+├── tflite               # If TFLite supports compiling ModuleName
+│   ├── method_1.tflite  # Methods on ModuleName compiled to bytes with TFLite
+│   ├── method_2.tflite
+│   └── traces
+│       └── ...
+└── tf_ref               # Directory storing the tensorflow reference traces
+    └── traces
+        └── ...
 ```
 
 Traces for a particular test can be loaded via the `Trace.load(trace_dir)`
@@ -228,9 +230,3 @@ which then allows reproducing the bug with an appropriate "opt" tool. Further
 debugging iteration can happen in opt.
 
 TODO(silvasean): debugging miscompiles
-
-## Test Harnesses
-
-### Simple function tests
-
-See `simple_arithmetic_test.py` for some basic examples.

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -83,6 +83,10 @@ SPECIAL_CASES = [
     "vision_model_test.py",
 ]
 
+TFLITE_FAILING = [
+    "lstm_test.py",
+]
+
 VMLA_FAILING = [
     "lstm_test.py",
 ]
@@ -101,6 +105,11 @@ VULKAN_FAILING = [
 TF_PASSING = glob(
     ["*_test.py"],
     exclude = SPECIAL_CASES,
+)
+
+TFLITE_PASSING = glob(
+    ["*_test.py"],
+    exclude = TFLITE_FAILING + SPECIAL_CASES,
 )
 
 VMLA_PASSING = glob(
@@ -122,6 +131,7 @@ iree_e2e_test_suite(
     name = "keras_tests",
     backends_to_srcs = {
         "tf": TF_PASSING,
+        "tflite": TFLITE_PASSING,
         "iree_vmla": VMLA_PASSING,
         "iree_llvmjit": LLVM_PASSING,
         "iree_vulkan": VULKAN_PASSING,
@@ -135,6 +145,7 @@ iree_e2e_test_suite(
 iree_e2e_test_suite(
     name = "keras_tests_failing",
     backends_to_srcs = {
+        "tflite": TFLITE_FAILING,
         "iree_vmla": VMLA_FAILING,
         "iree_llvmjit": LLVM_FAILING,
         "iree_vulkan": VULKAN_FAILING,
@@ -154,6 +165,7 @@ iree_vision_test_suite(
     name = "vision_internal_tests",
     backends = [
         "tf",
+        "tflite",
         "iree_vmla",
         "iree_llvmjit",
         "iree_vulkan",
@@ -171,6 +183,7 @@ iree_vision_test_suite(
     name = "vision_external_tests",
     backends = [
         "tf",
+        "tflite",
         "iree_vmla",
         "iree_llvmjit",
         "iree_vulkan",

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -28,7 +28,7 @@ REFERENCE_BACKEND = 'tf'
 # iree_vulkan backends.
 BACKENDS_TO_TITLES = collections.OrderedDict([
     ('tf', 'tensorflow'),
-    ('tflite', 'tf-lite'),
+    ('tflite', 'tflite'),
     ('iree_vmla', 'vmla'),
     ('iree_llvmjit', 'llvm-ir'),
     ('iree_vulkan', 'vulkan-spirv'),

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -28,6 +28,7 @@ REFERENCE_BACKEND = 'tf'
 # iree_vulkan backends.
 BACKENDS_TO_TITLES = collections.OrderedDict([
     ('tf', 'tensorflow'),
+    ('tflite', 'tf-lite'),
     ('iree_vmla', 'vmla'),
     ('iree_llvmjit', 'llvm-ir'),
     ('iree_vulkan', 'vulkan-spirv'),


### PR DESCRIPTION
This makes it very easy to benchmark IREE against TFLite, which will be elaborated in a future documentation update.

Our integrations tests no longer directly export `SavedModel`s, as the artifacts we need for benchmarking `TFLite` are saved under `/tmp/iree/modules/ModuleName/tflite/*.tflite`.

I also tested that `update_e2e_coverage.py` works with the added backend.