### PR TITLE
Remove e2e test case decorator

### DIFF
--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -107,7 +107,7 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 
     # Calls `simple_mul` once for each backend, recording the inputs and outputs
     # to `module` and then comparing them.
-    self.compare_backends(simple_mul, *self._modules)
+    self.compare_backends(simple_mul, self._modules)
 ```
 
 ## Test Suites

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -81,7 +81,10 @@ backend as a source of truth. For example:
 
 ```python
 # Compile a `tf.Module` named `SimpleArithmeticModule` into a `CompiledModule`.
-@tf_test_utils.compile_module(SimpleArithmeticModule)
+# This line goes in the main function before calling `tf.test.main()`, and is
+# here to provide context.
+tf_test_utils.compile_tf_module(SimpleArithmeticModule)
+
 # Inherit from `TracedModuleTestCase`.
 class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -80,13 +80,14 @@ outputs to these modules are then checked for correctness, using the reference
 backend as a source of truth. For example:
 
 ```python
-# Compile a `tf.Module` named `SimpleArithmeticModule` into a `CompiledModule`.
-# This line goes in the main function before calling `tf.test.main()`, and is
-# here to provide context.
-tf_test_utils.compile_tf_module(SimpleArithmeticModule)
-
 # Inherit from `TracedModuleTestCase`.
 class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
+
+  def __init__(self, methodName="runTest"):
+    super(SimpleArithmeticTest, self).__init__(methodName)
+    # Compile a `tf.Module` named `SimpleArithmeticModule` into
+    # `CompiledModule`s for each reference and target backend.
+    self._modules = tf_test_utils.compile_tf_module(SimpleArithmeticModule)
 
   # Unit test.
   def test_simple_mul(self):
@@ -106,7 +107,7 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 
     # Calls `simple_mul` once for each backend, recording the inputs and outputs
     # to `module` and then comparing them.
-    self.compare_backends(simple_mul)
+    self.compare_backends(simple_mul, *self._modules)
 ```
 
 ## Test Suites

--- a/integrations/tensorflow/e2e/batch_norm_test.py
+++ b/integrations/tensorflow/e2e/batch_norm_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Batch norm tests."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -39,7 +40,6 @@ class BatchNormModule(tf.Module):
         variance_epsilon=1e-4)
 
 
-@tf_test_utils.compile_module(BatchNormModule)
 class BatchNormTest(tf_test_utils.TracedModuleTestCase):
 
   def test_batch_norm_inference(self):
@@ -56,7 +56,13 @@ class BatchNormTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(batch_norm_inference)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(BatchNormModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/batch_norm_test.py
+++ b/integrations/tensorflow/e2e/batch_norm_test.py
@@ -57,7 +57,7 @@ class BatchNormTest(tf_test_utils.TracedModuleTestCase):
       scale = tf_utils.uniform((16,)) * 1e-3
       module.batch_norm_inference(x, mean, variance, offset, scale)
 
-    self.compare_backends(batch_norm_inference, *self._modules)
+    self.compare_backends(batch_norm_inference, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/batch_norm_test.py
+++ b/integrations/tensorflow/e2e/batch_norm_test.py
@@ -42,6 +42,10 @@ class BatchNormModule(tf.Module):
 
 class BatchNormTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(BatchNormTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(BatchNormModule)
+
   def test_batch_norm_inference(self):
 
     def batch_norm_inference(module):
@@ -53,14 +57,13 @@ class BatchNormTest(tf_test_utils.TracedModuleTestCase):
       scale = tf_utils.uniform((16,)) * 1e-3
       module.batch_norm_inference(x, mean, variance, offset, scale)
 
-    self.compare_backends(batch_norm_inference)
+    self.compare_backends(batch_norm_inference, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(BatchNormModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/bool_test.py
+++ b/integrations/tensorflow/e2e/bool_test.py
@@ -49,14 +49,14 @@ class BooleanTest(tf_test_utils.TracedModuleTestCase):
     def constant(module):
       module.constant()
 
-    self.compare_backends(constant, *self._modules)
+    self.compare_backends(constant, self._modules)
 
   def test_greater_than(self):
 
     def greater_than(module):
       module.greater_than(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(greater_than, *self._modules)
+    self.compare_backends(greater_than, self._modules)
 
   def test_logical_and(self):
 
@@ -65,7 +65,7 @@ class BooleanTest(tf_test_utils.TracedModuleTestCase):
           np.array([True, True, False, False], dtype=np.bool),
           np.array([True, False, False, True], dtype=np.bool))
 
-    self.compare_backends(logical_and, *self._modules)
+    self.compare_backends(logical_and, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/bool_test.py
+++ b/integrations/tensorflow/e2e/bool_test.py
@@ -40,19 +40,23 @@ class MathModule(tf.Module):
 
 class BooleanTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(BooleanTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MathModule)
+
   def test_constant(self):
 
     def constant(module):
       module.constant()
 
-    self.compare_backends(constant)
+    self.compare_backends(constant, *self._modules)
 
   def test_greater_than(self):
 
     def greater_than(module):
       module.greater_than(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(greater_than)
+    self.compare_backends(greater_than, *self._modules)
 
   def test_logical_and(self):
 
@@ -61,14 +65,13 @@ class BooleanTest(tf_test_utils.TracedModuleTestCase):
           np.array([True, True, False, False], dtype=np.bool),
           np.array([True, False, False, True], dtype=np.bool))
 
-    self.compare_backends(logical_and)
+    self.compare_backends(logical_and, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MathModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/bool_test.py
+++ b/integrations/tensorflow/e2e/bool_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for ops in the tf.math module."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -37,7 +38,6 @@ class MathModule(tf.Module):
     return tf.math.logical_and(x, y)
 
 
-@tf_test_utils.compile_module(MathModule)
 class BooleanTest(tf_test_utils.TracedModuleTestCase):
 
   def test_constant(self):
@@ -64,7 +64,13 @@ class BooleanTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(logical_and)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(MathModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/broadcast_to_test.py
+++ b/integrations/tensorflow/e2e/broadcast_to_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -30,7 +31,6 @@ class BroadcastToModule(tf.Module):
     return tf.broadcast_to(x, shape)
 
 
-@tf_test_utils.compile_module(BroadcastToModule)
 class BroadcastToTest(tf_test_utils.TracedModuleTestCase):
 
   def test_scalar_broadcast_to(self):
@@ -43,7 +43,13 @@ class BroadcastToTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(scalar_broadcast_to)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(BroadcastToModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/broadcast_to_test.py
+++ b/integrations/tensorflow/e2e/broadcast_to_test.py
@@ -33,6 +33,10 @@ class BroadcastToModule(tf.Module):
 
 class BroadcastToTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(BroadcastToTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(BroadcastToModule)
+
   def test_scalar_broadcast_to(self):
 
     def scalar_broadcast_to(module):
@@ -40,14 +44,13 @@ class BroadcastToTest(tf_test_utils.TracedModuleTestCase):
       shape = np.array([3, 3], dtype=np.int32)
       result = module.scalar_broadcast_to(x, shape)
 
-    self.compare_backends(scalar_broadcast_to)
+    self.compare_backends(scalar_broadcast_to, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(BroadcastToModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/broadcast_to_test.py
+++ b/integrations/tensorflow/e2e/broadcast_to_test.py
@@ -44,7 +44,7 @@ class BroadcastToTest(tf_test_utils.TracedModuleTestCase):
       shape = np.array([3, 3], dtype=np.int32)
       result = module.scalar_broadcast_to(x, shape)
 
-    self.compare_backends(scalar_broadcast_to, *self._modules)
+    self.compare_backends(scalar_broadcast_to, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/broadcasting_test.py
+++ b/integrations/tensorflow/e2e/broadcasting_test.py
@@ -33,6 +33,10 @@ class BroadcastingModule(tf.Module):
 
 class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(BroadcastingTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(BroadcastingModule)
+
   def test_add_same_shape(self):
 
     def add_same_shape(module):
@@ -40,7 +44,7 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([4])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_same_shape)
+    self.compare_backends(add_same_shape, *self._modules)
 
   def test_add_broadcast_lhs(self):
 
@@ -49,7 +53,7 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([4])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_broadcast_lhs)
+    self.compare_backends(add_broadcast_lhs, *self._modules)
 
   def test_add_broadcast_rhs(self):
 
@@ -58,14 +62,13 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([1])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_broadcast_rhs)
+    self.compare_backends(add_broadcast_rhs, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(BroadcastingModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/broadcasting_test.py
+++ b/integrations/tensorflow/e2e/broadcasting_test.py
@@ -44,7 +44,7 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([4])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_same_shape, *self._modules)
+    self.compare_backends(add_same_shape, self._modules)
 
   def test_add_broadcast_lhs(self):
 
@@ -53,7 +53,7 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([4])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_broadcast_lhs, *self._modules)
+    self.compare_backends(add_broadcast_lhs, self._modules)
 
   def test_add_broadcast_rhs(self):
 
@@ -62,7 +62,7 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
       rhs = tf_utils.uniform([1])
       module.add(lhs, rhs)
 
-    self.compare_backends(add_broadcast_rhs, *self._modules)
+    self.compare_backends(add_broadcast_rhs, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/broadcasting_test.py
+++ b/integrations/tensorflow/e2e/broadcasting_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Test broadcasting support."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -30,7 +31,6 @@ class BroadcastingModule(tf.Module):
     return lhs + rhs
 
 
-@tf_test_utils.compile_module(BroadcastingModule)
 class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
 
   def test_add_same_shape(self):
@@ -61,7 +61,13 @@ class BroadcastingTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(add_broadcast_rhs)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(BroadcastingModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/complex_test.py
+++ b/integrations/tensorflow/e2e/complex_test.py
@@ -46,7 +46,7 @@ class ComplexTest(tf_test_utils.TracedModuleTestCase):
       imag = np.array([-1., 0.4], dtype=np.float32)
       module.complex_exp(real, imag)
 
-    self.compare_backends(complex_exp, *self._modules)
+    self.compare_backends(complex_exp, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/complex_test.py
+++ b/integrations/tensorflow/e2e/complex_test.py
@@ -35,6 +35,10 @@ class ComplexModule(tf.Module):
 
 class ComplexTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ComplexTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(ComplexModule)
+
   def test_complex(self):
 
     def complex_exp(module):
@@ -42,14 +46,13 @@ class ComplexTest(tf_test_utils.TracedModuleTestCase):
       imag = np.array([-1., 0.4], dtype=np.float32)
       module.complex_exp(real, imag)
 
-    self.compare_backends(complex_exp)
+    self.compare_backends(complex_exp, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(ComplexModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/complex_test.py
+++ b/integrations/tensorflow/e2e/complex_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -32,7 +33,6 @@ class ComplexModule(tf.Module):
     return tf.math.real(exp)
 
 
-@tf_test_utils.compile_module(ComplexModule)
 class ComplexTest(tf_test_utils.TracedModuleTestCase):
 
   def test_complex(self):
@@ -45,7 +45,13 @@ class ComplexTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(complex_exp)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(ComplexModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/concat_test.py
+++ b/integrations/tensorflow/e2e/concat_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Test concat op."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -51,7 +52,6 @@ class ConcatOpsModule(tf.Module):
     return tf.concat([a, b], axis=2)
 
 
-@tf_test_utils.compile_module(ConcatOpsModule)
 class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
 
   def test_concat_zero_dim(self):
@@ -91,7 +91,13 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(concat2axis)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(ConcatOpsModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/concat_test.py
+++ b/integrations/tensorflow/e2e/concat_test.py
@@ -65,7 +65,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat_zero_dim(a, b)
 
-    self.compare_backends(concat_zero_dim, *self._modules)
+    self.compare_backends(concat_zero_dim, self._modules)
 
   def test_concat0axis(self):
 
@@ -74,7 +74,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat0axis(a, b)
 
-    self.compare_backends(concat0axis, *self._modules)
+    self.compare_backends(concat0axis, self._modules)
 
   def test_concat1axis(self):
 
@@ -83,7 +83,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat1axis(a, b)
 
-    self.compare_backends(concat1axis, *self._modules)
+    self.compare_backends(concat1axis, self._modules)
 
   def test_concat2axis(self):
 
@@ -92,7 +92,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat2axis(a, b)
 
-    self.compare_backends(concat2axis, *self._modules)
+    self.compare_backends(concat2axis, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/concat_test.py
+++ b/integrations/tensorflow/e2e/concat_test.py
@@ -54,6 +54,10 @@ class ConcatOpsModule(tf.Module):
 
 class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ConcatOpsTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(ConcatOpsModule)
+
   def test_concat_zero_dim(self):
 
     def concat_zero_dim(module):
@@ -61,7 +65,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat_zero_dim(a, b)
 
-    self.compare_backends(concat_zero_dim)
+    self.compare_backends(concat_zero_dim, *self._modules)
 
   def test_concat0axis(self):
 
@@ -70,7 +74,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat0axis(a, b)
 
-    self.compare_backends(concat0axis)
+    self.compare_backends(concat0axis, *self._modules)
 
   def test_concat1axis(self):
 
@@ -79,7 +83,7 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat1axis(a, b)
 
-    self.compare_backends(concat1axis)
+    self.compare_backends(concat1axis, *self._modules)
 
   def test_concat2axis(self):
 
@@ -88,14 +92,13 @@ class ConcatOpsTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform([1, 5, 1])
       module.concat2axis(a, b)
 
-    self.compare_backends(concat2axis)
+    self.compare_backends(concat2axis, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(ConcatOpsModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/control_flow_test.py
+++ b/integrations/tensorflow/e2e/control_flow_test.py
@@ -47,7 +47,7 @@ class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
       input_array = np.array(9., dtype=np.float32)
       module.collatz(input_array)
 
-    self.compare_backends(short_sequence, *self._modules)
+    self.compare_backends(short_sequence, self._modules)
 
   def test_long_sequence(self):
 
@@ -55,7 +55,7 @@ class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
       input_array = np.array(178., dtype=np.float32)
       module.collatz(input_array)
 
-    self.compare_backends(long_sequence, *self._modules)
+    self.compare_backends(long_sequence, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/control_flow_test.py
+++ b/integrations/tensorflow/e2e/control_flow_test.py
@@ -37,13 +37,17 @@ class ControlFlowModule(tf.Module):
 
 class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ControlFlowTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(ControlFlowModule)
+
   def test_short_sequence(self):
 
     def short_sequence(module):
       input_array = np.array(9., dtype=np.float32)
       module.collatz(input_array)
 
-    self.compare_backends(short_sequence)
+    self.compare_backends(short_sequence, *self._modules)
 
   def test_long_sequence(self):
 
@@ -51,14 +55,13 @@ class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
       input_array = np.array(178., dtype=np.float32)
       module.collatz(input_array)
 
-    self.compare_backends(long_sequence)
+    self.compare_backends(long_sequence, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(ControlFlowModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/control_flow_test.py
+++ b/integrations/tensorflow/e2e/control_flow_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -34,7 +35,6 @@ class ControlFlowModule(tf.Module):
     return i
 
 
-@tf_test_utils.compile_module(ControlFlowModule)
 class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
 
   def test_short_sequence(self):
@@ -54,7 +54,13 @@ class ControlFlowTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(long_sequence)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(ControlFlowModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/conv_test.py
+++ b/integrations/tensorflow/e2e/conv_test.py
@@ -102,6 +102,10 @@ class Conv2dModule(tf.Module):
 
 class ConvTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ConvTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(Conv2dModule)
+
   def test_id_batch_size_1(self):
 
     def id_batch_size_1(module):
@@ -109,7 +113,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_1451x1111_valid(i, k)
 
-    self.compare_backends(id_batch_size_1)
+    self.compare_backends(id_batch_size_1, *self._modules)
 
   def test_id_batch_size_2(self):
 
@@ -118,7 +122,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_2451x1111_valid(i, k)
 
-    self.compare_backends(id_batch_size_2)
+    self.compare_backends(id_batch_size_2, *self._modules)
 
   def test_asymmetric_kernel(self):
 
@@ -128,7 +132,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_valid(i, k)
 
-    self.compare_backends(asymmetric_kernel)
+    self.compare_backends(asymmetric_kernel, *self._modules)
 
   def test_padding(self):
 
@@ -138,7 +142,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_same(i, k)
 
-    self.compare_backends(padding)
+    self.compare_backends(padding, *self._modules)
 
   def test_batched_padding(self):
 
@@ -148,7 +152,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_2451x2311_same(i, k)
 
-    self.compare_backends(batched_padding)
+    self.compare_backends(batched_padding, *self._modules)
 
   def test_feature_reduce(self):
 
@@ -157,7 +161,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([3, 2, 2, 1], dtype=np.float32)
       module.conv2d_1452x3221_same(i, k)
 
-    self.compare_backends(feature_reduce)
+    self.compare_backends(feature_reduce, *self._modules)
 
   def test_feature_inflate(self):
 
@@ -166,7 +170,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([1, 1, 1, 2])
       module.conv2d_1451x1112_same(i, k)
 
-    self.compare_backends(feature_inflate)
+    self.compare_backends(feature_inflate, *self._modules)
 
   def test_feature_mix(self):
 
@@ -175,7 +179,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([1, 1, 2, 2])
       module.conv2d_1452x1122_same(i, k)
 
-    self.compare_backends(feature_mix)
+    self.compare_backends(feature_mix, *self._modules)
 
   def test_feature_padded(self):
 
@@ -184,7 +188,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_same(i, k)
 
-    self.compare_backends(feature_padded)
+    self.compare_backends(feature_padded, *self._modules)
 
   def test_feature_unpadded(self):
 
@@ -193,7 +197,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_valid(i, k)
 
-    self.compare_backends(feature_unpadded)
+    self.compare_backends(feature_unpadded, *self._modules)
 
   def test_batched_feature_unpadded(self):
 
@@ -202,14 +206,13 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2223_valid(i, k)
 
-    self.compare_backends(batched_feature_unpadded)
+    self.compare_backends(batched_feature_unpadded, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(Conv2dModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/conv_test.py
+++ b/integrations/tensorflow/e2e/conv_test.py
@@ -113,7 +113,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_1451x1111_valid(i, k)
 
-    self.compare_backends(id_batch_size_1, *self._modules)
+    self.compare_backends(id_batch_size_1, self._modules)
 
   def test_id_batch_size_2(self):
 
@@ -122,7 +122,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_2451x1111_valid(i, k)
 
-    self.compare_backends(id_batch_size_2, *self._modules)
+    self.compare_backends(id_batch_size_2, self._modules)
 
   def test_asymmetric_kernel(self):
 
@@ -132,7 +132,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_valid(i, k)
 
-    self.compare_backends(asymmetric_kernel, *self._modules)
+    self.compare_backends(asymmetric_kernel, self._modules)
 
   def test_padding(self):
 
@@ -142,7 +142,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_same(i, k)
 
-    self.compare_backends(padding, *self._modules)
+    self.compare_backends(padding, self._modules)
 
   def test_batched_padding(self):
 
@@ -152,7 +152,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_2451x2311_same(i, k)
 
-    self.compare_backends(batched_padding, *self._modules)
+    self.compare_backends(batched_padding, self._modules)
 
   def test_feature_reduce(self):
 
@@ -161,7 +161,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = np.ones([3, 2, 2, 1], dtype=np.float32)
       module.conv2d_1452x3221_same(i, k)
 
-    self.compare_backends(feature_reduce, *self._modules)
+    self.compare_backends(feature_reduce, self._modules)
 
   def test_feature_inflate(self):
 
@@ -170,7 +170,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([1, 1, 1, 2])
       module.conv2d_1451x1112_same(i, k)
 
-    self.compare_backends(feature_inflate, *self._modules)
+    self.compare_backends(feature_inflate, self._modules)
 
   def test_feature_mix(self):
 
@@ -179,7 +179,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([1, 1, 2, 2])
       module.conv2d_1452x1122_same(i, k)
 
-    self.compare_backends(feature_mix, *self._modules)
+    self.compare_backends(feature_mix, self._modules)
 
   def test_feature_padded(self):
 
@@ -188,7 +188,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_same(i, k)
 
-    self.compare_backends(feature_padded, *self._modules)
+    self.compare_backends(feature_padded, self._modules)
 
   def test_feature_unpadded(self):
 
@@ -197,7 +197,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_valid(i, k)
 
-    self.compare_backends(feature_unpadded, *self._modules)
+    self.compare_backends(feature_unpadded, self._modules)
 
   def test_batched_feature_unpadded(self):
 
@@ -206,7 +206,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2223_valid(i, k)
 
-    self.compare_backends(batched_feature_unpadded, *self._modules)
+    self.compare_backends(batched_feature_unpadded, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/conv_test.py
+++ b/integrations/tensorflow/e2e/conv_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -99,7 +100,6 @@ class Conv2dModule(tf.Module):
     return tf.nn.conv2d(img, kernel, [1, 1, 1, 1], "VALID", name="result")
 
 
-@tf_test_utils.compile_module(Conv2dModule)
 class ConvTest(tf_test_utils.TracedModuleTestCase):
 
   def test_id_batch_size_1(self):
@@ -205,7 +205,13 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(batched_feature_unpadded)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(Conv2dModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -63,7 +64,6 @@ class DepthConv2dModule(tf.Module):
         img, kernel, [1, 1, 1, 1], "SAME", name="result")
 
 
-@tf_test_utils.compile_module(DepthConv2dModule)
 class ConvTest(tf_test_utils.TracedModuleTestCase):
 
   def test_batched_feature_unpadded(self):
@@ -112,7 +112,13 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(batched_feature_padded_same_stride_1_output_1)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(DepthConv2dModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -28,43 +28,57 @@ class DepthConv2dModule(tf.Module):
       tf.TensorSpec([2, 2, 2, 3], tf.float32),
   ])
   def conv2d_2452x2423_valid(self, img, kernel):
-    return tf.nn.depthwise_conv2d(
-        img, kernel, [1, 1, 1, 1], "VALID", name="result")
+    return tf.nn.depthwise_conv2d(img,
+                                  kernel, [1, 1, 1, 1],
+                                  "VALID",
+                                  name="result")
 
   @tf.function(input_signature=[
       tf.TensorSpec([2, 4, 5, 2], tf.float32),
       tf.TensorSpec([2, 4, 2, 3], tf.float32),
   ])
   def conv2d_2452x2423_same(self, img, kernel):
-    return tf.nn.depthwise_conv2d(
-        img, kernel, [1, 1, 1, 1], "SAME", name="result")
+    return tf.nn.depthwise_conv2d(img,
+                                  kernel, [1, 1, 1, 1],
+                                  "SAME",
+                                  name="result")
 
   @tf.function(input_signature=[
       tf.TensorSpec([2, 4, 5, 2], tf.float32),
       tf.TensorSpec([2, 4, 2, 3], tf.float32),
   ])
   def conv2d_2452x2423_valid_stride_2(self, img, kernel):
-    return tf.nn.depthwise_conv2d(
-        img, kernel, [1, 2, 2, 1], "VALID", name="result")
+    return tf.nn.depthwise_conv2d(img,
+                                  kernel, [1, 2, 2, 1],
+                                  "VALID",
+                                  name="result")
 
   @tf.function(input_signature=[
       tf.TensorSpec([2, 4, 5, 2], tf.float32),
       tf.TensorSpec([2, 4, 2, 3], tf.float32),
   ])
   def conv2d_2452x2423_same_stride_2(self, img, kernel):
-    return tf.nn.depthwise_conv2d(
-        img, kernel, [1, 2, 2, 1], "SAME", name="result")
+    return tf.nn.depthwise_conv2d(img,
+                                  kernel, [1, 2, 2, 1],
+                                  "SAME",
+                                  name="result")
 
   @tf.function(input_signature=[
       tf.TensorSpec([2, 4, 5, 4], tf.float32),
       tf.TensorSpec([2, 4, 4, 1], tf.float32),
   ])
   def conv2d_2453x2441_same_stride_1(self, img, kernel):
-    return tf.nn.depthwise_conv2d(
-        img, kernel, [1, 1, 1, 1], "SAME", name="result")
+    return tf.nn.depthwise_conv2d(img,
+                                  kernel, [1, 1, 1, 1],
+                                  "SAME",
+                                  name="result")
 
 
 class ConvTest(tf_test_utils.TracedModuleTestCase):
+
+  def __init__(self, methodName="runTest"):
+    super(ConvTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(DepthConv2dModule)
 
   def test_batched_feature_unpadded(self):
 
@@ -73,7 +87,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2423_valid(i, k)
 
-    self.compare_backends(batched_feature_unpadded)
+    self.compare_backends(batched_feature_unpadded, *self._modules)
 
   def test_batched_feature_unpadded_same(self):
 
@@ -82,7 +96,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same(i, k)
 
-    self.compare_backends(batched_feature_unpadded_same)
+    self.compare_backends(batched_feature_unpadded_same, *self._modules)
 
   def test_batched_feature_unpadded_same_stride_2(self):
 
@@ -91,7 +105,8 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_valid_stride_2(i, k)
 
-    self.compare_backends(batched_feature_unpadded_same_stride_2)
+    self.compare_backends(batched_feature_unpadded_same_stride_2,
+                          *self._modules)
 
   def test_batched_feature_padded_same_stride_2(self):
 
@@ -100,7 +115,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same_stride_2(i, k)
 
-    self.compare_backends(batched_feature_padded_same_stride_2)
+    self.compare_backends(batched_feature_padded_same_stride_2, *self._modules)
 
   def test_batched_feature_padded_same_stride_1_output_1(self):
 
@@ -109,14 +124,14 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 4, 1])
       module.conv2d_2453x2441_same_stride_1(i, k)
 
-    self.compare_backends(batched_feature_padded_same_stride_1_output_1)
+    self.compare_backends(batched_feature_padded_same_stride_1_output_1,
+                          *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(DepthConv2dModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -87,7 +87,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2423_valid(i, k)
 
-    self.compare_backends(batched_feature_unpadded, *self._modules)
+    self.compare_backends(batched_feature_unpadded, self._modules)
 
   def test_batched_feature_unpadded_same(self):
 
@@ -96,7 +96,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same(i, k)
 
-    self.compare_backends(batched_feature_unpadded_same, *self._modules)
+    self.compare_backends(batched_feature_unpadded_same, self._modules)
 
   def test_batched_feature_unpadded_same_stride_2(self):
 
@@ -106,7 +106,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       module.conv2d_2452x2423_valid_stride_2(i, k)
 
     self.compare_backends(batched_feature_unpadded_same_stride_2,
-                          *self._modules)
+                          self._modules)
 
   def test_batched_feature_padded_same_stride_2(self):
 
@@ -115,7 +115,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same_stride_2(i, k)
 
-    self.compare_backends(batched_feature_padded_same_stride_2, *self._modules)
+    self.compare_backends(batched_feature_padded_same_stride_2, self._modules)
 
   def test_batched_feature_padded_same_stride_1_output_1(self):
 
@@ -125,7 +125,7 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
       module.conv2d_2453x2441_same_stride_1(i, k)
 
     self.compare_backends(batched_feature_padded_same_stride_1_output_1,
-                          *self._modules)
+                          self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
@@ -17,6 +17,7 @@
 # This uses a relu instead, allowing it to get to the remaining issue
 # (unimplemented dynamic dot_general).
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -65,7 +66,6 @@ class DynamicMlpReluModule(tf.Module):
     return tf.nn.softmax(self.mlp(x))
 
 
-@tf_test_utils.compile_module(DynamicMlpReluModule, exported_names=["predict"])
 class DynamicMlpReluTest(tf_test_utils.TracedModuleTestCase):
 
   def test_dynamic_batch(self):
@@ -77,7 +77,13 @@ class DynamicMlpReluTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(dynamic_batch)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(DynamicMlpReluModule, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
@@ -78,7 +78,7 @@ class DynamicMlpReluTest(tf_test_utils.TracedModuleTestCase):
       x = tf_utils.uniform([3, 28 * 28]) * 1e-3
       module.predict(x)
 
-    self.compare_backends(dynamic_batch, *self._modules)
+    self.compare_backends(dynamic_batch, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_relu_test.py
@@ -43,8 +43,8 @@ class DynamicMlpReluModule(tf.Module):
     self.input_dim = input_dim
     self.classes = classes
     self.h1_weights = tf.Variable(tf.random.normal([input_dim, hidden_1_dim]))
-    self.h2_weights = tf.Variable(
-        tf.random.normal([hidden_1_dim, hidden_2_dim]))
+    self.h2_weights = tf.Variable(tf.random.normal([hidden_1_dim,
+                                                    hidden_2_dim]))
     self.out_weights = tf.Variable(tf.random.normal([hidden_2_dim, classes]))
     self.h1_bias = tf.Variable(tf.random.normal([hidden_1_dim]))
     self.h2_bias = tf.Variable(tf.random.normal([hidden_2_dim]))
@@ -52,8 +52,7 @@ class DynamicMlpReluModule(tf.Module):
 
     # Compile with dynamic batch dim.
     self.predict = tf.function(
-        input_signature=[tf.TensorSpec([None, self.input_dim])])(
-            self.predict)
+        input_signature=[tf.TensorSpec([None, self.input_dim])])(self.predict)
 
   def mlp(self, x):
     layer_1 = tf.nn.relu(tf.add(tf.matmul(x, self.h1_weights), self.h1_bias))
@@ -68,20 +67,24 @@ class DynamicMlpReluModule(tf.Module):
 
 class DynamicMlpReluTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(DynamicMlpReluTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(DynamicMlpReluModule,
+                                                    exported_names=["predict"])
+
   def test_dynamic_batch(self):
 
     def dynamic_batch(module):
       x = tf_utils.uniform([3, 28 * 28]) * 1e-3
       module.predict(x)
 
-    self.compare_backends(dynamic_batch)
+    self.compare_backends(dynamic_batch, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(DynamicMlpReluModule, exported_names=["predict"])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/dynamic_mlp_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_test.py
@@ -74,7 +74,7 @@ class DynamicMlpTest(tf_test_utils.TracedModuleTestCase):
       x = tf_utils.uniform([3, 28 * 28]) * 1e-3
       module.predict(x)
 
-    self.compare_backends(dynamic_batch, *self._modules)
+    self.compare_backends(dynamic_batch, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/dynamic_mlp_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -61,7 +62,6 @@ class DynamicMlpModule(tf.Module):
     return tf.nn.softmax(self.mlp(x))
 
 
-@tf_test_utils.compile_module(DynamicMlpModule, exported_names=["predict"])
 class DynamicMlpTest(tf_test_utils.TracedModuleTestCase):
 
   def test_dynamic_batch(self):
@@ -73,7 +73,13 @@ class DynamicMlpTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(dynamic_batch)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(DynamicMlpModule, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/fill_test.py
+++ b/integrations/tensorflow/e2e/fill_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -30,7 +31,6 @@ class FillModule(tf.Module):
     return tf.fill(dims, value)
 
 
-@tf_test_utils.compile_module(FillModule)
 class FillTest(tf_test_utils.TracedModuleTestCase):
 
   def test_fill(self):
@@ -43,7 +43,13 @@ class FillTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(fill)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(FillModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/fill_test.py
+++ b/integrations/tensorflow/e2e/fill_test.py
@@ -33,6 +33,10 @@ class FillModule(tf.Module):
 
 class FillTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(FillTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(FillModule)
+
   def test_fill(self):
 
     def fill(module):
@@ -40,14 +44,13 @@ class FillTest(tf_test_utils.TracedModuleTestCase):
       value = np.array(9., dtype=np.float32)
       module.fill(dims, value)
 
-    self.compare_backends(fill)
+    self.compare_backends(fill, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(FillModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/fill_test.py
+++ b/integrations/tensorflow/e2e/fill_test.py
@@ -44,7 +44,7 @@ class FillTest(tf_test_utils.TracedModuleTestCase):
       value = np.array(9., dtype=np.float32)
       module.fill(dims, value)
 
-    self.compare_backends(fill, *self._modules)
+    self.compare_backends(fill, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/finite_test.py
+++ b/integrations/tensorflow/e2e/finite_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -24,7 +25,6 @@ class FiniteModule(tf.Module):
     return tf.math.is_finite(x)
 
 
-@tf_test_utils.compile_module(FiniteModule)
 class FiniteTest(tf_test_utils.TracedModuleTestCase):
 
   def test_finite(self):
@@ -35,7 +35,13 @@ class FiniteTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(finite)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(FiniteModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/finite_test.py
+++ b/integrations/tensorflow/e2e/finite_test.py
@@ -36,7 +36,7 @@ class FiniteTest(tf_test_utils.TracedModuleTestCase):
     def finite(module):
       module.finite(np.array([0.0, 1.2, -5.0, np.inf], dtype=np.float32))
 
-    self.compare_backends(finite, *self._modules)
+    self.compare_backends(finite, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/finite_test.py
+++ b/integrations/tensorflow/e2e/finite_test.py
@@ -27,19 +27,22 @@ class FiniteModule(tf.Module):
 
 class FiniteTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(FiniteTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(FiniteModule)
+
   def test_finite(self):
 
     def finite(module):
       module.finite(np.array([0.0, 1.2, -5.0, np.inf], dtype=np.float32))
 
-    self.compare_backends(finite)
+    self.compare_backends(finite, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(FiniteModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/gather_test.py
+++ b/integrations/tensorflow/e2e/gather_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -65,7 +66,6 @@ class GatherModule(tf.Module):
     return tf.gather(params, indices, axis=1, batch_dims=1)
 
 
-@tf_test_utils.compile_module(GatherModule)
 class GatherTest(tf_test_utils.TracedModuleTestCase):
 
   def test_gather_axis0_scalar(self):
@@ -124,7 +124,13 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
 
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(GatherModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/gather_test.py
+++ b/integrations/tensorflow/e2e/gather_test.py
@@ -79,7 +79,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_scalar(params, indices)
 
-    self.compare_backends(gather_axis0_scalar, *self._modules)
+    self.compare_backends(gather_axis0_scalar, self._modules)
 
   def test_gather_axis0_batch0(self):
 
@@ -88,7 +88,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_batch0(params, indices)
 
-    self.compare_backends(gather_axis0_batch0, *self._modules)
+    self.compare_backends(gather_axis0_batch0, self._modules)
 
   def test_gather_axis1_batch0(self):
 
@@ -97,7 +97,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8])
       module.gather_axis1_batch0(params, indices)
 
-    self.compare_backends(gather_axis1_batch0, *self._modules)
+    self.compare_backends(gather_axis1_batch0, self._modules)
 
   def test_gather_axis2_batch1(self):
 
@@ -106,7 +106,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis2_batch1(params, indices)
 
-    self.compare_backends(gather_axis2_batch1, *self._modules)
+    self.compare_backends(gather_axis2_batch1, self._modules)
 
   def test_gather_axis1_batch1(self):
 
@@ -115,7 +115,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis1_batch1(params, indices)
 
-    self.compare_backends(gather_axis1_batch1, *self._modules)
+    self.compare_backends(gather_axis1_batch1, self._modules)
 
   def test_gather_axis2_batch2(self):
 
@@ -124,7 +124,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       values = np.array([[0, 1, 2, 3], [9, 8, 7, 0]], dtype=np.int32)
       module.gather_axis2_batch2(values, indices)
 
-    self.compare_backends(gather_axis2_batch2, *self._modules)
+    self.compare_backends(gather_axis2_batch2, self._modules)
 
 
 

--- a/integrations/tensorflow/e2e/gather_test.py
+++ b/integrations/tensorflow/e2e/gather_test.py
@@ -68,6 +68,10 @@ class GatherModule(tf.Module):
 
 class GatherTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(GatherTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(GatherModule)
+
   def test_gather_axis0_scalar(self):
 
     def gather_axis0_scalar(module):
@@ -75,7 +79,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_scalar(params, indices)
 
-    self.compare_backends(gather_axis0_scalar)
+    self.compare_backends(gather_axis0_scalar, *self._modules)
 
   def test_gather_axis0_batch0(self):
 
@@ -84,7 +88,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_batch0(params, indices)
 
-    self.compare_backends(gather_axis0_batch0)
+    self.compare_backends(gather_axis0_batch0, *self._modules)
 
   def test_gather_axis1_batch0(self):
 
@@ -93,7 +97,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8])
       module.gather_axis1_batch0(params, indices)
 
-    self.compare_backends(gather_axis1_batch0)
+    self.compare_backends(gather_axis1_batch0, *self._modules)
 
   def test_gather_axis2_batch1(self):
 
@@ -102,7 +106,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis2_batch1(params, indices)
 
-    self.compare_backends(gather_axis2_batch1)
+    self.compare_backends(gather_axis2_batch1, *self._modules)
 
   def test_gather_axis1_batch1(self):
 
@@ -111,7 +115,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis1_batch1(params, indices)
 
-    self.compare_backends(gather_axis1_batch1)
+    self.compare_backends(gather_axis1_batch1, *self._modules)
 
   def test_gather_axis2_batch2(self):
 
@@ -120,7 +124,7 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
       values = np.array([[0, 1, 2, 3], [9, 8, 7, 0]], dtype=np.int32)
       module.gather_axis2_batch2(values, indices)
 
-    self.compare_backends(gather_axis2_batch2)
+    self.compare_backends(gather_axis2_batch2, *self._modules)
 
 
 
@@ -128,7 +132,6 @@ def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(GatherModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/keras/lstm_static_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_test.py
@@ -56,7 +56,7 @@ class LstmStaticTest(tf_test_utils.TracedModuleTestCase):
       inputs = tf_utils.ndarange(INPUT_SHAPE)
       module.predict(inputs, rtol=1e-5, atol=1e-5)
 
-    self.compare_backends(predict, *self._modules)
+    self.compare_backends(predict, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/keras/lstm_static_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_test.py
@@ -16,6 +16,7 @@
 # This test is the same as keras_lstm_test, but all shapes are static.
 # This stresses the TensorList lowering more specifically.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -42,7 +43,6 @@ class LstmStaticModule(tf.Module):
             self.m.call)
 
 
-@tf_test_utils.compile_module(LstmStaticModule, exported_names=["predict"])
 class LstmStaticTest(tf_test_utils.TracedModuleTestCase):
 
   def test_lstm(self):
@@ -54,7 +54,13 @@ class LstmStaticTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(predict)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(LstmStaticModule, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/keras/lstm_static_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_static_test.py
@@ -45,20 +45,24 @@ class LstmStaticModule(tf.Module):
 
 class LstmStaticTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(LstmStaticTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(LstmStaticModule,
+                                                    exported_names=["predict"])
+
   def test_lstm(self):
 
     def predict(module):
       inputs = tf_utils.ndarange(INPUT_SHAPE)
       module.predict(inputs, rtol=1e-5, atol=1e-5)
 
-    self.compare_backends(predict)
+    self.compare_backends(predict, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(LstmStaticModule, exported_names=["predict"])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/keras/lstm_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_test.py
@@ -32,16 +32,19 @@ class LstmModule(tf.Module):
     super(LstmModule, self).__init__()
     tf_utils.set_random_seed()
     inputs = tf.keras.layers.Input(batch_size=None, shape=DYNAMIC_SHAPE[1:])
-    outputs = tf.keras.layers.LSTM(
-        units=NUM_UNITS, return_sequences=True)(
-            inputs)
+    outputs = tf.keras.layers.LSTM(units=NUM_UNITS,
+                                   return_sequences=True)(inputs)
     self.m = tf.keras.Model(inputs, outputs)
     self.predict = tf.function(
-        input_signature=[tf.TensorSpec(DYNAMIC_SHAPE, tf.float32)])(
-            self.m.call)
+        input_signature=[tf.TensorSpec(DYNAMIC_SHAPE, tf.float32)])(self.m.call)
 
 
 class LstmTest(tf_test_utils.TracedModuleTestCase):
+
+  def __init__(self, methodName="runTest"):
+    super(LstmTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(LstmModule,
+                                                    exported_names=["predict"])
 
   def test_lstm(self):
 
@@ -49,14 +52,14 @@ class LstmTest(tf_test_utils.TracedModuleTestCase):
       inputs = tf_utils.ndarange(INPUT_SHAPE)
       module.predict(inputs)
 
-    self.compare_backends(predict)
+    self.compare_backends(predict, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(LstmModule, exported_names=["predict"])
+
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/keras/lstm_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_test.py
@@ -52,7 +52,7 @@ class LstmTest(tf_test_utils.TracedModuleTestCase):
       inputs = tf_utils.ndarange(INPUT_SHAPE)
       module.predict(inputs)
 
-    self.compare_backends(predict, *self._modules)
+    self.compare_backends(predict, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/keras/lstm_test.py
+++ b/integrations/tensorflow/e2e/keras/lstm_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -40,7 +41,6 @@ class LstmModule(tf.Module):
             self.m.call)
 
 
-@tf_test_utils.compile_module(LstmModule, exported_names=["predict"])
 class LstmTest(tf_test_utils.TracedModuleTestCase):
 
   def test_lstm(self):
@@ -52,7 +52,13 @@ class LstmTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(predict)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(LstmModule, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/keras/train/model_train_test.py
+++ b/integrations/tensorflow/e2e/keras/train/model_train_test.py
@@ -75,8 +75,6 @@ class ModelTrain(tf.Module):
     return loss_value
 
 
-@tf_test_utils.compile_module(
-    ModelTrain.CreateModule, exported_names=["train_step"])
 class ModelTrainTest(tf_test_utils.TracedModuleTestCase):
 
   def generate_regression_data(self, size=8):
@@ -110,5 +108,6 @@ class ModelTrainTest(tf_test_utils.TracedModuleTestCase):
 if __name__ == "__main__":
   if hasattr(tf, "enable_v2_behavior"):
     tf.enable_v2_behavior()
-
+  tf_test_utils.compile_tf_module(ModelTrain.CreateModule,
+                                  exported_names=["train_step"])
   tf.test.main()

--- a/integrations/tensorflow/e2e/keras/train/model_train_test.py
+++ b/integrations/tensorflow/e2e/keras/train/model_train_test.py
@@ -102,7 +102,7 @@ class ModelTrainTest(tf_test_utils.TracedModuleTestCase):
       # Run one iteration of training step.
       module.train_step(inputs, targets)
 
-    self.compare_backends(train_step, *self._modules)
+    self.compare_backends(train_step, self._modules)
 
 
 if __name__ == "__main__":

--- a/integrations/tensorflow/e2e/keras/train/model_train_test.py
+++ b/integrations/tensorflow/e2e/keras/train/model_train_test.py
@@ -102,7 +102,7 @@ class ModelTrainTest(tf_test_utils.TracedModuleTestCase):
       # Run one iteration of training step.
       module.train_step(inputs, targets)
 
-    self.compare_backends(train_step)
+    self.compare_backends(train_step, *self._modules)
 
 
 if __name__ == "__main__":

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -147,7 +147,7 @@ class AppTest(tf_test_utils.TracedModuleTestCase):
     def predict(module):
       module.predict(tf_utils.uniform(get_input_shape()))
 
-    self.compare_backends(predict, *self._modules)
+    self.compare_backends(predict, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -113,8 +113,9 @@ def initialize_model():
   # an external tf.keras URL.
   weights = 'imagenet' if FLAGS.data == 'imagenet' else None
 
-  model = APP_MODELS[FLAGS.model](
-      weights=weights, include_top=FLAGS.include_top, input_shape=input_shape)
+  model = APP_MODELS[FLAGS.model](weights=weights,
+                                  include_top=FLAGS.include_top,
+                                  input_shape=input_shape)
 
   if FLAGS.data == 'cifar10' and FLAGS.url:
     model = load_cifar10_weights(model)
@@ -131,18 +132,22 @@ class VisionModule(tf.Module):
     # TODO(b/142948097): Add support for dynamic shapes in SPIR-V lowering.
     # Replace input_shape with m.input_shape to make the batch size dynamic.
     self.predict = tf.function(
-        input_signature=[tf.TensorSpec(get_input_shape())])(
-            self.m.predict)
+        input_signature=[tf.TensorSpec(get_input_shape())])(self.m.predict)
 
 
 class AppTest(tf_test_utils.TracedModuleTestCase):
+
+  def __init__(self, methodName="runTest"):
+    super(AppTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(VisionModule,
+                                                    exported_names=['predict'])
 
   def test_application(self):
 
     def predict(module):
       module.predict(tf_utils.uniform(get_input_shape()))
 
-    self.compare_backends(predict)
+    self.compare_backends(predict, *self._modules)
 
 
 def main(argv):
@@ -155,7 +160,6 @@ def main(argv):
   # Override VisionModule's __name__ to be more specific.
   VisionModule.__name__ = os.path.join(FLAGS.model, FLAGS.data)
 
-  tf_test_utils.compile_tf_module(VisionModule, exported_names=['predict'])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -135,7 +135,6 @@ class VisionModule(tf.Module):
             self.m.predict)
 
 
-@tf_test_utils.compile_module(VisionModule, exported_names=['predict'])
 class AppTest(tf_test_utils.TracedModuleTestCase):
 
   def test_application(self):
@@ -156,6 +155,7 @@ def main(argv):
   # Override VisionModule's __name__ to be more specific.
   VisionModule.__name__ = os.path.join(FLAGS.model, FLAGS.data)
 
+  tf_test_utils.compile_tf_module(VisionModule, exported_names=['predict'])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/linspace_test.py
+++ b/integrations/tensorflow/e2e/linspace_test.py
@@ -47,7 +47,7 @@ class LinspaceTest(tf_test_utils.TracedModuleTestCase):
       stop = np.array(12., dtype=np.float32)
       module.linspace(start, stop)
 
-    self.compare_backends(linspace, *self._modules)
+    self.compare_backends(linspace, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/linspace_test.py
+++ b/integrations/tensorflow/e2e/linspace_test.py
@@ -36,6 +36,10 @@ class LinspaceModule(tf.Module):
 
 class LinspaceTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(LinspaceTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(LinspaceModule)
+
   def test_linspace(self):
 
     def linspace(module):
@@ -43,14 +47,13 @@ class LinspaceTest(tf_test_utils.TracedModuleTestCase):
       stop = np.array(12., dtype=np.float32)
       module.linspace(start, stop)
 
-    self.compare_backends(linspace)
+    self.compare_backends(linspace, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(LinspaceModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/linspace_test.py
+++ b/integrations/tensorflow/e2e/linspace_test.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
 
 
-class LinSpaceModule(tf.Module):
+class LinspaceModule(tf.Module):
 
   def __init__(self):
     pass
@@ -33,7 +34,6 @@ class LinSpaceModule(tf.Module):
     return tf.linspace(start, stop, num)
 
 
-@tf_test_utils.compile_module(LinSpaceModule)
 class LinspaceTest(tf_test_utils.TracedModuleTestCase):
 
   def test_linspace(self):
@@ -46,7 +46,13 @@ class LinspaceTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(linspace)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(LinspaceModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/logical_ops_test.py
+++ b/integrations/tensorflow/e2e/logical_ops_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for ops in the tf.math module that specifically handle logical ops."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -46,7 +47,6 @@ class LogicalOpsModule(tf.Module):
     return tf.math.logical_not(x)
 
 
-@tf_test_utils.compile_module(LogicalOpsModule)
 class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
 
   def test_logical_and(self):
@@ -84,7 +84,13 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(logical_not)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(LogicalOpsModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/logical_ops_test.py
+++ b/integrations/tensorflow/e2e/logical_ops_test.py
@@ -60,7 +60,7 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_and, *self._modules)
+    self.compare_backends(logical_and, self._modules)
 
   def test_logical_or(self):
 
@@ -69,7 +69,7 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_or, *self._modules)
+    self.compare_backends(logical_or, self._modules)
 
   def test_logical_xor(self):
 
@@ -78,14 +78,14 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_xor, *self._modules)
+    self.compare_backends(logical_xor, self._modules)
 
   def test_logical_not(self):
 
     def logical_not(module):
       module.logical_not(np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_not, *self._modules)
+    self.compare_backends(logical_not, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/logical_ops_test.py
+++ b/integrations/tensorflow/e2e/logical_ops_test.py
@@ -49,6 +49,10 @@ class LogicalOpsModule(tf.Module):
 
 class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(LogicalOpsTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(LogicalOpsModule)
+
   def test_logical_and(self):
 
     def logical_and(module):
@@ -56,7 +60,7 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_and)
+    self.compare_backends(logical_and, *self._modules)
 
   def test_logical_or(self):
 
@@ -65,7 +69,7 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_or)
+    self.compare_backends(logical_or, *self._modules)
 
   def test_logical_xor(self):
 
@@ -74,21 +78,20 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_xor)
+    self.compare_backends(logical_xor, *self._modules)
 
   def test_logical_not(self):
 
     def logical_not(module):
       module.logical_not(np.array([0, 1, 1, 0], dtype=np.bool))
 
-    self.compare_backends(logical_not)
+    self.compare_backends(logical_not, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(LogicalOpsModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/mandelbrot_test.py
+++ b/integrations/tensorflow/e2e/mandelbrot_test.py
@@ -105,7 +105,7 @@ class MandelbrotTest(tf_test_utils.TracedModuleTestCase):
       # This is a much more detailed view, so more iterations are needed.
       module.calculate(-0.7436447860, 0.1318252536, 0.0000029336, 400, 3000)
 
-    self.compare_backends(mandelbrot, *self._modules)
+    self.compare_backends(mandelbrot, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/mandelbrot_test.py
+++ b/integrations/tensorflow/e2e/mandelbrot_test.py
@@ -93,6 +93,10 @@ class MandelbrotModule(tf.Module):
 
 class MandelbrotTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(MandelbrotTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MandelbrotModule)
+
   def test_mandelbrot(self):
 
     def mandelbrot(module):
@@ -101,14 +105,13 @@ class MandelbrotTest(tf_test_utils.TracedModuleTestCase):
       # This is a much more detailed view, so more iterations are needed.
       module.calculate(-0.7436447860, 0.1318252536, 0.0000029336, 400, 3000)
 
-    self.compare_backends(mandelbrot)
+    self.compare_backends(mandelbrot, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MandelbrotModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/mandelbrot_test.py
+++ b/integrations/tensorflow/e2e/mandelbrot_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
 
@@ -90,7 +91,6 @@ class MandelbrotModule(tf.Module):
     return tf.reshape(in_the_set, shape=[view_pixels, view_pixels])
 
 
-@tf_test_utils.compile_module(MandelbrotModule)
 class MandelbrotTest(tf_test_utils.TracedModuleTestCase):
 
   def test_mandelbrot(self):
@@ -104,7 +104,13 @@ class MandelbrotTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(mandelbrot)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(MandelbrotModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/math_test.py
+++ b/integrations/tensorflow/e2e/math_test.py
@@ -54,35 +54,35 @@ class MathTest(tf_test_utils.TracedModuleTestCase):
     def abs(module):
       module.abs(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(abs, *self._modules)
+    self.compare_backends(abs, self._modules)
 
   def test_ceil(self):
 
     def ceil(module):
       module.ceil(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(ceil, *self._modules)
+    self.compare_backends(ceil, self._modules)
 
   def test_cos(self):
 
     def cos(module):
       module.cos(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(cos, *self._modules)
+    self.compare_backends(cos, self._modules)
 
   def test_log(self):
 
     def log(module):
       module.log(np.array([0.1, 0.2, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(log, *self._modules)
+    self.compare_backends(log, self._modules)
 
   def test_mod(self):
 
     def mod(module):
       module.mod(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(mod, *self._modules)
+    self.compare_backends(mod, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/math_test.py
+++ b/integrations/tensorflow/e2e/math_test.py
@@ -45,47 +45,50 @@ class MathModule(tf.Module):
 
 class MathTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(MathTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MathModule)
+
   def test_abs(self):
 
     def abs(module):
       module.abs(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(abs)
+    self.compare_backends(abs, *self._modules)
 
   def test_ceil(self):
 
     def ceil(module):
       module.ceil(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(ceil)
+    self.compare_backends(ceil, *self._modules)
 
   def test_cos(self):
 
     def cos(module):
       module.cos(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(cos)
+    self.compare_backends(cos, *self._modules)
 
   def test_log(self):
 
     def log(module):
       module.log(np.array([0.1, 0.2, 0.5, 1.0], dtype=np.float32))
 
-    self.compare_backends(log)
+    self.compare_backends(log, *self._modules)
 
   def test_mod(self):
 
     def mod(module):
       module.mod(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
 
-    self.compare_backends(mod)
+    self.compare_backends(mod, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MathModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/math_test.py
+++ b/integrations/tensorflow/e2e/math_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for ops in the tf.math module."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -42,7 +43,6 @@ class MathModule(tf.Module):
     return tf.math.mod(x, 2.0)
 
 
-@tf_test_utils.compile_module(MathModule)
 class MathTest(tf_test_utils.TracedModuleTestCase):
 
   def test_abs(self):
@@ -81,7 +81,13 @@ class MathTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(mod)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(MathModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
@@ -56,7 +56,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_high_rank_batch(
           tf_utils.uniform([1, 7, 4, 2]), tf_utils.uniform([7, 1, 2, 4]))
 
-    self.compare_backends(matmul_high_rank_batch, *self._modules)
+    self.compare_backends(matmul_high_rank_batch, self._modules)
 
   def test_matmul_dynamic_matching_batch(self):
 
@@ -64,7 +64,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([2, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_matching_batch, *self._modules)
+    self.compare_backends(matmul_dynamic_matching_batch, self._modules)
 
   def test_matmul_dynamic_broadcast_lhs(self):
 
@@ -72,7 +72,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([1, 2, 3]), tf_utils.uniform([2, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_broadcast_lhs, *self._modules)
+    self.compare_backends(matmul_dynamic_broadcast_lhs, self._modules)
 
   def test_matmul_dynamic_broadcast_rhs(self):
 
@@ -80,7 +80,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([1, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_broadcast_rhs, *self._modules)
+    self.compare_backends(matmul_dynamic_broadcast_rhs, self._modules)
 
   def test_matmul_dynamic_rank_broadcasting(self):
 
@@ -88,7 +88,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic_lhs_batch(
           tf_utils.uniform([7, 2, 3]), tf_utils.uniform([3, 4]))
 
-    self.compare_backends(matmul_dynamic_rank_broadcasting, *self._modules)
+    self.compare_backends(matmul_dynamic_rank_broadcasting, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Test matrix ops."""
 
+from absl import app
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
@@ -43,7 +44,6 @@ class MatrixOpsDynamicModule(tf.Module):
     return tf.matmul(lhs, rhs)
 
 
-@tf_test_utils.compile_module(MatrixOpsDynamicModule)
 class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
 
   def test_matmul_high_rank_batch(self):
@@ -87,7 +87,13 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(matmul_dynamic_rank_broadcasting)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(MatrixOpsDynamicModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
@@ -46,13 +46,17 @@ class MatrixOpsDynamicModule(tf.Module):
 
 class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(MatrixOpsDynamicTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MatrixOpsDynamicModule)
+
   def test_matmul_high_rank_batch(self):
 
     def matmul_high_rank_batch(module):
       module.matmul_high_rank_batch(
           tf_utils.uniform([1, 7, 4, 2]), tf_utils.uniform([7, 1, 2, 4]))
 
-    self.compare_backends(matmul_high_rank_batch)
+    self.compare_backends(matmul_high_rank_batch, *self._modules)
 
   def test_matmul_dynamic_matching_batch(self):
 
@@ -60,7 +64,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([2, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_matching_batch)
+    self.compare_backends(matmul_dynamic_matching_batch, *self._modules)
 
   def test_matmul_dynamic_broadcast_lhs(self):
 
@@ -68,7 +72,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([1, 2, 3]), tf_utils.uniform([2, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_broadcast_lhs)
+    self.compare_backends(matmul_dynamic_broadcast_lhs, *self._modules)
 
   def test_matmul_dynamic_broadcast_rhs(self):
 
@@ -76,7 +80,7 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([1, 3, 4]))
 
-    self.compare_backends(matmul_dynamic_broadcast_rhs)
+    self.compare_backends(matmul_dynamic_broadcast_rhs, *self._modules)
 
   def test_matmul_dynamic_rank_broadcasting(self):
 
@@ -84,14 +88,13 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
       module.matmul_dynamic_lhs_batch(
           tf_utils.uniform([7, 2, 3]), tf_utils.uniform([3, 4]))
 
-    self.compare_backends(matmul_dynamic_rank_broadcasting)
+    self.compare_backends(matmul_dynamic_rank_broadcasting, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MatrixOpsDynamicModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/matrix_ops_static_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_static_test.py
@@ -58,13 +58,17 @@ class MatrixOpsStaticModule(tf.Module):
 
 class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(MatrixOpsStaticTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MatrixOpsStaticModule)
+
   def test_basic_matmul(self):
 
     def basic_matmul(module):
       module.basic_matmul(tf_utils.uniform([LEFT_DIM, INNER_DIM]),
                           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(basic_matmul)
+    self.compare_backends(basic_matmul, *self._modules)
 
   def test_matmul_lhs_batch(self):
 
@@ -73,7 +77,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([BATCH_DIM, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_lhs_batch)
+    self.compare_backends(matmul_lhs_batch, *self._modules)
 
   def test_matmul_rhs_batch(self):
 
@@ -82,7 +86,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_rhs_batch)
+    self.compare_backends(matmul_rhs_batch, *self._modules)
 
   def test_matmul_broadcast_singleton_dimension(self):
 
@@ -91,14 +95,13 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([1, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_broadcast_singleton_dimension)
+    self.compare_backends(matmul_broadcast_singleton_dimension, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MatrixOpsStaticModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/matrix_ops_static_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_static_test.py
@@ -68,7 +68,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
       module.basic_matmul(tf_utils.uniform([LEFT_DIM, INNER_DIM]),
                           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(basic_matmul, *self._modules)
+    self.compare_backends(basic_matmul, self._modules)
 
   def test_matmul_lhs_batch(self):
 
@@ -77,7 +77,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([BATCH_DIM, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_lhs_batch, *self._modules)
+    self.compare_backends(matmul_lhs_batch, self._modules)
 
   def test_matmul_rhs_batch(self):
 
@@ -86,7 +86,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_rhs_batch, *self._modules)
+    self.compare_backends(matmul_rhs_batch, self._modules)
 
   def test_matmul_broadcast_singleton_dimension(self):
 
@@ -95,7 +95,7 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.uniform([1, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
 
-    self.compare_backends(matmul_broadcast_singleton_dimension, *self._modules)
+    self.compare_backends(matmul_broadcast_singleton_dimension, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/matrix_ops_static_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_static_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Test matrix ops."""
 
+from absl import app
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
@@ -55,7 +56,6 @@ class MatrixOpsStaticModule(tf.Module):
     return tf.matmul(lhs, rhs)
 
 
-@tf_test_utils.compile_module(MatrixOpsStaticModule)
 class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
 
   def test_basic_matmul(self):
@@ -94,7 +94,13 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(matmul_broadcast_singleton_dimension)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(MatrixOpsStaticModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -81,7 +81,6 @@ class MobileBertSquad(tf.Module):
     return self.inference_func(**inputs)
 
 
-@tf_test_utils.compile_module(MobileBertSquad, exported_names=["predict"])
 class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
   """Tests of MobileBertSquad."""
 
@@ -97,8 +96,13 @@ class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(predict)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-
+  tf_test_utils.compile_tf_module(MobileBertSquad, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -84,6 +84,11 @@ class MobileBertSquad(tf.Module):
 class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
   """Tests of MobileBertSquad."""
 
+  def __init__(self, methodName="runTest"):
+    super(MobileBertSquadTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(MobileBertSquad,
+                                                    exported_names=["predict"])
+
   def test_predict(self):
 
     def predict(module):
@@ -93,14 +98,13 @@ class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
 
       module.predict(input_ids, input_mask, segment_ids, atol=1e0)
 
-    self.compare_backends(predict)
+    self.compare_backends(predict, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(MobileBertSquad, exported_names=["predict"])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -98,7 +98,7 @@ class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
 
       module.predict(input_ids, input_mask, segment_ids, atol=1e0)
 
-    self.compare_backends(predict, *self._modules)
+    self.compare_backends(predict, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/range_test.py
+++ b/integrations/tensorflow/e2e/range_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -31,7 +32,6 @@ class RangeModule(tf.Module):
     return tf.range(start, stop, delta)
 
 
-@tf_test_utils.compile_module(RangeModule)
 class RangeTest(tf_test_utils.TracedModuleTestCase):
 
   def test_range(self):
@@ -45,7 +45,13 @@ class RangeTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(range)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(RangeModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/range_test.py
+++ b/integrations/tensorflow/e2e/range_test.py
@@ -46,7 +46,7 @@ class RangeTest(tf_test_utils.TracedModuleTestCase):
       delta = np.array(3, dtype=np.float32)
       result = module.range(start, stop, delta)
 
-    self.compare_backends(range, *self._modules)
+    self.compare_backends(range, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/range_test.py
+++ b/integrations/tensorflow/e2e/range_test.py
@@ -34,6 +34,10 @@ class RangeModule(tf.Module):
 
 class RangeTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(RangeTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(RangeModule)
+
   def test_range(self):
 
     def range(module):
@@ -42,14 +46,13 @@ class RangeTest(tf_test_utils.TracedModuleTestCase):
       delta = np.array(3, dtype=np.float32)
       result = module.range(start, stop, delta)
 
-    self.compare_backends(range)
+    self.compare_backends(range, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(RangeModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/resource_ops_test.py
+++ b/integrations/tensorflow/e2e/resource_ops_test.py
@@ -40,7 +40,7 @@ class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
     def add_assign(module):
       module.add_assign(np.array(9., dtype=np.float32))
 
-    self.compare_backends(add_assign, *self._modules)
+    self.compare_backends(add_assign, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/resource_ops_test.py
+++ b/integrations/tensorflow/e2e/resource_ops_test.py
@@ -31,19 +31,22 @@ class ResourcesOpsModule(tf.Module):
 
 class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ResourcesOpsTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(ResourcesOpsModule)
+
   def test_add_assign(self):
 
     def add_assign(module):
       module.add_assign(np.array(9., dtype=np.float32))
 
-    self.compare_backends(add_assign)
+    self.compare_backends(add_assign, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(ResourcesOpsModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/resource_ops_test.py
+++ b/integrations/tensorflow/e2e/resource_ops_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -28,7 +29,6 @@ class ResourcesOpsModule(tf.Module):
     return self.counter.assign_add(value)
 
 
-@tf_test_utils.compile_module(ResourcesOpsModule)
 class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
 
   def test_add_assign(self):
@@ -39,7 +39,13 @@ class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(add_assign)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(ResourcesOpsModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/ring_buffer_test.py
+++ b/integrations/tensorflow/e2e/ring_buffer_test.py
@@ -185,6 +185,11 @@ class StatefulRingBufferModule(tf.Module):
 
 class StatefulRingBufferTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(StatefulRingBufferTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(StatefulRingBufferModule,
+                                                    exported_names=["predict"])
+
   def test_stateful_ringbuffer(self):
 
     def stateful_ringbuffer(module):
@@ -202,15 +207,13 @@ class StatefulRingBufferTest(tf_test_utils.TracedModuleTestCase):
       module.predict(input3)
       # output = np.array([[3.0, 4.0]], dtype=np.float32)
 
-    self.compare_backends(stateful_ringbuffer)
+    self.compare_backends(stateful_ringbuffer, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(StatefulRingBufferModule,
-                               exported_names=["predict"])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/ring_buffer_test.py
+++ b/integrations/tensorflow/e2e/ring_buffer_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -31,16 +32,20 @@ class RingBuffer(tf.Module):
 
     # buffer has size [buffer_size, dims]
     # only the first dimension is used for updating buffer in a ring manner
-    self._buffer = tf.Variable(
-        tf.zeros((self._buffer_size,) + dims, dtype=dtype),
-        trainable=False,
-        name="RingBuffer")
+    self._buffer = tf.Variable(tf.zeros((self._buffer_size,) + dims,
+                                        dtype=dtype),
+                               trainable=False,
+                               name="RingBuffer")
     # Size of the data available for reading
-    self._data_size = tf.Variable(
-        0, trainable=False, dtype=tf.int32, name="FramerBuffer/Size")
+    self._data_size = tf.Variable(0,
+                                  trainable=False,
+                                  dtype=tf.int32,
+                                  name="FramerBuffer/Size")
     # The index pointing to the head of the data available for reading
-    self._read_head = tf.Variable(
-        0, trainable=False, dtype=tf.int32, name="FramerBuffer/Head")
+    self._read_head = tf.Variable(0,
+                                  trainable=False,
+                                  dtype=tf.int32,
+                                  name="FramerBuffer/Head")
 
   @property
   def dtype(self):
@@ -82,8 +87,8 @@ class RingBuffer(tf.Module):
     start = tf.math.floormod(
         self._read_head.read_value() + self._data_size.read_value(),
         self._buffer_size)
-    indices = tf.math.floormod(
-        tf.range(start, limit=start + elements_size), self._buffer_size)
+    indices = tf.math.floormod(tf.range(start, limit=start + elements_size),
+                               self._buffer_size)
 
     tf.compat.v1.scatter_update(self._buffer, indices, elements)
 
@@ -118,8 +123,8 @@ class RingBuffer(tf.Module):
       Tensor of elements with shape [length, dims...].
     """
     start = self._read_head + offset
-    indices = tf.math.floormod(
-        tf.range(start, limit=start + length), self._buffer_size)
+    indices = tf.math.floormod(tf.range(start, limit=start + length),
+                               self._buffer_size)
     result = tf.gather(self._buffer, indices)
     if consume:
       self.consume(length, offset)
@@ -148,8 +153,9 @@ class StatefulRingBuffer(tf.keras.layers.Layer):
   def build(self, input_shape):
     super(StatefulRingBuffer, self).build(input_shape)
     buffer_size = self.state_shape[1]
-    self.rb = RingBuffer(
-        buffer_size=buffer_size, dims=(self.state_shape[2],), dtype=tf.float32)
+    self.rb = RingBuffer(buffer_size=buffer_size,
+                         dims=(self.state_shape[2],),
+                         dtype=tf.float32)
 
   def call(self, inputs):
     self.rb.write(inputs)
@@ -177,8 +183,6 @@ class StatefulRingBufferModule(tf.Module):
     return self.rb(x)
 
 
-@tf_test_utils.compile_module(
-    StatefulRingBufferModule, exported_names=["predict"])
 class StatefulRingBufferTest(tf_test_utils.TracedModuleTestCase):
 
   def test_stateful_ringbuffer(self):
@@ -201,7 +205,14 @@ class StatefulRingBufferTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(stateful_ringbuffer)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(StatefulRingBufferModule,
+                               exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/ring_buffer_test.py
+++ b/integrations/tensorflow/e2e/ring_buffer_test.py
@@ -207,7 +207,7 @@ class StatefulRingBufferTest(tf_test_utils.TracedModuleTestCase):
       module.predict(input3)
       # output = np.array([[3.0, 4.0]], dtype=np.float32)
 
-    self.compare_backends(stateful_ringbuffer, *self._modules)
+    self.compare_backends(stateful_ringbuffer, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/scatter_update_test.py
+++ b/integrations/tensorflow/e2e/scatter_update_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Test scatter update behavior for tensorflow."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
-"""Test scatter update behavior for tensorflow."""
 
 
 class ScatterUpdateModule(tf.Module):
@@ -48,7 +49,6 @@ class ScatterUpdateModule(tf.Module):
     return tf.tensor_scatter_nd_update(tensor, indices, updates)
 
 
-@tf_test_utils.compile_module(ScatterUpdateModule)
 class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
 
   def test_scatter_update_1D(self):
@@ -82,7 +82,13 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(scatter_update_2D_slice)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(ScatterUpdateModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/scatter_update_test.py
+++ b/integrations/tensorflow/e2e/scatter_update_test.py
@@ -63,7 +63,7 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([9, 10, 11], dtype=np.int32)
       module.scatter_update_1D(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_1D, *self._modules)
+    self.compare_backends(scatter_update_1D, self._modules)
 
   def test_scatter_update_2D(self):
 
@@ -73,7 +73,7 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([2, 5, 8], dtype=np.int32)
       module.scatter_update_2D(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_2D, *self._modules)
+    self.compare_backends(scatter_update_2D, self._modules)
 
   def test_scatter_update_2D_slice(self):
 
@@ -83,7 +83,7 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([[2, 3, 4]], dtype=np.int32)
       module.scatter_update_2D_slice(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_2D_slice, *self._modules)
+    self.compare_backends(scatter_update_2D_slice, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/scatter_update_test.py
+++ b/integrations/tensorflow/e2e/scatter_update_test.py
@@ -51,6 +51,10 @@ class ScatterUpdateModule(tf.Module):
 
 class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(ScatterUpdateTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(ScatterUpdateModule)
+
   def test_scatter_update_1D(self):
 
     def scatter_update_1D(module):
@@ -59,7 +63,7 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([9, 10, 11], dtype=np.int32)
       module.scatter_update_1D(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_1D)
+    self.compare_backends(scatter_update_1D, *self._modules)
 
   def test_scatter_update_2D(self):
 
@@ -69,7 +73,7 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([2, 5, 8], dtype=np.int32)
       module.scatter_update_2D(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_2D)
+    self.compare_backends(scatter_update_2D, *self._modules)
 
   def test_scatter_update_2D_slice(self):
 
@@ -79,14 +83,13 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
       updates = np.array([[2, 3, 4]], dtype=np.int32)
       module.scatter_update_2D_slice(tensor, indices, updates)
 
-    self.compare_backends(scatter_update_2D_slice)
+    self.compare_backends(scatter_update_2D_slice, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(ScatterUpdateModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/simple_arithmetic_test.py
+++ b/integrations/tensorflow/e2e/simple_arithmetic_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Several baseline e2e simple arithmetic tests."""
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -37,7 +38,6 @@ class SimpleArithmeticModule(tf.Module):
     return tf.matmul(a, b)
 
 
-@tf_test_utils.compile_module(SimpleArithmeticModule)
 class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 
   def test_simple_mul(self):
@@ -61,7 +61,13 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(simple_matmul)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(SimpleArithmeticModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/simple_arithmetic_test.py
+++ b/integrations/tensorflow/e2e/simple_arithmetic_test.py
@@ -52,7 +52,7 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
       c = module.simple_mul(a, b)
       module.simple_mul(a, c)
 
-    self.compare_backends(simple_mul, *self._modules)
+    self.compare_backends(simple_mul, self._modules)
 
   def test_simple_matmul(self):
 
@@ -62,7 +62,7 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform((3072, 256)) * 1e-3
       module.simple_matmul(a, b)
 
-    self.compare_backends(simple_matmul, *self._modules)
+    self.compare_backends(simple_matmul, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/simple_arithmetic_test.py
+++ b/integrations/tensorflow/e2e/simple_arithmetic_test.py
@@ -40,6 +40,10 @@ class SimpleArithmeticModule(tf.Module):
 
 class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(SimpleArithmeticTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(SimpleArithmeticModule)
+
   def test_simple_mul(self):
 
     def simple_mul(module):
@@ -48,7 +52,7 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
       c = module.simple_mul(a, b)
       module.simple_mul(a, c)
 
-    self.compare_backends(simple_mul)
+    self.compare_backends(simple_mul, *self._modules)
 
   def test_simple_matmul(self):
 
@@ -58,14 +62,13 @@ class SimpleArithmeticTest(tf_test_utils.TracedModuleTestCase):
       b = tf_utils.uniform((3072, 256)) * 1e-3
       module.simple_matmul(a, b)
 
-    self.compare_backends(simple_matmul)
+    self.compare_backends(simple_matmul, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(SimpleArithmeticModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/simple_stateful_test.py
+++ b/integrations/tensorflow/e2e/simple_stateful_test.py
@@ -46,7 +46,7 @@ class StatefulTest(tf_test_utils.TracedModuleTestCase):
       module.inc_by(np.array(1., dtype=np.float32))
       module.get_state()
 
-    self.compare_backends(get_state, *self._modules)
+    self.compare_backends(get_state, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/simple_stateful_test.py
+++ b/integrations/tensorflow/e2e/simple_stateful_test.py
@@ -36,20 +36,23 @@ class SimpleStatefulModule(tf.Module):
 
 class StatefulTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(StatefulTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(SimpleStatefulModule)
+
   def test_stateful(self):
 
     def get_state(module):
       module.inc_by(np.array(1., dtype=np.float32))
       module.get_state()
 
-    self.compare_backends(get_state)
+    self.compare_backends(get_state, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(SimpleStatefulModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/simple_stateful_test.py
+++ b/integrations/tensorflow/e2e/simple_stateful_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -33,7 +34,6 @@ class SimpleStatefulModule(tf.Module):
     return self.counter
 
 
-@tf_test_utils.compile_module(SimpleStatefulModule)
 class StatefulTest(tf_test_utils.TracedModuleTestCase):
 
   def test_stateful(self):
@@ -45,7 +45,13 @@ class StatefulTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(get_state)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(SimpleStatefulModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/sliding_window_test.py
+++ b/integrations/tensorflow/e2e/sliding_window_test.py
@@ -78,6 +78,11 @@ class SlidingWindowModule(tf.Module):
 
 class SlidingWindowTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(SlidingWindowTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(SlidingWindowModule,
+                                                    exported_names=["predict"])
+
   def test_sliding_window(self):
 
     def sliding_window(module):
@@ -89,14 +94,13 @@ class SlidingWindowTest(tf_test_utils.TracedModuleTestCase):
       result2 = module.predict(input2)
       # output2 = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
 
-    self.compare_backends(sliding_window)
+    self.compare_backends(sliding_window, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(SlidingWindowModule, exported_names=["predict"])
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/sliding_window_test.py
+++ b/integrations/tensorflow/e2e/sliding_window_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import tensorflow.compat.v2 as tf
@@ -75,7 +76,6 @@ class SlidingWindowModule(tf.Module):
     return self.sw(x)
 
 
-@tf_test_utils.compile_module(SlidingWindowModule, exported_names=["predict"])
 class SlidingWindowTest(tf_test_utils.TracedModuleTestCase):
 
   def test_sliding_window(self):
@@ -92,7 +92,13 @@ class SlidingWindowTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(sliding_window)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(SlidingWindowModule, exported_names=["predict"])
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/sliding_window_test.py
+++ b/integrations/tensorflow/e2e/sliding_window_test.py
@@ -94,7 +94,7 @@ class SlidingWindowTest(tf_test_utils.TracedModuleTestCase):
       result2 = module.predict(input2)
       # output2 = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
 
-    self.compare_backends(sliding_window, *self._modules)
+    self.compare_backends(sliding_window, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 import string
@@ -40,7 +41,6 @@ class StringsModule(tf.Module):
     return tf.strings.reduce_join(wps, 1)
 
 
-@tf_test_utils.compile_module(StringsModule)
 class StringsTest(tf_test_utils.TracedModuleTestCase):
 
   def test_print_ids(self):
@@ -64,7 +64,13 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(strings_to_ids)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(StringsModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -55,7 +55,7 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
       module.print_ids(input_ids)
 
-    self.compare_backends(print_ids, *self._modules)
+    self.compare_backends(print_ids, self._modules)
 
   def test_strings_to_ids(self):
 
@@ -65,7 +65,7 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
       module.strings_to_ids(input_ids)
 
-    self.compare_backends(strings_to_ids, *self._modules)
+    self.compare_backends(strings_to_ids, self._modules)
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -43,6 +43,10 @@ class StringsModule(tf.Module):
 
 class StringsTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(StringsTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(StringsModule)
+
   def test_print_ids(self):
 
     def print_ids(module):
@@ -51,7 +55,7 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
       module.print_ids(input_ids)
 
-    self.compare_backends(print_ids)
+    self.compare_backends(print_ids, *self._modules)
 
   def test_strings_to_ids(self):
 
@@ -61,14 +65,13 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
            [13, 24, 16, 28, 94, 15, 24, 27, 94, 28, 29, 10, 34]])
       module.strings_to_ids(input_ids)
 
-    self.compare_backends(strings_to_ids)
+    self.compare_backends(strings_to_ids, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(StringsModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
 import numpy as np
 from pyiree.tf.support import tf_test_utils
 from pyiree.tf.support import tf_utils
@@ -66,7 +67,6 @@ class TensorListModule(tf.Module):
     return ta.stack()
 
 
-@tf_test_utils.compile_module(TensorListModule)
 class TensorListTest(tf_test_utils.TracedModuleTestCase):
 
   def test_identity_through_tensorlist(self):
@@ -109,7 +109,13 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
     self.compare_backends(concat_with_tensorlist_stack)
 
 
-if __name__ == "__main__":
-  if hasattr(tf, "enable_v2_behavior"):
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
+  tf_test_utils.compile_tf_module(TensorListModule)
   tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -51,8 +51,9 @@ class TensorListModule(tf.Module):
   @tf.function(
       input_signature=[tf.TensorSpec([STATIC_SIZE, STATIC_SIZE], tf.float32)])
   def slice_first_element_with_from_tensor_high_rank(self, t):
-    ta = tf.TensorArray(
-        dtype=tf.float32, size=STATIC_SIZE, element_shape=[STATIC_SIZE])
+    ta = tf.TensorArray(dtype=tf.float32,
+                        size=STATIC_SIZE,
+                        element_shape=[STATIC_SIZE])
     ta = ta.unstack(t)
     return ta.read(0)
 
@@ -69,20 +70,24 @@ class TensorListModule(tf.Module):
 
 class TensorListTest(tf_test_utils.TracedModuleTestCase):
 
+  def __init__(self, methodName="runTest"):
+    super(TensorListTest, self).__init__(methodName)
+    self._modules = tf_test_utils.compile_tf_module(TensorListModule)
+
   def test_identity_through_tensorlist(self):
 
     def identity_through_tensorlist(module):
       module.identity_through_tensorlist(np.array(42., dtype=np.float32))
 
-    self.compare_backends(identity_through_tensorlist)
+    self.compare_backends(identity_through_tensorlist, *self._modules)
 
   def test_add_through_tensorlist(self):
 
     def add_through_tensorlist(module):
-      module.add_through_tensorlist(
-          np.array(42., dtype=np.float32), np.array(43., dtype=np.float32))
+      module.add_through_tensorlist(np.array(42., dtype=np.float32),
+                                    np.array(43., dtype=np.float32))
 
-    self.compare_backends(add_through_tensorlist)
+    self.compare_backends(add_through_tensorlist, *self._modules)
 
   def test_slice_first_element_with_from_tensor(self):
 
@@ -90,7 +95,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.slice_first_element_with_from_tensor(
           np.arange(STATIC_SIZE, dtype=np.float32))
 
-    self.compare_backends(slice_first_element_with_from_tensor)
+    self.compare_backends(slice_first_element_with_from_tensor, *self._modules)
 
   def test_slice_first_element_with_from_tensor_high_rank(self):
 
@@ -98,22 +103,22 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.slice_first_element_with_from_tensor_high_rank(
           tf_utils.ndarange([STATIC_SIZE, STATIC_SIZE]))
 
-    self.compare_backends(slice_first_element_with_from_tensor_high_rank)
+    self.compare_backends(slice_first_element_with_from_tensor_high_rank,
+                          *self._modules)
 
   def test_concat_with_tensorlist_stack(self):
 
     def concat_with_tensorlist_stack(module):
-      module.concat_with_tensorlist_stack(
-          np.array(42., dtype=np.float32), np.array(43., dtype=np.float32))
+      module.concat_with_tensorlist_stack(np.array(42., dtype=np.float32),
+                                          np.array(43., dtype=np.float32))
 
-    self.compare_backends(concat_with_tensorlist_stack)
+    self.compare_backends(concat_with_tensorlist_stack, *self._modules)
 
 
 def main(argv):
   del argv  # Unused
   if hasattr(tf, 'enable_v2_behavior'):
     tf.enable_v2_behavior()
-  tf_test_utils.compile_tf_module(TensorListModule)
   tf.test.main()
 
 

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -79,7 +79,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
     def identity_through_tensorlist(module):
       module.identity_through_tensorlist(np.array(42., dtype=np.float32))
 
-    self.compare_backends(identity_through_tensorlist, *self._modules)
+    self.compare_backends(identity_through_tensorlist, self._modules)
 
   def test_add_through_tensorlist(self):
 
@@ -87,7 +87,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.add_through_tensorlist(np.array(42., dtype=np.float32),
                                     np.array(43., dtype=np.float32))
 
-    self.compare_backends(add_through_tensorlist, *self._modules)
+    self.compare_backends(add_through_tensorlist, self._modules)
 
   def test_slice_first_element_with_from_tensor(self):
 
@@ -95,7 +95,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.slice_first_element_with_from_tensor(
           np.arange(STATIC_SIZE, dtype=np.float32))
 
-    self.compare_backends(slice_first_element_with_from_tensor, *self._modules)
+    self.compare_backends(slice_first_element_with_from_tensor, self._modules)
 
   def test_slice_first_element_with_from_tensor_high_rank(self):
 
@@ -104,7 +104,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
           tf_utils.ndarange([STATIC_SIZE, STATIC_SIZE]))
 
     self.compare_backends(slice_first_element_with_from_tensor_high_rank,
-                          *self._modules)
+                          self._modules)
 
   def test_concat_with_tensorlist_stack(self):
 
@@ -112,7 +112,7 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.concat_with_tensorlist_stack(np.array(42., dtype=np.float32),
                                           np.array(43., dtype=np.float32))
 
-    self.compare_backends(concat_with_tensorlist_stack, *self._modules)
+    self.compare_backends(concat_with_tensorlist_stack, self._modules)
 
 
 def main(argv):


### PR DESCRIPTION
Replaces compiling a module with a decorator on a child of `TracedModuleTestCase` with calling `tf_test_utils.compile_tf_module` in the overridden `__init__` method of the child class.

This will make supporting alternative compilation paths easier.