### PR TITLE
Disable MLIR crash reproducer on CI in python tests.

### DIFF
--- a/build_tools/bazel/build_tensorflow.sh
+++ b/build_tools/bazel/build_tensorflow.sh
@@ -94,6 +94,7 @@ bazel \
             --config=generic_clang \
             --build_tag_filters="${BUILD_TAG_FILTERS?}" \
             --test_tag_filters="${TEST_TAG_FILTERS?}" \
+            --test_arg=--use_crash_reproducer=False \
             --config=rs \
             --test_output=errors \
             --keep_going

--- a/build_tools/bazel/build_tensorflow.sh
+++ b/build_tools/bazel/build_tensorflow.sh
@@ -94,7 +94,6 @@ bazel \
             --config=generic_clang \
             --build_tag_filters="${BUILD_TAG_FILTERS?}" \
             --test_tag_filters="${TEST_TAG_FILTERS?}" \
-            --test_arg=--use_crash_reproducer=False \
             --config=rs \
             --test_output=errors \
             --keep_going

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -36,6 +36,7 @@ FLAGS = flags.FLAGS
 
 
 def _running_bazel_test() -> bool:
+  # Bazel guarantees that TEST_TMPDIR is set when `bazel test` is running.
   return "TEST_TMPDIR" in os.environ
 
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -19,12 +19,20 @@ import os
 import tempfile
 from typing import Any, Callable, Dict, Sequence, Set, Tuple, Type, Union
 
+from absl import flags
 from absl import logging
 import numpy as np
 from pyiree import rt
 from pyiree.tf import compiler
 from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
+
+flags.DEFINE_bool(
+    "use_crash_reproducer", True,
+    "Uses the MLIR crash reproducer, generating reproducer files in the "
+    "artifacts directory for crashes and suppressing stack traces.")
+
+FLAGS = flags.FLAGS
 
 
 def _setup_mlir_crash_reproducer(
@@ -149,8 +157,10 @@ def _incrementally_compile_tf_module(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
-  _compile_module = _setup_mlir_crash_reproducer(_compile_module, artifacts_dir,
-                                                 backend_info.backend_id)
+  if (FLAGS.use_crash_reproducer):
+    _compile_module = _setup_mlir_crash_reproducer(_compile_module,
+                                                   artifacts_dir,
+                                                   backend_info.backend_id)
   return _compile_module(module, backend_info, exported_names, artifacts_dir)
 
 
@@ -188,8 +198,10 @@ def _incrementally_compile_tf_signature_def_saved_model(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
-  _compile_module = _setup_mlir_crash_reproducer(_compile_module, artifacts_dir,
-                                                 backend_info.backend_id)
+  if (FLAGS.use_crash_reproducer):
+    _compile_module = _setup_mlir_crash_reproducer(_compile_module,
+                                                   artifacts_dir,
+                                                   backend_info.backend_id)
   return _compile_module(saved_model_dir, saved_model_tags, backend_info,
                          exported_name, artifacts_dir)
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -28,11 +28,15 @@ from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
 
 flags.DEFINE_bool(
-    "use_crash_reproducer", True,
-    "Uses the MLIR crash reproducer, generating reproducer files in the "
-    "artifacts directory for crashes and suppressing stack traces.")
+    "capture_crash_reproducer", True,
+    "Captures MLIR crash reproducers in the artifacts directory for crashes "
+    "and suppresses C++ stack traces.")
 
 FLAGS = flags.FLAGS
+
+
+def _running_bazel_test() -> bool:
+  return "TEST_TMPDIR" in os.environ
 
 
 def _setup_mlir_crash_reproducer(
@@ -157,7 +161,7 @@ def _incrementally_compile_tf_module(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
-  if (FLAGS.use_crash_reproducer):
+  if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
     _compile_module = _setup_mlir_crash_reproducer(_compile_module,
                                                    artifacts_dir,
                                                    backend_info.backend_id)
@@ -198,7 +202,7 @@ def _incrementally_compile_tf_signature_def_saved_model(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
-  if (FLAGS.use_crash_reproducer):
+  if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
     _compile_module = _setup_mlir_crash_reproducer(_compile_module,
                                                    artifacts_dir,
                                                    backend_info.backend_id)

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -161,6 +161,9 @@ def _incrementally_compile_tf_module(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
+  # Avoid the crash reproducer under tests or if the flag is false.
+  # Developers can run tests outside of the test runner (e.g. `bazel run`) to
+  # use the crash reproducer.
   if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
     _compile_module = _setup_mlir_crash_reproducer(_compile_module,
                                                    artifacts_dir,
@@ -202,6 +205,9 @@ def _incrementally_compile_tf_signature_def_saved_model(
     return _incrementally_lower_compiler_module(compiler_module, backend_info,
                                                 artifacts_dir)
 
+  # Avoid the crash reproducer under tests or if the flag is false.
+  # Developers can run tests outside of the test runner (e.g. `bazel run`) to
+  # use the crash reproducer.
   if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
     _compile_module = _setup_mlir_crash_reproducer(_compile_module,
                                                    artifacts_dir,


### PR DESCRIPTION
We aren't uploading reproducer artifacts anywhere, and using the crash reproducer suppresses C++ stack traces. By disabling the reproducer on CI we should get more helpful error logs when the compiler crashes. As before, developers can run tests locally to generate reproducer artifacts.