### PR TITLE
Miscellaneous fixes to address issues seen with vectorization.

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.h
@@ -39,6 +39,7 @@ class ShapedType;
 class Value;
 
 namespace linalg {
+class LinalgDependenceGraph;
 class LinalgOp;
 }  // namespace linalg
 namespace iree_compiler {
@@ -71,7 +72,9 @@ class LaunchConfig {
   /// - tile sizes for each level,
   /// - the workgroup size, and
   /// - number of subgroups to use.
-  LogicalResult init(MLIRContext *context, const SPIRVCodegenOptions &options,
+  LogicalResult init(MLIRContext *context,
+                     const linalg::LinalgDependenceGraph &dependenceGraph,
+                     const SPIRVCodegenOptions &options,
                      ArrayRef<Operation *> linalgOps);
 
   /// Remove attributed added to operations for retrieving tile size

--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -521,9 +521,6 @@ static void applyVectorTransformation(FuncOp funcOp) {
   }
 
   {
-    // TODO(ravishankarm): remove this transformation once allocations get
-    // inserted at the top of the function.
-    linalg::hoistViewAllocOps(funcOp);
     linalg::hoistRedundantVectorTransfers(funcOp);
 
     LLVM_DEBUG({
@@ -567,7 +564,10 @@ void LinalgTileAndFusePass::runOnOperation() {
     LaunchConfig launchConfig;
     SmallVector<Operation *, 4> linalgOpsVec(linalgOps.begin(),
                                              linalgOps.end());
-    if (failed(launchConfig.init(context, options, linalgOpsVec))) {
+    linalg::Aliases aliases;
+    linalg::LinalgDependenceGraph dependenceGraph(aliases, linalgOpsVec);
+    if (failed(launchConfig.init(context, dependenceGraph, options,
+                                 linalgOpsVec))) {
       funcOp.emitError("unable to find launch configuration");
       return signalPassFailure();
     }
@@ -592,11 +592,6 @@ void LinalgTileAndFusePass::runOnOperation() {
     });
 
     {
-      // Compute the Linalg Dependence Graph.
-      linalg::Aliases aliases;
-      linalg::LinalgDependenceGraph dependenceGraph =
-          linalg::LinalgDependenceGraph::buildDependenceGraph(aliases, funcOp);
-
       OwningRewritePatternList firstLevelTilingPatterns;
       populateTilingToWorkgroupPatterns(context, dependenceGraph, launchConfig,
                                         firstLevelTilingPatterns);

--- a/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
@@ -34,18 +34,10 @@ class LogicalResult;
 namespace iree_compiler {
 
 static constexpr int kNumGPUDims = 3;
-
-/// Updates the workgroup size used for the dispatch region.
-LogicalResult updateWorkGroupSize(FuncOp funcOp,
-                                  ArrayRef<int64_t> workGroupSize);
-
 /// Allocation callback for allocation workgroup local memory.
 Optional<Value> allocateWorkgroupMemory(OpBuilder &b, SubViewOp subview,
                                         ArrayRef<Value> boundingSubViewSize,
                                         OperationFolder *folder);
-
-/// Deallocation callback for allocation workgroup local memory.
-LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer);
 
 /// Function used as callback for copyin/copyout in promotion pattern used
 /// to promote subviews to workgroup memory when the number of threads is
@@ -53,15 +45,24 @@ LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer);
 /// copy is lowered to.
 LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst);
 
-class GPUGlobalId;
-class GPUGlobalCount;
+/// Deallocation callback for allocation workgroup local memory.
+LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer);
 
 /// Generate the operations that compute the processor ID and number of
 /// processors. Used as the callback needed for LinalgDistributionOptions.
+class GPUGlobalId;
+class GPUGlobalCount;
 template <typename GPUIdOp, typename GPUCountOp>
 SmallVector<linalg::ProcInfo, 2> getGPUProcessorIdsAndCounts(OpBuilder &builder,
                                                              Location loc,
                                                              unsigned numDims);
+
+/// Function to get number of outer parallel loops of a linalgOp
+unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
+
+/// Updates the workgroup size used for the dispatch region.
+LogicalResult updateWorkGroupSize(FuncOp funcOp,
+                                  ArrayRef<int64_t> workGroupSize);
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/matmul_vectorization.mlir
@@ -274,19 +274,19 @@ module attributes {
 //  PROMOTE-DAG:  %[[C16:.+]] = constant 16
 //  PROMOTE-DAG:  %[[C32:.+]] = constant 32
 //  PROMOTE-DAG:  %[[C48:.+]] = constant 48
+//  PROMOTE-DAG:  %[[ALLOC1:.+]] = alloc() : memref<128x32xf16, 3>
+//  PROMOTE-DAG:  %[[ALLOC2:.+]] = alloc() : memref<32x128xf16, 3>
 
-//  PROMOTE:    %[[ALLOC1:.+]] = alloc()
-//  PROMOTE:    %[[ALLOC2:.+]] = alloc()
-//  PROMOTE:    %[[RESULT_SUBVIEW:.+]] = subview %[[RET0]]
-//  PROMOTE:    %[[WGMEM_LHS_SUBVIEW:.+]] = subview %[[ALLOC1]][0, 0] [128, 32] [1, 1]
-//  PROMOTE:    %[[WGMEM_RHS_SUBVIEW:.+]] = subview %[[ALLOC2]][0, 0] [32, 128] [1, 1]
-//  PROMOTE:    %[[SG_X:.+]] = gpu.subgroup_id
-//  PROMOTE:    %[[SG_Y:.+]] = divi_signed %[[SG_X]], %[[C2]]
-//  PROMOTE:    %[[SGOFFSET_Y:.+]] = affine.apply #[[MAP4]]()[%[[SG_Y]]]
-//  PROMOTE:    %[[SG_LHS_SUBVIEW:.+]] = subview %[[WGMEM_LHS_SUBVIEW]][%[[SGOFFSET_Y]], 0]
-//  PROMOTE:    %[[SGOFFSET_X:.+]] = affine.apply #[[MAP4]]()[%[[SG_X]]]
-//  PROMOTE:    %[[SG_RHS_SUBVIEW:.+]] = subview %[[WGMEM_RHS_SUBVIEW]][0, %[[SGOFFSET_X]]]
-//  PROMOTE:    %[[SG_RESULT_SUBVIEW:.+]] = subview %[[RESULT_SUBVIEW]][%[[SGOFFSET_Y]], %[[SGOFFSET_X]]]
+//      PROMOTE:  %[[RESULT_SUBVIEW:.+]] = subview %[[RET0]]
+//      PROMOTE:  %[[WGMEM_LHS_SUBVIEW:.+]] = subview %[[ALLOC1]][0, 0] [128, 32] [1, 1]
+//      PROMOTE:  %[[WGMEM_RHS_SUBVIEW:.+]] = subview %[[ALLOC2]][0, 0] [32, 128] [1, 1]
+//      PROMOTE:  %[[SG_X:.+]] = gpu.subgroup_id
+//      PROMOTE:  %[[SG_Y:.+]] = divi_signed %[[SG_X]], %[[C2]]
+//      PROMOTE:  %[[SGOFFSET_Y:.+]] = affine.apply #[[MAP4]]()[%[[SG_Y]]]
+//      PROMOTE:  %[[SG_LHS_SUBVIEW:.+]] = subview %[[WGMEM_LHS_SUBVIEW]][%[[SGOFFSET_Y]], 0]
+//      PROMOTE:  %[[SGOFFSET_X:.+]] = affine.apply #[[MAP4]]()[%[[SG_X]]]
+//      PROMOTE:  %[[SG_RHS_SUBVIEW:.+]] = subview %[[WGMEM_RHS_SUBVIEW]][0, %[[SGOFFSET_X]]]
+//      PROMOTE:  %[[SG_RESULT_SUBVIEW:.+]] = subview %[[RESULT_SUBVIEW]][%[[SGOFFSET_Y]], %[[SGOFFSET_X]]]
 
 //  PROMOTE-DAG:  %[[READ_INIT_0_0:.+]] = vector.transfer_read
 // PROMOTE-SAME:    %[[SG_RESULT_SUBVIEW]][%[[C0]], %[[C0]]]

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
@@ -31,7 +31,7 @@ module attributes {
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0
 //   CHECK-DAG:   %[[ALLOC1:.+]] = alloc() : memref<8x32xf32, 3>
-//   CHECK-DAG:     %[[ALLOC2:.+]] = alloc() : memref<32x16xf32, 3>
+//   CHECK-DAG:   %[[ALLOC2:.+]] = alloc() : memref<32x16xf32, 3>
 //       CHECK:   scf.for
 //       CHECK:     %[[ARG0SV:.+]] = subview %[[ARG0]]
 //       CHECK:     %[[ARG1SV:.+]] = subview %[[ARG1]]

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
@@ -30,13 +30,13 @@ module attributes {
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[ALLOC1:.+]] = alloc() : memref<8x32xf32, 3>
+//   CHECK-DAG:     %[[ALLOC2:.+]] = alloc() : memref<32x16xf32, 3>
 //       CHECK:   scf.for
 //       CHECK:     %[[ARG0SV:.+]] = subview %[[ARG0]]
 //       CHECK:     %[[ARG1SV:.+]] = subview %[[ARG1]]
 //       CHECK:     %[[RET0SV:.+]] = subview %[[RET0]]
-//       CHECK:     %[[ALLOC1:.+]] = alloc() : memref<8x32xf32, 3>
 //       CHECK:     %[[SUBVIEW1:.+]] = subview %[[ALLOC1]]
-//       CHECK:     %[[ALLOC2:.+]] = alloc() : memref<32x16xf32, 3>
 //       CHECK:     %[[SUBVIEW2:.+]] = subview %[[ALLOC2]]
 //       CHECK:     linalg.copy(%[[ARG0SV]], %[[SUBVIEW1]])
 //  CHECK-SAME:       "copy_to_workgroup_memory"
@@ -46,8 +46,6 @@ module attributes {
 //  CHECK-SAME:       "workgroup_memory"
 //  CHECK-SAME:       ins(%[[SUBVIEW1]], %[[SUBVIEW2]]
 //  CHECK-SAME:      outs(%[[RET0SV]]
-//   CHECK-DAG:     dealloc %[[ALLOC1]] : memref<8x32xf32, 3>
-//   CHECK-DAG:     dealloc %[[ALLOC2]] : memref<32x16xf32, 3>
 
 // -----
 
@@ -82,12 +80,11 @@ module attributes {
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0
 //   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1
 //   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0
+//   CHECK-DAG:   %[[ALLOC1:.+]] = alloc() : memref<1x6x35x3xf32, 3>
 //       CHECK:   %[[ARG1SV:.+]] = subview %[[ARG1]]
 //       CHECK:   %[[RET0SV:.+]] = subview %[[RET0]]
-//       CHECK:   %[[ALLOC1:.+]] = alloc() : memref<1x6x35x3xf32, 3>
 //       CHECK:   %[[SUBVIEW1:.+]] = subview %[[ALLOC1]]
 //       CHECK:   linalg.copy(%[[ARG1SV]], %[[SUBVIEW1]])
 //  CHECK-SAME:      "copy_to_workgroup_memory"
 //       CHECK:   linalg.conv(%[[ARG0]], %[[SUBVIEW1]], %[[RET0SV]])
 //  CHECK-SAME:      "workgroup_memory"
-//       CHECK:   dealloc %[[ALLOC1]] : memref<1x6x35x3xf32, 3>


### PR DESCRIPTION
Propogate tile sizes to use on root operation to all dependent
operations. This enables each operation can be tiled the same way if
needed.
Also modifies the allocation/deallocation callbacks to allocate
workgroup memory at the entry of the function and not explicitly
deallocate it. This better matches semantics of workgroup memory and
also avoid complications arising from having to hoist the allocation.

Depends on patch : https://reviews.llvm.org/D90582