### PR TITLE
Add directory structure for kws streaming artifacts.

### DIFF
--- a/scripts/get_e2e_artifacts.py
+++ b/scripts/get_e2e_artifacts.py
@@ -43,6 +43,10 @@ SUITE_NAME_TO_TARGET = {
         '//integrations/tensorflow/e2e:mobile_bert_squad_tests',
     'keras_tests':
         '//integrations/tensorflow/e2e/keras:keras_tests',
+    'keyword_spotting_tests':
+        '//integrations/tensorflow/e2e/keras:keyword_spotting_tests',
+    'keyword_spotting_internal_streaming_tests':
+        '//integrations/tensorflow/e2e/keras:keyword_spotting_internal_streaming_tests',
     'imagenet_non_hermetic_tests':
         '//integrations/tensorflow/e2e/keras:imagenet_non_hermetic_tests',
     'slim_vision_tests':


### PR DESCRIPTION
Also adds the kws_streaming test suites to `get_e2e_artifacts.py`.

Directory structure:

```
/tmp/iree/modules/keyword_spotting
├── att_mh_rnn
│   ├── external_streaming
│   ├── internal_streaming
│   └── non_streaming
├── att_rnn
│   ├── external_streaming
│   ├── internal_streaming
│   └── non_streaming
├── cnn
│   ├── external_streaming
│   ├── internal_streaming
│   └── non_streaming
.
.
.
└── xception
    ├── external_streaming
    ├── internal_streaming
    └── non_streaming
```