### PR TITLE
Update Vulkan SDK and ICDs within CI docker images

### DIFF
--- a/build_tools/docker/bazel-tensorflow-nvidia/Dockerfile
+++ b/build_tools/docker/bazel-tensorflow-nvidia/Dockerfile
@@ -18,4 +18,4 @@
 FROM gcr.io/iree-oss/bazel-tensorflow-vulkan AS final
 
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y vulkan-sdk nvidia-driver-440
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y nvidia-driver-450

--- a/build_tools/docker/bazel-tensorflow-vulkan/Dockerfile
+++ b/build_tools/docker/bazel-tensorflow-vulkan/Dockerfile
@@ -17,19 +17,8 @@
 
 FROM gcr.io/iree-oss/bazel-tensorflow AS final
 
-RUN apt-get update && apt-get install -y wget
+ARG VULKAN_SDK_VERSION=1.2.154.0
 
-ARG VULKAN_SDK_VERSION=1.2.141
+COPY --from=gcr.io/iree-oss/vulkan /opt/vulkan-sdk/ /opt/vulkan-sdk/
 
-# Disable apt-key parse waring. If someone knows how to do whatever the "proper"
-# thing is then feel free. The warning complains about parsing apt-key output,
-# which we're not even doing.
-ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-
-RUN wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc \
-    | apt-key add - \
-  && wget -qO \
-    "/etc/apt/sources.list.d/lunarg-vulkan-${VULKAN_SDK_VERSION?}-bionic.list" \
-    "http://packages.lunarg.com/vulkan/${VULKAN_SDK_VERSION?}/lunarg-vulkan-${VULKAN_SDK_VERSION?}-bionic.list" \
-  && apt-get update \
-  && apt-get install -y vulkan-sdk
+ENV VULKAN_SDK="/opt/vulkan-sdk/${VULKAN_SDK_VERSION}/x86_64"

--- a/build_tools/docker/cmake-python-nvidia/Dockerfile
+++ b/build_tools/docker/cmake-python-nvidia/Dockerfile
@@ -28,4 +28,4 @@
 FROM gcr.io/iree-oss/cmake-python-vulkan AS final
 
 RUN apt-get update \
-  && apt-get install -y nvidia-driver-440
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y nvidia-driver-450

--- a/build_tools/docker/manage_images.py
+++ b/build_tools/docker/manage_images.py
@@ -54,16 +54,17 @@ IMAGES_TO_DEPENDENCIES = {
     'bazel-tensorflow': ['bazel-python'],
     'bazel-tensorflow-nvidia': ['bazel-tensorflow-vulkan'],
     'bazel-tensorflow-swiftshader': ['bazel-tensorflow-vulkan', 'swiftshader'],
-    'bazel-tensorflow-vulkan': ['bazel-tensorflow'],
+    'bazel-tensorflow-vulkan': ['bazel-tensorflow', 'vulkan'],
     'cmake': ['base', 'util'],
     'cmake-android': ['cmake', 'util'],
     'cmake-python': ['cmake'],
     'cmake-python-nvidia': ['cmake-python-vulkan'],
     'cmake-python-swiftshader': ['cmake-python-vulkan', 'swiftshader'],
-    'cmake-python-vulkan': ['cmake-python'],
-    'rbe-toolchain': [],
+    'cmake-python-vulkan': ['cmake-python', 'vulkan'],
+    'rbe-toolchain': ['vulkan'],
     'swiftshader': ['cmake'],
     'util': [],
+    'vulkan': [],
 }
 
 IMAGES_TO_DEPENDENT_IMAGES = {k: [] for k in IMAGES_TO_DEPENDENCIES}

--- a/build_tools/docker/rbe-toolchain/Dockerfile
+++ b/build_tools/docker/rbe-toolchain/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 
 # This commit fixed support for the max version of libstdc++6 available through
 # Ubuntu 16.04 apt.
-ARG SWIFTSHADER_COMMIT=6287c18b1d249152563f0cb2d5cb0c6d0eb9e3d6
+ARG SWIFTSHADER_COMMIT=84f5eeb6dd9b225f465f93737fa76aad7de355cf
 
 RUN git clone https://github.com/google/swiftshader
 RUN cd swiftshader && git checkout "${SWIFTSHADER_COMMIT?}" && cd ..
@@ -79,25 +79,12 @@ RUN apt-get update \
   && python3 -m pip install numpy
 
 ######################## Vulkan SDK ############################################
-ARG VULKAN_SDK_VERSION=1.2.141
 
-# Disable apt-key parse waring. If someone knows how to do whatever the "proper"
-# thing is then feel free. The warning complains about parsing apt-key output,
-# which we're not even doing.
-ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+ARG VULKAN_SDK_VERSION=1.2.154.0
 
-RUN apt-get update \
-  && apt-get install apt-transport-https
+COPY --from=gcr.io/iree-oss/vulkan /opt/vulkan-sdk/ /opt/vulkan-sdk/
 
-# Note that this image is based on Ubuntu 16.04 (xenial) as opposed to
-# Ubuntu 18.04 (bionic), which we use for our other images.
-RUN wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc \
-    | apt-key add - \
-  && wget -qO \
-    "/etc/apt/sources.list.d/lunarg-vulkan-${VULKAN_SDK_VERSION?}-xenial.list" \
-    "http://packages.lunarg.com/vulkan/${VULKAN_SDK_VERSION?}/lunarg-vulkan-${VULKAN_SDK_VERSION?}-xenial.list" \
-  && apt-get update \
-  && apt-get install -y vulkan-sdk
+ENV VULKAN_SDK="/opt/vulkan-sdk/${VULKAN_SDK_VERSION}/x86_64"
 
 ######################## Swiftshader ###########################################
 COPY --from=install-swiftshader /swiftshader /swiftshader

--- a/build_tools/docker/swiftshader/Dockerfile
+++ b/build_tools/docker/swiftshader/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /install-swiftshader
 
 RUN apt-get update && apt-get install -y git
 
-ARG SWIFTSHADER_COMMIT=6287c18b1d249152563f0cb2d5cb0c6d0eb9e3d6
+ARG SWIFTSHADER_COMMIT=84f5eeb6dd9b225f465f93737fa76aad7de355cf
 
 # zlib is needed for compiling SwiftShader.
 RUN apt-get update && apt-get install -y zlib1g-dev

--- a/build_tools/docker/vulkan/Dockerfile
+++ b/build_tools/docker/vulkan/Dockerfile
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A base image for building IREE using CMake and running Vulkan tests. Requires
-# a child image to provide a Vulkan ICD.
+FROM ubuntu:18.04 AS final
 
-FROM gcr.io/iree-oss/cmake-python AS final
+RUN apt-get update && apt-get install -y wget
 
 ARG VULKAN_SDK_VERSION=1.2.154.0
 
-COPY --from=gcr.io/iree-oss/vulkan /opt/vulkan-sdk/ /opt/vulkan-sdk/
+RUN wget -q \
+  "https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION?}/linux/vulkansdk-linux-${VULKAN_SDK_VERSION?}.tar.gz" \
+  -O "/tmp/vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.gz"
 
-ENV VULKAN_SDK="/opt/vulkan-sdk/${VULKAN_SDK_VERSION}/x86_64"
+RUN mkdir -p /opt/vulkan-sdk
 
+RUN tar -xf /tmp/vulkansdk-linux-x86_64-$VULKAN_SDK_VERSION.tar.gz -C /opt/vulkan-sdk


### PR DESCRIPTION
This commit changes to download the Vulkan SDK tarball instead of
installing it from APT repo so that we can still get it for the
RBE toolchain. LunarG APT repo dropped support for Ubuntu 16.04
for recent SDK versions.

This commit also creates a base Vulkan SDK image so that other
docker images can copy the SDK from it.