### PR TITLE
Tag OSS-failing 'nokokoro' targets as 'manual'

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -128,6 +128,7 @@ iree_py_test(
     srcs = ["signature_def_saved_model_test.py"],
     python_version = "PY3",
     tags = [
+        "manual",
         "nokokoro",
     ],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -186,6 +186,7 @@ iree_e2e_test_suite(
     },
     reference_backend = "tf",
     tags = [
+        "manual",
         "nokokoro",
     ],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [


### PR DESCRIPTION
Allows running `bazel test integrations/...` in OSS without test failures.