### PR TITLE
Fix vmla::kernels::Gather::Execute handling of batching dims

### DIFF
--- a/integrations/tensorflow/e2e/gather_test.py
+++ b/integrations/tensorflow/e2e/gather_test.py
@@ -49,6 +49,22 @@ class GatherModule(tf.Module):
     return tf.gather(params, indices, axis=2, batch_dims=1)
 
 
+  @tf.function(input_signature=[
+      tf.TensorSpec([4, 7, 8, 2], tf.float32),
+      tf.TensorSpec([4, 1], tf.int32)
+  ])
+  def gather_axis1_batch1(self, params, indices):
+    return tf.gather(params, indices, axis=1, batch_dims=1)
+
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([2, 4], tf.int32),
+      tf.TensorSpec([2, 4], tf.int32)
+  ])
+  def gather_axis2_batch2(self, params, indices):
+    return tf.gather(params, indices, axis=1, batch_dims=1)
+
+
 @tf_test_utils.compile_module(GatherModule)
 class GatherTest(tf_test_utils.TracedModuleTestCase):
 
@@ -87,6 +103,25 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       module.gather_axis2_batch1(params, indices)
 
     self.compare_backends(gather_axis2_batch1)
+
+  def test_gather_axis1_batch1(self):
+
+    def gather_axis1_batch1(module):
+      indices = np.array([[2], [3], [0], [1]], dtype=np.int32)
+      params = tf_utils.ndarange([4, 7, 8, 2])
+      module.gather_axis1_batch1(params, indices)
+
+    self.compare_backends(gather_axis1_batch1)
+
+  def test_gather_axis2_batch2(self):
+
+    def gather_axis2_batch2(module):
+      indices = np.array([[0, 1, 2, 3], [3, 2, 1, 0]], dtype=np.int32)
+      values = np.array([[0, 1, 2, 3], [9, 8, 7, 0]], dtype=np.int32)
+      module.gather_axis2_batch2(values, indices)
+
+    self.compare_backends(gather_axis2_batch2)
+
 
 
 if __name__ == "__main__":

--- a/iree/hal/vmla/op_kernels_generic.h
+++ b/iree/hal/vmla/op_kernels_generic.h
@@ -343,8 +343,11 @@ Status Gather::Execute(absl::Span<const T> src_buffer,
   compute_strides(dst_shape, output_strides);
   compute_strides(src_shape, input_strides);
   compute_strides(indices_shape, indices_strides);
-  size_t outer_size = 1;
-  for (size_t i = 0; i < dim; ++i) {
+  size_t outer_size = 1, batching_size = 1;
+  for (size_t i = 0; i < batch_dims; ++i) {
+    batching_size *= src_shape[i];
+  }
+  for (size_t i = batch_dims; i < dim; ++i) {
     outer_size *= src_shape[i];
   }
   // stride for batch outer dims.
@@ -369,15 +372,19 @@ Status Gather::Execute(absl::Span<const T> src_buffer,
   // see:https://www.tensorflow.org/api_docs/python/tf/gather
   // TODO(ataei): Shrink inner loop by scanning indices_buffer for
   // contiguous indices and collide the copy of these slices.
-  for (size_t i = 0; i < outer_size; ++i) {
-    const int batch_offset =
-        batch_dims == 0 ? 0 : (i / batch_stride) * indices_strides[batch_dims];
-    for (size_t j = 0; j < indices_size; ++j) {
-      const size_t dst_offset = i * output_stride + j * slize_size;
-      const size_t src_offset =
-          i * input_stride + indices_buffer[batch_offset + j] * slize_size;
-      std::memcpy(dst_buffer.data() + dst_offset,
-                  src_buffer.data() + src_offset, sizeof(T) * slize_size);
+  for (size_t b = 0; b < batching_size; ++b) {
+    for (size_t i = 0; i < outer_size; ++i) {
+      const int index = b * outer_size + i;
+      for (size_t j = 0; j < indices_size; ++j) {
+        const int indices_batching_stride =
+            batch_dims > 0 ? indices_strides[batch_dims - 1] : 1;
+        const int indices_index = b * indices_batching_stride + j;
+        const size_t dst_offset = index * output_stride + j * slize_size;
+        const size_t src_offset =
+            index * input_stride + indices_buffer[indices_index] * slize_size;
+        std::memcpy(dst_buffer.data() + dst_offset,
+                    src_buffer.data() + src_offset, sizeof(T) * slize_size);
+      }
     }
   }
   return OkStatus();


### PR DESCRIPTION
The code wasn't correctly iterating over batch dim. This PR explicitly split the outer most dim into (batch + parallel) and explicitly compute corresponding indices.