### PR TITLE
Add (disabled) tests of KWS external streaming.

### DIFF
--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -401,6 +401,19 @@ KEYWORD_SPOTTING_MODELS = [
     "ds_tc_resnet",
 ]
 
+NON_STREAMING_KEYWORD_SPOTTING_MODELS = [
+    "att_mh_rnn",
+    "att_rnn",
+    "ds_cnn",
+    "inception",
+    "inception_resnet",
+    "mobilenet",
+    "mobilenet_v2",
+    "svdf_resnet",
+    "tc_resnet",
+    "xception",
+]
+
 iree_e2e_cartesian_product_test_suite(
     name = "keyword_spotting_tests",
     srcs = ["keyword_spotting_streaming_test.py"],
@@ -454,18 +467,7 @@ iree_e2e_cartesian_product_test_suite(
         },
         {
             # These models do not currently support streaming.
-            "model": [
-                "att_mh_rnn",
-                "att_rnn",
-                "ds_cnn",
-                "inception",
-                "inception_resnet",
-                "mobilenet",
-                "mobilenet_v2",
-                "svdf_resnet",
-                "tc_resnet",
-                "xception",
-            ],
+            "model": NON_STREAMING_KEYWORD_SPOTTING_MODELS,
         },
         {
             # Failing on IREE:
@@ -480,6 +482,46 @@ iree_e2e_cartesian_product_test_suite(
     flags_to_values = {
         "reference_backend": "tf",
         "mode": "internal_streaming",
+        "model": KEYWORD_SPOTTING_MODELS,
+        "target_backends": [
+            "tf",
+            "tflite",
+            "iree_vmla",
+            "iree_llvmjit",
+            "iree_vulkan",
+        ],
+    },
+    main = "keyword_spotting_streaming_test.py",
+    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+        "//integrations/tensorflow/bindings/python/pyiree/tf/support",
+        "@kws_streaming//:models_lib",
+        "@kws_streaming//:train_lib",
+    ],
+)
+
+iree_e2e_cartesian_product_test_suite(
+    name = "keyword_spotting_external_streaming_tests",
+    srcs = ["keyword_spotting_streaming_test.py"],
+    failing_configurations = [
+        {
+            # A bug in keras causes the external steraming conversion to fail
+            # when TensorFlow 2.x is used.
+            "target_backends": [
+                "tf",
+                "tflite",
+                "iree_vmla",
+                "iree_llvmjit",
+                "iree_vulkan",
+            ],
+        },
+        {
+            # These models do not currently support streaming.
+            "model": NON_STREAMING_KEYWORD_SPOTTING_MODELS,
+        },
+    ],
+    flags_to_values = {
+        "reference_backend": "tf",
+        "mode": "external_streaming",
         "model": KEYWORD_SPOTTING_MODELS,
         "target_backends": [
             "tf",

--- a/integrations/tensorflow/e2e/keras/keyword_spotting_streaming_test.py
+++ b/integrations/tensorflow/e2e/keras/keyword_spotting_streaming_test.py
@@ -43,12 +43,13 @@ flags.DEFINE_string(
     'See https://github.com/google-research/google-research/blob/master/kws_streaming/models/models.py#L38-L58'
 )
 flags.DEFINE_enum('mode', 'non_streaming',
-                  ['non_streaming', 'internal_streaming'],
+                  ['non_streaming', 'internal_streaming', 'external_streaming'],
                   'Mode to execute the model in.')
 
 MODE_ENUM_TO_MODE = {
     'non_streaming': modes.Modes.NON_STREAM_INFERENCE,
     'internal_streaming': modes.Modes.STREAM_INTERNAL_STATE_INFERENCE,
+    'external_streaming': modes.Modes.STREAM_EXTERNAL_STATE_INFERENCE,
 }
 
 


### PR DESCRIPTION
A tensorflow bug prevents us from running these tests, but this will make it trivial to enable them once that bug is fixed, and allows me to monitor that by running the failing tests.