### PR TITLE
Fix printf format for uint64_t from PRIXPTR to PRIu64.

### DIFF
--- a/iree/hal/dylib/registration/driver_module.cc
+++ b/iree/hal/dylib/registration/driver_module.cc
@@ -38,7 +38,7 @@ static iree_status_t iree_hal_dylib_driver_factory_try_create(
     iree_hal_driver_t** out_driver) {
   if (driver_id != IREE_HAL_DYLIB_DRIVER_ID) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIXPTR
+                            "no driver with ID %016" PRIu64
                             " is provided by this factory",
                             driver_id);
   }

--- a/iree/hal/llvmjit/registration/driver_module.cc
+++ b/iree/hal/llvmjit/registration/driver_module.cc
@@ -39,7 +39,7 @@ static iree_status_t iree_hal_llvmjit_driver_factory_try_create(
     iree_hal_driver_t** out_driver) {
   if (driver_id != IREE_HAL_LLVMJIT_DRIVER_ID) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIXPTR
+                            "no driver with ID %016" PRIu64
                             " is provided by this factory",
                             driver_id);
   }

--- a/iree/hal/metal/registration/driver_module.cc
+++ b/iree/hal/metal/registration/driver_module.cc
@@ -46,7 +46,7 @@ static iree_status_t iree_hal_metal_driver_factory_try_create(
     iree_hal_driver_t** out_driver) {
   if (driver_id != IREE_HAL_METAL_DRIVER_ID) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIXPTR
+                            "no driver with ID %016" PRIu64
                             " is provided by this factory",
                             driver_id);
   }

--- a/iree/hal/vmla/registration/driver_module.cc
+++ b/iree/hal/vmla/registration/driver_module.cc
@@ -38,7 +38,7 @@ static iree_status_t iree_hal_vmla_driver_factory_try_create(
     iree_hal_driver_t** out_driver) {
   if (driver_id != IREE_HAL_VMLA_DRIVER_ID) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIXPTR
+                            "no driver with ID %016" PRIu64
                             " is provided by this factory",
                             driver_id);
   }

--- a/iree/hal/vulkan/registration/driver_module.cc
+++ b/iree/hal/vulkan/registration/driver_module.cc
@@ -151,7 +151,7 @@ static iree_status_t iree_hal_vulkan_driver_factory_try_create(
     iree_hal_driver_t** out_driver) {
   if (driver_id != IREE_HAL_VULKAN_1_X_DRIVER_ID) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "no driver with ID %016" PRIXPTR
+                            "no driver with ID %016" PRIu64
                             " is provided by this factory",
                             driver_id);
   }


### PR DESCRIPTION
Should fix:
`format specifies types 'unsigned int' but the argument has type 'iree_hal_driver_id_t' (aka 'unsigned long long') [-Werror,-Wformat]`