### PR TITLE
Refactor and normalization of mhlo convolutions

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -423,8 +423,7 @@ class ReorderConvOpOutputDimensions : public OpRewritePattern<mhlo::ConvOp> {
         /*output_feature_dimension=*/
         rewriter.getI64IntegerAttr(newSpatialDimensions.size() + 1),
         /*output_sptial_dimensions=*/
-        rewriter.getI64TensorAttr(newSpatialDimensions),
-        op.getContext());
+        rewriter.getI64TensorAttr(newSpatialDimensions), op.getContext());
 
     SmallVector<Value, 2> operands = {op.lhs(), op.rhs()};
     auto newConv = rewriter.create<mhlo::ConvOp>(

--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -101,10 +101,12 @@ static bool hasKernelDilation(mhlo::ConvOp op) {
 static bool hasNormalizedConvolution(mhlo::ConvOp op) {
   auto dimensionNumbers = op.dimension_numbers();
 
-  if (dimensionNumbers.input_batch_dimension().getValue().getSExtValue() != 0)
+  if (dimensionNumbers.input_batch_dimension().getValue().getSExtValue() != 0) {
     return false;
-  if (dimensionNumbers.input_batch_dimension().getValue().getSExtValue() != 0)
+  }
+  if (dimensionNumbers.input_batch_dimension().getValue().getSExtValue() != 0) {
     return false;
+  }
 
   for (auto it : llvm::enumerate(dimensionNumbers.input_spatial_dimensions())) {
     if (it.value() != it.index() + 1) return false;

--- a/iree/test/e2e/xla_ops/convolution.mlir
+++ b/iree/test/e2e/xla_ops/convolution.mlir
@@ -133,35 +133,36 @@ func @conv2d_reorder_kernel() attributes { iree.module.export } {
   return
 }
 
-func @conv2d_nopadding_reorder_features() attributes { iree.module.export } {
+func @conv2d_reorder_output() attributes { iree.module.export } {
   %inputs = iree.unfoldable_constant dense<[[
       [[ 1.0,  2.0], [ 3.0,  4.0], [ 5.0,  6.0], [ 7.0,  8.0], [ 9.0, 10.0]],
       [[11.0, 12.0], [13.0, 14.0], [15.0, 16.0], [17.0, 18.0], [19.0, 20.0]],
       [[21.0, 22.0], [23.0, 24.0], [25.0, 26.0], [27.0, 28.0], [29.0, 30.0]],
       [[31.0, 32.0], [33.0, 34.0], [35.0, 36.0], [37.0, 38.0], [39.0, 40.0]]]]> : tensor<1x4x5x2xf32>
   %weights = iree.unfoldable_constant dense<[
-      [[[ 1.0,  2.0]], [[ 3.0,  4.0]]],
-      [[[ 5.0,  6.0]], [[ 7.0,  8.0]]],
-      [[[ 9.0, 10.0]], [[11.0, 12.0]]]]> : tensor<3x2x1x2xf32>
+      [[[ 1.0], [ 2.0]], [[ 3.0], [ 4.0]]],
+      [[[ 5.0], [ 6.0]], [[ 7.0], [ 8.0]]],
+      [[[ 9.0], [10.0]], [[11.0], [12.0]]]]> : tensor<3x2x2x1xf32>
   %res = "mhlo.convolution"(%inputs, %weights) {
         batch_group_count = 1 : i64,
         dimension_numbers = {
           input_batch_dimension = 0 : i64,
           input_feature_dimension = 3 : i64,
           input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
-          kernel_input_feature_dimension = 3 : i64,
-          kernel_output_feature_dimension = 2 : i64,
+          kernel_input_feature_dimension = 2 : i64,
+          kernel_output_feature_dimension = 3 : i64,
           kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
-          output_batch_dimension = 0 : i64,
-          output_feature_dimension = 3 : i64,
-          output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+          output_batch_dimension = 2 : i64,
+          output_feature_dimension = 0 : i64,
+          output_spatial_dimensions = dense<[3, 1]> : tensor<2xi64>},
         feature_group_count = 1 : i64,
         rhs_dilation = dense<1> : tensor<2xi64>,
-        window_strides = dense<1> : tensor<2xi64>} : (tensor<1x4x5x2xf32>, tensor<3x2x1x2xf32>) -> tensor<1x2x3x1xf32>
+        window_strides = dense<1> : tensor<2xi64>} : (tensor<1x4x5x2xf32>, tensor<3x2x2x1xf32>) -> tensor<1x3x1x2xf32>
   check.expect_almost_eq_const(%res, dense<[[
-      [[1310.0],[1466.0],[1622.0]],
-      [[2090.0],[2246.0],[2402.0]]
-  ]]> : tensor<1x2x3x1xf32>) : tensor<1x2x3x1xf32>
+      [[1310.0, 2090.0]],
+      [[1466.0, 2246.0]],
+      [[1622.0, 2402.0]]
+      ]]> : tensor<1x3x1x2xf32>) : tensor<1x3x1x2xf32>
   return
 }
 

--- a/iree/test/e2e/xla_ops/convolution.mlir
+++ b/iree/test/e2e/xla_ops/convolution.mlir
@@ -30,6 +30,109 @@ func @conv2d_nopadding() attributes { iree.module.export } {
   return
 }
 
+func @conv2d_nopadding_batch_feature() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[
+    [[[ 1.0], [ 3.0], [ 5.0], [ 7.0], [ 9.0]],
+     [[11.0], [13.0], [15.0], [17.0], [19.0]],
+     [[21.0], [23.0], [25.0], [27.0], [29.0]],
+     [[31.0], [33.0], [35.0], [37.0], [39.0]]],
+    [[[ 2.0], [ 4.0], [ 6.0], [ 8.0], [10.0]],
+     [[12.0], [14.0], [16.0], [18.0], [20.0]],
+     [[22.0], [24.0], [26.0], [28.0], [30.0]],
+     [[32.0], [34.0], [36.0], [38.0], [40.0]]]     
+      ]> : tensor<2x4x5x1xf32>
+  %weights = iree.unfoldable_constant dense<[
+      [[[ 1.0], [ 2.0]], [[ 3.0], [ 4.0]]],
+      [[[ 5.0], [ 6.0]], [[ 7.0], [ 8.0]]],
+      [[[ 9.0], [10.0]], [[11.0], [12.0]]]]> : tensor<3x2x2x1xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+        batch_group_count = 1 : i64,
+        dimension_numbers = {
+          input_batch_dimension = 3 : i64,
+          input_feature_dimension = 0 : i64,
+          input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+          kernel_input_feature_dimension = 2 : i64,
+          kernel_output_feature_dimension = 3 : i64,
+          kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+          output_batch_dimension = 0 : i64,
+          output_feature_dimension = 3 : i64,
+          output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+        feature_group_count = 1 : i64,
+        rhs_dilation = dense<1> : tensor<2xi64>,
+        window_strides = dense<1> : tensor<2xi64>} : (tensor<2x4x5x1xf32>, tensor<3x2x2x1xf32>) -> tensor<1x2x3x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[
+      [[1310.0],[1466.0],[1622.0]],
+      [[2090.0],[2246.0],[2402.0]]
+  ]]> : tensor<1x2x3x1xf32>) : tensor<1x2x3x1xf32>
+  return
+}
+
+func @conv2d_reorder_input_spatial() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[[
+      [[ 1.0,  2.0], [11.0, 12.0], [21.0, 22.0], [31.0, 32.0]],
+      [[ 3.0,  4.0], [13.0, 14.0], [23.0, 24.0], [33.0, 34.0]],
+      [[ 5.0,  6.0], [15.0, 16.0], [25.0, 26.0], [35.0, 36.0]],
+      [[ 7.0,  8.0], [17.0, 18.0], [27.0, 28.0], [37.0, 38.0]],
+      [[ 9.0, 10.0], [19.0, 20.0], [29.0, 30.0], [39.0, 40.0]]]]> : tensor<1x5x4x2xf32>
+
+  %weights = iree.unfoldable_constant dense<[
+      [[[ 1.0], [ 2.0]], [[ 3.0], [ 4.0]]],
+      [[[ 5.0], [ 6.0]], [[ 7.0], [ 8.0]]],
+      [[[ 9.0], [10.0]], [[11.0], [12.0]]]]> : tensor<3x2x2x1xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+        batch_group_count = 1 : i64,
+        dimension_numbers = {
+          input_batch_dimension = 0 : i64,
+          input_feature_dimension = 3 : i64,
+          input_spatial_dimensions = dense<[2, 1]> : tensor<2xi64>,
+          kernel_input_feature_dimension = 2 : i64,
+          kernel_output_feature_dimension = 3 : i64,
+          kernel_spatial_dimensions = dense<[0, 1]> : tensor<2xi64>,
+          output_batch_dimension = 0 : i64,
+          output_feature_dimension = 3 : i64,
+          output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+        feature_group_count = 1 : i64,
+        rhs_dilation = dense<1> : tensor<2xi64>,
+        window_strides = dense<1> : tensor<2xi64>} : (tensor<1x5x4x2xf32>, tensor<3x2x2x1xf32>) -> tensor<1x2x3x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[
+      [[1310.0],[1466.0],[1622.0]],
+      [[2090.0],[2246.0],[2402.0]]
+  ]]> : tensor<1x2x3x1xf32>) : tensor<1x2x3x1xf32>
+  return
+}
+
+func @conv2d_reorder_kernel() attributes { iree.module.export } {
+  %inputs = iree.unfoldable_constant dense<[[
+      [[ 1.0,  2.0], [ 3.0,  4.0], [ 5.0,  6.0], [ 7.0,  8.0], [ 9.0, 10.0]],
+      [[11.0, 12.0], [13.0, 14.0], [15.0, 16.0], [17.0, 18.0], [19.0, 20.0]],
+      [[21.0, 22.0], [23.0, 24.0], [25.0, 26.0], [27.0, 28.0], [29.0, 30.0]],
+      [[31.0, 32.0], [33.0, 34.0], [35.0, 36.0], [37.0, 38.0], [39.0, 40.0]]]]> : tensor<1x4x5x2xf32>
+  %weights = iree.unfoldable_constant dense<
+      [[[[ 1.0,  3.0], [ 2.0,  4.0]],
+        [[ 5.0,  7.0], [ 6.0,  8.0]],
+        [[ 9.0, 11.0], [10.0, 12.0]]]]> : tensor<1x3x2x2xf32>
+  %res = "mhlo.convolution"(%inputs, %weights) {
+        batch_group_count = 1 : i64,
+        dimension_numbers = {
+          input_batch_dimension = 0 : i64,
+          input_feature_dimension = 3 : i64,
+          input_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>,
+          kernel_input_feature_dimension = 2 : i64,
+          kernel_output_feature_dimension = 0 : i64,
+          kernel_spatial_dimensions = dense<[1, 3]> : tensor<2xi64>,
+          output_batch_dimension = 0 : i64,
+          output_feature_dimension = 3 : i64,
+          output_spatial_dimensions = dense<[1, 2]> : tensor<2xi64>},
+        feature_group_count = 1 : i64,
+        rhs_dilation = dense<1> : tensor<2xi64>,
+        window_strides = dense<1> : tensor<2xi64>} : (tensor<1x4x5x2xf32>, tensor<1x3x2x2xf32>) -> tensor<1x2x3x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[
+      [[1310.0],[1466.0],[1622.0]],
+      [[2090.0],[2246.0],[2402.0]]
+  ]]> : tensor<1x2x3x1xf32>) : tensor<1x2x3x1xf32>
+  return
+}
+
 func @conv2d_nopadding_reorder_features() attributes { iree.module.export } {
   %inputs = iree.unfoldable_constant dense<[[
       [[ 1.0,  2.0], [ 3.0,  4.0], [ 5.0,  6.0], [ 7.0,  8.0], [ 9.0, 10.0]],


### PR DESCRIPTION
Added a refactor to normalize convolution values. This is designed to decompose and simplify
convolutions for use with IREE's compiler passes. The different dimension orders are not
usually constructed via the TF compilation pass but are technically legal.