### PR TITLE
Add support for benchmarking all exported functions.

### DIFF
--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -127,7 +127,7 @@ class IREEBenchmark {
         context_(nullptr),
         input_module_(nullptr){};
   ~IREEBenchmark() {
-    // Order matters. This is caller's responsibility to clean up the resources.
+    // Order matters.
     inputs_.reset();
     iree_vm_module_release(hal_module_);
     iree_vm_module_release(input_module_);

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -60,7 +60,7 @@ namespace iree {
 namespace {
 
 void RegisterModuleBenchmarks(
-    std::string& function_name, iree_vm_context_t* context,
+    const std::string& function_name, iree_vm_context_t* context,
     iree_vm_function_t function, iree_vm_list_t* inputs,
     const std::vector<RawSignatureParser::Description>& output_descs) {
   auto benchmark_name = "BM_" + function_name;
@@ -173,7 +173,7 @@ class IREEBenchmark {
     return iree::OkStatus();
   }
 
-  Status RegisterSpecificFunction(std::string& function_name) {
+  Status RegisterSpecificFunction(const std::string& function_name) {
     iree_vm_function_t function;
     IREE_RETURN_IF_ERROR(input_module_->lookup_function(
         input_module_->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
@@ -196,8 +196,7 @@ class IREEBenchmark {
     }
 
     // Creates output singnature.
-    std::vector<iree::RawSignatureParser::Description> output_descs;
-    IREE_ASSIGN_OR_RETURN(output_descs, ParseOutputSignature(function));
+    IREE_ASSIGN_OR_RETURN(auto output_descs, ParseOutputSignature(function));
     RegisterModuleBenchmarks(function_name, context_, function, inputs_.get(),
                              output_descs);
     return iree::OkStatus();
@@ -205,7 +204,6 @@ class IREEBenchmark {
 
   Status RegisterAllExportedFunctions() {
     iree_vm_function_t function;
-    std::vector<iree::RawSignatureParser::Description> output_descs;
     iree_vm_module_signature_t signature =
         input_module_->signature(input_module_->self);
     for (int i = 0; i < signature.export_function_count; ++i) {
@@ -222,7 +220,7 @@ class IREEBenchmark {
                << "Expect not to have input arguments for '" << function_name
                << "'";
       }
-      IREE_ASSIGN_OR_RETURN(output_descs, ParseOutputSignature(function));
+      IREE_ASSIGN_OR_RETURN(auto output_descs, ParseOutputSignature(function));
       iree::RegisterModuleBenchmarks(function_name, context_, function,
                                      /*inputs=*/nullptr, output_descs);
     }

--- a/iree/tools/test/BUILD
+++ b/iree/tools/test/BUILD
@@ -41,6 +41,7 @@ iree_lit_test_suite(
     data = [
         "//iree/tools:IreeFileCheck",
         "//iree/tools:iree-benchmark-module",
+        "//iree/tools:iree-translate",
     ],
     tags = ["hostonly"],
 )

--- a/iree/tools/test/CMakeLists.txt
+++ b/iree/tools/test/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_lit_test_suite(
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-benchmark-module
+    iree::tools::iree-translate
   LABELS
     "hostonly"
 )

--- a/iree/tools/test/benchmark_flags.txt
+++ b/iree/tools/test/benchmark_flags.txt
@@ -8,5 +8,18 @@
 // RUN: ( iree-benchmark-module --unknown-flag 2>&1 || [[ $? == 1 ]] ) | IreeFileCheck --check-prefix=UNKNOWN %s
 // RUN: ( iree-benchmark-module --driver=vmla --unknown-flag --benchmark_list_tests 2>&1 || [[ $? == 1 ]] ) | IreeFileCheck --check-prefix=UNKNOWN %s
 
-// LIST-BENCHMARKS: BM_some_function
-// RUN: iree-benchmark-module --benchmark_list_tests --entry_function=some_function | IreeFileCheck --check-prefix=LIST-BENCHMARKS %s
+// LIST-BENCHMARKS: BM_foo1
+// LIST-BENCHMARKS: BM_foo2
+// RUN: ( iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --benchmark_list_tests --module_file=${TEST_TMPDIR?}/bc.module --driver=vmla --benchmark_list_tests ) | IreeFileCheck --check-prefix=LIST-BENCHMARKS %s
+module {
+  func @foo1() -> tensor<4xf32> attributes { iree.module.export } {
+    %input = iree.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
+    %result = "mhlo.exponential"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    return %result : tensor<4xf32>
+  }
+  func @foo2() -> tensor<4xf32> attributes { iree.module.export } {
+    %input = iree.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
+    %result = "mhlo.abs"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    return %result : tensor<4xf32>
+  }
+}

--- a/iree/tools/test/multiple_exported_functions.mlir
+++ b/iree/tools/test/multiple_exported_functions.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --module_file=${TEST_TMPDIR?}/bc.module | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vulkan --module_file=${TEST_TMPDIR?}/bc.module | IreeFileCheck %s)
+
+module {
+  func @foo1() -> tensor<4xf32> attributes { iree.module.export } {
+    %input = iree.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
+    %result = "mhlo.exponential"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    return %result : tensor<4xf32>
+  }
+  func @foo2() -> tensor<4xf32> attributes { iree.module.export } {
+    %input = iree.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
+    %result = "mhlo.abs"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    return %result : tensor<4xf32>
+  }
+}
+// CHECK: BM_foo1
+// CHECK: BM_foo2


### PR DESCRIPTION
If the entry_function is set, the behavior is the same, ie, will
benchmark on the entry_function. Otherwise, will benchmark on all
exported functions which are expected to have no function inputs.

Fixes https://github.com/google/iree/issues/3388