### PR TITLE
Test negative numbers in our e2e tests

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -405,7 +405,7 @@ class Trace:
         return True, None
 
       if np.issubdtype(ref.dtype, np.floating):
-        same = np.allclose(ref, tar, rtol=rtol, atol=atol)
+        same = np.allclose(ref, tar, rtol=rtol, atol=atol, equal_nan=True)
         abs_diff = np.max(np.abs(ref - tar))
         rel_diff = np.max(np.abs(ref - tar) / np.max(np.abs(tar)))
         diff_string = (f"Max abs diff: {abs_diff:.2e}, atol: {atol:.2e}, "

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_utils.py
@@ -43,8 +43,8 @@ InputGeneratorType = Callable[[Sequence[int], Union[tf.DType, np.dtype]],
 
 def uniform(shape: Sequence[int],
             dtype: Union[tf.DType, np.dtype] = np.float32,
-            low: float = 0.,
-            high: float = 1.) -> np.ndarray:
+            low: float = -1.0,
+            high: float = 1.0) -> np.ndarray:
   """np.random.uniform with simplified API and dtype control."""
   dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype
   return np.random.uniform(size=shape, low=low, high=high).astype(dtype)

--- a/integrations/tensorflow/e2e/batch_norm_test.py
+++ b/integrations/tensorflow/e2e/batch_norm_test.py
@@ -51,7 +51,7 @@ class BatchNormTest(tf_test_utils.TracedModuleTestCase):
       # Note: scaling by a small value to increase numerical stability.
       x = tf_utils.uniform((4, 16)) * 1e-3
       mean = tf_utils.uniform((16,)) * 1e-3
-      variance = tf_utils.uniform((16,)) * 1e-3
+      variance = tf_utils.uniform((16,), low=0.0) * 1e-3
       offset = tf_utils.uniform((16,)) * 1e-3
       scale = tf_utils.uniform((16,)) * 1e-3
       module.batch_norm_inference(x, mean, variance, offset, scale)

--- a/integrations/tensorflow/e2e/keras/BUILD
+++ b/integrations/tensorflow/e2e/keras/BUILD
@@ -191,6 +191,14 @@ iree_e2e_cartesian_product_test_suite(
     srcs = ["vision_model_test.py"],
     failing_configurations = [
         {
+            # Failing on vmla with negative inputs.
+            "model": [
+                "NASNetLarge",
+                "NASNetMobile",
+            ],
+            "target_backends": "iree_vmla",
+        },
+        {
             # Failing on llvm and vulkan:
             "model": [
                 "NASNetLarge",
@@ -283,6 +291,14 @@ iree_e2e_cartesian_product_test_suite(
     size = "enormous",
     srcs = ["vision_model_test.py"],
     failing_configurations = [
+        {
+            # Failing on vmla with negative inputs.
+            "model": [
+                "NASNetLarge",
+                "NASNetMobile",
+            ],
+            "target_backends": "iree_vmla",
+        },
         {
             # Failing vulkan:
             "model": [

--- a/integrations/tensorflow/e2e/keras/layers/BUILD
+++ b/integrations/tensorflow/e2e/keras/layers/BUILD
@@ -186,7 +186,12 @@ FAILING_STATIC = [
     },
     {
         # Failing on LLVM and Vulkan
-        "layer": "Lambda",
+        "layer": [
+            "Lambda",
+            "MaxPool1D",
+            "MaxPool2D",
+            "MaxPool3D",
+        ],
         "target_backends": [
             "iree_llvmjit",
             "iree_vulkan",
@@ -200,9 +205,6 @@ FAILING_STATIC = [
             "AveragePooling3D",
             "GRU",
             "LSTM",  # TODO(silvasean): Get this test working on Vulkan.
-            "MaxPool1D",
-            "MaxPool2D",
-            "MaxPool3D",
             "ThresholdedReLU",
         ],
         "target_backends": "iree_vulkan",
@@ -322,20 +324,14 @@ FAILING_FULL_API = [
             "AveragePooling2D",
             "AveragePooling3D",
             "Conv1DTranspose",
+            "MaxPool1D",
+            "MaxPool2D",
+            "MaxPool3D",
         ],
         "target_backends": [
             "iree_llvmjit",
             "iree_vulkan",
         ],
-    },
-    {
-        # Failing on Vulkan
-        "layer": [
-            "MaxPool1D",
-            "MaxPool2D",
-            "MaxPool3D",
-        ],
-        "target_backends": "iree_vulkan",
     },
 ]
 

--- a/integrations/tensorflow/e2e/slim_vision_models/BUILD
+++ b/integrations/tensorflow/e2e/slim_vision_models/BUILD
@@ -58,6 +58,14 @@ iree_e2e_cartesian_product_test_suite(
             "model": "amoebanet_a_n18_f448",
         },
         {
+            # Failing on vmla with negative inputs.
+            "model": [
+                "nasnet_large",
+                "nasnet_mobile",
+            ],
+            "target_backends": "iree_vmla",
+        },
+        {
             # Failing llvmjit and vulkan:
             "model": [
                 "nasnet_mobile",


### PR DESCRIPTION
Our input generation was only using positive numbers, which left a blind spot in our testing.

Thankfully this only affects a few targets:

- `NASNetLarge` on `iree_vmla` (for both `keras` and `slim` tests)
- `NASNetMobile` on `iree_vmla` (for both `keras` and `slim` tests)
- `MaxPoolXD` on `iree_llvmjit` (in the new keras layers tests)

I also added `equal_nan` to `np.allclose` and `np.array_equal` since we want to have identical behavior to tensorflow there as well. This required updating the `bazel-*`docker images to upgrade `numpy`.

_Note: After the tests pass on the CI, I will update the `:prod` tag and the digests to match._