### PR TITLE
Remove `tf.keras.set_learning_phase` before it's deprecated

### DIFF
--- a/colab/resnet.ipynb
+++ b/colab/resnet.ipynb
@@ -112,8 +112,6 @@
       "source": [
         "#@title Construct a pretrained ResNet model with ImageNet weights\n",
         "\n",
-        "tf.keras.backend.set_learning_phase(False)\n",
-        "\n",
         "# Static shape, including batch size (1).\n",
         "# Can be dynamic once dynamic shape support is ready.\n",
         "INPUT_SHAPE = [1, 224, 224, 3]\n",
@@ -127,8 +125,9 @@
         "  def __init__(self):\n",
         "    super(ResNetModule, self).__init__()\n",
         "    self.m = tf_model\n",
+        "    self.m.predict = lambda x: self.m.call(x, training=False)\n",
         "    self.predict = tf.function(\n",
-        "        input_signature=[tf.TensorSpec(INPUT_SHAPE, tf.float32)])(tf_model.call)"
+        "        input_signature=[tf.TensorSpec(INPUT_SHAPE, tf.float32)])(tf_model.predict)"
       ]
     },
     {

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -104,7 +104,6 @@ def load_cifar10_weights(model):
 
 def initialize_model():
   tf_utils.set_random_seed()
-  tf.keras.backend.set_learning_phase(False)
 
   # Keras applications models receive input shapes without a batch dimension, as
   # the batch size is dynamic by default. This selects just the image size.
@@ -127,12 +126,13 @@ class VisionModule(tf.Module):
   def __init__(self):
     super(VisionModule, self).__init__()
     self.m = initialize_model()
+    self.m.predict = lambda x: self.m.call(x, training=False)
     # Specify input shape with a static batch size.
     # TODO(b/142948097): Add support for dynamic shapes in SPIR-V lowering.
     # Replace input_shape with m.input_shape to make the batch size dynamic.
     self.predict = tf.function(
         input_signature=[tf.TensorSpec(get_input_shape())])(
-            self.m.call)
+            self.m.predict)
 
 
 @tf_test_utils.compile_module(VisionModule, exported_names=['predict'])


### PR DESCRIPTION
This addresses the following `tf.keras` warning:

```
`tf.keras.backend.set_learning_phase` is deprecated and will be 
removed after 2020-10-11. To update it, simply pass a True/False 
value to the `training` argument of the `__call__` method of your
layer or model.
```