### PR TITLE
Force fetch tags from llvm-bazel

### DIFF
--- a/scripts/git/update_to_llvm_syncpoint.py
+++ b/scripts/git/update_to_llvm_syncpoint.py
@@ -157,8 +157,9 @@ def get_commit(path, rev="HEAD"):
 
 
 def find_new_llvm_bazel_commit(llvm_bazel_path, llvm_commit, llvm_bazel_commit):
-  # Explicitly specify tags. We need these.
-  utils.execute(["git", "fetch", "--tags"], cwd=llvm_bazel_path)
+  # Explicitly force-fetch tags. Tags in llvm-bazel are not guaranteed to be
+  # stable.
+  utils.execute(["git", "fetch", "--tags", "--force"], cwd=llvm_bazel_path)
 
   if llvm_bazel_commit not in COMMIT_OPTIONS:
     return get_commit(llvm_bazel_path, rev=llvm_bazel_commit)


### PR DESCRIPTION
llvm-bazel does not guarantee that flag refs will be stable, so we need
to use `--force` to update them.
