### PR TITLE
Make cmake-bazel output color for the CI

### DIFF
--- a/build_tools/cmake/bazel.bat.in
+++ b/build_tools/cmake/bazel.bat.in
@@ -14,4 +14,4 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 
 cd /d "@_bazel_src_root@"
-@IREE_BAZEL_EXECUTABLE@ @_bazel_startup_options@ %* || exit /b
+@IREE_BAZEL_EXECUTABLE@ @_bazel_startup_options@ %* @_bazel_build_options@ || exit /b

--- a/build_tools/cmake/bazel.sh.in
+++ b/build_tools/cmake/bazel.sh.in
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 cd "@_bazel_src_root@"
-exec '@IREE_BAZEL_EXECUTABLE@' @_bazel_startup_options@ "$@"
+exec '@IREE_BAZEL_EXECUTABLE@' @_bazel_startup_options@ "$@" @_bazel_build_options@

--- a/build_tools/cmake/configure_bazel.cmake
+++ b/build_tools/cmake/configure_bazel.cmake
@@ -60,6 +60,7 @@ import ${_bazel_src_root}/build_tools/bazel/iree.bazelrc
   # would have --nohome_rc). This is mainly about disabling interference from
   # interactive builds in the workspace.
   set(_bazel_startup_options "--nosystem_rc --noworkspace_rc '--bazelrc=${_bazelrc_file}' '--output_base=${_bazel_output_base}'")
+  set(_bazel_build_options "--color=yes")
 
   # And emit scripts to delegate to bazel.
   set(IREE_BAZEL_WRAPPER "${CMAKE_BINARY_DIR}/bazel")


### PR DESCRIPTION
Tested that this builds locally and works as intended [on the CI](https://source.cloud.google.com/results/invocations/5611aaf1-7b17-48bb-b163-18f0417579e9/targets/iree%2Fgcp_ubuntu%2Fcmake-bazel%2Flinux%2Fx86-swiftshader%2Fpresubmit/log). Unable to personally test the behavior on windows.