### PR TITLE
[metal] Enable the initial batch of HLO op tests (7/n)

### DIFF
--- a/iree/hal/metal/metal_direct_allocator.mm
+++ b/iree/hal/metal/metal_direct_allocator.mm
@@ -46,11 +46,11 @@ MTLResourceOptions SelectMTLResourceStorageMode(MemoryType memory_type) {
   if (AllBitsSet(memory_type, MemoryType::kDeviceLocal)) {
     if (AllBitsSet(memory_type, MemoryType::kHostVisible)) {
       // Device-local, host-visible.
-#ifdef IREE_PLATFORM_MACOS
-      return MTLResourceStorageModeManaged;
-#else
+      // TODO(antiagainst): Enable using MTLResourceStorageModeManaged on macOS once we have
+      // defined invalidate/flush C APIs and wired up their usage through the stack. At the
+      // moment if we use MTLResourceStorageModeManaged, due to no proper invlidate/flush
+      // actions, the kernel invocations' data read/write will not be properly synchronized.
       return MTLResourceStorageModeShared;
-#endif
     } else {
       // Device-local only.
       return MTLResourceStorageModePrivate;

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -20,11 +20,47 @@
 # TODO(hanchung): Reorganize/fix existing tests so the above is true.
 
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
 
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
+)
+
+iree_cmake_extra_content(
+    content = """
+iree_check_single_backend_test_suite(
+  NAME
+    check_metal-spirv_metal
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "broadcast.mlir"
+    "broadcast_in_dim.mlir"
+    "convert.mlir"
+    "constant.mlir"
+    "cosine.mlir"
+    "exponential.mlir"
+    "log.mlir"
+    "log_plus_one.mlir"
+    "maximum.mlir"
+    "minimum.mlir"
+    "multiply.mlir"
+    "negate.mlir"
+    "reshape.mlir"
+    "rsqrt.mlir"
+    "sine.mlir"
+    "slice.mlir"
+    "sqrt.mlir"
+    "tanh.mlir"
+    "transpose.mlir"
+  TARGET_BACKEND
+    metal-spirv
+  DRIVER
+    metal
+)
+""",
 )
 
 iree_check_single_backend_test_suite(

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -12,6 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_metal-spirv_metal
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "broadcast.mlir"
+    "broadcast_in_dim.mlir"
+    "convert.mlir"
+    "constant.mlir"
+    "cosine.mlir"
+    "exponential.mlir"
+    "log.mlir"
+    "log_plus_one.mlir"
+    "maximum.mlir"
+    "minimum.mlir"
+    "multiply.mlir"
+    "negate.mlir"
+    "reshape.mlir"
+    "rsqrt.mlir"
+    "sine.mlir"
+    "slice.mlir"
+    "sqrt.mlir"
+    "tanh.mlir"
+    "transpose.mlir"
+  TARGET_BACKEND
+    metal-spirv
+  DRIVER
+    metal
+)
+
 iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)


### PR DESCRIPTION
This commit throws in a temporary workaround to enable a few
XLA MHLO end-to-end tests for the Metal HAL driver.