### PR TITLE
Splitting link options from link libraries in cmake.

### DIFF
--- a/build_tools/cmake/external_cc_library.cmake
+++ b/build_tools/cmake/external_cc_library.cmake
@@ -130,12 +130,14 @@ function(external_cc_library)
         ${_RULE_COPTS}
         ${IREE_DEFAULT_COPTS}
     )
-    target_link_libraries(${_NAME}
-      PUBLIC
-        ${_RULE_DEPS}
+    target_link_options(${_NAME}
       PRIVATE
         ${IREE_DEFAULT_LINKOPTS}
         ${_RULE_LINKOPTS}
+    )
+    target_link_libraries(${_NAME}
+      PUBLIC
+        ${_RULE_DEPS}
     )
     target_compile_definitions(${_NAME}
       PUBLIC
@@ -169,10 +171,13 @@ function(external_cc_library)
         ${IREE_DEFAULT_COPTS}
         ${_RULE_COPTS}
     )
-    target_link_libraries(${_NAME}
+    target_link_options(${_NAME}
       INTERFACE
         ${IREE_DEFAULT_LINKOPTS}
         ${_RULE_LINKOPTS}
+    )
+    target_link_libraries(${_NAME}
+      INTERFACE
         ${_RULE_DEPS}
     )
     iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})

--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -128,13 +128,14 @@ function(iree_cc_library)
         ${IREE_DEFAULT_COPTS}
         ${_RULE_COPTS}
     )
-
-    target_link_libraries(${_NAME}
-      PUBLIC
-        ${_RULE_DEPS}
+    target_link_options(${_NAME}
       PRIVATE
         ${IREE_DEFAULT_LINKOPTS}
         ${_RULE_LINKOPTS}
+    )
+    target_link_libraries(${_NAME}
+      PUBLIC
+        ${_RULE_DEPS}
     )
 
     iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
@@ -168,11 +169,14 @@ function(iree_cc_library)
         ${IREE_DEFAULT_COPTS}
         ${_RULE_COPTS}
     )
-    target_link_libraries(${_NAME}
+    target_link_options(${_NAME}
       INTERFACE
         ${IREE_DEFAULT_LINKOPTS}
-        ${_RULE_DEPS}
         ${_RULE_LINKOPTS}
+    )
+    target_link_libraries(${_NAME}
+      INTERFACE
+        ${_RULE_DEPS}
     )
     iree_add_data_dependencies(NAME ${_NAME} DATA ${_RULE_DATA})
     target_compile_definitions(${_NAME}


### PR DESCRIPTION
This was causing issues where flags like /LTCG were getting interpreted
as libraries that couldn't be found.