### PR TITLE
[vulkan] Bump target Vulkan API version

### DIFF
--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -493,6 +493,7 @@ cc_library(
         ":vulkan_device",
         "//iree/base:memory",
         "//iree/base:status",
+        "//iree/base:target_platform",
         "//iree/base:tracing",
         "//iree/hal:device_info",
         "//iree/hal:driver",

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -556,6 +556,7 @@ iree_cc_library(
     absl::inlined_vector
     iree::base::memory
     iree::base::status
+    iree::base::target_platform
     iree::base::tracing
     iree::hal::device_info
     iree::hal::driver

--- a/iree/hal/vulkan/vulkan_driver.cc
+++ b/iree/hal/vulkan/vulkan_driver.cc
@@ -20,6 +20,7 @@
 #include "absl/flags/flag.h"
 #include "iree/base/memory.h"
 #include "iree/base/status.h"
+#include "iree/base/target_platform.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/device_info.h"
 #include "iree/hal/vulkan/extensibility_util.h"
@@ -45,7 +46,11 @@ VkApplicationInfo GetDefaultApplicationInfo() {
   info.applicationVersion = 0;
   info.pEngineName = "IREE";
   info.engineVersion = 0;
-  info.apiVersion = VK_API_VERSION_1_0;
+#ifdef IREE_PLATFORM_ANDROID
+  info.apiVersion = VK_API_VERSION_1_1;
+#else
+  info.apiVersion = VK_API_VERSION_1_2;
+#endif
   return info;
 }
 


### PR DESCRIPTION
Per the spec, VkApplicationInfo::apiVersion "must be the highest
version of Vulkan that the application is designed to use."

Targeting Vulkan 1.0 means we cannot use Vulkan 1.1/1.2 features.
This isn't strongly enforced on all Vulkan loaders/ICDs but I do
see issues raised due to this on, for example, Linux Mesa drivers.