### PR TITLE
make IREE build and run on Linux AArch64 machines

### DIFF
--- a/iree/hal/llvmjit/BUILD
+++ b/iree/hal/llvmjit/BUILD
@@ -65,6 +65,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         #TODO(ataei): Link with native target dep.
         "@llvm-project//llvm:X86CodeGen",
+        "@llvm-project//llvm:AArch64CodeGen",
     ],
     alwayslink = 1,
 )

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_cc_library(
     ::llvmjit_driver
     LLVMSupport
     LLVMX86CodeGen
+    LLVMAArch64CodeGen
     iree::base::init
     iree::base::status
     iree::hal::driver_registry

--- a/iree/hal/llvmjit/CMakeLists.txt
+++ b/iree/hal/llvmjit/CMakeLists.txt
@@ -55,9 +55,9 @@ iree_cc_library(
     "llvmjit_driver_module.cc"
   DEPS
     ::llvmjit_driver
+    LLVMAArch64CodeGen
     LLVMSupport
     LLVMX86CodeGen
-    LLVMAArch64CodeGen
     iree::base::init
     iree::base::status
     iree::hal::driver_registry


### PR DESCRIPTION
With this additional I was able to build IREE and run `ctest` on NVIDIA [Jetson Xavier NX](https://developer.nvidia.com/embedded/jetson-xavier-nx).

```
99% tests passed, 1 tests failed out of 435

Label Time Summary:
driver=llvm                                  =  10.98 sec*proc (47 tests)
driver=vmla                                  =   1.73 sec*proc (51 tests)
driver=vulkan                                =  14.49 sec*proc (58 tests)
hostonly                                     = 109.21 sec*proc (28 tests)
.......
```

The only failed test is the `iree/hal/cts/semaphore_test`.