### PR TITLE
Revert "Remove explicitly setting IREE_LLVMAOT_LINKER_PATH in build scripts"

### DIFF
--- a/build_tools/docker/base/Dockerfile
+++ b/build_tools/docker/base/Dockerfile
@@ -17,6 +17,7 @@ FROM ubuntu@sha256:fd25e706f3dea2a5ff705dbc3353cf37f08307798f3e360a13e9385840f73
 # Environment variables for IREE.
 ENV CC /usr/bin/clang
 ENV CXX /usr/bin/clang++
+ENV IREE_LLVMAOT_LINKER_PATH /usr/bin/ld
 
 RUN apt-get update \
   && apt-get install -y \

--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -50,6 +50,8 @@ if [[ -z "${model}" ]]; then
   exit 1
 fi
 
+export IREE_LLVMAOT_LINKER_PATH="${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++ -static-libstdc++ -O3"
+
 IFS=',' read -ra targets_array <<< "$targets"
 for target in "${targets_array[@]}"
 do
@@ -58,7 +60,7 @@ do
   extra_flags=()
   case "${target}" in
     "dylib-llvm-aot")
-      extra_flags+=('--iree-llvm-target-triple=aarch64-none-linux-android30')
+      extra_flags+=('--iree-llvm-target-triple=aarch64-linux-android')
       ;;
     *)
       ;;


### PR DESCRIPTION
This didn't actually update the docker images and makes our docker files out of sync with the images being used. The base image is used
by basically all of our production images, so it has far-reaching
effects (not just Android).

Reverts google/iree#4110