### PR TITLE
Disable LLVM warnings when building with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,9 @@ function(add_iree_mlir_src_dep llvm_monorepo_path)
     set(MLIR_VULKAN_RUNNER_ENABLED ON)
   endif()
 
+  # Disable LLVM's warnings
+  set(LLVM_ENABLE_WARNINGS OFF)
+
   add_subdirectory("${llvm_monorepo_path}/llvm" "third_party/llvm-project/llvm" EXCLUDE_FROM_ALL)
 
   # Reset CMAKE_BUILD_TYPE to its previous setting


### PR DESCRIPTION
As a dependent project, these warnings are out of our direct control and are *very* spammy through MSVC.

Default behavior was changed (from implicit to explicit) with https://reviews.llvm.org/D87243.

Relates to https://github.com/google/iree/issues/3315