### PR TITLE
Port the TensorFlow e2e tests to use the new compiler2 api.

### DIFF
--- a/bindings/python/pyiree/compiler2/tf.py
+++ b/bindings/python/pyiree/compiler2/tf.py
@@ -85,6 +85,8 @@ class ImportOptions(CompilerOptions):
                import_type: Union[ImportType, str] = ImportType.OBJECT_GRAPH,
                saved_model_tags: Set[str] = set(),
                import_extra_args: Sequence[str] = (),
+               save_temp_tf_input: Optional[str] = None,
+               save_temp_iree_input: Optional[str] = None,
                **kwargs):
     """Initialize options from keywords.
 
@@ -101,6 +103,10 @@ class ImportOptions(CompilerOptions):
       saved_model_tags: Set of tags to export (signature def/v1 saved models
         only).
       import_extra_args: Extra arguments to pass to the iree-tf-import tool.
+      save_temp_tf_input: Optionally save the IR that is input to the
+        TensorFlow pipeline.
+      save_temp_iree_input: Optionally save the IR that is the result of the
+        import (ready to be passed to IREE).
     """
     super().__init__(**kwargs)
     self.exported_names = exported_names
@@ -108,6 +114,8 @@ class ImportOptions(CompilerOptions):
     self.import_type = ImportType.parse(import_type)
     self.saved_model_tags = saved_model_tags
     self.import_extra_args = import_extra_args
+    self.save_temp_tf_input = save_temp_tf_input
+    self.save_temp_iree_input = save_temp_iree_input
 
 
 def build_import_command_line(input_path: str,
@@ -132,6 +140,12 @@ def build_import_command_line(input_path: str,
     # Import stage directly outputs.
     if options.output_file:
       cl.append(f"-o={options.output_file}")
+  # Save temps flags.
+  if options.save_temp_tf_input:
+    cl.append(f"--save-temp-tf-input={options.save_temp_tf_input}")
+  if options.save_temp_iree_input:
+    cl.append(f"--save-temp-iree-input={options.save_temp_iree_input}")
+  # Extra args.
   cl.extend(options.import_extra_args)
   return cl
 

--- a/bindings/python/setup_tools_tf.py.in
+++ b/bindings/python/setup_tools_tf.py.in
@@ -68,9 +68,11 @@ setup(
     ],
     python_requires=">=3.6",
     package_dir={"": this_dir},
-    packages=find_namespace_packages(where=this_dir,
-                                     include=["pyiree.tools.tf"],
-                                     exclude=["*.CMakeFiles"]),
+    packages=find_namespace_packages(
+        where=this_dir,
+        # TODO: 
+        include=["pyiree.tools.tf", "pyiree.tf.support"],
+        exclude=["*.CMakeFiles"]),
     # Matching the native extension as a data file keeps setuptools from
     # "building" it (i.e. turning it into a static binary).
     package_data={

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/CMakeLists.txt
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Overlays a subdirectory into the main python bindings directory.
-function(_add_overlay_subdirectory dir)
-  # Overlay binary directories onto the main bindings directory.
-  set(_MAIN_PYTHON_DIR "${CMAKE_BINARY_DIR}/bindings/python")
-  add_subdirectory(${dir} "${_MAIN_PYTHON_DIR}/${dir}")
-endfunction()
+iree_py_library(
+  NAME
+    support
+  SRCS
+    "__init__.py"
+    "module_utils.py"
+    "tf_test_driver.py"
+    "tf_test_utils.py"
+    "tf_utils.py"
+    "trace_utils.py"
+)
 
-_add_overlay_subdirectory(pyiree/tools/tf)
-# TODO: Find another place for the TF support library.
-_add_overlay_subdirectory(pyiree/tf/support)
+# TODO: Add tests.

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -17,13 +17,13 @@
 import collections
 import os
 import tempfile
-from typing import Any, Callable, Dict, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union
 
 from absl import flags
 from absl import logging
 import numpy as np
 from pyiree import rt
-from pyiree.tf import compiler
+from pyiree.compiler2 import tf as tf_compiler
 from pyiree.tf.support import tf_utils
 import tensorflow.compat.v2 as tf
 
@@ -40,107 +40,63 @@ def _running_bazel_test() -> bool:
   return "TEST_TMPDIR" in os.environ
 
 
-def _setup_mlir_crash_reproducer(
-    function: Any,  # pytype doesn't support arbitrary Callable[*args, **kwargs]
-    artifacts_dir: str,
-    backend_id: str,
-) -> Any:  # Callable[Any, Any]
-  """Wraps `function` so that it a MLIR crash reproducer is saved if it crashes.
+def _get_tf_import_output_kwargs(artifacts_dir: str,
+                                 backend_id: str,
+                                 *,
+                                 needs_temp_saved_model_dir: bool = False):
+  """Gets output kwargs dict to pass to tf.compile() for output generation.
 
-  Writes to `artifacts_dir/reproducer__{backend}.mlir` in the case of a crash.
-
-  Args:
-    function: The callable to decorate.
-    artifacts_dir: The directory to write the reproducer to.
-    backend_id: The unique backend name to use when writting the reproducer.
-
-  Returns:
-    A function with the same API as the passed function.
-  """
-
-  def decorator(*args, **kwargs):
-    # Set up a crash reproducer for debugging.
-    if artifacts_dir is not None:
-      compiler.Context.default_crash_reproducer_path = os.path.join(
-          artifacts_dir, f"reproducer__{backend_id}.mlir")
-    try:
-      results = function(*args, **kwargs)
-    except Exception:  # pylint: disable=broad-except
-      # Disable the crash reproducer (to avoid inadvertently overwriting it).
-      if artifacts_dir is not None:
-        compiler.Context.default_crash_reproducer_path = None
-      raise
-    return results
-
-  return decorator
-
-
-def _incrementally_lower_compiler_module(
-    compiler_module: compiler.Module,
-    backend_info: "BackendInfo",
-    artifacts_dir: str,
-) -> Tuple[compiler.binding.OpaqueBlob, Union[str, None]]:
-  """Lowers a MLIR compiler module incrementally and saves its outputs.
-
-  If artifacts_dir is provided then the following artifacts will be saved:
+  When artifacts_dir is set, writes:
     tf_input.mlir:
       MLIR for the module in TF's input dialect.
     iree_input.mlir:
       The MLIR above translated to IREE via compiler.TF_IMPORT_PASS_PIPELINE.
     backend_id/compiled.vmfb:
       A VM FlatBuffer compiled to the target backend from the IREE MLIR above.
+    `artifacts_dir/reproducer__{backend}.mlir` in the case of a crash.
 
   Args:
-    compiler_module: A compiler.Module to lower.
-    backend_info: BackendInfo with the details for lowering compiler_module to
-      IREE.
-    artifacts_dir: An optional string pointing to where compilation artifacts
-      should be saved. No compilation artifacts will be saved if this is not
-      provided.
+    artifacts_dir: The artifacts directory.
+    backend_id: The backend id (for artifacts that are backend dependent).
+    needs_temp_saved_model_dir: Whether a temporary 'saved_model_dir' directory
+      needs to be set.
+  Returns:
+    A dict of output kwargs.
   """
-  if artifacts_dir is not None:
-    os.makedirs(artifacts_dir, exist_ok=True)
-    tf_mlir_path = os.path.join(artifacts_dir, "tf_input.mlir")
-    logging.info("Saving raw TF input MLIR to: %s", tf_mlir_path)
-    with open(tf_mlir_path, "w") as f:
-      f.write(compiler_module.to_asm())
+  kwargs = {}
+  backend_dir = os.path.join(artifacts_dir, backend_id)
+  os.makedirs(backend_dir, exist_ok=True)
+  kwargs["output_file"] = os.path.join(backend_dir, "compiled.vmfb")
+  if needs_temp_saved_model_dir:
+    kwargs["saved_model_dir"] = os.path.join(artifacts_dir,
+                                             "tfmodule.saved_model")
+  kwargs["save_temp_tf_input"] = os.path.join(artifacts_dir, "tf_input.mlir")
+  kwargs["save_temp_iree_input"] = os.path.join(artifacts_dir,
+                                                "iree_input.mlir")
 
-  # Manually run the passes that tf_module_to_compiler_module usually would.
-  compiler_module.run_pass_pipeline(compiler.TF_IMPORT_PASS_PIPELINE)
+  # Avoid the crash reproducer under tests or if the flag is false.
+  # Developers can run tests outside of the test runner (e.g. `bazel run`) to
+  # use the crash reproducer.
+  if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
+    kwargs["crash_reproducer_path"] = os.path.join(
+        artifacts_dir, f"reproducer__{backend_id}.mlir")
 
-  if artifacts_dir is not None:
-    iree_mlir_path = os.path.join(artifacts_dir, "iree_input.mlir")
-    logging.info("Saving IREE input MLIR to: %s", iree_mlir_path)
-    with open(iree_mlir_path, "w") as f:
-      f.write(compiler_module.to_asm())
-
-  compiled_module = compiler_module.compile(
-      target_backends=backend_info.compiler_targets)
-
-  compiled_path = None
-  if artifacts_dir is not None:
-    backend_dir = os.path.join(artifacts_dir, backend_info.backend_id)
-    os.makedirs(backend_dir, exist_ok=True)
-    compiled_path = os.path.join(backend_dir, "compiled.vmfb")
-    logging.info("Saving compiled IREE module to: %s", compiled_path)
-    with open(compiled_path, "wb") as f:
-      f.write(compiled_module)
-  return compiled_module, compiled_path
+  logging.info(
+      "Outputting intermediate artifacts (--artifacts_dir is set):\n%s",
+      "\n".join(f"  {k}: {v}" for k, v in kwargs.items()))
+  return kwargs
 
 
 def _incrementally_compile_tf_module(
     module: Type[tf.Module],
     backend_info: "BackendInfo",
     exported_names: Sequence[str] = (),
-    artifacts_dir: str = None,
-) -> Tuple[compiler.binding.OpaqueBlob, Union[str, None]]:
+    artifacts_dir: Optional[str] = None,
+) -> Tuple[bytes, Optional[str]]:
   """Compile a TensorFlow tf.Module and optionally save compilation artifacts.
 
   The module blob this creates is not callable. See IreeCompiledModule for an
   API that returns a module that can be called without any further steps.
-
-  See _incrementally_lower_compiler_module's docstring for details about which
-  artifacts will be saved.
 
   Args:
     module: A tf.Module.
@@ -154,22 +110,22 @@ def _incrementally_compile_tf_module(
     A compiled IREE module blob and the path to the compiled VM FlatBuffer if
     artifacts_dir is provided.
   """
+  output_kwargs = (_get_tf_import_output_kwargs(
+      artifacts_dir,
+      backend_info.backend_id,
+      needs_temp_saved_model_dir=True,
+  ) if artifacts_dir else {})
+  immediate_result = tf_compiler.compile_module(
+      module,
+      target_backends=backend_info.compiler_targets,
+      exported_names=exported_names,
+      **output_kwargs)
 
-  def _compile_module(module, backend_info, exported_names, artifacts_dir):
-    compiler_module = compiler.tf_module_to_compiler_module(module,
-                                                            exported_names,
-                                                            pass_pipeline=())
-    return _incrementally_lower_compiler_module(compiler_module, backend_info,
-                                                artifacts_dir)
-
-  # Avoid the crash reproducer under tests or if the flag is false.
-  # Developers can run tests outside of the test runner (e.g. `bazel run`) to
-  # use the crash reproducer.
-  if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
-    _compile_module = _setup_mlir_crash_reproducer(_compile_module,
-                                                   artifacts_dir,
-                                                   backend_info.backend_id)
-  return _compile_module(module, backend_info, exported_names, artifacts_dir)
+  output_file = output_kwargs.get("output_file")
+  if output_file:
+    with open(output_file, "rb") as f:
+      immediate_result = f.read()
+  return immediate_result, output_file
 
 
 def _incrementally_compile_tf_signature_def_saved_model(
@@ -179,9 +135,6 @@ def _incrementally_compile_tf_signature_def_saved_model(
 
   The module blob this creates is not callable. See IreeCompiledModule for an
   API that returns a module that can be called without any further steps.
-
-  See _incrementally_lower_compiler_module's docstring for details about which
-  artifacts will be saved.
 
   Args:
     saved_model_dir: Directory of the saved model.
@@ -197,24 +150,21 @@ def _incrementally_compile_tf_signature_def_saved_model(
     A compiled IREE module blob and the path to the compiled VM FlatBuffer if
     artifacts_dir is provided.
   """
+  output_kwargs = (_get_tf_import_output_kwargs(
+      artifacts_dir, backend_info.backend_id) if artifacts_dir else {})
+  immediate_result = tf_compiler.compile_saved_model(
+      saved_model_dir,
+      import_type="SIGNATURE_DEF",
+      target_backends=backend_info.compiler_targets,
+      exported_names=[exported_name],
+      saved_model_tags=saved_model_tags,
+      **output_kwargs)
 
-  def _compile_module(saved_model_dir, saved_model_tags, backend_info,
-                      exported_name, artifacts_dir):
-    # Convert the tf_module into raw TF input MLIR.
-    compiler_module = compiler.tf_signature_def_saved_model_to_compiler_module(
-        saved_model_dir, saved_model_tags, [exported_name], pass_pipeline=())
-    return _incrementally_lower_compiler_module(compiler_module, backend_info,
-                                                artifacts_dir)
-
-  # Avoid the crash reproducer under tests or if the flag is false.
-  # Developers can run tests outside of the test runner (e.g. `bazel run`) to
-  # use the crash reproducer.
-  if (FLAGS.capture_crash_reproducer and not _running_bazel_test()):
-    _compile_module = _setup_mlir_crash_reproducer(_compile_module,
-                                                   artifacts_dir,
-                                                   backend_info.backend_id)
-  return _compile_module(saved_model_dir, saved_model_tags, backend_info,
-                         exported_name, artifacts_dir)
+  output_file = output_kwargs.get("output_file")
+  if output_file:
+    with open(output_file, "rb") as f:
+      immediate_result = f.read()
+  return immediate_result, output_file
 
 
 class _FunctionWrapper(object):

--- a/integrations/tensorflow/e2e/mobile_bert_squad_test.py
+++ b/integrations/tensorflow/e2e/mobile_bert_squad_test.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import numpy as np
 from pyiree.tf.support import tf_test_utils
-from pyiree.tf import compiler
 import tensorflow.compat.v2 as tf
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
* Also adds some flags to iree-tf-import to save temps, making things line up just like they were.
* Tested with simple_arithmetic_test.py and mobile_bert_squad_test.py by running each of them individually after a ninja build.