### PR TITLE
Check in BuildKite pipeline for android tests

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -1,0 +1,123 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - label: "build"
+    commands:
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/cmake-android@sha256:15d3266ae4865f7642a4ef4d76e5181f0dc3482a7cfba9021b6b55be524208ec build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh arm64-v8a"
+      - "tar --exclude='build/host' --exclude='*.o' --exclude='*.a' -czvf build-artifacts.tgz build"
+    agents:
+      - "build=true"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    artifact_paths: "build-artifacts.tgz"
+
+  - wait
+
+  - label: "test on exynos-990 (mali-g77)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=exynos-990"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+    skip: true
+
+  - label: "test on exynos-9820 (mali-g76)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=exynos-9820"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+
+  - label: "test on snapdragon-835 (adreno-540)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=snapdragon-835"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+    soft_fail:
+      - exit_status: "*"
+    skip: true
+
+  - label: "test on snapdragon-855 (adreno-640)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=snapdragon-855"
+      - "android-version=10"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+
+  - label: "test on snapdragon-855 (adreno-640) (Android 11)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=snapdragon-855"
+      - "android-version=11"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    branches: "main"
+    timeout_in_minutes: "20"
+    soft_fail: true
+    skip: true
+
+  - label: "test on snapdragon-865 (adreno-650)"
+    commands:
+      - "buildkite-agent artifact download --step build build-artifacts.tgz ./"
+      - "tar xzf build-artifacts.tgz"
+      - "find build/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
+      - "cd build/"
+      - "ctest --output-on-failure"
+    agents:
+      - "test-android=true"
+      - "android-soc=snapdragon-865"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    timeout_in_minutes: "15"
+
+notify:
+  - email: "bdi-build-cop+buildkite@grotations.appspotmail.com"
+    if: build.state == "failed"


### PR DESCRIPTION
This is a direct copy of the pipeline at
https://buildkite.com/iree/iree-android-arm64-v8a/steps with the 
modification being the addition of a license header. I'd like to make
further edits (like some line wrapping), but will hold off on that
until this is actually getting tested. After this is checked in, I'll
change the pipeline configured in the BuildKite UI to just load the
pipeline from this file per the instructions at
https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipelines.

Note that this workflow only runs post-submit (or when manually
triggered by a project member), so this level of dynamic execution is
safe. If we start running BuildKite pipelines on presubmit we should
investigate some checks to ensure they've been reasonably vetted.