### PR TITLE
Update ModelBuilder to mark function declarations private.

### DIFF
--- a/experimental/ModelBuilder/VulkanWrapperPass.cpp
+++ b/experimental/ModelBuilder/VulkanWrapperPass.cpp
@@ -95,9 +95,9 @@ LogicalResult AddVulkanLaunchWrapper::declareVulkanLaunchFunc(Location loc) {
   vulkanLaunchTypes.insert(vulkanLaunchTypes.end(), args.begin(), args.end());
 
   // Declare vulkan launch function.
-  builder.create<FuncOp>(loc, kVulkanLaunch,
-                         FunctionType::get(vulkanLaunchTypes, ArrayRef<Type>{},
-                                           loc->getContext()));
+  auto type = FunctionType::get(vulkanLaunchTypes, {}, loc->getContext());
+  FuncOp vkLaunch = builder.create<FuncOp>(loc, kVulkanLaunch, type);
+  vkLaunch.setPrivate();
   return success();
 }
 


### PR DESCRIPTION
This is in prep for a proposed MLIR change to disallow public
declarations. See
https://llvm.discourse.group/t/rfc-symbol-definition-declaration-x-visibility-checks/2140