### PR TITLE
Switch flow.dispatch ops to use nested references to entry points.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -570,22 +570,11 @@ static void printDispatchEntryOp(OpAsmPrinter &p, DispatchEntryOp op) {
 
 static ParseResult parseDispatchOp(OpAsmParser &parser,
                                    OperationState *result) {
-  auto executableLoc = parser.getNameLoc();
-
-  // TODO(benvanik): replace with SymbolRefAttr.
-  StringAttr executableAttr;
-  StringAttr entryPointAttr;
-  if (failed(parser.parseSymbolName(executableAttr, "executable",
-                                    result->attributes)) ||
-      failed(parser.parseColon()) || failed(parser.parseColon()) ||
-      failed(parser.parseSymbolName(entryPointAttr, "entry_point",
-                                    result->attributes))) {
+  SymbolRefAttr entryPointAttr;
+  if (failed(parser.parseAttribute(entryPointAttr, "entry_point",
+                                   result->attributes))) {
     return failure();
   }
-  result->attributes.set("entry_point", parser.getBuilder().getSymbolRefAttr(
-                                            entryPointAttr.getValue()));
-  result->attributes.set("executable", parser.getBuilder().getSymbolRefAttr(
-                                           executableAttr.getValue()));
 
   OpAsmParser::OperandType workloadArg;
   Type workloadArgType;
@@ -607,7 +596,7 @@ static ParseResult parseDispatchOp(OpAsmParser &parser,
       failed(
           parser.addTypesToList(entryPointType.getResults(), result->types)) ||
       failed(parser.resolveOperands(operands, entryPointType.getInputs(),
-                                    executableLoc, result->operands))) {
+                                    parser.getNameLoc(), result->operands))) {
     return failure();
   }
   return success();
@@ -615,10 +604,7 @@ static ParseResult parseDispatchOp(OpAsmParser &parser,
 
 static void printDispatchOp(OpAsmPrinter &p, DispatchOp op) {
   p << op.getOperationName() << ' ';
-  // TODO(benvanik): replace with SymbolRefAttr.
-  p.printSymbolName(op.executable());
-  p << "::";
-  p.printSymbolName(op.entry_point());
+  p.printAttributeWithoutType(op.entry_point());
   p << "[";
   p.printOperand(op.workload());
   p << " : ";
@@ -626,13 +612,29 @@ static void printDispatchOp(OpAsmPrinter &p, DispatchOp op) {
   p << "](";
   p.printOperands(op.operands());
   p << ')';
-  p.printOptionalAttrDict(op.getAttrs(), /*elidedAttrs=*/{
-                              "executable",
-                              "entry_point",
-                          });
+  p.printOptionalAttrDict(op.getAttrs(), /*elidedAttrs=*/{"entry_point"});
   p << " : ";
   p.printType(op.getEntryPointType());
 }
+
+void DispatchOp::build(OpBuilder &builder, OperationState &state,
+                       DispatchEntryOp entryPoint, Value workload,
+                       ArrayRef<Type> results, ValueRange operands) {
+  state.addOperands({workload});
+  state.addOperands(operands);
+  // Construct Executable::Entry nested reference.
+  StringRef executableOpSymName =
+      entryPoint.getParentOp()
+          ->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
+  state.addAttribute(
+      "entry_point",
+      builder.getSymbolRefAttr(executableOpSymName,
+                               {builder.getSymbolRefAttr(entryPoint)}));
+  state.addTypes(results);
+}
+
+StringRef DispatchOp::executable() { return entry_point().getRootReference(); }
 
 FunctionType DispatchOp::getEntryPointType() {
   SmallVector<Type, 8> argTypes(operand_type_range{operands()});

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -346,10 +346,7 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   }];
 
   let arguments = (ins
-    // TODO(benvanik): replace with SymbolRefAttr.
-    // TODO(benvanik): validate target is an executable.
-    FlatSymbolRefAttr:$executable,
-    FlatSymbolRefAttr:$entry_point,
+    SymbolRefAttr:$entry_point,
     FLOW_Workload:$workload,
     Variadic<AnyType>:$operands
   );
@@ -360,19 +357,13 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<[{
-      OpBuilder &builder, OperationState &result, StringRef executable,
-      StringRef entryPoint, Value workload,
-      ArrayRef<Type> results, ValueRange operands = {}
-    }], [{
-      result.addOperands({workload});
-      result.addOperands(operands);
-      result.addAttribute("executable", builder.getSymbolRefAttr(executable));
-      result.addAttribute("entry_point", builder.getSymbolRefAttr(entryPoint));
-      result.addTypes(results);
+      OpBuilder &builder, OperationState &result, DispatchEntryOp entryPoint,
+      Value workload, ArrayRef<Type> results, ValueRange operands = {}
     }]>,
   ];
 
   let extraClassDeclaration = [{
+    StringRef executable();
     FunctionType getEntryPointType();
 
     // StreamableOpInterface:

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -77,8 +77,8 @@ LogicalResult convertToDispatchOp(DispatchRegionOp regionOp,
 
   // Create the dispatch op to the executable function.
   auto dispatchOp = builder.create<DispatchOp>(
-      regionOp.getLoc(), executableOp.getName(), entryPointOp.getName(),
-      regionOp.workload(), outlinedFuncOp.getType().getResults(), newArgs);
+      regionOp.getLoc(), entryPointOp, regionOp.workload(),
+      outlinedFuncOp.getType().getResults(), newArgs);
 
   if (traceDispatchTensors) {
     builder.create<TensorTraceOp>(regionOp.getLoc(),


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/1890 (except for Vulkan-SPIRV backend still using ordinal HAL dispatch ops due to how it splits dispatch ops)