### PR TITLE
Expand page width and padding for E2E coverage

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -21,3 +21,11 @@
 .failure-table-cell {
   background-color: $grey-lt-000
 }
+
+.main-content {
+  max-width: 860px;
+}
+
+th, td {
+  padding: 0.5rem 1.0rem !important;
+}


### PR DESCRIPTION
Changes the `max-width` of the `main-content` section of the page from `800px` to `860px` to accommodate for the added TFLite backend in the E2E ops coverage table.

Before:
<img width="752" alt="Before pic of coverage table" src="https://user-images.githubusercontent.com/40036383/94981228-3ea5b080-04e5-11eb-9c5a-9442c0ddeb70.png">

After:
<img width="814" alt="After pic of coverage table" src="https://user-images.githubusercontent.com/40036383/94981236-511fea00-04e5-11eb-8641-cc82f2cb33b6.png">
