### PR TITLE
Introduce hal.interface.tensor.load/store.tile

### DIFF
--- a/iree/compiler/Dialect/HAL/IR/HALOps.h
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.h
@@ -28,6 +28,7 @@
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #define GET_OP_CLASSES
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h.inc"

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -19,6 +19,7 @@ include "iree/compiler/Dialect/HAL/IR/HALBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 
 class HAL_PureOp<string mnemonic, list<OpTrait> traits = []> :
     HAL_Op<mnemonic, !listconcat(traits, [NoSideEffect])>;
@@ -2176,6 +2177,155 @@ def HAL_InterfaceStoreTensorOp : HAL_Op<"interface.store.tensor"> {
   }];
 }
 
+def HAL_InterfaceLoadTensorTileOp : HAL_PureOp<
+    "interface.load.tensor.tile",
+    [AttrSizedOperandSegments, OffsetSizeAndStrideOpInterface]> {
+  let summary = [{loads a tensor tile from an executable IO binding}];
+  let description = [{
+    Loads a tensor tile value from an executable IO binding at the given
+    offset/size/stride. This is a pseudo op that can be used to tie SSA tensor
+    values in the IR to the bindings that contain those tensors.
+
+    Note that because there may not be a 1:1 mapping between original tensor
+    arguments to the entry point function and the bindings in the interface the
+    backend must use the offset provided on this op to properly compute the base
+    address of the tensor data. The offset is in bytes relative to the base
+    binding address, irrespective of the type of the tensor loaded by this
+    operation.
+
+    The base_offset provided, if non-zero, will have an alignment compatible
+    with the tensor type represented. For example, a `tensor<16xf32>` will be
+    aligned on at least a 4 byte boundary.
+
+    The op follows the semantic of similar core MLIR strided subview / subtensor
+    ops where offset-list, size-list and stride-list are SSA value or constants
+    of type index.
+
+    Example:
+    ```
+      `hal.interface.load.tensor.tile` $binding `,`
+        `base_offset` `=` base_offset `,`
+        `offsets` `=` `[` offset-list `]` `,`
+        `sizes` `=` `[` size-list `]` `,`
+        `strides` `=` `[` stride-list `]` attr-dict `:` type($result)
+    ```
+  }];
+
+  let arguments = (ins
+    SymbolRefAttr:$binding,
+    HAL_DeviceSize:$base_offset,
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides,
+    I64ArrayAttr:$static_offsets,
+    I64ArrayAttr:$static_sizes,
+    I64ArrayAttr:$static_strides
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+  let extraClassDeclaration = [{
+    /// Returns the hal.interface.binding op associated with this op.
+    /// Returns null op if not found.
+    IREE::HAL::InterfaceBindingOp queryBindingOp();
+
+    /// Return the expected rank of each of the`static_offsets`, `static_sizes`
+    /// and `static_strides` attributes.
+    std::array<unsigned, 3> getArrayAttrRanks() {
+      unsigned resultRank = getResult().getType().cast<ShapedType>().getRank();
+      return {resultRank, resultRank, resultRank};
+    }
+
+    /// Special attribute names.
+    static StringRef getBindingAttrName() {
+      return "binding";
+    }
+    static ArrayRef<StringRef> getSpecialAttrNames() {
+      static SmallVector<StringRef, 5> names{getBindingAttrName()};
+      if (names.size() !=
+          1 + OffsetSizeAndStrideOpInterface::getSpecialAttrNames().size()) {
+        auto otherNames = OffsetSizeAndStrideOpInterface::getSpecialAttrNames();
+        names.append(otherNames.begin(), otherNames.end());
+      }
+      return names;
+    }
+  }];
+}
+
+def HAL_InterfaceStoreTensorTileOp :  HAL_Op<
+    "interface.store.tensor.tile",
+    [AttrSizedOperandSegments, OffsetSizeAndStrideOpInterface]> {
+  let summary = [{stores a tensor tile in an executable IO binding}];
+  let description = [{
+    Stores a tensor value into an executable IO binding. This is a pseudo op
+    indicating that the value of the operand tensor should be stored into the
+    specified binding at the given offset/size/stride.
+
+    Note that because there may not be a 1:1 mapping between original tensor
+    arguments to the entry point function and the bindings in the interface the
+    backend must use the offset provided on this op to properly compute the base
+    address of the tensor data. The offset is in bytes relative to the base
+    binding address, irrespective of the type of the tensor loaded by this
+    operation.
+
+    The base_offset provided, if non-zero, will have an alignment compatible
+    with the tensor type represented. For example, a `tensor<16xf32>` will be
+    aligned on at least a 4 byte boundary.
+
+    The op follows the semantic of similar core MLIR strided subview / subtensor
+    ops where offset-list, size-list and stride-list are SSA value or constants
+    of type index.
+
+    Grammar:
+    ```
+      `hal.interface.store.tensor.tile` $operand $binding `,`
+        `base_offset` `=` base_offset `,`
+        `offsets` `=` `[` offset-list `]` `,`
+        `sizes` `=` `[` size-list `]` `,`
+        `strides` `=` `[` stride-list `]` attr-dict `:` type($operand)
+    ```
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$operand,
+    SymbolRefAttr:$binding,
+    HAL_DeviceSize:$base_offset,
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides,
+    I64ArrayAttr:$static_offsets,
+    I64ArrayAttr:$static_sizes,
+    I64ArrayAttr:$static_strides
+  );
+
+  let extraClassDeclaration = [{
+    /// Returns the hal.interface.binding op associated with this op.
+    /// Returns null op if not found.
+    IREE::HAL::InterfaceBindingOp queryBindingOp();
+
+    /// Return the expected rank of each of the`static_offsets`, `static_sizes`
+    /// and `static_strides` attributes.
+    std::array<unsigned, 3> getArrayAttrRanks() {
+      unsigned rank = operand().getType().cast<ShapedType>().getRank();
+      return {rank, rank, rank};
+    }
+
+    /// Special attribute names.
+    static StringRef getBindingAttrName() {
+      return "binding";
+    }
+    static ArrayRef<StringRef> getSpecialAttrNames() {
+      static SmallVector<StringRef, 5> names{getBindingAttrName()};
+      if (names.size() !=
+          1 + OffsetSizeAndStrideOpInterface::getSpecialAttrNames().size()) {
+        auto otherNames = OffsetSizeAndStrideOpInterface::getSpecialAttrNames();
+        llvm::append_range(names, otherNames);
+      }
+      return names;
+    }
+  }];
+}
 //===----------------------------------------------------------------------===//
 // iree::hal::ExecutableCache
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -94,3 +94,22 @@ func @executable_layout_create(%arg0 : !hal.device, %arg1 : !hal.descriptor_set_
   %executable_layout = hal.executable_layout.create %arg0, set_layouts = [%arg1], push_constants = 1 : !hal.executable_layout
   return
 }
+
+// -----
+
+// CHECK-LABEL: @interface_io
+func @interface_io() {
+  %c16 = constant 16 : index
+  //      CHECK: %[[ARG0:.+]] = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16
+  // CHECK-SAME:   offsets = [0], sizes = [4], strides = [1] : tensor<4xf32>
+  %arg0 = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16,
+    offsets = [0], sizes = [4], strides = [1]: tensor<4xf32>
+  // CHECK-NEXT: %[[TEMP:.+]] = mhlo.add %[[ARG0]], %[[ARG0]]
+  %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
+  %c32 = constant 32 : index
+  //      CHECK: hal.interface.store.tensor.tile %[[TEMP]], @interface::@s0b1, base_offset = %c32
+  // CHECK-SAME:   offsets = [4], sizes = [7], strides = [1] : tensor<4xf32>
+  hal.interface.store.tensor.tile %0, @interface::@s0b1, base_offset = %c32,
+    offsets = [4], sizes = [7], strides = [1]: tensor<4xf32>
+  return
+}


### PR DESCRIPTION
This revision introduces a tiled tensor.load/store interface abstraction that is expected to help bridge the tensor - buffer gap after "linalg on tensor"-based transformations.

At this time, only the vanilla core OffsetSizeAndStrideOpInterface verification is implemented.

Further type verification and canonicalizations are left for the future, on a per-need basis.