### PR TITLE
Fix ill-configured slim vision model tests

### DIFF
--- a/integrations/tensorflow/e2e/slim_vision_models/BUILD
+++ b/integrations/tensorflow/e2e/slim_vision_models/BUILD
@@ -49,6 +49,7 @@ iree_py_binary(
 
 iree_slim_vision_test_suite(
     name = "slim_vision_tests",
+    size = "enormous",
     backends = [
         "tf",
         "tflite",
@@ -62,16 +63,16 @@ iree_slim_vision_test_suite(
             "models": [
                 "inception_resnet_v2",
                 # tflite: RuntimeError: tensorflow/lite/kernels/reshape.cc:66 num_input_elements != num_output_elements (38400 != -1571481807)Node number 333 (RESHAPE) failed to prepare.
-                # llvmjit: *** Received signal 6 *** (mangled stack trace)
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 1.3961234, atol: 2e-05, max relative diff: 0.27304956, rtol: 1e-06
+                # llvmjit: *** Received signal 6 ***
+                # vulkan: Floating point difference was too large. Max abs diff: 1.3961234, atol: 5e-05, max relative diff: 0.27304956, rtol: 1e-06
                 "resnet_v2_101",
                 # tflite: RuntimeError: tensorflow/lite/core/subgraph.cc BytesRequired number of elements overflowed.
-                # llvmjit: Floating point difference between ref and tar was too large. Max abs diff: 11.668068, atol: 2e-05, max relative diff: 0.93950737, rtol: 1e-06
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 11.668067, atol: 2e-05, max relative diff: 0.93950737, rtol: 1e-06
+                # llvmjit: Floating point difference was too large. Max abs diff: 11.668068, atol: 5e-05, max relative diff: 0.93950737, rtol: 1e-06
+                # vulkan: Floating point difference was too large. Max abs diff: 11.668067, atol: 5e-05, max relative diff: 0.93950737, rtol: 1e-06
                 "resnet_v2_152",
                 # tflite: RuntimeError: tensorflow/lite/core/subgraph.cc BytesRequired number of elements overflowed.
-                # llvmjit: Floating point difference between ref and tar was too large. Max abs diff: 7.080696, atol: 2e-05, max relative diff: 0.97750616, rtol: 1e-06
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 7.08069, atol: 2e-05, max relative diff: 0.97750485, rtol: 1e-06
+                # llvmjit: Floating point difference was too large. Max abs diff: 7.080696, atol: 5e-05, max relative diff: 0.97750616, rtol: 1e-06
+                # vulkan: Floating point difference was too large. Max abs diff: 7.08069, atol: 5e-05, max relative diff: 0.97750485, rtol: 1e-06
             ],
             "backends": [
                 "tflite",
@@ -84,16 +85,22 @@ iree_slim_vision_test_suite(
             "models": [
                 "inception_v2",
                 # llvmjit: double free or corruption (!prev); *** Received signal 6 ***
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 1.0769763, atol: 2e-05, max relative diff: 0.19576924, rtol: 1e-06
+                # vulkan: Floating point difference was too large. Max abs diff: 1.0769763, atol: 5e-05, max relative diff: 0.19576924, rtol: 1e-06
                 "inception_v3",
                 # llvmjit: double free or corruption (!prev); *** Received signal 6 ***
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 2.5201874, atol: 2e-05, max relative diff: 0.53700095, rtol: 1e-06
+                # vulkan: Floating point difference was too large. Max abs diff: 2.5201874, atol: 5e-05, max relative diff: 0.53700095, rtol: 1e-06
                 "nasnet_mobile",
                 # llvmjit: corrupted size vs. prev_size; *** Received signal 6 ***
                 # vulkan: *** Received signal 11 ***
+                "nasnet_large",
+                # llvmjit: *** Received signal 6 ***
+                # vulkan: *** Received signal 11 ***
+                "pnasnet_large",
+                # llvmjit: Floating point difference was too large. Max abs diff: 1.0411791, atol: 5e-05, max relative diff: 0.20533353, rtol: 1e-06
+                # vulkan: *** Received signal 11 ***
                 "resnet_v2_50",
-                # llvmjit: Floating point difference between ref and tar was too large. Max abs diff: 5.8187943, atol: 2e-05, max relative diff: 0.7946711, rtol: 1e-06
-                # vulkan: Floating point difference between ref and tar was too large. Max abs diff: 5.8187933, atol: 2e-05, max relative diff: 0.79467094, rtol: 1e-06
+                # llvmjit: Floating point difference was too large. Max abs diff: 5.8187943, atol: 5e-05, max relative diff: 0.7946711, rtol: 1e-06
+                # vulkan: Floating point difference was too large. Max abs diff: 5.8187933, atol: 5e-05, max relative diff: 0.79467094, rtol: 1e-06
             ],
             "backends": [
                 "iree_llvmjit",
@@ -102,10 +109,12 @@ iree_slim_vision_test_suite(
         },
     ],
     models = [
+        # "amoebanet_a_n18_f448",  # SavedModelV2 (classification/4) not available.
         "inception_resnet_v2",
         "inception_v1",
         "inception_v2",
         "inception_v3",
+        # MobileNetV1
         "mobilenet_v1_025_128",
         "mobilenet_v1_025_160",
         "mobilenet_v1_025_192",
@@ -122,98 +131,38 @@ iree_slim_vision_test_suite(
         "mobilenet_v1_100_160",
         "mobilenet_v1_100_192",
         "mobilenet_v1_100_224",
+        # MobileNetV2:
+        "mobilenet_v2_035_96",
+        "mobilenet_v2_035_128",
+        "mobilenet_v2_035_160",
+        "mobilenet_v2_035_192",
         "mobilenet_v2_035_224",
+        "mobilenet_v2_050_96",
+        "mobilenet_v2_050_128",
+        "mobilenet_v2_050_160",
+        "mobilenet_v2_050_192",
         "mobilenet_v2_050_224",
+        "mobilenet_v2_075_96",
+        "mobilenet_v2_075_128",
+        "mobilenet_v2_075_160",
+        "mobilenet_v2_075_192",
         "mobilenet_v2_075_224",
+        "mobilenet_v2_100_96",
+        "mobilenet_v2_100_128",
+        "mobilenet_v2_100_160",
+        "mobilenet_v2_100_192",
         "mobilenet_v2_100_224",
         "mobilenet_v2_130_224",
         "mobilenet_v2_140_224",
         "nasnet_mobile",
-        "resnet_v1_101",
-        "resnet_v1_152",
-        "resnet_v1_50",
-        "resnet_v2_101",
-        "resnet_v2_152",
-        "resnet_v2_50",
-    ],
-    reference_backend = "tf",
-    tags = [
-        "external",
-        "guitar",
-        "manual",
-        "no-remote",
-        "nokokoro",
-        "notap",
-    ],
-    tf_hub_url = "https://tfhub.dev/google/imagenet/",
-    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
-        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
-    ],
-)
-
-# TODO(meadowlark): Get these working on tf.
-iree_slim_vision_test_suite(
-    name = "slim_vision_ill_configured_tests",
-    backends = [
-        "tf",
-        "tflite",
-        "iree_vmla",
-        "iree_llvmjit",
-        "iree_vulkan",
-    ],
-    failing_configurations = [
-        {
-            # Failing on all backends:
-            "models": [
-                "amoebanet_a_n18_f448",
-                "mobilenet_v2_035_128",
-                "mobilenet_v2_035_160",
-                "mobilenet_v2_035_192",
-                "mobilenet_v2_035_96",
-                "mobilenet_v2_050_128",
-                "mobilenet_v2_050_160",
-                "mobilenet_v2_050_192",
-                "mobilenet_v2_050_96",
-                "mobilenet_v2_075_128",
-                "mobilenet_v2_075_160",
-                "mobilenet_v2_075_192",
-                "mobilenet_v2_075_96",
-                "mobilenet_v2_100_128",
-                "mobilenet_v2_100_160",
-                "mobilenet_v2_100_192",
-                "mobilenet_v2_100_96",
-                "nasnet_large",
-                "pnasnet_large",
-            ],
-            "backends": [
-                "tf",
-                "tflite",
-                "iree_vmla",
-                "iree_llvmjit",
-                "iree_vulkan",
-            ],
-        },
-    ],
-    models = [
-        "amoebanet_a_n18_f448",
-        "mobilenet_v2_035_128",
-        "mobilenet_v2_035_160",
-        "mobilenet_v2_035_192",
-        "mobilenet_v2_035_96",
-        "mobilenet_v2_050_128",
-        "mobilenet_v2_050_160",
-        "mobilenet_v2_050_192",
-        "mobilenet_v2_050_96",
-        "mobilenet_v2_075_128",
-        "mobilenet_v2_075_160",
-        "mobilenet_v2_075_192",
-        "mobilenet_v2_075_96",
-        "mobilenet_v2_100_128",
-        "mobilenet_v2_100_160",
-        "mobilenet_v2_100_192",
-        "mobilenet_v2_100_96",
         "nasnet_large",
         "pnasnet_large",
+        "resnet_v1_50",
+        "resnet_v1_101",
+        "resnet_v1_152",
+        "resnet_v2_50",
+        "resnet_v2_101",
+        "resnet_v2_152",
     ],
     reference_backend = "tf",
     tags = [

--- a/integrations/tensorflow/e2e/slim_vision_models/BUILD
+++ b/integrations/tensorflow/e2e/slim_vision_models/BUILD
@@ -59,6 +59,19 @@ iree_slim_vision_test_suite(
     ],
     failing_configurations = [
         {
+            # SavedModelV2 (classification/4) not available.
+            "models": [
+                "amoebanet_a_n18_f448",
+            ],
+            "backends": [
+                "tf",
+                "tflite",
+                "iree_vmla",
+                "iree_llvmjit",
+                "iree_vulkan",
+            ],
+        },
+        {
             # Failing all but tf and vmla:
             "models": [
                 "inception_resnet_v2",
@@ -109,7 +122,6 @@ iree_slim_vision_test_suite(
         },
     ],
     models = [
-        # "amoebanet_a_n18_f448",  # SavedModelV2 (classification/4) not available.
         "inception_resnet_v2",
         "inception_v1",
         "inception_v2",
@@ -157,9 +169,11 @@ iree_slim_vision_test_suite(
         "nasnet_mobile",
         "nasnet_large",
         "pnasnet_large",
+        # ResNetV1
         "resnet_v1_50",
         "resnet_v1_101",
         "resnet_v1_152",
+        # ResNetV2
         "resnet_v2_50",
         "resnet_v2_101",
         "resnet_v2_152",

--- a/integrations/tensorflow/e2e/slim_vision_models/slim_vision_model_test.py
+++ b/integrations/tensorflow/e2e/slim_vision_models/slim_vision_model_test.py
@@ -37,13 +37,26 @@ flags.DEFINE_string(
     'mobilenet_v2_035_224]\nAt least a subset can be viewed here:\n'
     'https://tfhub.dev/s?dataset=imagenet&module-type=image-classification,image-classifier'
 )
-flags.DEFINE_string('tf_hub_url', None,
-                    'Base URL for the models to test. URL at the time of '
-                    'writing:\nhttps://tfhub.dev/google/imagenet/')
+flags.DEFINE_string(
+    'tf_hub_url', None, 'Base URL for the models to test. URL at the time of '
+    'writing:\nhttps://tfhub.dev/google/imagenet/')
 
 # Classification mode; 4 - is a format of the model (SavedModel TF v2).
 MODE = 'classification/4'
-INPUT_SHAPE = (1, 224, 224, 3)
+LARGE_MODELS = ['amoebanet_a_n18_f448', "nasnet_large", "pnasnet_large"]
+
+
+def get_input_shape():
+  if FLAGS.model in LARGE_MODELS:
+    return (1, 331, 331, 3)
+  elif FLAGS.model.startswith('mobilenet_v2'):
+    # The MobileNetV2 models have variable size that seems to be only inferrible
+    # from their TFHub name.
+    size = int(FLAGS.model.split('_')[-1])
+    return (1, size, size, 3)
+  else:
+    # Default input shape.
+    return (1, 224, 224, 3)
 
 
 class SlimVisionModule(tf.Module):
@@ -54,8 +67,9 @@ class SlimVisionModule(tf.Module):
     model_path = posixpath.join(FLAGS.tf_hub_url, FLAGS.model, MODE)
     hub_layer = hub.KerasLayer(model_path)
     self.m = tf.keras.Sequential([hub_layer])
-    self.m.build(INPUT_SHAPE)
-    self.predict = tf.function(input_signature=[tf.TensorSpec(INPUT_SHAPE)])(
+    input_shape = get_input_shape()
+    self.m.build(input_shape)
+    self.predict = tf.function(input_signature=[tf.TensorSpec(input_shape)])(
         self.m.call)
 
 
@@ -69,8 +83,9 @@ class SlimVisionTest(tf_test_utils.TracedModuleTestCase):
   def test_predict(self):
 
     def predict(module):
-      input_data = np.random.rand(*INPUT_SHAPE).astype(np.float32)
-      module.predict(input_data, atol=2e-5)
+      input_data = np.random.rand(*get_input_shape()).astype(np.float32)
+      # Only TF vs. TF passes at the default atol.
+      module.predict(input_data, atol=5e-5)
 
     self.compare_backends(predict, self._modules)
 

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -21,6 +21,7 @@ Example usage: python3 update_e2e_coverage.py build-docs
 import argparse
 import collections
 import os
+import re
 import subprocess
 
 REFERENCE_BACKEND = 'tf'
@@ -53,6 +54,11 @@ SINGLE_SOURCE_SUITES = {
     '//integrations/tensorflow/e2e/slim_vision_models:slim_vision_tests':
         'slim_vision_model_test',
 }
+
+TARGET_FILTERS = [
+    r'mobilenet_v1_.*',  # Slim vision MobileNetV1
+    r'mobilenet_v2_.*',  # Slim vision MobileNetV2
+]
 
 # The symbols to show in the table if the operation is supported or not.
 SUCCESS_ELEMENT = '<span class="success-table-element">✓</span>'
@@ -161,6 +167,9 @@ def generate_table(test_suite):
   # Generate the coverage table as a 2D array.
   rows = [first_row, second_row]
   for name, backends in sorted(table.items()):
+    if any(re.match(pattern, name) for pattern in TARGET_FILTERS):
+      continue
+
     row = [get_name_element(test_suite, name)]
     row.extend([
         SUCCESS_ELEMENT if backend else FAILURE_ELEMENT for backend in backends

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -55,7 +55,7 @@ SINGLE_SOURCE_SUITES = {
         'slim_vision_model_test',
 }
 
-TARGET_FILTERS = [
+TARGET_EXCLUSION_FILTERS = [
     r'mobilenet_v1_.*',  # Slim vision MobileNetV1
     r'mobilenet_v2_.*',  # Slim vision MobileNetV2
 ]

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -56,8 +56,9 @@ SINGLE_SOURCE_SUITES = {
 }
 
 TARGET_EXCLUSION_FILTERS = [
-    r'mobilenet_v1_.*',  # Slim vision MobileNetV1
-    r'mobilenet_v2_.*',  # Slim vision MobileNetV2
+    r'mobilenet_v1_.*',  # Slim vision MobileNetV1.
+    r'mobilenet_v2_.*',  # Slim vision MobileNetV2.
+    r'amoebanet_a_n18_f448',  # SavedModelV2 not available.
 ]
 
 # The symbols to show in the table if the operation is supported or not.
@@ -167,7 +168,7 @@ def generate_table(test_suite):
   # Generate the coverage table as a 2D array.
   rows = [first_row, second_row]
   for name, backends in sorted(table.items()):
-    if any(re.match(pattern, name) for pattern in TARGET_FILTERS):
+    if any(re.match(pattern, name) for pattern in TARGET_EXCLUSION_FILTERS):
       continue
 
     row = [get_name_element(test_suite, name)]


### PR DESCRIPTION
- Enables all `mobilenet_v*` models, `nasnet_large` and `pnasnes_large`.
- Adds the ability to filter targets from out E2E coverage table. This is useful because slim vision has 37 versions of MobileNet that all pass on all backends, which isn't very interesting from a coverage standpoint. They all have different sizes however, so the targets could be useful for benchmarking a diverse set of input shapes and filter counts.

I left `amoebanet_a_n18_f448` in the build file because it may eventually be supported.