### PR TITLE
Propagate comparison errors into e2e test failures

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -424,7 +424,7 @@ class Trace:
               "Floating point difference between ref and tar was within "
               "tolerance. %s", diff_string)
         return same, error
-      else:
+      elif np.issubdtype(ref.dtype, np.integer):
         same = np.array_equal(ref, tar)
         if not same:
           abs_diff = np.max(np.abs(ref - tar))
@@ -434,6 +434,8 @@ class Trace:
         else:
           error = None
         return same, error
+      else:
+        return np.array_equal(ref, tar), None
 
     # Base check for native number types.
     elif isinstance(ref, (int, float)):

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -313,7 +313,8 @@ class Trace:
       yield call
 
   @staticmethod
-  def compare_traces(ref_trace: "Trace", tar_trace: "Trace") -> bool:
+  def compare_traces(ref_trace: "Trace",
+                     tar_trace: "Trace") -> Tuple[bool, Sequence[str]]:
     traces_match = True
     error_messages = []
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -411,19 +411,17 @@ class Trace:
         same = np.allclose(ref, tar, rtol=rtol, atol=atol)
         abs_diff = np.max(np.abs(ref - tar))
         rel_diff = np.max(np.abs(ref - tar) / np.max(np.abs(tar)))
+        diff_string = (f"Max abs diff: {abs_diff:.2e}, atol: {atol:.2e}, "
+                       f"max relative diff: {rel_diff:.2e}, rtol: {rtol:.2e}")
         if not same:
-          error = (
-              "Floating point difference between ref and tar was too large. "
-              f"Max abs diff: {abs_diff}, atol: {atol}, "
-              f"max relative diff: {rel_diff}, rtol: {rtol}")
+          error = ("Floating point difference between ref and tar was too "
+                   f"large. {diff_string}")
           logging.error(error)
         else:
           error = None
           logging.info(
               "Floating point difference between ref and tar was within "
-              "tolerance. "
-              "Max abs diff: %s, atol: %s, max relative diff: %s, rtol: %s",
-              abs_diff, atol, rel_diff, rtol)
+              "tolerance. %s", diff_string)
         return same, error
       else:
         same = np.array_equal(ref, tar)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -758,7 +758,7 @@ class TracedModuleTestCase(tf.test.TestCase):
       failed_backends = [
           tar_traces[i].backend_id for i in failed_backend_indices
       ]
-      error_list = '\n  - ' + '\n  - '.join(error_messages)
+      error_list = ''.join([f'\n  - {message}' for message in error_messages])
       self.fail(
           "Comparison between the reference backend and the following targets "
           f"failed: {failed_backends}. Errors: {error_list}\n"

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -171,7 +171,9 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
     vmla_trace = tf_test_utils.Trace(vmla_module, vmla_function)
     vmla_function(tf_test_utils.TracedModule(vmla_module, vmla_trace))
 
-    self.assertFalse(tf_test_utils.Trace.compare_traces(tf_trace, vmla_trace))
+    same, error_messages = tf_test_utils.Trace.compare_traces(
+        tf_trace, vmla_trace)
+    self.assertFalse(same)
 
   def test_trace_serialize_and_load(self):
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils_test.py
@@ -104,7 +104,7 @@ class UtilsTests(tf.test.TestCase, parameterized.TestCase):
         ],
     }
     # yapf: enable
-    same = tf_test_utils.Trace._check_same(ref, tar, rtol=1e-6, atol=1e-6)
+    same, _ = tf_test_utils.Trace._check_same(ref, tar, rtol=1e-6, atol=1e-6)
     self.assertEqual(tar_same, same)
 
   def test_trace_inputs_and_outputs(self):

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -150,7 +150,7 @@ class AppTest(tf_test_utils.TracedModuleTestCase):
     self._modules = tf_test_utils.compile_tf_module(VisionModule,
                                                     exported_names=['predict'])
 
-  def test_application(self):
+  def test_predict(self):
 
     def predict(module):
       module.predict(tf_utils.uniform(get_input_shape()), atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Tracks the specific comparison errors found during testing and propagates them to the `self.fail` statement so that it is easier to understand them without having access to the full logs.

Example message:

```
======================================================================
FAIL: test_predict (__main__.AppTest)
AppTest.test_predict
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../integrations/tensorflow/e2e/keras/vision_model_test.py", line 158, in test_predict
    self.compare_backends(predict, self._modules)
  File .../integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py", line 762, in compare_backends
    self.fail(
  File "/usr/local/google/home/meadowlark/.pyenv/versions/3.8.3/lib/python3.8/site-packages/absl/testing/absltest.py", line 1764, in fail
    return super(TestCase, self).fail(self._formatMessage(prefix, msg))
AssertionError: Comparison between the reference backend and the following targets failed: ['iree_llvmjit']. Errors: 
  - Floating point difference between ref and tar was too large. Max abs diff: 5.28e-01, atol: 1.00e-05, max relative diff: 9.98e-01, rtol: 1.00e-05
See the logs above for more details about the non-matching calls.

----------------------------------------------------------------------
```