### PR TITLE
Fix submodule action by changing how environment variables are set

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -33,8 +33,8 @@ jobs:
         run: ./scripts/git/submodule_versions.py init
       - name: Checking submodule state
         run: |
-          echo "::set-env name=has_diff::false"
-          git diff --cached --exit-code || echo "::set-env name=has_diff::true"
+          echo "has_diff=false" >> $GITHUB_ENV
+          git diff --cached --exit-code || echo "has_diff=true" >> $GITHUB_ENV
       - name: Committing updates
         if: env.has_diff == 'true'
         run: |


### PR DESCRIPTION
Issues and solution detailed in the links below.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable