### PR TITLE
Add workflow_dispatch trigger to update submodules action.

### DIFF
--- a/.github/workflows/update_llvm_dependent_submodules.yml
+++ b/.github/workflows/update_llvm_dependent_submodules.yml
@@ -18,6 +18,7 @@
 name: Synchronize LLVM Dependents
 
 on:
+  workflow_dispatch:
   schedule:
     # Every 6 hours at 0, 6, 12, 18 UTC (4, 10, 16, 22 PST)
     - cron: "0 */6 * * *"


### PR DESCRIPTION
Untested.

The goal with this is to be able to update the PRs generated by `iree-github-actions-bot` on demand in addition to on a schedule, for cases when the LLVM commit or https://github.com/google/llvm-bazel update between the scheduled runs. Reusing the bot-generated PRs instead of running https://github.com/google/iree/blob/main/scripts/git/update_llvm_dependent_submodules.sh directly will reduce PR noise on the repository and save a few steps for maintainers.

See documentation: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/