### PR TITLE
Refactor 'CompiledModule' to use cls constructors

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/__init__.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/__init__.py
@@ -99,7 +99,7 @@ TF_IMPORT_PASS_PIPELINE = (
 
 def tf_saved_model_to_compiler_module(
     saved_model_dir: str,
-    exported_names: Collection[str] = (),
+    exported_names: Sequence[str] = (),
     pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
     compiler_context: Optional[Context] = None) -> Module:
   """Converts a TensorFlow SavedModel into a MLIR module.
@@ -108,8 +108,7 @@ def tf_saved_model_to_compiler_module(
 
   Args:
     saved_model_dir: Directory of the saved model.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
+    exported_names: Optional sequence representing the exported names to keep.
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.
@@ -131,18 +130,17 @@ def tf_saved_model_to_compiler_module(
 
 def compile_tf_saved_model(
     saved_model_dir: str,
-    exported_names: Collection[str] = (),
-    target_backends: Collection[str] = (),
+    exported_names: Sequence[str] = (),
+    target_backends: Sequence[str] = (),
     pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
     compiler_context: Optional[Context] = None) -> binding.OpaqueBlob:
   """Compiles a TensorFlow SavedModel to IREE in one shot.
 
   Args:
     saved_model_dir: Directory of the saved model.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
-    target_backends: The specific target backends to compile for (defaults to
-      all compiled in targets).
+    exported_names: Optional sequence representing the exported names to keep.
+    target_backends: Optional sequence of specific target backends to compile
+      for (defaults to all compiled in targets).
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.
@@ -160,7 +158,7 @@ def compile_tf_saved_model(
 def tf_signature_def_saved_model_to_compiler_module(
     saved_model_dir: str,
     saved_model_tags: Set[str] = set(),
-    exported_names: Collection[str] = [],
+    exported_names: Sequence[str] = (),
     pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
     compiler_context: Optional[Context] = None) -> Module:
   """Converts a TensorFlow SignatureDef SavedModel into a MLIR module.
@@ -168,8 +166,7 @@ def tf_signature_def_saved_model_to_compiler_module(
   Args:
     saved_model_dir: Directory of the saved model.
     saved_model_tags: Optional set of tags to use when loading the model.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
+    exported_names: Optional sequence representing the exported names to keep.
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.
@@ -194,8 +191,8 @@ def tf_signature_def_saved_model_to_compiler_module(
 def compile_tf_signature_def_saved_model(
     saved_model_dir: str,
     saved_model_tags: Set[str] = set(),
-    exported_names: Collection[str] = (),
-    target_backends: Collection[str] = (),
+    exported_names: Sequence[str] = (),
+    target_backends: Sequence[str] = (),
     pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
     compiler_context: Optional[Context] = None) -> binding.OpaqueBlob:
   """Compiles a TensorFlow SignatureDef SavedModel to IREE in one shot.
@@ -203,10 +200,9 @@ def compile_tf_signature_def_saved_model(
   Args:
     saved_model_dir: Directory of the saved model.
     saved_model_tags: Optional set of tags to use when loading the model.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
-    target_backends: The specific target backends to compile for (defaults to
-      all compiled in targets).
+    exported_names: Optional sequence representing the exported names to keep.
+    target_backends: Optional sequence of specific target backends to compile
+      for (defaults to all compiled in targets).
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.
@@ -222,7 +218,7 @@ def compile_tf_signature_def_saved_model(
 
 def tf_module_to_compiler_module(
     module: tf.Module,
-    exported_names: Collection[str] = (),
+    exported_names: Sequence[str] = (),
     pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
     compiler_context: Optional[Context] = None,
     saved_model_dir: str = None) -> Module:
@@ -230,8 +226,7 @@ def tf_module_to_compiler_module(
 
   Args:
     module: The tf.Module instance to convert to MLIR
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
+    exported_names: Optional sequence representing the exported names to keep.
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.
@@ -259,8 +254,8 @@ def tf_module_to_compiler_module(
 
 
 def compile_tf_module(module: tf.Module,
-                      exported_names: Collection[str] = (),
-                      target_backends: Collection[str] = (),
+                      exported_names: Sequence[str] = (),
+                      target_backends: Sequence[str] = (),
                       pass_pipeline: Sequence[str] = TF_IMPORT_PASS_PIPELINE,
                       compiler_context: Optional[Context] = None,
                       saved_model_dir: str = None):
@@ -268,10 +263,9 @@ def compile_tf_module(module: tf.Module,
 
   Args:
     module: The tf.Module instance to convert to MLIR
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
-    target_backends: The specific target backends to compile for (defaults to
-      all compiled in targets).
+    exported_names: Optional sequence representing the exported names to keep.
+    target_backends: Optional sequence of specific target backends to compile
+      for (defaults to all compiled in targets).
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to TF_IMPORT_PASS_PIPELINE.
     compiler_context: The pyiree.compiler.Context() backing the module.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -66,22 +66,22 @@ def _setup_artifacts_dir(module_name: str) -> str:
 
 
 def _parse_target_backends() -> Tuple[Sequence[str], Sequence[str]]:
-  """Decodes --target_backends and creates unique names for their artifacts."""
+  """Decodes --target_backends and creates unique ids for them."""
   backend_names = FLAGS.target_backends.split(",")
   backend_to_index = {k: 0 for k in backend_names if backend_names.count(k) > 1}
-  artifact_names = []
+  backend_ids = []
 
   # If there are multiple copies of the same backend_name, index them. e.g.
   # backend_names = ["tf", "iree_vmla", "tf"]
-  # --> artifact_names = ["tf_0", "iree_vmla", "tf_1"]
+  # --> backend_ids = ["tf_0", "iree_vmla", "tf_1"]
   for backend_name in backend_names:
     if backend_name in backend_to_index:
-      artifact_names.append(f"{backend_name}_{backend_to_index[backend_name]}")
+      backend_ids.append(f"{backend_name}_{backend_to_index[backend_name]}")
       backend_to_index[backend_name] += 1
     else:
-      artifact_names.append(backend_name)
+      backend_ids.append(backend_name)
 
-  return backend_names, artifact_names
+  return backend_names, backend_ids
 
 
 def get_target_backends() -> Sequence[tf_utils.BackendInfo]:
@@ -95,10 +95,10 @@ def get_target_backends() -> Sequence[tf_utils.BackendInfo]:
   """
   if FLAGS.target_backends is not None:
     logging.info("Using backends from command line: %s", FLAGS.target_backends)
-    backend_names, names = _parse_target_backends()
+    backend_names, backend_ids = _parse_target_backends()
     backends = [
-        tf_utils.BackendInfo(backend, name)
-        for backend, name in zip(backend_names, names)
+        tf_utils.BackendInfo(backend_name, backend_id)
+        for backend_name, backend_id in zip(backend_names, backend_ids)
     ]
   else:
     # If no backends are specified, use them all.
@@ -261,10 +261,11 @@ class Trace:
       # Extract metadata from module and function.
       self.module_name = module.module_name
       self.compiled_paths = module.compiled_paths
-      self.backend_name = module.backend
+      self.backend_name = module.backend_info.backend_name
+      self.backend_id = module.backend_info.backend_id
+      self.backend_driver = module.backend_info.driver
       self.iree_serializable = module.iree_serializable()
       self.tflite_serializable = module.tflite_serializable()
-      self.backend_driver = module.backend_driver
       self.function_name = function.__name__
       self.function_sourcefile = inspect.getsourcefile(function)
       source, start_line = inspect.getsourcelines(function)
@@ -276,9 +277,10 @@ class Trace:
       self.module_name = _load_dict["module_name"]
       self.compiled_paths = _load_dict["compiled_paths"]
       self.backend_name = _load_dict["backend_name"]
+      self.backend_id = _load_dict["backend_id"]
+      self.backend_driver = _load_dict["backend_driver"]
       self.iree_serializable = _load_dict["iree_serializable"]
       self.tflite_serializable = _load_dict["tflite_serializable"]
-      self.backend_driver = _load_dict["backend_driver"]
       self.function_name = _load_dict["function_name"]
       self.function_sourcefile = _load_dict["function_sourcefile"]
       self.function_line_numbers = _load_dict["function_line_numbers"]
@@ -286,7 +288,7 @@ class Trace:
       self.calls = _load_dict["calls"]
 
   def __str__(self):
-    header = (f"Trace of {self.module_name} compiled to '{self.backend_name}' "
+    header = (f"Trace of {self.module_name} compiled to '{self.backend_id}' "
               f"on function '{self.function_name}':")
     # Give each call a number so it's easier to compare between multiple traces.
     calls = [f"{i + 1}. {str(call)}" for i, call in enumerate(self.calls)]
@@ -327,11 +329,11 @@ class Trace:
 
       if not calls_match:
         logging.error("Comparision between '%s' and '%s' failed on method '%s'",
-                      ref_trace.backend_name, tar_trace.backend_name,
+                      ref_trace.backend_id, tar_trace.backend_id,
                       ref_call.method)
-        logging.error("Reference call '%s':\n%s", ref_trace.backend_name,
+        logging.error("Reference call '%s':\n%s", ref_trace.backend_id,
                       ref_call)
-        logging.error("Target call '%s':\n%s", tar_trace.backend_name, tar_call)
+        logging.error("Target call '%s':\n%s", tar_trace.backend_id, tar_call)
 
       traces_match = traces_match and calls_match
     return traces_match
@@ -434,14 +436,20 @@ class Trace:
       trace_dir: str, path to the directory to serialize the trace to.
     """
 
+    compiled_paths = None
+    if self.compiled_paths is not None:
+      # Convert to a dict to avoid the issues with serializing defaultdicts.
+      compiled_paths = dict(self.compiled_paths)
+
     # Python serialization.
     metadata = {
         "module_name": self.module_name,
-        "compiled_paths": self.compiled_paths,
+        "compiled_paths": compiled_paths,
         "backend_name": self.backend_name,
+        "backend_id": self.backend_id,
+        "backend_driver": self.backend_driver,
         "iree_serializable": self.iree_serializable,
         "tflite_serializable": self.tflite_serializable,
-        "backend_driver": self.backend_driver,
         "function_name": self.function_name,
         "function_sourcefile": self.function_sourcefile,
         "function_line_numbers": self.function_line_numbers,
@@ -493,7 +501,7 @@ class Trace:
 
 
 def _get_trace_dir(artifacts_dir: str, trace: Trace) -> str:
-  trace_dir = os.path.join(artifacts_dir, trace.backend_name, "traces",
+  trace_dir = os.path.join(artifacts_dir, trace.backend_id, "traces",
                            trace.function_name)
   os.makedirs(trace_dir, exist_ok=True)
   return trace_dir
@@ -559,17 +567,17 @@ Modules = collections.namedtuple('Modules',
 def compile_tf_module(
     module_class: Type[tf.Module], exported_names: Sequence[str] = ()
 ) -> Callable[[Any], Any]:
-  """CompiledModuleTestCase decorator that compiles a tf.Module.
-
-  A CompiledModule is created for each backend in --target_backends. They can
-  be accessed individually via self.compiled_modules.backend_name or as a union
-  via self.get_module().
+  """Compiles module_class to each backend that we test.
 
   Args:
     module_class: the tf.Module subclass to compile.
     exported_names: optional iterable of strings representing which of
       module_class's functions to compile. If exported_names is empty all
       functions will be compiled.
+
+  Returns:
+    A 'Modules' namedtuple containing the reference module, target modules and
+    artifacts directory.
   """
 
   # Setup the directory for saving compilation artifacts and traces.
@@ -580,7 +588,7 @@ def compile_tf_module(
                                           f"{FLAGS.reference_backend}_ref")
   tar_backend_infos = get_target_backends()
 
-  compile_backend = lambda backend_info: backend_info.compile(
+  compile_backend = lambda backend_info: backend_info.compile_from_class(
       module_class, exported_names, artifacts_dir)
 
   ref_module = compile_backend(ref_backend_info)
@@ -631,7 +639,7 @@ class TracedModuleTestCase(tf.test.TestCase):
     failed_backend_indices = []
     for i, tar_trace in enumerate(tar_traces):
       logging.info("Comparing the reference backend '%s' with '%s'",
-                   ref_trace.backend_name, tar_trace.backend_name)
+                   ref_trace.backend_id, tar_trace.backend_id)
       traces_match = Trace.compare_traces(ref_trace, tar_trace)
       if not traces_match:
         failed_backend_indices.append(i)
@@ -649,7 +657,7 @@ class TracedModuleTestCase(tf.test.TestCase):
     if failed_backend_indices:
       # Extract info for logging.
       failed_backends = [
-          tar_traces[i].backend_name for i in failed_backend_indices
+          tar_traces[i].backend_id for i in failed_backend_indices
       ]
       self.fail(
           "Comparision between the reference backend and the following targets "

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -117,8 +117,8 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       # Only outputs
       module.get_count()
 
-    module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                       tf_utils.BackendInfo('tf'))
+    module = tf_utils.TfCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('tf'))
     trace = tf_test_utils.Trace(module, trace_function)
     trace_function(tf_test_utils.TracedModule(module, trace))
 
@@ -140,13 +140,13 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
       module.increment()
       module.decrement()
 
-    tf_module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                          tf_utils.BackendInfo('tf'))
+    tf_module = tf_utils.TfCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('tf'))
     tf_trace = tf_test_utils.Trace(tf_module, tf_function)
     tf_function(tf_test_utils.TracedModule(tf_module, tf_trace))
 
-    vmla_module = tf_utils.IreeCompiledModule(StatefulCountingModule,
-                                              tf_utils.BackendInfo('iree_vmla'))
+    vmla_module = tf_utils.IreeCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('iree_vmla'))
     vmla_trace = tf_test_utils.Trace(vmla_module, vmla_function)
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 
@@ -161,13 +161,13 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     def vmla_function(module):
       module.increment_by(np.array([22.], dtype=np.float32))
 
-    tf_module = tf_utils.TfCompiledModule(StatefulCountingModule,
-                                          tf_utils.BackendInfo('tf'))
+    tf_module = tf_utils.TfCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('tf'))
     tf_trace = tf_test_utils.Trace(tf_module, tf_function)
     tf_function(tf_test_utils.TracedModule(tf_module, tf_trace))
 
-    vmla_module = tf_utils.IreeCompiledModule(StatefulCountingModule,
-                                              tf_utils.BackendInfo('iree_vmla'))
+    vmla_module = tf_utils.IreeCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('iree_vmla'))
     vmla_trace = tf_test_utils.Trace(vmla_module, vmla_function)
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 
@@ -178,12 +178,12 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     def trace_function(module):
       module.increment()
       module.increment_by(np.array([81.], dtype=np.float32))
-      module.increment_by_max(
-          np.array([81], dtype=np.float32), np.array([92], dtype=np.float32))
+      module.increment_by_max(np.array([81], dtype=np.float32),
+                              np.array([92], dtype=np.float32))
       module.get_count()
 
-    module = tf_utils.IreeCompiledModule(StatefulCountingModule,
-                                         tf_utils.BackendInfo('iree_vmla'))
+    module = tf_utils.IreeCompiledModule.create_from_class(
+        StatefulCountingModule, tf_utils.BackendInfo('iree_vmla'))
     trace = tf_test_utils.Trace(module, trace_function)
     trace_function(tf_test_utils.TracedModule(module, trace))
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils_test.py
@@ -89,7 +89,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
   ])
   def test_unaltered_state(self, backend_name):
     backend_info = tf_utils.BackendInfo(backend_name)
-    module = backend_info.compile(StatefulCountingModule)
+    module = backend_info.compile_from_class(StatefulCountingModule)
 
     # Test that incrementing works properly.
     self.assertEqual([0.], module.get_count())
@@ -126,8 +126,8 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     backend_info = tf_utils.BackendInfo(backend_name)
 
     # Test compilation is the same.
-    module_1 = backend_info.compile(RandomInitModule)
-    module_2 = backend_info.compile(RandomInitModule)
+    module_1 = backend_info.compile_from_class(RandomInitModule)
+    module_2 = backend_info.compile_from_class(RandomInitModule)
     self.assertAllEqual(module_1.get(), module_2.get())
 
     # Test reinitialization is the same.

--- a/integrations/tensorflow/bindings/python/pyiree/xla/compiler/__init__.py
+++ b/integrations/tensorflow/bindings/python/pyiree/xla/compiler/__init__.py
@@ -54,7 +54,7 @@ XLA_IMPORT_PASS_PIPELINE = (
 def xla_load_module_proto(
     xla_computation,
     compiler_context: Optional[Context] = None,
-    exported_names: Collection[str] = (),
+    exported_names: Sequence[str] = (),
     pass_pipeline: Sequence[str] = XLA_IMPORT_PASS_PIPELINE) -> Module:
   """Loads a XLA saved model from its persistent representation.
 
@@ -63,8 +63,7 @@ def xla_load_module_proto(
   Args:
     xla_computation: XLA Computation generate from XLA Python client
     compiler_context: The pyiree.compiler.Context() backing the module.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
+    exported_names: Optional sequence representing the exported names to keep.
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to XLA_IMPORT_PASS_PIPELINE.
 
@@ -85,21 +84,20 @@ def xla_load_module_proto(
 def xla_compile_module_proto(
     xla_computation,
     compiler_context: Optional[Context] = None,
-    exported_names: Collection[str] = (),
+    exported_names: Sequence[str] = (),
     pass_pipeline: Sequence[str] = XLA_IMPORT_PASS_PIPELINE,
-    target_backends: Collection[str] = ()
+    target_backends: Sequence[str] = ()
 ) -> binding.OpaqueBlob:
   """Loads and compiles a XLA saved model in one shot.
 
   Args:
     xla_computation: XLA Computation generate from XLA Python client
     compiler_context: The pyiree.compiler.Context() backing the module.
-    exported_names: Optional tuple of strings representing the exported names to
-      keep.
+    exported_names: Optional sequence representing the exported names to keep.
     pass_pipeline: Passes to run on the imported module prior to returning.
       Defaults to XLA_IMPORT_PASS_PIPELINE.
-    target_backends: The specific target backends to compile for (defaults to
-      all compiled in targets).
+    target_backends: Optional sequence of specific target backends to compile
+      for (defaults to all compiled in targets).
 
   Returns:
     An OpaqueBlob representing the compiled module.

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -218,7 +218,6 @@ iree_e2e_test_suite(
     name = "mobile_bert_squad_tests",
     backends_to_srcs = {
         "tf": ["mobile_bert_squad_test.py"],
-        "tflite": ["mobile_bert_squad_test.py"],
     },
     reference_backend = "tf",
     tags = [
@@ -234,6 +233,7 @@ iree_e2e_test_suite(
 iree_e2e_test_suite(
     name = "mobile_bert_squad_tests_failing",
     backends_to_srcs = {
+        "tflite": ["mobile_bert_squad_test.py"],
         "iree_vmla": ["mobile_bert_squad_test.py"],
         "iree_llvmjit": ["mobile_bert_squad_test.py"],
         "iree_vulkan": ["mobile_bert_squad_test.py"],


### PR DESCRIPTION
Refactors `CompiledModule` and its subclasses to use the name constructors `create_from_class` and `create_from_instance`. This makes it easier to add additional compilation paths to our TensorFlow integration tests.

Additional changes:
- Clean up docstrings and make type info more accurate.
- Explicitly differentiate between `backend_name` and `backend_id`:
  - `backend_name` is one of `[tf, tflite, iree_vmla, iree_llvmjit, iree_vulkan]`.
  - `backend_id` uniquely identifies each instantiated backend at test time for the purpose of saving compilation artifacts.
- Use a `defaultdict` to match IREE's behavior of compiling all methods into one binary.