### PR TITLE
Split `matrix_ops_test` into static and dynamic tests

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -65,7 +65,7 @@ TFLITE_FAILING = [
     "finite_test.py",
     "gather_test.py",
     "mandelbrot_test.py",
-    "matrix_ops_test.py",
+    "matrix_ops_dynamic_test.py",
     "resource_ops_test.py",
     "ring_buffer_test.py",
     "scatter_update_test.py",
@@ -90,7 +90,7 @@ LLVM_FAILING = [
     "fill_test.py",  # TODO(jennik): Get this test working on IREE.
     "finite_test.py",
     "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
-    "matrix_ops_test.py",
+    "matrix_ops_dynamic_test.py",
     "range_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
@@ -107,7 +107,7 @@ VULKAN_FAILING = [
     "fill_test.py",  # TODO(jennik): Get this test working on IREE.
     "finite_test.py",
     "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
-    "matrix_ops_test.py",
+    "matrix_ops_dynamic_test.py",
     "range_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",

--- a/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
@@ -1,0 +1,93 @@
+# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test matrix ops."""
+
+from pyiree.tf.support import tf_test_utils
+from pyiree.tf.support import tf_utils
+import tensorflow.compat.v2 as tf
+
+
+class MatrixOpsDynamicModule(tf.Module):
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([None, None, 4, 2], tf.float32),
+      tf.TensorSpec([None, None, 2, 4], tf.float32),
+  ])
+  def matmul_high_rank_batch(self, lhs, rhs):
+    return tf.matmul(lhs, rhs)
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([None, None, None], tf.float32),
+      tf.TensorSpec([None, None, None], tf.float32),
+  ])
+  def matmul_dynamic(self, lhs, rhs):
+    return tf.matmul(lhs, rhs)
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([None, None, None], tf.float32),
+      tf.TensorSpec([None, None], tf.float32),
+  ])
+  def matmul_dynamic_lhs_batch(self, lhs, rhs):
+    return tf.matmul(lhs, rhs)
+
+
+@tf_test_utils.compile_module(MatrixOpsDynamicModule)
+class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
+
+  def test_matmul_high_rank_batch(self):
+
+    def matmul_high_rank_batch(module):
+      module.matmul_high_rank_batch(
+          tf_utils.uniform([1, 7, 4, 2]), tf_utils.uniform([7, 1, 2, 4]))
+
+    self.compare_backends(matmul_high_rank_batch)
+
+  def test_matmul_dynamic_matching_batch(self):
+
+    def matmul_dynamic_matching_batch(module):
+      module.matmul_dynamic(
+          tf_utils.uniform([2, 2, 3]), tf_utils.uniform([2, 3, 4]))
+
+    self.compare_backends(matmul_dynamic_matching_batch)
+
+  def test_matmul_dynamic_broadcast_lhs(self):
+
+    def matmul_dynamic_broadcast_lhs(module):
+      module.matmul_dynamic(
+          tf_utils.uniform([1, 2, 3]), tf_utils.uniform([2, 3, 4]))
+
+    self.compare_backends(matmul_dynamic_broadcast_lhs)
+
+  def test_matmul_dynamic_broadcast_rhs(self):
+
+    def matmul_dynamic_broadcast_rhs(module):
+      module.matmul_dynamic(
+          tf_utils.uniform([2, 2, 3]), tf_utils.uniform([1, 3, 4]))
+
+    self.compare_backends(matmul_dynamic_broadcast_rhs)
+
+  def test_matmul_dynamic_rank_broadcasting(self):
+
+    def matmul_dynamic_rank_broadcasting(module):
+      module.matmul_dynamic_lhs_batch(
+          tf_utils.uniform([7, 2, 3]), tf_utils.uniform([3, 4]))
+
+    self.compare_backends(matmul_dynamic_rank_broadcasting)
+
+
+if __name__ == "__main__":
+  if hasattr(tf, "enable_v2_behavior"):
+    tf.enable_v2_behavior()
+  tf.test.main()

--- a/integrations/tensorflow/e2e/matrix_ops_static_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_static_test.py
@@ -19,7 +19,7 @@ from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
 
 
-class MatrixOpsModule(tf.Module):
+class MatrixOpsStaticModule(tf.Module):
 
   @tf.function(input_signature=[
       tf.TensorSpec([4, 2], tf.float32),
@@ -49,30 +49,9 @@ class MatrixOpsModule(tf.Module):
   def matmul_broadcast_singleton_dimension(self, lhs, rhs):
     return tf.matmul(lhs, rhs)
 
-  @tf.function(input_signature=[
-      tf.TensorSpec([None, None, 4, 2], tf.float32),
-      tf.TensorSpec([None, None, 2, 4], tf.float32),
-  ])
-  def matmul_high_rank_batch(self, lhs, rhs):
-    return tf.matmul(lhs, rhs)
 
-  @tf.function(input_signature=[
-      tf.TensorSpec([None, None, None], tf.float32),
-      tf.TensorSpec([None, None, None], tf.float32),
-  ])
-  def matmul_dynamic(self, lhs, rhs):
-    return tf.matmul(lhs, rhs)
-
-  @tf.function(input_signature=[
-      tf.TensorSpec([None, None, None], tf.float32),
-      tf.TensorSpec([None, None], tf.float32),
-  ])
-  def matmul_dynamic_lhs_batch(self, lhs, rhs):
-    return tf.matmul(lhs, rhs)
-
-
-@tf_test_utils.compile_module(MatrixOpsModule)
-class MatrixOpsTest(tf_test_utils.TracedModuleTestCase):
+@tf_test_utils.compile_module(MatrixOpsStaticModule)
+class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
 
   def test_basic_matmul(self):
 
@@ -104,46 +83,6 @@ class MatrixOpsTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([1, 4, 2]), tf_utils.uniform([3, 2, 4]))
 
     self.compare_backends(matmul_broadcast_singleton_dimension)
-
-  def test_matmul_high_rank_batch(self):
-
-    def matmul_high_rank_batch(module):
-      module.matmul_high_rank_batch(
-          tf_utils.uniform([1, 7, 4, 2]), tf_utils.uniform([7, 1, 2, 4]))
-
-    self.compare_backends(matmul_high_rank_batch)
-
-  def test_matmul_dynamic_matching_batch(self):
-
-    def matmul_dynamic_matching_batch(module):
-      module.matmul_dynamic(
-          tf_utils.uniform([2, 2, 3]), tf_utils.uniform([2, 3, 4]))
-
-    self.compare_backends(matmul_dynamic_matching_batch)
-
-  def test_matmul_dynamic_broadcast_lhs(self):
-
-    def matmul_dynamic_broadcast_lhs(module):
-      module.matmul_dynamic(
-          tf_utils.uniform([1, 2, 3]), tf_utils.uniform([2, 3, 4]))
-
-    self.compare_backends(matmul_dynamic_broadcast_lhs)
-
-  def test_matmul_dynamic_broadcast_rhs(self):
-
-    def matmul_dynamic_broadcast_rhs(module):
-      module.matmul_dynamic(
-          tf_utils.uniform([2, 2, 3]), tf_utils.uniform([1, 3, 4]))
-
-    self.compare_backends(matmul_dynamic_broadcast_rhs)
-
-  def test_matmul_dynamic_rank_broadcasting(self):
-
-    def matmul_dynamic_rank_broadcasting(module):
-      module.matmul_dynamic_lhs_batch(
-          tf_utils.uniform([7, 2, 3]), tf_utils.uniform([3, 4]))
-
-    self.compare_backends(matmul_dynamic_rank_broadcasting)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows us to generate static matrix multiplication benchmarking artifacts for TFLite, LLVM JIT and Vulkan.