### PR TITLE
Avoid reading command-line flags in various VM related passes

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
@@ -107,8 +107,6 @@ namespace {
 class ConvertHALToVMPass
     : public PassWrapper<ConvertHALToVMPass, OperationPass<ModuleOp>> {
  public:
-  ConvertHALToVMPass()
-      : targetOptions_(IREE::VM::getTargetOptionsFromFlags()) {}
   explicit ConvertHALToVMPass(IREE::VM::TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -157,7 +155,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertHALToVMPass(
 
 static PassRegistration<ConvertHALToVMPass> pass(
     "iree-convert-hal-to-vm",
-    "Convert the IREE HAL dialect to the IREE VM dialect");
+    "Convert the IREE HAL dialect to the IREE VM dialect", [] {
+      auto options = IREE::VM::getTargetOptionsFromFlags();
+      return std::make_unique<ConvertHALToVMPass>(options);
+    });
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/IdentifyConstantPools.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/IdentifyConstantPools.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
@@ -36,7 +37,6 @@ namespace HAL {
 class IdentifyConstantPoolsPass
     : public PassWrapper<IdentifyConstantPoolsPass, OperationPass<ModuleOp>> {
  public:
-  IdentifyConstantPoolsPass() : targetOptions_(getTargetOptionsFromFlags()) {}
   explicit IdentifyConstantPoolsPass(TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -310,7 +310,11 @@ std::unique_ptr<OperationPass<ModuleOp>> createIdentifyConstantPoolsPass(
 static PassRegistration<IdentifyConstantPoolsPass> pass(
     "iree-hal-identify-constant-pools",
     "Combines constant variables into one or more hal.constant_pools based on "
-    "usage semantics.");
+    "usage semantics.",
+    [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<IdentifyConstantPoolsPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -32,7 +33,6 @@ namespace HAL {
 class LinkExecutablesPass
     : public PassWrapper<LinkExecutablesPass, OperationPass<mlir::ModuleOp>> {
  public:
-  LinkExecutablesPass() : executableOptions_(getTargetOptionsFromFlags()) {}
   explicit LinkExecutablesPass(TargetOptions executableOptions)
       : executableOptions_(executableOptions) {}
 
@@ -71,7 +71,10 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkExecutablesPass(
 
 static PassRegistration<LinkExecutablesPass> pass(
     "iree-hal-link-executables",
-    "Links together hal.executables depending on target backend rules");
+    "Links together hal.executables depending on target backend rules", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<LinkExecutablesPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -344,7 +345,6 @@ static LogicalResult declareTargetOps(TargetOptions targetOptions,
 class MaterializeInterfacesPass
     : public PassWrapper<MaterializeInterfacesPass, OperationPass<ModuleOp>> {
  public:
-  MaterializeInterfacesPass() : targetOptions_(getTargetOptionsFromFlags()) {}
   explicit MaterializeInterfacesPass(TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -405,7 +405,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeInterfacesPass(
 
 static PassRegistration<MaterializeInterfacesPass> pass(
     "iree-hal-materialize-interfaces",
-    "Materializes hal.executable ops from flow.executable ops");
+    "Materializes hal.executable ops from flow.executable ops", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<MaterializeInterfacesPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -35,8 +36,6 @@ class MaterializeResourceCachesPass
     : public PassWrapper<MaterializeResourceCachesPass,
                          OperationPass<ModuleOp>> {
  public:
-  MaterializeResourceCachesPass()
-      : targetOptions_(getTargetOptionsFromFlags()) {}
   explicit MaterializeResourceCachesPass(TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -352,7 +351,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeResourceCachesPass(
 
 static PassRegistration<MaterializeResourceCachesPass> pass(
     "iree-hal-materialize-resource-caches",
-    "Materializes hal.executable resource caches and rewrites lookups.");
+    "Materializes hal.executable resource caches and rewrites lookups.", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<MaterializeResourceCachesPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -33,8 +34,6 @@ class SerializeExecutablesPass
     : public PassWrapper<SerializeExecutablesPass,
                          OperationPass<IREE::HAL::ExecutableOp>> {
  public:
-  SerializeExecutablesPass()
-      : executableOptions_(getTargetOptionsFromFlags()) {}
   explicit SerializeExecutablesPass(TargetOptions executableOptions)
       : executableOptions_(executableOptions) {}
 
@@ -71,7 +70,10 @@ createSerializeExecutablesPass(TargetOptions executableOptions) {
 
 static PassRegistration<SerializeExecutablesPass> pass(
     "iree-hal-serialize-executables",
-    "Serializes hal.executable.target ops to hal.executable.binary ops");
+    "Serializes hal.executable.target ops to hal.executable.binary ops", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<SerializeExecutablesPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <utility>
 
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
@@ -34,8 +35,6 @@ class TranslateExecutablesPass
     : public PassWrapper<TranslateExecutablesPass,
                          OperationPass<IREE::HAL::ExecutableOp>> {
  public:
-  TranslateExecutablesPass()
-      : executableOptions_(getTargetOptionsFromFlags()) {}
   explicit TranslateExecutablesPass(TargetOptions executableOptions)
       : executableOptions_(executableOptions) {}
 
@@ -86,7 +85,10 @@ createTranslateExecutablesPass(TargetOptions executableOptions) {
 
 static PassRegistration<TranslateExecutablesPass> pass(
     "iree-hal-translate-executables",
-    "Translates hal.executable.target via the target backend pipelines");
+    "Translates hal.executable.target via the target backend pipelines", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<TranslateExecutablesPass>(options);
+    });
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.h"
 
 #include "iree/compiler/Dialect/IREE/IR/IREETypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/TargetOptions.h"
 #include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -178,7 +179,8 @@ class ConstantOpConversion : public OpConversionPattern<ConstantOp> {
       return srcOp.emitRemark() << "unsupported const type for dialect";
     }
     // TODO(#2878): use getTypeConverter() when we pass it upon creation.
-    IREE::VM::TypeConverter typeConverter;
+    IREE::VM::TypeConverter typeConverter(
+        IREE::VM::getTargetOptionsFromFlags());
     auto targetType = typeConverter.convertType(srcOp.getType());
     switch (targetType.getIntOrFloatBitWidth()) {
       case 1:

--- a/iree/compiler/Dialect/VM/Conversion/TypeConverter.h
+++ b/iree/compiler/Dialect/VM/Conversion/TypeConverter.h
@@ -25,8 +25,7 @@ namespace VM {
 
 class TypeConverter : public mlir::TypeConverter {
  public:
-  explicit TypeConverter(
-      TargetOptions targetOptions = getTargetOptionsFromFlags());
+  explicit TypeConverter(TargetOptions targetOptions);
 
   const TargetOptions& targetOptions() const { return targetOptions_; }
 

--- a/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <tuple>
 
 #include "iree/compiler/Dialect/IREE/Conversion/PreserveCompilerHints.h"
@@ -79,7 +80,6 @@ SmallVector<const T *, 4> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 class ConversionPass
     : public PassWrapper<ConversionPass, OperationPass<mlir::ModuleOp>> {
  public:
-  ConversionPass() : targetOptions_(getTargetOptionsFromFlags()) {}
   explicit ConversionPass(TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -153,7 +153,11 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass(
 }
 
 static PassRegistration<ConversionPass> pass(
-    "iree-vm-conversion", "Converts from various dialects to the VM dialect");
+    "iree-vm-conversion", "Converts from various dialects to the VM dialect",
+    [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<ConversionPass>(options);
+    });
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
@@ -374,8 +374,6 @@ namespace {
 class ConvertVMLAToVMPass
     : public PassWrapper<ConvertVMLAToVMPass, OperationPass<ModuleOp>> {
  public:
-  ConvertVMLAToVMPass()
-      : targetOptions_(IREE::VM::getTargetOptionsFromFlags()) {}
   explicit ConvertVMLAToVMPass(IREE::VM::TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
@@ -428,7 +426,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertVMLAToVMPass(
 
 static PassRegistration<ConvertVMLAToVMPass> pass(
     "iree-convert-vmla-to-vm",
-    "Convert the IREE VMLA dialect to the IREE VM dialect");
+    "Convert the IREE VMLA dialect to the IREE VM dialect", [] {
+      auto options = IREE::VM::getTargetOptionsFromFlags();
+      return std::make_unique<ConvertVMLAToVMPass>(options);
+    });
 
 }  // namespace iree_compiler
 }  // namespace mlir


### PR DESCRIPTION
This commit moves command-line option interaction into pass
registration and makes passes themselves cleaner.