### PR TITLE
Add support for stdin to iree-benchmark-module

### DIFF
--- a/iree/test/e2e/regression/executable_benchmark.mlir
+++ b/iree/test/e2e/regression/executable_benchmark.mlir
@@ -1,5 +1,5 @@
 // Only checks registered benchmarks.
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-executable-benchmark-vm-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla -module_file=${TEST_TMPDIR?}/bc.module --benchmark_list_tests=true | IreeFileCheck %s
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-executable-benchmark-vm-module %s | iree-benchmark-module --driver=vmla --benchmark_list_tests=true | IreeFileCheck %s
 
 func @two_dispatch() -> (tensor<5x5xf32>, tensor<3x5xf32>) attributes { iree.module.export } {
   %0 = iree.unfoldable_constant dense<1.0> : tensor<5x3xf32>

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -117,13 +117,6 @@ StatusOr<std::string> GetModuleContentsFromFlags() {
   return contents;
 }
 
-Status GetModuleContentsFromFlags(std::string& module_data) {
-  IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
-  auto module_file = absl::GetFlag(FLAGS_module_file);
-  IREE_ASSIGN_OR_RETURN(module_data, file_io::GetFileContents(module_file));
-  return iree::OkStatus();
-}
-
 // TODO(hanchung): Consider to refactor this out and reuse in iree-run-module.
 // This class helps organize required resources for IREE. The order of
 // construction and destruction for resources matters. And the lifetime of

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -26,12 +26,9 @@
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"
 
-// TODO(gcmn): Allow stdin in a non-gross way. The benchmark framework invokes
-// the benchmarking function multiple times, so we have to do something to only
-// process stdin once. Probably requires dynamic benchmark registration.
-ABSL_FLAG(std::string, module_file, "",
+ABSL_FLAG(std::string, module_file, "-",
           "File containing the module to load that contains the entry "
-          "function. Required and cannot be stdin.");
+          "function. Defaults to stdin.");
 
 ABSL_FLAG(std::string, entry_function, "",
           "Name of a function contained in the module specified by module_file "
@@ -107,6 +104,19 @@ void RegisterModuleBenchmarks(
       ->Unit(benchmark::kMillisecond);
 }
 
+StatusOr<std::string> GetModuleContentsFromFlags() {
+  IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
+  auto module_file = absl::GetFlag(FLAGS_module_file);
+  std::string contents;
+  if (module_file == "-") {
+    contents = std::string{std::istreambuf_iterator<char>(std::cin),
+                           std::istreambuf_iterator<char>()};
+  } else {
+    IREE_ASSIGN_OR_RETURN(contents, file_io::GetFileContents(module_file));
+  }
+  return contents;
+}
+
 Status GetModuleContentsFromFlags(std::string& module_data) {
   IREE_TRACE_SCOPE0("GetModuleContentsFromFlags");
   auto module_file = absl::GetFlag(FLAGS_module_file);
@@ -161,7 +171,7 @@ class IREEBenchmark {
     IREE_TRACE_SCOPE0("IREEBenchmark::Init");
     IREE_TRACE_FRAME_MARK_BEGIN_NAMED("init");
 
-    IREE_RETURN_IF_ERROR(GetModuleContentsFromFlags(module_data_));
+    IREE_ASSIGN_OR_RETURN(module_data_, GetModuleContentsFromFlags());
 
     IREE_RETURN_IF_ERROR(iree_hal_module_register_types());
     IREE_RETURN_IF_ERROR(

--- a/iree/tools/test/benchmark_flags.txt
+++ b/iree/tools/test/benchmark_flags.txt
@@ -10,7 +10,7 @@
 
 // LIST-BENCHMARKS: BM_foo1
 // LIST-BENCHMARKS: BM_foo2
-// RUN: ( iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --benchmark_list_tests --module_file=${TEST_TMPDIR?}/bc.module --driver=vmla --benchmark_list_tests ) | IreeFileCheck --check-prefix=LIST-BENCHMARKS %s
+// RUN: ( iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --benchmark_list_tests --driver=vmla --benchmark_list_tests ) | IreeFileCheck --check-prefix=LIST-BENCHMARKS %s
 module {
   func @foo1() -> tensor<4xf32> attributes { iree.module.export } {
     %input = iree.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>

--- a/iree/tools/test/multiple_args.mlir
+++ b/iree/tools/test/multiple_args.mlir
@@ -1,10 +1,8 @@
-// RUN: (iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_inputs='2xi32=[1 2], 2xi32=[3 4]') | IreeFileCheck %s
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_inputs='2xi32=[1 2], 2xi32=[3 4]' | IreeFileCheck %s
+// RUN: iree-run-mlir --iree-hal-target-backends=vmla --function-input='2xi32=[1 2]' --function-input='2xi32=[3 4]' %s | IreeFileCheck %s
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmla --entry_function=multi_input --function_inputs='2xi32=[1 2], 2xi32=[3 4]' | IreeFileCheck --check-prefix=BENCHMARK %s
 
-// (only checking exit codes).
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --entry_function=multi_input --function_inputs='2xi32=[1 2], 2xi32=[3 4]' --module_file=${TEST_TMPDIR?}/bc.module
-
-// RUN: (iree-run-mlir --iree-hal-target-backends=vmla --function-input='2xi32=[1 2]' --function-input='2xi32=[3 4]' %s) | IreeFileCheck %s
-
+// BENCHMARK-LABEL: BM_multi_input
 // CHECK-LABEL: EXEC @multi_input
 func @multi_input(%arg0 : tensor<2xi32>, %arg1 : tensor<2xi32>) -> (tensor<2xi32>, tensor<2xi32>) attributes { iree.module.export } {
   return %arg0, %arg1 : tensor<2xi32>, tensor<2xi32>

--- a/iree/tools/test/multiple_exported_functions.mlir
+++ b/iree/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --module_file=${TEST_TMPDIR?}/bc.module | IreeFileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vulkan --module_file=${TEST_TMPDIR?}/bc.module | IreeFileCheck %s)
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmla | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan | IreeFileCheck %s)
 
 module {
   func @foo1() -> tensor<4xf32> attributes { iree.module.export } {

--- a/iree/tools/test/repeated_return.mlir
+++ b/iree/tools/test/repeated_return.mlir
@@ -1,10 +1,8 @@
 // RUN: (iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=many_tensor) | IreeFileCheck %s
-
-// (only checking exit codes).
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --entry_function=many_tensor --module_file=${TEST_TMPDIR?}/bc.module
-
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmla --entry_function=many_tensor | IreeFileCheck --check-prefix=BENCHMARK %s
 // RUN: iree-run-mlir -export-all -iree-hal-target-backends=vmla %s | IreeFileCheck %s
 
+// BENCHMARK-LABEL: BM_many_tensor
 // CHECK-LABEL: EXEC @many_tensor
 func @many_tensor() -> (tensor<2x2xf32>, tensor<2x2xf32>, tensor<2x2xf32>,
                         tensor<2x2xf32>, tensor<2x2xf32>, tensor<2x2xf32>) attributes { iree.module.export } {

--- a/iree/tools/test/scalars.mlir
+++ b/iree/tools/test/scalars.mlir
@@ -1,12 +1,8 @@
-// iree-run-module
 // RUN: (iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=scalar --function_inputs='i32=42') | IreeFileCheck %s
-
-// iree-benchmark-module (only checking exit codes).
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --entry_function=scalar --function_inputs='i32=42' --module_file=${TEST_TMPDIR?}/bc.module
-
-// iree-run-mlir
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmla --entry_function=scalar --function_inputs='i32=42' | IreeFileCheck --check-prefix=BENCHMARK %s
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmla --function-input=i32=42 %s) | IreeFileCheck %s
 
+// BENCHMARK-LABEL: BM_scalar
 // CHECK-LABEL: EXEC @scalar
 func @scalar(%arg0 : i32) -> i32 attributes { iree.module.export } {
   return %arg0 : i32

--- a/iree/tools/test/simple.mlir
+++ b/iree/tools/test/simple.mlir
@@ -1,18 +1,19 @@
 // iree-run-module
 // RUN: (iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vmla --entry_function=abs --function_inputs="i32=-2") | IreeFileCheck %s
-
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vulkan --entry_function=abs --function_inputs="i32=-2") | IreeFileCheck %s)
+// RUN: [[ $IREE_LLVMJIT_DISABLE == 1 ]] || ((iree-translate --iree-hal-target-backends=llvm-ir -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=llvm --entry_function=abs --function_inputs="i32=-2") | IreeFileCheck %s)
 
-// iree-benchmark-module (only checking exit codes).
-// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vmla --entry_function=abs --function_inputs="i32=-2" --module_file=${TEST_TMPDIR?}/bc.module
-
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s -o ${TEST_TMPDIR?}/bc.module && iree-benchmark-module --driver=vulkan --entry_function=abs --function_inputs="i32=-2" --module_file=${TEST_TMPDIR?}/bc.module)
+// iree-benchmark-module
+// RUN: iree-translate --iree-hal-target-backends=vmla -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmla --entry_function=abs --function_inputs="i32=-2" | IreeFileCheck %s --check-prefix=BENCHMARK
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan --entry_function=abs --function_inputs="i32=-2" | IreeFileCheck %s --check-prefix=BENCHMARK)
+// RUN: [[ $IREE_LLVMJIT_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=llvm-ir -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=llvm --entry_function=abs --function_inputs="i32=-2" | IreeFileCheck %s --check-prefix=BENCHMARK)
 
 // iree-run-mlir
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmla --function-input="i32=-2" %s) | IreeFileCheck %s
-
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -iree-hal-target-backends=vulkan-spirv --function-input="i32=-2" %s | IreeFileCheck %s)
+// RUN: [[ $IREE_LLVMJIT_DISABLE == 1 ]] || (iree-run-mlir -iree-hal-target-backends=llvm-ir --function-input="i32=-2" %s | IreeFileCheck %s)
 
+// BENCHMARK-LABEL: BM_abs
 // CHECK-LABEL: EXEC @abs
 func @abs(%input : tensor<i32>) -> (tensor<i32>) attributes { iree.module.export } {
   %result = "mhlo.abs"(%input) : (tensor<i32>) -> tensor<i32>


### PR DESCRIPTION
Now that we dynamically register benchmarks we don't need to worry about
the input getting loaded multiple times by the benchmark framework, so
we can support stdin.

Did a little bit of test cleanup while I was in there.
