### PR TITLE
Let Linalg on tensor ops pass LegalizeInputTypes

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -61,6 +61,7 @@ cc_library(
         "//iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Shape",
         "@llvm-project//mlir:ShapeTransforms",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRIR
+    MLIRLinalg
     MLIRPass
     MLIRShape
     MLIRShapeOpsTransforms

--- a/iree/compiler/Dialect/Flow/Transforms/LegalizeInputTypes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/LegalizeInputTypes.cpp
@@ -14,6 +14,7 @@
 
 #include "iree/compiler/Dialect/Flow/Conversion/TypeConverter.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
@@ -83,6 +84,13 @@ LogicalResult convertOperation(Operation *oldOp,
                                FlowTypeConverter &typeConverter,
                                BlockAndValueMapping &mapping,
                                OpBuilder &builder) {
+  if (llvm::isa<mlir::linalg::LinalgOp>(oldOp)) {
+    // Currently assumes linalg ops have legal types.
+    // TODO: rewrite to generic and back.
+    builder.clone(*oldOp, mapping);
+    return success();
+  }
+
   OperationState state(oldOp->getLoc(), oldOp->getName());
   for (auto oldType : oldOp->getResultTypes()) {
     if (failed(typeConverter.convertType(oldType, state.types))) {

--- a/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
@@ -107,3 +107,11 @@ func @compareI64(%arg0 : tensor<i64>, %arg1 : tensor<i64>) -> (i1, tensor<i64>) 
 ^bb2(%4 : i1, %5 : tensor<i64>):
   return %4, %5 : i1, tensor<i64>
 }
+
+// -----
+
+func @tensor(%A: tensor<2x3xf32>, %B: tensor<3x4xf32>, %C: tensor<2x4xf32>)  -> tensor<2x4xf32> attributes { iree.module.export } {
+  %E = linalg.matmul ins(%A, %B: tensor<2x3xf32>, tensor<3x4xf32>)
+                    init(%C: tensor<2x4xf32>) -> tensor<2x4xf32>
+  return %E : tensor<2x4xf32>
+}


### PR DESCRIPTION
Assume that all Linalg ops on tensors have legal input types for now.
This allows IREE to ingest Linalg on tensor ops from the frontend and pipe it through.
This is necessary to use Linalg on tensors as a programming model for IREE without relying on HLO.