### PR TITLE
Update tests to eliminate public function declarations.

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
@@ -66,10 +66,9 @@ module attributes {
       : memref<3x4x3x2xf32>, memref<?x?x?x3xf32>, memref<?x?x?x2xf32>
     return
   }
-  func @conv_no_padding_tile__num_workgroups__
+  func private @conv_no_padding_tile__num_workgroups__
     (!shapex.ranked_shape<[3,4,3,2]>, !shapex.ranked_shape<[?,?,?,3]>,
      !shapex.ranked_shape<[?,?,?,2]>) -> (index, index, index)
-    attributes {symbol_visibility = "private"}
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"

--- a/iree/compiler/Dialect/Flow/IR/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/variable_ops.mlir
@@ -16,7 +16,7 @@ flow.variable @v_initialized_const dense<4> : tensor<4xi32>
 
 // CHECK: flow.variable @v_initialized init(@initializer) : tensor<4xi32>
 flow.variable @v_initialized init(@initializer) : tensor<4xi32>
-func @initializer() -> tensor<4xi32>
+func private @initializer() -> tensor<4xi32>
 
 // -----
 

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/constant_ops.mlir
@@ -56,7 +56,7 @@ func @fn() {
 // TODO(b/145839814): It should not be possible to produce a name collision
 // expected-error @+3 {{redefinition of symbol named '__var_with_initializer_initializer'}}
 // expected-note @+1 {{see existing symbol definition here}}
-func @__var_with_initializer_initializer() -> ()
+func private @__var_with_initializer_initializer() -> ()
 flow.variable @var_with_initializer mutable dense<0.000000e+00> : tensor<f32>
 func @fn() {
   %0 = flow.variable.load @var_with_initializer : tensor<f32>

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/variable_ops.mlir
@@ -54,7 +54,7 @@ func @fn() {
 // TODO(b/145839814): It should not be possible to produce a name collision
 // expected-error @+3 {{redefinition of symbol named '__var_with_initializer_initializer'}}
 // expected-note @+1 {{see existing symbol definition here}}
-func @__var_with_initializer_initializer() -> ()
+func private @__var_with_initializer_initializer() -> ()
 flow.variable @var_with_initializer mutable dense<0.000000e+00> : tensor<f32>
 func @fn() {
   %0 = flow.variable.load @var_with_initializer : tensor<f32>

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/variable_ops.mlir
@@ -7,7 +7,7 @@ hal.variable @v_initialized_const = 4 : i32
 
 // CHECK: vm.global.ref @v_initialized init(@initializer) : !vm.ref<!hal.buffer>
 hal.variable @v_initialized init(@initializer) : !hal.buffer
-func @initializer() -> !hal.buffer
+func private @initializer() -> !hal.buffer
 
 // -----
 

--- a/iree/compiler/Dialect/HAL/IR/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/variable_ops.mlir
@@ -22,7 +22,7 @@ hal.variable @v_initialized_const2 : i32 = 40 : i64
 
 // CHECK: hal.variable @v_initialized init(@initializer) : !hal.buffer
 hal.variable @v_initialized init(@initializer) : !hal.buffer
-func @initializer() -> !hal.buffer
+func private @initializer() -> !hal.buffer
 
 // -----
 

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
@@ -78,7 +78,7 @@ module {
 module @t005_call {
 
 module {
-  func @import_fn(%arg0 : i32) -> i32
+  func private @import_fn(%arg0 : i32) -> i32
   // CHECK: func @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i32) -> (i32) {
@@ -95,7 +95,7 @@ module {
 module @t005_call_int_promotion {
 
 module {
-  func @import_fn(%arg0 : i1) -> i1
+  func private @import_fn(%arg0 : i1) -> i1
   // CHECK: func @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i1) -> (i1) {

--- a/iree/compiler/Dialect/VM/Transforms/test/mark_public_symbols_exported.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/mark_public_symbols_exported.mlir
@@ -5,4 +5,6 @@ func private @private_symbol()
 
 // CHECK-LABEL: @public_symbol
 // CHECK-SAME: {iree.module.export}
-func @public_symbol()
+func @public_symbol() {
+  return
+}


### PR DESCRIPTION
This is in prep for proposed MLIR change to disallow this. See
https://llvm.discourse.group/t/rfc-symbol-definition-declaration-x-visibility-checks/2140