### PR TITLE
Revert "Add LoadStoreVectorizationPass to GPU pipeline as default (#3194)"

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
@@ -130,11 +130,8 @@ Value getPushConstantValue(Operation *op, unsigned elementCount,
 spirv::GlobalVariableOp getOrInsertResourceVariable(Location loc, Type type,
                                                     unsigned set,
                                                     unsigned binding,
-                                                    StringRef funcName,
                                                     Block &block) {
-  auto name =
-      llvm::formatv("__resource_var_{0}_{1}_{2}__", set, binding, funcName)
-          .str();
+  auto name = llvm::formatv("__resource_var_{0}_{1}__", set, binding).str();
   for (auto varOp : block.getOps<spirv::GlobalVariableOp>()) {
     if (varOp.sym_name() == name) return varOp;
   }
@@ -371,10 +368,9 @@ LogicalResult IREEPlaceholderConverter::matchAndRewrite(
       SymbolTable::lookupNearestSymbolFrom(
           phOp, phOp.getAttrOfType<SymbolRefAttr>("binding")));
 
-  StringRef funcName = phOp.getParentOfType<spirv::FuncOp>().getName();
-  spirv::GlobalVariableOp varOp = getOrInsertResourceVariable(
-      phOp.getLoc(), convertedType, bindingOp.set(), bindingOp.binding(),
-      funcName, *moduleOp.getBody());
+  spirv::GlobalVariableOp varOp =
+      getOrInsertResourceVariable(phOp.getLoc(), convertedType, bindingOp.set(),
+                                  bindingOp.binding(), *moduleOp.getBody());
 
   rewriter.replaceOpWithNewOp<spirv::AddressOfOp>(phOp, varOp);
   return success();

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
@@ -63,6 +63,11 @@ struct LinalgToSPIRVPassPipelineOptions
       llvm::cl::desc(
           "Enable use of vectorization in SPIR-V code generation pipeline"),
       llvm::cl::init(false)};
+  Option<bool> useVectorPass{
+      *this, "use-vector-pass",
+      llvm::cl::desc("Enable use of Linalg vectorization in SPIR-V code "
+                     "generation pipeline"),
+      llvm::cl::init(false)};
 };
 
 static void addLinalgToSPIRVPasses(OpPassManager &pm,
@@ -94,7 +99,9 @@ static void addLinalgToSPIRVPasses(OpPassManager &pm,
   //===--------------------------------------------------------------------===//
   pm.addPass(createSplitDispatchFunctionPass());
   pm.addPass(createLinalgTileAndFusePass(options));
-  pm.addPass(createLoadStoreVectorizationPass());
+  if (options.useVectorPass) {
+    pm.addPass(createLoadStoreVectorizationPass());
+  }
   pm.addPass(createCanonicalizerPass());
 
   //===--------------------------------------------------------------------===//

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
@@ -29,6 +29,7 @@ struct SPIRVCodegenOptions {
   SmallVector<int64_t, 3> tileSizes = {};
   bool useWorkgroupMemory = false;
   bool useVectorization = false;
+  bool useVectorPass = false;
 };
 
 /// Pass to initialize the function that computes the number of workgroups for

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/convert_to_spirv.mlir
@@ -23,12 +23,12 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SP
 
 module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
 
-  // CHECK: spv.globalVariable @__resource_var_3_4_resource_variable__ bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.globalVariable @__resource_var_1_2_resource_variable__ bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.globalVariable @__resource_var_3_4__ bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.globalVariable @__resource_var_1_2__ bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
   // CHECK: spv.func @resource_variable()
   func @resource_variable() {
-    // CHECK: spv._address_of @__resource_var_1_2_resource_variable__ : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-    // CHECK: spv._address_of @__resource_var_3_4_resource_variable__ : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+    // CHECK: spv._address_of @__resource_var_1_2__ : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+    // CHECK: spv._address_of @__resource_var_3_4__ : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
     %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<4x4xf32>
     %1 = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<4x4xf32>
     return
@@ -37,24 +37,6 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SP
   hal.interface @legacy_io attributes {push_constants = 5 : i32, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
-  }
-}
-
-// -----
-
-module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>, vkspv.entry_point_schedule = ["ForwardPass_ex_dispatch_8_dispatch_0", "ForwardPass_ex_dispatch_8_dispatch_1"]} {
-  // CHECK: spv.globalVariable @__resource_var_0_0_dispatch_0__ bind(0, 0) : !spv.ptr<!spv.struct<(!spv.array<1 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
-  // CHECK: spv.globalVariable @__resource_var_0_0_dispatch_1__ bind(0, 0) : !spv.ptr<!spv.struct<(!spv.array<4 x f32, stride=4> [0])>, StorageBuffer>
-  func @dispatch_1() attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}, vkspv.num_workgroups_fn = @ForwardPass_ex_dispatch_8_dispatch_1__num_workgroups__} {
-    %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<4xf32>
-    return
-  }
-  func @dispatch_0() attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}, vkspv.num_workgroups_fn = @ForwardPass_ex_dispatch_8_dispatch_0__num_workgroups__} {
-    %0 = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<1xvector<4xf32>>
-    return
-  }
-  hal.interface @legacy_io attributes {sym_visibility = "private"} {
-    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
   }
 }
 

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -48,6 +48,12 @@ VulkanSPIRVTargetOptions getVulkanSPIRVTargetOptionsFromFlags() {
   // llvm::cl::OptionCategory halVulkanSPIRVOptionsCategory(
   //     "IREE Vulkan/SPIR-V backend options");
 
+  static llvm::cl::opt<bool> clUseVectorPass(
+      "iree-spirv-use-vector-pass",
+      llvm::cl::desc(
+          "Enable use of Linalg vectorization in SPIR-V code generation"),
+      llvm::cl::init(false));
+
   static llvm::cl::opt<bool> clUseWorkgroupMemory(
       "iree-spirv-use-workgroup-memory",
       llvm::cl::desc(
@@ -81,6 +87,7 @@ VulkanSPIRVTargetOptions getVulkanSPIRVTargetOptionsFromFlags() {
   targetOptions.codegenOptions.tileSizes.assign(clTileSizes.begin(),
                                                 clTileSizes.end());
   targetOptions.codegenOptions.useWorkgroupMemory = clUseWorkgroupMemory;
+  targetOptions.codegenOptions.useVectorPass = clUseVectorPass;
   if (!clVulkanTargetEnv.empty()) {
     targetOptions.vulkanTargetEnv = clVulkanTargetEnv;
   } else {

--- a/iree/test/e2e/vulkan_specific/BUILD
+++ b/iree/test/e2e/vulkan_specific/BUILD
@@ -45,3 +45,15 @@ iree_check_single_backend_test_suite(
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )
+
+iree_check_single_backend_test_suite(
+    name = "check_vulkan-spirv_vulkan_vector",
+    srcs = [
+        "compare.mlir",
+        "log_plus_one.mlir",
+        "pw_add_multiwg.mlir",
+    ],
+    compiler_flags = ["-iree-spirv-use-vector-pass"],
+    driver = "vulkan",
+    target_backend = "vulkan-spirv",
+)

--- a/iree/test/e2e/vulkan_specific/CMakeLists.txt
+++ b/iree/test/e2e/vulkan_specific/CMakeLists.txt
@@ -41,3 +41,18 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "-iree-spirv-use-workgroup-memory"
 )
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_vulkan-spirv_vulkan_vector
+  SRCS
+    "compare.mlir"
+    "log_plus_one.mlir"
+    "pw_add_multiwg.mlir"
+  TARGET_BACKEND
+    vulkan-spirv
+  DRIVER
+    vulkan
+  COMPILER_FLAGS
+    "-iree-spirv-use-vector-pass"
+)

--- a/iree/test/e2e/vulkan_specific/compare.mlir
+++ b/iree/test/e2e/vulkan_specific/compare.mlir
@@ -1,0 +1,164 @@
+func @compare_tensor() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[0, 1, 0, 1]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_scalar() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1> : tensor<i32>
+  %rhs = iree.unfoldable_constant dense<5> : tensor<i32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_i8() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1> : tensor<i8>
+  %rhs = iree.unfoldable_constant dense<5> : tensor<i8>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<i8>, tensor<i8>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_i16() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1> : tensor<i16>
+  %rhs = iree.unfoldable_constant dense<5> : tensor<i16>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<i16>, tensor<i16>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_i32() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1> : tensor<i32>
+  %rhs = iree.unfoldable_constant dense<5> : tensor<i32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_i64() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1> : tensor<i64>
+  %rhs = iree.unfoldable_constant dense<5> : tensor<i64>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<i64>, tensor<i64>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_f32() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1.0> : tensor<f32>
+  %rhs = iree.unfoldable_constant dense<5.0> : tensor<f32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<f32>, tensor<f32>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_f64() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<1.0> : tensor<f64>
+  %rhs = iree.unfoldable_constant dense<5.0> : tensor<f64>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<f64>, tensor<f64>) -> tensor<i1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<i1>, tensor<i8>, tensor<i8>) -> tensor<i8>
+  check.expect_eq_const(%output, dense<0> : tensor<i8>) : tensor<i8>
+  return
+}
+
+func @compare_tensor_odd_length() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7]> : tensor<3xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3]> : tensor<3xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<3xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<3xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<3xi1>, tensor<3xi8>, tensor<3xi8>) -> tensor<3xi8>
+  check.expect_eq_const(%output, dense<[0, 1, 0]> : tensor<3xi8>) : tensor<3xi8>
+  return
+}
+
+func @compare_eq() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[0, 1, 0, 1]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_ne() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "NE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[1, 0, 1, 0]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_lt() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "LT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[1, 0, 0, 0]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_le() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "LE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[1, 1, 0, 1]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_gt() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "GT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[0, 0, 1, 0]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}
+
+func @compare_ge() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<[1, 2, 7, 4]> : tensor<4xi32>
+  %rhs = iree.unfoldable_constant dense<[5, 2, 3, 4]> : tensor<4xi32>
+  %result = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "GE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %c0 = iree.unfoldable_constant dense<0> : tensor<4xi8>
+  %c1 = iree.unfoldable_constant dense<1> : tensor<4xi8>
+  %output = "mhlo.select"(%result, %c1, %c0) : (tensor<4xi1>, tensor<4xi8>, tensor<4xi8>) -> tensor<4xi8>
+  check.expect_eq_const(%output, dense<[0, 1, 1, 1]> : tensor<4xi8>) : tensor<4xi8>
+  return
+}

--- a/iree/test/e2e/vulkan_specific/log_plus_one.mlir
+++ b/iree/test/e2e/vulkan_specific/log_plus_one.mlir
@@ -1,0 +1,6 @@
+func @log_plus_one() attributes { iree.module.export } {
+  %input = iree.unfoldable_constant dense<[0.0, 0.5, 1.0, 5.0]> : tensor<4xf32>
+  %result = "mhlo.log_plus_one"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+  check.expect_almost_eq_const(%result, dense<[0.0, 0.4054651, 0.6931472, 1.7917595]> : tensor<4xf32>) : tensor<4xf32>
+  return
+}


### PR DESCRIPTION
This reverts commit 0fa16645176b40fded1a61d99f07a9b9bd9349b5.

Causes some internal model failures. Reverting according to @MaheshRavishankar request.