### PR TITLE
Enable MobileBert on VMLA via SignatureDef SavedModels

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -141,10 +141,6 @@ iree_py_test(
     name = "signature_def_saved_model_test",
     srcs = ["signature_def_saved_model_test.py"],
     python_version = "PY3",
-    tags = [
-        "manual",
-        "nokokoro",
-    ],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "@absl_py//absl/testing:absltest",
         "//integrations/tensorflow/bindings/python/pyiree/tf/compiler",

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -55,7 +55,7 @@ SAVED_MODEL_TF_RUNTIME_DEPS = [
     # Deps for MobileBert
     "@org_tensorflow//tensorflow/core:direct_session",
     "@org_tensorflow//tensorflow/core/kernels:parameterized_truncated_normal_op",  # TruncatedNormal
-    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops", #  VarHandleOp
+    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops",  #  VarHandleOp
     "@org_tensorflow//tensorflow/core/kernels:state",  # Assign.
     "@org_tensorflow//tensorflow/core/kernels:logging_ops",  # Assert
     "@org_tensorflow//tensorflow/core/kernels:bias_op",  # BiasAdd

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -51,20 +51,6 @@ config_setting(
 # See: https://github.com/google/iree/issues/1506
 SAVED_MODEL_TF_RUNTIME_DEPS = [
     "@org_tensorflow//tensorflow/core:ops",
-
-    # Deps for MobileBert
-    "@org_tensorflow//tensorflow/core:direct_session",
-    "@org_tensorflow//tensorflow/core/kernels:parameterized_truncated_normal_op",  # TruncatedNormal
-    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops",  #  VarHandleOp
-    "@org_tensorflow//tensorflow/core/kernels:state",  # Assign.
-    "@org_tensorflow//tensorflow/core/kernels:logging_ops",  # Assert
-    "@org_tensorflow//tensorflow/core/kernels:bias_op",  # BiasAdd
-    "@org_tensorflow//tensorflow/core/kernels:softmax_op",  # Softmax
-    "@org_tensorflow//tensorflow/core/kernels:relu_op",  # Relu
-    "@org_tensorflow//tensorflow/core/kernels:regex_full_match_op",  # StaticRegexFullMatch
-    "@org_tensorflow//tensorflow/core/kernels:string_join_op",  # StringJoin
-    "@org_tensorflow//tensorflow/core/kernels:save_op",  # SharedFilename
-    "@org_tensorflow//tensorflow/core/kernels:save_restore_v2_ops",  # SaveV2
 ] + select({
     ":disable_kernels": [],
     "//conditions:default": [
@@ -72,6 +58,32 @@ SAVED_MODEL_TF_RUNTIME_DEPS = [
         "@org_tensorflow//tensorflow/core/kernels:math",
     ],
 })
+
+# TODO: Isolate SignatureDef SavedModel support into its own library to decrease buildtime cost.
+# While it would be nice to simply depend on TensorFlow, manually paring
+# down the dependencies significantly reduces the build time that this adds.
+#
+# Baseline: 449s
+# SignatureDef SavedModels: 546s – 22% increase in build time.
+# SignatureDef SavedModels + Deps for MobileBert: 572s – 27% increase in build time.
+# TF OpenSource: 664s – 49% increase in build time.
+SIGNATURE_DEF_SAVED_MODEL_TF_RUNTIME_DEPS = [
+    # Deps for SignatureDef SavedModels:
+    "@org_tensorflow//tensorflow/core:direct_session",
+    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops",  #  VarHandleOp
+    "@org_tensorflow//tensorflow/core/kernels:regex_full_match_op",  # StaticRegexFullMatch
+    "@org_tensorflow//tensorflow/core/kernels:string_join_op",  # StringJoin
+    "@org_tensorflow//tensorflow/core/kernels:save_op",  # SharedFilename
+    "@org_tensorflow//tensorflow/core/kernels:save_restore_v2_ops",  # SaveV2
+
+    # Deps for MobileBert:
+    "@org_tensorflow//tensorflow/core/kernels:parameterized_truncated_normal_op",  # TruncatedNormal
+    "@org_tensorflow//tensorflow/core/kernels:state",  # Assign.
+    "@org_tensorflow//tensorflow/core/kernels:logging_ops",  # Assert
+    "@org_tensorflow//tensorflow/core/kernels:bias_op",  # BiasAdd
+    "@org_tensorflow//tensorflow/core/kernels:softmax_op",  # Softmax
+    "@org_tensorflow//tensorflow/core/kernels:relu_op",  # Relu
+]
 
 TF_XLA_PASS_DEPS = [
     "//integrations/tensorflow/compiler:tensorflow",
@@ -115,7 +127,7 @@ pybind_cc_library(
     hdrs = [
         "register_tensorflow.h",
     ],
-    deps = SAVED_MODEL_TF_RUNTIME_DEPS + TF_XLA_PASS_DEPS + [
+    deps = SAVED_MODEL_TF_RUNTIME_DEPS + TF_XLA_PASS_DEPS + SIGNATURE_DEF_SAVED_MODEL_TF_RUNTIME_DEPS + [
         "//bindings/python/pyiree/common",
         "//bindings/python/pyiree/compiler:compiler_library",
         "@llvm-project//llvm:Support",

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -51,7 +51,20 @@ config_setting(
 # See: https://github.com/google/iree/issues/1506
 SAVED_MODEL_TF_RUNTIME_DEPS = [
     "@org_tensorflow//tensorflow/core:ops",
-    "@org_tensorflow//tensorflow/core:tensorflow",
+
+    # Deps for MobileBert
+    "@org_tensorflow//tensorflow/core:direct_session",
+    "@org_tensorflow//tensorflow/core/kernels:parameterized_truncated_normal_op",  # TruncatedNormal
+    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops", #  VarHandleOp
+    "@org_tensorflow//tensorflow/core/kernels:state",  # Assign.
+    "@org_tensorflow//tensorflow/core/kernels:logging_ops",  # Assert
+    "@org_tensorflow//tensorflow/core/kernels:bias_op",  # BiasAdd
+    "@org_tensorflow//tensorflow/core/kernels:softmax_op",  # Softmax
+    "@org_tensorflow//tensorflow/core/kernels:relu_op",  # Relu
+    "@org_tensorflow//tensorflow/core/kernels:regex_full_match_op",  # StaticRegexFullMatch
+    "@org_tensorflow//tensorflow/core/kernels:string_join_op",  # StringJoin
+    "@org_tensorflow//tensorflow/core/kernels:save_op",  # SharedFilename
+    "@org_tensorflow//tensorflow/core/kernels:save_restore_v2_ops",  # SaveV2
 ] + select({
     ":disable_kernels": [],
     "//conditions:default": [

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -51,6 +51,7 @@ config_setting(
 # See: https://github.com/google/iree/issues/1506
 SAVED_MODEL_TF_RUNTIME_DEPS = [
     "@org_tensorflow//tensorflow/core:ops",
+    "@org_tensorflow//tensorflow/core:tensorflow",
 ] + select({
     ":disable_kernels": [],
     "//conditions:default": [

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -30,7 +30,7 @@ import os
 import pickle
 import sys
 import tempfile
-from typing import Any, Callable, Dict, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, Sequence, Set, Tuple, Type, Union
 
 from absl import flags
 from absl import logging
@@ -590,6 +590,48 @@ def compile_tf_module(
 
   compile_backend = lambda backend_info: backend_info.compile_from_class(
       module_class, exported_names, artifacts_dir)
+
+  ref_module = compile_backend(ref_backend_info)
+  tar_modules = [
+      compile_backend(backend_info) for backend_info in tar_backend_infos
+  ]
+  return Modules(ref_module, tar_modules, artifacts_dir)
+
+
+def compile_tf_signature_def_saved_model(saved_model_dir: str,
+                                         saved_model_tags: Set[str],
+                                         module_name: str, exported_name: str,
+                                         input_names: Sequence[str],
+                                         output_names: Sequence[str]):
+  """Compiles a SignatureDef SavedModel to each backend that we test.
+
+  Args:
+    saved_model_dir: Directory of the saved model.
+    saved_model_tags: Optional set of tags to use when loading the model.
+    module_name: A name for this compiled module.
+    backend_info: BackendInfo with the details for compiling the saved model.
+    exported_name: A str representing the signature on the saved model to
+      compile.
+    input_names: A sequence of kwargs to feed to the saved model.
+    output_names: A sequence of named outputs to extract from the saved model.
+
+  Returns:
+    A 'Modules' namedtuple containing the reference module, target modules and
+    artifacts directory.
+  """
+
+  # Setup the directory for saving compilation artifacts and traces.
+  artifacts_dir = _setup_artifacts_dir(module_name)
+
+  # Get the backend information for this test.
+  ref_backend_info = tf_utils.BackendInfo(FLAGS.reference_backend,
+                                          f"{FLAGS.reference_backend}_ref")
+  tar_backend_infos = get_target_backends()
+
+  compile_backend = (
+      lambda backend_info: backend_info.compile_signature_def_saved_model(
+          saved_model_dir, saved_model_tags, module_name, exported_name,
+          input_names, output_names, artifacts_dir))
 
   ref_module = compile_backend(ref_backend_info)
   tar_modules = [

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -383,6 +383,9 @@ class Trace:
             "Expected ref and tar to have the same dtype, but got %s  and %s",
             ref.dtype, tar.dtype)
         return False
+      if ref.size == tar.size == 0:
+        return True
+
       if np.issubdtype(ref.dtype, np.floating):
         same = np.allclose(ref, tar, rtol=rtol, atol=atol)
         abs_diff = np.max(np.abs(ref - tar))

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -385,11 +385,17 @@ class Trace:
         return False
       if np.issubdtype(ref.dtype, np.floating):
         same = np.allclose(ref, tar, rtol=rtol, atol=atol)
+        abs_diff = np.max(np.abs(ref - tar))
+        rel_diff = np.max(np.abs(ref - tar) / np.max(np.abs(tar)))
         if not same:
-          abs_diff = np.max(np.abs(ref - tar))
-          rel_diff = np.max(np.abs(ref - tar) / np.max(tar))
           logging.error(
               "Floating point difference between ref and tar was too large. "
+              "Max abs diff: %s, atol: %s, max relative diff: %s, rtol: %s",
+              abs_diff, atol, rel_diff, rtol)
+        else:
+          logging.info(
+              "Floating point difference between ref and tar was within "
+              "tolerance. "
               "Max abs diff: %s, atol: %s, max relative diff: %s, rtol: %s",
               abs_diff, atol, rel_diff, rtol)
         return same

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -771,7 +771,7 @@ def tflite_module_bytes_to_tflite_interpreters(
   if artifacts_dir is not None:
     compiled_paths = dict()
 
-  def _interpret_bytes(tflite_module: bytes, base_dir: str):
+  def _interpret_bytes(method_name: str, tflite_module: bytes, base_dir: str):
     """Save compiled TFLite module bytes and convert into an interpreter."""
     tflite_dir = os.path.join(base_dir, "tflite")
     os.makedirs(tflite_dir, exist_ok=True)
@@ -787,9 +787,9 @@ def tflite_module_bytes_to_tflite_interpreters(
   for method_name, tflite_module in tflite_module_bytes.items():
     if artifacts_dir is None:
       with tempfile.TemporaryDirectory() as base_dir:
-        _interpret_bytes(tflite_module, base_dir)
+        _interpret_bytes(method_name, tflite_module, base_dir)
     else:
-      _interpret_bytes(tflite_module, artifacts_dir)
+      _interpret_bytes(method_name, tflite_module, artifacts_dir)
 
   return interpreters, compiled_paths
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -717,7 +717,7 @@ def tf_module_to_tflite_module_bytes(
   for method in methods:
     converter = tf.lite.TFLiteConverter.from_concrete_functions([method])
     tflite_modules.append(converter.convert())
-  return dict(method_names, tflite_modules)
+  return dict(zip(method_names, tflite_modules))
 
 
 def tf_signature_def_saved_model_to_tflite_module_bytes(

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -220,10 +220,16 @@ iree_e2e_test_suite(
     name = "mobile_bert_squad_tests",
     backends_to_srcs = {
         "tf": ["mobile_bert_squad_test.py"],
+        "tflite": ["mobile_bert_squad_test.py"],
+        "iree_vmla": ["mobile_bert_squad_test.py"],
     },
     reference_backend = "tf",
+    size = "enormous",
     tags = [
+        "external",
+        "guitar",
         "manual",
+        "no-remote",
         "nokokoro",
         "notap",
     ],
@@ -235,14 +241,15 @@ iree_e2e_test_suite(
 iree_e2e_test_suite(
     name = "mobile_bert_squad_tests_failing",
     backends_to_srcs = {
-        "tflite": ["mobile_bert_squad_test.py"],
-        "iree_vmla": ["mobile_bert_squad_test.py"],
         "iree_llvmjit": ["mobile_bert_squad_test.py"],
         "iree_vulkan": ["mobile_bert_squad_test.py"],
     },
     reference_backend = "tf",
     tags = [
+        "external",
+        "guitar",
         "manual",
+        "no-remote",
         "nokokoro",
         "notap",
     ],

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -218,13 +218,13 @@ iree_e2e_test_suite(
 
 iree_e2e_test_suite(
     name = "mobile_bert_squad_tests",
+    size = "enormous",
     backends_to_srcs = {
         "tf": ["mobile_bert_squad_test.py"],
         "tflite": ["mobile_bert_squad_test.py"],
         "iree_vmla": ["mobile_bert_squad_test.py"],
     },
     reference_backend = "tf",
-    size = "enormous",
     tags = [
         "external",
         "guitar",
@@ -240,6 +240,7 @@ iree_e2e_test_suite(
 
 iree_e2e_test_suite(
     name = "mobile_bert_squad_tests_failing",
+    size = "enormous",
     backends_to_srcs = {
         "iree_llvmjit": ["mobile_bert_squad_test.py"],
         "iree_vulkan": ["mobile_bert_squad_test.py"],

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -221,14 +221,10 @@ debugging iteration can happen in opt.
 
 TODO(silvasean): debugging miscompiles
 
-## Legacy TFLite Compilation
+## Testing SignatureDef SavedModels
 
-_Please don't use this unless you are forced to._
-
-We support using `tf.compat.v1.lite.TFLiteConverter.from_saved_model` to compile
-older `tf.Module`s with TFLite. This will be used if the `tf.Module` being
-tested has a method named `get_legacy_tflite_saved_model_converter_kwargs`. This
-method must return a dict with the following kwargs: `model_path`,
-`input_arrays`, `output_arrays`, and `exported_name`. The module must use only
-one exported name, and `exported_name` should be equal to that name. See
-`mobile_bert_squad_test.py` for a concrete example.
+TensorFlow 1.x SavedModels can be tested using
+`tf_test_utils.compile_tf_signature_def_saved_model` instead of
+`tf_test_utils.compile_tf_module`. See `mobile_bert_squad_test.py` for a
+concrete example. The compilation artifacts will be saved under whatever
+you specify for `module_name`.

--- a/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
+++ b/integrations/tensorflow/e2e/iree_e2e_test_suite.bzl
@@ -21,6 +21,7 @@ def iree_e2e_test_suite(
         backends_to_srcs,
         reference_backend,
         deps = None,
+        size = None,
         tags = None,
         python_version = "PY3",
         **kwargs):
@@ -73,6 +74,7 @@ def iree_e2e_test_suite(
                 srcs = [src],
                 deps = deps,
                 args = args,
+                size = size,
                 tags = py_test_tags,
                 python_version = python_version,
                 **kwargs

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -70,7 +70,10 @@ class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
       input_mask = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
       segment_ids = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
 
-      module.serving_default(input_ids, input_mask, segment_ids, atol=1e0)
+      module.serving_default(input_ids=input_ids,
+                             input_mask=input_mask,
+                             segment_ids=segment_ids,
+                             atol=1e0)
 
     self.compare_backends(serving_default, self._modules)
 

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -25,80 +25,54 @@ from absl import app
 from absl import flags
 import numpy as np
 from pyiree.tf.support import tf_test_utils
+from pyiree.tf import compiler
 import tensorflow.compat.v2 as tf
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_boolean("use_quantized_weights", False,
-                     "Whether to use quantized or floating point weights.")
+flags.DEFINE_boolean('use_quantized_weights', False,
+                     'Whether to use quantized or floating point weights.')
 
 MAX_SEQ_LENGTH = 384  # Max input sequence length used in mobilebert_squad.
 
-FILE_NAME = "mobilebert_squad_savedmodels.tar.gz"
+FILE_NAME = 'mobilebert_squad_savedmodels.tar.gz'
 MODEL_URL = posixpath.join(
-    "https://storage.googleapis.com/cloud-tpu-checkpoints/mobilebert/",
+    'https://storage.googleapis.com/cloud-tpu-checkpoints/mobilebert/',
     FILE_NAME)
-
-
-class MobileBertSquad(tf.Module):
-  """Wrapper of MobileBertSquad saved model v1."""
-
-  def __init__(self):
-    self.model_path = self.get_model_path()
-    self.saved_model = tf.saved_model.load(self.model_path, tags=["serve"])
-    self.inference_func = self.saved_model.signatures["serving_default"]
-
-  @staticmethod
-  def get_model_path():
-    model_type = "quant_saved_model" if FLAGS.use_quantized_weights else "float"
-
-    # Get_file will download the model weights from a publicly available folder,
-    # save them to cache_dir=~/.keras/datasets/ and return a path to them.
-    model_path = tf.keras.utils.get_file(FILE_NAME, MODEL_URL, untar=True)
-    model_dir = os.path.dirname(model_path)
-    extracted_name = FILE_NAME.split(".")[0]
-    model_path = os.path.join(model_dir, extracted_name, model_type)
-    return model_path
-
-  @staticmethod
-  def get_legacy_tflite_saved_model_converter_kwargs():
-    return dict([("input_arrays", ["input_ids", "input_mask", "segment_ids"]),
-                 ("output_arrays", ["start_logits", "end_logits"]),
-                 ("exported_name", "predict"),
-                 ("model_path", MobileBertSquad.get_model_path())])
-
-  @tf.function(input_signature=[
-      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
-      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
-      tf.TensorSpec((1, MAX_SEQ_LENGTH), tf.int32),
-  ])
-  def predict(self, input_ids, input_mask, segment_ids):
-    inputs = {
-        "input_ids": input_ids,
-        "input_mask": input_mask,
-        "segment_ids": segment_ids,
-    }
-    return self.inference_func(**inputs)
 
 
 class MobileBertSquadTest(tf_test_utils.TracedModuleTestCase):
   """Tests of MobileBertSquad."""
 
-  def __init__(self, methodName="runTest"):
+  def __init__(self, methodName='runTest'):
     super(MobileBertSquadTest, self).__init__(methodName)
-    self._modules = tf_test_utils.compile_tf_module(MobileBertSquad,
-                                                    exported_names=["predict"])
+    model_type = 'quant_saved_model' if FLAGS.use_quantized_weights else 'float'
 
-  def test_predict(self):
+    # Get_file will download the model weights from a publicly available folder,
+    # save them to cache_dir=~/.keras/datasets/ and return a path to them.
+    model_path = tf.keras.utils.get_file(FILE_NAME, MODEL_URL, untar=True)
+    model_dir = os.path.dirname(model_path)
+    extracted_name = FILE_NAME.split('.')[0]
+    model_path = os.path.join(model_dir, extracted_name, model_type)
 
-    def predict(module):
+    self._modules = tf_test_utils.compile_tf_signature_def_saved_model(
+        saved_model_dir=model_path,
+        saved_model_tags=set(['serve']),
+        module_name='MobileBertSquad',
+        exported_name='serving_default',
+        input_names=['input_ids', 'input_mask', 'segment_ids'],
+        output_names=['start_logits', 'end_logits'])
+
+  def test_serving_default(self):
+
+    def serving_default(module):
       input_ids = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
       input_mask = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
       segment_ids = np.zeros((1, MAX_SEQ_LENGTH), dtype=np.int32)
 
-      module.predict(input_ids, input_mask, segment_ids, atol=1e0)
+      module.serving_default(input_ids, input_mask, segment_ids, atol=1e0)
 
-    self.compare_backends(predict, self._modules)
+    self.compare_backends(serving_default, self._modules)
 
 
 def main(argv):

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -38,6 +38,8 @@ BACKENDS_TO_TITLES = collections.OrderedDict([
 TEST_SUITES_TO_HEADERS = {
     '//integrations/tensorflow/e2e:e2e_tests':
         'End to end TensorFlow tests',
+    '//integrations/tensorflow/e2e:mobile_bert_squad_tests':
+        'End to end test of MobileBert on SQuAD',
     '//integrations/tensorflow/e2e/keras:keras_tests':
         'End to end tests written using tf.keras',
     '//integrations/tensorflow/e2e/keras:imagenet_external_tests':


### PR DESCRIPTION
Adds a named constructor `create_from_signature_def_saved_model` to compile and test SignatureDef SavedModels.

Also fixes #3258.