### PR TITLE
Fix compile and benchmark scripts for benchmarking automation.

### DIFF
--- a/build_tools/mako/benchmark_modules_on_android.sh
+++ b/build_tools/mako/benchmark_modules_on_android.sh
@@ -21,6 +21,7 @@
 
 set -e
 set -o pipefail
+set -o xtrace
 
 git_hash=UNKNOWN
 while [[ $# -gt 0 ]]; do
@@ -67,7 +68,7 @@ function append_mako_metadata {
   cat >> "${mako_log}" << EOF
 metadata: {
   git_hash: "${git_hash}"
-  timestamp_ms: "${TS}"
+  timestamp_ms: ${TS}
   benchmark_key: "${benchmark_key}"
 }
 EOF
@@ -79,7 +80,7 @@ function append_mako_sample {
   local tag="$3"
   cat >> "${mako_log}" << EOF
 samples: {
-  time: "${value}"
+  time: ${value}
   target: "${tag}"
 }
 EOF

--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -22,6 +22,10 @@
 #   2) IREE is built to Android in `build/` directory. E.g., build with
 #      build_tools/cmake/build_android.sh script.
 
+set -e
+set -o pipefail
+set -o xtrace
+
 prefix="module"
 while [[ $# -gt 0 ]]; do
   token="$1"

--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -63,7 +63,7 @@ do
   esac
   build/host/iree/tools/iree-translate \
     --iree-mlir-to-vm-bytecode-module \
-    --iree-hal-target-backends=vmla \
+    --iree-hal-target-backends="${target}" \
     "${extra_flags[@]}" \
     "${model}" \
     -o "${module_name}"


### PR DESCRIPTION
- Make compile_android_modules.sh to take the variable as target.
- Remove `"` from numbers because they are NUMERIC.
- Add `xtrace` to scripts to make debug easier.