### PR TITLE
Clean up and fix some Bazel flags on Windows.

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -303,6 +303,5 @@ build:windows --define with_default_optimizations=true
 # MSVC (Windows): Standards-conformant preprocessor mode
 # See https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
 build:windows --per_file_copt=tensorflow@/experimental:preprocessor
-build:windows --per_file_copt=tensorflow@/experimental:preprocessor
 
 ###############################################################################

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -298,10 +298,11 @@ build:windows --define=override_eigen_strong_inline=true
 # Another TensorFlow flag from their config script.
 build:windows --define with_default_optimizations=true
 
-# TensorFlow builds depend on these flags so we will as well
+# TensorFlow builds depend on this flag, but it doesn't appear to work with
+# gmock in some of our unit tests, so only enable it for TensorFlow files.
 # MSVC (Windows): Standards-conformant preprocessor mode
 # See https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
-build:windows --copt=/experimental:preprocessor
-build:windows --host_copt=/experimental:preprocessor
+build:windows --per_file_copt=tensorflow@/experimental:preprocessor
+build:windows --per_file_copt=tensorflow@/experimental:preprocessor
 
 ###############################################################################

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -395,7 +395,12 @@ cc_library(
     name = "synchronization",
     srcs = ["synchronization.c"],
     hdrs = ["synchronization.h"],
-    linkopts = ["-lpthread"],
+    linkopts = select({
+        "//iree:iree_is_msvc": [],
+        "//conditions:default": [
+            "-lpthread",
+        ],
+    }),
     deps = [
         ":api",
         ":atomics",
@@ -460,10 +465,13 @@ cc_library(
     copts = [
         "-D_GNU_SOURCE=1",
     ],
-    linkopts = [
-        "-ldl",
-        "-lpthread",
-    ],
+    linkopts = select({
+        "//iree:iree_is_msvc": [],
+        "//conditions:default": [
+            "-ldl",
+            "-lpthread",
+        ],
+    }),
     deps = [
         ":api",
         ":atomics",

--- a/iree/build_defs.oss.bzl
+++ b/iree/build_defs.oss.bzl
@@ -85,11 +85,14 @@ def iree_flatbuffer_cc_library(**kwargs):
 def cc_binary(linkopts = [], **kwargs):
     """Wrapper around low-level cc_binary that adds flags."""
     _cc_binary(
-        linkopts = linkopts + [
-            # Just include libraries that should be presumed in 2020.
-            "-ldl",
-            "-lpthread",
-        ],
+        linkopts = linkopts + select({
+            "//iree:iree_is_msvc": [],
+            "//conditions:default": [
+                # Just include libraries that should be presumed in 2020.
+                "-ldl",
+                "-lpthread",
+            ],
+        }),
         **kwargs
     )
 


### PR DESCRIPTION
Reducing the number of these warnings:

```
LINK : warning LNK4044: unrecognized option '/lm'; ignored
LINK : warning LNK4044: unrecognized option '/lpthread'; ignored
```

---

Our tests using `googlemock` have compilation errors with `/experimental:preprocessor`:

```
ERROR: D:/dev/projects/iree/iree/hal/BUILD:103:8: C++ compilation of rule '//iree/hal:buffer_test' failed (Exit 2) C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um\winbase.h(9305): warning C5105: macro expansion producing 'defined' has undefined behavior
iree/hal/buffer_mapping_test.cc(55): error C4002: too many arguments for function-like macro invocation 'GMOCK_PP_INTERNAL_TAIL_CAT_I'
external/com_google_googletest/googlemock/include\gmock/internal/gmock-pp.h(64): note: in expansion of macro 'GMOCK_PP_TAIL'
external/com_google_googletest/googlemock/include\gmock/internal/gmock-pp.h(201): note: in expansion of macro 'GMOCK_PP_INTERNAL_TAIL_CAT'
external/com_google_googletest/googlemock/include\gmock/gmock-function-mocker.h(178): note: in expansion of macro 'GMOCK_INTERNAL_SIGNATURE'
external/com_google_googletest/googlemock/include\gmock/internal/gmock-pp.h(161): note: in expansion of macro 'GMOCK_PP_FOR_EACH'
external/com_google_googletest/googlemock/include\gmock/internal/gmock-pp.h(271): note: in expansion of macro 'GMOCK_PP_INTERNAL_FOR_EACH_IMPL_4'
external/com_google_googletest/googlemock/include\gmock/gmock-function-mocker.h(29): note: in expansion of macro 'GMOCK_INTERNAL_MOCK_METHOD_ARG_4'
external/com_google_googletest/googlemock/include\gmock/gmock-function-mocker.h(8): note: in expansion of macro 'MOCK_METHOD'
external/com_google_googletest/googlemock/include\gmock/internal/gmock-pp.h(69): note: in expansion of macro 'GMOCK_PP_VARIADIC_CALL'
iree/hal/buffer_mapping_test.cc(52): error C2275: 'iree::device_size_t': illegal use of this type as an expression .\iree/hal/buffer.h(78): note: see declaration of 'iree::device_size_t'
iree/hal/buffer_mapping_test.cc(52): error C2146: syntax error: missing ')' before identifier 'byte_offset'
iree/hal/buffer_mapping_test.cc(52): error C2146: syntax error: missing '>' before identifier 'byte_offset'
```

(full logs [here](https://gist.github.com/ScottTodd/94d9f3a1388300af5014dc8c009a7c60))