### PR TITLE
Make gtest_main include gtest shim

### DIFF
--- a/iree/testing/gtest_main.cc
+++ b/iree/testing/gtest_main.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gtest/gtest.h"
 #include "iree/base/flags.h"
+#include "iree/testing/gtest.h"
 
 extern "C" int main(int argc, char** argv) {
   iree_flags_parse_checked(&argc, &argv);


### PR DESCRIPTION
For consistency with other usage throughout the project and to isolate
some of the shimming we have to do internally due to different include
paths.