### PR TITLE
Unbreak usage of applyPatternsAndFoldGreedily

### DIFF
--- a/iree/compiler/Conversion/CodegenUtils/MatmulCodegenStrategy.cpp
+++ b/iree/compiler/Conversion/CodegenUtils/MatmulCodegenStrategy.cpp
@@ -253,7 +253,7 @@ void MatmulCodegenStrategy::transform(FuncOp func) const {
     }
     OwningRewritePatternList patterns;
     vector::populateVectorSlicesLoweringPatterns(patterns, op->getContext());
-    applyPatternsAndFoldGreedily(op, patterns);
+    applyPatternsAndFoldGreedily(op, std::move(patterns));
   };
   postStageTransforms(func);
   if (lowering != nullptr) lowering(func);


### PR DESCRIPTION
MLIR APIs changed and this was merged after being tested based on an
older commit. Not much we could do differently here other than always
testing the merge commit instead of the head commit, but that comes
with its own set of issues.