### PR TITLE
Put sanitizer flags in global CMake variables, affecting all code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ option(IREE_ENABLE_TSAN "Enable thread sanitizer" OFF)
 
 include(iree_macros)
 include(iree_copts)
+include(sanitizers)
 include(iree_whole_archive_link)
 include(iree_cc_binary)
 include(iree_cc_library)

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -135,35 +135,6 @@ set(IREE_DEFAULT_LINKOPTS "${ABSL_DEFAULT_LINKOPTS}")
 set(IREE_TEST_COPTS "${ABSL_TEST_COPTS}")
 
 #-------------------------------------------------------------------------------
-# Sanitizer configurations
-#-------------------------------------------------------------------------------
-
-# Note: we add these flags to the global CMake flags, not to IREE-specific
-# variables such as IREE_DEFAULT_COPTS so that all symbols are consistently
-# defined with the same sanitizer flags, including e.g. standard library
-# symbols that might be used by both IREE and non-IREE (e.g. LLVM) code.
-
-if(${IREE_ENABLE_ASAN})
-  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=address")
-  string(APPEND CMAKE_C_FLAGS " -fsanitize=address")
-endif()
-if(${IREE_ENABLE_MSAN})
-  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=memory")
-  string(APPEND CMAKE_C_FLAGS " -fsanitize=memory")
-endif()
-if(${IREE_ENABLE_TSAN})
-  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=thread")
-  string(APPEND CMAKE_C_FLAGS " -fsanitize=thread")
-endif()
-if(ANDROID)
-  # Work around https://github.com/android/ndk/issues/1088
-  if(${IREE_ENABLE_ASAN} OR ${IREE_ENABLE_MSAN} OR ${IREE_ENABLE_TSAN})
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=gold")
-    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fuse-ld=gold")
-  endif()
-endif()
-
-#-------------------------------------------------------------------------------
 # Size-optimized build flags
 #-------------------------------------------------------------------------------
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -138,19 +138,28 @@ set(IREE_TEST_COPTS "${ABSL_TEST_COPTS}")
 # Sanitizer configurations
 #-------------------------------------------------------------------------------
 
+# Note: we add these flags to the global CMake flags, not to IREE-specific
+# variables such as IREE_DEFAULT_COPTS so that all symbols are consistently
+# defined with the same sanitizer flags, including e.g. standard library
+# symbols that might be used by both IREE and non-IREE (e.g. LLVM) code.
+
 if(${IREE_ENABLE_ASAN})
-  list(APPEND IREE_DEFAULT_COPTS "-fsanitize=address")
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=address")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=address")
 endif()
 if(${IREE_ENABLE_MSAN})
-  list(APPEND IREE_DEFAULT_COPTS "-fsanitize=memory")
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=memory")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=memory")
 endif()
 if(${IREE_ENABLE_TSAN})
-  list(APPEND IREE_DEFAULT_COPTS "-fsanitize=thread")
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=thread")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=thread")
 endif()
 if(ANDROID)
   # Work around https://github.com/android/ndk/issues/1088
   if(${IREE_ENABLE_ASAN} OR ${IREE_ENABLE_MSAN} OR ${IREE_ENABLE_TSAN})
-    list(APPEND IREE_DEFAULT_LINKOPTS "-fuse-ld=gold")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=gold")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fuse-ld=gold")
   endif()
 endif()
 

--- a/build_tools/cmake/sanitizers.cmake
+++ b/build_tools/cmake/sanitizers.cmake
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-------------------------------------------------------------------------------
+# Sanitizer configurations
+#-------------------------------------------------------------------------------
+
+# Note: we add these flags to the global CMake flags, not to IREE-specific
+# variables such as IREE_DEFAULT_COPTS so that all symbols are consistently
+# defined with the same sanitizer flags, including e.g. standard library
+# symbols that might be used by both IREE and non-IREE (e.g. LLVM) code.
+
+if(${IREE_ENABLE_ASAN})
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=address")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=address")
+endif()
+if(${IREE_ENABLE_MSAN})
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=memory")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=memory")
+endif()
+if(${IREE_ENABLE_TSAN})
+  string(APPEND CMAKE_CXX_FLAGS " -fsanitize=thread")
+  string(APPEND CMAKE_C_FLAGS " -fsanitize=thread")
+endif()
+if(ANDROID)
+  # Work around https://github.com/android/ndk/issues/1088
+  if(${IREE_ENABLE_ASAN} OR ${IREE_ENABLE_MSAN} OR ${IREE_ENABLE_TSAN})
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=gold")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fuse-ld=gold")
+  endif()
+endif()


### PR DESCRIPTION
My concern with putting it only on IREE code and not say on LLVM code
is that we might end up getting inconsistent results, particularly
with symbols used in both IREE and non-IREE code --- ODR violations,
concern here is both with the undefined-behavior aspect of that and
with the more down to earch concern that we want consistent sanitizer
behavior in say std::string code that might be used on both sides.