### PR TITLE
Remove apt repository for wrong Ubuntu version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,6 @@ jobs:
     steps:
       - name: Installing dependencies
         run: |
-          sudo add-apt-repository -y "deb http://mirror.enzu.com/ubuntu/ eoan main universe"
           sudo apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format


### PR DESCRIPTION
"eoan" is Ubuntu 19.04 and these containers are Ubuntu 18.04. This is
causing failures in the action complaining that "The repository does
not have a Release file." (e.g. 
https://github.com/google/iree/pull/4301/checks?check_run_id=1601595431)
We could replace with "bionic", but this
actually doesn't seem to be necessary at all. It's been in place since
https://github.com/google/iree/commit/1206452e7816 and
https://github.com/google/iree/commit/6f203bbd5b99 when we were running
with the "latest" ubuntu containers, which probably explains why they
were pointing at a different version.