### PR TITLE
Clarify behavior of iree-translate

### DIFF
--- a/iree/tools/iree-translate-main.cc
+++ b/iree/tools/iree-translate-main.cc
@@ -14,8 +14,10 @@
 
 // IREE translation main entry function.
 //
-// We need this entry function because we want to register PassManager CLI
-// options, which is missing in MLIR's translation main entry function.
+// Note that this differs from mlir-translate and similar because we use the
+// PassManger and do transformations on the IR before translating to other
+// formats. Thus we use our own main entry function because we register
+// Dialects and PassManager CLI options.
 
 #include "iree/compiler/Conversion/init_conversions.h"
 #include "iree/compiler/Dialect/VM/Target/init_targets.h"
@@ -57,14 +59,8 @@ static llvm::cl::opt<bool> splitInputFile(
                    "process each chunk independently"),
     llvm::cl::init(false));
 
-// TODO(#2958): We shouldn't need to register dialects here if translations
-// correctly declare the dialects they support.
-// TODO(#2958): Investigate whether we can use mlir-translate.cpp as an entry
-// point.
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
-  // TODO(#2958): We shouldn't need to register dialects here if translations
-  // correctly declare the dialects they support.
   mlir::DialectRegistry registry;
   mlir::registerMlirDialects(registry);
 #ifdef IREE_HAVE_EMITC_DIALECT


### PR DESCRIPTION
There are a couple of investigation TODOs in here that stem from
iree-translate differing from mlir-translate. They are not feasible
without reworking the tool. Instead I added additional documenation on
the differences for future readers and deleted the TODOs.

We could still reconsider the expanded role of iree-translate and reduce
it to a tool more akin to mlir-translate, creating a separate
iree-compiler tool to run full compilation passes without taking
translations to perform as command line flags. But that's larger in
scope than these TODOs.

Closes https://github.com/google/iree/issues//2958