### PR TITLE
Forward some more CMake variables to host builds.

### DIFF
--- a/build_tools/cmake/iree_cross_compile.cmake
+++ b/build_tools/cmake/iree_cross_compile.cmake
@@ -118,19 +118,18 @@ function(iree_create_configuration CONFIG_NAME)
         -DIREE_BUILD_PYTHON_BINDINGS=${_CONFIG_BUILD_PYTHON_BINDINGS}
         -DIREE_BUILD_JAVA_BINDINGS=${_CONFIG_BUILD_JAVA_BINDINGS}
         -DIREE_BUILD_EXPERIMENTAL=${_CONFIG_BUILD_EXPERIMENTAL}
-        -DIREE_ENABLE_ASAN=${IREE_ENABLE_ASAN}
-        -DIREE_ENABLE_MSAN=${IREE_ENABLE_MSAN}
-        -DIREE_ENABLE_TSAN=${IREE_ENABLE_TSAN}
-        -DIREE_ENABLE_CCACHE=${IREE_ENABLE_CCACHE}
-        -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
-        -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
-        
         # LINT.ThenChange(
         #   https://github.com/google/iree/tree/main/CMakeLists.txt:iree_options,
         #   https://github.com/google/iree/tree/main/build_tools/cmake/iree_cross_compile.cmake:iree_cross_compile_options,
         # )
         -DIREE_HAL_DRIVERS_TO_BUILD="${_CONFIG_HAL_DRIVERS_TO_BUILD}"
         -DIREE_TARGET_BACKENDS_TO_BUILD="${_CONFIG_TARGET_BACKENDS_TO_BUILD}"
+        -DIREE_ENABLE_ASAN=${IREE_ENABLE_ASAN}
+        -DIREE_ENABLE_MSAN=${IREE_ENABLE_MSAN}
+        -DIREE_ENABLE_TSAN=${IREE_ENABLE_TSAN}
+        -DIREE_ENABLE_CCACHE=${IREE_ENABLE_CCACHE}
+        -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
+        -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
     WORKING_DIRECTORY ${_CONFIG_BINARY_ROOT}
     DEPENDS iree_prepare_${CONFIG_NAME}_dir
     COMMENT "Configuring IREE for ${CONFIG_NAME} build...")

--- a/build_tools/cmake/iree_cross_compile.cmake
+++ b/build_tools/cmake/iree_cross_compile.cmake
@@ -118,6 +118,13 @@ function(iree_create_configuration CONFIG_NAME)
         -DIREE_BUILD_PYTHON_BINDINGS=${_CONFIG_BUILD_PYTHON_BINDINGS}
         -DIREE_BUILD_JAVA_BINDINGS=${_CONFIG_BUILD_JAVA_BINDINGS}
         -DIREE_BUILD_EXPERIMENTAL=${_CONFIG_BUILD_EXPERIMENTAL}
+        -DIREE_ENABLE_ASAN=${IREE_ENABLE_ASAN}
+        -DIREE_ENABLE_MSAN=${IREE_ENABLE_MSAN}
+        -DIREE_ENABLE_TSAN=${IREE_ENABLE_TSAN}
+        -DIREE_ENABLE_CCACHE=${IREE_ENABLE_CCACHE}
+        -DLLVM_CCACHE_BUILD=${LLVM_CCACHE_BUILD}
+        -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
+        
         # LINT.ThenChange(
         #   https://github.com/google/iree/tree/main/CMakeLists.txt:iree_options,
         #   https://github.com/google/iree/tree/main/build_tools/cmake/iree_cross_compile.cmake:iree_cross_compile_options,


### PR DESCRIPTION
This makes it so that these variables (which control sanitizers, use of
ccache, and cmake verbosity) apply also to the host build, not just to
the target build.