### PR TITLE
Build iree-tf-opt as part of the cmake build when tests are enabled.

### DIFF
--- a/build_tools/cmake/configure_bazel.cmake
+++ b/build_tools/cmake/configure_bazel.cmake
@@ -134,13 +134,16 @@ endfunction()
 #     the "/" with "_".
 function(iree_add_bazel_invocation)
   cmake_parse_arguments(ARG
-    ""
+    "ALL"
     "INVOCATION_TARGET"
     "BAZEL_TARGETS;EXECUTABLE_PATHS"
     ${ARGN}
   )
-
-  add_custom_target(${ARG_INVOCATION_TARGET}
+  set(_all_option)
+  if(${ARG_ALL})
+    set(_all_option "ALL")
+  endif()
+  add_custom_target(${ARG_INVOCATION_TARGET} ${_all_option}
     USES_TERMINAL
     COMMAND ${CMAKE_COMMAND} -E echo
         "Starting bazel build of targets '${ARG_BAZEL_TARGETS}'"

--- a/integrations/tensorflow/CMakeLists.txt
+++ b/integrations/tensorflow/CMakeLists.txt
@@ -47,6 +47,20 @@ iree_add_bazel_invocation(
   EXECUTABLE_PATHS ${_executable_paths}
 )
 
+if(${IREE_BUILD_TESTS})
+  # Separate bazel invocation for test tools.
+  iree_add_bazel_invocation(
+    ALL
+    INVOCATION_TARGET
+      integrations_iree_tensorflow_test_tools
+    BAZEL_TARGETS
+      //integrations/tensorflow/compiler:iree-tf-opt
+    EXECUTABLE_PATHS
+      integrations/tensorflow/compiler/iree-tf-opt
+  )
+  add_subdirectory(compiler/test)
+endif()
+
 if(${IREE_BUILD_PYTHON_BINDINGS})
   add_subdirectory(bindings/python)
 endif()

--- a/integrations/tensorflow/compiler/BUILD
+++ b/integrations/tensorflow/compiler/BUILD
@@ -72,24 +72,14 @@ cc_binary(
         ":tensorflow",
         "//integrations/tensorflow/compiler/dialect/tf_strings/ir:dialect",
         "//integrations/tensorflow/compiler/dialect/tf_tensorlist/ir:tf_tensorlist_dialect",
-        "//iree/tools:init_passes_and_dialects",
-        "//iree/tools:init_targets",
+        "//iree/tools:init_xla_dialects",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
-    ],
-)
-
-cc_binary(
-    name = "iree-tf-translate",
-    deps = [
-        ":tensorflow",
-        "//iree/tools:iree_translate_main",
     ],
 )
 

--- a/integrations/tensorflow/compiler/iree-tf-opt-main.cpp
+++ b/integrations/tensorflow/compiler/iree-tf-opt-main.cpp
@@ -14,12 +14,12 @@
 
 // Main entry function for iree-tf-opt and derived binaries.
 //
-// Based on iree-opt with the addition of TF dialects and passes
+// This is a bare-bones, minimal *-opt just for testing the handful of local
+// passes here. If you need something, add it, but add only what you need as
+// each addition will likely end up on the build critical path.
 
 #include "integrations/tensorflow/compiler/Passes.h"
-#include "iree/tools/init_dialects.h"
-#include "iree/tools/init_passes.h"
-#include "iree/tools/init_targets.h"
+#include "iree/tools/init_xla_dialects.h"
 #include "llvm/Support/InitLLVM.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Support/MlirOptMain.h"
@@ -29,13 +29,10 @@ int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
   mlir::DialectRegistry registry;
-  mlir::iree_compiler::registerAllDialects(registry);
-  mlir::iree_compiler::registerAllPasses();
-  mlir::iree_compiler::registerHALTargetBackends();
+  mlir::registerXLADialects(registry);
 
   mlir::RegisterAllTensorFlowDialects(registry);
   mlir::iree_integrations::TF::registerAllDialects(registry);
-  mlir::iree_integrations::TF::registerAllPasses();
 
   if (failed(MlirOptMain(argc, argv, "IREE-TF modular optimizer driver\n",
                          registry,

--- a/integrations/tensorflow/compiler/test/CMakeLists.txt
+++ b/integrations/tensorflow/compiler/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "${_GLOB_X_MLIR}"
+  DATA
+    iree::tools::IreeFileCheck
+    integrations_tensorflow_compiler_iree-tf-opt
+)


### PR DESCRIPTION
* Also adds the handful of lit tests in integrations/tensorflow.
* Strips down iree-tf-opt to its minimum requirements (it is on the critical build path).
* Applies more patches to run_lit.sh (really need to get rid of that soon).