### PR TITLE
Fix resource preparation issue in iree-benchmark-module.

### DIFF
--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -77,8 +77,7 @@ Status PrepareIREEVMFunction(
       iree_vm_instance_create(iree_allocator_system(), instance));
 
   // Create IREE's device and module.
-  IREE_RETURN_IF_ERROR(
-      iree::CreateDevice(absl::GetFlag(FLAGS_driver), device));
+  IREE_RETURN_IF_ERROR(iree::CreateDevice(absl::GetFlag(FLAGS_driver), device));
   IREE_RETURN_IF_ERROR(CreateHalModule(*device, hal_module));
   IREE_RETURN_IF_ERROR(LoadBytecodeModule(module_data, input_module));
 

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -89,10 +89,12 @@ Status PrepareIREEVMFunction(
       *instance, modules.data(), modules.size(), iree_allocator_system(),
       context));
 
-  IREE_RETURN_IF_ERROR((*input_module)->lookup_function(
-      (*input_module)->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
-      iree_string_view_t{function_name.data(), function_name.size()},
-      &function));
+  IREE_RETURN_IF_ERROR(
+      (*input_module)
+          ->lookup_function(
+              (*input_module)->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+              iree_string_view_t{function_name.data(), function_name.size()},
+              &function));
   IREE_RETURN_IF_ERROR(ValidateFunctionAbi(function));
 
   // Construct inputs.


### PR DESCRIPTION
Some resources (except context) were stored in local varialbe. Thus,
they were nil after returning from PrepareIREEVMFunction. Passing
the address instead (as context) to address the issue.

Also add a cleanup for inputs before resources are released.