### PR TITLE
Relax and document IREE_BUILD_COMPILER checks in cmake functions.

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -32,10 +32,12 @@ include(CMakeParseArguments)
 #   LABELS: Additional labels to apply to the test. The package path and
 #       "driver=${DRIVER}" are added automatically.
 function(iree_check_test)
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+  if(NOT IREE_BUILD_TESTS)
     return()
   endif()
 
+  # When *not* cross compiling, respect the IREE_BUILD_COMPILER option.
+  # Cross compilation uses its own "IREE_HOST_BUILD_COMPILER" option.
   if(NOT IREE_BUILD_COMPILER AND NOT CMAKE_CROSSCOMPILING)
     return()
   endif()
@@ -180,9 +182,13 @@ endfunction()
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
 function(iree_check_single_backend_test_suite)
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+  if(NOT IREE_BUILD_TESTS)
     return()
   endif()
+
+  # Note: we could check IREE_BUILD_COMPILER here, but cross compilation makes
+  # that a little tricky. Instead, we let iree_check_test handle the checks,
+  # meaning this function may run some configuration but generate no targets.
 
   cmake_parse_arguments(
     _RULE
@@ -249,7 +255,7 @@ endfunction()
 #   LABELS: Additional labels to apply to the generated tests. The package path is
 #       added automatically.
 function(iree_check_test_suite)
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+  if(NOT IREE_BUILD_TESTS)
     return()
   endif()
 

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -31,7 +31,15 @@ include(CMakeParseArguments)
 # TODO(gcmn): allow using alternative driver
 # A driver other than the default iree/tools/run_lit.sh is not currently supported.
 function(iree_lit_test)
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
+  # When *not* cross compiling, respect the IREE_BUILD_COMPILER option.
+  # Cross compilation uses its own "IREE_HOST_BUILD_COMPILER" option.
+  # Note: lit tests are not *required* to be "compiler" tests, but we only use
+  # them for compiler tests in practice.
+  if(NOT IREE_BUILD_COMPILER AND NOT CMAKE_CROSSCOMPILING)
     return()
   endif()
 
@@ -108,9 +116,13 @@ endfunction()
 # TODO(gcmn): allow using alternative driver
 # A driver other than the default iree/tools/run_lit.sh is not currently supported.
 function(iree_lit_test_suite)
-  if(NOT IREE_BUILD_TESTS OR NOT IREE_BUILD_COMPILER)
+  if(NOT IREE_BUILD_TESTS)
     return()
   endif()
+
+  # Note: we could check IREE_BUILD_COMPILER here, but cross compilation makes
+  # that a little tricky. Instead, we let iree_check_test handle the checks,
+  # meaning this function may run some configuration but generate no targets.
 
   cmake_parse_arguments(
     _RULE


### PR DESCRIPTION
Follow-up to https://github.com/google/iree/pull/4279, aiming to fix [failing benchmarks](https://buildkite.com/iree/iree-android-benchmark/builds/1177) and re-enable skipped tests: [before](https://buildkite.com/iree/iree-android-arm64-v8a/builds/3351), [after](https://buildkite.com/iree/iree-android-arm64-v8a/builds/3352).