### PR TITLE
Sketch an experimental Linalg on tensors LLVM compiler

### DIFF
--- a/iree/compiler/Dialect/Flow/Utils/BUILD
+++ b/iree/compiler/Dialect/Flow/Utils/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "//iree/compiler/Dialect/Shape/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo",

--- a/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Utils/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRIR
+    MLIRLinalg
     MLIRStandard
     MLIRSupport
     iree::compiler::Dialect::Flow::IR

--- a/iree/compiler/Dialect/Flow/Utils/DispatchUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Utils/DispatchUtils.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "llvm/ADT/SetVector.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Linalg/IR/LinalgTypes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
@@ -35,7 +36,8 @@ bool isOpOfKnownDialect(Operation *op) {
   return dialectNamespace == mhlo::MhloDialect::getDialectNamespace() ||
          dialectNamespace == mlir::StandardOpsDialect::getDialectNamespace() ||
          dialectNamespace == FlowDialect::getDialectNamespace() ||
-         dialectNamespace == ShapeDialect::getDialectNamespace();
+         dialectNamespace == ShapeDialect::getDialectNamespace() ||
+         dialectNamespace == linalg::LinalgDialect::getDialectNamespace();
 }
 
 namespace {


### PR DESCRIPTION
This is a minimal sketch of a prototype pass to connect Linalg on tensors to CPU execution. This does not require dispatch region reordering and can connect to end-to-end execution once the 2 missing passes are upstreamed.

At the same time, this allows working on a common pass ordering sketch to allow reordering dispatch region creation as necessary.