### PR TITLE
Address dynamic shape issue for ceil

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -71,6 +71,7 @@ TFLITE_FAILING = [
     "gather_test.py",
     "image_resize_test.py",
     "mandelbrot_test.py",
+    "math_dyn_test.py",
     "matrix_ops_dynamic_test.py",
     "resource_ops_test.py",
     "ring_buffer_test.py",
@@ -106,6 +107,7 @@ LLVM_FAILING = [
     "linspace_test.py",  # TODO(https://github.com/google/iree/issues/1521)
     "logical_ops_test.py",
     "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
+    "math_dyn_test.py",
     "matrix_ops_dynamic_test.py",
     "range_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
@@ -129,6 +131,7 @@ VULKAN_FAILING = [
     "linspace_test.py",  # TODO(https://github.com/google/iree/issues/1521)
     "logical_ops_test.py",
     "mandelbrot_test.py",  # TODO(silvasean): Get this working on IREE.
+    "math_dyn_test.py",
     "matrix_ops_dynamic_test.py",
     "range_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)

--- a/integrations/tensorflow/e2e/math_dyn_test.py
+++ b/integrations/tensorflow/e2e/math_dyn_test.py
@@ -22,27 +22,27 @@ import tensorflow.compat.v2 as tf
 
 class MathModule(tf.Module):
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def abs(self, x):
     return tf.math.abs(x)
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def ceil(self, x):
     return tf.math.ceil(x)
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def cos(self, x):
     return tf.math.cos(x)
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def log(self, x):
     return tf.math.log(x)
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def mod(self, x):
     return tf.math.mod(x, 2.0)
 
-  @tf.function(input_signature=[tf.TensorSpec([4], tf.float32)])
+  @tf.function(input_signature=[tf.TensorSpec([None], tf.float32)])
   def fake_quant(self, x):
     return tf.quantization.fake_quant_with_min_max_args(x,
                                                         min=-6,

--- a/iree/compiler/Dialect/Shape/Plugins/XLA/XlaHloShapeBuilder.cpp
+++ b/iree/compiler/Dialect/Shape/Plugins/XLA/XlaHloShapeBuilder.cpp
@@ -34,8 +34,8 @@ namespace mhlo {
 namespace {
 
 template <typename HloOp>
-Value rewriteXlaBinaryElementwiseOpShape(RankedShapeType resultShape, HloOp op,
-                                         OpBuilder &builder) {
+Value rewriteXlaNaryElementwiseOpShape(RankedShapeType resultShape, HloOp op,
+                                       OpBuilder &builder) {
   if (!op) return nullptr;
   SmallVector<Value, 4> inputOperands(op.getOperands());
   return buildCastInputsToResultShape(op.getLoc(), resultShape, inputOperands,
@@ -448,7 +448,7 @@ void populateXlaHloCustomOpShapeBuilder(CustomOpShapeBuilderList &builders) {
   // NOTE: Most of these *should not* be "custom ops". They should be coming
   // from declarative shape information, but that doesn't exist yet.
 #define INSERT_EW_OP(OpTy) \
-  b.insertOpRankedShapeBuilder<OpTy>(rewriteXlaBinaryElementwiseOpShape<OpTy>);
+  b.insertOpRankedShapeBuilder<OpTy>(rewriteXlaNaryElementwiseOpShape<OpTy>);
   INSERT_EW_OP(AddOp);
   INSERT_EW_OP(Atan2Op);
   INSERT_EW_OP(DivOp);
@@ -462,6 +462,7 @@ void populateXlaHloCustomOpShapeBuilder(CustomOpShapeBuilderList &builders) {
   INSERT_EW_OP(ShiftRightLogicalOp);
   INSERT_EW_OP(SubOp);
   INSERT_EW_OP(CompareOp);
+  INSERT_EW_OP(ClampOp);
 
   b.insertOpRankedShapeBuilder<SelectOp>(rewriteSelectOp);
   b.insertOpRankedShapeBuilder<DotOp>(rewriteXlaDotOpShape);

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertHLOToVMLA.cpp
@@ -843,6 +843,8 @@ void populateHLOToVMLAPatterns(MLIRContext *context,
       typeConverter, context);
   patterns.insert<VMLAOpConversion<mhlo::LogOp, IREE::VMLA::LogOp>>(
       typeConverter, context);
+  patterns.insert<VMLAOpConversion<mhlo::CeilOp, IREE::VMLA::CeilOp>>(
+      typeConverter, context);
   patterns.insert<VMLAOpConversion<mhlo::FloorOp, IREE::VMLA::FloorOp>>(
       typeConverter, context);
   patterns.insert<VMLAOpConversion<mhlo::RoundOp, IREE::VMLA::RoundOp>>(


### PR DESCRIPTION
Added direct lowering from HLO to VMLA with shape dialect additions. Includes
an additional canonicalizer to bypass index cast. Includes a dynamic version of
math_test for verifying dynamic support.