### PR TITLE
Explicitly fetch tags for llvm-bazel

### DIFF
--- a/.github/workflows/update_llvm_dependent_submodules.yml
+++ b/.github/workflows/update_llvm_dependent_submodules.yml
@@ -23,7 +23,7 @@ on:
     - cron: "0 */6 * * *"
 
 jobs:
-  update_tf:
+  update_llvm_dependents:
     # Don't run this in everyone's forks.
     if: github.repository == 'google/iree'
     runs-on: ubuntu-18.04

--- a/scripts/git/update_to_llvm_syncpoint.py
+++ b/scripts/git/update_to_llvm_syncpoint.py
@@ -157,7 +157,8 @@ def get_commit(path, rev="HEAD"):
 
 
 def find_new_llvm_bazel_commit(llvm_bazel_path, llvm_commit, llvm_bazel_commit):
-  utils.execute(["git", "fetch"], cwd=llvm_bazel_path)
+  # Explicitly specify tags. We need these.
+  utils.execute(["git", "fetch", "--tags"], cwd=llvm_bazel_path)
 
   if llvm_bazel_commit not in COMMIT_OPTIONS:
     return get_commit(llvm_bazel_path, rev=llvm_bazel_commit)


### PR DESCRIPTION
We need the tags to find the matching LLVM commit and in some git
configurations (e.g. in the GitHub actions) they won't be fetched by
default. This fixes the
[Synchronize LLVM Dependents workflow](https://github.com/google/iree/actions?query=workflow%3A%22Synchronize+LLVM+Dependents%22)
which has been broken for a bit in the case where it actually needs to
fetch a new version of llvm-bazel.

Tested:
  Pushed to my fork
  https://github.com/GMNGeoffrey/iree/runs/1334664578 created
  https://github.com/GMNGeoffrey/iree/pull/60