### PR TITLE
Fix linker errors with tracing on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,14 @@ mark_as_advanced(
   CMAKE_SHARED_LINKER_FLAGS_FASTBUILD
 )
 
+if(${IREE_ENABLE_RUNTIME_TRACING})
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")  # Selects Clang or GCC.
+    string (APPEND CMAKE_EXE_LINKER_FLAGS " -ldl")
+  endif()
+endif()
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS -ldl)
+
 include(iree_setup_toolchain)
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The problem was: when configuring with
```
  cmake -DIREE_ENABLE_RUNTIME_TRACING=ON
```
on Linux, building some targets such as
```
  cmake --build . --target iree/base/iree_base_status_test
```
failed with linker errors such as:
```
/usr/bin/ld: iree/base/libiree_base_tracing.a(tracing.cc.o): in function `tracy::DecodeCallstackPtr(unsigned long)':
/usr/local/google/home/benoitjacob/iree/third_party/tracy/client/TracyCallstack.cpp:657: undefined reference to `dladdr'
```