### PR TITLE
Revert "Add dependency to :tensorflow_opensource in pyiree tf compiler"

### DIFF
--- a/build_tools/docker/bazel-tensorflow/Dockerfile
+++ b/build_tools/docker/bazel-tensorflow/Dockerfile
@@ -18,6 +18,3 @@ FROM gcr.io/iree-oss/bazel-python AS final
 
 # Install tensorflow.
 RUN python3 -m pip install tf-nightly
-
-# Install python2 future for TensorFlow.
-RUN python2 -m pip install future

--- a/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-swiftshader/integrations/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-swiftshader/integrations/build_kokoro.sh
@@ -32,7 +32,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docke
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/bazel-tensorflow-swiftshader@sha256:4247a514aac61db114f615072acfc30f125895375b461d1a2b9127668bb18bb8 \
+  gcr.io/iree-oss/bazel-tensorflow-swiftshader@sha256:269a3a42ca71fa6b040135056f1f5639c2f2c7d651099a88ddd513a011365144 \
   build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-swiftshader/integrations/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-turing/integrations/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-turing/integrations/build_kokoro.sh
@@ -32,7 +32,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   --gpus all \
-  gcr.io/iree-oss/bazel-tensorflow-nvidia@sha256:995c0b3a392ed03c4530337dc14f7cc81660a024521abf1cfc2095fd6ef3f960 \
+  gcr.io/iree-oss/bazel-tensorflow-nvidia@sha256:754dc09c558157f82e9d53451486951fc096e8d2a2b9a1306a29ebfe9e0772df \
   build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-turing/integrations/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/BUILD
@@ -31,6 +31,60 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+config_setting(
+    name = "disable_kernels",
+    define_values = {"PYIREE_TF_DISABLE_KERNELS": "1"},
+)
+
+# Runtime deps needed to compile the tensorflow compiler.
+# As of 2020-04-13, robust constant folding is dependent on the legacy
+# TensorFlow executor, which requires kernels to operate on/simplify
+# the graph. This should become less necessary as more robust support
+# is implemented as part of the MLIR-based tf2xla bridge. This adds
+# about ~350 files to the system, many of which are quite heavy to
+# compile. Excluding them disables TensorFlow constant propagation,
+# which can cause non-optimized binaries (and tickle bugs and unimplemented
+# features). However, it is allowed, especially for development because it
+# is such a burden to build them. Disable kernels with this command line
+# options:
+#   --define=PYIREE_TF_DISABLE_KERNELS=1
+# See: https://github.com/google/iree/issues/1506
+SAVED_MODEL_TF_RUNTIME_DEPS = [
+    "@org_tensorflow//tensorflow/core:ops",
+] + select({
+    ":disable_kernels": [],
+    "//conditions:default": [
+        "@org_tensorflow//tensorflow/core/kernels:array",
+        "@org_tensorflow//tensorflow/core/kernels:math",
+    ],
+})
+
+# TODO: Isolate SignatureDef SavedModel support into its own library to decrease buildtime cost.
+# While it would be nice to simply depend on TensorFlow, manually paring
+# down the dependencies significantly reduces the build time that this adds.
+#
+# Baseline: 449s
+# SignatureDef SavedModels: 546s – 22% increase in build time.
+# SignatureDef SavedModels + Deps for MobileBert: 572s – 27% increase in build time.
+# TF OpenSource: 664s – 49% increase in build time.
+SIGNATURE_DEF_SAVED_MODEL_TF_RUNTIME_DEPS = [
+    # Deps for SignatureDef SavedModels:
+    "@org_tensorflow//tensorflow/core:direct_session",
+    "@org_tensorflow//tensorflow/core/kernels:resource_variable_ops",  #  VarHandleOp
+    "@org_tensorflow//tensorflow/core/kernels:regex_full_match_op",  # StaticRegexFullMatch
+    "@org_tensorflow//tensorflow/core/kernels:string_join_op",  # StringJoin
+    "@org_tensorflow//tensorflow/core/kernels:save_op",  # SharedFilename
+    "@org_tensorflow//tensorflow/core/kernels:save_restore_v2_ops",  # SaveV2
+
+    # Deps for MobileBert:
+    "@org_tensorflow//tensorflow/core/kernels:parameterized_truncated_normal_op",  # TruncatedNormal
+    "@org_tensorflow//tensorflow/core/kernels:state",  # Assign.
+    "@org_tensorflow//tensorflow/core/kernels:logging_ops",  # Assert
+    "@org_tensorflow//tensorflow/core/kernels:bias_op",  # BiasAdd
+    "@org_tensorflow//tensorflow/core/kernels:softmax_op",  # Softmax
+    "@org_tensorflow//tensorflow/core/kernels:relu_op",  # Relu
+]
+
 TF_XLA_PASS_DEPS = [
     "//integrations/tensorflow/compiler:tensorflow",
     "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
@@ -73,7 +127,7 @@ pybind_cc_library(
     hdrs = [
         "register_tensorflow.h",
     ],
-    deps = TF_XLA_PASS_DEPS + [
+    deps = SAVED_MODEL_TF_RUNTIME_DEPS + TF_XLA_PASS_DEPS + SIGNATURE_DEF_SAVED_MODEL_TF_RUNTIME_DEPS + [
         "//bindings/python/pyiree/common",
         "//bindings/python/pyiree/compiler:compiler_library",
         "@llvm-project//llvm:Support",
@@ -82,7 +136,6 @@ pybind_cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:convert_graphdef",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
         "@org_tensorflow//tensorflow/core:core_cpu",
-        "@org_tensorflow//tensorflow/core:tensorflow_opensource",
     ],
 )
 


### PR DESCRIPTION
Reverts google/iree#3368

This broke the real GPU turing build.

```
$ docker run -it --rm --gpus all gcr.io/iree-oss/bazel-tensorflow-nvidia@sha256:995c0b3a392ed03c4530337dc14f7cc81660a024521abf1cfc2095fd6ef3f960
root@643cddba22b6:/# vulkaninfo
ERROR: [Loader Message] Code 0 : loader_scanned_icd_add: Could not get 'vkCreateInstance' via 'vk_icdGetInstanceProcAddr' for ICD libGLX_nvidia.so.0
Cannot create Vulkan instance.
This problem is often caused by a faulty installation of the Vulkan driver or attempting to use a GPU that does not support Vulkan.
ERROR at /build/vulkan-tools-1.2.141.0~rc3/vulkaninfo/vulkaninfo.h:640:vkCreateInstance failed with ERROR_INCOMPATIBLE_DRIVER
root@643cddba22b6:/# exit
```