### PR TITLE
Revert "Relax TorchIndexSelectOp to fuse with other ops."

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -33,8 +33,8 @@ namespace {
 // from this exclusion list eventually.
 bool isUnsupportedFusionOp(Operation *op) {
   return isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp, mhlo::DotOp,
-             mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp, mhlo::SliceOp>(
-      op);
+             mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp, mhlo::SliceOp,
+             mhlo::TorchIndexSelectOp>(op);
 }
 
 // Allowlist of ops that materialize to a an index-permuted copy of some kind

--- a/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
@@ -199,7 +199,7 @@ bool isDispatchRegionMergable(DispatchRegionOp &regionOp) {
       // TODO(b/144530470): replace with tablegen attributes/interfaces.
       if (isa<mhlo::ConcatenateOp, mhlo::ConvOp, mhlo::DotGeneralOp,
               mhlo::DotOp, mhlo::PadOp, mhlo::ReduceOp, mhlo::ReduceWindowOp,
-              mhlo::SliceOp>(op)) {
+              mhlo::SliceOp, mhlo::TorchIndexSelectOp>(op)) {
         return false;
       }
     }


### PR DESCRIPTION
Reverts google/iree#3682

This breaks internal tests.