### PR TITLE
Added a pass to validate TF has been lowered away

### DIFF
--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -21,6 +21,7 @@ package(
 cc_library(
     name = "tensorflow",
     srcs = [
+        "CheckNoTF.cpp",
         "LegalizeTF.cpp",
         "Passes.cpp",
         "PropagateResourceCasts.cpp",

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -39,20 +39,20 @@ class CheckNoTF : public PassWrapper<CheckNoTF, FunctionPass> {
 
   /// Performs the lowering to XLA dialect.
   void runOnFunction() override {
-    auto op = getFunction();  
+    auto op = getFunction();
     auto context = op.getContext();
 
-    Dialect* dialect = context->getLoadedDialect("tf");
+    Dialect *dialect = context->getLoadedDialect("tf");
     DenseSet<Operation *> illegalOps;
     op.walk([&](Operation *op) {
-        if (op->getDialect() == dialect) {
-            illegalOps.insert(op);
-        }
+      if (op->getDialect() == dialect) {
+        illegalOps.insert(op);
+      }
     });
 
     if (!illegalOps.empty()) {
-        EmitLegalizationErrors(op, illegalOps);
-        return signalPassFailure();
+      EmitLegalizationErrors(op, illegalOps);
+      return signalPassFailure();
     }
   }
 
@@ -77,14 +77,15 @@ class CheckNoTF : public PassWrapper<CheckNoTF, FunctionPass> {
     std::vector<std::string> error_messages;
     error_messages.reserve(op_name_to_error_info.size());
     for (const auto &op_info : op_name_to_error_info) {
-      error_messages.push_back(
-          llvm::formatv("{0} (count: {1})", op_info.first, op_info.second.first));
+      error_messages.push_back(llvm::formatv("{0} (count: {1})", op_info.first,
+                                             op_info.second.first));
     }
     Location loc = op->getLoc();
-    emitError(loc) << "The following operations cannot be legalized: "
-                   << llvm::join(error_messages, "; ")
-                   << ". These legalization failure(s) may be due to missing TF "
-                      "to HLO lowerings and/or unsupported attributes, etc.";
+    emitError(loc)
+        << "The following operations cannot be legalized: "
+        << llvm::join(error_messages, "; ")
+        << ". These legalization failure(s) may be due to missing TF "
+           "to HLO lowerings and/or unsupported attributes, etc.";
     // Emit more information about the missing ops. This error message
     // contains useful details beyond the op name (input and output shapes,
     // attributes, etc.).
@@ -94,8 +95,8 @@ class CheckNoTF : public PassWrapper<CheckNoTF, FunctionPass> {
   }
 };
 
-static PassRegistration<CheckNoTF> pass(
-    "iree-check-no-tf", "Check that no TF remains");
+static PassRegistration<CheckNoTF> pass("iree-check-no-tf",
+                                        "Check that no TF remains");
 }  // namespace
 
 std::unique_ptr<OperationPass<FuncOp>> createCheckNoTF() {

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -65,7 +65,8 @@ class CheckNoTensorflow : public PassWrapper<CheckNoTensorflow, FunctionPass> {
     for (Operation *nonlegalizedOp : nonlegalizedOps) {
       StringRef opName = nonlegalizedOp->getName().getStringRef();
       opNameCounts[opName]++;
-      nonlegalizedOp->emitOpError() << ": unlegalized TensorFlow op still exists";
+      nonlegalizedOp->emitOpError()
+          << ": unlegalized TensorFlow op still exists";
     }
 
     std::vector<std::string> errorMessages;

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -73,8 +73,8 @@ class CheckNoTensorflow : public PassWrapper<CheckNoTensorflow, FunctionPass> {
     std::vector<std::string> errorMessages;
     errorMessages.reserve(opNameCounts.size());
     for (const auto &opInfo : opNameCounts) {
-      errorMessages.push_back(llvm::formatv("\t{0} (count: {1})", opInfo.first,
-                                            opInfo.second));
+      errorMessages.push_back(
+          llvm::formatv("\t{0} (count: {1})", opInfo.first, opInfo.second));
     }
     Location loc = op->getLoc();
     emitError(loc) << "The following Tensorflow operations still remain: \n"

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
+#include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
+#include "tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.h"
+#include "tensorflow/compiler/mlir/xla/transforms/passes.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+class CheckNoTF : public PassWrapper<CheckNoTF, FunctionPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<chlo::HloClientDialect, mhlo::MhloDialect,
+                    shape::ShapeDialect, StandardOpsDialect>();
+  }
+
+  CheckNoTF() = default;
+  CheckNoTF(const CheckNoTF &) {}
+
+  /// Performs the lowering to XLA dialect.
+  void runOnFunction() override {
+    auto op = getFunction();  
+    auto context = op.getContext();
+
+    Dialect* dialect = context->getLoadedDialect("tf");
+    DenseSet<Operation *> illegalOps;
+    op.walk([&](Operation *op) {
+        if (op->getDialect() == dialect) {
+            illegalOps.insert(op);
+        }
+    });
+
+    if (!illegalOps.empty()) {
+        EmitLegalizationErrors(op, illegalOps);
+        return signalPassFailure();
+    }
+  }
+
+  // Emits debug information which includes the number of ops of each type which
+  // failed to legalize.
+  void EmitLegalizationErrors(Operation *op,
+                              const DenseSet<Operation *> &nonlegalized_ops) {
+    // Track the legalization failures by mapping op name to information about
+    // that failure: the number of unlegalized occurrences of the op, and one
+    // example operation that failed.
+    std::map<StringRef, std::pair<int, Operation *>> op_name_to_error_info;
+    DenseSet<Operation *> error_ops;
+    for (Operation *nonlegalized_op : nonlegalized_ops) {
+      // Increment count of this legalization failure.
+      StringRef op_name = nonlegalized_op->getName().getStringRef();
+      // If this emplace is successful, it's the first time we've encountered
+      // this op type. Initialize count to 0 so that after increment, it is 1.
+      auto insertion_result = op_name_to_error_info.emplace(
+          op_name, std::make_pair(0, nonlegalized_op));
+      ++insertion_result.first->second.first;
+    }
+    std::vector<std::string> error_messages;
+    error_messages.reserve(op_name_to_error_info.size());
+    for (const auto &op_info : op_name_to_error_info) {
+      error_messages.push_back(
+          llvm::formatv("{0} (count: {1})", op_info.first, op_info.second.first));
+    }
+    Location loc = op->getLoc();
+    emitError(loc) << "The following operations cannot be legalized: "
+                   << llvm::join(error_messages, "; ")
+                   << ". These legalization failure(s) may be due to missing TF "
+                      "to HLO lowerings and/or unsupported attributes, etc.";
+    // Emit more information about the missing ops. This error message
+    // contains useful details beyond the op name (input and output shapes,
+    // attributes, etc.).
+    for (const auto &op_info : op_name_to_error_info) {
+      op_info.second.second->emitOpError() << "is not legalizable";
+    }
+  }
+};
+
+static PassRegistration<CheckNoTF> pass(
+    "iree-check-no-tf", "Check that no TF remains");
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createCheckNoTF() {
+  return std::make_unique<CheckNoTF>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -60,14 +60,12 @@ class CheckNoTensorflow : public PassWrapper<CheckNoTensorflow, FunctionPass> {
   // failed to legalize.
   void emitLegalizationErrors(Operation *op,
                               const DenseSet<Operation *> &nonlegalizedOps) {
-    // Track the legalization failures by mapping op name to information about
-    // that failure: the number of unlegalized occurrences of the op, and one
-    // example operation that failed.
+    // Print op errors for each of the TensorFlow ops that still remain.
     std::map<StringRef, int> opNameCounts;
     for (Operation *nonlegalizedOp : nonlegalizedOps) {
       StringRef opName = nonlegalizedOp->getName().getStringRef();
       opNameCounts[opName]++;
-      nonlegalizedOp->emitOpError() << "still exists";
+      nonlegalizedOp->emitOpError() << ": unlegalized TensorFlow op still exists";
     }
 
     std::vector<std::string> errorMessages;

--- a/integrations/tensorflow/compiler/CheckNoTF.cpp
+++ b/integrations/tensorflow/compiler/CheckNoTF.cpp
@@ -69,8 +69,8 @@ class CheckNoTensorflow : public PassWrapper<CheckNoTensorflow, FunctionPass> {
       StringRef op_name = nonlegalizedOp->getName().getStringRef();
       // If this emplace is successful, it's the first time we've encountered
       // this op type. Initialize count to 0 so that after increment, it is 1.
-      auto insertion_result = opNametoErrorInfo.emplace(
-          op_name, std::make_pair(0, nonlegalizedOp));
+      auto insertion_result =
+          opNametoErrorInfo.emplace(op_name, std::make_pair(0, nonlegalizedOp));
       ++insertion_result.first->second.first;
       nonlegalizedOp->emitOpError() << "still existed";
     }
@@ -79,17 +79,16 @@ class CheckNoTensorflow : public PassWrapper<CheckNoTensorflow, FunctionPass> {
     errorMessages.reserve(opNametoErrorInfo.size());
     for (const auto &opInfo : opNametoErrorInfo) {
       errorMessages.push_back(llvm::formatv("\t{0} (count: {1})", opInfo.first,
-                                             opInfo.second.first));
+                                            opInfo.second.first));
     }
     Location loc = op->getLoc();
-    emitError(loc)
-        << "The following Tensorflow operations still remain: \n"
-        << llvm::join(errorMessages, "\n") << "\n";
+    emitError(loc) << "The following Tensorflow operations still remain: \n"
+                   << llvm::join(errorMessages, "\n") << "\n";
   }
 };
 
 static PassRegistration<CheckNoTensorflow> pass(
-  "iree-check-no-tf", "Check that no TensorFlow frontend ops remain");
+    "iree-check-no-tf", "Check that no TensorFlow frontend ops remain");
 }  // namespace
 
 std::unique_ptr<OperationPass<FuncOp>> createCheckNoTF() {

--- a/integrations/tensorflow/compiler/Passes.cpp
+++ b/integrations/tensorflow/compiler/Passes.cpp
@@ -64,6 +64,11 @@ void createIreeTfImportPipeline(OpPassManager &pm) {
   // - It removes tf_saved_model.semantics from the module, which we can only
   //   do at the very end.
   pm.addPass(createTFSavedModelLowerExportedFunctions());
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Validate that all Tensorflow has been legalized away.
+  ////////////////////////////////////////////////////////////////////////////
+  pm.addPass(createCheckNoTF());
 }
 
 static mlir::PassPipelineRegistration<> pipeline(

--- a/integrations/tensorflow/compiler/Passes.h
+++ b/integrations/tensorflow/compiler/Passes.h
@@ -40,6 +40,9 @@ createTFSavedModelLowerExportedFunctions();
 // Push resource casts forward to better propagate resource related shapes.
 std::unique_ptr<OperationPass<ModuleOp>> createPropagateResourceCasts();
 
+// Validates whether any Tensorflow operations remain.
+std::unique_ptr<OperationPass<FuncOp>> createCheckNoTF();
+
 // Create a single pipeline that will run all the needed IREE-specific TF import
 // passes in the right order.
 void createIreeTfImportPipeline(OpPassManager &pm);

--- a/integrations/tensorflow/compiler/test/check-no-tf.mlir
+++ b/integrations/tensorflow/compiler/test/check-no-tf.mlir
@@ -9,9 +9,21 @@ func @f() -> (tensor<i32>) {
 
 // -----
 
-// expected-error@+3 {{'tf.Const' op still existed}}
+// expected-error@+3 {{'tf.Const' op still exists}}
 // expected-error@below {{The following Tensorflow operations still remain}}
 func @f() -> (tensor<i32>) {
   %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
   return %0 : tensor<i32>
 }
+
+// -----
+
+// expected-error@+4 {{'tf.Const' op still exists}}
+// expected-error@+4 {{'tf.Add' op still exists}}
+// expected-error@below {{The following Tensorflow operations still remain}}
+func @f(%arg0 : tensor<i32>) -> (tensor<i32>) {
+  %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
+  %1 = "tf.Add"(%arg0, %0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+  return %1 : tensor<i32>
+}
+

--- a/integrations/tensorflow/compiler/test/check-no-tf.mlir
+++ b/integrations/tensorflow/compiler/test/check-no-tf.mlir
@@ -26,4 +26,3 @@ func @f(%arg0 : tensor<i32>) -> (tensor<i32>) {
   %1 = "tf.Add"(%arg0, %0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
   return %1 : tensor<i32>
 }
-

--- a/integrations/tensorflow/compiler/test/check-no-tf.mlir
+++ b/integrations/tensorflow/compiler/test/check-no-tf.mlir
@@ -9,7 +9,7 @@ func @f() -> (tensor<i32>) {
 
 // -----
 
-// expected-error@+3 {{'tf.Const' op still exists}}
+// expected-error@+3 {{'tf.Const' op : unlegalized TensorFlow op still exists}}
 // expected-error@below {{The following Tensorflow operations still remain}}
 func @f() -> (tensor<i32>) {
   %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
@@ -18,8 +18,8 @@ func @f() -> (tensor<i32>) {
 
 // -----
 
-// expected-error@+4 {{'tf.Const' op still exists}}
-// expected-error@+4 {{'tf.Add' op still exists}}
+// expected-error@+4 {{'tf.Const' op : unlegalized TensorFlow op still exists}}
+// expected-error@+4 {{'tf.Add' op : unlegalized TensorFlow op still exists}}
 // expected-error@below {{The following Tensorflow operations still remain}}
 func @f(%arg0 : tensor<i32>) -> (tensor<i32>) {
   %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>

--- a/integrations/tensorflow/compiler/test/check-no-tf.mlir
+++ b/integrations/tensorflow/compiler/test/check-no-tf.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-tf-opt %s -iree-check-no-tf -split-input-file -verify-diagnostics
+
+// CHECK-LABEL: func @f
+func @f() -> (tensor<i32>) {
+  // CHECK: [[VAL0:%.+]] = mhlo.constant dense<3>
+  %0 = mhlo.constant dense<3> : tensor<i32>
+  return %0 : tensor<i32>
+}
+
+// -----
+
+// expected-error@below {{The following operations cannot be legalized: tf.Const (count: 1). These legalization failure(s) may be due to missing TF to HLO lowerings and/or unsupported attributes, etc.}}
+func @f() -> (tensor<i32>) {
+  // expected-error@+1 {{'tf.Const' op is not legalizable}}
+  %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
+  return %0 : tensor<i32>
+}

--- a/integrations/tensorflow/compiler/test/check-no-tf.mlir
+++ b/integrations/tensorflow/compiler/test/check-no-tf.mlir
@@ -9,9 +9,9 @@ func @f() -> (tensor<i32>) {
 
 // -----
 
-// expected-error@below {{The following operations cannot be legalized: tf.Const (count: 1). These legalization failure(s) may be due to missing TF to HLO lowerings and/or unsupported attributes, etc.}}
+// expected-error@+3 {{'tf.Const' op still existed}}
+// expected-error@below {{The following Tensorflow operations still remain}}
 func @f() -> (tensor<i32>) {
-  // expected-error@+1 {{'tf.Const' op is not legalizable}}
   %0 = "tf.Const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
   return %0 : tensor<i32>
 }

--- a/integrations/tensorflow/compiler/test/saved_model_adopt_exports.py
+++ b/integrations/tensorflow/compiler/test/saved_model_adopt_exports.py
@@ -23,6 +23,7 @@ import tensorflow.compat.v2 as tf
 SAVED_MODEL_IMPORT_PASSES = [
     "tf-executor-graph-pruning",
     "tf-standard-pipeline",
+    "iree-xla-legalize-tf",
     "iree-tf-import-pipeline",
     "canonicalize",
 ]
@@ -114,8 +115,8 @@ class T0002c_SimpleConst(tf.Module):
 # CHECK: attributes
 # CHECK-SAME: iree.module.export
 # CHECK-SAME: iree.reflection = {abi = "sip", abiv = 1 : i32, sip = "I1!R1!"}
-# CHECK-DAG:   [[CONST_2xf32:%.+]] = "tf.Const"() {value = dense<[0.000000e+00, 1.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
-# CHECK-DAG:   [[CONST_3xf32:%.+]] = "tf.Const"() {value = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>} : () -> tensor<3xf32>
+# CHECK-DAG:   [[CONST_2xf32:%.+]] = mhlo.constant dense<[0.000000e+00, 1.000000e+00]>
+# CHECK-DAG:   [[CONST_3xf32:%.+]] = mhlo.constant dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]>
 # CHECK-DAG:   flow.variable.store [[CONST_2xf32]], @v : tensor<2xf32>
 # CHECK-DAG:   flow.variable.store [[CONST_3xf32]], @v : tensor<3xf32>
 # CHECK: FINISH_TEST


### PR DESCRIPTION
Added a pass that verifies that all TF has been lowered away. This guarantees
we terminate early when a TF operation should no longer exist.