### PR TITLE
Silence some CMake/Linux warnings in VMA.

### DIFF
--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -477,6 +477,11 @@ iree_cc_library(
     "-DVK_NO_PROTOTYPES"
     # Only needed in the implementation cc and not by external users.
     "-DVMA_STATIC_VULKAN_FUNCTIONS=0"
+    # Silence some warnings.
+    "-Wno-nullability-completeness"
+    # Note: IREE_DEFAULT_COPTS sets -Wthread-safety-analysis, so we can't
+    #   disable here without switching off of iree_cc_library or refactoring
+    # "-Wno-thread-safety-analysis"
   INCLUDES
     ${VMA_SRC_ROOT}
   DEPS

--- a/iree/hal/vulkan/internal_vk_mem_alloc.cc
+++ b/iree/hal/vulkan/internal_vk_mem_alloc.cc
@@ -50,7 +50,7 @@
 
 // Use absl::Mutex for VMA_MUTEX.
 #define VMA_MUTEX absl::Mutex
-class AbslVmaRWMutex {
+class ABSL_SCOPED_LOCKABLE AbslVmaRWMutex {
  public:
   void LockRead() ABSL_SHARED_LOCK_FUNCTION() { mutex_.ReaderLock(); }
   void UnlockRead() ABSL_UNLOCK_FUNCTION() { mutex_.ReaderUnlock(); }


### PR DESCRIPTION
Sample logs with warning spam: https://source.cloud.google.com/results/invocations/e8a4e187-8f85-4ef2-af9f-de137633ee23/targets/iree%2Fgcp_ubuntu%2Fcmake%2Flinux%2Fx86-swiftshader%2Fmain/log

There are still some warnings from `Wthread-safety-analysis`, but they are much less spammy (see [new logs](https://source.cloud.google.com/results/invocations/16651c8d-151a-400d-8826-b87a47a52932/targets/iree%2Fgcp_ubuntu%2Fcmake%2Flinux%2Fx86-swiftshader%2Fpresubmit/log)). Refactoring (like setting up a dedicated CMakeLists.txt for VMA) could help there.