### PR TITLE
Add 'yapf: disable' to difficult-to-read tests

### DIFF
--- a/integrations/tensorflow/e2e/conv_test.py
+++ b/integrations/tensorflow/e2e/conv_test.py
@@ -106,107 +106,87 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
     super(ConvTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(Conv2dModule)
 
+  # yapf: disable
   def test_id_batch_size_1(self):
-
     def id_batch_size_1(module):
       i = tf_utils.ndarange([1, 4, 5, 1])
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_1451x1111_valid(i, k)
-
     self.compare_backends(id_batch_size_1, self._modules)
 
   def test_id_batch_size_2(self):
-
     def id_batch_size_2(module):
       i = tf_utils.ndarange([2, 4, 5, 1])
       k = np.ones([1, 1, 1, 1], dtype=np.float32)
       module.conv2d_2451x1111_valid(i, k)
-
     self.compare_backends(id_batch_size_2, self._modules)
 
   def test_asymmetric_kernel(self):
-
     def asymmetric_kernel(module):
       i = tf_utils.ndarange([1, 4, 5, 1])
       k = np.array([[1, 4, 2], [-2, 0, 1]],
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_valid(i, k)
-
     self.compare_backends(asymmetric_kernel, self._modules)
 
   def test_padding(self):
-
     def padding(module):
       i = tf_utils.ndarange([1, 4, 5, 1])
       k = np.array([[1, 4, 2], [-2, 0, 1]],
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_1451x2311_same(i, k)
-
     self.compare_backends(padding, self._modules)
 
   def test_batched_padding(self):
-
     def batched_padding(module):
       i = tf_utils.ndarange([2, 4, 5, 1])
       k = np.array([[1, 4, 2], [-2, 0, 1]],
                    dtype=np.float32).reshape(2, 3, 1, 1)
       module.conv2d_2451x2311_same(i, k)
-
     self.compare_backends(batched_padding, self._modules)
 
   def test_feature_reduce(self):
-
     def feature_reduce(module):
       i = tf_utils.ndarange([1, 4, 5, 2])
       k = np.ones([3, 2, 2, 1], dtype=np.float32)
       module.conv2d_1452x3221_same(i, k)
-
     self.compare_backends(feature_reduce, self._modules)
 
   def test_feature_inflate(self):
-
     def feature_inflate(module):
       i = tf_utils.ndarange([1, 4, 5, 1])
       k = tf_utils.ndarange([1, 1, 1, 2])
       module.conv2d_1451x1112_same(i, k)
-
     self.compare_backends(feature_inflate, self._modules)
 
   def test_feature_mix(self):
-
     def feature_mix(module):
       i = tf_utils.ndarange([1, 4, 5, 2])
       k = tf_utils.ndarange([1, 1, 2, 2])
       module.conv2d_1452x1122_same(i, k)
-
     self.compare_backends(feature_mix, self._modules)
 
   def test_feature_padded(self):
-
     def feature_padded(module):
       i = tf_utils.ndarange([1, 4, 5, 2])
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_same(i, k)
-
     self.compare_backends(feature_padded, self._modules)
 
   def test_feature_unpadded(self):
-
     def feature_unpadded(module):
       i = tf_utils.ndarange([1, 4, 5, 2])
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_1452x2223_valid(i, k)
-
     self.compare_backends(feature_unpadded, self._modules)
 
   def test_batched_feature_unpadded(self):
-
     def batched_feature_unpadded(module):
       i = tf_utils.ndarange([2, 4, 5, 2])
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2223_valid(i, k)
-
     self.compare_backends(batched_feature_unpadded, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/depth_conv_test.py
+++ b/integrations/tensorflow/e2e/depth_conv_test.py
@@ -80,52 +80,44 @@ class ConvTest(tf_test_utils.TracedModuleTestCase):
     super(ConvTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(DepthConv2dModule)
 
+  # yapf: disable
   def test_batched_feature_unpadded(self):
-
     def batched_feature_unpadded(module):
       i = tf_utils.ndarange([2, 4, 5, 2])
       k = tf_utils.ndarange([2, 2, 2, 3])
       module.conv2d_2452x2423_valid(i, k)
-
     self.compare_backends(batched_feature_unpadded, self._modules)
 
   def test_batched_feature_unpadded_same(self):
-
     def batched_feature_unpadded_same(module):
       i = tf_utils.ndarange([2, 4, 5, 2])
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same(i, k)
-
     self.compare_backends(batched_feature_unpadded_same, self._modules)
 
   def test_batched_feature_unpadded_same_stride_2(self):
-
     def batched_feature_unpadded_same_stride_2(module):
       i = tf_utils.ndarange([2, 4, 5, 2])
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_valid_stride_2(i, k)
-
     self.compare_backends(batched_feature_unpadded_same_stride_2,
                           self._modules)
 
   def test_batched_feature_padded_same_stride_2(self):
-
     def batched_feature_padded_same_stride_2(module):
       i = tf_utils.ndarange([2, 4, 5, 2])
       k = tf_utils.ndarange([2, 4, 2, 3])
       module.conv2d_2452x2423_same_stride_2(i, k)
-
     self.compare_backends(batched_feature_padded_same_stride_2, self._modules)
 
   def test_batched_feature_padded_same_stride_1_output_1(self):
-
     def batched_feature_padded_same_stride_1_output_1(module):
       i = tf_utils.ndarange([2, 4, 5, 4])
       k = tf_utils.ndarange([2, 4, 4, 1])
       module.conv2d_2453x2441_same_stride_1(i, k)
-
     self.compare_backends(batched_feature_padded_same_stride_1_output_1,
                           self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/gather_test.py
+++ b/integrations/tensorflow/e2e/gather_test.py
@@ -49,14 +49,12 @@ class GatherModule(tf.Module):
   def gather_axis2_batch1(self, params, indices):
     return tf.gather(params, indices, axis=2, batch_dims=1)
 
-
   @tf.function(input_signature=[
       tf.TensorSpec([4, 7, 8, 2], tf.float32),
       tf.TensorSpec([4, 1], tf.int32)
   ])
   def gather_axis1_batch1(self, params, indices):
     return tf.gather(params, indices, axis=1, batch_dims=1)
-
 
   @tf.function(input_signature=[
       tf.TensorSpec([2, 4], tf.int32),
@@ -72,60 +70,49 @@ class GatherTest(tf_test_utils.TracedModuleTestCase):
     super(GatherTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(GatherModule)
 
+  # yapf: disable
   def test_gather_axis0_scalar(self):
-
     def gather_axis0_scalar(module):
       indices = np.array(2, dtype=np.int32)
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_scalar(params, indices)
-
     self.compare_backends(gather_axis0_scalar, self._modules)
 
   def test_gather_axis0_batch0(self):
-
     def gather_axis0_batch0(module):
       indices = np.array([2, 3], dtype=np.int32)
       params = tf_utils.ndarange([4, 8])
       module.gather_axis0_batch0(params, indices)
-
     self.compare_backends(gather_axis0_batch0, self._modules)
 
   def test_gather_axis1_batch0(self):
-
     def gather_axis1_batch0(module):
       indices = np.array([2, 3], dtype=np.int32)
       params = tf_utils.ndarange([4, 7, 8])
       module.gather_axis1_batch0(params, indices)
-
     self.compare_backends(gather_axis1_batch0, self._modules)
 
   def test_gather_axis2_batch1(self):
-
     def gather_axis2_batch1(module):
       indices = np.array([[2], [3], [0], [1]], dtype=np.int32)
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis2_batch1(params, indices)
-
     self.compare_backends(gather_axis2_batch1, self._modules)
 
   def test_gather_axis1_batch1(self):
-
     def gather_axis1_batch1(module):
       indices = np.array([[2], [3], [0], [1]], dtype=np.int32)
       params = tf_utils.ndarange([4, 7, 8, 2])
       module.gather_axis1_batch1(params, indices)
-
     self.compare_backends(gather_axis1_batch1, self._modules)
 
   def test_gather_axis2_batch2(self):
-
     def gather_axis2_batch2(module):
       indices = np.array([[0, 1, 2, 3], [3, 2, 1, 0]], dtype=np.int32)
       values = np.array([[0, 1, 2, 3], [9, 8, 7, 0]], dtype=np.int32)
       module.gather_axis2_batch2(values, indices)
-
     self.compare_backends(gather_axis2_batch2, self._modules)
-
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/logical_ops_test.py
+++ b/integrations/tensorflow/e2e/logical_ops_test.py
@@ -53,39 +53,33 @@ class LogicalOpsTest(tf_test_utils.TracedModuleTestCase):
     super(LogicalOpsTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(LogicalOpsModule)
 
+  # yapf: disable
   def test_logical_and(self):
-
     def logical_and(module):
       module.logical_and(
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
-
     self.compare_backends(logical_and, self._modules)
 
   def test_logical_or(self):
-
     def logical_or(module):
       module.logical_or(
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
-
     self.compare_backends(logical_or, self._modules)
 
   def test_logical_xor(self):
-
     def logical_xor(module):
       module.logical_xor(
           np.array([1, 1, 0, 0], dtype=np.bool),
           np.array([0, 1, 1, 0], dtype=np.bool))
-
     self.compare_backends(logical_xor, self._modules)
 
   def test_logical_not(self):
-
     def logical_not(module):
       module.logical_not(np.array([0, 1, 1, 0], dtype=np.bool))
-
     self.compare_backends(logical_not, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/math_test.py
+++ b/integrations/tensorflow/e2e/math_test.py
@@ -49,40 +49,32 @@ class MathTest(tf_test_utils.TracedModuleTestCase):
     super(MathTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(MathModule)
 
+  # yapf: disable
   def test_abs(self):
-
     def abs(module):
       module.abs(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
-
     self.compare_backends(abs, self._modules)
 
   def test_ceil(self):
-
     def ceil(module):
       module.ceil(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
-
     self.compare_backends(ceil, self._modules)
 
   def test_cos(self):
-
     def cos(module):
       module.cos(np.array([-0.5, 0.0, 0.5, 1.0], dtype=np.float32))
-
     self.compare_backends(cos, self._modules)
 
   def test_log(self):
-
     def log(module):
       module.log(np.array([0.1, 0.2, 0.5, 1.0], dtype=np.float32))
-
     self.compare_backends(log, self._modules)
 
   def test_mod(self):
-
     def mod(module):
       module.mod(np.array([0.0, 1.2, 1.5, 3.75], dtype=np.float32))
-
     self.compare_backends(mod, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_dynamic_test.py
@@ -50,45 +50,37 @@ class MatrixOpsDynamicTest(tf_test_utils.TracedModuleTestCase):
     super(MatrixOpsDynamicTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(MatrixOpsDynamicModule)
 
+  # yapf: disable
   def test_matmul_high_rank_batch(self):
-
     def matmul_high_rank_batch(module):
       module.matmul_high_rank_batch(
           tf_utils.uniform([1, 7, 4, 2]), tf_utils.uniform([7, 1, 2, 4]))
-
     self.compare_backends(matmul_high_rank_batch, self._modules)
 
   def test_matmul_dynamic_matching_batch(self):
-
     def matmul_dynamic_matching_batch(module):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([2, 3, 4]))
-
     self.compare_backends(matmul_dynamic_matching_batch, self._modules)
 
   def test_matmul_dynamic_broadcast_lhs(self):
-
     def matmul_dynamic_broadcast_lhs(module):
       module.matmul_dynamic(
           tf_utils.uniform([1, 2, 3]), tf_utils.uniform([2, 3, 4]))
-
     self.compare_backends(matmul_dynamic_broadcast_lhs, self._modules)
 
   def test_matmul_dynamic_broadcast_rhs(self):
-
     def matmul_dynamic_broadcast_rhs(module):
       module.matmul_dynamic(
           tf_utils.uniform([2, 2, 3]), tf_utils.uniform([1, 3, 4]))
-
     self.compare_backends(matmul_dynamic_broadcast_rhs, self._modules)
 
   def test_matmul_dynamic_rank_broadcasting(self):
-
     def matmul_dynamic_rank_broadcasting(module):
       module.matmul_dynamic_lhs_batch(
           tf_utils.uniform([7, 2, 3]), tf_utils.uniform([3, 4]))
-
     self.compare_backends(matmul_dynamic_rank_broadcasting, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/matrix_ops_static_test.py
+++ b/integrations/tensorflow/e2e/matrix_ops_static_test.py
@@ -62,40 +62,34 @@ class MatrixOpsStaticTest(tf_test_utils.TracedModuleTestCase):
     super(MatrixOpsStaticTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(MatrixOpsStaticModule)
 
+  # yapf: disable
   def test_basic_matmul(self):
-
     def basic_matmul(module):
       module.basic_matmul(tf_utils.uniform([LEFT_DIM, INNER_DIM]),
                           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
-
     self.compare_backends(basic_matmul, self._modules)
 
   def test_matmul_lhs_batch(self):
-
     def matmul_lhs_batch(module):
       module.matmul_lhs_batch(
           tf_utils.uniform([BATCH_DIM, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([INNER_DIM, RIGHT_DIM]))
-
     self.compare_backends(matmul_lhs_batch, self._modules)
 
   def test_matmul_rhs_batch(self):
-
     def matmul_rhs_batch(module):
       module.matmul_rhs_batch(
           tf_utils.uniform([LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
-
     self.compare_backends(matmul_rhs_batch, self._modules)
 
   def test_matmul_broadcast_singleton_dimension(self):
-
     def matmul_broadcast_singleton_dimension(module):
       module.matmul_broadcast_singleton_dimension(
           tf_utils.uniform([1, LEFT_DIM, INNER_DIM]),
           tf_utils.uniform([BATCH_DIM, INNER_DIM, RIGHT_DIM]))
-
     self.compare_backends(matmul_broadcast_singleton_dimension, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/scatter_update_test.py
+++ b/integrations/tensorflow/e2e/scatter_update_test.py
@@ -55,35 +55,31 @@ class ScatterUpdateTest(tf_test_utils.TracedModuleTestCase):
     super(ScatterUpdateTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(ScatterUpdateModule)
 
+  # yapf: disable
   def test_scatter_update_1D(self):
-
     def scatter_update_1D(module):
       tensor = np.ones([8], dtype=np.int32)
       indices = np.array([[4], [5], [6]], dtype=np.int32)
       updates = np.array([9, 10, 11], dtype=np.int32)
       module.scatter_update_1D(tensor, indices, updates)
-
     self.compare_backends(scatter_update_1D, self._modules)
 
   def test_scatter_update_2D(self):
-
     def scatter_update_2D(module):
       tensor = np.ones([4, 3], dtype=np.int32)
       indices = np.array([[1, 0], [2, 1], [3, 2]], dtype=np.int32)
       updates = np.array([2, 5, 8], dtype=np.int32)
       module.scatter_update_2D(tensor, indices, updates)
-
     self.compare_backends(scatter_update_2D, self._modules)
 
   def test_scatter_update_2D_slice(self):
-
     def scatter_update_2D_slice(module):
       tensor = np.ones([4, 3], dtype=np.int32)
       indices = np.array([[1]], dtype=np.int32)
       updates = np.array([[2, 3, 4]], dtype=np.int32)
       module.scatter_update_2D_slice(tensor, indices, updates)
-
     self.compare_backends(scatter_update_2D_slice, self._modules)
+  # yapf: enable
 
 
 def main(argv):

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -74,45 +74,37 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
     super(TensorListTest, self).__init__(methodName)
     self._modules = tf_test_utils.compile_tf_module(TensorListModule)
 
+  # yapf: disable
   def test_identity_through_tensorlist(self):
-
     def identity_through_tensorlist(module):
       module.identity_through_tensorlist(np.array(42., dtype=np.float32))
-
     self.compare_backends(identity_through_tensorlist, self._modules)
 
   def test_add_through_tensorlist(self):
-
     def add_through_tensorlist(module):
       module.add_through_tensorlist(np.array(42., dtype=np.float32),
                                     np.array(43., dtype=np.float32))
-
     self.compare_backends(add_through_tensorlist, self._modules)
 
   def test_slice_first_element_with_from_tensor(self):
-
     def slice_first_element_with_from_tensor(module):
       module.slice_first_element_with_from_tensor(
           np.arange(STATIC_SIZE, dtype=np.float32))
-
     self.compare_backends(slice_first_element_with_from_tensor, self._modules)
 
   def test_slice_first_element_with_from_tensor_high_rank(self):
-
     def slice_first_element_with_from_tensor_high_rank(module):
       module.slice_first_element_with_from_tensor_high_rank(
           tf_utils.ndarange([STATIC_SIZE, STATIC_SIZE]))
-
     self.compare_backends(slice_first_element_with_from_tensor_high_rank,
                           self._modules)
 
   def test_concat_with_tensorlist_stack(self):
-
     def concat_with_tensorlist_stack(module):
       module.concat_with_tensorlist_stack(np.array(42., dtype=np.float32),
                                           np.array(43., dtype=np.float32))
-
     self.compare_backends(concat_with_tensorlist_stack, self._modules)
+  # yapf: enable
 
 
 def main(argv):


### PR DESCRIPTION
Some of these tests were really hard to visually chunk because of a yapf heuristic that wraps nested functions with newlines. As far as I know there isn't a more fine-grained way to disable that heuristic. Thoughts?