### PR TITLE
Fix `TfCompiledModule` reinitialization and test random initialization

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -286,6 +286,8 @@ class IreeCompiledModule(CompiledModule):
 
   def reinitialize(self):
     """Reinitializes to the initial state of the passed module_class."""
+    # set_random_seed is not needed here because the model_class.__init__ is not
+    # called.
     self._context = rt.SystemContext(
         modules=[self._module], config=self._config)
 
@@ -358,11 +360,11 @@ class TfCompiledModule(CompiledModule):
         effect for this subclass as nothing is compiled.
     """
     super().__init__(module_class, backend_info, exported_names, artifacts_dir)
-    set_random_seed()
     self.reinitialize()
 
   def reinitialize(self):
     """Reinitializes to the initial state of the passed module_class."""
+    set_random_seed()
     self._tf_module = self._module_class()
 
   def __getattr__(self, attr: str) -> _TfFunctionWrapper:

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -44,6 +44,15 @@ class StatefulCountingModule(tf.Module):
   def get_count(self):
     return self.count
 
+class RandomInitModule(tf.Module):
+
+  def __init__(self):
+    self.value = tf.Variable(tf.random.uniform([1]))
+
+  @tf.function(input_signature=[])
+  def get(self):
+    return self.value
+
 
 class UtilsTests(tf.test.TestCase, parameterized.TestCase):
 
@@ -111,6 +120,30 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     self.assertEqual('2xi32=1 2', tf_utils.save_input_values(inputs))
     inputs = [np.array([1, 2], dtype=np.float32)]
     self.assertEqual('2xf32=1.0 2.0', tf_utils.save_input_values(inputs))
+
+
+  @parameterized.named_parameters([
+      {
+          'testcase_name': 'tensorflow',
+          'backend_name': 'tf',
+      },
+      {
+          'testcase_name': 'vmla',
+          'backend_name': 'iree_vmla',
+      },
+  ])
+  def test_random_initialization(self, backend_name):
+    backend_info = tf_utils.BackendInfo(backend_name)
+
+    # Test compilation is the same.
+    module_1 = backend_info.compile(RandomInitModule)
+    module_2 = backend_info.compile(RandomInitModule)
+    self.assertAllEqual(module_1.get(), module_2.get())
+
+    # Test reinitialization is the same.
+    old_value = module_1.get()
+    module_1.reinitialize()
+    self.assertAllEqual(old_value, module_1.get())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I wrote the `RandomInitModule` with a `get()` function so that we can hopefully also use it to test TFLite.