### PR TITLE
Add fusion of chain of linalg operations on buffers.

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -609,9 +609,7 @@ struct MapLinalgOpToLocalInvocationId : public OpConversionPattern<LinalgOpTy> {
           return outputType &&
                  outputType.getMemorySpace() == getWorkgroupMemorySpace();
         })) {
-      rewriter.create<spirv::ControlBarrierOp>(
-          linalgOp.getLoc(), spirv::Scope::Workgroup, spirv::Scope::Workgroup,
-          spirv::MemorySemantics::AcquireRelease);
+      insertBarrier(rewriter, linalgOp.getLoc());
     }
     rewriter.eraseOp(linalgOp);
     return success();
@@ -716,9 +714,7 @@ struct TileAndDistributeCopyOp : public OpConversionPattern<linalg::CopyOp> {
           return output.getType().cast<MemRefType>().getMemorySpace() ==
                  getWorkgroupMemorySpace();
         })) {
-      rewriter.create<spirv::ControlBarrierOp>(
-          linalgOp.getLoc(), spirv::Scope::Workgroup, spirv::Scope::Workgroup,
-          spirv::MemorySemantics::AcquireRelease);
+      insertBarrier(rewriter, linalgOp.getLoc());
     }
     rewriter.eraseOp(linalgOp);
     return success();

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
@@ -25,10 +25,12 @@
 #include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
 #include "iree/compiler/Conversion/LinalgToSPIRV/Attributes.h"
 #include "iree/compiler/Conversion/LinalgToSPIRV/Passes.h"
+#include "iree/compiler/Conversion/LinalgToSPIRV/Utils.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SPIRV/TargetAndABI.h"
@@ -431,9 +433,9 @@ Optional<StringRef> LaunchConfig::getKey(Operation *op) const {
   return attr.getValue();
 }
 
-LogicalResult LaunchConfig::init(MLIRContext *context,
-                                 const SPIRVCodegenOptions &options,
-                                 ArrayRef<Operation *> linalgOps) {
+LogicalResult LaunchConfig::init(
+    MLIRContext *context, const linalg::LinalgDependenceGraph &dependenceGraph,
+    const SPIRVCodegenOptions &options, ArrayRef<Operation *> linalgOps) {
   unsigned numTiledOps = 0;
   auto setKey = [&](Operation *op) -> std::string {
     std::string key = llvm::formatv("__op_num_{0}__", numTiledOps++).str();
@@ -486,6 +488,63 @@ LogicalResult LaunchConfig::init(MLIRContext *context,
     DISPATCH(linalg::PoolingSumOp)
 
 #undef DISPATCH
+  }
+
+  if (!rootOperation) {
+    // No root operations found. Dont need to do anything.
+    return success();
+  }
+
+  // Check the dependencies going into and out of the root operation. For now
+  // only the following dependencies are supported
+  // - WAW dependencies going into the root operation.
+  // - RAW dependencies going out of the root operation.
+  // - WAW dependencies going out of the root operation.
+  // i.e. there are no RAW dependences going into the root operation.
+  auto inRAWDependencies = dependenceGraph.getDependencesInto(
+      *rootOperation, linalg::LinalgDependenceGraph::RAW);
+  if (!inRAWDependencies.empty()) {
+    return rootOperation->getOperation()->emitError(
+        "unhandled fusion of root operation with producer");
+  }
+  auto dependences =
+      dependenceGraph.getDependentOperations(rootOperation.getValue());
+  unsigned numOuterParallel = getNumOuterParallelLoops(*rootOperation);
+
+  // Check that for all dependences into and out of the root operation,
+  // - The result expressions of the indexing maps of the fused view in the
+  //   producer and consumer must match for the parallel loops.
+  for (auto dependence :
+       dependenceGraph.getDependentOperations(rootOperation.getValue())) {
+    Optional<unsigned> viewIndex =
+        rootOperation->getIndexOfShapedOperand(dependence.indexingView);
+    AffineMap indexingMap = rootOperation->getIndexingMap(*viewIndex);
+    linalg::LinalgOp fusedOp =
+        cast<linalg::LinalgOp>(dependence.dependentOpView.op);
+    Optional<unsigned> fusedViewIndex =
+        fusedOp.getIndexOfShapedOperand(dependence.dependentOpView.view);
+    AffineMap fusedIndexingMap = fusedOp.getIndexingMap(*fusedViewIndex);
+    if (indexingMap.getNumResults() < numOuterParallel ||
+        fusedIndexingMap.getNumResults() < numOuterParallel ||
+        !llvm::all_of(
+            llvm::seq<unsigned>(0, numOuterParallel),
+            [&indexingMap, fusedIndexingMap](unsigned i) {
+              return indexingMap.getResult(i).isa<AffineDimExpr>() &&
+                     fusedIndexingMap.getResult(i).isa<AffineDimExpr>() &&
+                     indexingMap.getResult(i) == fusedIndexingMap.getResult(i);
+            })) {
+      return rootOperation->getOperation()->emitError(
+          "unhandled fusion of root operation with all operations in the "
+          "dispatch region");
+    }
+  }
+  // The dependent operations get the same tile size information as the root
+  // operation. To propogate that information, just use the same key as the root
+  // operation.
+  for (auto dependence : dependences) {
+    dependence.dependentOpView.op->setAttr(
+        Identifier::get(kLaunchInfoKey, context),
+        StringAttr::get(getKey(*rootOperation).getValue(), context));
   }
 
   // TODO(ravishankarm): Verify that the set configurations is within the device

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.h
@@ -39,6 +39,7 @@ class ShapedType;
 class Value;
 
 namespace linalg {
+class LinalgDependenceGraph;
 class LinalgOp;
 }  // namespace linalg
 namespace iree_compiler {
@@ -95,7 +96,9 @@ class LaunchConfig {
   /// - tile sizes for each level,
   /// - the workgroup size, and
   /// - number of subgroups to use.
-  LogicalResult init(MLIRContext *context, const SPIRVCodegenOptions &options,
+  LogicalResult init(MLIRContext *context,
+                     const linalg::LinalgDependenceGraph &dependenceGraph,
+                     const SPIRVCodegenOptions &options,
                      ArrayRef<Operation *> linalgOps);
 
   /// Remove attributed added to operations for retrieving tile size

--- a/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
@@ -31,6 +31,10 @@ class OperationFolder;
 class OpBuilder;
 class LogicalResult;
 
+namespace linalg {
+class LinalgOp;
+}
+
 namespace iree_compiler {
 
 static constexpr int kNumGPUDims = 3;
@@ -52,6 +56,12 @@ LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer);
 /// known to be greater than equal to the number of iteration of loops the
 /// copy is lowered to.
 LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst);
+
+/// Function to get number of outer parallel loops of a linalgOp
+unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
+
+/// Function to insert synchronization across workgroup.
+LogicalResult insertBarrier(OpBuilder &b, Location loc);
 
 class GPUGlobalId;
 class GPUGlobalCount;

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/fusion.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/fusion.mlir
@@ -1,0 +1,48 @@
+
+module attributes {
+  spv.target_env =
+    #spv.target_env<#spv.vce<v1.3,
+    [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+    {max_compute_workgroup_invocations = 128 : i32,
+     max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @matmul_fusion() attributes {vkspv.num_workgroups_fn = @matmul_fusion__num_workgroups__} {
+    %0 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<?x?xf32>
+    %1 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<?x?xf32>
+    %2 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@arg2, operand_result_index = 2 : i32} : memref<?xf32>
+    %3 = iree.placeholder for "interace buffer"
+      {binding = @legacy_io::@ret0, operand_result_index = 3 : i32} : memref<?x?xf32>
+    %cst = constant 0.000000e+00 : f32
+    %c0 = constant 0 : index
+    %c1 = constant 0 : index
+    %d0 = dim %0, %c0 : memref<?x?xf32>
+    %d1 = dim %1, %c1 : memref<?x?xf32>
+    %4 = alloc(%d0, %d1) : memref<?x?xf32>
+    linalg.fill(%4, %cst) : memref<?x?xf32>, f32
+    linalg.matmul ins(%0, %1 : memref<?x?xf32>, memref<?x?xf32>)
+      outs(%4 : memref<?x?xf32>)
+    linalg.generic
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]}
+      ins(%4, %2 : memref<?x?xf32>, memref<?xf32>)
+      outs(%3 : memref<?x?xf32>) {
+      ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32) :
+        %5 = addf %arg0, %arg1 : f32
+        linalg.yield %5 : f32
+      }
+    return
+  }
+  func @matmul_fusion__num_workgroups__
+    (!shapex.ranked_shape<[?,?]>, !shapex.ranked_shape<[?,?]>,
+     !shapex.ranked_shape<[?,?]>) -> (index, index, index)
+    attributes {sym_visibility = "private"}
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}


### PR DESCRIPTION
This is the first (of a few) changes to enable fusion of linalg
operations like matmul, conv, etc with its consumers. This is by
taking a sequence of linalg operations, tiling the last one in the
sequence and fusing everything else with it. It also promoted the
intermediate results to be written and read from workgroup memory.

The change steps away from using pattern based rewrites for the first
level of tiling (i.e. tiling to map to workgroups). Since we need to
do potentially more than 1 fusion steps, staging that with markers,
etc. can get very complex. The current implementation separates parts
that can be moved into Linalg (and is probably better to do that
anyway) from the IREE specific parts.