### PR TITLE
Use simpler MlirOptMain in iree-opt

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/test/split_dispatch_function.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/split_dispatch_function.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-split-dispatch-function -verify-diagnostics %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-codegen-split-dispatch-function -verify-diagnostics %s | IreeFileCheck %s
 
 module {
   // CHECK: func @kernel_fusable_fill_conv_ops

--- a/iree/compiler/Dialect/Flow/Analysis/test/dispatchability.mlir
+++ b/iree/compiler/Dialect/Flow/Analysis/test/dispatchability.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -test-iree-flow-dispatchability %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -test-iree-flow-dispatchability %s | IreeFileCheck %s
 
 // CHECK-LABEL: @empty
 // CHECK-SAME: dispatchable = true

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_regions.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_regions.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of dispatch region ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @singleArg
 func @singleArg(%arg0 : tensor<?xf32>) {

--- a/iree/compiler/Dialect/Flow/IR/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/variable_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of variable ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK: flow.variable @v_immutable : tensor<i32>
 flow.variable @v_immutable : tensor<i32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions_ranked_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions_ranked_dynamic.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-flow-outline-dispatch-regions -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-flow-outline-dispatch-regions -canonicalize %s | IreeFileCheck %s
 // NOTE: Most of the common cases for outlining are tested via
 // transformation.mlir; however, this test performs some specific tests
 // of corner cases that are easier to access at this level.

--- a/iree/compiler/Dialect/HAL/IR/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/allocator_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of hal.allocator ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @allocator_compute_size
 func @allocator_compute_size() -> index {

--- a/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: byte_range.offset_length
 "byte_range.offset_length"() {

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_folding.mlir
@@ -1,6 +1,6 @@
 // Tests folding and canonicalization of HAL buffer ops.
 
-// RUN: iree-opt -split-input-file -canonicalize %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @skip_buffer_allocator
 func @skip_buffer_allocator() -> !hal.allocator {

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of hal.buffer ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @buffer_allocator
 func @buffer_allocator() -> !hal.allocator {

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -canonicalize %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @expand_buffer_view_const
 func @expand_buffer_view_const() -> !hal.buffer_view {

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of hal.buffer_view ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // -----
 

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of hal.command_buffer ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @make_memory_barrier
 func @make_memory_barrier() -> tuple<i32, i32> {

--- a/iree/compiler/Dialect/HAL/IR/test/device_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/device_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @device_allocator
 func @device_allocator() -> !hal.allocator {

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of executable/structural ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @interface_io
 func @interface_io() {

--- a/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of experimental ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @shared_device
 func @shared_device() -> !hal.device {

--- a/iree/compiler/Dialect/HAL/IR/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/variable_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of variable ops.
 
-// RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK: hal.variable @v_immutable : tensor<i32>
 hal.variable @v_immutable : tensor<i32>

--- a/iree/compiler/Dialect/HAL/Transforms/test/inline_device_switches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/inline_device_switches.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-hal-inline-device-switches -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-hal-inline-device-switches -canonicalize %s | IreeFileCheck %s
 
 // CHECK-LABEL: @simple_constants
 // CHECK-SAME: %[[DEVICE:.+]]: !hal.device

--- a/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-hal-resolve-entry-point-ordinals %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-hal-resolve-entry-point-ordinals %s | IreeFileCheck %s
 
 // CHECK: module {
 module {

--- a/iree/compiler/Dialect/Shape/Transforms/test/expand_function_dynamic_dims.mlir
+++ b/iree/compiler/Dialect/Shape/Transforms/test/expand_function_dynamic_dims.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-shape-expand-function-dynamic-dims %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -verify-diagnostics -iree-shape-expand-function-dynamic-dims %s | IreeFileCheck %s
 
 // CHECK-LABEL: @staticFunctionArgs
 // CHECK-NOT: ranked_shape

--- a/iree/compiler/Dialect/Shape/Transforms/test/hoist_shape_calculations.mlir
+++ b/iree/compiler/Dialect/Shape/Transforms/test/hoist_shape_calculations.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-shape-hoist-shape-calculations %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -verify-diagnostics -iree-shape-hoist-shape-calculations %s | IreeFileCheck %s
 
 // CHECK-LABEL: func @f
 func @f(%arg0: tensor<?xf32>, %arg1: index) {

--- a/iree/compiler/Dialect/Shape/Transforms/test/materialize_shape_calculations.mlir
+++ b/iree/compiler/Dialect/Shape/Transforms/test/materialize_shape_calculations.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-shape-materialize-calculations -iree-shape-cleanup-placeholders %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -verify-diagnostics -iree-shape-materialize-calculations -iree-shape-cleanup-placeholders %s | IreeFileCheck %s
 
 // CHECK-LABEL: @compileTime
 // CHECK-SAME: %[[T:[^:[:space:]]+]]: tensor<?x2xf32>

--- a/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
@@ -1,6 +1,6 @@
 // Tests printing and parsing of assignment ops.
 
-// RUN: iree-opt -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @select_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Transforms/test/sink_defining_ops.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/sink_defining_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-vm-sink-defining-ops %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-vm-sink-defining-ops %s | IreeFileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @single_uses

--- a/iree/compiler/Dialect/Vulkan/IR/test/target_env.mlir
+++ b/iree/compiler/Dialect/Vulkan/IR/test/target_env.mlir
@@ -1,6 +1,6 @@
 // Test parsing and printing Vulkan target environment attribute.
 
-// RUN: iree-opt -split-input-file -verify-diagnostics %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -verify-diagnostics %s | IreeFileCheck %s
 
 "vk_configure_op"() {
   // CHECK:      #vk.target_env<v1.1, r(120), [VK_KHR_spirv_1_4, VK_KHR_storage_buffer_storage_class], AMD:DiscreteGPU, {


### PR DESCRIPTION
This dramatically simplifies iree-opt-main.cc

The only functional difference is inverting the default of
`allow-unregistered-dialect` to match `mlir-opt`, which seems like a
good change.
