### PR TITLE
Fix-forward sync.h include on Android.

### DIFF
--- a/iree/base/wait_handle.h
+++ b/iree/base/wait_handle.h
@@ -32,8 +32,7 @@
 #endif  // IREE_PLATFORM_*
 
 // TODO(benvanik): see if we can get sync file on linux too:
-// TODO(scotttodd): fix include on Android (missing linkopts?)
-#if 0 && defined(IREE_PLATFORM_ANDROID)
+#if defined(IREE_PLATFORM_ANDROID)
 #define IREE_HAVE_WAIT_TYPE_SYNC_FILE 1
 #endif  // IREE_PLATFORM_ANDROID
 

--- a/iree/base/wait_handle_posix.c
+++ b/iree/base/wait_handle_posix.c
@@ -27,7 +27,7 @@
 #include <sys/eventfd.h>
 #endif  // IREE_HAVE_WAIT_TYPE_EVENTFD
 #if defined(IREE_HAVE_WAIT_TYPE_SYNC_FILE)
-#include <sync.h>
+#include <android/sync.h>
 #endif  // IREE_HAVE_WAIT_TYPE_SYNC_FILE
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Following https://github.com/google/iree/pull/3884 now that I have Android building locally.