### PR TITLE
Fix CMake Android cross-compilation on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,8 +394,8 @@ add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
 if(CMAKE_CROSSCOMPILING)
   # We need flatc to generate some source code. When cross-compiling, we need
   # to make sure the flatc binary is configured under host environment.
-  iree_declare_host_excutable(flatc BUILDONLY)
-  iree_declare_host_excutable(flatcc_cli BUILDONLY)
+  iree_declare_host_excutable(flatc "flatc" BUILDONLY)
+  iree_declare_host_excutable(flatcc_cli "flatcc_cli" BUILDONLY)
 
   # Set the FLATBUFFERS_FLATC_EXECUTABLE. It controls where to find the flatc
   # binary in BuildFlatBuffers().
@@ -414,7 +414,7 @@ if(CMAKE_CROSSCOMPILING)
     COMMAND
       "${CMAKE_COMMAND}" -E copy_if_different
         "${PROJECT_SOURCE_DIR}/third_party/flatcc/bin/flatcc${IREE_HOST_EXECUTABLE_SUFFIX}"
-        "${IREE_HOST_BINARY_ROOT}/bin/flatcc_cli"
+        "${IREE_HOST_BINARY_ROOT}/bin/flatcc_cli${IREE_HOST_EXECUTABLE_SUFFIX}"
     DEPENDS iree_host_build_flatcc_cli
     COMMENT "Installing host flatcc..."
   )

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -78,7 +78,7 @@ function(iree_cc_binary)
     # The binary is marked as host only. We need to declare the rules for
     # generating them under host configuration so when cross-compiling towards
     # target we can still have this binary.
-    iree_declare_host_excutable(${_RULE_NAME})
+    iree_declare_host_excutable(${_RULE_NAME} ${_NAME})
 
     # Still define the package-prefixed target so we can have a consistent way
     # to reference this binary, whether cross-compiling or not. But this time

--- a/build_tools/cmake/iree_cross_compile.cmake
+++ b/build_tools/cmake/iree_cross_compile.cmake
@@ -131,13 +131,13 @@ endfunction()
 
 # iree_get_build_command
 #
-# Gets the CMake build command for the given `EXECUTABLE`.
+# Gets the CMake build command for the given `EXECUTABLE_TARGET`.
 #
 # Parameters:
-# EXECUTABLE: the executable to build.
+# EXECUTABLE_TARGET: the target for the executable to build.
 # BINDIR: root binary directory containing CMakeCache.txt.
 # CMDVAR: variable name for receiving the build command.
-function(iree_get_build_command EXECUTABLE)
+function(iree_get_build_command EXECUTABLE_TARGET)
   cmake_parse_arguments(_RULE "" "BINDIR;CMDVAR;CONFIG" "" ${ARGN})
   if(NOT _RULE_CONFIG)
     set(_RULE_CONFIG "$<CONFIG>")
@@ -145,11 +145,11 @@ function(iree_get_build_command EXECUTABLE)
   if (CMAKE_GENERATOR MATCHES "Make")
     # Use special command for Makefiles to support parallelism.
     set(${_RULE_CMDVAR}
-        "$(MAKE)" "-C" "${_RULE_BINDIR}" "${EXECUTABLE}" PARENT_SCOPE)
+        "$(MAKE)" "-C" "${_RULE_BINDIR}" "${EXECUTABLE_TARGET}" PARENT_SCOPE)
   else()
     set(${_RULE_CMDVAR}
         "${CMAKE_COMMAND}" --build ${_RULE_BINDIR}
-                           --target ${EXECUTABLE}${IREE_HOST_EXECUTABLE_SUFFIX}
+                           --target ${EXECUTABLE_TARGET}
                            --config ${_RULE_CONFIG} PARENT_SCOPE)
   endif()
 endfunction()
@@ -201,14 +201,15 @@ endfunction()
 #
 # Parameters:
 # EXECUTABLE: the executable to build on host.
+# EXECUTABLE_TARGET: the target name for the executable.
 # BUILDONLY: only generates commands for building the target.
 # DEPENDS: any additional dependencies for the target.
-function(iree_declare_host_excutable EXECUTABLE)
+function(iree_declare_host_excutable EXECUTABLE EXECUTABLE_TARGET)
   cmake_parse_arguments(_RULE "BUILDONLY" "" "DEPENDS" ${ARGN})
 
   iree_get_executable_path(_OUTPUT_PATH ${EXECUTABLE})
 
-  iree_get_build_command(${EXECUTABLE}
+  iree_get_build_command(${EXECUTABLE_TARGET}
     BINDIR ${IREE_HOST_BINARY_ROOT}
     CMDVAR build_cmd)
 

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 if(CMAKE_CROSSCOMPILING)
-  iree_declare_host_excutable(generate_cc_embed_data)
+  iree_declare_host_excutable(generate_cc_embed_data "generate_cc_embed_data")
 else()
   add_executable(generate_cc_embed_data)
   target_sources(generate_cc_embed_data PRIVATE generate_cc_embed_data_main.cc)


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/3457

* CMake targets shouldn't have executable suffixes (e.g. `.exe`) in them and `flatcc_cli.exe` was getting copied to `flatcc_cli` (dropping the extension where it matters).

* `iree_get_build_command` should take a target name, not an executable name (alias).

  The generated commands are of the format:
  ```
  C:/Program Files/CMake/bin/cmake.exe;--build;D:/dev/projects/iree-build-android/host;--target;iree-tblgen;-- config;$<CONFIG>
  ```
  Where `--target iree-tblgen` can't find the target on my system, but `--target iree_tools_iree-tblgen` can.

  I tried using `get_target_property(... ALIASED_TARGET)` but I get this error:
  `get_target_property() called with non-existent target "iree-translate"`