### PR TITLE
Remove no-longer-functional flag

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -50,9 +50,6 @@ flags.DEFINE_bool(
     "Summarize the inputs and outputs of each module trace logged to disk.")
 flags.DEFINE_bool("log_all_traces", False,
                   "Log all traces to logging.info, even if comparison passes.")
-flags.DEFINE_bool(
-    "get_saved_model", False,
-    "Creates and stores a SavedModel for the tf.Module class to be tested.")
 
 FLAGS = flags.FLAGS
 DEFAULT_INPUT_GENERATOR = tf_utils.uniform

--- a/scripts/get_e2e_artifacts.py
+++ b/scripts/get_e2e_artifacts.py
@@ -162,10 +162,7 @@ def main(argv):
 
   if FLAGS.run_test_suites:
     # Use bazel test to execute all of the test suites in parallel.
-    command = [
-        'bazel', 'test', *test_suites, '--color=yes',
-        '--test_arg=--get_saved_model'
-    ]
+    command = ['bazel', 'test', *test_suites, '--color=yes']
     print(f'Running: `{" ".join(command)}`')
     if not FLAGS.dry_run:
       subprocess.check_call(command)


### PR DESCRIPTION
`get_saved_model` doesn't actually do anything anymore, and no-one has been missing it for some months now.