### PR TITLE
Auto discover unix linker path and setup Android NDK linker

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "WindowsLinkerTool.cpp",
     ],
     deps = [
+        "//iree/base:core_headers",
         "//iree/compiler/Dialect/HAL/Target/LLVM/AOT:LinkerTool_hdrs",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     LLVMCore
     LLVMSupport
     MLIRSupport
+    iree::base::core_headers
     iree::compiler::Dialect::HAL::Target::LLVM::AOT::LinkerTool_hdrs
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/AOT/internal/UnixLinkerTool.cpp
@@ -34,15 +34,17 @@ class UnixLinkerTool : public LinkerTool {
     auto toolPath = LinkerTool::getToolPath();
     if (!toolPath.empty()) return toolPath;
     if (targetTriple.isAndroid()) {
+      char *androidNDKPath = std::getenv("ANDROID_NDK");
+      if (!androidNDKPath) return toolPath;
 // TODO(ataei, benvanik): Windows cross-linking android NDK support.
 #if defined(IREE_ARCH_X86_64) && defined(IREE_PLATFORM_LINUX)
-      return llvm::Twine(std::getenv("ANDROID_NDK"))
+      return llvm::Twine(androidNDKPath)
           .concat("/toolchains/llvm/prebuilt/linux-x86_64/bin/")
           // TODO(ataei): Set target archicture and ABI from targetTriple.
           .concat("aarch64-linux-android30-clang++")
           .str();
 #elif defined(IREE_ARCH_X86_64) && defined(IREE_PLATFORM_APPLE)
-      return llvm::Twine(std::getenv("ANDROID_NDK"))
+      return llvm::Twine(androidNDKPath)
           .concat("/toolchains/llvm/prebuilt/darwin-x86_64/bin/")
           .concat("aarch64-linux-android30-clang++")
           .str();


### PR DESCRIPTION
Change default behavior when `IREE_LLVMAOT_LINKER_PATH` isn't set for unix host and target systems:
- For unix host & target search for system linker path.
- For android target set up linker path using `ANDROID_NDK` variable.
  