### PR TITLE
Adding noinline (and sym_visibility=private) to bert w/ fake weights.

### DIFF
--- a/iree/test/e2e/models/bert_encoder_unrolled_fake_weights.mlir
+++ b/iree/test/e2e/models/bert_encoder_unrolled_fake_weights.mlir
@@ -1,1119 +1,1119 @@
 // MobileBert encoder model with placeholder weights, for testing.
 
 module {
-  flow.variable @"__iree_flow_bert/embeddings/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/embedding_transformation/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/embedding_transformation/kernel" dense<0.0001> : tensor<384x512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/position_embeddings" dense<0.0> : tensor<512x512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/token_type_embeddings" dense<0.0> : tensor<2x512xf32>
-  flow.variable @"__iree_flow_bert/embeddings/word_embeddings" dense<0.0> : tensor<30522x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_10/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_11/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_12/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_13/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_14/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_15/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_16/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_17/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_18/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_19/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_20/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_21/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_22/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_23/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_3/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_4/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_5/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_6/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_7/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_8/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/key/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/query/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/value/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/intermediate/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/dense/bias" dense<0.1> : tensor<128xf32>
-  flow.variable @"__iree_flow_bert/encoder/layer_9/output/dense/kernel" dense<0.0001> : tensor<512x128xf32>
-  flow.variable @"__iree_flow_cls/squad/output_bias" dense<0.1> : tensor<2xf32>
-  flow.variable @"__iree_flow_cls/squad/output_weights" dense<1.0> : tensor<2x512xf32>
+  flow.variable @"__iree_flow_bert/embeddings/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/embedding_transformation/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/embedding_transformation/kernel" dense<0.0001> : tensor<384x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/position_embeddings" dense<0.0> : tensor<512x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/token_type_embeddings" dense<0.0> : tensor<2x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/embeddings/word_embeddings" dense<0.0> : tensor<30522x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_10/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_11/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_12/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_13/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_14/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_15/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_16/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_17/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_18/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_19/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_20/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_21/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_22/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_23/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_3/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_4/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_5/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_6/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_7/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_8/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/output/dense/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/key/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/key/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/query/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/query/kernel" dense<0.0001> : tensor<128x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/value/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/attention/self/value/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/attention/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/bottleneck/input/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_0/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_1/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/ffn_layer_2/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/intermediate/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/intermediate/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/FakeLayerNorm/beta" dense<1.0> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/FakeLayerNorm/gamma" dense<0.4> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/FakeLayerNorm/beta" dense<1.0> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/FakeLayerNorm/gamma" dense<0.4> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/dense/bias" dense<0.1> : tensor<512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/bottleneck/dense/kernel" dense<0.0001> : tensor<128x512xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/dense/bias" dense<0.1> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_bert/encoder/layer_9/output/dense/kernel" dense<0.0001> : tensor<512x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow_cls/squad/output_bias" dense<0.1> : tensor<2xf32> attributes {sym_visibility = "private"}
+  flow.variable @"__iree_flow_cls/squad/output_weights" dense<1.0> : tensor<2x512xf32> attributes {sym_visibility = "private"}
   func @serving_default() {
     %arg0 = iree.unfoldable_constant dense<0> : tensor<1x384xi32>
     %arg1 = iree.unfoldable_constant dense<0> : tensor<1x384xi32>


### PR DESCRIPTION
Makes it more representative of the real weights model.