### PR TITLE
Support for TF.Gather including intermediate dialect work

### DIFF
--- a/integrations/tensorflow/compiler/Passes.cpp
+++ b/integrations/tensorflow/compiler/Passes.cpp
@@ -72,6 +72,12 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
 
   //----------------------------------------------------------------------------
+  // Lowering module specific TF behavior to intermediate dialects.
+  //----------------------------------------------------------------------------
+  pm.addPass(tf_strings::createConvertTFToTFStringsPass());
+  pm.addPass(tf_tensorlist::createConvertTFToTFTensorListPass());
+
+  //----------------------------------------------------------------------------
   // Legalize to XLA
   //----------------------------------------------------------------------------
   pm.addPass(createConvertToMHLOPass());
@@ -93,11 +99,8 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
 
   //----------------------------------------------------------------------------
-  // Lowering module specific TF behavior to custom dialects.
+  // Lowering intermediate dialects to module specific dialects.
   //----------------------------------------------------------------------------
-  pm.addPass(tf_strings::createConvertTFToTFStringsPass());
-  pm.addPass(tf_tensorlist::createConvertTFToTFTensorListPass());
-  pm.addPass(createCanonicalizerPass());
   pm.addPass(tf_strings::createConvertTFStringsToStringsPass());
   pm.addPass(tf_tensorlist::createConvertTFTensorListToTensorListPass());
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_strings_to_strings.cc
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_strings_to_strings.cc
@@ -80,6 +80,9 @@ void populateTFStringsToStringsPatterns(MLIRContext *context,
   patterns.insert<OpConversion<tf_strings::ToStringTensorOp,
                                iree_compiler::IREE::Strings::ToStringTensorOp>>(
       context);
+  patterns.insert<OpConversion<tf_strings::GatherOp,
+                               iree_compiler::IREE::Strings::GatherOp>>(
+      context);
   patterns.insert<
       OpConversion<tf_strings::StringTensorToStringOp,
                    iree_compiler::IREE::Strings::StringTensorToStringOp>>(

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.cc
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.cc
@@ -92,8 +92,8 @@ struct GatherV2OpLowering : public OpRewritePattern<TF::GatherV2Op> {
   LogicalResult matchAndRewrite(TF::GatherV2Op op,
                                 PatternRewriter &rewriter) const override {
     auto tensor = op.params();
-    auto tensor_ty = tensor.getType().dyn_cast<RankedTensorType>();
-    if (!tensor_ty || !tensor_ty.getElementType().isa<TF::StringType>()) {
+    auto tensorTy = tensor.getType().dyn_cast<RankedTensorType>();
+    if (!tensorTy || !tensorTy.getElementType().isa<TF::StringType>()) {
       return failure();
     }
 
@@ -106,17 +106,17 @@ struct GatherV2OpLowering : public OpRewritePattern<TF::GatherV2Op> {
       return failure();
     }
 
-    auto axis_value = axis.getValue<IntegerAttr>({});
-    auto axis_int = axis_value.getValue().getZExtValue();
+    auto axisValue = axis.getValue<IntegerAttr>({});
+    auto axisInt = axisValue.getValue().getZExtValue();
 
-    if (axis_int != tensor_ty.getRank() - 1) {
+    if (axisInt != tensorTy.getRank() - 1) {
       return failure();
     }
 
-    auto result_ty = op.getType().cast<ShapedType>();
+    auto resultTy = op.getType().cast<ShapedType>();
     rewriter.replaceOpWithNewOp<tf_strings::GatherOp>(
         op,
-        RankedTensorType::get(result_ty.getShape(),
+        RankedTensorType::get(resultTy.getShape(),
                               tf_strings::StringType::get(op.getContext())),
         tensor, op.indices());
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.cc
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.cc
@@ -115,8 +115,10 @@ struct GatherV2OpLowering : public OpRewritePattern<TF::GatherV2Op> {
 
     auto result_ty = op.getType().cast<ShapedType>();
     rewriter.replaceOpWithNewOp<tf_strings::GatherOp>(
-      op, RankedTensorType::get(result_ty.getShape(), tf_strings::StringType::get(op.getContext())),
-      tensor, op.indices());
+        op,
+        RankedTensorType::get(result_ty.getShape(),
+                              tf_strings::StringType::get(op.getContext())),
+        tensor, op.indices());
 
     return success();
   }

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.td
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/convert_tf_to_tf_strings.td
@@ -17,6 +17,9 @@ include "mlir/Dialect/StandardOps/IR/Ops.td"
 include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.td"
 include "integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td"
 
+def : Pat<(TF_IdentityOp TF_StrTensor:$value),
+           (replaceWithValue $value)>;
+
 def : Pat<(TF_PrintV2Op TF_Str:$value, $unused1, $unused2),
           (TFStrings_PrintOp $value)>;
 

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/tf_strings_to_strings.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/tf_strings_to_strings.mlir
@@ -35,3 +35,12 @@ func @string_tensor_to_string(%arg0 : tensor<!tf_strings.string>) -> !tf_strings
   // CHECK: return [[VAL0]]
   return %0 : !tf_strings.string
 }
+
+// CHECK-LABEL: @gather
+func @gather(%arg0: tensor<5x!tf_strings.string>, %arg1: tensor<3xi32>) -> tensor<3x!tf_strings.string> {
+  // CHECK-DAG: [[VAL0:%.+]] = "strings.gather"(%arg0, %arg1)
+  %0 = "tf_strings.gather"(%arg0, %arg1) : (tensor<5x!tf_strings.string>, tensor<3xi32>) -> tensor<3x!tf_strings.string>
+
+  // CHECK: return [[VAL0]]
+  return %0 : tensor<3x!tf_strings.string>
+}

--- a/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/tf_to_tf_strings.mlir
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/conversion/test/tf_to_tf_strings.mlir
@@ -36,3 +36,11 @@ func @printv2.tensor.f32(%arg0: tensor<5xf32>) {
   return
 }
 
+// CHECK-LABEL: func @gatherv2
+func @gatherv2(%arg0: tensor<5x!tf.string>, %arg1: tensor<3xi32>) {
+  %0 = "tf.Const"() {device = "", value = dense<0> : tensor<i32>} : () -> tensor<i32>
+
+  // CHECK-DAG: [[VAL0:%.+]] = "tf_strings.gather"(%arg0, %arg1)
+  %1 = "tf.GatherV2"(%arg0, %arg1, %0) {batch_dims = 0 : i64, device = ""} : (tensor<5x!tf.string>, tensor<3xi32>, tensor<i32>) -> tensor<3x!tf.string>
+  return
+}

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
@@ -44,6 +44,36 @@ def TFStrings_ToStringOp : TFStrings_Op<"to_string"> {
     OpBuilderDAG<(ins "Value":$value)>];
 }
 
+def TFStrings_GatherOp : Op<TFStrings_Dialect, "gather"> {
+  let summary = [{gathers all the strings from a Tensor by index}];
+  let description = [{
+    Gathers all the strings from a Tensor by ID.
+  }];
+
+  let arguments = (ins TFStrings_StringTensor:$dict,
+                  TFStrings_ValueTensor:$ids);
+
+  let results = (outs
+    TFStrings_StringTensor:$result
+  );
+}
+
+def TFStrings_ConcatOp : Op<TFStrings_Dialect, "concat"> {
+  let summary = [{
+  concatenates the strings in the tensor along the last dimension
+  }];
+
+  let description = [{
+    Concatenates the strings in the tensor along the last dimension.
+  }];
+
+  let arguments = (ins TFStrings_StringTensor:$value);
+
+  let results = (outs
+    TFStrings_StringTensor:$result
+  );
+}
+
 def TFStrings_ToStringTensorOp : TFStrings_Op<"to_string_tensor"> {
   let summary = "Converts a tensor of values to a tensor of strings.";
   let description = [{

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
@@ -45,9 +45,9 @@ def TFStrings_ToStringOp : TFStrings_Op<"to_string"> {
 }
 
 def TFStrings_GatherOp : Op<TFStrings_Dialect, "gather"> {
-  let summary = "Gathers all the strings from a Tensor by index of the last dimension.";
+  let summary = "Gathers all the strings from by index.";
   let description = [{
-    Gathers all the strings from a Tensor by ID.
+    Gathers all the strings from a Tensor using the index of the last dimension.
   }];
 
   let arguments = (ins TFStrings_StringTensor:$dict,

--- a/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
+++ b/integrations/tensorflow/compiler/dialect/tf_strings/ir/ops.td
@@ -45,13 +45,13 @@ def TFStrings_ToStringOp : TFStrings_Op<"to_string"> {
 }
 
 def TFStrings_GatherOp : Op<TFStrings_Dialect, "gather"> {
-  let summary = [{gathers all the strings from a Tensor by index}];
+  let summary = "Gathers all the strings from a Tensor by index of the last dimension.";
   let description = [{
     Gathers all the strings from a Tensor by ID.
   }];
 
   let arguments = (ins TFStrings_StringTensor:$dict,
-                  TFStrings_ValueTensor:$ids);
+                  TFStrings_ValueTensor:$indices);
 
   let results = (outs
     TFStrings_StringTensor:$result
@@ -59,9 +59,7 @@ def TFStrings_GatherOp : Op<TFStrings_Dialect, "gather"> {
 }
 
 def TFStrings_ConcatOp : Op<TFStrings_Dialect, "concat"> {
-  let summary = [{
-  concatenates the strings in the tensor along the last dimension
-  }];
+  let summary = "Concatenates the strings in the tensor along the last dimension.";
 
   let description = [{
     Concatenates the strings in the tensor along the last dimension.

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -66,7 +66,8 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
   def test_gather(self):
 
     def gather(module):
-      string_values = np.asarray([ord(c) for c in string.printable], dtype=np.int32)
+      string_values = np.asarray([ord(c) for c in string.printable],
+                                 dtype=np.int32)
       input_indices = np.asarray([12, 10, 29, 21, 10, 34], dtype=np.int32)
       module.gather(string_values, input_indices)
 

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -37,8 +37,8 @@ class StringsModule(tf.Module):
       tf.TensorSpec((None,), dtype=tf.int32),
       tf.TensorSpec((None,), dtype=tf.int32),
   ])
-  def gather(self, wp, ids):
-    tf.print(tf.gather(tf.as_string(wp), ids))
+  def gather(self, string_values, indices):
+    tf.print(tf.gather(tf.as_string(string_values), indices))
 
 #  @tf.function(input_signature=[
 #      tf.TensorSpec((None, None), dtype=tf.int32),
@@ -66,9 +66,9 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
   def test_gather(self):
 
     def gather(module):
-      wordparts = np.asarray([ord(c) for c in string.printable], dtype=np.int32)
-      input_ids = np.asarray([12, 10, 29, 21, 10, 34], dtype=np.int32)
-      module.gather(wordparts, input_ids)
+      string_values = np.asarray([ord(c) for c in string.printable], dtype=np.int32)
+      input_indices = np.asarray([12, 10, 29, 21, 10, 34], dtype=np.int32)
+      module.gather(string_values, input_indices)
 
     self.compare_backends(gather, self._modules)
 

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -63,7 +63,6 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
 
     self.compare_backends(print_ids, self._modules)
 
-
   def test_gather(self):
 
     def gather(module):

--- a/integrations/tensorflow/e2e/strings_test.py
+++ b/integrations/tensorflow/e2e/strings_test.py
@@ -33,6 +33,13 @@ class StringsModule(tf.Module):
     string_tensor = tf.strings.as_string(ids)
     tf.print(string_tensor)
 
+  @tf.function(input_signature=[
+      tf.TensorSpec((None,), dtype=tf.int32),
+      tf.TensorSpec((None,), dtype=tf.int32),
+  ])
+  def gather(self, wp, ids):
+    tf.print(tf.gather(tf.as_string(wp), ids))
+
 #  @tf.function(input_signature=[
 #      tf.TensorSpec((None, None), dtype=tf.int32),
 #  ])
@@ -55,6 +62,17 @@ class StringsTest(tf_test_utils.TracedModuleTestCase):
       module.print_ids(input_ids)
 
     self.compare_backends(print_ids, self._modules)
+
+
+  def test_gather(self):
+
+    def gather(module):
+      wordparts = np.asarray([ord(c) for c in string.printable], dtype=np.int32)
+      input_ids = np.asarray([12, 10, 29, 21, 10, 34], dtype=np.int32)
+      module.gather(wordparts, input_ids)
+
+    self.compare_backends(gather, self._modules)
+
 
 #  def test_strings_to_ids(self):
 #

--- a/iree/compiler/Dialect/Modules/Strings/Conversion/ConversionPatterns.cc
+++ b/iree/compiler/Dialect/Modules/Strings/Conversion/ConversionPatterns.cc
@@ -29,6 +29,9 @@ void populateStringsToHALPatterns(MLIRContext *context,
   patterns.insert<HALOpConversion<IREE::Strings::ToStringTensorOp,
                                   IREE::Strings::ToStringTensorOp>>(
       context, typeConverter);
+  patterns.insert<HALOpConversion<IREE::Strings::GatherOp,
+                                  IREE::Strings::GatherOp>>(
+      context, typeConverter);
 }
 
 void populateStringsToVMPatterns(MLIRContext *context,

--- a/iree/compiler/Dialect/Modules/Strings/Conversion/ConversionPatterns.cc
+++ b/iree/compiler/Dialect/Modules/Strings/Conversion/ConversionPatterns.cc
@@ -29,8 +29,8 @@ void populateStringsToHALPatterns(MLIRContext *context,
   patterns.insert<HALOpConversion<IREE::Strings::ToStringTensorOp,
                                   IREE::Strings::ToStringTensorOp>>(
       context, typeConverter);
-  patterns.insert<HALOpConversion<IREE::Strings::GatherOp,
-                                  IREE::Strings::GatherOp>>(
+  patterns.insert<
+      HALOpConversion<IREE::Strings::GatherOp, IREE::Strings::GatherOp>>(
       context, typeConverter);
 }
 

--- a/iree/compiler/Dialect/Modules/Strings/IR/Ops.td
+++ b/iree/compiler/Dialect/Modules/Strings/IR/Ops.td
@@ -94,7 +94,7 @@ def STRINGS_StringTensorToStringOp : Op<STRINGS_Dialect, "string_tensor_to_strin
 }
 
 def STRINGS_GatherOp : Op<STRINGS_Dialect, "gather", [NoSideEffect]> {
-  let summary = "Gathers all the strings from a Tensor by id.";
+  let summary = "Gathers all the strings from a Tensor by index.";
   let description = [{
     Gathers all the strings from a Tensor by index values along the final axis.
   }];

--- a/iree/compiler/Dialect/Modules/Strings/IR/Ops.td
+++ b/iree/compiler/Dialect/Modules/Strings/IR/Ops.td
@@ -94,13 +94,13 @@ def STRINGS_StringTensorToStringOp : Op<STRINGS_Dialect, "string_tensor_to_strin
 }
 
 def STRINGS_GatherOp : Op<STRINGS_Dialect, "gather", [NoSideEffect]> {
-  let summary = [{gathers all the strings from a Tensor by id}];
+  let summary = "Gathers all the strings from a Tensor by id.";
   let description = [{
-    Gathers all the strings from a Tensor by ID.
+    Gathers all the strings from a Tensor by index values along the final axis.
   }];
 
   let arguments = (ins STRINGS_StringTensor:$dict,
-                  STRINGS_ValueTensor:$ids);
+                  STRINGS_ValueTensor:$indices);
 
   let results = (outs
     STRINGS_StringTensor:$result
@@ -108,9 +108,7 @@ def STRINGS_GatherOp : Op<STRINGS_Dialect, "gather", [NoSideEffect]> {
 }
 
 def STRINGS_ConcatOp : Op<STRINGS_Dialect, "concat", [NoSideEffect]> {
-  let summary = [{
-  concatenates the strings in the tensor along the last dimension
-  }];
+  let summary = "Concatenates a tensor of strings along the last dimension";
 
   let description = [{
     Concatenates the strings in the tensor along the last dimension.
@@ -124,7 +122,7 @@ def STRINGS_ConcatOp : Op<STRINGS_Dialect, "concat", [NoSideEffect]> {
 }
 
 def STRINGS_PrintOp : Op<STRINGS_Dialect, "print"> {
-  let summary = [{prints the contents of a string}];
+  let summary = "Prints the contents of a string.";
   let description = [{
     Prints the contents of a string.
   }];


### PR DESCRIPTION
Gather operations added to the strings and tf_strings dialect with
lowerings from TensorFlow to tf_strings and tf_string to strings.
This includes tests for each and an end-to-end test. Right now the
python test does not validate values (missing conversion from
StringTensor to Numpy equivalent) but prints instead. Close enough
for current support.