### PR TITLE
Use existing ConversionPattern TypeConverter in some subclasses

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
+++ b/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
@@ -141,7 +141,7 @@ class VMImportOpConversion : public OpConversionPattern<T> {
  public:
   VMImportOpConversion(MLIRContext *context, SymbolTable &importSymbols,
                        TypeConverter &typeConverter, StringRef importName)
-      : OpConversionPattern<T>(context), typeConverter(typeConverter) {
+      : OpConversionPattern<T>(typeConverter, context) {
     importOp = importSymbols.lookup<IREE::VM::ImportOp>(importName);
     assert(importOp);
   }
@@ -149,13 +149,12 @@ class VMImportOpConversion : public OpConversionPattern<T> {
   LogicalResult matchAndRewrite(
       T op, llvm::ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    return rewriteToCall(op, Adaptor{operands}, importOp, typeConverter,
-                         rewriter);
+    return rewriteToCall(op, Adaptor{operands}, importOp,
+                         *this->getTypeConverter(), rewriter);
   }
 
  protected:
   mutable IREE::VM::ImportOp importOp;
-  TypeConverter &typeConverter;
 };
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/VMLA/Conversion/ConversionTarget.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/ConversionTarget.cpp
@@ -53,7 +53,11 @@ VMLAConversionTarget::VMLAConversionTarget(MLIRContext *context,
   });
   addDynamicallyLegalOp<ConstantOp>(
       [&](ConstantOp op) { return typeConverter.isLegal(op.getType()); });
-  addLegalOp<ReturnOp>();
+  addDynamicallyLegalOp<ReturnOp>([&](ReturnOp op) {
+    return llvm::all_of(op.getOperandTypes(), [&typeConverter](Type t) {
+      return typeConverter.isLegal(t);
+    });
+  });
 }
 
 bool VMLAConversionTarget::isDynamicallyLegal(Operation *op) const {

--- a/iree/compiler/Dialect/VMLA/Conversion/ConversionTarget.h
+++ b/iree/compiler/Dialect/VMLA/Conversion/ConversionTarget.h
@@ -88,19 +88,15 @@ template <typename SRC, typename DST,
           VMLAOpSemantics semantics = VMLAOpSemantics::kDefault>
 class VMLAOpConversion : public OpConversionPattern<SRC> {
  public:
-  VMLAOpConversion(MLIRContext *context, TypeConverter &typeConverter)
-      : OpConversionPattern<SRC>(context), typeConverter(typeConverter) {}
+  using OpConversionPattern<SRC>::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
       SRC srcOp, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     return VMLAConversionTarget::applyDefaultBufferRewrite(
-        srcOp, operands, semantics, DST::getOperationName(), typeConverter,
-        rewriter);
+        srcOp, operands, semantics, DST::getOperationName(),
+        *this->getTypeConverter(), rewriter);
   }
-
- protected:
-  TypeConverter &typeConverter;
 };
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertConvOps.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertConvOps.cpp
@@ -40,8 +40,6 @@ namespace {
 
 struct VMLAConvOpConverter : public OpConversionPattern<mhlo::ConvOp> {
   using OpConversionPattern::OpConversionPattern;
-  VMLAConvOpConverter(MLIRContext *context, TypeConverter &typeConverter)
-      : OpConversionPattern(context), typeConverter(typeConverter) {}
 
   LogicalResult matchAndRewrite(
       mhlo::ConvOp op, ArrayRef<Value> operands,
@@ -105,14 +103,14 @@ struct VMLAConvOpConverter : public OpConversionPattern<mhlo::ConvOp> {
     }
 
     auto inputShape = VMLAConversionTarget::getTensorShape(
-        op.getLoc(), op.lhs(), typeConverter, rewriter);
+        op.getLoc(), op.lhs(), *getTypeConverter(), rewriter);
     auto filterShape = VMLAConversionTarget::getTensorShape(
-        op.getLoc(), op.rhs(), typeConverter, rewriter);
+        op.getLoc(), op.rhs(), *getTypeConverter(), rewriter);
     auto dstShape = VMLAConversionTarget::getTensorShape(
-        op.getLoc(), op.getResult(), typeConverter, rewriter);
+        op.getLoc(), op.getResult(), *getTypeConverter(), rewriter);
 
     auto dst = VMLAConversionTarget::allocateOutputBuffer(
-        op.getLoc(), op.getResult(), typeConverter, rewriter);
+        op.getLoc(), op.getResult(), *getTypeConverter(), rewriter);
 
     auto lhsType =
         TypeAttr::get(op.lhs().getType().cast<ShapedType>().getElementType());
@@ -164,7 +162,6 @@ struct VMLAConvOpConverter : public OpConversionPattern<mhlo::ConvOp> {
 
     return success();
   }
-  TypeConverter &typeConverter;
 };
 
 }  // namespace
@@ -172,7 +169,7 @@ struct VMLAConvOpConverter : public OpConversionPattern<mhlo::ConvOp> {
 void populateHLOConvToVMLAPatterns(MLIRContext *context,
                                    OwningRewritePatternList &patterns,
                                    TypeConverter &typeConverter) {
-  patterns.insert<VMLAConvOpConverter>(context, typeConverter);
+  patterns.insert<VMLAConvOpConverter>(typeConverter, context);
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/BUILD
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/BUILD
@@ -34,6 +34,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
+++ b/iree/compiler/Dialect/VMLA/Conversion/StandardToVMLA/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     MLIRIR
     MLIRPass
     MLIRStandard
+    MLIRSupport
     MLIRTransforms
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::VMLA::Conversion

--- a/iree/compiler/Dialect/VMLA/IR/BUILD
+++ b/iree/compiler/Dialect/VMLA/IR/BUILD
@@ -76,9 +76,6 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
-        "@llvm-project//mlir:StandardOps",
-        "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TransformUtils",
     ],
 )
 

--- a/iree/compiler/Dialect/VMLA/IR/BUILD
+++ b/iree/compiler/Dialect/VMLA/IR/BUILD
@@ -76,6 +76,9 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )
 


### PR DESCRIPTION
These are currently shadowing the field in the base class that was
added in https://github.com/llvm/llvm-project/commit/8d67d187ba1b. 

These show up as clang-tidy warnings and are just generally not great.

This change doesn't fix all cases because I didn't have time to debug
issues I ran into changing some of the others, but at least moves us in
the right direction.
