### PR TITLE
Fix help output for iree-benchmark-module

### DIFF
--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -40,6 +40,8 @@ iree_cc_binary(
     deps = [
         ":vm_util",
         "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/flags:usage",
         "@com_google_absl//absl/strings",
         "@com_google_benchmark//:benchmark",
         "//iree/base:init",

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -59,6 +59,8 @@ iree_cc_binary(
   DEPS
     ::vm_util
     absl::flags
+    absl::flags_parse
+    absl::flags_usage
     absl::strings
     benchmark
     iree::base::init

--- a/iree/tools/test/BUILD
+++ b/iree/tools/test/BUILD
@@ -34,3 +34,13 @@ iree_lit_test_suite(
     ],
     tags = ["hostonly"],
 )
+
+iree_lit_test_suite(
+    name = "flag_parse",
+    srcs = glob(["*.txt"]),
+    data = [
+        "//iree/tools:IreeFileCheck",
+        "//iree/tools:iree-benchmark-module",
+    ],
+    tags = ["hostonly"],
+)

--- a/iree/tools/test/BUILD
+++ b/iree/tools/test/BUILD
@@ -36,8 +36,8 @@ iree_lit_test_suite(
 )
 
 iree_lit_test_suite(
-    name = "flag_parse",
-    srcs = glob(["*.txt"]),
+    name = "benchmark_flags",
+    srcs = ["benchmark_flags.txt"],
     data = [
         "//iree/tools:IreeFileCheck",
         "//iree/tools:iree-benchmark-module",

--- a/iree/tools/test/CMakeLists.txt
+++ b/iree/tools/test/CMakeLists.txt
@@ -29,3 +29,16 @@ iree_lit_test_suite(
   LABELS
     "hostonly"
 )
+
+file(GLOB _GLOB_X_TXT LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.txt)
+iree_lit_test_suite(
+  NAME
+    flag_parse
+  SRCS
+    "${_GLOB_X_TXT}"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-benchmark-module
+  LABELS
+    "hostonly"
+)

--- a/iree/tools/test/CMakeLists.txt
+++ b/iree/tools/test/CMakeLists.txt
@@ -30,12 +30,11 @@ iree_lit_test_suite(
     "hostonly"
 )
 
-file(GLOB _GLOB_X_TXT LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.txt)
 iree_lit_test_suite(
   NAME
-    flag_parse
+    benchmark_flags
   SRCS
-    "${_GLOB_X_TXT}"
+    "benchmark_flags.txt"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-benchmark-module

--- a/iree/tools/test/benchmark_flags.txt
+++ b/iree/tools/test/benchmark_flags.txt
@@ -1,0 +1,12 @@
+// HELP: iree-benchmark-module
+// HELP: --input_file
+// HELP: --benchmark_list_tests
+// RUN: ( iree-benchmark-module --help || [[ $? == 1 ]] )  | IreeFileCheck --check-prefix=HELP %s
+// RUN: ( iree-benchmark-module --helpshort || [[ $? == 1 ]] ) | IreeFileCheck --check-prefix=HELP %s
+
+// UNKNOWN: unknown-flag
+// RUN: ( iree-benchmark-module --unknown-flag 2>&1 || [[ $? == 1 ]] ) | IreeFileCheck --check-prefix=UNKNOWN %s
+// RUN: ( iree-benchmark-module --driver=vmla --unknown-flag --benchmark_list_tests 2>&1 || [[ $? == 1 ]] ) | IreeFileCheck --check-prefix=UNKNOWN %s
+
+// LIST-BENCHMARKS: BM_some_function
+// RUN: iree-benchmark-module --benchmark_list_tests --entry_function=some_function | IreeFileCheck --check-prefix=LIST-BENCHMARKS %s


### PR DESCRIPTION
Benchmark and Absl fight. Right now, benchmark eats the `--help` flag
and so we lose all the help information for iree-benchmark-module.

This is not elegant, but it works and includes tests. A number of better
options are not available because both Absl and Benchmark bake behavior
into the only functions callable through their public API.

Fixes https://github.com/google/iree/issues/3247
