### PR TITLE
Fixup EmitC include directories

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
@@ -28,6 +28,9 @@ if(${IREE_ENABLE_EMITC})
       MLIREmitC
       MLIRTransforms
       iree::compiler::Dialect::VM::IR
+    INCLUDES
+      "${PROJECT_SOURCE_DIR}/third_party/mlir-emitc/include"
+      "${PROJECT_BINARY_DIR}/third_party/mlir-emitc/include"
     PUBLIC
   )
 endif()

--- a/iree/compiler/Dialect/VM/Target/C/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/C/CMakeLists.txt
@@ -32,6 +32,8 @@ if(${IREE_ENABLE_EMITC})
       MLIRSupport
       iree::compiler::Dialect::VM::IR
       iree::compiler::Dialect::VM::Conversion::VMToEmitC
+    INCLUDES
+      "${PROJECT_SOURCE_DIR}/third_party/mlir-emitc/include"
     PUBLIC
   )
 endif()

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -53,6 +53,9 @@ if(IREE_ENABLE_EMITC)
     MLIREmitC
     MLIRTargetCpp
   )
+  set(IREE_EMITC_INCLUDES
+    "${PROJECT_SOURCE_DIR}/third_party/mlir-emitc/include"
+  )
 endif()
 
 iree_cc_binary(
@@ -208,6 +211,8 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Conversion::init_conversions
       iree::compiler::Conversion::HLOToLinalg
       iree::compiler::Dialect::HAL::Conversion::Passes
+    INCLUDES
+      "${IREE_EMITC_INCLUDES}"
     PUBLIC
   )
 
@@ -295,6 +300,8 @@ if(${IREE_BUILD_COMPILER})
       iree::compiler::Dialect::VM::Target::init_targets
       iree::compiler::Translation::IREEVM
       ${IREE_TRANSLATE_CONDITIONAL_DEPS}
+    INCLUDES
+      "${IREE_EMITC_INCLUDES}"
     PUBLIC
   )
 


### PR DESCRIPTION
Required after IREE_COMMON_INCLUDE_DIRS were (finally!) dropped with
pull request #3874.