### PR TITLE
Add fusion on buffers to LinalgTileAndFuse Pass.

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -605,8 +605,9 @@ struct MapLinalgOpToLocalInvocationId : public OpConversionPattern<LinalgOpTy> {
     // If the `linalgOp` writes to workgroup memory insert barrier after the
     // op.
     if (llvm::any_of(linalgOp.getOperands(), [](Value output) {
-          return output.getType().cast<MemRefType>().getMemorySpace() ==
-                 getWorkgroupMemorySpace();
+          MemRefType outputType = output.getType().dyn_cast<MemRefType>();
+          return outputType &&
+                 outputType.getMemorySpace() == getWorkgroupMemorySpace();
         })) {
       rewriter.create<spirv::ControlBarrierOp>(
           linalgOp.getLoc(), spirv::Scope::Workgroup, spirv::Scope::Workgroup,
@@ -751,6 +752,7 @@ void ConvertToGPUPass::runOnOperation() {
                   MapLinalgOpToGlobalInvocationId<linalg::IndexedGenericOp>,
                   MapLinalgOpToLocalInvocationId<linalg::ConvOp>,
                   MapLinalgOpToLocalInvocationId<linalg::CopyOp>,
+                  MapLinalgOpToLocalInvocationId<linalg::FillOp>,
                   MapLinalgOpToLocalInvocationId<linalg::MatmulOp>,
                   MapLinalgOpToLocalInvocationId<linalg::BatchMatmulOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingMaxOp>,

--- a/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.cpp
@@ -27,6 +27,8 @@ struct VectorTransforms {
 const StringLiteral VectorTransforms::kVectorTransformMarker =
     "__internal_vector_transform__";
 
+StringRef getFusedMarker() { return "fused_numprocs_ge_numiters"; }
+
 StringRef getWorkgroupMarker() { return "workgroup"; }
 
 StringRef getWorkgroupMemoryMarker() { return "workgroup_memory"; }
@@ -44,6 +46,8 @@ StringRef getCopyToWorkgroupMemoryMarker() {
 }
 
 StringRef getVectorizeMarker() { return "vectorize"; }
+
+StringRef getDeleteMarker() { return "delete"; }
 
 bool hasMarker(Operation *op, ArrayRef<StringRef> marker) {
   StringAttr attr = op->getAttrOfType<StringAttr>(

--- a/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
@@ -44,6 +44,12 @@ StringRef getCopyToWorkgroupMemoryMarker();
 /// Marker for operations that are going to be vectorized.
 StringRef getVectorizeMarker();
 
+/// Marker for tagging an operation for deletion. Tile and fuse pattern does not
+/// delete the original operation to not invalidate the
+/// `linalg::LinalgDependenceGraph` data structure. Instead it is marked with a
+/// marker that can be used later to delete these operations.
+StringRef getDeleteMarker();
+
 /// Returns true if an operation has the specified `marker`. When `marker` is
 /// empty, returns true if the operation has any marker.
 bool hasMarker(Operation *, ArrayRef<StringRef> markers = {});

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
@@ -85,21 +85,17 @@ static void addLinalgToSPIRVPasses(OpPassManager &pm,
   //   - All Linalg ops have buffer semantics.
   //
   // Post-conditions:
+  //   - The operations that cannot be fused at buffer levels are split into
+  //     separate entry points.
   //   - If the input Linalg ops are tilable:
   //     - loop.parallel ops are generated for mapping to workgroups.
   //     - Linalg ops are nested inside loop.parallel ops and ready for mapping
   //       to workitems.
+  //     - If multiple linalg operations are present they get tiled and fused to
+  //       get outer loop.parallel ops which can be mapped to workitems.
   //   - Otherwise:
   //     - The Linalg op is kept untouched.
-  //   - Dispatch functions might be split into multiple ones.
   //
-  // Note:
-  //   We first try to tile and fuse the dispatch function as a whole. If there
-  //   are multiple Linalg ops inside, they may not share any number of common
-  //   outer parallel iterators. Then the first tile and fuse pass will do
-  //   nothing. We split all the Linalg ops into their own dispatch functions
-  //   afterwards. This gives each Linalg op a second chance to be tiled,
-  //   with the second tile and fuse pass.
   //===--------------------------------------------------------------------===//
   pm.addPass(createSplitDispatchFunctionPass());
   pm.addPass(createLinalgTileAndFusePass(options));

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
@@ -355,9 +355,9 @@ module attributes {
 //       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]][%[[LBY_2]], %[[LBX_2]]]
 //       CHECK:   %[[VIEW3:.+]] = subview %[[RET0]][%[[LBY_2]], %[[LBX_2]]]
 //       CHECK:   linalg.fill(%[[VIEW3]], %{{.+}})
-//  CHECK-SAME:     "workgroup_numprocs_ge_numiters"
+//  CHECK-SAME:     "workgroup"
 //       CHECK:   linalg.matmul
-//  CHECK-SAME:     "workgroup_numprocs_ge_numiters"
+//  CHECK-SAME:     "workgroup"
 //  CHECK-SAME:     ins(%[[VIEW0]], %[[VIEW1]]
 //  CHECK-SAME:     outs(%[[VIEW2]]
 
@@ -407,7 +407,7 @@ module attributes {
 //       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]]
 //  CHECK-SAME:     [%[[BIDZ]], %[[LBY_2]], %[[LBX_2]], 0]
 //       CHECK:   %[[VIEW3:.+]] = subview %[[RET0]]
-//  CHECK-SAME:     [%[[BIDX]], %[[LBY_2]], %[[LBX_2]], 0]
+//  CHECK-SAME:     [%[[BIDZ]], %[[LBY_2]], %[[LBX_2]], 0]
 //       CHECK:   linalg.fill(%[[VIEW3]], %{{.*}})
 //  CHECK-SAME:     "workgroup"
 //       CHECK:   linalg.conv

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
@@ -302,3 +302,114 @@ module attributes {
 //       CHECK:   %[[T1:.+]] = addi %[[DIM0]], %[[C3]]
 //   CHECK-DAG:   %[[NBY:.+]] = divi_signed %[[T1]], %[[C4]]
 //       CHECK:   return %[[NBX]], %[[NBY]], %[[C1]]
+
+// -----
+
+module attributes {
+  spv.target_env =
+    #spv.target_env<#spv.vce<v1.3,
+    [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+    {max_compute_workgroup_invocations = 128 : i32,
+     max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @matmul_fusion() attributes {vkspv.num_workgroups_fn = @matmul_fusion__num_workgroups__} {
+    %0 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?xf32>
+    %1 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<?x?xf32>
+    %2 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<?x?xf32>
+    %cst = constant 0.000000e+00 : f32
+    linalg.fill(%2, %cst) : memref<?x?xf32>, f32
+    linalg.matmul ins(%0, %1 : memref<?x?xf32>, memref<?x?xf32>)
+      outs(%2 : memref<?x?xf32>)
+    return
+  }
+  func @matmul_fusion__num_workgroups__
+    (!shapex.ranked_shape<[?,?]>, !shapex.ranked_shape<[?,?]>,
+     !shapex.ranked_shape<[?,?]>) -> (index, index, index)
+    attributes {sym_visibility = "private"}
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}
+
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 8)>
+//   CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0 * 16)>
+//       CHECK: func @matmul_fusion()
+//  CHECK-SAME:   local_size = dense<[16, 8, 1]>
+//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
+//   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
+//   CHECK-NOT:   scf.parallel
+//   CHECK-NOT:   scf.for
+//       CHECK:   %[[LBY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[VIEW0:.+]] = subview %[[ARG0]][%[[LBY]], 0]
+//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP3]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW1:.+]] = subview %[[ARG1]][0, %[[LBX]]]
+//       CHECK:   %[[LBY_2:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX_2:.+]] = affine.apply #[[MAP3]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]][%[[LBY_2]], %[[LBX_2]]]
+//       CHECK:   %[[VIEW3:.+]] = subview %[[RET0]][%[[LBY_2]], %[[LBX_2]]]
+//       CHECK:   linalg.fill(%[[VIEW3]], %{{.+}})
+//  CHECK-SAME:     "workgroup_numprocs_ge_numiters"
+//       CHECK:   linalg.matmul
+//  CHECK-SAME:     "workgroup_numprocs_ge_numiters"
+//  CHECK-SAME:     ins(%[[VIEW0]], %[[VIEW1]]
+//  CHECK-SAME:     outs(%[[VIEW2]]
+
+// -----
+
+module attributes {
+  spv.target_env =
+    #spv.target_env<#spv.vce<v1.3,
+    [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+    {max_compute_workgroup_invocations = 128 : i32,
+     max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @conv_no_padding_fusion() {
+    %0 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?x?x?xf32>
+    %1 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<?x?x?x?xf32>
+    %2 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<?x?x?x?xf32>
+    %cst = constant 0.000000e+00 : f32
+    linalg.fill(%2, %cst) : memref<?x?x?x?xf32>, f32
+    linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [1, 1]} :
+      memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 4)>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
+//       CHECK: func @conv_no_padding_fusion()
+//  CHECK-SAME:   local_size = dense<[32, 4, 1]>
+//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
+//   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
+//   CHECK-DAG:   %[[BIDZ:.+]] = "gpu.block_id"() {dimension = "z"}
+//       CHECK:   %[[LBY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW1:.+]] = subview %[[ARG1]]
+//  CHECK-SAME:     [%[[BIDZ]], %[[LBY]], %[[LBX]], 0]
+//       CHECK:   %[[LBY_2:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX_2:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]]
+//  CHECK-SAME:     [%[[BIDZ]], %[[LBY_2]], %[[LBX_2]], 0]
+//       CHECK:   %[[VIEW3:.+]] = subview %[[RET0]]
+//  CHECK-SAME:     [%[[BIDX]], %[[LBY_2]], %[[LBX_2]], 0]
+//       CHECK:   linalg.fill(%[[VIEW3]], %{{.*}})
+//  CHECK-SAME:     "workgroup"
+//       CHECK:   linalg.conv
+//  CHECK-SAME:     %[[ARG0]], %[[VIEW1]], %[[VIEW2]]
+//  CHECK-SAME:     "workgroup"


### PR DESCRIPTION
Use pattern to tile and fuse in IREE. Initial commit only fuses the
linalg.fill operation added in lowering to Linalg on buffers from MHLO
(HLOToLinalgOnBuffersPass) with the gemm/conv/pool operations. This
removes the need for splitting dispatch functions when multiple linalg
operations on buffers (SplitDispatchFunctionPass) exist in the
dispatch function.