### PR TITLE
Extract standalone "iree-tf-import" tool.

### DIFF
--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/__init__.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/__init__.py
@@ -52,48 +52,9 @@ OutputFormat = binding.OutputFormat
 # Pass pipeline that should run to lower a TF saved_model to a form suitable
 # for input to the IREE compiler.
 TF_IMPORT_PASS_PIPELINE = (
-    # Clean up tf_executor and extraneous unused functions.
-    "symbol-dce",
-    "tf-executor-graph-pruning",
-    "tf-guarantee-all-funcs-one-use",
-    "tf-standard-pipeline",
-    "tf-device-index-selector",
-
-    # Try to get the IR in good condition.
-    # In particular, because IREE doesn't handle dynamic shapes, we need to
-    # guarantee here that all dynamic shapes are gone.
-    # TODO(silvasean): Add a verifier pass that enforces that.
-    "inline",
-    "canonicalize",
-    "tf-device-decompose-resource-ops",
-    "iree-tf-propagate-resource-casts",
-    "tf-shape-inference",
-
-    # Lower to CFG.
-    # After this point, most TF optimizations won't work properly besides
-    # simple canonicalizations.
-    "tf-functional-control-flow-to-cfg",
-    # Inline, as tf-functional-control-flow-to-cfg leaves in calls.
-    "inline",
-
-    # Some further cleanups now that control flow is in better shape.
-    "symbol-dce",
-    "canonicalize",
-
-    # Convert TF to MHLO, the expected input to the next stage of lowering.
-    "iree-tf-convert-to-mhlo",
-    "canonicalize",
-
-    # Now that the IR is starting to look nice, optimize global tensors.
-    "tf-saved-model-optimize-global-tensors",
-
     # IREE-specific passes to prepare TF code for IREE compilation.
     # In particular, this eliminates tf_saved_model.
     "iree-tf-import-pipeline",
-
-    # Temporary: Does some special case fixups of HLO ops with dynamic
-    # shapes until these can be done properly upstream.
-    "iree-shape-convert-hlo",
 )
 
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/compiler/test/saved_model_adopt_exports.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/compiler/test/saved_model_adopt_exports.py
@@ -21,9 +21,6 @@ from pyiree.tf.support import tf_test_driver
 import tensorflow.compat.v2 as tf
 
 SAVED_MODEL_IMPORT_PASSES = [
-    "tf-executor-graph-pruning",
-    "tf-standard-pipeline",
-    "iree-tf-convert-to-mhlo",
     "iree-tf-import-pipeline",
     "canonicalize",
 ]
@@ -141,19 +138,6 @@ class T0002e_Error_VarMultipleExportedNames(tf.Module):
     self.v2 = self.v
 
 
-# CHECK-LABEL: RUN_TEST: T0002f_Error_UnsupportedResourceOp
-# CHECK: [ERROR]: could not lower resource op to flow
-# CHECK: FINISH_TEST
-class T0002f_Error_UnsupportedResourceOp(tf.Module):
-
-  def __init__(self):
-    self.v = tf.Variable([0.], shape=[None])
-
-  @tf.function(input_signature=[])
-  def f(self):
-    self.v.assign_add(tf.constant([0., 1.]))
-
-
 tf_test_driver.add_test(test_name="T0002a_SimpleVarRead",
                         tf_module_builder=T0002a_SimpleVarRead,
                         passes=SAVED_MODEL_IMPORT_PASSES,
@@ -172,11 +156,6 @@ tf_test_driver.add_test(test_name="T0002d_VarCompatibleShapeChange",
                         print_input_module=True)
 tf_test_driver.add_test(test_name="T0002e_Error_VarMultipleExportedNames",
                         tf_module_builder=T0002e_Error_VarMultipleExportedNames,
-                        passes=SAVED_MODEL_IMPORT_PASSES,
-                        print_input_module=True,
-                        expect_pass_failure=True)
-tf_test_driver.add_test(test_name="T0002f_Error_UnsupportedResourceOp",
-                        tf_module_builder=T0002f_Error_UnsupportedResourceOp,
                         passes=SAVED_MODEL_IMPORT_PASSES,
                         print_input_module=True,
                         expect_pass_failure=True)

--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -58,6 +58,7 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:lower_tf_lib",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
     ],
 )
@@ -87,5 +88,22 @@ cc_binary(
     deps = [
         ":tensorflow",
         "//iree/tools:iree_translate_main",
+    ],
+)
+
+cc_binary(
+    name = "iree-tf-import",
+    srcs = ["iree-tf-import-main.cc"],
+    deps = [
+        ":tensorflow",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@org_tensorflow//tensorflow/cc/saved_model:loader",
+        "@org_tensorflow//tensorflow/compiler/mlir:init_mlir",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:convert_graphdef",
+        "@org_tensorflow//tensorflow/core/platform:errors",
     ],
 )

--- a/integrations/tensorflow/compiler/ConvertToMHLO.cpp
+++ b/integrations/tensorflow/compiler/ConvertToMHLO.cpp
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "integrations/tensorflow/compiler/Passes.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/integrations/tensorflow/compiler/Passes.h
+++ b/integrations/tensorflow/compiler/Passes.h
@@ -62,6 +62,9 @@ std::unique_ptr<OperationPass<FuncOp>> createStripFunctionMetadataPass();
 // Validates whether any Tensorflow operations remain.
 std::unique_ptr<OperationPass<FuncOp>> createVerifyFullyConvertedPass();
 
+// Creates an IREE-specific variant of the upstream XLA LegalizeTF pass.
+std::unique_ptr<OperationPass<FuncOp>> createIREEXLALegalizeTF();
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//

--- a/integrations/tensorflow/compiler/README.md
+++ b/integrations/tensorflow/compiler/README.md
@@ -1,3 +1,32 @@
 This directory should be the only one in IREE that pulls a dependency on `tf`
 dialect and related dialects (with the exception of a small selection of "safe"
 XLA IR).
+
+## Tools
+
+### Development Tools
+
+*   `iree-tf-opt` : MLIR Opt tool with TensorFlow and IREE passes/dialects
+    linked in
+*   `iree-tf-translate` : Equivalent to `mlir-tf-translate` tool in TensorFlow,
+    with IREE passes/dialects linked in
+
+### Production Tools
+
+#### iree-tf-import
+
+`iree-tf-import` provides a single entry-point for compiling TensorFlow saved
+models to "IREE Input Dialects" that can be fed to `iree-translate` or
+`iree-opt` and operated on further.
+
+##### Usage:
+
+```shell
+iree-tf-import /path/to/saved_model_v2
+# Optional args: --tf-savedmodel-exported-names=subset,of,exported,names
+
+iree-tf-import /path/to/saved_model_v1 --tf-import-type=savedmodel_v1
+# Optional args:
+#   --tf-savedmodel-exported-names=subset,of,exported,names
+#   --tf-savedmodel-tags=serving
+```

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/BUILD
@@ -81,7 +81,6 @@ cc_library(
         "//integrations/tensorflow/compiler/dialect/tf_strings/ir",
         "//integrations/tensorflow/compiler/dialect/tf_strings/ir:dialect",
         "//integrations/tensorflow/compiler/dialect/tf_strings/ir:ops",
-        "//iree/compiler/Utils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:StandardOps",

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/BUILD
@@ -71,9 +71,9 @@ cc_library(
     ],
     deps = [
         ":op_interface_gen",
+        ":ops",
         ":ops_gen",
         "//integrations/tensorflow/compiler/dialect/tf_strings/conversion:convert_flow_to_hal",
-        "//integrations/tensorflow/compiler/dialect/tf_strings/ir:ops",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
     ],

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion/BUILD
@@ -75,7 +75,6 @@ cc_library(
         "//iree/compiler/Dialect/Modules/TensorList/IR",
         "//iree/compiler/Dialect/Modules/TensorList/IR:TensorListDialect",
         "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
     ],

--- a/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
+++ b/integrations/tensorflow/compiler/dialect/tf_tensorlist/ir/BUILD
@@ -60,7 +60,6 @@ cc_library(
     deps = [
         ":ir",
         "//integrations/tensorflow/compiler/dialect/tf_tensorlist/conversion:convert_flow_to_hal",
-        "//iree/compiler/Dialect/IREE/IR",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/integrations/tensorflow/compiler/iree-tf-import-main.cc
+++ b/integrations/tensorflow/compiler/iree-tf-import-main.cc
@@ -1,0 +1,202 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Main entry function for the iree-tf-import tool (and derived binaries).
+// Note that this is not an e2e tool: it is purely the first stage of the
+// pipeline intended to lower TensorFlow GraphDefs and SavedModels to a form
+// suitable for input to the IREE compiler.
+//
+// Since none of the TensorFlow imports come from an MLIR text form, it is a bit
+// of an odd fit for a *-translate style tool, which is why this diverges.
+
+#include "integrations/tensorflow/compiler/Passes.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "tensorflow/cc/saved_model/loader.h"
+#include "tensorflow/compiler/mlir/init_mlir.h"
+#include "tensorflow/compiler/mlir/tensorflow/dialect_registration.h"
+#include "tensorflow/compiler/mlir/tensorflow/translate/import_model.h"
+#include "tensorflow/core/platform/errors.h"
+
+using namespace llvm;
+using namespace mlir;
+
+namespace {
+
+enum ImportType {
+  savedmodel_v2,
+  savedmodel_v1,
+};
+
+}  // namespace
+
+static OwningModuleRef importSavedModelV2(
+    MLIRContext &context, const std::string &inputPath,
+    const std::string &savedModelExportedNames) {
+  tensorflow::SavedModelV2Bundle bundle;
+  auto loadStatus = tensorflow::SavedModelV2Bundle::Load(inputPath, &bundle);
+  if (!loadStatus.ok()) {
+    std::cerr << "TensorFlow reported error loading saved model:\n  "
+              << loadStatus << "\n\n";
+    if (!tensorflow::errors::IsNotFound(loadStatus)) {
+      std::cerr << "Note: Attempted to load V2 SavedModel. Double check that "
+                   "this is correct "
+                << "and adjust via the flag "
+                   "--tf-import-type=savedmodel_v1|savedmodel_v2\n";
+    }
+    return nullptr;
+  }
+
+  std::vector<std::string> exportedNamesVector =
+      absl::StrSplit(savedModelExportedNames, ',', absl::SkipEmpty());
+  auto loadedModule = tensorflow::ConvertSavedModelToMlir(
+      &bundle, &context, absl::MakeSpan(exportedNamesVector));
+  if (!loadedModule.ok()) {
+    std::cerr << "Error performing initial import from SavedModel to MLIR. "
+              << "Reported error below (and see diagnostics):\n"
+              << "  " << loadedModule.status() << "\n";
+    return nullptr;
+  }
+
+  return loadedModule.ConsumeValueOrDie();
+}
+
+static OwningModuleRef importSavedModelV1(
+    MLIRContext &context, const std::string &inputPath,
+    const std::string &savedModelExportedNames,
+    const std::string &savedModelTags) {
+  tensorflow::SavedModelBundle bundle;
+  tensorflow::SessionOptions session_options;
+  // Force saved model states to be restored to CPU.
+  (*session_options.config.mutable_device_count())["GPU"] = 0;
+
+  std::unordered_set<std::string> tags =
+      absl::StrSplit(savedModelTags, ',', absl::SkipEmpty());
+  auto loadStatus =
+      tensorflow::LoadSavedModel(session_options,
+                                 /*run_options=*/{}, inputPath, tags, &bundle);
+  if (!loadStatus.ok()) {
+    std::cerr << "TensorFlow reported error loading saved model:\n  "
+              << loadStatus << "\n\n";
+    if (!tensorflow::errors::IsNotFound(loadStatus)) {
+      std::cerr << "Note: Attempted to load V1 SavedModel. Double check that "
+                   "this is correct "
+                << "and adjust via the flag "
+                   "--tf-import-type=savedmodel_v1|savedmodel_v2\n";
+    }
+    return nullptr;
+  }
+
+  std::vector<std::string> exportedNamesVector =
+      absl::StrSplit(savedModelExportedNames, ',', absl::SkipEmpty());
+
+  auto loadedModule = ConvertSavedModelV1ToMlir(
+      bundle, absl::MakeSpan(exportedNamesVector), &context,
+      /*upgrade_legacy=*/false);
+
+  if (!loadedModule.ok()) {
+    std::cerr << "Error performing initial import from SavedModel to MLIR. "
+              << "Reported error below (and see diagnostics):\n"
+              << "  " << loadedModule.status() << "\n";
+    return nullptr;
+  }
+
+  return loadedModule.ConsumeValueOrDie();
+}
+
+int main(int argc, char **argv) {
+  tensorflow::InitMlir y(&argc, &argv);
+
+  static cl::opt<std::string> inputPath(
+      cl::Positional, cl::desc("<saved model directory>"), cl::Required);
+  static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+                                             cl::value_desc("filename"),
+                                             cl::init("-"));
+  static cl::opt<ImportType> importType(
+      "tf-import-type", cl::desc("The type of TensorFlow model to import"),
+      cl::values(clEnumVal(savedmodel_v2,
+                           "Import a TensorFlow SavedModel V2 (directory)"),
+                 clEnumVal(savedmodel_v1,
+                           "Import a TensorFlow SavedModel V1 (directory)")));
+
+  static llvm::cl::opt<std::string> savedModelExportedNames(
+      "tf-savedmodel-exported-names",
+      llvm::cl::desc("Names to export from SavedModel, separated by ','. Empty "
+                     "(the default) means export all."),
+      llvm::cl::init(""));
+
+  static llvm::cl::opt<std::string> savedModelTags(
+      "tf-savedmodel-tags",
+      llvm::cl::desc("Tags used to indicate which MetaGraphDef to import, "
+                     "separated by ','"),
+      llvm::cl::init("serve"));
+
+  // Register any command line options.
+  registerAsmPrinterCLOptions();
+  registerMLIRContextCLOptions();
+  registerPassManagerCLOptions();
+  cl::ParseCommandLineOptions(argc, argv);
+
+  DialectRegistry registry;
+  RegisterAllTensorFlowDialects(registry);
+
+  MLIRContext context;
+  OwningModuleRef module;
+  registry.loadAll(&context);
+
+  // First stage import.
+  switch (importType) {
+    case savedmodel_v2:
+      module = importSavedModelV2(context, inputPath, savedModelExportedNames);
+      break;
+    case savedmodel_v1:
+      module = importSavedModelV1(context, inputPath, savedModelExportedNames,
+                                  savedModelTags);
+      break;
+    default:
+      llvm_unreachable("unsupported import type enum");
+  }
+  if (!module) return 1;
+
+  // Run passes.
+  PassManager pm(&context, PassManager::Nesting::Implicit);
+  iree_compiler::TF::buildTFImportPassPipeline(pm);
+  if (failed(pm.run(*module))) {
+    std::cerr
+        << "Running iree-tf-import pass pipeline failed (see diagnostics)\n";
+    return 2;
+  }
+
+  // Output.
+  auto outputFile = openOutputFile(outputFilename);
+  if (!outputFile) {
+    return 3;
+  }
+  OpPrintingFlags printFlags;
+  printFlags.enableDebugInfo();
+  module->print(outputFile->os(), printFlags);
+  outputFile->os() << "\n";
+  outputFile->keep();
+
+  return 0;
+}


### PR DESCRIPTION
* Step 1/n of refactoring Python bindings to be based on a pure executable dep for TensorFlow interop.
* All tests pass except Vulkan (no GPU on this VM).