### PR TITLE
Avoid deadlock in get_e2e_artifacts

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -51,7 +51,7 @@ def check_and_get_output_lines(command: Sequence[str],
 
   process.check_returncode()
 
-  return [line.strip(os.linesep) for line in process.stdout]
+  return process.stdout.split(os.linesep)
 
 
 def get_test_targets(test_suite_path: str):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -45,13 +45,13 @@ def check_and_get_output_lines(command: Sequence[str],
                            universal_newlines=True)
 
   if log_stderr:
-    for line in process.stderr.split(os.linesep):
+    for line in process.stderr.splitlines():
       if not any(re.match(pattern, line) for pattern in stderr_filters):
         print(line)
 
   process.check_returncode()
 
-  return process.stdout.split(os.linesep)
+  return process.stdout.splitlines()
 
 
 def get_test_targets(test_suite_path: str):


### PR DESCRIPTION
You can't use `process.wait()` with pipes.

Fixes https://github.com/google/iree/issues/3499