### PR TITLE
Fix mis-copied path in kokoro config

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -35,6 +35,19 @@ python3 -c 'import tensorflow as tf; print(tf.__version__)'
 # Print SwiftShader git commit
 cat /swiftshader/git-commit
 
+# TODO(4195): TensorFlow integrations can only be built out-of-tree (and kokoro
+#             does not support that).
+# Temporarily get around these conflicting restrictions by nesting the git
+# repo under `/src/github/iree/iree`
+echo "Nesting iree.git into /src/github/iree/iree"
+mv iree iree-core  # Temporarily move iree/ so that we move the repo under it.
+shopt -s dotglob nullglob  # Make globs include dotfiles/dirs like `.git`.
+mkdir iree
+mv * ./iree | true  # | true to catch "can't mv ./iree into itself"
+cd iree
+mv iree-core iree # Move iree-core/ back to iree/
+ls -1 -a
+
 echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init
 

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -36,7 +36,7 @@ python3 -c 'import tensorflow as tf; print(tf.__version__)'
 cat /swiftshader/git-commit
 
 # TODO(4195): TensorFlow integrations can only be built out-of-tree (and kokoro
-#             does not support that).
+# does not support that).
 # Temporarily get around these conflicting restrictions by nesting the git
 # repo under `/src/github/iree/iree`
 echo "Nesting iree.git into /src/github/iree/iree"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build_kokoro.sh
@@ -33,7 +33,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   gcr.io/iree-oss/cmake-bazel-tensorflow-swiftshader@sha256:e4516f3ffadf40f2111c3f152453928f5af24951c7b5770ef3477f897709df0d \
-  build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
+  build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -35,6 +35,19 @@ python3 -c 'import tensorflow as tf; print(tf.__version__)'
 # Print SwiftShader git commit
 cat /swiftshader/git-commit
 
+# TODO(4195): TensorFlow integrations can only be built out-of-tree (and kokoro
+#             does not support that).
+# Temporarily get around these conflicting restrictions by nesting the git
+# repo under `/src/github/iree/iree`
+echo "Nesting iree.git into /src/github/iree/iree"
+mv iree iree-core  # Temporarily move iree/ so that we move the repo under it.
+shopt -s dotglob nullglob  # Make globs include dotfiles/dirs like `.git`.
+mkdir iree
+mv * ./iree | true  # | true to catch "can't mv ./iree into itself"
+cd iree
+mv iree-core iree # Move iree-core/ back to iree/
+ls -1 -a
+
 echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init
 

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -36,7 +36,7 @@ python3 -c 'import tensorflow as tf; print(tf.__version__)'
 cat /swiftshader/git-commit
 
 # TODO(4195): TensorFlow integrations can only be built out-of-tree (and kokoro
-#             does not support that).
+# does not support that).
 # Temporarily get around these conflicting restrictions by nesting the git
 # repo under `/src/github/iree/iree`
 echo "Nesting iree.git into /src/github/iree/iree"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
@@ -33,7 +33,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   gcr.io/iree-oss/cmake-bazel-tensorflow-nvidia@sha256:1351b5befd1bc4b89fc6f203754a05accff204579f122ec1123e86ed7e2bd319 \
-  build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+  build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
@@ -33,7 +33,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   gcr.io/iree-oss/cmake-bazel-tensorflow-nvidia@sha256:1351b5befd1bc4b89fc6f203754a05accff204579f122ec1123e86ed7e2bd319 \
-  build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader/build.sh
+  build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the
 # build which takes forever and is totally useless.


### PR DESCRIPTION
Kokoro makes you specify this path at least five times, which does not make it less error prone.

Fixes a mistake in https://github.com/google/iree/pull/4183. Will re-run the manual presubmits to verify that things work as expected.

Edit: Found #4195, which I'm getting around temporarily by moving all of the PR files into an `iree/` sub directory and then using `/src/github/iree/` as the base for an out-of-tree build.