### PR TITLE
Add and/or reduce support to VMLA

### DIFF
--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -107,6 +107,7 @@ LLVM_FAILING = [
     "matrix_ops_dynamic_test.py",
     "quantization_dyn_test.py",
     "range_test.py",
+    "reduce_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
     "strings_test.py",
@@ -129,6 +130,7 @@ VULKAN_FAILING = [
     "matrix_ops_dynamic_test.py",
     "quantization_dyn_test.py",
     "range_test.py",
+    "reduce_test.py",
     "ring_buffer_test.py",  # TODO(b/148747011)
     "scatter_update_test.py",
     "strings_test.py",

--- a/integrations/tensorflow/e2e/BUILD
+++ b/integrations/tensorflow/e2e/BUILD
@@ -71,6 +71,7 @@ TFLITE_FAILING = [
     "mandelbrot_test.py",
     "matrix_ops_dynamic_test.py",
     "quantization_dyn_test.py",
+    "reduce_test.py",
     "resource_ops_test.py",
     "ring_buffer_test.py",
     "scatter_update_test.py",

--- a/integrations/tensorflow/e2e/reduce_test.py
+++ b/integrations/tensorflow/e2e/reduce_test.py
@@ -1,0 +1,94 @@
+# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ops in the tf.math module."""
+
+from absl import app
+import numpy as np
+from pyiree.tf.support import tf_test_utils
+from pyiree.tf.support import tf_utils
+import tensorflow.compat.v2 as tf
+
+
+class ReduceModule(tf.Module):
+
+  @tf.function(input_signature=[tf.TensorSpec([4, 4, 4], tf.float32)])
+  def max(self, x):
+    return tf.math.reduce_max(x, axis=1)
+
+  @tf.function(input_signature=[tf.TensorSpec([4, 4, 4], tf.float32)])
+  def min(self, x):
+    return tf.math.reduce_min(x, axis=1)
+
+  @tf.function(input_signature=[tf.TensorSpec([4, 4, 4], tf.float32)])
+  def sum(self, x):
+    return tf.math.reduce_sum(x, axis=1)
+
+  @tf.function(input_signature=[tf.TensorSpec([4, 2], tf.bool)])
+  def reduce_any(self, x):
+    return tf.math.reduce_any(x, axis=1)
+
+  @tf.function(input_signature=[tf.TensorSpec([4, 2], tf.bool)])
+  def reduce_all(self, x):
+    return tf.math.reduce_all(x, axis=1)
+
+
+class ReduceTest(tf_test_utils.TracedModuleTestCase):
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._modules = tf_test_utils.compile_tf_module(ReduceModule)
+
+  # yapf: disable
+  def test_max(self):
+    def max(module):
+      arr = tf_utils.uniform([4, 4, 4], dtype=tf.float32)
+      module.max(arr)
+    self.compare_backends(max, self._modules)
+
+  def test_min(self):
+    def min(module):
+      arr = tf_utils.uniform([4, 4, 4], dtype=tf.float32)
+      module.min(arr)
+    self.compare_backends(min, self._modules)
+
+  def test_sum(self):
+    def sum(module):
+      arr = tf_utils.uniform([4, 4, 4], dtype=tf.float32)
+      module.sum(arr)
+    self.compare_backends(sum, self._modules)
+
+  def test_any(self):
+    def reduce_any(module):
+      arr = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.bool)
+      module.reduce_any(arr)
+    self.compare_backends(reduce_any, self._modules)
+
+  def test_all(self):
+    def reduce_all(module):
+      arr = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.bool)
+      module.reduce_all(arr)
+    self.compare_backends(reduce_all, self._modules)
+  # yapf: enable
+
+
+def main(argv):
+  del argv  # Unused
+  if hasattr(tf, 'enable_v2_behavior'):
+    tf.enable_v2_behavior()
+  tf.test.main()
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertReductionOps.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertReductionOps.cpp
@@ -191,12 +191,12 @@ struct BuiltinReduceOpConversion : public OpConversionPattern<mhlo::ReduceOp> {
           srcOp.getLoc(), operand, operandShape, initValue, initValueShape,
           rewriter.getI32IntegerAttr(dimension), dst, dstShape,
           TypeAttr::get(elementType));
-     } else if (isa<mhlo::OrOp>(computeOp)) {
+    } else if (isa<mhlo::OrOp>(computeOp)) {
       rewriter.create<IREE::VMLA::ReduceOrOp>(
           srcOp.getLoc(), operand, operandShape, initValue, initValueShape,
           rewriter.getI32IntegerAttr(dimension), dst, dstShape,
           TypeAttr::get(elementType));
-     } else {
+    } else {
       computeOp.emitRemark() << "unsupported builtin reduction operation";
       return failure();
     }

--- a/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertReductionOps.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/HLOToVMLA/ConvertReductionOps.cpp
@@ -186,7 +186,17 @@ struct BuiltinReduceOpConversion : public OpConversionPattern<mhlo::ReduceOp> {
           srcOp.getLoc(), operand, operandShape, initValue, initValueShape,
           rewriter.getI32IntegerAttr(dimension), dst, dstShape,
           TypeAttr::get(elementType));
-    } else {
+    } else if (isa<mhlo::AndOp>(computeOp)) {
+      rewriter.create<IREE::VMLA::ReduceAndOp>(
+          srcOp.getLoc(), operand, operandShape, initValue, initValueShape,
+          rewriter.getI32IntegerAttr(dimension), dst, dstShape,
+          TypeAttr::get(elementType));
+     } else if (isa<mhlo::OrOp>(computeOp)) {
+      rewriter.create<IREE::VMLA::ReduceOrOp>(
+          srcOp.getLoc(), operand, operandShape, initValue, initValueShape,
+          rewriter.getI32IntegerAttr(dimension), dst, dstShape,
+          TypeAttr::get(elementType));
+     } else {
       computeOp.emitRemark() << "unsupported builtin reduction operation";
       return failure();
     }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
@@ -359,6 +359,8 @@ void populateVMLAToVMPatterns(MLIRContext *context,
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::ReduceSumOp, "vmla.reduce.sum");
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::ReduceMinOp, "vmla.reduce.min");
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::ReduceMaxOp, "vmla.reduce.max");
+  VMLA_TYPED_IMPORT_OP(IREE::VMLA::ReduceAndOp, "vmla.reduce.and");
+  VMLA_TYPED_IMPORT_OP(IREE::VMLA::ReduceOrOp, "vmla.reduce.or");
 
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::PoolingSumOp, "vmla.pooling.sum");
   VMLA_TYPED_IMPORT_OP(IREE::VMLA::PoolingMinOp, "vmla.pooling.min");

--- a/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
+++ b/iree/compiler/Dialect/VMLA/IR/VMLAOps.td
@@ -601,6 +601,8 @@ class VMLA_ReduceOp<string mnemonic, list<OpTrait> traits = []> :
 def VMLA_ReduceSumOp : VMLA_ReduceOp<"reduce.sum">;
 def VMLA_ReduceMinOp : VMLA_ReduceOp<"reduce.min">;
 def VMLA_ReduceMaxOp : VMLA_ReduceOp<"reduce.max">;
+def VMLA_ReduceAndOp : VMLA_ReduceOp<"reduce.and">;
+def VMLA_ReduceOrOp  : VMLA_ReduceOp<"reduce.or">;
 
 class VMLA_PoolingOp<string mnemonic, list<OpTrait> traits = []> :
     VMLA_ElementTypeOp<mnemonic, !listconcat(traits, [VMLA_IncludeShapes])> {

--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -475,6 +475,20 @@ vm.import @reduce.max.f32(
   %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
 )
 
+vm.import @reduce.and.i8(
+  %src : !vm.ref<!vmla.buffer>, %src_shape : i32 ...,
+  %init : !vm.ref<!vmla.buffer>, %init_shape : i32 ...,
+  %dimension : i32,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
+)
+
+vm.import @reduce.or.i8(
+  %src : !vm.ref<!vmla.buffer>, %src_shape : i32 ...,
+  %init : !vm.ref<!vmla.buffer>, %init_shape : i32 ...,
+  %dimension : i32,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
+)
+
 vm.import @pooling.sum.i8(
   %src : !vm.ref<!vmla.buffer>, %src_shape : i32 ...,
   %init : !vm.ref<!vmla.buffer>, %init_shape : i32 ...,

--- a/iree/hal/vmla/op_kernels.h
+++ b/iree/hal/vmla/op_kernels.h
@@ -455,6 +455,22 @@ struct ReduceMax {
                         ShapeSpan src_shape, ShapeSpan dst_shape);
 };
 
+struct ReduceAnd {
+  template <typename T>
+  static Status Execute(absl::Span<const T> src_buffer,
+                        absl::Span<const T> init_buffer,
+                        absl::Span<T> dst_buffer, int32_t dimension,
+                        ShapeSpan src_shape, ShapeSpan dst_shape);
+};
+
+struct ReduceOr {
+  template <typename T>
+  static Status Execute(absl::Span<const T> src_buffer,
+                        absl::Span<const T> init_buffer,
+                        absl::Span<T> dst_buffer, int32_t dimension,
+                        ShapeSpan src_shape, ShapeSpan dst_shape);
+};
+
 struct PoolingSum {
   template <typename T>
   static Status Execute(absl::Span<const T> src_buffer,

--- a/iree/hal/vmla/op_kernels_generic.h
+++ b/iree/hal/vmla/op_kernels_generic.h
@@ -904,6 +904,20 @@ struct MaxKernel {
   }
 };
 
+struct AndKernel {
+  template <typename T>
+  inline void operator()(T* value0, const T value1) {
+    *value0 = *value0 && value1;
+  }
+};
+
+struct OrKernel {
+  template <typename T>
+  inline void operator()(T* value0, const T value1) {
+    *value0 = *value0 || value1;
+  }
+};
+
 template <typename T, typename KernelImpl>
 inline void ReduceDimension(absl::Span<const T> src_buffer,
                             absl::Span<T> dst_buffer, ShapeSpan src_shape,
@@ -1025,6 +1039,25 @@ Status ReduceMax::Execute(absl::Span<const T> src_buffer,
                           absl::Span<T> dst_buffer, int32_t dimension,
                           ShapeSpan src_shape, ShapeSpan dst_shape) {
   return impl::GenericReduce<T, impl::MaxKernel>(
+      src_buffer, init_buffer, dst_buffer, dimension, src_shape, dst_shape);
+}
+
+
+template <typename T>
+Status ReduceAnd::Execute(absl::Span<const T> src_buffer,
+                          absl::Span<const T> init_buffer,
+                          absl::Span<T> dst_buffer, int32_t dimension,
+                          ShapeSpan src_shape, ShapeSpan dst_shape) {
+  return impl::GenericReduce<T, impl::AndKernel>(
+      src_buffer, init_buffer, dst_buffer, dimension, src_shape, dst_shape);
+}
+
+template <typename T>
+Status ReduceOr::Execute(absl::Span<const T> src_buffer,
+                         absl::Span<const T> init_buffer,
+                         absl::Span<T> dst_buffer, int32_t dimension,
+                         ShapeSpan src_shape, ShapeSpan dst_shape) {
+  return impl::GenericReduce<T, impl::OrKernel>(
       src_buffer, init_buffer, dst_buffer, dimension, src_shape, dst_shape);
 }
 

--- a/iree/hal/vmla/op_kernels_generic.h
+++ b/iree/hal/vmla/op_kernels_generic.h
@@ -1042,7 +1042,6 @@ Status ReduceMax::Execute(absl::Span<const T> src_buffer,
       src_buffer, init_buffer, dst_buffer, dimension, src_shape, dst_shape);
 }
 
-
 template <typename T>
 Status ReduceAnd::Execute(absl::Span<const T> src_buffer,
                           absl::Span<const T> init_buffer,

--- a/iree/hal/vmla/vmla_module.cc
+++ b/iree/hal/vmla/vmla_module.cc
@@ -814,6 +814,8 @@ class VMLAModuleState final {
   IREE_VMLA_REDUCTION_OP(ReduceMaxI16, kernels::ReduceMax, int16_t);
   IREE_VMLA_REDUCTION_OP(ReduceMaxI32, kernels::ReduceMax, int32_t);
   IREE_VMLA_REDUCTION_OP(ReduceMaxF32, kernels::ReduceMax, float);
+  IREE_VMLA_REDUCTION_OP(ReduceAndI8, kernels::ReduceAnd, int8_t);
+  IREE_VMLA_REDUCTION_OP(ReduceOrI8, kernels::ReduceOr, int8_t);
 
 #define IREE_VMLA_POOLING_OP(name, kernel, type)                              \
   Status name(const vm::ref<Buffer>& src, iree_vmla_shape_t src_shape,        \
@@ -1028,6 +1030,8 @@ static const vm::NativeFunction<VMLAModuleState> kVMLAModuleFunctions[] = {
     vm::MakeNativeFunction("reduce.max.i16", &VMLAModuleState::ReduceMaxI16),
     vm::MakeNativeFunction("reduce.max.i32", &VMLAModuleState::ReduceMaxI32),
     vm::MakeNativeFunction("reduce.max.f32", &VMLAModuleState::ReduceMaxF32),
+    vm::MakeNativeFunction("reduce.and.i8", &VMLAModuleState::ReduceAndI8),
+    vm::MakeNativeFunction("reduce.or.i8", &VMLAModuleState::ReduceOrI8),
 
     vm::MakeNativeFunction("pooling.sum.i8", &VMLAModuleState::PoolingSumI8),
     vm::MakeNativeFunction("pooling.sum.i16", &VMLAModuleState::PoolingSumI16),


### PR DESCRIPTION
Handles the tf.math.reduce_any and tf.math.reduce_all operations.
Added a reduce_test.py file to check all reductions.