### PR TITLE
Add missing dependency on tensorflow_hub to slim_vision_tests

### DIFF
--- a/integrations/tensorflow/e2e/slim_vision_models/BUILD
+++ b/integrations/tensorflow/e2e/slim_vision_models/BUILD
@@ -164,7 +164,7 @@ iree_e2e_cartesian_product_test_suite(
         "nokokoro",
         "notap",
     ],
-    deps = INTREE_TENSORFLOW_PY_DEPS + NUMPY_DEPS + [
+    deps = INTREE_TENSORFLOW_PY_DEPS + INTREE_TF_HUB_DEPS + NUMPY_DEPS + [
         "//integrations/tensorflow/bindings/python/pyiree/tf/support",
     ],
 )


### PR DESCRIPTION
This only affects the tests when they run internally.