### PR TITLE
Fix VectorizeMemref out-of-bound access

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemref.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemref.cpp
@@ -84,6 +84,7 @@ static unsigned isMemRefAndVectorizable(Value v,
   if (memrefType && !memrefType.getElementType().isa<VectorType>() &&
       (kMaxVectorizationSizeInBits % memrefType.getElementTypeBitWidth() ==
        0) &&
+      memrefType.getRank() > 0 &&
       !ShapedType::isDynamic(memrefType.getShape().back()) &&
       getUsesIfAllTransferOp(v, uses)) {
     return calculateMemrefVecSize(uses);


### PR DESCRIPTION
We need to make sure memrefType has non-0 rank before accesing
its shape with `.back()`.