### PR TITLE
Disable WAIT_TYPE_SYNC_FILE until include issues on CI are resolved.

### DIFF
--- a/iree/base/wait_handle.h
+++ b/iree/base/wait_handle.h
@@ -32,7 +32,8 @@
 #endif  // IREE_PLATFORM_*
 
 // TODO(benvanik): see if we can get sync file on linux too:
-#if defined(IREE_PLATFORM_ANDROID)
+// TODO(scotttodd): fix include on Android (missing linkopts?)
+#if 0 && defined(IREE_PLATFORM_ANDROID)
 #define IREE_HAVE_WAIT_TYPE_SYNC_FILE 1
 #endif  // IREE_PLATFORM_ANDROID
 


### PR DESCRIPTION
Fixes these errors: https://source.cloud.google.com/results/invocations/f1a13a65-8f08-4f9e-9bfc-747e190f82f7/targets/iree%2Fgcp_ubuntu%2Fcmake%2Fandroid%2Farm64-v8a%2Fmain/log

```
FAILED: iree/base/CMakeFiles/iree_base_wait_handle.dir/wait_handle_posix.c.o
/usr/src/android-ndk-r21d/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=aarch64-none-linux-android29 --gcc-toolchain=/usr/src/android-ndk-r21d/toolchains/llvm/prebuilt/linux-x86_64 --sysroot=/usr/src/android-ndk-r21d/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DABSL_FLAGS_STRIP_NAMES=0 -I../third_party/abseil-cpp -isystem ../ -isystem . -isystem ../third_party/llvm-project/llvm/include -isystem third_party/llvm-project/llvm/include -isystem ../third_party/llvm-project/mlir/include -isystem third_party/llvm-project/llvm/tools/mlir/include -isystem ../third_party/tensorflow -isystem ../third_party/tensorflow/tensorflow/compiler/mlir/hlo/include -isystem third_party/tensorflow -isystem third_party/tensorflow/tensorflow/compiler/mlir/hlo/include -isystem third_party/tensorflow/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR -isystem third_party/tensorflow/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -DNDEBUG  -fPIC   -D_GNU_SOURCE=1 -Wall -Wno-ambiguous-member-template -Wno-char-subscripts -Wno-error=deprecated-declarations -Wno-extern-c-compat -Wno-gnu-alignof-expression -Wno-gnu-variable-sized-type-not-at-end -Wno-ignored-optimization-argument -Wno-invalid-offsetof -Wno-invalid-source-encoding -Wno-mismatched-tags -Wno-pointer-sign -Wno-reserved-user-defined-literal -Wno-return-type-c-linkage -Wno-self-assign-overloaded -Wno-sign-compare -Wno-signed-unsigned-wchar -Wno-strict-overflow -Wno-trigraphs -Wno-unknown-pragmas -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-unused-const-variable -Wno-unused-function -Wno-unused-local-typedef -Wno-unused-private-field -Wno-user-defined-warnings -Wctad-maybe-unsupported -Wfloat-overflow-conversion -Wfloat-zero-conversion -Wfor-loop-analysis -Wformat-security -Wgnu-redeclared-enum -Wimplicit-fallthrough -Winfinite-recursion -Wliteral-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wself-assign -Wstring-conversion -Wtautological-overlap-compare -Wthread-safety -Wthread-safety-beta -Wunused-comparison -Wunused-variable -Wvla -Wno-strict-prototypes -Wno-shadow-uncaptured-local -Wno-gnu-zero-variadic-macro-arguments -Wno-shadow-field-in-constructor -Wno-unreachable-code-return -Wno-missing-variable-declarations -Wno-gnu-label-as-value -Wno-unused-parameter -Wno-undef -fvisibility=hidden -Wno-documentation -Wno-documentation-unknown-command -std=gnu11 -MD -MT iree/base/CMakeFiles/iree_base_wait_handle.dir/wait_handle_posix.c.o -MF iree/base/CMakeFiles/iree_base_wait_handle.dir/wait_handle_posix.c.o.d -o iree/base/CMakeFiles/iree_base_wait_handle.dir/wait_handle_posix.c.o   -c ../iree/base/wait_handle_posix.c
../iree/base/wait_handle_posix.c:30:10: fatal error: 'sync.h' file not found
#include <sync.h>
         ^~~~~~~~
```