### PR TITLE
Pass pointer of iree_vm_func_t to IREE_DISPATCH_LOG_CALL.

### DIFF
--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -109,7 +109,7 @@ static iree_status_t iree_vm_bytecode_function_enter(
     iree_vm_stack_t* stack, const iree_vm_function_t function,
     iree_vm_stack_frame_t** out_callee_frame,
     iree_vm_registers_t* out_callee_registers) {
-  IREE_DISPATCH_LOG_CALL(function);
+  IREE_DISPATCH_LOG_CALL(&function);
 
   iree_vm_bytecode_module_t* module =
       (iree_vm_bytecode_module_t*)function.module->self;


### PR DESCRIPTION
This was not caught by CI because it needs to build with
`#define IREE_DISPATCH_LOGGING 1`, which logs more information for
dispatches. The macro takes `const iree_vm_function_t *` type as
argument, so we have to pass by pointer.