### PR TITLE
fix a trivial problem in macos guide

### DIFF
--- a/docs/get_started/getting_started_macos_cmake.md
+++ b/docs/get_started/getting_started_macos_cmake.md
@@ -69,7 +69,7 @@ $ git submodule update --init
 Configure:
 
 ```shell
-$ cmake -G Ninja -B build/ .
+$ cmake -G Ninja -B ../iree-build/ .
 ```
 
 Note: this should use `Clang` by default on macOS. `GCC` is not fully supported


### PR DESCRIPTION
make the build path consistent