### PR TITLE
Add more information for each dump.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -607,7 +607,10 @@ def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", []> {
     Trace point for dispatchable functions.
   }];
 
-  let arguments = (ins Variadic<FLOW_Tensor>:$operands);
+  let arguments = (ins
+    Variadic<FLOW_Tensor>:$operands,
+    StrAttr:$trace_info
+  );
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -71,8 +71,9 @@ LogicalResult convertToDispatchOp(DispatchRegionOp regionOp,
     return res;
   };
   if (traceDispatchTensors) {
-    builder.create<TensorTraceOp>(regionOp.getLoc(),
-                                  getTensorTypeArgs(newArgs));
+    std::string str = "Input for " + std::string(outlinedFuncOp.getName());
+    builder.create<TensorTraceOp>(regionOp.getLoc(), getTensorTypeArgs(newArgs),
+                                  builder.getStringAttr(str));
   }
 
   // Create the dispatch op to the executable function.
@@ -81,8 +82,10 @@ LogicalResult convertToDispatchOp(DispatchRegionOp regionOp,
       outlinedFuncOp.getType().getResults(), newArgs);
 
   if (traceDispatchTensors) {
+    std::string str = "Output for " + std::string(outlinedFuncOp.getName());
     builder.create<TensorTraceOp>(regionOp.getLoc(),
-                                  getTensorTypeArgs(dispatchOp.getResults()));
+                                  getTensorTypeArgs(dispatchOp.getResults()),
+                                  builder.getStringAttr(str));
   }
 
   // Replace uses of the existing results with the new results.

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
@@ -153,8 +153,8 @@ class TensorTraceOpConversion
           loc, traceOp.getOperand(operand.index()), operand.value(), rewriter);
       bufferViews.emplace_back(adaptor.getBufferView());
     }
-    rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewTraceOp>(traceOp,
-                                                              bufferViews);
+    rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewTraceOp>(
+        traceOp, bufferViews, traceOp.trace_infoAttr());
     return success();
   }
 };

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -933,7 +933,10 @@ def HAL_BufferViewTraceOp : HAL_Op<"buffer_view.trace", []> {
     Trace point for dispatchable functions.
   }];
 
-  let arguments = (ins Variadic<HAL_BufferView>:$operands);
+  let arguments = (ins
+    Variadic<HAL_BufferView>:$operands,
+    StrAttr:$trace_info
+  );
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -216,7 +216,8 @@ attributes {nosideeffects}
 
 // Prints out the content of buffers.
 vm.import @buffer_view.trace(
-  %operands : !vm.ref<!hal.buffer_view> ...
+  %operands : !vm.ref<!hal.buffer_view> ...,
+  %trace_info : !vm.ref<!iree.byte_buffer>
 )
 
 //===----------------------------------------------------------------------===//

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -426,10 +426,9 @@ class HALModuleState final {
   }
 
   Status BufferViewTrace(
-      absl::Span<const vm::ref<iree_hal_buffer_view_t>> buffer_views) {
-    // TODO(hanchung): Have better information for each dump, eg, having StrAttr
-    // for each trace event so we can map the dump to dispatch functions easier.
-    fprintf(stderr, "=== DEBUG DUMP ===\n");
+      absl::Span<const vm::ref<iree_hal_buffer_view_t>> buffer_views,
+      absl::string_view trace_info) {
+    fprintf(stderr, "=== %s ===\n", std::string(trace_info).c_str());
     for (auto& view : buffer_views) {
       std::string result_str(4096, '\0');
       iree_status_t status;

--- a/iree/test/e2e/regression/trace_dispatch_tensors.mlir
+++ b/iree/test/e2e/regression/trace_dispatch_tensors.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-run-mlir -iree-hal-target-backends=vmla -iree-flow-trace-dispatch-tensors %s 2>&1 | IreeFileCheck %s
+
+func @two_dispatch() -> (tensor<5x5xf32>, tensor<3x5xf32>) attributes { iree.module.export } {
+  %0 = iree.unfoldable_constant dense<1.0> : tensor<5x3xf32>
+  %1 = iree.unfoldable_constant dense<0.4> : tensor<3x5xf32>
+  %2 = "mhlo.dot"(%0, %1) : (tensor<5x3xf32>, tensor<3x5xf32>) -> tensor<5x5xf32>
+  %3 = "mhlo.dot"(%1, %2) : (tensor<3x5xf32>, tensor<5x5xf32>) -> tensor<3x5xf32>
+  return %2, %3 : tensor<5x5xf32>, tensor<3x5xf32>
+}
+// CHECK: === Input for two_dispatch_ex_dispatch_0 ===
+// CHECK: 5x3xf32=
+// CHECK: 3x5xf32=
+// CHECK: === Output for two_dispatch_ex_dispatch_0 ===
+// CHECK: 5x5xf32=
+// CHECK: === Input for two_dispatch_ex_dispatch_1 ===
+// CHECK: 3x5xf32=
+// CHECK: 5x5xf32=
+// CHECK: === Output for two_dispatch_ex_dispatch_1 ===
+// CHECK: 3x5xf32=


### PR DESCRIPTION
Tested with command:

build/iree/tools/iree-run-mlir \
  -iree-hal-target-backends=vmla \
  -iree-flow-trace-dispatch-tensors \
  -input-value="1x5xf32=1,-2,-3,4,-5" \
  -input-value="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1"
  iree/test/e2e/models/fullyconnected.mlir

The output looks like:

```
EXEC @main                                                                                                                                   === Input for main_ex_dispatch_0 ===
=== Input for main_ex_dispatch_0 ===
1x5x3x1xf32=...

=== Output for main_ex_dispatch_0 ===
5x3xf32=...

=== Input for main_ex_dispatch_1 ===
5x3xf32=...
3x5xf32=...

=== Output for main_ex_dispatch_1 ===
5x5xf32=...

...

```