### PR TITLE
Add file pointing to correct tflite-graph for benchmarking

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -191,7 +191,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       trace_function_dir = tf_test_utils._get_trace_dir(artifacts_dir, trace)
       trace.serialize(trace_function_dir)
       self.assertTrue(
-          os.path.exists(os.path.join(trace_function_dir, 'flagfile')))
+          os.path.exists(os.path.join(trace_function_dir, 'metadata.pkl')))
       loaded_trace = tf_test_utils.Trace.load(trace_function_dir)
 
       # Check all calls match.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -406,11 +406,11 @@ def compile_to_tflite(module_class: Type[tf.Module],
   """Compile a dict of TFLite interpreters for the methods on module_class."""
   functions, names = get_concrete_functions(module_class, exported_names)
   interpreters = dict()
-  compiled_paths = dict()
+  compiled_paths = None
+  if artifacts_dir is not None:
+    compiled_paths = dict()
 
-  def _interpret_bytes(tflite_module: bytes,
-                       base_dir: str,
-                       update_paths: bool = False):
+  def _interpret_bytes(tflite_module: bytes, base_dir: str):
     """Save compiled TFLite module bytes and convert into an interpreter."""
     tflite_dir = os.path.join(base_dir, "tflite")
     os.makedirs(tflite_dir, exist_ok=True)
@@ -419,7 +419,7 @@ def compile_to_tflite(module_class: Type[tf.Module],
       f.write(tflite_module)
 
     interpreters[name] = tf.lite.Interpreter(tflite_path)
-    if update_paths:
+    if artifacts_dir is not None:
       compiled_paths[name] = tflite_path
 
   for name, function in zip(names, functions):
@@ -430,7 +430,7 @@ def compile_to_tflite(module_class: Type[tf.Module],
       with tempfile.TemporaryDirectory() as base_dir:
         _interpret_bytes(tflite_module, base_dir)
     else:
-      _interpret_bytes(tflite_module, artifacts_dir, update_paths=True)
+      _interpret_bytes(tflite_module, artifacts_dir)
 
   return interpreters, compiled_paths
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -292,6 +292,9 @@ class IreeCompiledModule(CompiledModule):
     if compiled_path is not None:
       if not len(exported_names):
         # Get all method names on 'module_class' that aren't on 'tf.Module'.
+        # This doesn't address all possbile scenarios.
+        # TODO(meadowlark): Figure out how to get a list of all of the functions
+        # that this module has access to via `pyiree.rt.system_api.BoundModule`.
         exported_names = _get_non_inhereted_function_names(module_class)
       self.compiled_paths = dict([
           (method, compiled_path) for method in exported_names


### PR DESCRIPTION
Adds a file `graph_path` to our `TfLiteCompiledModule` `Trace` serialization. This allows us to specify which TFLite-compiled module method the TFLite benchmark module should use when benchmarking a given trace.
```
/tmp/iree/modules/ModuleName
    └── tflite
        ├── forward_pass.tflite
        └── traces
            └── predict
                └── graph_path  # points to `/tmp/iree/modules/ModuleName/tflite/forward_pass.tflite`
```

The graph can be passed to `benchmark_model` like follows:
```shell
./third_party/tensorflow/bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model -- \
  --graph="$(cat /tmp/iree/modules/ResNet50/cifar10/tflite/traces/predict/graph_path)"
```

Unfortunately we the use of `cat` here because `benchmark_module` does not support flagfiles.