### PR TITLE
Add a development pass for replacing flow.variables with splats.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "Passes.cpp",
         "PrePostPartitioningConversion.cpp",
         "RematerializeDispatchConstants.cpp",
+        "StripAndSplatConstantVariables.cpp",
     ],
     hdrs = [
         "DispatchConfig.h",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     "Passes.cpp"
     "PrePostPartitioningConversion.cpp"
     "RematerializeDispatchConstants.cpp"
+    "StripAndSplatConstantVariables.cpp"
   DEPS
     LLVMSupport
     MLIRIR

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -160,6 +160,18 @@ std::unique_ptr<OperationPass<FuncOp>> createHoistUnstreamableOpsPass();
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
+// Simplification and Development Tools
+//===----------------------------------------------------------------------===//
+
+// Strips constant flow.variables and replaces them with splats.
+// This destructively removes data (often model weights and other parameters)
+// and is intended for use as a development tool.
+// TODO(scotttodd): pass pipeline with this and other development passes to
+//                  generate test cases / models suitable for check-in
+std::unique_ptr<OperationPass<ModuleOp>>
+createStripAndSplatConstantVariablesPass();
+
+//===----------------------------------------------------------------------===//
 // Register all Passes
 //===----------------------------------------------------------------------===//
 
@@ -183,6 +195,7 @@ inline void registerFlowPasses() {
   createCreateFuncsToInvokeExecOpsPass();
   createFormStreamsPass();
   createHoistUnstreamableOpsPass();
+  createStripAndSplatConstantVariablesPass();
 }
 
 }  // namespace Flow

--- a/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
@@ -43,7 +43,7 @@ class StripAndSplatConstantVariablesPass
     // Use a heuristic to space out splat values in hopes of avoiding NaN and
     // INF values at runtime:
     //   floats: 1/1, 1/2, 1/3, ...
-    //   ints: 1, 2, 3, 4
+    //   ints: 1, 2, 3, 4, ...
     // TODO(scotttodd): flags to control numbers used (all 0, all 1, increasing)
     int replaceIndex = 1;
 
@@ -72,7 +72,6 @@ class StripAndSplatConstantVariablesPass
       builder.setInsertionPointAfter(op);
       auto newOp = builder.create<VariableOp>(
           op.getLoc(), op.sym_name(), op.is_mutable(), op.type(), newValue);
-
       SymbolTable::setSymbolVisibility(newOp,
                                        SymbolTable::getSymbolVisibility(op));
       newOp.setAttr("noinline", UnitAttr::get(builder.getContext()));

--- a/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
@@ -1,0 +1,99 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+class StripAndSplatConstantVariablesPass
+    : public PassWrapper<StripAndSplatConstantVariablesPass,
+                         OperationPass<ModuleOp>> {
+ public:
+  StripAndSplatConstantVariablesPass() = default;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect>();
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    auto builder = OpBuilder::atBlockBegin(moduleOp.getBody());
+
+    // Use a heuristic to space out splat values in hopes of avoiding NaN and
+    // INF values at runtime:
+    //   floats: 1/1, 1/2, 1/3, ...
+    //   ints: 1, 2, 3, 4
+    // TODO(scotttodd): flags to control numbers used (all 0, all 1, increasing)
+    int replaceIndex = 1;
+
+    moduleOp.walk([&](VariableOp op) {
+      // Only strip constant variables.
+      if (op.is_mutable()) {
+        return;
+      }
+
+      // Only strip tensor type constants (to replace with dense<>).
+      if (!op.type().isa<TensorType>()) {
+        return;
+      }
+
+      auto tensorType = op.type().cast<TensorType>();
+      auto elementType = tensorType.getElementType();
+      DenseElementsAttr newValue;
+      if (elementType.isa<FloatType>()) {
+        newValue = DenseElementsAttr::get(
+            tensorType, FloatAttr::get(elementType, 1.0 / replaceIndex));
+      } else {
+        newValue = DenseElementsAttr::get(
+            tensorType, IntegerAttr::get(elementType, replaceIndex));
+      }
+
+      builder.setInsertionPointAfter(op);
+      auto newOp = builder.create<VariableOp>(
+          op.getLoc(), op.sym_name(), op.is_mutable(), op.type(), newValue);
+
+      SymbolTable::setSymbolVisibility(newOp,
+                                       SymbolTable::getSymbolVisibility(op));
+      newOp.setAttr("noinline", UnitAttr::get(builder.getContext()));
+      op.erase();
+
+      replaceIndex++;
+    });
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createStripAndSplatConstantVariablesPass() {
+  return std::make_unique<StripAndSplatConstantVariablesPass>();  // NOLINT
+}
+
+static PassRegistration<StripAndSplatConstantVariablesPass> pass(
+    "iree-flow-strip-and-splat-constant-variables",
+    "Strips constant flow.variables and replaces them with splats.",
+    [] { return std::make_unique<StripAndSplatConstantVariablesPass>(); });
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
@@ -84,7 +84,7 @@ class StripAndSplatConstantVariablesPass
 
 std::unique_ptr<OperationPass<ModuleOp>>
 createStripAndSplatConstantVariablesPass() {
-  return std::make_unique<StripAndSplatConstantVariablesPass>();  // NOLINT
+  return std::make_unique<StripAndSplatConstantVariablesPass>();
 }
 
 static PassRegistration<StripAndSplatConstantVariablesPass> pass(

--- a/iree/compiler/Dialect/Flow/Transforms/test/strip_and_splat_constant_variables.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/strip_and_splat_constant_variables.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-opt -split-input-file -iree-flow-strip-and-splat-constant-variables %s | IreeFileCheck %s
+
+func @fn() -> () {
+  // CHECK: flow.variable @float_0 dense<1.000000e+00> : tensor<3xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @float_0 dense<"0x012345670123456701234567"> : tensor<3xf32> attributes {sym_visibility = "private"}
+  // CHECK: flow.variable @float_1 dense<5.000000e-01> : tensor<3xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @float_1 dense<"0x89ABCDEF89ABCDEF89ABCDEF"> : tensor<3xf32> attributes {sym_visibility = "private"}
+  // CHECK: flow.variable @int_1 dense<3> : tensor<3xi32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @int_1 dense<"0x89ABCDEF89ABCDEF89ABCDEF"> : tensor<3xi32> attributes {sym_visibility = "private"}
+  return
+}

--- a/iree/test/e2e/models/mnist_fake_weights.mlir
+++ b/iree/test/e2e/models/mnist_fake_weights.mlir
@@ -5,10 +5,10 @@
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all -iree-hal-target-backends=vulkan-spirv %s -function-input="1x28x28x1xf32" | IreeFileCheck %s)
 
 module attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 443 : i32}} {
-  flow.variable @"__iree_flow___sm_node17__model.layer-1.kernel" dense<0.5> : tensor<784x128xf32> attributes {sym_visibility = "private"}
-  flow.variable @"__iree_flow___sm_node18__model.layer-1.bias" dense<0.1> : tensor<128xf32> attributes {sym_visibility = "private"}
-  flow.variable @"__iree_flow___sm_node24__model.layer-2.kernel" dense<0.5> : tensor<128x10xf32> attributes {sym_visibility = "private"}
-  flow.variable @"__iree_flow___sm_node25__model.layer-2.bias" dense<0.1> : tensor<10xf32> attributes {sym_visibility = "private"}
+  flow.variable @"__iree_flow___sm_node17__model.layer-1.kernel" dense<1.000000e+00> : tensor<784x128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow___sm_node18__model.layer-1.bias" dense<5.000000e-01> : tensor<128xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow___sm_node24__model.layer-2.kernel" dense<0.333333343> : tensor<128x10xf32> attributes {noinline, sym_visibility = "private"}
+  flow.variable @"__iree_flow___sm_node25__model.layer-2.bias" dense<2.500000e-01> : tensor<10xf32> attributes {noinline, sym_visibility = "private"}
   // CHECK-LABEL: EXEC @predict
   func @predict(%arg0: tensor<1x28x28x1xf32> {tf._user_specified_name = "x"}) -> tensor<1x10xf32> attributes {iree.module.export, iree.reflection = {abi = "sip", abiv = 1 : i32, sip = "I8!S5!k0_0R3!_0"}, tf._input_shapes = [#tf.shape<1x28x28x1>, #tf.shape<*>, #tf.shape<*>, #tf.shape<*>, #tf.shape<*>], tf.signature.is_stateful} {
     %0 = flow.variable.address @"__iree_flow___sm_node17__model.layer-1.kernel" : !iree.ptr<tensor<784x128xf32>>


### PR DESCRIPTION
This can be used to process large model files down to a reasonable size for check-in as tests or other in-tree examples for compilation.

A heuristic is used to set the replacement values hoping to avoid NaNs/INFs. We could add flags to give some control over that (some models are fine with all `0`, `0.5`, or `1` values, while others are more sensitive).

We can add similar passes for inserting certain `check` ops, converting inputs into constants (https://github.com/google/iree/pull/3624), and other steps that we've previously performed manually.