### PR TITLE
Fix linalg::GenericOp constructor in img2col converter pattern

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/ConvImg2ColMatmulConversion.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvImg2ColMatmulConversion.cpp
@@ -95,8 +95,6 @@ class ConvImg2ColMatmulConversion : public OpRewritePattern<linalg::ConvOp> {
 
     Value result = rewriter.create<AllocaOp>(loc, ColBufferMemrefType);
 
-    llvm::SmallVector<Value, 4> linalgOpArgs = {op.input(), result};
-
     // (n, d1, d2, d3, ..., dn, k1, k2, k3, ...kn, ci) ->
     // (n, d_1 * stride_1 + k_1, d_2 * stride_2 + k_2, ...d_n * stride_n + k_n,
     // ci)
@@ -123,10 +121,9 @@ class ConvImg2ColMatmulConversion : public OpRewritePattern<linalg::ConvOp> {
         ColBufferMemrefType.getRank(), rewriter.getContext()));
 
     rewriter.create<linalg::GenericOp>(
-        loc, ArrayRef<Type>{}, linalgOpArgs,
-        1,  // args_in
-        1,  // args_out
-        indexingMaps, loopAttributeTypes,
+        loc, /*resultTensorTypes=*/ArrayRef<Type>{},
+        /*inputs=*/op.input(), /*outputs=*/result,
+        /*intTensors*/ ValueRange{}, indexingMaps, loopAttributeTypes,
         [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
           nestedBuilder.create<linalg::YieldOp>(nestedLoc, args[0]);
         });

--- a/iree/compiler/Conversion/LinalgToLLVM/test/conv_img2col.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/conv_img2col.mlir
@@ -12,7 +12,7 @@ func @conv_16433136(%arg0: memref<1x16x16x4xf32>, %arg1: memref<3x3x4x16xf32>, %
 // CHECK-DAG: #[[MAP5:.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
 // CHECK: func @conv_16433136(%[[INPUT:.+]]: memref<1x16x16x4xf32>, %[[FILTER:.+]]: memref<3x3x4x16xf32>, %[[OUTPUT:.+]]: memref<1x14x14x16xf32>)
 // CHECK: %[[COLBUFFER:.+]] =   alloca() : memref<1x14x14x3x3x4xf32>
-// CHECK: linalg.generic {args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#[[MAP0]], #[[MAP1]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} %[[INPUT]], %[[COLBUFFER]]
+// CHECK: linalg.generic {indexing_maps = [#[[MAP0]], #[[MAP1]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%[[INPUT]] : memref<1x16x16x4xf32>) outs(%[[COLBUFFER]] :  memref<1x14x14x3x3x4xf32>)
 // CHECK: %[[X:.+]] = linalg.reshape %[[COLBUFFER]] [#[[MAP2]], #[[MAP3]]] : memref<1x14x14x3x3x4xf32> into memref<196x36xf32>
 // CHECK: %[[W:.+]] = linalg.reshape %[[FILTER]] [#[[MAP4]], #[[MAP5]]] : memref<3x3x4x16xf32> into memref<36x16xf32>
 // CHECK: %[[Y:.+]] = linalg.reshape %[[OUTPUT]] [#[[MAP4]], #[[MAP5]]] : memref<1x14x14x16xf32> into memref<196x16xf32>


### PR DESCRIPTION
This fixes build break caused by #3216. 