### PR TITLE
Remove all !r from python f-strings

### DIFF
--- a/bindings/python/pyiree/rt/system_api.py
+++ b/bindings/python/pyiree/rt/system_api.py
@@ -68,7 +68,7 @@ def _create_default_iree_driver(
       # TODO(laurenzo): Remove these prints to stderr (for now, more information
       # is better and there is no better way to report it yet).
     except Exception as ex:  # pylint: disable=broad-except
-      print(f"Could not create default driver {driver_name}: {ex:!r}",
+      print(f"Could not create default driver {driver_name}: {repr(ex)}",
             file=sys.stderr)
       driver_exceptions[driver_name] = ex
       continue
@@ -80,12 +80,12 @@ def _create_default_iree_driver(
     try:
       device = driver.create_default_device()
     except Exception as ex:
-      print(f"Could not create default driver device {driver_name}: {ex:!r}",
+      print(f"Could not create default driver device {driver_name}: {repr(ex)}",
             file=sys.stderr)
       driver_exceptions[driver_name] = ex
       continue
 
-    print("Created IREE driver {driver_name}: {driver:!r}", file=sys.stderr)
+    print(f"Created IREE driver {driver_name}: {repr(driver)}", file=sys.stderr)
     return driver
 
   # All failed.
@@ -192,7 +192,7 @@ class BoundModule:
     return bound_function
 
   def __repr__(self):
-    return f"<BoundModule {self._vm_module:!r}>"
+    return f"<BoundModule {repr(self._vm_module)}>"
 
 
 class Modules(dict):
@@ -210,7 +210,6 @@ class SystemContext:
 
   def __init__(self, modules=None, config: Optional[Config] = None):
     self._config = config if config is not None else _get_global_config()
-    # :!r does not work with the _binding.HalDriver class.
     print(f"SystemContext driver={repr(self._config.driver)}", file=sys.stderr)
     self._is_dynamic = modules is None
     if not self._is_dynamic:


### PR DESCRIPTION
`f"{variable:!r}"` is not equivalent to `f"{repr(variable)}"` in general. 

PEP 498 says that `!r` and others are supported for compatibility with `str.format()`, but doesn't mention that it inherits `str.format`'s limitations (or that there are any). For example:

```python
array = [0, 1, 2]
print(f"{repr(array)}")  # [0, 1, 2]
print(f"{array:!r}")  # TypeError: unsupported format string passed to list.__format__
```

Given this it seems like `!r` should probably be avoided.