### PR TITLE
Relax TorchIndexSelectOp to fuse with other ops.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -33,8 +33,8 @@ namespace {
 // from this exclusion list eventually.
 bool isUnsupportedFusionOp(Operation *op) {
   return isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp, mhlo::DotOp,
-             mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp, mhlo::SliceOp,
-             mhlo::TorchIndexSelectOp>(op);
+             mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp, mhlo::SliceOp>(
+      op);
 }
 
 // Allowlist of ops that materialize to a an index-permuted copy of some kind

--- a/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
@@ -199,7 +199,7 @@ bool isDispatchRegionMergable(DispatchRegionOp &regionOp) {
       // TODO(b/144530470): replace with tablegen attributes/interfaces.
       if (isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp,
               mhlo::DotOp, mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp,
-              mhlo::SliceOp, mhlo::TorchIndexSelectOp>(op)) {
+              mhlo::SliceOp>(op)) {
         return false;
       }
     }


### PR DESCRIPTION
After moving the op to tensors world, the ops can be fused with their
consumer. The patch also allows the ops to live with their producers in
the same dispatch function. This does not break any models. Go through
some models and lowering from TF, the input of the ops usually are from
constant or model input, which becomes a buffer in IREE.

Fixes https://github.com/google/iree/issues/3562