### PR TITLE
Use fmtstr instead of string::c_str().

### DIFF
--- a/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
+++ b/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
@@ -128,11 +128,11 @@ Status RunModuleAndUpdateImGuiWindow(
                ImGuiWindowFlags_AlwaysAutoResize);
 
   ImGui::Text("Entry function:");
-  ImGui::Text(function_name.c_str());
+  ImGui::Text("%s", function_name.c_str());
   ImGui::Separator();
 
   ImGui::Text("Invocation result:");
-  ImGui::Text(oss.str().c_str());
+  ImGui::Text("%s", oss.str().c_str());
   ImGui::Separator();
 
   // Framerate counter.


### PR DESCRIPTION
Using string literal can cause security issue, e.g., format string
attack. There are several options to leak memory, and a `%n` option to
overwrite memory.