### PR TITLE
Tensorlist refactor to remove shape input and support empty reserve behavior

### DIFF
--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
     ],
     alwayslink = 1,
 )
@@ -70,6 +71,8 @@ cc_library(
     deps = [
         "//integrations/tensorflow/compiler/dialect/tf_tensorlist/ir",
         "//iree/compiler/Dialect/HAL/Conversion",
+        "//iree/compiler/Dialect/HAL/IR",
+        "//iree/compiler/Dialect/HAL/Utils",
         "//iree/compiler/Dialect/Modules/TensorList/IR",
         "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
         "@llvm-project//mlir:IR",

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_flow_to_hal.cc
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_flow_to_hal.cc
@@ -16,10 +16,120 @@
 
 #include "integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_ops.h"
 #include "iree/compiler/Dialect/HAL/Conversion/ConversionTarget.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/HAL/Utils/TypeUtils.h"
 #include "iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.h"
+#include "iree/compiler/Dialect/Modules/TensorList/IR/TensorListTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/StandardTypes.h"
 
 namespace mlir {
 namespace iree_compiler {
+
+namespace {
+
+LogicalResult getBufferView(Operation *srcOp, Value srcOperand,
+                            Value dstOperand,
+                            ConversionPatternRewriter &rewriter,
+                            Value &retValue) {
+  auto operand = IREE::HAL::TensorRewriteAdaptor::getChecked(
+      srcOp->getLoc(), srcOperand, dstOperand, rewriter);
+  if (!operand.hasValue()) {
+    return srcOp->emitOpError() << "unable to create adaptor for operand";
+  }
+  auto bufferView = operand->getBufferView();
+  if (!bufferView) {
+    return srcOp->emitOpError() << "unable to get buffer view for operand";
+  }
+
+  retValue = bufferView;
+  return success();
+}
+
+class ReserveOpConversion : public OpConversionPattern<tf_tensorlist::Reserve> {
+ public:
+  ReserveOpConversion(MLIRContext *ctx, TypeConverter &converter)
+      : OpConversionPattern(ctx) {}
+
+  LogicalResult matchAndRewrite(
+      tf_tensorlist::Reserve reserveOp, llvm::ArrayRef<Value> newOperands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto elementTy = reserveOp.element_type();
+    auto element_value = IREE::HAL::getElementTypeValue(elementTy).getValue();
+
+    Value operand0, operand1;
+    getBufferView(reserveOp, reserveOp.getOperand(0), newOperands[0], rewriter,
+                  operand0);
+    getBufferView(reserveOp, reserveOp.getOperand(1), newOperands[1], rewriter,
+                  operand1);
+
+    rewriter.replaceOpWithNewOp<IREE::TensorList::Reserve>(
+        reserveOp,
+        IREE::TensorList::TensorListType::get(reserveOp.getContext()), operand0,
+        operand1, rewriter.getI32IntegerAttr(element_value));
+    return success();
+  }
+};
+
+class ConcatOpConversion : public OpConversionPattern<tf_tensorlist::Concat> {
+ public:
+  ConcatOpConversion(MLIRContext *ctx, TypeConverter &converter)
+      : OpConversionPattern(ctx) {}
+
+  LogicalResult matchAndRewrite(
+      tf_tensorlist::Concat concatOp, llvm::ArrayRef<Value> newOperands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto device =
+        rewriter.createOrFold<IREE::HAL::ExSharedDeviceOp>(concatOp.getLoc());
+    auto allocator =
+        rewriter.create<IREE::HAL::DeviceAllocatorOp>(concatOp.getLoc(), device)
+            .getResult();
+
+    auto newConcatOp = rewriter.createOrFold<IREE::TensorList::Concat>(
+        concatOp.getLoc(),
+        IREE::HAL::BufferViewType::get(rewriter.getContext()), allocator,
+        newOperands[0]);
+
+    auto bufferOp = rewriter.createOrFold<IREE::HAL::BufferViewBufferOp>(
+        newConcatOp.getLoc(), newConcatOp);
+
+    rewriter.replaceOp(concatOp, bufferOp);
+    return success();
+  }
+};
+
+class StackOpConversion : public OpConversionPattern<tf_tensorlist::Stack> {
+ public:
+  StackOpConversion(MLIRContext *ctx, TypeConverter &converter)
+      : OpConversionPattern(ctx) {}
+
+  LogicalResult matchAndRewrite(
+      tf_tensorlist::Stack stackOp, llvm::ArrayRef<Value> newOperands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto device =
+        rewriter.createOrFold<IREE::HAL::ExSharedDeviceOp>(stackOp.getLoc());
+    auto allocator =
+        rewriter.create<IREE::HAL::DeviceAllocatorOp>(stackOp.getLoc(), device)
+            .getResult();
+
+    Value operand1;
+    getBufferView(stackOp, stackOp.getOperand(1), newOperands[1], rewriter,
+                  operand1);
+
+    auto newStackOp = rewriter.createOrFold<IREE::TensorList::Stack>(
+        stackOp.getLoc(), IREE::HAL::BufferViewType::get(rewriter.getContext()),
+        allocator, newOperands[0], operand1);
+
+    auto bufferOp = rewriter.createOrFold<IREE::HAL::BufferViewBufferOp>(
+        stackOp.getLoc(), newStackOp);
+
+    rewriter.replaceOp(stackOp, bufferOp);
+    return success();
+  }
+};
+
+}  // namespace
 
 void populateTensorListToHALPatterns(MLIRContext *context,
                                      OwningRewritePatternList &patterns,
@@ -28,9 +138,9 @@ void populateTensorListToHALPatterns(MLIRContext *context,
   // as we just want the simple form. If we wanted to perform additional
   // verification or have a specific use case (such as a place where only the
   // buffer is required and the shape is not) we could add our own.
-  patterns.insert<
-      HALOpConversion<tf_tensorlist::Reserve, IREE::TensorList::Reserve>>(
-      context, typeConverter);
+  // patterns.insert<
+  //     HALOpConversion<tf_tensorlist::Reserve, IREE::TensorList::Reserve>>(
+  //     context, typeConverter);
   patterns.insert<
       HALOpConversion<tf_tensorlist::GetItem, IREE::TensorList::GetItem>>(
       context, typeConverter);
@@ -40,12 +150,10 @@ void populateTensorListToHALPatterns(MLIRContext *context,
   patterns.insert<
       HALOpConversion<tf_tensorlist::FromTensor, IREE::TensorList::FromTensor>>(
       context, typeConverter);
-  patterns
-      .insert<HALOpConversion<tf_tensorlist::Concat, IREE::TensorList::Concat>>(
-          context, typeConverter);
-  patterns
-      .insert<HALOpConversion<tf_tensorlist::Stack, IREE::TensorList::Stack>>(
-          context, typeConverter);
+
+  patterns.insert<ConcatOpConversion>(context, typeConverter);
+  patterns.insert<ReserveOpConversion>(context, typeConverter);
+  patterns.insert<StackOpConversion>(context, typeConverter);
 }
 
 }  // namespace iree_compiler

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_tf_to_tf_tensorlist.cc
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_tf_to_tf_tensorlist.cc
@@ -19,9 +19,25 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_types.h"
 
 namespace mlir {
 namespace tf_tensorlist {
+
+namespace {
+TypeAttr GetVariantElementTypeAttr(Type type) {
+  if (auto variantTy = type.dyn_cast<TF::VariantType>()) {
+    return GetVariantElementTypeAttr(variantTy.getSubtypes().front());
+  }
+
+  if (auto shapedTy = type.dyn_cast<ShapedType>()) {
+    return GetVariantElementTypeAttr(shapedTy.getElementType());
+  }
+
+  return TypeAttr::get(type);
+}
+
+}  // namespace
 
 #include "integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_tf_to_tf_tensorlist.inc"
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_tf_to_tf_tensorlist.td
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/convert_tf_to_tf_tensorlist.td
@@ -17,26 +17,27 @@ include "mlir/Dialect/StandardOps/IR/Ops.td"
 include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.td"
 include "integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_ops.td"
 
-def : Pat<(TF_TensorListReserveOp $element_shape, $num_elements),
-          (TfTensorList_Reserve $element_shape, $num_elements)>;
+// GetElementTypeAttr
+def GetVariantElementTypeAttr : NativeCodeCall<
+  "GetVariantElementTypeAttr($0.getType())">;
+
+def : Pat<(TF_TensorListReserveOp:$result $element_shape, $num_elements),
+          (TfTensorList_Reserve $element_shape, $num_elements,
+           (GetVariantElementTypeAttr $result))>;
 
 def : Pat<(TF_TensorListGetItemOp $input_handle, $index, $element_shape),
-          (TfTensorList_GetItem
-            $input_handle,
-            $index,
-            $element_shape)>;
+          (TfTensorList_GetItem $input_handle, $index)>;
 
 def : Pat<(TF_TensorListSetItemOp $input_handle, $index, $item),
           (TfTensorList_SetItem $input_handle, $index, $item)>;
 
 def : Pat<(TF_TensorListFromTensorOp $tensor, $element_shape),
-          (TfTensorList_FromTensor $tensor, $element_shape)>;
+          (TfTensorList_FromTensor $tensor)>;
 
 def WrapScalarI64InTensor : NativeCodeCall<
     "DenseElementsAttr::get(RankedTensorType::get({}, $_builder.getIntegerType(64)), {$_self.getValue()})">;
 def : Pat<(TF_TensorListStackOp $input_handle, $element_shape, $num_elements),
           (TfTensorList_Stack
             $input_handle,
-            $element_shape,
             (ConstantOp WrapScalarI64InTensor:$num_elements))>;
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_flow_to_hal.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_flow_to_hal.mlir
@@ -5,7 +5,7 @@ func @Reserve(%arg0: tensor<0xi32>, %arg1: tensor<i32>) -> !tf_tensorlist.list{
 // CHECK:         [[VIEW0:%.+]] = hal.buffer_view.create %arg0{{.*}}
 // CHECK:         [[VIEW1:%.+]] = hal.buffer_view.create %arg1{{.*}}
 // CHECK:         "tensorlist.Reserve"([[VIEW0]], [[VIEW1]])
-  %0 = "tf_tensorlist.Reserve"(%arg0, %arg1) : (tensor<0xi32>, tensor<i32>) -> !tf_tensorlist.list
+  %0 = "tf_tensorlist.Reserve"(%arg0, %arg1) {element_type = f32} : (tensor<0xi32>, tensor<i32>) -> !tf_tensorlist.list
   return %0 : !tf_tensorlist.list
 }
 
@@ -18,20 +18,26 @@ func @SetItem(%arg0: !tf_tensorlist.list, %arg1: tensor<i32>, %arg2: tensor<f32>
   return %0 : !tf_tensorlist.list
 }
 
-// CHECK-LABEL: func @GetItem(%arg0: !tensorlist.list, %arg1: !hal.buffer, %arg2: !hal.buffer) -> !hal.buffer {
-func @GetItem(%arg0: !tf_tensorlist.list, %arg1: tensor<i32>, %arg2: tensor<0xi32>) -> tensor<f32> {
+// CHECK-LABEL: func @GetItem(%arg0: !tensorlist.list, %arg1: !hal.buffer) -> !hal.buffer {
+func @GetItem(%arg0: !tf_tensorlist.list, %arg1: tensor<i32>) -> tensor<f32> {
 // CHECK:         [[VIEW1:%.+]] = hal.buffer_view.create %arg1{{.*}}
-// CHECK:         [[VIEW2:%.+]] = hal.buffer_view.create %arg2{{.*}}
-// CHECK:         "tensorlist.GetItem"(%arg0, [[VIEW1]], [[VIEW2]])
-  %0 = "tf_tensorlist.GetItem"(%arg0, %arg1, %arg2) : (!tf_tensorlist.list, tensor<i32>, tensor<0xi32>) -> tensor<f32>
+// CHECK:         "tensorlist.GetItem"(%arg0, [[VIEW1]])
+  %0 = "tf_tensorlist.GetItem"(%arg0, %arg1) : (!tf_tensorlist.list, tensor<i32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
-// CHECK-LABEL: func @Stack(%arg0: !tensorlist.list, %arg1: !hal.buffer, %arg2: !hal.buffer) -> !hal.buffer {
-func @Stack(%arg0: !tf_tensorlist.list, %arg1: tensor<1xi32>, %arg2: tensor<i32>) -> tensor<1xf32> {
+// CHECK-LABEL: func @Stack(%arg0: !tensorlist.list, %arg1: !hal.buffer) -> !hal.buffer {
+func @Stack(%arg0: !tf_tensorlist.list, %arg1: tensor<i32>) -> tensor<1xf32> {
 // CHECK:         [[VIEW1:%.+]] = hal.buffer_view.create %arg1{{.*}}
-// CHECK:         [[VIEW2:%.+]] = hal.buffer_view.create %arg2{{.*}}
-// CHECK:         "tensorlist.Stack"(%arg0, [[VIEW1]], [[VIEW2]])
-  %0 = "tf_tensorlist.Stack"(%arg0, %arg1, %arg2) : (!tf_tensorlist.list, tensor<1xi32>, tensor<i32>) -> tensor<1xf32>
+// CHECK:         "tensorlist.Stack"(%allocator, %arg0, [[VIEW1]])
+  %0 = "tf_tensorlist.Stack"(%arg0, %arg1) : (!tf_tensorlist.list, tensor<i32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
+
+// CHECK-LABEL: func @Concat(%arg0: !tensorlist.list) -> !hal.buffer {
+func @Concat(%arg0: !tf_tensorlist.list) -> (tensor<1xf32>) {
+// CHECK:         "tensorlist.Concat"(%allocator, %arg0)
+  %0 = "tf_tensorlist.Concat"(%arg0) : (!tf_tensorlist.list) -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
@@ -4,9 +4,9 @@
 
 // CHECK-LABEL: func @basic
 func @basic(%arg0: tensor<f32>, %num_elements: tensor<i32>, %element_shape: tensor<0xi32>, %index: tensor<i32>, %item: tensor<f32>) -> tensor<f32> {
-  // CHECK-NEXT: [[LIST0:%.+]] = "tf_tensorlist.Reserve"(%arg2, %arg1) : (tensor<0xi32>, tensor<i32>) -> !tf_tensorlist.list
+  // CHECK-NEXT: [[LIST0:%.+]] = "tf_tensorlist.Reserve"(%arg2, %arg1) {element_type = f32} : (tensor<0xi32>, tensor<i32>) -> !tf_tensorlist.list
   // CHECK-NEXT: [[LIST1:%.+]] = "tf_tensorlist.SetItem"([[LIST0]], %arg3, %arg4) : (!tf_tensorlist.list, tensor<i32>, tensor<f32>) -> !tf_tensorlist.list
-  // CHECK-NEXT: [[T:%.+]] = "tf_tensorlist.GetItem"([[LIST1]], %arg3, %arg2) : (!tf_tensorlist.list, tensor<i32>, tensor<0xi32>) -> tensor<f32>
+  // CHECK-NEXT: [[T:%.+]] = "tf_tensorlist.GetItem"([[LIST1]], %arg3) : (!tf_tensorlist.list, tensor<i32>) -> tensor<f32>
   // CHECK-NEXT: return [[T]] : tensor<f32>
   %list0 = "tf.TensorListReserve"(%element_shape, %num_elements) : (tensor<0xi32>, tensor<i32>) -> tensor<!tf.variant<tensor<f32>>>
   %list1 = "tf.TensorListSetItem"(%list0, %index, %item) : (tensor<!tf.variant<tensor<f32>>>, tensor<i32>, tensor<f32>) -> tensor<!tf.variant<tensor<f32>>>
@@ -16,9 +16,9 @@ func @basic(%arg0: tensor<f32>, %num_elements: tensor<i32>, %element_shape: tens
 
 // CHECK-LABEL: func @stack
 func @stack(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>) -> tensor<?xf32> {
-  // CHECK-NEXT: [[LIST0:%.+]] = "tf_tensorlist.FromTensor"(%arg0, %arg1) : (tensor<?xf32>, tensor<0xi32>) -> !tf_tensorlist.list
+  // CHECK-NEXT: [[LIST0:%.+]] = "tf_tensorlist.FromTensor"(%arg0) : (tensor<?xf32>) -> !tf_tensorlist.list
   // CHECK-NEXT: [[CONST:%.+]] = constant dense<-1> : tensor<i64>
-  // CHECK-NEXT: [[T:%.+]] = "tf_tensorlist.Stack"([[LIST0]], %arg1, [[CONST]]) : (!tf_tensorlist.list, tensor<0xi32>, tensor<i64>) -> tensor<?xf32>
+  // CHECK-NEXT: [[T:%.+]] = "tf_tensorlist.Stack"([[LIST0]], [[CONST]]) : (!tf_tensorlist.list, tensor<i64>) -> tensor<?xf32>
   // CHECK-NEXT: return [[T]]
 
   %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<?xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
@@ -27,16 +27,17 @@ func @stack(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>) -> tensor<?xf32
 }
 
 // CHECK-LABEL: func @concat
-func @concat(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>, %lead: tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>) {
-  // CHECK-DAG: [[LIST0:%.+]] = "tf_tensorlist.FromTensor"(%arg0, %arg1)
+func @concat(%arg0: tensor<5xf32>, %element_shape: tensor<0xi32>, %lead: tensor<i64>) -> (tensor<5xf32>, tensor<0xi64>) {
+  // CHECK-DAG: [[LIST0:%.+]] = "tf_tensorlist.FromTensor"(%arg0)
   // CHECK-DAG: [[T:%.+]] = "tf_tensorlist.Concat"([[LIST0]])
   // CHECK-DAG: [[L:%.+]] = "tf_tensorlist.GetDim0"([[LIST0]])
   // CHECK: return [[T]], [[L]]
 
-  %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<?xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
-  %t:2 = "tf.TensorListConcatV2"(%list0, %element_shape, %lead) : (tensor<!tf.variant<tensor<f32>>>, tensor<0xi32>, tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>)
-  return %t#0, %t#1 : tensor<?xf32>, tensor<0xi64>
+  %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<5xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
+  %t:2 = "tf.TensorListConcatV2"(%list0, %element_shape, %lead) : (tensor<!tf.variant<tensor<f32>>>, tensor<0xi32>, tensor<i64>) -> (tensor<5xf32>, tensor<0xi64>)
+  return %t#0, %t#1 : tensor<5xf32>, tensor<0xi64>
 }
+
 
 // CHECK-LABEL: func @control_flow_simple
 func @control_flow_simple(%arg0: tensor<f32>, %num_elements: tensor<i32>, %element_shape: tensor<0xi32>, %index: tensor<i32>, %item: tensor<f32>) {

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
@@ -27,15 +27,15 @@ func @stack(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>) -> tensor<?xf32
 }
 
 // CHECK-LABEL: func @concat
-func @concat(%arg0: tensor<5xf32>, %element_shape: tensor<0xi32>, %lead: tensor<i64>) -> (tensor<5xf32>, tensor<0xi64>) {
+func @concat(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>, %lead: tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>) {
   // CHECK-DAG: [[LIST0:%.+]] = "tf_tensorlist.FromTensor"(%arg0)
   // CHECK-DAG: [[T:%.+]] = "tf_tensorlist.Concat"([[LIST0]])
   // CHECK-DAG: [[L:%.+]] = "tf_tensorlist.GetDim0"([[LIST0]])
   // CHECK: return [[T]], [[L]]
 
-  %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<5xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
-  %t:2 = "tf.TensorListConcatV2"(%list0, %element_shape, %lead) : (tensor<!tf.variant<tensor<f32>>>, tensor<0xi32>, tensor<i64>) -> (tensor<5xf32>, tensor<0xi64>)
-  return %t#0, %t#1 : tensor<5xf32>, tensor<0xi64>
+  %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<?xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
+  %t:2 = "tf.TensorListConcatV2"(%list0, %element_shape, %lead) : (tensor<!tf.variant<tensor<f32>>>, tensor<0xi32>, tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>)
+  return %t#0, %t#1 : tensor<?xf32>, tensor<0xi64>
 }
 
 

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/test/ops.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/test/ops.mlir
@@ -9,13 +9,13 @@ func @f(
   %item: tensor<?xf32>
 ) {
   // CHECK: tf_tensorlist.Reserve
-  %2 = "tf_tensorlist.Reserve"(%element_shape, %num_elements) : (tensor<1xi32>, tensor<i32>) -> !tf_tensorlist.list
+  %2 = "tf_tensorlist.Reserve"(%element_shape, %num_elements) { element_type = f32 } : (tensor<1xi32>, tensor<i32>) -> !tf_tensorlist.list
   // CHECK: tf_tensorlist.GetItem
-  %3 = "tf_tensorlist.GetItem"(%list, %index, %element_shape) : (!tf_tensorlist.list, tensor<i32>, tensor<1xi32>) -> tensor<?xf32>
+  %3 = "tf_tensorlist.GetItem"(%list, %index) : (!tf_tensorlist.list, tensor<i32>) -> tensor<?xf32>
   // CHECK: tf_tensorlist.SetItem
   %4 = "tf_tensorlist.SetItem"(%list, %index, %item) : (!tf_tensorlist.list, tensor<i32>, tensor<?xf32>) -> !tf_tensorlist.list
   // CHECK: tf_tensorlist.Stack
-  %5 = "tf_tensorlist.Stack"(%list, %element_shape, %index) : (!tf_tensorlist.list, tensor<1xi32>, tensor<i32>) -> tensor<1x2xf32>
+  %5 = "tf_tensorlist.Stack"(%list, %index) : (!tf_tensorlist.list, tensor<i32>) -> tensor<1x2xf32>
   // CHECK: tf_tensorlist.Concat
   %6 = "tf_tensorlist.Concat"(%list) : (!tf_tensorlist.list) -> tensor<1x2xf32>
   // CHECK: tf_tensorlist.GetDim0

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_ops.td
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/tf_tensorlist_ops.td
@@ -34,7 +34,8 @@ def TfTensorList_Reserve : TfTensorList_Op<"Reserve"> {
 
   let arguments = (ins
     TF_I32OrI64Tensor:$element_shape,
-    I32Tensor:$num_elements
+    I32Tensor:$num_elements,
+    TypeAttr:$element_type
   );
 
   let results = (outs
@@ -62,8 +63,7 @@ def TfTensorList_GetItem : TfTensorList_Op<"GetItem"> {
 
   let arguments = (ins
     TfTensorList_TensorList:$list,
-    I32Tensor:$index,
-    I32Tensor:$element_shape
+    I32Tensor:$index
   );
 
   let results = (outs
@@ -103,8 +103,7 @@ def TfTensorList_FromTensor : TfTensorList_Op<"FromTensor", [NoSideEffect]> {
   }];
 
   let arguments = (ins
-    TF_Tensor:$tensor,
-    I32Tensor:$element_shape
+    TF_Tensor:$tensor
   );
 
   let results = (outs
@@ -125,7 +124,6 @@ def TfTensorList_Stack : TfTensorList_Op<"Stack", [NoSideEffect]> {
 
   let arguments = (ins
     TfTensorList_TensorList:$list,
-    I32Tensor:$element_shape,
     // TODO(silvasean): Properly handle IREE's blind truncation to 32-bit.
     // This is logically `index` type, but coming from TensorFlow it
     // comes in as i64. IREE then proceeds to blindly truncate it to I32

--- a/integrations/tensorflow/e2e/tensorlist_test.py
+++ b/integrations/tensorflow/e2e/tensorlist_test.py
@@ -67,6 +67,12 @@ class TensorListModule(tf.Module):
     ta = ta.write(1, b)
     return ta.stack()
 
+  @tf.function(input_signature=[tf.TensorSpec([], tf.float32)])
+  def partially_empty_stack(self, x):
+    ta = tf.TensorArray(dtype=tf.float32, size=2, element_shape=[])
+    ta = ta.write(0, x)
+    return ta.stack()
+
 
 class TensorListTest(tf_test_utils.TracedModuleTestCase):
 
@@ -104,6 +110,11 @@ class TensorListTest(tf_test_utils.TracedModuleTestCase):
       module.concat_with_tensorlist_stack(np.array(42., dtype=np.float32),
                                           np.array(43., dtype=np.float32))
     self.compare_backends(concat_with_tensorlist_stack, self._modules)
+
+  def test_partially_empty_stack(self):
+    def partially_empty_stack(module):
+      module.partially_empty_stack(np.array(42., dtype=np.float32))
+    self.compare_backends(partially_empty_stack, self._modules)
   # yapf: enable
 
 

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_hal_to_vm.mlir
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_hal_to_vm.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @Reserve
 func @Reserve(%element_shape: !hal.buffer_view, %num_elements: !hal.buffer_view) -> !tensorlist.list {
   // CHECK: vm.call @tensorlist.reserve
-  %0 = "tensorlist.Reserve"(%element_shape, %num_elements) : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %0 = "tensorlist.Reserve"(%element_shape, %num_elements) { element_type = 50331680 : i32 } : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
   return %0 : !tensorlist.list
 }
 // CHECK: vm.import @tensorlist.reserve
@@ -11,9 +11,9 @@ func @Reserve(%element_shape: !hal.buffer_view, %num_elements: !hal.buffer_view)
 // -----
 
 // CHECK-LABEL: @GetItem
-func @GetItem(%list: !tensorlist.list, %index: !hal.buffer_view, %element_shape: !hal.buffer_view) -> !hal.buffer_view {
+func @GetItem(%list: !tensorlist.list, %index: !hal.buffer_view) -> !hal.buffer_view {
   // CHECK: vm.call @tensorlist.get_item
-  %0 = "tensorlist.GetItem"(%list, %index, %element_shape) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %0 = "tensorlist.GetItem"(%list, %index) : (!tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 // CHECK: vm.import @tensorlist.get_item
@@ -31,9 +31,11 @@ func @SetItem(%list: !tensorlist.list, %index: !hal.buffer_view, %item: !hal.buf
 // -----
 
 // CHECK-LABEL: @Stack
-func @Stack(%list: !tensorlist.list, %element_shape: !hal.buffer_view, %num_elements: !hal.buffer_view) -> !hal.buffer_view {
+func @Stack(%list: !tensorlist.list, %num_elements: !hal.buffer_view) -> !hal.buffer_view {
+  %dev = hal.ex.shared_device : !hal.device
+  %allocator = hal.device.allocator %dev : !hal.allocator
   // CHECK: vm.call @tensorlist.stack
-  %0 = "tensorlist.Stack"(%list, %element_shape, %num_elements) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %0 = "tensorlist.Stack"(%allocator, %list, %num_elements) : (!hal.allocator, !tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 
@@ -41,7 +43,9 @@ func @Stack(%list: !tensorlist.list, %element_shape: !hal.buffer_view, %num_elem
 
 // CHECK-LABEL: @Concat
 func @Concat(%list: !tensorlist.list) -> !hal.buffer_view {
+  %dev = hal.ex.shared_device : !hal.device
+  %allocator = hal.device.allocator %dev : !hal.allocator
   // CHECK: vm.call @tensorlist.concat
-  %0 = "tensorlist.Concat"(%list) : (!tensorlist.list) -> !hal.buffer_view
+  %0 = "tensorlist.Concat"(%allocator, %list) : (!hal.allocator, !tensorlist.list) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }

--- a/iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.cpp
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.h"
 
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "mlir/IR/Builders.h"
 
 #define GET_OP_CLASSES
 #include "iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.cpp.inc"

--- a/iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.td
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/TensorListOps.td
@@ -27,10 +27,10 @@ def TensorList_Reserve : Op<TensorList_Dialect, "Reserve"> {
   }];
 
   let arguments = (ins
-    // TODO(silvasean): Do we need element_shape?
     HAL_BufferView:$element_shape,
     // TODO(silvasean): Convert to `I32:$count` instead.
-    HAL_BufferView:$count
+    HAL_BufferView:$count,
+    HAL_ElementTypeAttr:$element_type
   );
 
   let results = (outs
@@ -47,9 +47,7 @@ def TensorList_GetItem : Op<TensorList_Dialect, "GetItem"> {
   let arguments = (ins
     TensorList_TensorList:$list,
     // TODO(silvasean): Convert to `I32:$index` instead.
-    HAL_BufferView:$index,
-    // TODO(silvasean): Do we need element_shape?
-    HAL_BufferView:$element_shape
+    HAL_BufferView:$index
   );
 
   let results = (outs
@@ -83,9 +81,7 @@ def TensorList_FromTensor : Op<TensorList_Dialect, "FromTensor"> {
     a tensorlist `list` of length equal to `tensor`'s leading dimension.
   }];
   let arguments = (ins
-    HAL_BufferView:$tensor,
-    // TODO(silvasean): Do we need element_shape?
-    HAL_BufferView:$element_shape
+    HAL_BufferView:$tensor
   );
   let results = (outs
     TensorList_TensorList:$list
@@ -102,8 +98,8 @@ def TensorList_Stack : Op<TensorList_Dialect, "Stack"> {
     Requires all tensors contained in `list` to be the same shape.
   }];
   let arguments = (ins
+    HAL_Allocator:$allocator,
     TensorList_TensorList:$list,
-    HAL_BufferView:$element_shape,
     HAL_BufferView:$num_elements
   );
   let results = (outs
@@ -122,6 +118,7 @@ def TensorList_Concat : Op<TensorList_Dialect, "Concat"> {
     the non-leading axes.
   }];
   let arguments = (ins
+    HAL_Allocator:$allocator,
     TensorList_TensorList:$list
   );
   let results = (outs

--- a/iree/compiler/Dialect/Modules/TensorList/IR/test/ops.mlir
+++ b/iree/compiler/Dialect/Modules/TensorList/IR/test/ops.mlir
@@ -3,16 +3,16 @@
 // CHECK-LABEL: @Reserve
 func @Reserve(%element_shape: !hal.buffer_view, %num_elements: !hal.buffer_view) -> !tensorlist.list {
   // CHECK: tensorlist.Reserve
-  %0 = "tensorlist.Reserve"(%element_shape, %num_elements) : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %0 = "tensorlist.Reserve"(%element_shape, %num_elements) {element_type = 13 : i32 } : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
   return %0 : !tensorlist.list
 }
 
 // -----
 
 // CHECK-LABEL: @GetItem
-func @GetItem(%list: !tensorlist.list, %index: !hal.buffer_view, %element_shape: !hal.buffer_view) -> !hal.buffer_view {
+func @GetItem(%list: !tensorlist.list, %index: !hal.buffer_view) -> !hal.buffer_view {
   // CHECK: tensorlist.GetItem
-  %0 = "tensorlist.GetItem"(%list, %index, %element_shape) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %0 = "tensorlist.GetItem"(%list, %index) : (!tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 
@@ -28,17 +28,17 @@ func @SetItem(%list: !tensorlist.list, %index: !hal.buffer_view, %item: !hal.buf
 // -----
 
 // CHECK-LABEL: @Stack
-func @Stack(%list: !tensorlist.list, %element_shape: !hal.buffer_view, %num_elements: !hal.buffer_view) -> !hal.buffer_view {
+func @Stack(%allocator: !hal.allocator, %list: !tensorlist.list, %num_elements: !hal.buffer_view) -> !hal.buffer_view {
   // CHECK: tensorlist.Stack
-  %0 = "tensorlist.Stack"(%list, %element_shape, %num_elements) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %0 = "tensorlist.Stack"(%allocator, %list, %num_elements) : (!hal.allocator, !tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
 
 // -----
 
 // CHECK-LABEL: @Concat
-func @Concat(%list: !tensorlist.list) -> !hal.buffer_view {
+func @Concat(%allocator: !hal.allocator, %list: !tensorlist.list) -> !hal.buffer_view {
   // CHECK: tensorlist.Concat
-  %0 = "tensorlist.Concat"(%list) : (!tensorlist.list) -> !hal.buffer_view
+  %0 = "tensorlist.Concat"(%allocator, %list) : (!hal.allocator, !tensorlist.list) -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }

--- a/iree/compiler/Dialect/Modules/TensorList/tensorlist.imports.mlir
+++ b/iree/compiler/Dialect/Modules/TensorList/tensorlist.imports.mlir
@@ -17,15 +17,15 @@ vm.module @tensorlist {
 // Maps to IREE::TensorList::Reserve.
 vm.import @reserve(
   %element_shape : !vm.ref<!hal.buffer_view>,
-  %num_elements : !vm.ref<!hal.buffer_view>
+  %num_elements : !vm.ref<!hal.buffer_view>,
+  %element_type : i32
 ) -> !vm.ref<!tensorlist.list>
 attributes {nosideeffects}
 
 // Maps to IREE::TensorList::GetItem.
 vm.import @get_item(
   %list : !vm.ref<!tensorlist.list>,
-  %index : !vm.ref<!hal.buffer_view>,
-  %element_shape: !vm.ref<!hal.buffer_view>
+  %index : !vm.ref<!hal.buffer_view>
 ) -> !vm.ref<!hal.buffer_view>
 attributes {nosideeffects}
 
@@ -39,21 +39,21 @@ attributes {nosideeffects}
 
 // Maps to IREE:TensorList::FromTensor
 vm.import @from_tensor(
-  %tensor : !vm.ref<!hal.buffer_view>,
-  %element_shape : !vm.ref<!hal.buffer_view>
+  %tensor : !vm.ref<!hal.buffer_view>
 ) -> !vm.ref<!tensorlist.list>
 attributes {nosideeffects}
 
 // Maps to IREE:TensorList::Concat
 vm.import @concat(
+  %allocator : !vm.ref<!hal.allocator>,
   %list : !vm.ref<!tensorlist.list>
 ) -> !vm.ref<!hal.buffer_view>
 attributes {nosideeffects}
 
 // Maps to IREE:TensorList::Stack
 vm.import @stack(
+  %allocator : !vm.ref<!hal.allocator>,
   %list : !vm.ref<!tensorlist.list>,
-  %element_shape : !vm.ref<!hal.buffer_view>,
   %num_elements : !vm.ref<!hal.buffer_view>
 ) -> !vm.ref<!hal.buffer_view>
 attributes {nosideeffects}

--- a/iree/modules/tensorlist/tensorlist_test.cc
+++ b/iree/modules/tensorlist/tensorlist_test.cc
@@ -96,6 +96,91 @@ class TensorListModulesTest : public ::testing::Test {
     return function;
   }
 
+  void Invoke(absl::string_view function_name,
+              absl::Span<const float> input_values,
+              absl::Span<const int32_t> input_shape,
+              absl::Span<const float> expected_values,
+              absl::Span<const int32_t> expected_shape) {
+    vm::ref<iree_hal_buffer_view_t> input_buffer_view;
+    CreateBufferView(input_values, input_shape, device_, &input_buffer_view);
+
+    // Pass in the tensor as a HAL buffer view.
+    vm::ref<iree_vm_list_t> inputs;
+    IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
+                                       iree_allocator_system(), &inputs));
+    iree_vm_ref_t input_buffer_view_ref =
+        iree_hal_buffer_view_move_ref(input_buffer_view.get());
+    IREE_ASSERT_OK(
+        iree_vm_list_push_ref_retain(inputs.get(), &input_buffer_view_ref));
+
+    // Prepare outputs list to accept the results from the invocation.
+    vm::ref<iree_vm_list_t> outputs;
+    IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
+                                       iree_allocator_system(), &outputs));
+
+    // Synchronously invoke the function.
+    IREE_ASSERT_OK(iree_vm_invoke(context_, LookupFunction(function_name),
+                                  /*policy=*/nullptr, inputs.get(),
+                                  outputs.get(), iree_allocator_system()));
+
+    auto* returned_buffer_view =
+        reinterpret_cast<iree_hal_buffer_view_t*>(iree_vm_list_get_ref_deref(
+            outputs.get(), 0, iree_hal_buffer_view_get_descriptor()));
+
+    absl::InlinedVector<int32_t, 5> returned_shape(
+        iree_hal_buffer_view_shape_rank(returned_buffer_view));
+    iree_hal_buffer_view_shape(returned_buffer_view, returned_shape.size(),
+                               returned_shape.data(), nullptr);
+
+    EXPECT_EQ(returned_shape, expected_shape);
+
+    iree_hal_buffer_t* returned_buffer =
+        iree_hal_buffer_view_buffer(returned_buffer_view);
+    ASSERT_NE(returned_buffer, nullptr);
+
+    iree_hal_mapped_memory_t mapped_memory;
+    IREE_ASSERT_OK(iree_hal_buffer_map(returned_buffer,
+                                       IREE_HAL_MEMORY_ACCESS_READ, 0,
+                                       IREE_WHOLE_BUFFER, &mapped_memory));
+    for (int i = 0; i < expected_values.size(); i++) {
+      EXPECT_EQ(reinterpret_cast<float*>(mapped_memory.contents.data)[i],
+                expected_values[i]);
+    }
+
+    IREE_ASSERT_OK(iree_hal_buffer_unmap(returned_buffer, &mapped_memory));
+  }
+
+  void CreateBufferView(absl::Span<const float> contents,
+                        absl::Span<const int32_t> shape,
+                        iree_hal_device_t* device,
+                        iree_hal_buffer_view_t** out_buffer_view) {
+    size_t num_elements = 1;
+    for (int32_t dim : shape) {
+      num_elements *= dim;
+    }
+    ASSERT_EQ(contents.size(), num_elements);
+    vm::ref<iree_hal_buffer_t> buffer;
+    iree_hal_allocator_t* allocator = iree_hal_device_allocator(device);
+    IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
+        allocator,
+        static_cast<iree_hal_memory_type_t>(
+            IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+            IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE),
+        IREE_HAL_BUFFER_USAGE_ALL, contents.size() * sizeof(float), &buffer));
+    iree_hal_mapped_memory_t mapped_memory;
+    IREE_ASSERT_OK(iree_hal_buffer_map(buffer.get(),
+                                       IREE_HAL_MEMORY_ACCESS_WRITE, 0,
+                                       IREE_WHOLE_BUFFER, &mapped_memory));
+    memcpy(mapped_memory.contents.data,
+           static_cast<const void*>(contents.data()),
+           mapped_memory.contents.data_length);
+    IREE_ASSERT_OK(iree_hal_buffer_unmap(buffer.get(), &mapped_memory));
+    IREE_ASSERT_OK(iree_hal_buffer_view_create(
+        buffer.get(), shape.data(), shape.size(),
+        IREE_HAL_ELEMENT_TYPE_FLOAT_32, iree_allocator_system(),
+        &*out_buffer_view));
+  }
+
   iree_hal_device_t* device_ = nullptr;
   iree_vm_instance_t* instance_ = nullptr;
   iree_vm_context_t* context_ = nullptr;
@@ -104,176 +189,53 @@ class TensorListModulesTest : public ::testing::Test {
   iree_vm_module_t* hal_module_ = nullptr;
 };
 
-void CreateBufferView(absl::Span<float> contents,
-                      absl::Span<const int32_t> shape,
-                      iree_hal_device_t* device,
-                      iree_hal_buffer_view_t** out_buffer_view) {
-  size_t num_elements = 1;
-  for (int32_t dim : shape) {
-    num_elements *= dim;
-  }
-  ASSERT_EQ(contents.size(), num_elements);
-  vm::ref<iree_hal_buffer_t> buffer;
-  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device);
-  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
-      allocator,
-      static_cast<iree_hal_memory_type_t>(IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
-                                          IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE),
-      IREE_HAL_BUFFER_USAGE_ALL, contents.size() * sizeof(float), &buffer));
-  iree_hal_mapped_memory_t mapped_memory;
-  IREE_ASSERT_OK(iree_hal_buffer_map(buffer.get(), IREE_HAL_MEMORY_ACCESS_WRITE,
-                                     0, IREE_WHOLE_BUFFER, &mapped_memory));
-  memcpy(mapped_memory.contents.data, static_cast<void*>(contents.data()),
-         mapped_memory.contents.data_length);
-  IREE_ASSERT_OK(iree_hal_buffer_unmap(buffer.get(), &mapped_memory));
-  IREE_ASSERT_OK(iree_hal_buffer_view_create(
-      buffer.get(), shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-      iree_allocator_system(), &*out_buffer_view));
-}
-
 TEST_F(TensorListModulesTest, IdentityThroughSetItemGetItem) {
   // Allocate the buffer we'll be passing through.
-  static float kBufferContents[1] = {42.0f};
-  absl::InlinedVector<int32_t, 4> shape;
-  vm::ref<iree_hal_buffer_view_t> input_buffer_view;
-  CreateBufferView(kBufferContents, shape, device_, &input_buffer_view);
+  std::vector<float> input = {42.0f};
+  std::vector<int32_t> input_shape = {};
+  Invoke("identity_through_set_item_get_item", input, input_shape, input,
+         input_shape);
+}
 
-  // Pass in the tensor as a HAL buffer view.
-  vm::ref<iree_vm_list_t> inputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &inputs));
-  iree_vm_ref_t input_buffer_view_ref =
-      iree_hal_buffer_view_move_ref(input_buffer_view.get());
-  IREE_ASSERT_OK(
-      iree_vm_list_push_ref_retain(inputs.get(), &input_buffer_view_ref));
-
-  // Prepare outputs list to accept the results from the invocation.
-  vm::ref<iree_vm_list_t> outputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &outputs));
-
-  // Synchronously invoke the function.
-  IREE_ASSERT_OK(iree_vm_invoke(
-      context_, LookupFunction("identity_through_set_item_get_item"),
-      /*policy=*/nullptr, inputs.get(), outputs.get(),
-      iree_allocator_system()));
-
-  auto* returned_buffer_view =
-      reinterpret_cast<iree_hal_buffer_view_t*>(iree_vm_list_get_ref_deref(
-          outputs.get(), 0, iree_hal_buffer_view_get_descriptor()));
-  ASSERT_NE(nullptr, returned_buffer_view);
-  iree_hal_buffer_t* returned_buffer =
-      iree_hal_buffer_view_buffer(returned_buffer_view);
-  ASSERT_NE(nullptr, returned_buffer);
-
-  iree_hal_mapped_memory_t mapped_memory;
-  IREE_ASSERT_OK(iree_hal_buffer_map(returned_buffer,
-                                     IREE_HAL_MEMORY_ACCESS_READ, 0,
-                                     IREE_WHOLE_BUFFER, &mapped_memory));
-  EXPECT_EQ(reinterpret_cast<float*>(mapped_memory.contents.data)[0],
-            kBufferContents[0]);
-  IREE_ASSERT_OK(iree_hal_buffer_unmap(returned_buffer, &mapped_memory));
+TEST_F(TensorListModulesTest, IdentityThroughSetItemGetItem2D) {
+  // Allocate the buffer we'll be passing through.
+  std::vector<float> input = {42.0f};
+  std::vector<int32_t> input_shape = {1, 1};
+  Invoke("identity_through_set_item_get_item", input, input_shape, input,
+         input_shape);
 }
 
 TEST_F(TensorListModulesTest, IdentityThroughConcat) {
   // Allocate the buffer we'll be passing through.
-  static float kBufferContents[4] = {42.0f, 43.0f, 44.0f, 45.0f};
-  absl::InlinedVector<int32_t, 4> shape = {4, 1};
-  vm::ref<iree_hal_buffer_view_t> input_buffer_view;
-  CreateBufferView(kBufferContents, shape, device_, &input_buffer_view);
+  std::vector<float> input = {42.0f, 43.0f, 44.0f, 45.0f};
+  absl::InlinedVector<int32_t, 4> input_shape = {4, 1};
+  absl::InlinedVector<int32_t, 4> expected_shape = {4};
+  Invoke("identity_through_concat", input, input_shape, input, expected_shape);
+}
 
-  // Pass in the tensor as a HAL buffer view.
-  vm::ref<iree_vm_list_t> inputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &inputs));
-  iree_vm_ref_t input_buffer_view_ref =
-      iree_hal_buffer_view_move_ref(input_buffer_view.get());
-  IREE_ASSERT_OK(
-      iree_vm_list_push_ref_retain(inputs.get(), &input_buffer_view_ref));
-
-  // Prepare outputs list to accept the results from the invocation.
-  vm::ref<iree_vm_list_t> outputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &outputs));
-
-  // Synchronously invoke the function.
-  IREE_ASSERT_OK(iree_vm_invoke(context_,
-                                LookupFunction("identity_through_concat"),
-                                /*policy=*/nullptr, inputs.get(), outputs.get(),
-                                iree_allocator_system()));
-
-  auto* returned_buffer_view =
-      reinterpret_cast<iree_hal_buffer_view_t*>(iree_vm_list_get_ref_deref(
-          outputs.get(), 0, iree_hal_buffer_view_get_descriptor()));
-  ASSERT_NE(nullptr, returned_buffer_view);
-  iree_hal_buffer_t* returned_buffer =
-      iree_hal_buffer_view_buffer(returned_buffer_view);
-  ASSERT_NE(nullptr, returned_buffer);
-
-  // Dimemsionality is reduced by 1.
-  auto returned_rank = iree_hal_buffer_view_shape_rank(returned_buffer_view);
-  ASSERT_EQ(returned_rank, shape.size() - 1);
-
-  iree_hal_dim_t returned_shape[1];
-  iree_hal_buffer_view_shape(returned_buffer_view, 1, returned_shape,
-                             &returned_rank);
-  EXPECT_EQ(returned_shape[0], shape[0] * shape[1]);
-
-  iree_hal_mapped_memory_t mapped_memory;
-  IREE_ASSERT_OK(iree_hal_buffer_map(returned_buffer,
-                                     IREE_HAL_MEMORY_ACCESS_READ, 0,
-                                     IREE_WHOLE_BUFFER, &mapped_memory));
-  EXPECT_EQ(std::memcmp(mapped_memory.contents.data,
-                        static_cast<void*>(&kBufferContents[0]),
-                        mapped_memory.contents.data_length),
-            0);
-  IREE_ASSERT_OK(iree_hal_buffer_unmap(returned_buffer, &mapped_memory));
+TEST_F(TensorListModulesTest, ConcatAppendsEmpty) {
+  // Allocate the buffer we'll be passing through.
+  std::vector<float> input = {42.0f};
+  absl::InlinedVector<int32_t, 4> input_shape = {1};
+  std::vector<float> expected = {42.0f, 0.0f};
+  absl::InlinedVector<int32_t, 4> expected_shape = {2};
+  Invoke("concat_appends_empty", input, input_shape, expected, expected_shape);
 }
 
 TEST_F(TensorListModulesTest, IdentityThroughStack) {
   // Allocate the buffer we'll be passing through.
-  static float kBufferContents[2] = {42.0f, 43.0f};
-  absl::InlinedVector<int32_t, 4> shape = {2, 1};
-  vm::ref<iree_hal_buffer_view_t> input_buffer_view;
-  CreateBufferView(kBufferContents, shape, device_, &input_buffer_view);
+  std::vector<float> input = {42.0f, 43.0f};
+  absl::InlinedVector<int32_t, 4> input_shape = {2, 1};
+  Invoke("identity_through_stack", input, input_shape, input, input_shape);
+}
 
-  // Pass in the tensor as a HAL buffer view.
-  vm::ref<iree_vm_list_t> inputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &inputs));
-  iree_vm_ref_t input_buffer_view_ref =
-      iree_hal_buffer_view_move_ref(input_buffer_view.get());
-  IREE_ASSERT_OK(
-      iree_vm_list_push_ref_retain(inputs.get(), &input_buffer_view_ref));
-
-  // Prepare outputs list to accept the results from the invocation.
-  vm::ref<iree_vm_list_t> outputs;
-  IREE_ASSERT_OK(iree_vm_list_create(/*element_type=*/nullptr, 1,
-                                     iree_allocator_system(), &outputs));
-
-  // Synchronously invoke the function.
-  IREE_ASSERT_OK(iree_vm_invoke(context_,
-                                LookupFunction("identity_through_stack"),
-                                /*policy=*/nullptr, inputs.get(), outputs.get(),
-                                iree_allocator_system()));
-
-  auto* returned_buffer_view =
-      reinterpret_cast<iree_hal_buffer_view_t*>(iree_vm_list_get_ref_deref(
-          outputs.get(), 0, iree_hal_buffer_view_get_descriptor()));
-  ASSERT_NE(nullptr, returned_buffer_view);
-  iree_hal_buffer_t* returned_buffer =
-      iree_hal_buffer_view_buffer(returned_buffer_view);
-  ASSERT_NE(nullptr, returned_buffer);
-
-  iree_hal_mapped_memory_t mapped_memory;
-  IREE_ASSERT_OK(iree_hal_buffer_map(returned_buffer,
-                                     IREE_HAL_MEMORY_ACCESS_READ, 0,
-                                     IREE_WHOLE_BUFFER, &mapped_memory));
-  EXPECT_EQ(std::memcmp(mapped_memory.contents.data,
-                        static_cast<void*>(&kBufferContents[0]),
-                        mapped_memory.contents.data_length),
-            0);
-  IREE_ASSERT_OK(iree_hal_buffer_unmap(returned_buffer, &mapped_memory));
+TEST_F(TensorListModulesTest, StackAppendsEmpty) {
+  // Allocate the buffer we'll be passing through.
+  std::vector<float> input = {42.0f};
+  absl::InlinedVector<int32_t, 4> input_shape = {};
+  std::vector<float> expected = {42.0f, 0.0f};
+  absl::InlinedVector<int32_t, 4> expected_shape = {2};
+  Invoke("stack_appends_empty", input, input_shape, expected, expected_shape);
 }
 
 }  // namespace

--- a/iree/modules/tensorlist/tensorlist_test.mlir
+++ b/iree/modules/tensorlist/tensorlist_test.mlir
@@ -4,27 +4,62 @@ func @identity_through_set_item_get_item(%arg0: !hal.buffer_view) -> !hal.buffer
   %0 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<1> : tensor<i32>
   %1 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[]> : tensor<0xi32>
   %2 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<0> : tensor<i32>
-  %3 = "tensorlist.Reserve"(%1, %0) : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %3 = "tensorlist.Reserve"(%1, %0) { element_type = 50331680 : i32} : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
   %4 = "tensorlist.SetItem"(%3, %2, %arg0) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
-  %5 = "tensorlist.GetItem"(%4, %2, %1) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %5 = "tensorlist.GetItem"(%4, %2) : (!tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %5 : !hal.buffer_view
+}
+
+func @identity_through_set_item_get_item_2D(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.module.export, iree.abi.none} {
+  %dev = hal.ex.shared_device : !hal.device
+  %allocator = hal.device.allocator %dev : !hal.allocator
+  %0 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<1> : tensor<i32>
+  %1 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[1, 1]> : tensor<2xi32>
+  %2 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<0> : tensor<i32>
+  %3 = "tensorlist.Reserve"(%1, %0) { element_type = 50331680 : i32} : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %4 = "tensorlist.SetItem"(%3, %2, %arg0) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %stacked = "tensorlist.Stack"(%allocator, %4, %0) : (!hal.allocator, !tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
+  return %stacked : !hal.buffer_view
 }
 
 func @identity_through_concat(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.module.export, iree.abi.none} {
   %dev = hal.ex.shared_device : !hal.device
   %allocator = hal.device.allocator %dev : !hal.allocator
   %element_shape = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[]> : tensor<0xi32>
-  %list = "tensorlist.FromTensor"(%arg0, %element_shape) : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
-  %concat = "tensorlist.Concat"(%list) : (!tensorlist.list) -> !hal.buffer_view
+  %list = "tensorlist.FromTensor"(%arg0) : (!hal.buffer_view) -> !tensorlist.list
+  %concat = "tensorlist.Concat"(%allocator, %list) : (!hal.allocator, !tensorlist.list) -> !hal.buffer_view
+  return %concat : !hal.buffer_view
+}
+
+func @concat_appends_empty(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.module.export, iree.abi.none} {
+  %dev = hal.ex.shared_device : !hal.device
+  %allocator = hal.device.allocator %dev : !hal.allocator
+  %0 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<2> : tensor<i32>
+  %1 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[1]> : tensor<1xi32>
+  %2 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<0> : tensor<i32>
+  %3 = "tensorlist.Reserve"(%1, %0) { element_type = 50331680 : i32} : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %4 = "tensorlist.SetItem"(%3, %2, %arg0) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %concat = "tensorlist.Concat"(%allocator, %4) : (!hal.allocator, !tensorlist.list) -> !hal.buffer_view
   return %concat : !hal.buffer_view
 }
 
 func @identity_through_stack(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.module.export, iree.abi.none} {
   %dev = hal.ex.shared_device : !hal.device
   %allocator = hal.device.allocator %dev : !hal.allocator
-  %element_shape = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[]> : tensor<0xi32>
   %num_elements = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<2> : tensor<i32>
-  %list = "tensorlist.FromTensor"(%arg0, %element_shape) : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
-  %stacked = "tensorlist.Stack"(%list, %element_shape, %num_elements) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !hal.buffer_view
+  %list = "tensorlist.FromTensor"(%arg0) : (!hal.buffer_view) -> !tensorlist.list
+  %stacked = "tensorlist.Stack"(%allocator, %list, %num_elements) : (!hal.allocator, !tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
+  return %stacked : !hal.buffer_view
+}
+
+func @stack_appends_empty(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.module.export, iree.abi.none} {
+  %dev = hal.ex.shared_device : !hal.device
+  %allocator = hal.device.allocator %dev : !hal.allocator
+  %0 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<2> : tensor<i32>
+  %1 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<[]> : tensor<0xi32>
+  %2 = hal.buffer_view.const %allocator, "HostLocal|DeviceVisible", "All" : !hal.buffer_view = dense<0> : tensor<i32>
+  %3 = "tensorlist.Reserve"(%1, %0) { element_type = 50331680 : i32} : (!hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %4 = "tensorlist.SetItem"(%3, %2, %arg0) : (!tensorlist.list, !hal.buffer_view, !hal.buffer_view) -> !tensorlist.list
+  %stacked = "tensorlist.Stack"(%allocator, %4, %0) : (!hal.allocator, !tensorlist.list, !hal.buffer_view) -> !hal.buffer_view
   return %stacked : !hal.buffer_view
 }


### PR DESCRIPTION
Tensorlist needed a refactor on inputs. To handle support incomplete / unfilled entries for reserve
we need to track tensor information on the tensorlist (shape, element type) and support allocation
when not provided a hal buffer. This was solved by adding type information to the reserve op,
adding allocator attributes to concat and stack.

This included removing unneeded operators from the stack/concat operators.