### PR TITLE
Expand keras vision model test coverage

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -163,7 +163,6 @@ iree_e2e_test_suite(
 
 iree_vision_test_suite(
     name = "medium_cifar10_internal_tests",
-    test_size = "medium",
     backends = [
         "tf",
         "tflite",
@@ -182,6 +181,7 @@ iree_vision_test_suite(
     ],
     reference_backend = "tf",
     tags = ["manual"],
+    test_size = "medium",
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -162,7 +162,8 @@ iree_e2e_test_suite(
 )
 
 iree_vision_test_suite(
-    name = "short_cifar10_internal_tests",
+    name = "medium_cifar10_internal_tests",
+    test_size = "medium",
     backends = [
         "tf",
         "tflite",

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -162,7 +162,7 @@ iree_e2e_test_suite(
 )
 
 iree_vision_test_suite(
-    name = "vision_internal_tests",
+    name = "short_cifar10_internal_tests",
     backends = [
         "tf",
         "tflite",
@@ -171,7 +171,14 @@ iree_vision_test_suite(
         "iree_vulkan",
     ],
     datasets = ["cifar10"],
-    models = ["ResNet50"],
+    models = [
+        # All models with runtime shorter than ResNet50.
+        "MobileNet",  # Max: Vulkan 61.0s
+        "MobileNetV2",  # Max: LLVM 96.3s
+        "ResNet50",  # Max: LLVM 145.6s
+        "VGG16",  # Max: LLVM 89.5s
+        "VGG19",  # Max: LLVM 94.7s
+    ],
     reference_backend = "tf",
     tags = ["manual"],
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
@@ -180,7 +187,8 @@ iree_vision_test_suite(
 )
 
 iree_vision_test_suite(
-    name = "vision_external_tests",
+    name = "long_cifar10_internal_tests",
+    size = "enormous",
     backends = [
         "tf",
         "tflite",
@@ -188,10 +196,59 @@ iree_vision_test_suite(
         "iree_llvmjit",
         "iree_vulkan",
     ],
-    datasets = [
-        "cifar10",
-        "imagenet",
+    datasets = ["cifar10"],
+    failing_configurations = [
+        {
+            # Failing all but tf and vmla:
+            "models": [
+                "NASNetLarge",
+                "NASNetMobile",
+                "ResNet50V2",
+                "ResNet101V2",
+                "ResNet152V2",
+            ],
+            "datasets": ["cifar10"],
+            "backends": [
+                "tflite",
+                "iree_llvmjit",
+                "iree_vulkan",
+            ],
+        },
     ],
+    models = [
+        "DenseNet121",
+        "DenseNet169",
+        "DenseNet201",
+        "NASNetLarge",
+        "NASNetMobile",
+        "ResNet50V2",
+        "ResNet101",
+        "ResNet101V2",
+        "ResNet152",
+        "ResNet152V2",
+    ],
+    reference_backend = "tf",
+    tags = [
+        "guitar",
+        "manual",
+        "nokokoro",
+        "notap",
+    ],
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+iree_vision_test_suite(
+    name = "cifar10_external_tests",
+    backends = [
+        "tf",
+        "tflite",
+        "iree_vmla",
+        "iree_llvmjit",
+        "iree_vulkan",
+    ],
+    datasets = ["cifar10"],
     models = [
         "MobileNet",
         "MobileNetV2",
@@ -206,6 +263,74 @@ iree_vision_test_suite(
         "nokokoro",
         "notap",
     ],
+    url = "https://storage.googleapis.com/iree_models/",
+    use_external_weights = True,
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+    ],
+)
+
+iree_vision_test_suite(
+    name = "imagenet_external_tests",
+    size = "enormous",
+    backends = [
+        "tf",
+        "tflite",
+        "iree_vmla",
+        "iree_llvmjit",
+        "iree_vulkan",
+    ],
+    datasets = ["imagenet"],
+    failing_configurations = [
+        {
+            # Failing all but tf and vmla:
+            "models": [
+                "InceptionResNetV2",
+                "InceptionV3",
+                "NASNetLarge",
+                "NASNetMobile",
+                "ResNet50V2",
+                "ResNet101V2",
+                "ResNet152V2",
+                "Xception",
+            ],
+            "datasets": ["imagenet"],
+            "backends": [
+                "tflite",
+                "iree_llvmjit",
+                "iree_vulkan",
+            ],
+        },
+    ],
+    models = [
+        "DenseNet121",
+        "DenseNet169",
+        "DenseNet201",
+        "InceptionResNetV2",
+        "InceptionV3",
+        "MobileNet",
+        "MobileNetV2",
+        "NASNetLarge",
+        "NASNetMobile",
+        "ResNet50",
+        "ResNet50V2",
+        "ResNet101",
+        "ResNet101V2",
+        "ResNet152",
+        "ResNet152V2",
+        "VGG16",
+        "VGG19",
+        "Xception",
+    ],
+    reference_backend = "tf",
+    tags = [
+        "external",
+        "guitar",
+        "manual",
+        "nokokoro",
+        "notap",
+    ],
+    use_external_weights = True,
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -163,6 +163,7 @@ iree_e2e_test_suite(
 
 iree_vision_test_suite(
     name = "medium_cifar10_internal_tests",
+    size = "medium",
     backends = [
         "tf",
         "tflite",
@@ -181,7 +182,6 @@ iree_vision_test_suite(
     ],
     reference_backend = "tf",
     tags = ["manual"],
-    test_size = "medium",
     deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -188,7 +188,7 @@ iree_vision_test_suite(
 )
 
 iree_vision_test_suite(
-    name = "long_cifar10_internal_tests",
+    name = "enormous_cifar10_internal_tests",
     size = "enormous",
     backends = [
         "tf",

--- a/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
@@ -24,8 +24,9 @@ def iree_vision_test_suite(
         backends,
         reference_backend,
         failing_configurations = None,
-        external_weights = None,
         tags = None,
+        url = None,
+        use_external_weights = None,
         deps = None,
         size = "large",
         python_version = "PY3",
@@ -55,11 +56,13 @@ def iree_vision_test_suite(
         an iterable of dictionaries with the keys `models`, `datasets` and
         `backends`. Each key points to a string or iterable of strings
         specifying a set of models, datasets and backends that are failing.
-      external_weights:
-        a base url to fetch trained model weights from.
       tags:
         tags to apply to the test. Note that as in standard test suites, manual
         is treated specially and will also apply to the test suite itself.
+      url:
+        a base url to fetch non-keras trained model weights from.
+      use_external_weights:
+        whether or not to load model weights from keras or a supplied url.
       deps:
         test dependencies.
       size:
@@ -94,13 +97,21 @@ def iree_vision_test_suite(
 
                 # Append "_failing" to name if this is a failing configuration.
                 test_name = name if not failing else name + "_failing"
-                test_name = "{}_{}_{}__{}__{}".format(
-                    test_name,
-                    model,
-                    dataset,
-                    reference_backend,
-                    backend,
-                )
+                if len(datasets) > 1:
+                    test_name = "{}_{}_{}__{}__{}".format(
+                        test_name,
+                        model,
+                        dataset,
+                        reference_backend,
+                        backend,
+                    )
+                else:
+                    test_name = "{}_{}__{}__{}".format(
+                        test_name,
+                        model,
+                        reference_backend,
+                        backend,
+                    )
                 tests.append(test_name)
 
                 args = [
@@ -109,8 +120,11 @@ def iree_vision_test_suite(
                     "--reference_backend={}".format(reference_backend),
                     "--target_backends={}".format(backend),
                 ]
-                if external_weights:
-                    args.append("--url={}".format(external_weights))
+                if url:
+                    args.append("--url={}".format(url))
+                if use_external_weights:
+                    args.append(
+                        "--use_external_weights={}".format(use_external_weights))
 
                 # TODO(GH-2175): Simplify this after backend names are
                 # standardized.

--- a/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
@@ -62,7 +62,8 @@ def iree_vision_test_suite(
       url:
         a base url to fetch non-keras trained model weights from.
       use_external_weights:
-        whether or not to load model weights from keras or a supplied url.
+        whether or not to load model weights from the web (either uses keras or
+          the supplied url).
       deps:
         test dependencies.
       size:

--- a/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
+++ b/integrations/tensorflow/e2e/keras/iree_vision_test_suite.bzl
@@ -125,7 +125,8 @@ def iree_vision_test_suite(
                     args.append("--url={}".format(url))
                 if use_external_weights:
                     args.append(
-                        "--use_external_weights={}".format(use_external_weights))
+                        "--use_external_weights={}".format(use_external_weights),
+                    )
 
                 # TODO(GH-2175): Simplify this after backend names are
                 # standardized.

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -33,7 +33,7 @@ flags.DEFINE_string(
     'for example https://storage.googleapis.com/iree_models/')
 flags.DEFINE_bool(
     'use_external_weights', False,
-    'Whether or not to load external weights from tf.keras.applications')
+    'Whether or not to load external weights from the web')
 flags.DEFINE_enum('data', 'cifar10', ['cifar10', 'imagenet'],
                   'data sets on which model was trained: imagenet, cifar10')
 flags.DEFINE_bool(

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -31,6 +31,9 @@ flags.DEFINE_string('model', 'ResNet50', 'model name')
 flags.DEFINE_string(
     'url', '', 'url with model weights '
     'for example https://storage.googleapis.com/iree_models/')
+flags.DEFINE_bool(
+    'use_external_weights', False,
+    'Whether or not to load external weights from tf.keras.applications')
 flags.DEFINE_enum('data', 'cifar10', ['cifar10', 'imagenet'],
                   'data sets on which model was trained: imagenet, cifar10')
 flags.DEFINE_bool(
@@ -111,13 +114,18 @@ def initialize_model():
 
   # If weights == 'imagenet', the model will load the appropriate weights from
   # an external tf.keras URL.
-  weights = 'imagenet' if FLAGS.data == 'imagenet' else None
+  weights = None
+  if FLAGS.use_external_weights and FLAGS.data == 'imagenet':
+    weights = 'imagenet'
 
   model = APP_MODELS[FLAGS.model](weights=weights,
                                   include_top=FLAGS.include_top,
                                   input_shape=input_shape)
 
-  if FLAGS.data == 'cifar10' and FLAGS.url:
+  if FLAGS.use_external_weights and FLAGS.data == 'cifar10':
+    if not FLAGS.url:
+      raise ValueError(
+          'cifar10 weights cannot be loaded without the `--url` flag.')
     model = load_cifar10_weights(model)
   return model
 

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -39,8 +39,8 @@ TEST_SUITES_TO_HEADERS = {
         'End to end TensorFlow tests',
     '//integrations/tensorflow/e2e/keras:keras_tests':
         'End to end tests written using tf.keras',
-    '//integrations/tensorflow/e2e/keras:vision_external_tests':
-        'End to end tests of tf.keras.applications vision models',
+    '//integrations/tensorflow/e2e/keras:imagenet_external_tests':
+        'End to end tests of tf.keras.applications vision models on Imagenet',
     '//integrations/tensorflow/e2e/slim_vision_models:slim_vision_tests':
         'End to end tests of TensorFlow slim vision models',
 }
@@ -48,7 +48,7 @@ TEST_SUITES_TO_HEADERS = {
 # Some test suites are generated from a single source. This allows us to point
 # to the right test file when generating test URLs.
 SINGLE_SOURCE_SUITES = {
-    '//integrations/tensorflow/e2e/keras:vision_external_tests':
+    '//integrations/tensorflow/e2e/keras:imagenet_external_tests':
         'vision_model_test',
     '//integrations/tensorflow/e2e/slim_vision_models:slim_vision_tests':
         'slim_vision_model_test',


### PR DESCRIPTION
Adds tests for the following models through `tf.keras.applications`:

- `DenseNet121`, `DenseNet169`, `DenseNet201`
- `InceptionResNetV2`, `InceptionV3`
- `NASNetLarge`, `NASNetMobile`
- `ResNet50V2`, `ResNet101`, `ResNet101V2`, `ResNet152`, `ResNet152V2`
- `VGG16`, `VGG19`
- `Xception`

Additional changes:
- `cifar10` and `imagenet` test suites are separated because `InceptionResNetV2`, `InceptionV3` and `Xception` do not support `cifar10` shapes.
- The `external_weights` macro keyword argument is renamed to `url` to match test flag.
- Added a `--use_external_weights` flag to make it clear whether or not external data is being used, and to allow testing `imagenet` shapes on random weights.
- The E2E coverage page only uses `imagenet` results because of the first point above and because `imagenet` and `cifar10` coverage are identical otherwise.
- `MobileNet`, `MobileNetV2`, `VGG16` and `VGG19` are added to the test suite that is ran by the CI because they have a shorter runtime than `ResNet50` (which was previously the only model tested by the CI).
- The option to give the `iree_vision_test_suite` macro multiple datasets was kept, but if only one dataset is provided then the dataset will be excluded from the part of the target names that is generated by the macro. This also makes the E2E coverage table look cleaner.

There is some overlap here between our Keras and Slim vision tests, but the coverage (particularly for TFLite) differs between them.