### PR TITLE
[doc] Use v3 Ninja setup to unbreak doc publication

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
       - name: Installing Ninja build
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
       - name: Building documentation
         run: |
           ./build_tools/cmake/build_docs.sh


### PR DESCRIPTION
This addresses the "The `add-path` command is disabled. Please upgrade
to using Environment Files or opt into unsecure command execution by
setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to
`true`." issue.