### PR TITLE
Add Kokoro config for integrations tests

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and test the python bindings and tensorflow integrations.
+
+set -e
+set -x
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+# Check these exist and print the versions for later debugging
+export CMAKE_BIN="$(which cmake)"
+"${CMAKE_BIN?}" --version
+"${CC?}" --version
+"${CXX?}" --version
+python3 --version
+python3 -c 'import tensorflow as tf; print(tf.__version__)'
+
+./build_tools/kokoro/gcp_ubuntu/check_vulkan.sh
+
+# Print SwiftShader git commit
+cat /swiftshader/git-commit
+
+echo "Initializing submodules"
+./scripts/git/submodule_versions.py init
+
+# TODO(gcmn): It would be nice to be able to build and test as much as possible,
+# so a build failure only prevents building/testing things that depend on it and
+# we can still run the other tests.
+echo "Configuring CMake"
+"${CMAKE_BIN}" -B ../iree-build/ -G Ninja \
+   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+   -DIREE_BUILD_COMPILER=ON \
+   -DIREE_BUILD_TESTS=ON \
+   -DIREE_BUILD_SAMPLES=OFF \
+   -DIREE_BUILD_DEBUGGER=OFF \
+   -DIREE_BUILD_TENSORFLOW_COMPILER=ON .
+
+echo "Building with Ninja"
+cd ../iree-build/
+ninja
+
+echo "Testing with CTest"
+ctest -R 'tensorflow_e2e|bindings/python'

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and test the python bindings and tensorflow integrations within
+# gcr.io/iree-oss/cmake-bazel-tensorflow-swiftshader
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
+
+set -x
+set -e
+set -o pipefail
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docker_common.sh"
+
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/cmake-bazel-tensorflow-swiftshader@sha256:e4516f3ffadf40f2111c3f152453928f5af24951c7b5770ef3477f897709df0d \
+  build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless.
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/common.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/common.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "iree/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/google.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/main.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/presubmit.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and test the python bindings and tensorflow integrations on GPU.
+
+set -e
+set -x
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+# Check these exist and print the versions for later debugging
+export CMAKE_BIN="$(which cmake)"
+"${CMAKE_BIN?}" --version
+"${CC?}" --version
+"${CXX?}" --version
+python3 --version
+python3 -c 'import tensorflow as tf; print(tf.__version__)'
+
+./build_tools/kokoro/gcp_ubuntu/check_vulkan.sh
+
+# Print SwiftShader git commit
+cat /swiftshader/git-commit
+
+echo "Initializing submodules"
+./scripts/git/submodule_versions.py init
+
+# TODO(gcmn): It would be nice to be able to build and test as much as possible,
+# so a build failure only prevents building/testing things that depend on it and
+# we can still run the other tests.
+echo "Configuring CMake"
+"${CMAKE_BIN}" -B ../iree-build/ -G Ninja \
+   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+   -DIREE_BUILD_COMPILER=ON \
+   -DIREE_BUILD_TESTS=ON \
+   -DIREE_BUILD_SAMPLES=OFF \
+   -DIREE_BUILD_DEBUGGER=OFF \
+   -DIREE_BUILD_TENSORFLOW_COMPILER=ON .
+
+echo "Building with Ninja"
+cd ../iree-build/
+ninja
+
+echo "Testing with CTest"
+ctest -R 'tensorflow_e2e|bindings/python'

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and test the python bindings and tensorflow integrations on GPU within
+# gcr.io/iree-oss/cmake-bazel-tensorflow-nvidia
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
+
+set -x
+set -e
+set -o pipefail
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docker_common.sh"
+
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/cmake-bazel-tensorflow-nvidia@sha256:1351b5befd1bc4b89fc6f203754a05accff204579f122ec1123e86ed7e2bd319 \
+  build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless.
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/common.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/common.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "iree/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/google.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/google.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/main.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/presubmit.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/simulate_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/simulate_kokoro.sh
@@ -17,14 +17,14 @@
 # Simulates the behavior of Kokoro on a local machine.
 # Usage:
 #   ./build_tools/kokoro/gcp_ubuntu/simulate_kokoro.sh \
-#     build_tools/kokoro/gcp_ubuntu/bazel/core/build.sh
+#     build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-swiftshader/core/build_kokoro.sh
 #
 # Just does the part of the Kokoro setup that we care about and invokes the
 # given build script.
 # An optional second parameter can be used to specify a different repo to clone
 # from. Especially useful for cloning the current git repo.
 #   ./build_tools/kokoro/gcp_ubuntu/simulate_kokoro.sh \
-#     build_tools/kokoro/gcp_ubuntu/bazel/core/build.sh \
+#     build_tools/kokoro/gcp_ubuntu/bazel/linux/x86-swiftshader/core/build_kokoro.sh \
 #     "${PWD?}/.git"
 
 set -x


### PR DESCRIPTION
Creates CI configs that use the images added in #4176 to test the tensorflow 
integrations on swiftshader and nvidia GPU.