### PR TITLE
Allow mhlo.reshape ops to exist within unfused ops region

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -141,6 +141,10 @@ OpDispatchPolicy::FusionType OpDispatchPolicy::fuseInput(Operation *anchorOp,
     // original position. This should apply to any such "metadata" ops.
     return FusionType::CLONE_INTO;
   }
+  if (isUnsupportedFusionOp(anchorOp) && isa<mhlo::ReshapeOp>(inputOp)) {
+    // Clones reshape op to the same region as its consumer.
+    return FusionType::CLONE_INTO;
+  }
   if (isUnsupportedFusionOp(anchorOp) || isUnsupportedFusionOp(inputOp)) {
     return FusionType::DISABLED;
   }
@@ -159,6 +163,11 @@ OpDispatchPolicy::FusionType OpDispatchPolicy::fuseOutput(Operation *anchorOp,
     return FusionType::DISABLED;
   }
   if (isIdentityMetadata(outputOp)) {
+    return FusionType::MOVE_INTO;
+  }
+
+  if (isUnsupportedFusionOp(anchorOp) && isa<mhlo::ReshapeOp>(outputOp)) {
+    // Moves reshape op to the same region as its producer.
     return FusionType::MOVE_INTO;
   }
   if (isUnsupportedFusionOp(anchorOp) || isUnsupportedFusionOp(outputOp)) {

--- a/iree/compiler/Dialect/Flow/Transforms/test/identify_dispatch_regions2_hlo.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/identify_dispatch_regions2_hlo.mlir
@@ -144,3 +144,19 @@ func @clone_broadcast(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<
   %3 = "mhlo.add"(%0, %2) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
   return %3: tensor<4x4xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @reshaped_dot
+func @reshaped_dot(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf32> {
+  // CHECK: flow.dispatch.region
+  // CHECK:     "mhlo.reshape"
+  // CHECK:     "mhlo.reshape"
+  // CHECK:     "mhlo.dot"
+  // CHECK:     "mhlo.reshape"
+  %0 = "mhlo.reshape"(%arg0) : (tensor<16xf32>) -> tensor<4x4xf32>
+  %1 = "mhlo.reshape"(%arg1) : (tensor<16xf32>) -> tensor<4x4xf32>
+  %2 = "mhlo.dot"(%0, %1) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+  %3 = "mhlo.reshape"(%2) : (tensor<4x4xf32>) -> tensor<16xf32>
+  return %3 : tensor<16xf32>
+}


### PR DESCRIPTION
This will prevent cutting the IR in the middle between a reshape and its consumer or producer op that we isolate (e.g reshape + dot + reshape).