### PR TITLE
Step 2/n: Implementing new compiler python API.

### DIFF
--- a/bindings/python/pyiree/compiler2/README.md
+++ b/bindings/python/pyiree/compiler2/README.md
@@ -1,0 +1,46 @@
+# IREE Compiler Python Bindings
+
+Transitional note: These bindings are not complete yet and will ultimately
+replace the `pyiree.compiler` and `pyiree.tf.compiler` packages.
+
+## Core compiler
+
+```py
+from pyiree.compiler2 import *
+
+SIMPLE_MUL_ASM = """
+func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
+      attributes { iree.module.export } {
+    %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    return %0 : tensor<4xf32>
+}
+"""
+
+# Also see compile_file()
+# There are many keyword options available.
+# See pyiree.compiler2.CompilerOptions
+binary = compile_str(SIMPLE_MUL_ASM, target_backends=["vulkan-spirv"])
+```
+
+
+## TensorFlow compiler
+
+```py
+import tensorflow as tf
+from pyiree.compiler2.tf import *
+
+class SimpleArithmeticModule(tf.Module):
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([4], tf.float32),
+      tf.TensorSpec([4], tf.float32)
+  ])
+  def simple_mul(self, a, b):
+    return a * b
+
+# Also see compile_saved_model to directly compile an on-disk saved model.
+# There are many keyword options available.
+# See: pyiree.compiler2.tf.ImportOptions
+binary = compile_module(
+    SimpleArithmeticModule(), target_backends=["vulkan-spirv"])
+```

--- a/bindings/python/pyiree/compiler2/__init__.py
+++ b/bindings/python/pyiree/compiler2/__init__.py
@@ -1,0 +1,17 @@
+# Lint-as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .core import *
+from .tools import CompilerToolError

--- a/bindings/python/pyiree/compiler2/core.py
+++ b/bindings/python/pyiree/compiler2/core.py
@@ -1,0 +1,158 @@
+# Lint-as: python3
+"""Core compiler interface."""
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+import subprocess
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .tools import *
+
+__all__ = [
+    "DEFAULT_TESTING_BACKENDS",
+    "compile_file",
+    "compile_str",
+    "CompilerOptions",
+    "OutputFormat",
+]
+
+# Default testing backend for invoking the compiler.
+DEFAULT_TESTING_BACKENDS = ["vmla"]
+
+
+class OutputFormat(Enum):
+  """The output format of the compiler."""
+  FLATBUFFER_BINARY = "flatbuffer-binary"
+  FLATBUFFER_TEXT = "flatbuffer-text"
+  MLIR_TEXT = "mlir-text"
+
+  @staticmethod
+  def parse(spec) -> "OutputFormat":
+    if isinstance(spec, OutputFormat):
+      return spec
+    spec = spec.upper()
+    if spec not in OutputFormat.__members__:
+      raise ValueError(f"For output_format= argument, expected one of: "
+                       f"{', '.join(OutputFormat.__members__.keys())}")
+    return OutputFormat[spec]
+
+
+class CompilerOptions:
+  """Options to the compiler backend."""
+
+  def __init__(self,
+               *,
+               output_file: Optional[str] = None,
+               target_backends: Sequence[str] = (),
+               output_format: Union[OutputFormat,
+                                    str] = OutputFormat.FLATBUFFER_BINARY,
+               extra_args: Sequence[str] = (),
+               optimize: bool = True,
+               strip_debug_ops: bool = False,
+               strip_source_map: bool = False,
+               strip_symbols: bool = False,
+               crash_reproducer_path: Optional[str] = None,
+               enable_benchmark: bool = False):
+    self.output_file = output_file
+    self.target_backends = target_backends
+    self.output_format = OutputFormat.parse(output_format)
+    self.extra_args = extra_args
+    self.optimize = optimize
+    self.strip_debug_ops = strip_debug_ops
+    self.strip_source_map = strip_source_map
+    self.strip_symbols = strip_symbols
+    self.crash_reproducer_path = crash_reproducer_path
+    self.enable_benchmark = enable_benchmark
+
+
+def build_compile_command_line(input_file: str,
+                               options: CompilerOptions) -> List[str]:
+  """Builds a command line for invoking the compiler.
+
+  Args:
+    input_file: The input file name.
+    options: Compiler options.
+  Returns:
+    List of strings of command line.
+  """
+  iree_translate = find_tool("iree-translate")
+  if not options.target_backends:
+    raise ValueError("Expected a non-empty list for 'target_backends'")
+
+  cl = [
+      iree_translate,
+      input_file,
+      f"--iree-vm-bytecode-module-output-format={options.output_format.value}",
+      f"--iree-hal-target-backends={','.join(options.target_backends or [])}",
+  ]
+
+  # Output file.
+  if options.output_file:
+    cl.append(f"-o={options.output_file}")
+
+  # Translation to perform.
+  cl.append("--iree-mlir-to-vm-bytecode-module" if not options.enable_benchmark
+            else "--iree-mlir-to-executable-benchmark-vm-module")
+
+  # Other options to set if specified.
+  if options.strip_debug_ops:
+    cl.append("--iree-vm-bytecode-module-strip-debug-ops")
+  if options.strip_source_map:
+    cl.append("--iree-vm-bytecode-module-strip-source-map")
+  if options.strip_symbols:
+    cl.append("--iree-vm-bytecode-module-strip-symbols")
+  if options.crash_reproducer_path:
+    cl.append(
+        f"--pass-pipeline-crash-reproducer={options.crash_reproducer_path}")
+
+  cl.extend(options.extra_args)
+  return cl
+
+
+def compile_file(input_file: str, **kwargs):
+  """Invokes the IREE compiler on an input file.
+
+  Args:
+    input_file: Path to the input file.
+    **kwargs: Keyword arguments corresponding to CompilerOptions named tuple.
+  Returns:
+    Either a byte buffer of the compiled content or None if output_file
+    was specified in the options.
+  """
+  options = CompilerOptions(**kwargs)
+  cl = build_compile_command_line(input_file, options)
+  result = invoke_immediate(cl)
+  if options.output_file:
+    return None
+  return result
+
+
+def compile_str(input_str: str, **kwargs):
+  """Invokes the IREE compiler with an input string.
+
+  Args:
+    input_file: Path to the input file.
+    **kwargs: Keyword arguments corresponding to CompilerOptions named tuple.
+  Returns:
+    Either a byte buffer of the compiled content or None if output_file
+    was specified in the options.
+  """
+  options = CompilerOptions(**kwargs)
+  cl = build_compile_command_line("-", options)
+  result = invoke_immediate(cl, immediate_input=input_str.encode("utf-8"))
+  if options.output_file:
+    return None
+  return result

--- a/bindings/python/pyiree/compiler2/tf.py
+++ b/bindings/python/pyiree/compiler2/tf.py
@@ -55,7 +55,15 @@ class ImportType(Enum):
   V1 = "savedmodel_v1"
 
   @staticmethod
-  def parse(spec) -> "ImportType":
+  def parse(spec: Union[str, "ImportType"]) -> "ImportType":
+    """Parses or returns an ImportType.
+
+    Args:
+      spec: An ImportType instance or the case-insensitive name of one of
+        the enum values.
+    Returns:
+      An ImportType instance.
+    """
     if isinstance(spec, ImportType):
       return spec
     spec = spec.upper()
@@ -126,7 +134,15 @@ def build_import_command_line(input_path: str,
 
 
 def compile_saved_model(saved_model_dir: str, **kwargs):
-  """Compiles an on-disk saved model to an IREE binary."""
+  """Compiles an on-disk saved model to an IREE binary.
+
+  Args:
+    saved_model_dir: Path to directory where the model was saved.
+    **kwargs: Keyword args corresponding to ImportOptions or CompilerOptions.
+  Returns:
+    A bytes-like object with the compiled output or None if output_file=
+    was specified.
+  """
   options = ImportOptions(**kwargs)
   import_cl = build_import_command_line(saved_model_dir, options)
   if options.import_only:
@@ -151,6 +167,7 @@ def compile_module(module, saved_model_dir: Optional[str] = None, **kwargs):
     module: The tf.Module instance to convert to MLIR
     saved_model_dir: Optional path to save the tf.Module to. The module will not
       be persisted on disk outside of this call if this is not provided.
+    **kwargs: Keyword args corresponding to ImportOptions or CompilerOptions.
   Returns:
     Same as compile_saved_model().
   """

--- a/bindings/python/pyiree/compiler2/tf.py
+++ b/bindings/python/pyiree/compiler2/tf.py
@@ -1,0 +1,168 @@
+# Lint-as: python3
+"""TensorFlow compiler interface."""
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+import tempfile
+from typing import List, Optional, Sequence, Set, Union
+
+from .tools import *
+from .core import CompilerOptions, DEFAULT_TESTING_BACKENDS, build_compile_command_line
+
+__all__ = [
+    "compile_saved_model",
+    "compile_module",
+    "is_available",
+    "DEFAULT_TESTING_BACKENDS",
+    "ImportOptions",
+    "ImportType",
+]
+
+_TF_IMPORT_TOOL = "iree-tf-import"
+
+
+def is_available():
+  """Determine if TensorFlow and the compiler are available."""
+  try:
+    import tensorflow as tf
+  except ModuleNotFoundError:
+    return False
+  try:
+    find_tool(_TF_IMPORT_TOOL)
+  except ValueError:
+    return False
+  return True
+
+
+class ImportType(Enum):
+  """Import type of the model."""
+  OBJECT_GRAPH = "savedmodel_v2"
+  V2 = "savedmodel_v2"
+  SIGNATURE_DEF = "savedmodel_v1"
+  V1 = "savedmodel_v1"
+
+  @staticmethod
+  def parse(spec) -> "ImportType":
+    if isinstance(spec, ImportType):
+      return spec
+    spec = spec.upper()
+    if spec not in ImportType.__members__:
+      raise ValueError(f"For import_type= argument, expected one of: "
+                       f"{', '.join(ImportType.__members__.keys())}")
+    return ImportType[spec]
+
+
+class ImportOptions(CompilerOptions):
+  """Import options layer on top of the backend compiler options."""
+
+  def __init__(self,
+               exported_names: Sequence[str] = (),
+               import_only: bool = False,
+               import_type: Union[ImportType, str] = ImportType.OBJECT_GRAPH,
+               saved_model_tags: Set[str] = set(),
+               import_extra_args: Sequence[str] = (),
+               **kwargs):
+    """Initialize options from keywords.
+
+    Args:
+      exported_names: Optional sequence representing the exported names to
+        keep (object graph/v2 models only).
+      import_only: Only import the module. If True, the result will be textual
+        MLIR that can be further fed to the IREE compiler. If False (default),
+        the result will be the fully compiled IREE binary. In both cases,
+        bytes-like output is returned. Note that if the output_file= is
+        specified and import_only=True, then the MLIR form will be written to
+        the output file.
+      import_type: Type of import to perform. See ImportType enum.
+      saved_model_tags: Set of tags to export (signature def/v1 saved models
+        only).
+      import_extra_args: Extra arguments to pass to the iree-tf-import tool.
+    """
+    super().__init__(**kwargs)
+    self.exported_names = exported_names
+    self.import_only = import_only
+    self.import_type = ImportType.parse(import_type)
+    self.saved_model_tags = saved_model_tags
+    self.import_extra_args = import_extra_args
+
+
+def build_import_command_line(input_path: str,
+                              options: ImportOptions) -> List[str]:
+  """Builds a command line for invoking the import stage.
+
+  Args:
+    input_path: The input path.
+    options: Import options.
+  Returns:
+    List of strings of command line.
+  """
+  tf_import = find_tool(_TF_IMPORT_TOOL)
+  cl = [
+      tf_import,
+      input_path,
+      f"--tf-import-type={options.import_type.value}",
+      f"--tf-savedmodel-exported-names={','.join(options.exported_names)}",
+      f"--tf-savedmodel-tags={','.join(options.saved_model_tags)}",
+  ]
+  if options.import_only and options.output_file:
+    # Import stage directly outputs.
+    if options.output_file:
+      cl.append(f"-o={options.output_file}")
+  cl.extend(options.import_extra_args)
+  return cl
+
+
+def compile_saved_model(saved_model_dir: str, **kwargs):
+  """Compiles an on-disk saved model to an IREE binary."""
+  options = ImportOptions(**kwargs)
+  import_cl = build_import_command_line(saved_model_dir, options)
+  if options.import_only:
+    # One stage tool pipeline.
+    result = invoke_immediate(import_cl)
+    if options.output_file:
+      return None
+    return result
+
+  # Full compilation pipeline.
+  compile_cl = build_compile_command_line("-", options)
+  result = invoke_pipeline([import_cl, compile_cl])
+  if options.output_file:
+    return None
+  return result
+
+
+def compile_module(module, saved_model_dir: Optional[str] = None, **kwargs):
+  """Compiles a tf.Module to an IREE binary (by saving to disk).
+
+  Args:
+    module: The tf.Module instance to convert to MLIR
+    saved_model_dir: Optional path to save the tf.Module to. The module will not
+      be persisted on disk outside of this call if this is not provided.
+  Returns:
+    Same as compile_saved_model().
+  """
+
+  def do_it(saved_model_dir):
+    import tensorflow as tf
+    options = tf.saved_model.SaveOptions(save_debug_info=True)
+    tf.saved_model.save(module, saved_model_dir, options=options)
+    return compile_saved_model(saved_model_dir, **kwargs)
+
+  if saved_model_dir:
+    return do_it(saved_model_dir)
+  else:
+    with tempfile.TemporaryDirectory(suffix=".sm") as td:
+      return do_it(td)

--- a/bindings/python/pyiree/compiler2/tools.py
+++ b/bindings/python/pyiree/compiler2/tools.py
@@ -1,0 +1,244 @@
+# Lint-as: python3
+"""Utilities for locating and invoking compiler tools."""
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import io
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+
+from typing import List, Optional
+
+__all__ = [
+    "find_tool",
+    "invoke_immediate",
+    "invoke_pipeline",
+    "get_tool_path",
+    "CompilerToolError",
+]
+
+# In normal distribution circumstances, each named tool is associated with
+# a python module that provides a `get_tool` function for getting its absolute
+# path. This dictionary maps the tool name to the module.
+_TOOL_MODULE_MAP = {
+    "iree-tf-import": "pyiree.tools.tf",
+    "iree-translate": "pyiree.tools.core",
+}
+
+# Map of tool module to package name as distributed to archives (used for
+# error messages).
+_TOOL_MODULE_PACKAGES = {
+    "pyiree.tools.tf": "pyiree_compiler_tf",
+    "pyiree.tools.core": "pyiree_compiler_core",
+}
+
+# Environment variable holding directories to be searched for named tools.
+# Delimitted by os.pathsep.
+_TOOL_PATH_ENVVAR = "IREE_TOOL_PATH"
+
+
+class CompilerToolError(Exception):
+  """Compiler exception that preserves the command line and error output."""
+
+  def __init__(self, process: subprocess.CompletedProcess):
+    try:
+      errs = process.stderr.decode("utf-8")
+    except:
+      errs = str(process.stderr)  # Decode error or other: best we can do.
+
+    tool_name = os.path.basename(process.args[0])
+    super().__init__(f"Error invoking IREE compiler tool {tool_name}\n"
+                     f"Diagnostics:\n{errs}\n\n"
+                     f"Invoked with:\n  {' '.join(process.args)}")
+
+
+def get_tool_path() -> List[str]:
+  """Returns list of paths to search for tools."""
+  list_str = os.environ.get(_TOOL_PATH_ENVVAR)
+  if not list_str:
+    return []
+  return list_str.split(os.pathsep)
+
+
+def find_tool(exe_name: str) -> str:
+  """Finds a tool by its (extension-less) executable name.
+
+  Args:
+    exe_name: The name of the executable (extension-less).
+  Returns:
+    An absolute path to the tool.
+  Raises:
+    ValueError: If the tool is not known or not found.
+  """
+  if exe_name not in _TOOL_MODULE_MAP:
+    raise ValueError(f"IREE compiler tool '{exe_name}' is not a known tool")
+  # First search an explicit tool path.
+  tool_path = get_tool_path()
+  for path_entry in tool_path:
+    if not path_entry:
+      continue
+    candidate_exe = os.path.join(path_entry, exe_name)
+    if os.path.isfile(candidate_exe) and os.access(candidate_exe, os.X_OK):
+      return candidate_exe
+
+  # Attempt to load the tool module.
+  tool_module_name = _TOOL_MODULE_MAP[exe_name]
+  tool_module_package = _TOOL_MODULE_PACKAGES[tool_module_name]
+  try:
+    tool_module = importlib.import_module(tool_module_name)
+  except ModuleNotFoundError:
+    raise ValueError(
+        f"IREE compiler tool '{exe_name}' is not installed (it should have been "
+        f"found in the python module '{tool_module_name}', typically installed "
+        f"via the package {tool_module_package}).\n\n"
+        f"Either install the package or set the {_TOOL_PATH_ENVVAR} environment "
+        f"variable to contain the path of the tool executable "
+        f"(current {_TOOL_PATH_ENVVAR} = {repr(tool_path)})") from None
+
+  # Ask the module for its tool.
+  candidate_exe = tool_module.get_tool(exe_name)
+  if (not candidate_exe or not os.path.isfile(candidate_exe) or
+      not os.access(candidate_exe, os.X_OK)):
+    raise ValueError(
+        f"IREE compiler tool '{exe_name}' was located in module "
+        f"'{tool_module_name}' but the file was not found or not executable: "
+        f"{candidate_exe}")
+  return candidate_exe
+
+
+def invoke_immediate(command_line: List[str],
+                     *,
+                     input_file: Optional[str] = None,
+                     immediate_input=None):
+  """Invokes an immediate command.
+
+  This is separate from invoke_pipeline as it is simpler and supports more
+  complex input redirection, using recommended facilities for sub-processes
+  (less magic).
+  """
+  run_args = {}
+  input_file_handle = None
+  stderr_handle = sys.stderr
+  try:
+    # Redirect input.
+    if input_file is not None:
+      input_file_handle = open(input_file, "rb")
+      run_args["stdin"] = input_file_handle
+    elif immediate_input is not None:
+      run_args["input"] = immediate_input
+
+    # Capture output.
+    run_args["capture_output"] = True
+    process = subprocess.run(command_line, **run_args)
+    if process.returncode != 0:
+      raise CompilerToolError(process)
+    # Emit stderr contents.
+    _write_binary_stderr(stderr_handle, process.stderr)
+    return process.stdout
+  finally:
+    if input_file_handle:
+      input_file_handle.close()
+
+
+def invoke_pipeline(command_lines: List[List[str]]):
+  """Invoke a pipeline of commands.
+
+  The first stage of the pipeline will have its stdin set to DEVNULL and each
+  subsequent stdin will derive from the prior stdout. The final stdout will
+  be accumulated and returned. All stderr contents are accumulated and printed
+  to stderr on completion or the first failing stage of the pipeline will have
+  an exception raised with its stderr output.
+  """
+  stages = []
+  prev_out = subprocess.DEVNULL
+  stderr_handle = sys.stderr
+
+  # Create all stages.
+  for i in range(len(command_lines)):
+    command_line = command_lines[i]
+    popen_args = {
+        "stdin": prev_out,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+    }
+    process = subprocess.Popen(command_line, **popen_args)
+    prev_out = process.stdout
+    stages.append(_PipelineStage(process, i == (len(command_lines) - 1)))
+
+  # Start stages.
+  for stage in stages:
+    stage.start()
+
+  # Join.
+  for stage in stages:
+    stage.join()
+
+  # Check for errors.
+  for stage in stages:
+    if stage.completed.returncode != 0:
+      raise CompilerToolError(stage.completed)
+
+  # Print any stderr output.
+  for stage in stages:
+    _write_binary_stderr(stderr_handle, stage.errs)
+  return stages[-1].outs
+
+
+class _PipelineStage(threading.Thread):
+  """Wraps a process and pumps its handles, waiting for completion."""
+
+  def __init__(self, process, capture_output):
+    super().__init__()
+    self.process = process
+    self.capture_output = capture_output
+    self.outs = None
+    self.errs = None
+
+  def pump_stderr(self):
+    self.errs = self.process.stderr.read()
+
+  def pump_stdout(self):
+    self.outs = self.process.stdout.read()
+
+  def run(self):
+    stderr_thread = threading.Thread(target=self.pump_stderr)
+    stderr_thread.start()
+    if self.capture_output:
+      stdout_thread = threading.Thread(target=self.pump_stdout)
+      stdout_thread.start()
+    self.process.wait()
+    stderr_thread.join()
+    if self.capture_output:
+      stdout_thread.join()
+    self.completed = subprocess.CompletedProcess(self.process.args,
+                                                 self.process.returncode,
+                                                 self.outs, self.errs)
+    self.process.stderr.close()
+    self.process.stdout.close()
+
+
+def _write_binary_stderr(out_handle, contents):
+  # Fast-paths buffered text-io (which stderr is by default) while allowing
+  # full decode for non buffered and binary io.
+  if hasattr(out_handle, "buffer"):
+    out_handle.buffer.write(contents)
+  elif isinstance(out_handle, io.TextIOBase):
+    out_handle.write(contents.decode("utf-8"))
+  else:
+    out_handle.write(contents)

--- a/bindings/python/pyiree/compiler2/tools.py
+++ b/bindings/python/pyiree/compiler2/tools.py
@@ -197,6 +197,7 @@ def invoke_pipeline(command_lines: List[List[str]]):
 
   # Check for errors.
   for stage in stages:
+    assert stage.completed
     if stage.completed.returncode != 0:
       raise CompilerToolError(stage.completed)
 
@@ -213,7 +214,7 @@ class _PipelineStage(threading.Thread):
     super().__init__()
     self.process = process
     self.capture_output = capture_output
-    self.completed = None
+    self.completed: Optional[subprocess.CompletedProcess] = None
     self.outs = None
     self.errs = None
 

--- a/bindings/python/pyiree/compiler2/tools.py
+++ b/bindings/python/pyiree/compiler2/tools.py
@@ -213,6 +213,7 @@ class _PipelineStage(threading.Thread):
     super().__init__()
     self.process = process
     self.capture_output = capture_output
+    self.completed = None
     self.outs = None
     self.errs = None
 

--- a/bindings/python/tests/README.md
+++ b/bindings/python/tests/README.md
@@ -1,0 +1,8 @@
+# Python API Tests
+
+These tests are run in an environment where all available Python bindings
+are setup on the `PYTHONPATH`. Each will internally skip itself if optional
+components are not available.
+
+Note that IREE compiler tool locations can be overriden by specifying the
+`IREE_TOOL_PATH` environment variable.

--- a/bindings/python/tests/compiler_core_test.py
+++ b/bindings/python/tests/compiler_core_test.py
@@ -1,0 +1,136 @@
+# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+import io
+import tempfile
+import unittest
+
+from pyiree import compiler2 as compiler
+
+SIMPLE_MUL_ASM = """
+func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
+      attributes { iree.module.export } {
+    %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    return %0 : tensor<4xf32>
+}
+"""
+
+
+class CompilerTest(unittest.TestCase):
+
+  def testNoTargetBackends(self):
+    with self.assertRaisesRegex(
+        ValueError, "Expected a non-empty list for 'target_backends'"):
+      binary = compiler.compile_str(SIMPLE_MUL_ASM)
+
+  def testCompileStr(self):
+    binary = compiler.compile_str(
+        SIMPLE_MUL_ASM, target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+    print("Flatbuffer size =", len(binary))
+    self.assertTrue(binary)
+
+  def testCompileInputFile(self):
+    with tempfile.NamedTemporaryFile("wt", delete=False) as f:
+      try:
+        f.write(SIMPLE_MUL_ASM)
+        f.close()
+        binary = compiler.compile_file(
+            f.name, target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+      finally:
+        os.remove(f.name)
+    print("Flatbuffer size =", len(binary))
+    self.assertIn(b"simple_mul", binary)
+
+  def testCompileOutputFile(self):
+    with tempfile.NamedTemporaryFile("wt", delete=False) as f:
+      try:
+        f.close()
+        output = compiler.compile_str(
+            SIMPLE_MUL_ASM,
+            output_file=f.name,
+            target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+        self.assertIsNone(output)
+
+        with open(f.name, "rb") as f_read:
+          binary = f_read.read()
+      finally:
+        os.remove(f.name)
+    print("Flatbuffer size =", len(binary))
+    self.assertIn(b"simple_mul", binary)
+
+  def testOutputFbText(self):
+    text = compiler.compile_str(
+        SIMPLE_MUL_ASM,
+        output_format=compiler.OutputFormat.FLATBUFFER_TEXT,
+        target_backends=compiler.DEFAULT_TESTING_BACKENDS).decode("utf-8")
+    # Just check for an arbitrary JSON-tag.
+    self.assertIn('"exported_functions"', text)
+
+  def testBadOutputFormat(self):
+    with self.assertRaisesRegex(
+        ValueError, "For output_format= argument, expected one of: "
+        "FLATBUFFER_BINARY, FLATBUFFER_TEXT, MLIR_TEXT"):
+      _ = compiler.compile_str(
+          SIMPLE_MUL_ASM,
+          output_format="foobar",
+          target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+
+  def testOutputFbTextParsed(self):
+    text = compiler.compile_str(
+        SIMPLE_MUL_ASM,
+        output_format='flatbuffer_text',
+        target_backends=compiler.DEFAULT_TESTING_BACKENDS).decode("utf-8")
+    # Just check for an arbitrary JSON-tag.
+    self.assertIn('"exported_functions"', text)
+
+  def testOutputMlirText(self):
+    text = compiler.compile_str(
+        SIMPLE_MUL_ASM,
+        output_format=compiler.OutputFormat.MLIR_TEXT,
+        target_backends=compiler.DEFAULT_TESTING_BACKENDS).decode("utf-8")
+    # Just check for a textual op name.
+    self.assertIn("vm.module", text)
+
+  def testExtraArgsStderr(self):
+    # pass-timing is not special: it just does something and emits to stderr.
+    with io.StringIO() as buf, contextlib.redirect_stderr(buf):
+      compiler.compile_str(SIMPLE_MUL_ASM,
+                           extra_args=["--pass-timing"],
+                           target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+      stderr = buf.getvalue()
+    self.assertIn("Pass execution timing report", stderr)
+
+  def testAllOptions(self):
+    binary = compiler.compile_str(
+        SIMPLE_MUL_ASM,
+        optimize=False,
+        strip_debug_ops=True,
+        strip_source_map=True,
+        strip_symbols=True,
+        crash_reproducer_path="foobar.txt",
+        enable_benchmark=True,
+        target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+
+  def testException(self):
+    with self.assertRaisesRegex(compiler.CompilerToolError, "Invoked with"):
+      _ = compiler.compile_str(
+          "I'm a little teapot but not a valid program",
+          target_backends=compiler.DEFAULT_TESTING_BACKENDS)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/bindings/python/tests/compiler_core_test.py
+++ b/bindings/python/tests/compiler_core_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import contextlib
+import logging
 import os
 import io
 import tempfile
@@ -40,7 +41,7 @@ class CompilerTest(unittest.TestCase):
   def testCompileStr(self):
     binary = compiler.compile_str(
         SIMPLE_MUL_ASM, target_backends=compiler.DEFAULT_TESTING_BACKENDS)
-    print("Flatbuffer size =", len(binary))
+    logging.info("Flatbuffer size = %d", len(binary))
     self.assertTrue(binary)
 
   def testCompileInputFile(self):
@@ -52,7 +53,7 @@ class CompilerTest(unittest.TestCase):
             f.name, target_backends=compiler.DEFAULT_TESTING_BACKENDS)
       finally:
         os.remove(f.name)
-    print("Flatbuffer size =", len(binary))
+    logging.info("Flatbuffer size = %d", len(binary))
     self.assertIn(b"simple_mul", binary)
 
   def testCompileOutputFile(self):
@@ -69,7 +70,7 @@ class CompilerTest(unittest.TestCase):
           binary = f_read.read()
       finally:
         os.remove(f.name)
-    print("Flatbuffer size =", len(binary))
+    logging.info("Flatbuffer size = %d", len(binary))
     self.assertIn(b"simple_mul", binary)
 
   def testOutputFbText(self):
@@ -133,4 +134,5 @@ class CompilerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
+  logging.basicConfig(level=logging.DEBUG)
   unittest.main()

--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -1,0 +1,82 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+import unittest
+
+from pyiree.compiler2.tf import *
+
+if not is_available():
+  print(f"Skipping test {__file__} because TensorFlow is not installed")
+  sys.exit(0)
+
+import tensorflow as tf
+
+
+class SimpleArithmeticModule(tf.Module):
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([4], tf.float32),
+      tf.TensorSpec([4], tf.float32)
+  ])
+  def simple_mul(self, a, b):
+    return a * b
+
+  @tf.function(input_signature=[
+      tf.TensorSpec([128, 3072], tf.float32),
+      tf.TensorSpec([3072, 256], tf.float32),
+  ])
+  def simple_matmul(self, a, b):
+    return tf.matmul(a, b)
+
+
+class TfCompilerTest(unittest.TestCase):
+
+  def testImportSavedModel(self):
+    import_mlir = compile_saved_model(self.smdir,
+                                      import_only=True).decode("utf-8")
+    self.assertIn("func @simple_matmul", import_mlir)
+
+  def testCompileSavedModel(self):
+    binary = compile_saved_model(self.smdir,
+                                 target_backends=DEFAULT_TESTING_BACKENDS)
+    print("Compiled len:", len(binary))
+    self.assertIn(b"simple_matmul", binary)
+    self.assertIn(b"simple_mul", binary)
+
+  def testCompileModule(self):
+    binary = compile_module(self.m, target_backends=DEFAULT_TESTING_BACKENDS)
+    print("Compiled len:", len(binary))
+    self.assertIn(b"simple_matmul", binary)
+    self.assertIn(b"simple_mul", binary)
+
+  @classmethod
+  def setUpClass(cls):
+    cls.m = SimpleArithmeticModule()
+    cls.tempdir = tempfile.TemporaryDirectory()
+    cls.smdir = os.path.join(cls.tempdir.name, "arith.sm")
+    tf.saved_model.save(
+        cls.m,
+        cls.smdir,
+        options=tf.saved_model.SaveOptions(save_debug_info=True))
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.tempdir.cleanup()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -44,6 +44,8 @@ class SimpleArithmeticModule(tf.Module):
     return tf.matmul(a, b)
 
 
+# TODO(laurenzo): More test cases needed (may need additional files).
+# Specifically, figure out how to test v1 models.
 class TfCompilerTest(unittest.TestCase):
 
   def testImportSavedModel(self):

--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -18,6 +18,8 @@ import sys
 import tempfile
 import unittest
 
+# TODO: No idea why pytype cannot find names from this module.
+# pytype: disable=name-error
 from pyiree.compiler2.tf import *
 
 if not is_available():

--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
 import tempfile
@@ -53,13 +54,13 @@ class TfCompilerTest(unittest.TestCase):
   def testCompileSavedModel(self):
     binary = compile_saved_model(self.smdir,
                                  target_backends=DEFAULT_TESTING_BACKENDS)
-    print("Compiled len:", len(binary))
+    logging.info("Compiled len: %d", len(binary))
     self.assertIn(b"simple_matmul", binary)
     self.assertIn(b"simple_mul", binary)
 
   def testCompileModule(self):
     binary = compile_module(self.m, target_backends=DEFAULT_TESTING_BACKENDS)
-    print("Compiled len:", len(binary))
+    logging.info("Compiled len: %d", len(binary))
     self.assertIn(b"simple_matmul", binary)
     self.assertIn(b"simple_mul", binary)
 
@@ -79,4 +80,5 @@ class TfCompilerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
+  logging.basicConfig(level=logging.DEBUG)
   unittest.main()


### PR DESCRIPTION
* Builds on the iree-tf-import work submitted prior.
* Creates a temporary pyiree.compiler2 module to eventually replace pyiree.compiler and pyiree.tf.compiler.
* Stays somewhat close to the original API but shaves off a lot of rough edges that accumulated over time.
* Will introduce more logging and debugability in a follow-on once more is wired up.
* No build support yet: just running tests individually at the moment with IREE_TOOL_PATH set to find the compiled tools.