### PR TITLE
Increase tolerances of keras vision tests

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -200,7 +200,7 @@ iree_vision_test_suite(
     datasets = ["cifar10"],
     failing_configurations = [
         {
-            # Failing all but tf and vmla:
+            # Failing on llvm and vulkan:
             "models": [
                 "NASNetLarge",
                 "NASNetMobile",
@@ -210,7 +210,6 @@ iree_vision_test_suite(
             ],
             "datasets": ["cifar10"],
             "backends": [
-                "tflite",
                 "iree_llvmjit",
                 "iree_vulkan",
             ],
@@ -284,10 +283,19 @@ iree_vision_test_suite(
     datasets = ["imagenet"],
     failing_configurations = [
         {
-            # Failing all but tf and vmla:
+            # Failing vulkan:
             "models": [
                 "InceptionResNetV2",
                 "InceptionV3",
+            ],
+            "datasets": ["imagenet"],
+            "backends": [
+                "iree_vulkan",
+            ],
+        },
+        {
+            # Failing llvm and vulkan:
+            "models": [
                 "NASNetLarge",
                 "NASNetMobile",
                 "ResNet50V2",
@@ -297,7 +305,6 @@ iree_vision_test_suite(
             ],
             "datasets": ["imagenet"],
             "backends": [
-                "tflite",
                 "iree_llvmjit",
                 "iree_vulkan",
             ],

--- a/integrations/tensorflow/e2e/keras/vision_model_test.py
+++ b/integrations/tensorflow/e2e/keras/vision_model_test.py
@@ -153,7 +153,7 @@ class AppTest(tf_test_utils.TracedModuleTestCase):
   def test_application(self):
 
     def predict(module):
-      module.predict(tf_utils.uniform(get_input_shape()))
+      module.predict(tf_utils.uniform(get_input_shape()), atol=1e-5, rtol=1e-5)
 
     self.compare_backends(predict, self._modules)
 


### PR DESCRIPTION
The relative and absolute tolerances are increased to `1e-5` to address TFLite failing internally.