### PR TITLE
Reduce control flow overhead when tiling conv/pool ops. (google branch version)

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -449,13 +449,8 @@ static LogicalResult mapToWorkgroups(ConversionPatternRewriter &rewriter,
 }
 
 /// Distributes scf.parallel to workitems using local invocation ID.
-static LogicalResult mapToLocalInvocationId(
-    ConversionPatternRewriter &rewriter, scf::ParallelOp pLoopOp,
-    bool useCyclicDistribution = false) {
-  if (useCyclicDistribution) {
-    return distributeCyclicallyToProcessors<gpu::ThreadIdOp, gpu::BlockDimOp>(
-        rewriter, pLoopOp);
-  }
+static LogicalResult mapToLocalInvocationId(ConversionPatternRewriter &rewriter,
+                                            scf::ParallelOp pLoopOp) {
   return distributeSingleIterationPerProcessor<gpu::ThreadIdOp,
                                                gpu::BlockDimOp>(rewriter,
                                                                 pLoopOp);
@@ -546,9 +541,7 @@ static LogicalResult mapLinalgOpToLocalInvocationIdImpl(
   if (loops.getValue().empty()) return success();
 
   auto pLoopOp = cast<scf::ParallelOp>(loops.getValue()[0]);
-  return mapToLocalInvocationId(
-      rewriter, pLoopOp,
-      hasMarker(linalgOp, {getWorkgroupMarker(), getWorkgroupMemoryMarker()}));
+  return mapToLocalInvocationId(rewriter, pLoopOp);
 }
 
 static LogicalResult distributeCopyOp(linalg::CopyOp copyOp,

--- a/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/MarkerUtils.h
@@ -30,17 +30,12 @@ namespace mlir {
 class Operation;
 namespace iree_compiler {
 
-/// Marker to denote that a linalg operation is to be partitioned to
-/// workitems. No assumption can be made about the number of woritems in the
-/// workgroup and number of iterations, i.e. a cyclic distribution is required.
+/// Marker to denote that a linalg operation has been partitioned to workgroups.
 StringRef getWorkgroupMarker();
-StringRef getWorkgroupMemoryMarker();
 
-/// Marker to denote that a linalg operation is to be partitioned to workitems
-/// with the assumption that the number of workitems in the workgroup is greater
-/// than equal to the number of iterations.
-StringRef getWorkgroupNumItemsGENumItersMarker();
-StringRef getWorkgroupMemoryNumItemsGENumItersMarker();
+/// Marker to denote that a linalg operation has been partitioned to workgroups
+/// and operands promoted to scratchspace memory.
+StringRef getWorkgroupMemoryMarker();
 
 /// Marker for copy operations that are moving data from StorageClass to
 /// Workgroup memory.

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
@@ -40,7 +40,8 @@ module attributes {
     [Shader], [SPV_KHR_storage_buffer_storage_class]>,
     {max_compute_workgroup_invocations = 128 : i32,
      max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  func @conv_no_padding() {
+  func @conv_no_padding()
+    attributes {vkspv.num_workgroups_fn = @conv_no_padding__num_workgroups__} {
     %0 = iree.placeholder for "interace buffer"
       {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?x?x?xf32>
     %1 = iree.placeholder for "interace buffer"
@@ -51,6 +52,10 @@ module attributes {
       memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
     return
   }
+  func @conv_no_padding__num_workgroups__
+    (!shapex.ranked_shape<[?,?,?,?]>, !shapex.ranked_shape<[?,?,?,?]>,
+     !shapex.ranked_shape<[?,?,?,?]>) -> (index, index, index)
+    attributes {sym_visibility = "private"}
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
@@ -61,28 +66,44 @@ module attributes {
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //       CHECK: func @conv_no_padding()
 //  CHECK-SAME:   local_size = dense<[32, 4, 1]>
+//  CHECK-SAME:   vkspv.num_workgroups_fn = @[[NUM_WORKGROUPS_FN:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
 //   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
-//   CHECK-DAG:   %[[NBLOCKSX:.+]] = "gpu.grid_dim"() {dimension = "x"}
 //   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
-//   CHECK-DAG:   %[[NBLOCKSY:.+]] = "gpu.grid_dim"() {dimension = "y"}
 //   CHECK-DAG:   %[[BIDZ:.+]] = "gpu.block_id"() {dimension = "z"}
-//   CHECK-DAG:   %[[NBLOCKSZ:.+]] = "gpu.grid_dim"() {dimension = "z"}
 //       CHECK:   %[[LBY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
-//       CHECK:   %[[STEPY:.+]] = affine.apply #[[MAP0]]()[%[[NBLOCKSY]]]
-//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]
-//       CHECK:   %[[STEPX:.+]] = affine.apply #[[MAP1]]()[%[[NBLOCKSX]]]
-//       CHECK:   scf.parallel (%[[IV0:.+]], %[[IV1:.+]], %[[IV2:.+]]) = (%[[BIDZ]], %[[LBY]], %[[LBX]])
-//  CHECK-SAME:     step (%[[NBLOCKSZ]], %[[STEPY]], %[[STEPX]])
-//       CHECK:     %[[VIEW1:.+]] = subview %[[ARG1]]
-//  CHECK-SAME:       [%[[IV0]], %[[IV1]], %[[IV2]], 0]
-//       CHECK:     %[[VIEW2:.+]] = subview %[[RET0]]
-//  CHECK-SAME:       [%[[IV0]], %[[IV1]], %[[IV2]], 0]
-//       CHECK:     linalg.conv
-//  CHECK-SAME:       %[[ARG0]], %[[VIEW1]], %[[VIEW2]]
-//  CHECK-SAME:       "workgroup"
+//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW1:.+]] = subview %[[ARG1]]
+//  CHECK-SAME:     [%[[BIDZ]], %[[LBY]], %[[LBX]], 0]
+//       CHECK:   %[[LBY_2:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX_2:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]]
+//  CHECK-SAME:     [%[[BIDZ]], %[[LBY_2]], %[[LBX_2]], 0]
+//       CHECK:   linalg.conv
+//  CHECK-SAME:     %[[ARG0]], %[[VIEW1]], %[[VIEW2]]
+//  CHECK-SAME:     "workgroup"
+//       CHECK: func @[[NUM_WORKGROUPS_FN]]
+//   CHECK-DAG:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[C1:.+]] = constant 1
+//   CHECK-DAG:   %[[C2:.+]] = constant 2
+//   CHECK-DAG:   %[[C32:.+]] = constant 32
+//   CHECK-DAG:   %[[C31:.+]] = constant 31
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[C3:.+]] = constant 3
+//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.+}} {binding = @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.+}} {binding = @legacy_io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.+}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[DIM0:.+]] = dim %[[ARG1]], %[[C0]]
+//   CHECK-DAG:   %[[DIM1:.+]] = dim %[[RET0]], %[[C1]]
+//   CHECK-DAG:   %[[DIM2:.+]] = dim %[[RET0]], %[[C2]]
+//       CHECK:   %[[T0:.+]] = addi %[[DIM2]], %[[C31]]
+//   CHECK-DAG:   %[[NBX:.+]] = divi_signed %[[T0]], %[[C32]]
+//       CHECK:   %[[T1:.+]] = addi %[[DIM1]], %[[C3]]
+//   CHECK-DAG:   %[[NBY:.+]] = divi_signed %[[T1]], %[[C4]]
+//       CHECK:   return %[[NBX]], %[[NBY]], %[[DIM0]]
+
 
 // -----
 
@@ -118,7 +139,7 @@ module attributes {
 //   CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0 * 16)>
 //       CHECK: func @matmul()
 //  CHECK-SAME:   local_size = dense<[16, 8, 1]>
-//  CHECK-SAME:   vkspv.num_workgroups_fn = @[[NUM_WORKGROUPS_FN:.[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   vkspv.num_workgroups_fn = @[[NUM_WORKGROUPS_FN:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
@@ -134,9 +155,9 @@ module attributes {
 //       CHECK:   %[[LBX_2:.+]] = affine.apply #[[MAP3]]()[%[[BIDX]]]
 //       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]][%[[LBY_2]], %[[LBX_2]]]
 //       CHECK:   linalg.matmul
-//  CHECK-SAME:     "workgroup_numprocs_ge_numiters"
+//  CHECK-SAME:     "workgroup"
 //  CHECK-SAME:     ins(%[[VIEW0]], %[[VIEW1]]
-//  CHECK-SAME:    outs(%[[VIEW2]]
+//  CHECK-SAME:     outs(%[[VIEW2]]
 //       CHECK: func @[[NUM_WORKGROUPS_FN]]
 //   CHECK-DAG:   %[[C8:.+]] = constant 8 : index
 //   CHECK-DAG:   %[[C7:.+]] = constant 7 : index
@@ -160,7 +181,8 @@ module attributes {
     [Shader], [SPV_KHR_storage_buffer_storage_class]>,
     {max_compute_workgroup_invocations = 128 : i32,
      max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  func @pooling_sum_no_padding() {
+  func @pooling_sum_no_padding()
+    attributes {vkspv.num_workgroups_fn = @pooling_sum_no_padding__num_workgroups__} {
     %0 = iree.placeholder for "interace buffer"
       {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?xf32>
     %1 = iree.placeholder for "interace buffer"
@@ -171,6 +193,10 @@ module attributes {
       memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>
     return
   }
+  func @pooling_sum_no_padding__num_workgroups__
+    (!shapex.ranked_shape<[?,?]>, !shapex.ranked_shape<[?,?]>,
+     !shapex.ranked_shape<[?,?]>) -> (index, index, index)
+    attributes {sym_visibility = "private"}
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
@@ -181,21 +207,98 @@ module attributes {
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //       CHECK: func @pooling_sum_no_padding()
 //  CHECK-SAME:   local_size = dense<[32, 4, 1]>
+//  CHECK-SAME:   vkspv.num_workgroups_fn = @[[NUM_WORKGROUPS_FN:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
 //   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
-//   CHECK-DAG:   %[[NBLOCKSX:.+]] = "gpu.grid_dim"() {dimension = "x"}
 //   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
-//   CHECK-DAG:   %[[NBLOCKSY:.+]] = "gpu.grid_dim"() {dimension = "y"}
 //       CHECK:   %[[LBY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
-//       CHECK:   %[[STEPY:.+]] = affine.apply #[[MAP0]]()[%[[NBLOCKSY]]]
-//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]
-//       CHECK:   %[[STEPX:.+]] = affine.apply #[[MAP1]]()[%[[NBLOCKSX]]]
-//       CHECK:   scf.parallel (%[[IV0:.+]], %[[IV1:.+]]) = (%[[LBY]], %[[LBX]])
-//  CHECK-SAME:      step (%[[STEPY]], %[[STEPX]])
-//       CHECK:     %[[VIEW0:.+]] = subview %[[ARG0]][%[[IV0]], %[[IV1]]]
-//       CHECK:     %[[VIEW2:.+]] = subview %[[RET0]][%[[IV0]], %[[IV1]]]
-//       CHECK:     linalg.pooling_max
-//  CHECK-SAME:       %[[VIEW0]], %[[ARG1]], %[[VIEW2]]
-//  CHECK-SAME:       "workgroup"
+//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW0:.+]] = subview %[[ARG0]][%[[LBY]], %[[LBX]]]
+//       CHECK:   %[[LBY2:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX2:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]][%[[LBY2]], %[[LBX2]]]
+//       CHECK:   linalg.pooling_max
+//  CHECK-SAME:     %[[VIEW0]], %[[ARG1]], %[[VIEW2]]
+//  CHECK-SAME:     "workgroup"
+//       CHECK: func @[[NUM_WORKGROUPS_FN]]
+//   CHECK-DAG:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[C1:.+]] = constant 1
+//   CHECK-DAG:   %[[C32:.+]] = constant 32
+//   CHECK-DAG:   %[[C31:.+]] = constant 31
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[C3:.+]] = constant 3
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.+}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[DIM0:.+]] = dim %[[RET0]], %[[C0]]
+//   CHECK-DAG:   %[[DIM1:.+]] = dim %[[RET0]], %[[C1]]
+//       CHECK:   %[[T0:.+]] = addi %[[DIM1]], %[[C31]]
+//   CHECK-DAG:   %[[NBX:.+]] = divi_signed %[[T0]], %[[C32]]
+//       CHECK:   %[[T1:.+]] = addi %[[DIM0]], %[[C3]]
+//   CHECK-DAG:   %[[NBY:.+]] = divi_signed %[[T1]], %[[C4]]
+//       CHECK:   return %[[NBX]], %[[NBY]], %[[C1]]
+
+// -----
+
+module attributes {
+  spv.target_env =
+    #spv.target_env<#spv.vce<v1.3,
+    [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+    {max_compute_workgroup_invocations = 128 : i32,
+     max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @pooling_max_4D()
+    attributes {vkspv.num_workgroups_fn = @pooling_max_4D__num_workgroups__} {
+    %0 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?x?x?xf32>
+    %1 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<?x?x?x?xf32>
+    %2 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<?x?x?x?xf32>
+    linalg.pooling_max(%0, %1, %2) {dilations = [1, 1, 1, 1], strides = [1, 1, 1, 1]} :
+      memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+    return
+  }
+  func @pooling_max_4D__num_workgroups__
+    (!shapex.ranked_shape<[?,?,?,?]>, !shapex.ranked_shape<[?,?,?,?]>,
+     !shapex.ranked_shape<[?,?,?,?]>) -> (index, index, index)
+    attributes {sym_visibility = "private"}
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}
+
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 4)>
+//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 32)>
+//       CHECK: func @pooling_max_4D()
+//  CHECK-SAME:   local_size = dense<[32, 4, 1]>
+//  CHECK-SAME:   vkspv.num_workgroups_fn = @[[NUM_WORKGROUPS_FN:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.*}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
+//   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
+//       CHECK:   %[[LBY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX:.+]] = affine.apply #[[MAP2]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW0:.+]] = subview %[[ARG0]][0, %[[LBY]], %[[LBX]], 0]
+//       CHECK:   %[[LBY2:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[LBX2:.+]] = affine.apply #[[MAP2]]()[%[[BIDX]]]
+//       CHECK:   %[[VIEW2:.+]] = subview %[[RET0]][0, %[[LBY2]], %[[LBX2]], 0]
+//       CHECK:   linalg.pooling_max
+//  CHECK-SAME:     %[[VIEW0]], %[[ARG1]], %[[VIEW2]]
+//  CHECK-SAME:     "workgroup"
+//       CHECK: func @[[NUM_WORKGROUPS_FN]]
+//   CHECK-DAG:   %[[C1:.+]] = constant 1
+//   CHECK-DAG:   %[[C32:.+]] = constant 32
+//   CHECK-DAG:   %[[C31:.+]] = constant 31
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[C3:.+]] = constant 3
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder {{.+}} {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[DIM0:.+]] = dim %[[RET0]], %[[C1]]
+//   CHECK-DAG:   %[[DIM1:.+]] = dim %[[RET0]], %[[C2]]
+//       CHECK:   %[[T0:.+]] = addi %[[DIM1]], %[[C31]]
+//   CHECK-DAG:   %[[NBX:.+]] = divi_signed %[[T0]], %[[C32]]
+//       CHECK:   %[[T1:.+]] = addi %[[DIM0]], %[[C3]]
+//   CHECK-DAG:   %[[NBY:.+]] = divi_signed %[[T1]], %[[C4]]
+//       CHECK:   return %[[NBX]], %[[NBY]], %[[C1]]

--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -188,7 +188,6 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
   ConversionPatternRewriter &rewriter = switchBuilder.getRewriter();
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToEnd(&entryBlock);
-  auto workload = entryBlock.getArgument(0);
   auto commandBuffer = entryBlock.getArgument(1);
 
   // We have multiple entry points to dispatch. Record in the order
@@ -196,25 +195,27 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
   // ones.
   for (auto it : llvm::enumerate(spvEntryPointFns)) {
     spirv::FuncOp spvFuncOp = it.value();
-    auto workgroupSize = calculateDispatchWorkgroupSize(
-        loc, spvModuleOp, spvFuncOp.sym_name(), workload, rewriter);
 
     FlatSymbolRefAttr numWorkgroupsFnAttr =
         spvFuncOp.getAttrOfType<FlatSymbolRefAttr>(
             getNumWorkgroupsFnAttrName());
+    if (!numWorkgroupsFnAttr) {
+      return spvFuncOp.emitError(
+          "expected vkspv.num_workgroups_fn attribute to refer to function "
+          "that computes number of workgroups to use");
+    }
 
     std::array<Value, 3> workgroupCount = {nullptr, nullptr, nullptr};
-    if (numWorkgroupsFnAttr) {
-      FuncOp numWorkgroupsFn = dyn_cast<FuncOp>(SymbolTable::lookupSymbolIn(
-          spvFuncOp.getParentOfType<ModuleOp>(), numWorkgroupsFnAttr));
-      if (!numWorkgroupsFn) return failure();
-      workgroupCount = calculateWorkgroupCountFromNumWorkgroupsFn(
-          loc, numWorkgroupsFn, dispatchState.executableOp.getInterfaceOp(),
-          dispatchState.operands, dispatchState.results, rewriter);
-    } else {
-      workgroupCount = calculateDispatchWorkgroupCount(loc, workload,
-                                                       workgroupSize, rewriter);
+    FuncOp numWorkgroupsFn = dyn_cast<FuncOp>(SymbolTable::lookupSymbolIn(
+        spvFuncOp.getParentOfType<ModuleOp>(), numWorkgroupsFnAttr));
+    if (!numWorkgroupsFn) {
+      return spvFuncOp.emitError("unable to fund function ")
+             << numWorkgroupsFnAttr
+             << " that computes the number of workgroups to use";
     }
+    workgroupCount = calculateWorkgroupCountFromNumWorkgroupsFn(
+        loc, numWorkgroupsFn, dispatchState.executableOp.getInterfaceOp(),
+        dispatchState.operands, dispatchState.results, rewriter);
 
     if (llvm::any_of(workgroupCount,
                      [](Value v) -> bool { return v == nullptr; }))


### PR DESCRIPTION
This PR fixes the issues that were preventing conv/pool tile loop
distribution and lowering to loops from following the same approach as
matmul. With this PR the inter-tile loops can be eliminated and the
workitem loops can be converted to a simple `scf.if` reducing the
control flow overhead significantly. This also means that all the
tiling to workgroups patterns are now using the same pattern. These
can always be specialized later, but based on explicit needs.
This also means that the conv/pool operations also generate a function
to determine the number of workgroups to use during the launch,
cleaning up some of the fallback paths in the SPIRVTarget code.
Adding a test that was causing the correctness issues.