### PR TITLE
Use recommended python3.6 APIs and document 3.7 upgrades

### DIFF
--- a/bindings/python/build_tools/python/generate_build.py
+++ b/bindings/python/build_tools/python/generate_build.py
@@ -42,8 +42,8 @@ if os.name == "nt":
                                                       minor=sys.version_info[1])
   implib_abs_path = os.path.join(exec_prefix, "libs", implib_basename)
   if not os.path.exists(implib_abs_path):
-    raise RuntimeError("Could not find Windows python import library: %s" %
-                       (implib_abs_path,))
+    raise RuntimeError(
+        f"Could not find Windows python import library: {implib_abs_path}")
   implib_ws_path = "libs/" + implib_basename
   print("# SYMLINK: {abs}\t{ws}".format(abs=implib_abs_path, ws=implib_ws_path))
   extra_srcs.append(implib_ws_path)

--- a/bindings/python/pyiree/compiler2/core.py
+++ b/bindings/python/pyiree/compiler2/core.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 from enum import Enum
 import subprocess
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -57,7 +59,7 @@ class OutputFormat(Enum):
                        f"{', '.join(OutputFormat.__members__.keys())}")
     return OutputFormat[spec]
 
-
+# TODO(#4131) python>=3.7: Consider using a dataclass.
 class CompilerOptions:
   """Options to the compiler backend.
 

--- a/bindings/python/pyiree/compiler2/core.py
+++ b/bindings/python/pyiree/compiler2/core.py
@@ -59,6 +59,7 @@ class OutputFormat(Enum):
                        f"{', '.join(OutputFormat.__members__.keys())}")
     return OutputFormat[spec]
 
+
 # TODO(#4131) python>=3.7: Consider using a dataclass.
 class CompilerOptions:
   """Options to the compiler backend.

--- a/bindings/python/pyiree/compiler2/tf.py
+++ b/bindings/python/pyiree/compiler2/tf.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 from enum import Enum
 import logging
 import tempfile
@@ -76,6 +78,7 @@ class ImportType(Enum):
     return ImportType[spec]
 
 
+# TODO(#4131) python>=3.7: Consider using a dataclass.
 class ImportOptions(CompilerOptions):
   """Import options layer on top of the backend compiler options."""
 

--- a/bindings/python/pyiree/compiler2/tools.py
+++ b/bindings/python/pyiree/compiler2/tools.py
@@ -149,7 +149,7 @@ def invoke_immediate(command_line: List[str],
       run_args["input"] = immediate_input
 
     # Capture output.
-    # Upgrade note: Python >= 3.7 can just use capture_output=True
+    # TODO(#4131) python>=3.7: Use capture_output=True.
     run_args["stdout"] = subprocess.PIPE
     run_args["stderr"] = subprocess.PIPE
     process = subprocess.run(command_line, **run_args)

--- a/bindings/python/pyiree/rt/system_api.py
+++ b/bindings/python/pyiree/rt/system_api.py
@@ -58,7 +58,7 @@ def _create_default_iree_driver(
   driver_exceptions = {}
   for driver_name in driver_names:
     if driver_name not in available_driver_names:
-      print("Could not create driver %s (not registered)" % driver_name,
+      print(f"Could not create driver {driver_name} (not registered)",
             file=sys.stderr)
       continue
     try:
@@ -66,7 +66,7 @@ def _create_default_iree_driver(
       # TODO(laurenzo): Remove these prints to stderr (for now, more information
       # is better and there is no better way to report it yet).
     except Exception as ex:  # pylint: disable=broad-except
-      print("Could not create default driver %s: %r" % (driver_name, ex),
+      print(f"Could not create default driver {driver_name}: {ex:!r}",
             file=sys.stderr)
       driver_exceptions[driver_name] = ex
       continue
@@ -78,18 +78,18 @@ def _create_default_iree_driver(
     try:
       device = driver.create_default_device()
     except Exception as ex:
-      print("Could not create default driver device %s: %r" % (driver_name, ex),
+      print(f"Could not create default driver device {driver_name}: {ex:!r}",
             file=sys.stderr)
       driver_exceptions[driver_name] = ex
       continue
 
-    print("Created IREE driver %s: %r" % (driver_name, driver), file=sys.stderr)
+    print("Created IREE driver {driver_name}: {driver:!r}", file=sys.stderr)
     return driver
 
   # All failed.
-  raise RuntimeError("Could not create any requested driver "
-                     "%r (available=%r) : %r" %
-                     (driver_names, available_driver_names, driver_exceptions))
+  raise RuntimeError(
+      f"Could not create any requested driver {driver_names:!r} (available="
+      f"{available_driver_names:!r}) : {driver_exceptions:!r}")
 
 
 class Config:
@@ -147,10 +147,7 @@ class BoundFunction:
     return unpacked_results
 
   def __repr__(self):
-    return "<BoundFunction %r (%r)>" % (
-        self._abi,
-        self._vm_function,
-    )
+    return f"<BoundFunction {self._abi:!r} ({self._vm_function:!r})>"
 
   def get_serialized_values(self):
     if self._serialized_inputs is None:
@@ -187,14 +184,13 @@ class BoundModule:
 
     vm_function = self._vm_module.lookup_function(name)
     if vm_function is None:
-      raise KeyError("Function '%s' not found in module '%s'" %
-                     (name, self.name))
+      raise KeyError(f"Function '{name}' not found in module '{self.name}'")
     bound_function = BoundFunction(self._context, vm_function)
     self._lazy_functions[name] = bound_function
     return bound_function
 
   def __repr__(self):
-    return "<BoundModule %r>" % (self._vm_module,)
+    return f"<BoundModule {self._vm_module:!r}>"
 
 
 class Modules(dict):
@@ -212,7 +208,8 @@ class SystemContext:
 
   def __init__(self, modules=None, config: Optional[Config] = None):
     self._config = config if config is not None else _get_global_config()
-    print("SystemContext driver=%r" % self._config.driver, file=sys.stderr)
+    # :!r does not work with the _binding.HalDriver class.
+    print(f"SystemContext driver={repr(self._config.driver)}", file=sys.stderr)
     self._is_dynamic = modules is None
     if not self._is_dynamic:
       init_modules = self._config.default_modules + tuple(modules)
@@ -258,7 +255,7 @@ class SystemContext:
     for m in modules:
       name = m.name
       if name in self._modules:
-        raise ValueError("Attempt to register duplicate module: '%s'" % (name,))
+        raise ValueError(f"Attempt to register duplicate module: '{name}'")
       self._modules[m.name] = BoundModule(self, m)
     self._vm_context.register_modules(modules)
 

--- a/bindings/python/pyiree/rt/system_api.py
+++ b/bindings/python/pyiree/rt/system_api.py
@@ -23,6 +23,8 @@ and functions.
 # pylint: disable=unused-argument
 # pylint: disable=g-explicit-length-test
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 __all__ = ["load_module", "load_modules", "Config", "SystemContext"]
 
 import os

--- a/bindings/python/pyiree/rt/system_api.py
+++ b/bindings/python/pyiree/rt/system_api.py
@@ -90,8 +90,8 @@ def _create_default_iree_driver(
 
   # All failed.
   raise RuntimeError(
-      f"Could not create any requested driver {driver_names:!r} (available="
-      f"{available_driver_names:!r}) : {driver_exceptions:!r}")
+      f"Could not create any requested driver {repr(driver_names)} (available="
+      f"{repr(available_driver_names)}) : {repr(driver_exceptions)}")
 
 
 class Config:
@@ -149,7 +149,7 @@ class BoundFunction:
     return unpacked_results
 
   def __repr__(self):
-    return f"<BoundFunction {self._abi:!r} ({self._vm_function:!r})>"
+    return f"<BoundFunction {repr(self._abi)} ({repr(self._vm_function)})>"
 
   def get_serialized_values(self):
     if self._serialized_inputs is None:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -30,7 +30,7 @@ def run_sub_setup(name):
   sub_path = os.path.join(this_dir, f"{name}.py")
   args = [sys.executable, sub_path] + sys.argv[1:]
   print(f"##### Running sub setup: {' '.join(args)}")
-  subprocess.check_call(args)
+  subprocess.run(args, check=True)
   print("")
 
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -137,4 +137,4 @@ def convert_external_target(target):
     # All Bazel targets map to a single CMake target.
     return ["ruy"]
 
-  raise KeyError("No conversion found for target '%s'" % target)
+  raise KeyError(f"No conversion found for target '{target}'")

--- a/build_tools/docker/utils.py
+++ b/build_tools/docker/utils.py
@@ -40,9 +40,9 @@ def run_command(command: Sequence[str],
 
   # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
   completed_process = subprocess.run(command,
-                                      universal_newlines=text,
-                                      check=check,
-                                      **run_kwargs)
+                                     universal_newlines=text,
+                                     check=check,
+                                     **run_kwargs)
   return completed_process
 
 

--- a/build_tools/docker/utils.py
+++ b/build_tools/docker/utils.py
@@ -25,23 +25,25 @@ def run_command(command: Sequence[str],
                 dry_run: bool = False,
                 check: bool = True,
                 capture_output: bool = False,
-                universal_newlines: bool = True,
+                text: bool = True,
                 **run_kwargs) -> subprocess.CompletedProcess:
   """Thin wrapper around subprocess.run"""
   print(f"Running: `{' '.join(command)}`")
-  if not dry_run:
-    if capture_output:
-      # Hardcode support for python <= 3.6.
-      run_kwargs["stdout"] = subprocess.PIPE
-      run_kwargs["stderr"] = subprocess.PIPE
+  if dry_run:
+    # Dummy CompletedProess with successful returncode.
+    return subprocess.CompletedProcess(command, returncode=0)
 
-    completed_process = subprocess.run(command,
-                                       universal_newlines=universal_newlines,
-                                       check=check,
-                                       **run_kwargs)
-    return completed_process
-  # Dummy CompletedProess with successful returncode.
-  return subprocess.CompletedProcess(command, returncode=0)
+  if capture_output:
+    # TODO(#4131) python>=3.7: Use capture_output=True.
+    run_kwargs["stdout"] = subprocess.PIPE
+    run_kwargs["stderr"] = subprocess.PIPE
+
+  # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+  completed_process = subprocess.run(command,
+                                      universal_newlines=text,
+                                      check=check,
+                                      **run_kwargs)
+  return completed_process
 
 
 def check_gcloud_auth(dry_run: bool = False):

--- a/build_tools/manylinux_py_setup.py
+++ b/build_tools/manylinux_py_setup.py
@@ -47,7 +47,7 @@ def install_deps():
         "numpy",
     ]
     print("EXEC:", " ".join(args))
-    subprocess.check_call(args)
+    subprocess.run(args, check=True)
 
 
 def dump_current(identifier):
@@ -65,8 +65,8 @@ def dump_all():
     identifier = python_exe.parent.parent.name
     versions_ids.append(identifier)
     # Invoke ourselves with a different interpreter/args to dump config.
-    subprocess.check_call(
-        [str(python_exe), __file__, "_current_args", identifier])
+    subprocess.run([str(python_exe), __file__, "_current_args", identifier],
+                   check=True)
   print("-DIREE_MULTIPY_VERSIONS='{}'".format(";".join(versions_ids)))
 
 

--- a/colab/start_colab_kernel.py
+++ b/colab/start_colab_kernel.py
@@ -65,10 +65,16 @@ def setup_environment():
   # Detect python and query bazel for its output.
   print(f"Setting Bazel PYTHON_BIN={sys.executable}")
   bazel_env["PYTHON_BIN"] = sys.executable
-  bazel_bin = subprocess.check_output([bazel_exe, "info", "bazel-bin"],
-                                      cwd=repo_root,
-                                      env=bazel_env).decode("utf-8")
-  bazel_bin = bazel_bin.splitlines()[0]
+  completed_process = subprocess.run(
+      [bazel_exe, "info", "bazel-bin"],
+      cwd=repo_root,
+      env=bazel_env,
+      check=True,
+      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+      universal_newlines=True,
+      # TODO(#4131) python>=3.7: Use capture_output=True.
+      stdout=subprocess.PIPE)
+  bazel_bin = completed_process.stdout.splitlines()[0]
   # Bazel always reports the path with '/'. On windows, switch it
   # since we need native path manipulation code below to have it the
   # right way.
@@ -80,9 +86,10 @@ def setup_environment():
 def build():
   """Builds the python bundle."""
   print("Building python bindings...")
-  subprocess.check_call([bazel_exe, "build", "//colab:everything_for_colab"],
-                        cwd=repo_root,
-                        env=bazel_env)
+  subprocess.run([bazel_exe, "build", "//colab:everything_for_colab"],
+                 cwd=repo_root,
+                 env=bazel_env,
+                 check=True)
 
 
 def run():

--- a/colab/start_colab_kernel.py
+++ b/colab/start_colab_kernel.py
@@ -53,17 +53,17 @@ def setup_environment():
 
   # Determine the repository root (one dir-level up).
   repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-  print("Repository root: %s" % (repo_root,))
+  print(f"Repository root: {repo_root}")
 
   # Use 'bazelisk' instead of 'bazel' if it exists on the path.
   # Bazelisk is an optional utility that pick versions of Bazel to use and
   # passes through all command-line arguments to the real Bazel binary:
   # https://github.com/bazelbuild/bazelisk
   bazel_exe = "bazelisk" if shutil.which("bazelisk") else "bazel"
-  print("Using bazel executable: %s" % (bazel_exe))
+  print(f"Using bazel executable: {bazel_exe}")
 
   # Detect python and query bazel for its output.
-  print("Setting Bazel PYTHON_BIN=%s" % (sys.executable,))
+  print(f"Setting Bazel PYTHON_BIN={sys.executable}")
   bazel_env["PYTHON_BIN"] = sys.executable
   bazel_bin = subprocess.check_output([bazel_exe, "info", "bazel-bin"],
                                       cwd=repo_root,
@@ -74,7 +74,7 @@ def setup_environment():
   # right way.
   if os.path.sep == "\\":
     bazel_bin = bazel_bin.replace("/", "\\")
-  print("Found Bazel bin: %s" % (bazel_bin))
+  print(f"Found Bazel bin: {bazel_bin}")
 
 
 def build():
@@ -139,9 +139,9 @@ def launch_jupyter(python_path):
 def show_install_instructions():
   """Prints some install instructions."""
   print("ERROR: Unable to load Jupyter. Ensure that it is installed:")
-  print("  %s -m pip install --upgrade pip" % (sys.executable,))
-  print("  %s -m pip install jupyter" % (sys.executable,))
-  print("  %s -m pip install jupyter_http_over_ws" % (sys.executable,))
+  print(f"  {sys.executable} -m pip install --upgrade pip")
+  print(f"  {sys.executable} -m pip install jupyter")
+  print(f"  {sys.executable} -m pip install jupyter_http_over_ws")
   print("  jupyter serverextension enable --py jupyter_http_over_ws")
 
 

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -47,14 +47,14 @@ def write_python_path(bazelrc):
   # is typically where "pip install --user" libraries end up. Inject it.
   try:
     user_site = subprocess.run(
-      [sys.executable, "-m", "site", "--user-site"],
-      check=True,
-      # TODO(#4131) python>=3.7: Use capture_output=True.
-      stderr=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
-      universal_newlines=True,
-    ).strip()
+        [sys.executable, "-m", "site", "--user-site"],
+        check=True,
+        # TODO(#4131) python>=3.7: Use capture_output=True.
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+        universal_newlines=True,
+    ).stdout.strip()
     print("Found user site directory:", user_site)
   except subprocess.CalledProcessError:
     print("Could not resolve user site directory")

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -46,8 +46,15 @@ def write_python_path(bazelrc):
   # For some reason, bazel doesn't always find the user site path, which
   # is typically where "pip install --user" libraries end up. Inject it.
   try:
-    user_site = subprocess.check_output(
-        [sys.executable, "-m", "site", "--user-site"]).decode("utf-8").strip()
+    user_site = subprocess.run(
+      [sys.executable, "-m", "site", "--user-site"],
+      check=True,
+      # TODO(#4131) python>=3.7: Use capture_output=True.
+      stderr=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+      universal_newlines=True,
+    ).strip()
     print("Found user site directory:", user_site)
   except subprocess.CalledProcessError:
     print("Could not resolve user site directory")

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/module_utils.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Utilities for compiling 'tf.Module's"""
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 import collections
 import os
 import tempfile

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/tf_test_utils.py
@@ -22,6 +22,8 @@
 #   ref: reference – for the reference CompiledModule
 #   tar: target - for one of the target CompiledModules
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 import collections
 import copy
 import itertools
@@ -111,7 +113,7 @@ def get_target_backends() -> Sequence[module_utils.BackendInfo]:
     backends = module_utils.BackendInfo.get_all_backends()
   return backends
 
-
+# TODO(#4131) python>=3.7: Consider using a (frozen) dataclass.
 Modules = collections.namedtuple("Modules",
                                  ["ref_module", "tar_modules", "artifacts_dir"])
 

--- a/integrations/tensorflow/bindings/python/pyiree/tf/support/trace_utils.py
+++ b/integrations/tensorflow/bindings/python/pyiree/tf/support/trace_utils.py
@@ -18,6 +18,8 @@
 #   ref: reference – for the reference CompiledModule
 #   tar: target - for one of the target CompiledModules
 
+# TODO(#4131) python>=3.7: Use postponed type annotations.
+
 import copy
 import glob
 import inspect

--- a/scripts/get_e2e_artifacts.py
+++ b/scripts/get_e2e_artifacts.py
@@ -163,7 +163,7 @@ def main(argv):
     command = ['bazel', 'test', *test_suites, '--color=yes']
     print(f'Running: `{" ".join(command)}`')
     if not FLAGS.dry_run:
-      subprocess.check_call(command)
+      subprocess.run(command, check=True)
     print()
 
   written_paths = set()

--- a/scripts/git/submodule_versions.py
+++ b/scripts/git/submodule_versions.py
@@ -105,7 +105,7 @@ def import_versions(repo_dir):
              "still in the version file") % (path,))
       continue
     if written is None:
-      print("Warning: Submodule %s is not in the version file" % (current,))
+      print(f"Warning: Submodule '{current}' is not in the version file")
       continue
     # Directly update the submodule commit hash in the index.
     # See: https://stackoverflow.com/questions/33514642
@@ -138,7 +138,7 @@ def check_submodule_versions(repo_dir):
         "  ./scripts/git/submodule_versions.py export # Use version in git state ('actual')"
     )
     for k, (current, written) in diff_versions.items():
-      print("%s : actual=%s written=%s" % (k, current, written))
+      print(f"{k} : actual={current} written={written}")
     return False
   return True
 

--- a/scripts/git/submodule_versions.py
+++ b/scripts/git/submodule_versions.py
@@ -46,7 +46,7 @@ def get_submodule_versions(repo_dir):
   raw_status = utils.execute(["git", "submodule", "status"],
                              cwd=repo_dir,
                              silent=True,
-                             capture_output=True).decode("UTF-8")
+                             capture_output=True).stdout
   status_lines = []
   for line in raw_status.splitlines():
     # Format is a status char followed by revision, space and path.

--- a/scripts/git/update_to_llvm_syncpoint.py
+++ b/scripts/git/update_to_llvm_syncpoint.py
@@ -149,11 +149,13 @@ def main(args):
 
 
 def get_commit(path, rev="HEAD"):
-  return utils.execute(["git", "rev-parse", rev],
-                       cwd=path,
-                       silent=True,
-                       capture_output=True,
-                       universal_newlines=True).strip()
+
+  return utils.execute(
+      ["git", "rev-parse", rev],
+      cwd=path,
+      silent=True,
+      capture_output=True,
+  ).stdout.strip()
 
 
 def find_new_llvm_bazel_commit(llvm_bazel_path, llvm_commit, llvm_bazel_commit):
@@ -192,8 +194,7 @@ def find_llvm_bazel_llvm_commit(llvm_bazel_path):
   return utils.execute(
       ["git", "submodule", "status", "third_party/llvm-project"],
       capture_output=True,
-      universal_newlines=True,
-      cwd=llvm_bazel_path).split()[0].lstrip("+-")
+      cwd=llvm_bazel_path).stdout.split()[0].lstrip("+-")
 
 
 def find_new_tf_commit(tensorflow_path, llvm_commit, tf_commit):
@@ -233,8 +234,7 @@ def find_new_tf_commit(tensorflow_path, llvm_commit, tf_commit):
           "tensorflow/workspace.bzl"
       ],
       capture_output=True,
-      universal_newlines=True,
-      cwd=tensorflow_path).split()
+      cwd=tensorflow_path).stdout.split()
   if len(tf_integrate_commits) > 2:
     raise RuntimeError(
         f"Expected one or two TF commits to involve LLVM commit {llvm_commit},"

--- a/scripts/git/update_to_llvm_syncpoint.py
+++ b/scripts/git/update_to_llvm_syncpoint.py
@@ -149,13 +149,10 @@ def main(args):
 
 
 def get_commit(path, rev="HEAD"):
-
-  return utils.execute(
-      ["git", "rev-parse", rev],
-      cwd=path,
-      silent=True,
-      capture_output=True,
-  ).stdout.strip()
+  return utils.execute(["git", "rev-parse", rev],
+                       cwd=path,
+                       silent=True,
+                       capture_output=True).stdout.strip()
 
 
 def find_new_llvm_bazel_commit(llvm_bazel_path, llvm_commit, llvm_bazel_commit):

--- a/scripts/git/utils.py
+++ b/scripts/git/utils.py
@@ -56,7 +56,7 @@ def execute(args, cwd, capture_output=False, silent=False, **kwargs):
     The output if capture_output, otherwise None.
   """
   if not silent:
-    print("+", " ".join(args), "  [from %s]" % cwd)
+    print(f"+{' '.join(args)}  [from {cwd}]")
   if capture_output:
     return subprocess.check_output(args, cwd=cwd, **kwargs)
   else:

--- a/scripts/update_e2e_coverage.py
+++ b/scripts/update_e2e_coverage.py
@@ -30,6 +30,7 @@ TENSORFLOW_COVERAGE_DIR = 'tensorflow_coverage'
 REFERENCE_BACKEND = 'tf'
 # Assumes that tests are expanded for the tf, iree_vmla, and
 # iree_vulkan backends.
+# TODO(#4131) python>=3.7: Remove redundant OrderedDict
 BACKENDS_TO_TITLES = collections.OrderedDict([
     ('tf', 'tensorflow'),
     ('tflite', 'tflite'),

--- a/scripts/update_op_coverage.py
+++ b/scripts/update_op_coverage.py
@@ -79,9 +79,15 @@ def get_backend_op_pair(test):
 def get_tested_ops_for_backends(build_dir):
   """Parses current op tests for each backend."""
 
-  ctest_output = subprocess.check_output(
-      ['ctest', '-N', '-L', E2E_XLA_OPS_PATH], cwd=build_dir)
-  tests = ctest_output.decode('ascii').strip().split('\n')
+  completed_process = subprocess.run(
+      ['ctest', '-N', '-L', E2E_XLA_OPS_PATH],
+      cwd=build_dir,
+      # TODO(#4131) python>=3.7: Use capture_output=True.
+      stderr=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+      universal_newlines=True)
+  tests = completed_process.stdout.strip().split('\n')
   res = collections.defaultdict(list)
   for t in tests:
     if not t.endswith('.mlir'):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -39,8 +39,7 @@ def check_and_get_output_lines(command: Sequence[str],
       stderr=subprocess.PIPE,
       stdout=subprocess.PIPE,
       # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
-      universal_newlines=True,
-  )
+      universal_newlines=True)
 
   if log_stderr:
     for line in process.stderr.splitlines():

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -33,10 +33,14 @@ def check_and_get_output_lines(command: Sequence[str],
   print(f'Running: `{" ".join(command)}`')
   if dry_run:
     return None, None
-  process = subprocess.run(command,
-                           stderr=subprocess.PIPE,
-                           stdout=subprocess.PIPE,
-                           universal_newlines=True)
+  process = subprocess.run(
+      command,
+      # TODO(#4131) python>=3.7: Use capture_output=True.
+      stderr=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      # TODO(#4131) python>=3.7: Replace 'universal_newlines' with 'text'.
+      universal_newlines=True,
+  )
 
   if log_stderr:
     for line in process.stderr.splitlines():


### PR DESCRIPTION
Note: It's probably easiest to review each commit separately.

Changes:

- Remove remaining %-string substitutions (`absl.logging` excluded).
- Replace all `subprocess.check_*` calls with the recommended `subprocess.run(check=True,...)`.
- Add TODO(#4131) for the following:
  - `python>=3.7: Use postponed type annotations.`
  - `python>=3.7: Consider using a dataclass.`
  - `python>=3.7: Use capture_output=True.`
  - `python>=3.7: Replace 'universal_newlines' with 'text'.`
  - `python>=3.7: Remove redundant OrderedDict.`