### PR TITLE
Fix return during loop in executable deduping.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -121,7 +121,9 @@ bool areExecutablesEquivalent(ExecutableOp lhs, ExecutableOp rhs) {
   for (int i = 0; i < lhsFuncOps.size(); ++i) {
     auto lhsRegion = lhsFuncOps[i].getCallableRegion();
     auto rhsRegion = rhsFuncOps[i].getCallableRegion();
-    return areRegionsEquivalent(lhsRegion, rhsRegion);
+    if (!areRegionsEquivalent(lhsRegion, rhsRegion)) {
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
Bug in https://github.com/google/iree/pull/3702 caught by ClangTidy.