### PR TITLE
Replace style file with directives to not sort vulkan_headers.h

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,13 +16,3 @@
 # mostly LLVM style (for naming/etc) but the Google formatting (because internal
 # tooling has... issues).
 BasedOnStyle: Google
-
-# Some includes have specific inclusion order requirements. To prevent
-# clang-format from breaking things when bucketing headers into categories we
-# override the behavior here for those well-known headers.
-IncludeCategories:
-  # We override VK_NO_PROTOTYPES so we don't pull in auto-imported symbols and
-  # this must always sort above any header (ours or otherwise) that may
-  # transitively #include <vulkan/vulkan.h>.
-  - Regex:           'iree/hal/vulkan/vulkan_headers.h'
-    Priority:        -1

--- a/iree/hal/vulkan/api.h
+++ b/iree/hal/vulkan/api.h
@@ -17,7 +17,7 @@
 #ifndef IREE_HAL_VULKAN_API_H_
 #define IREE_HAL_VULKAN_API_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/api.h
+++ b/iree/hal/vulkan/api.h
@@ -17,7 +17,9 @@
 #ifndef IREE_HAL_VULKAN_API_H_
 #define IREE_HAL_VULKAN_API_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/base/api.h"
 #include "iree/hal/api.h"

--- a/iree/hal/vulkan/debug_reporter.h
+++ b/iree/hal/vulkan/debug_reporter.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_DEBUG_REPORTER_H_
 #define IREE_HAL_VULKAN_DEBUG_REPORTER_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/debug_reporter.h
+++ b/iree/hal/vulkan/debug_reporter.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_DEBUG_REPORTER_H_
 #define IREE_HAL_VULKAN_DEBUG_REPORTER_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/base/status.h"
 #include "iree/hal/vulkan/dynamic_symbols.h"

--- a/iree/hal/vulkan/direct_command_buffer.h
+++ b/iree/hal/vulkan/direct_command_buffer.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_DIRECT_COMMAND_BUFFER_H_
 #define IREE_HAL_VULKAN_DIRECT_COMMAND_BUFFER_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/direct_command_buffer.h
+++ b/iree/hal/vulkan/direct_command_buffer.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_DIRECT_COMMAND_BUFFER_H_
 #define IREE_HAL_VULKAN_DIRECT_COMMAND_BUFFER_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/hal/command_buffer.h"
 #include "iree/hal/vulkan/descriptor_pool_cache.h"

--- a/iree/hal/vulkan/direct_command_queue.h
+++ b/iree/hal/vulkan/direct_command_queue.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_DIRECT_COMMAND_QUEUE_H_
 #define IREE_HAL_VULKAN_DIRECT_COMMAND_QUEUE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/direct_command_queue.h
+++ b/iree/hal/vulkan/direct_command_queue.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_DIRECT_COMMAND_QUEUE_H_
 #define IREE_HAL_VULKAN_DIRECT_COMMAND_QUEUE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <cstdint>
 #include <string>

--- a/iree/hal/vulkan/dynamic_symbols.h
+++ b/iree/hal/vulkan/dynamic_symbols.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_DYNAMIC_SYMBOLS_H_
 #define IREE_HAL_VULKAN_DYNAMIC_SYMBOLS_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <cstdint>
 #include <functional>

--- a/iree/hal/vulkan/dynamic_symbols.h
+++ b/iree/hal/vulkan/dynamic_symbols.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_DYNAMIC_SYMBOLS_H_
 #define IREE_HAL_VULKAN_DYNAMIC_SYMBOLS_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/emulated_timeline_semaphore.h
+++ b/iree/hal/vulkan/emulated_timeline_semaphore.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_ENUMLATED_TIMELINE_SEMAPHORE_H_
 #define IREE_HAL_VULKAN_ENUMLATED_TIMELINE_SEMAPHORE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <atomic>
 #include <vector>

--- a/iree/hal/vulkan/emulated_timeline_semaphore.h
+++ b/iree/hal/vulkan/emulated_timeline_semaphore.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_ENUMLATED_TIMELINE_SEMAPHORE_H_
 #define IREE_HAL_VULKAN_ENUMLATED_TIMELINE_SEMAPHORE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/extensibility_util.h
+++ b/iree/hal/vulkan/extensibility_util.h
@@ -17,7 +17,9 @@
 #ifndef IREE_HAL_VULKAN_EXTENSIBILITY_UTIL_H_
 #define IREE_HAL_VULKAN_EXTENSIBILITY_UTIL_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <vector>
 

--- a/iree/hal/vulkan/extensibility_util.h
+++ b/iree/hal/vulkan/extensibility_util.h
@@ -17,7 +17,7 @@
 #ifndef IREE_HAL_VULKAN_EXTENSIBILITY_UTIL_H_
 #define IREE_HAL_VULKAN_EXTENSIBILITY_UTIL_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/handle_util.h
+++ b/iree/hal/vulkan/handle_util.h
@@ -24,7 +24,7 @@
 #ifndef IREE_HAL_VULKAN_HANDLE_UTIL_H_
 #define IREE_HAL_VULKAN_HANDLE_UTIL_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/handle_util.h
+++ b/iree/hal/vulkan/handle_util.h
@@ -24,7 +24,9 @@
 #ifndef IREE_HAL_VULKAN_HANDLE_UTIL_H_
 #define IREE_HAL_VULKAN_HANDLE_UTIL_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "absl/synchronization/mutex.h"
 #include "iree/base/ref_ptr.h"

--- a/iree/hal/vulkan/internal_vk_mem_alloc.h
+++ b/iree/hal/vulkan/internal_vk_mem_alloc.h
@@ -16,7 +16,7 @@
 #define IREE_HAL_VULKAN_INTERNAL_VK_MEM_ALLOC_H_
 
 // NOTE: ensure our vulkan headers are used (as we define VK_NO_PROTOTYPES).
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/internal_vk_mem_alloc.h
+++ b/iree/hal/vulkan/internal_vk_mem_alloc.h
@@ -15,7 +15,6 @@
 #ifndef IREE_HAL_VULKAN_INTERNAL_VK_MEM_ALLOC_H_
 #define IREE_HAL_VULKAN_INTERNAL_VK_MEM_ALLOC_H_
 
-// NOTE: ensure our vulkan headers are used (as we define VK_NO_PROTOTYPES).
 // clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on

--- a/iree/hal/vulkan/internal_vk_mem_alloc.h
+++ b/iree/hal/vulkan/internal_vk_mem_alloc.h
@@ -16,7 +16,9 @@
 #define IREE_HAL_VULKAN_INTERNAL_VK_MEM_ALLOC_H_
 
 // NOTE: ensure our vulkan headers are used (as we define VK_NO_PROTOTYPES).
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 // Force all Vulkan calls to go through an indirect pVulkanFunctions interface.
 // https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/configuration.html

--- a/iree/hal/vulkan/native_descriptor_set.h
+++ b/iree/hal/vulkan/native_descriptor_set.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_DESCRIPTOR_SET_H_
 #define IREE_HAL_VULKAN_NATIVE_DESCRIPTOR_SET_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/native_descriptor_set.h
+++ b/iree/hal/vulkan/native_descriptor_set.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_DESCRIPTOR_SET_H_
 #define IREE_HAL_VULKAN_NATIVE_DESCRIPTOR_SET_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/hal/descriptor_set.h"
 #include "iree/hal/vulkan/handle_util.h"

--- a/iree/hal/vulkan/native_event.h
+++ b/iree/hal/vulkan/native_event.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_EVENT_H_
 #define IREE_HAL_VULKAN_NATIVE_EVENT_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/hal/event.h"
 #include "iree/hal/vulkan/handle_util.h"

--- a/iree/hal/vulkan/native_event.h
+++ b/iree/hal/vulkan/native_event.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_EVENT_H_
 #define IREE_HAL_VULKAN_NATIVE_EVENT_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/native_timeline_semaphore.h
+++ b/iree/hal/vulkan/native_timeline_semaphore.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_TIMELINE_SEMAPHORE_H_
 #define IREE_HAL_VULKAN_NATIVE_TIMELINE_SEMAPHORE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "absl/synchronization/mutex.h"
 #include "iree/hal/semaphore.h"

--- a/iree/hal/vulkan/native_timeline_semaphore.h
+++ b/iree/hal/vulkan/native_timeline_semaphore.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_NATIVE_TIMELINE_SEMAPHORE_H_
 #define IREE_HAL_VULKAN_NATIVE_TIMELINE_SEMAPHORE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/pipeline_cache.h
+++ b/iree/hal/vulkan/pipeline_cache.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_CACHE_H_
 #define IREE_HAL_VULKAN_PIPELINE_CACHE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "absl/container/inlined_vector.h"
 #include "iree/hal/executable.h"

--- a/iree/hal/vulkan/pipeline_cache.h
+++ b/iree/hal/vulkan/pipeline_cache.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_CACHE_H_
 #define IREE_HAL_VULKAN_PIPELINE_CACHE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/pipeline_executable.h
+++ b/iree/hal/vulkan/pipeline_executable.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_H_
 #define IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <vector>
 

--- a/iree/hal/vulkan/pipeline_executable.h
+++ b/iree/hal/vulkan/pipeline_executable.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_H_
 #define IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/pipeline_executable_layout.h
+++ b/iree/hal/vulkan/pipeline_executable_layout.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_LAYOUT_H_
 #define IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_LAYOUT_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/pipeline_executable_layout.h
+++ b/iree/hal/vulkan/pipeline_executable_layout.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_LAYOUT_H_
 #define IREE_HAL_VULKAN_PIPELINE_EXECUTABLE_LAYOUT_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"

--- a/iree/hal/vulkan/serializing_command_queue.h
+++ b/iree/hal/vulkan/serializing_command_queue.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_SERIALIZING_COMMAND_QUEUE_H_
 #define IREE_HAL_VULKAN_SERIALIZING_COMMAND_QUEUE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/serializing_command_queue.h
+++ b/iree/hal/vulkan/serializing_command_queue.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_SERIALIZING_COMMAND_QUEUE_H_
 #define IREE_HAL_VULKAN_SERIALIZING_COMMAND_QUEUE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <memory>
 #include <string>

--- a/iree/hal/vulkan/status_util.h
+++ b/iree/hal/vulkan/status_util.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_STATUS_UTIL_H_
 #define IREE_HAL_VULKAN_STATUS_UTIL_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/status_util.h
+++ b/iree/hal/vulkan/status_util.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_STATUS_UTIL_H_
 #define IREE_HAL_VULKAN_STATUS_UTIL_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/base/status.h"
 

--- a/iree/hal/vulkan/timepoint_util.h
+++ b/iree/hal/vulkan/timepoint_util.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_TIMEPOINT_UTIL_H_
 #define IREE_HAL_VULKAN_TIMEPOINT_UTIL_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <atomic>
 #include <vector>

--- a/iree/hal/vulkan/timepoint_util.h
+++ b/iree/hal/vulkan/timepoint_util.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_TIMEPOINT_UTIL_H_
 #define IREE_HAL_VULKAN_TIMEPOINT_UTIL_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/vma_allocator.h
+++ b/iree/hal/vulkan/vma_allocator.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_VMA_ALLOCATOR_H_
 #define IREE_HAL_VULKAN_VMA_ALLOCATOR_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/vma_allocator.h
+++ b/iree/hal/vulkan/vma_allocator.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_VMA_ALLOCATOR_H_
 #define IREE_HAL_VULKAN_VMA_ALLOCATOR_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <memory>
 

--- a/iree/hal/vulkan/vma_buffer.h
+++ b/iree/hal/vulkan/vma_buffer.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_VMA_BUFFER_H_
 #define IREE_HAL_VULKAN_VMA_BUFFER_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/vma_buffer.h
+++ b/iree/hal/vulkan/vma_buffer.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_VMA_BUFFER_H_
 #define IREE_HAL_VULKAN_VMA_BUFFER_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include "iree/hal/buffer.h"
 #include "iree/hal/vulkan/internal_vk_mem_alloc.h"

--- a/iree/hal/vulkan/vulkan_device.h
+++ b/iree/hal/vulkan/vulkan_device.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_VULKAN_DEVICE_H_
 #define IREE_HAL_VULKAN_VULKAN_DEVICE_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/vulkan_device.h
+++ b/iree/hal/vulkan/vulkan_device.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_VULKAN_DEVICE_H_
 #define IREE_HAL_VULKAN_VULKAN_DEVICE_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <functional>
 #include <memory>

--- a/iree/hal/vulkan/vulkan_driver.h
+++ b/iree/hal/vulkan/vulkan_driver.h
@@ -15,7 +15,7 @@
 #ifndef IREE_HAL_VULKAN_VULKAN_DRIVER_H_
 #define IREE_HAL_VULKAN_VULKAN_DRIVER_H_
 
-// clang-format off
+// clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
 

--- a/iree/hal/vulkan/vulkan_driver.h
+++ b/iree/hal/vulkan/vulkan_driver.h
@@ -15,7 +15,9 @@
 #ifndef IREE_HAL_VULKAN_VULKAN_DRIVER_H_
 #define IREE_HAL_VULKAN_VULKAN_DRIVER_H_
 
+// clang-format off
 #include "iree/hal/vulkan/vulkan_headers.h"
+// clang-format on
 
 #include <memory>
 #include <vector>


### PR DESCRIPTION
The internal formatter does not respect `.clang-format` files for...
reasons. This method works without having to use the style file. It's
also nice for humans to have the comment about what's going on. It's a
bit verbose, unfortunately. 