### PR TITLE
Open source `mobile_bert_squad_test` with TFLite support

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -418,8 +418,8 @@ def compile_to_tflite(
 
   Args:
     module_class: A tf.Module subclass to compile with TFLite. If module_class
-      has an attr get_tflite_v1_kwargs then it will be compiled using
-      tf.compat.v1.lite.
+      has an attr get_legacy_tflite_saved_model_converter_kwargs then it will
+      be compiled using tf.compat.v1.lite. It's best not to use this, however.
     exported_names: an optional iterable of strings representing which of the
       module_class's functions should be callable. If exported_names is empty
       then all functions will be callable.
@@ -449,14 +449,14 @@ def compile_to_tflite(
 
   tflite_modules = []
   names = []
-  if hasattr(module_class, "get_tflite_v1_kwargs"):
-    tflite_v1_kwargs = module_class.get_tflite_v1_kwargs()
+  if hasattr(module_class, "get_legacy_tflite_saved_model_converter_kwargs"):
+    kwargs = module_class.get_legacy_tflite_saved_model_converter_kwargs()
     converter = tf.compat.v1.lite.TFLiteConverter.from_saved_model(
-        tflite_v1_kwargs["model_path"],
-        input_arrays=tflite_v1_kwargs["input_arrays"],
-        output_arrays=tflite_v1_kwargs["output_arrays"])
+        kwargs["model_path"],
+        input_arrays=kwargs["input_arrays"],
+        output_arrays=kwargs["output_arrays"])
     tflite_modules.append(converter.convert())
-    names.append(tflite_v1_kwargs["function_name"])
+    names.append(kwargs["exported_name"])
   else:
     functions, names = _get_concrete_functions(module_class, exported_names)
     for function in functions:

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -54,6 +54,7 @@ package(
 # keep sorted
 SPECIAL_CASES = [
     "linspace_test.py",
+    "mobile_bert_squad_test.py",
 ]
 
 TFLITE_FAILING = [
@@ -201,6 +202,41 @@ iree_e2e_test_suite(
     backends_to_srcs = {
         "iree_llvmjit": ["linspace_test.py"],
         "iree_vulkan": ["linspace_test.py"],
+    },
+    reference_backend = "tf",
+    tags = [
+        "manual",
+        "nokokoro",
+        "notap",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+iree_e2e_test_suite(
+    name = "mobile_bert_squad_tests",
+    backends_to_srcs = {
+        "tf": ["mobile_bert_squad_test.py"],
+        "tflite": ["mobile_bert_squad_test.py"],
+    },
+    reference_backend = "tf",
+    tags = [
+        "manual",
+        "nokokoro",
+        "notap",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+iree_e2e_test_suite(
+    name = "mobile_bert_squad_tests_failing",
+    backends_to_srcs = {
+        "iree_vmla": ["mobile_bert_squad_test.py"],
+        "iree_llvmjit": ["mobile_bert_squad_test.py"],
+        "iree_vulkan": ["mobile_bert_squad_test.py"],
     },
     reference_backend = "tf",
     tags = [

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -16,8 +16,8 @@ instructions.
 ## Vulkan Setup
 
 If you do not have your environment setup to use IREE with Vulkan (see
-[this doc](https://google.github.io/iree/get-started/generic-vulkan-env-setup)), 
-then you can run the manual test targets with 
+[this doc](https://google.github.io/iree/get-started/generic-vulkan-env-setup)),
+then you can run the manual test targets with
 `--target_backends=tf,iree_vmla,iree_llvmjit` (that is, by omitting
 `iree_vulkan` from the list of backends to run the tests on).
 
@@ -229,3 +229,15 @@ which then allows reproducing the bug with an appropriate "opt" tool. Further
 debugging iteration can happen in opt.
 
 TODO(silvasean): debugging miscompiles
+
+## Legacy TFLite Compilation
+
+_Please don't use this unless you are forced to._
+
+We support using `tf.compat.v1.lite.TFLiteConverter.from_saved_model` to compile
+older `tf.Module`s with TFLite. This will be used if the `tf.Module` being
+tested has a method named `get_legacy_tflite_saved_model_converter_kwargs`. This
+method must return a dict with the following kwargs: `model_path`,
+`input_arrays`, `output_arrays`, and `exported_name`. The module must use only
+one exported name, and `exported_name` should be equal to that name. See
+`mobile_bert_squad_test.py` for a concrete example.

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -1,0 +1,91 @@
+# Lint as: python3
+"""Test MobileBERT.
+
+Model topology and weights are from
+https://github.com/google-research/google-research/tree/master/mobilebert
+"""
+
+import os
+import posixpath
+
+from absl import app
+from absl import flags
+import numpy as np
+from pyiree.tf.support import tf_test_utils
+import tensorflow.compat.v2 as tf
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_boolean("use_quantized_weights", False,
+                     "Whether to use quantized or floating point weights.")
+
+MAX_SEQ_LENGTH = 384  # Max input sequence length used in mobilebert_squad.
+
+FILE_NAME = "mobilebert_squad_savedmodels.tar.gz"
+MODEL_URL = posixpath.join(
+    "https://storage.googleapis.com/cloud-tpu-checkpoints/mobilebert/",
+    FILE_NAME)
+
+
+class MobileBertSquad(tf.Module):
+  """Wrapper of MobileBertSquad saved model v1."""
+
+  def __init__(self):
+    self.model_path = self.get_model_path()
+    self.saved_model = tf.saved_model.load(self.model_path, tags=["serve"])
+    self.inference_func = self.saved_model.signatures["serving_default"]
+
+  @staticmethod
+  def get_model_path():
+    model_type = "quant_saved_model" if FLAGS.use_quantized_weights else "float"
+
+    # Get_file will download the model weights from a publicly available folder,
+    # save them to cache_dir=~/.keras/datasets/ and return a path to them.
+    model_path = tf.keras.utils.get_file(FILE_NAME, MODEL_URL, untar=True)
+    model_dir = os.path.dirname(model_path)
+    extracted_name = FILE_NAME.split(".")[0]
+    model_path = os.path.join(model_dir, extracted_name, model_type)
+    return model_path
+
+  @staticmethod
+  def get_tflite_v1_kwargs():
+    return dict([("input_arrays", ["input_ids", "input_mask", "segment_ids"]),
+                 ("output_arrays", ["start_logits", "end_logits"]),
+                 ("function_name", "predict"),
+                 ("model_path", MobileBertSquad.get_model_path())])
+
+  @tf.function(input_signature=[
+      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
+      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
+      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
+  ])
+  def predict(self, input_ids, input_mask, segment_ids):
+    inputs = {
+        "input_ids": input_ids,
+        "input_mask": input_mask,
+        "segment_ids": segment_ids,
+    }
+    return self.inference_func(**inputs)
+
+
+@tf_test_utils.compile_module(MobileBertSquad, exported_names=["predict"])
+class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
+  """Tests of MobileBertSquad."""
+
+  def test_predict(self):
+
+    def predict(module):
+      input_ids = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
+      input_mask = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
+      segment_ids = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
+
+      module.predict(input_ids, input_mask, segment_ids, atol=1e0)
+
+    self.compare_backends(predict)
+
+
+if __name__ == "__main__":
+  if hasattr(tf, "enable_v2_behavior"):
+    tf.enable_v2_behavior()
+
+  tf.test.main()

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -48,10 +48,10 @@ class MobileBertSquad(tf.Module):
     return model_path
 
   @staticmethod
-  def get_tflite_v1_kwargs():
+  def get_legacy_tflite_saved_model_converter_kwargs():
     return dict([("input_arrays", ["input_ids", "input_mask", "segment_ids"]),
                  ("output_arrays", ["start_logits", "end_logits"]),
-                 ("function_name", "predict"),
+                 ("exported_name", "predict"),
                  ("model_path", MobileBertSquad.get_model_path())])
 
   @tf.function(input_signature=[


### PR DESCRIPTION
Open sources a test for MobileBert on the SQuAD task. 

Support for compiling `tf.Module`s with `tf.compat.v1.lite` was added to get TFLite to support compiling the model. The comparison `atol` is set to `1e0` because TFLite has a numerical difference of `~0.13` with TensorFlow on this model/input pair.

These tests don't run on the CI, so I tested them locally.