### PR TITLE
[NFC] Eliminate use of SymbolTable::getSymbolVisibility()

### DIFF
--- a/iree/compiler/Conversion/CodegenUtils/FunctionUtils.cpp
+++ b/iree/compiler/Conversion/CodegenUtils/FunctionUtils.cpp
@@ -20,10 +20,7 @@
 namespace mlir {
 namespace iree_compiler {
 
-bool isEntryPoint(FuncOp func) {
-  return SymbolTable::getSymbolVisibility(func) ==
-         SymbolTable::Visibility::Public;
-}
+bool isEntryPoint(FuncOp func) { return func.isPublic(); }
 
 unsigned getNumOuterParallelLoops(linalg::LinalgOp op) {
   return op.iterator_types()

--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
@@ -184,9 +184,8 @@ class ConvertFuncWithHALInterface : public ConvertToLLVMPattern {
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    if (SymbolTable::getSymbolVisibility(op) != SymbolTable::Visibility::Public)
-      return failure();
-    auto funcOp = dyn_cast_or_null<FuncOp>(op);
+    auto funcOp = dyn_cast<FuncOp>(op);
+    if (!funcOp.isPublic()) return failure();
     FunctionType fnType = funcOp.getType();
     if (fnType.getNumInputs() != 0) {
       return rewriter.notifyMatchFailure(

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
@@ -496,8 +496,7 @@ void ConvertToSPIRVPass::runOnOperation() {
   target->markUnknownOpDynamicallyLegal([](Operation *) { return false; });
   SmallVector<FuncOp, 1> functions;
   for (FuncOp fn : moduleOp.getOps<FuncOp>()) {
-    if (SymbolTable::getSymbolVisibility(fn) != SymbolTable::Visibility::Public)
-      continue;
+    if (!fn.isPublic()) continue;
     functions.push_back(fn);
   }
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/IR/LLVMIRTarget.cpp
@@ -46,8 +46,7 @@ class LLVMIRTargetBackend final : public LLVMBaseTargetBackend {
     // Remove all private functions, e.g tile size calcuations.
     SmallVector<FuncOp, 4> nonPublicFn;
     for (auto func : targetOp.getInnerModule().getOps<FuncOp>()) {
-      if (SymbolTable::getSymbolVisibility(func) !=
-          SymbolTable::Visibility::Public) {
+      if (!func.isPublic()) {
         nonPublicFn.push_back(func);
       }
     }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMBaseTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMBaseTarget.cpp
@@ -220,8 +220,7 @@ LogicalResult LLVMBaseTargetBackend::recordDispatch(
 
   SmallVector<LLVM::LLVMFuncOp, 2> entryPointFns;
   for (LLVM::LLVMFuncOp funcOp : llvmIRModuleOp.getOps<LLVM::LLVMFuncOp>()) {
-    if (SymbolTable::getSymbolVisibility(funcOp) ==
-        SymbolTable::Visibility::Public) {
+    if (funcOp.isPublic()) {
       entryPointFns.push_back(funcOp);
     }
   }

--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -94,9 +94,7 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
   SmallVector<spirv::FuncOp, 2> spvEntryPointFns;
   if (!entryPointScheduleAttr) {
     for (spirv::FuncOp spvFuncOp : spvModuleOp.getOps<spirv::FuncOp>()) {
-      if (SymbolTable::getSymbolVisibility(spvFuncOp) ==
-          SymbolTable::Visibility::Public)
-        spvEntryPointFns.push_back(spvFuncOp);
+      if (spvFuncOp.isPublic()) spvEntryPointFns.push_back(spvFuncOp);
     }
     if (!llvm::hasSingleElement(spvEntryPointFns)) {
       return spvModuleOp.emitError(
@@ -106,9 +104,7 @@ LogicalResult SPIRVTargetBackend::recordDispatch(
   } else {
     llvm::StringMap<spirv::FuncOp> publicFns;
     for (spirv::FuncOp spvFuncOp : spvModuleOp.getOps<spirv::FuncOp>()) {
-      if (SymbolTable::getSymbolVisibility(spvFuncOp) ==
-          SymbolTable::Visibility::Public)
-        publicFns[spvFuncOp.sym_name()] = spvFuncOp;
+      if (spvFuncOp.isPublic()) publicFns[spvFuncOp.sym_name()] = spvFuncOp;
     }
     for (Attribute entryNameAttr : entryPointScheduleAttr) {
       StringRef entryName = entryNameAttr.cast<StringAttr>().getValue();

--- a/iree/compiler/Dialect/VM/Transforms/MarkPublicSymbolsExported.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/MarkPublicSymbolsExported.cpp
@@ -29,8 +29,7 @@ class MarkPublicSymbolsExportedPass
  public:
   void runOnOperation() override {
     for (auto funcOp : getOperation().getOps<mlir::FuncOp>()) {
-      if (SymbolTable::getSymbolVisibility(funcOp) ==
-          SymbolTable::Visibility::Public) {
+      if (funcOp.isPublic()) {
         funcOp.setAttr("iree.module.export", UnitAttr::get(&getContext()));
       }
     }

--- a/iree/compiler/Dialect/VMLA/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/VMLA/Transforms/Conversion.cpp
@@ -42,8 +42,7 @@ namespace VMLA {
 // The runtime will provide these values during invocation.
 static LogicalResult insertInterfacesToEntryPoints(mlir::ModuleOp moduleOp) {
   for (auto funcOp : moduleOp.getOps<FuncOp>()) {
-    if (SymbolTable::getSymbolVisibility(funcOp) !=
-        SymbolTable::Visibility::Public) {
+    if (!funcOp.isPublic()) {
       continue;
     }
     auto originalType = funcOp.getType();


### PR DESCRIPTION
- This is in preparation of upstream MLIR changes.