### PR TITLE
Update bazel_to_cmake to support testonly for iree_bytecode_module

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -460,12 +460,14 @@ class BuildFileFunctions(object):
                            src,
                            flags=["-iree-mlir-to-vm-bytecode-module"],
                            translate_tool="//iree/tools:iree-translate",
-                           cc_namespace=None):
+                           cc_namespace=None,
+                           testonly=False):
     name_block = self._convert_name_block(name)
     src_block = self._convert_src_block(src)
     namespace_block = self._convert_cc_namespace_block(cc_namespace)
     translate_tool_block = self._convert_translate_tool_block(translate_tool)
     flags_block = self._convert_string_list_block("FLAGS", flags)
+    testonly_block = self._convert_testonly_block(testonly)
 
     self.converter.body += (f"iree_bytecode_module(\n"
                             f"{name_block}"
@@ -473,6 +475,7 @@ class BuildFileFunctions(object):
                             f"{namespace_block}"
                             f"{translate_tool_block}"
                             f"{flags_block}"
+                            f"{testonly_block}"
                             f"  PUBLIC\n)\n\n")
 
   def iree_flatbuffer_c_library(self, name, srcs, flatcc_args=None):

--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -65,8 +65,8 @@ cc_test(
 
 iree_bytecode_module(
     name = "strings_module_test_module",
+    testonly = True,
     src = "strings_module_test.mlir",
     cc_namespace = "iree::strings_module_test",
     flags = ["-iree-mlir-to-vm-bytecode-module"],
-    testonly = True,
 )

--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -34,7 +34,7 @@ cc_library(
 
 iree_cmake_extra_content(
     content = """
-if (NOT ${IREE_BUILD_COMPILER} OR NOT ${IREE_BUILD_TESTS})
+if (NOT ${IREE_BUILD_COMPILER})
   return()
 endif()
 """,
@@ -68,4 +68,5 @@ iree_bytecode_module(
     src = "strings_module_test.mlir",
     cc_namespace = "iree::strings_module_test",
     flags = ["-iree-mlir-to-vm-bytecode-module"],
+    testonly = True,
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -38,7 +38,7 @@ iree_cc_library(
   PUBLIC
 )
 
-if (NOT ${IREE_BUILD_COMPILER} OR NOT ${IREE_BUILD_TESTS})
+if (NOT ${IREE_BUILD_COMPILER})
   return()
 endif()
 
@@ -74,5 +74,6 @@ iree_bytecode_module(
     "iree::strings_module_test"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
+  TESTONLY
   PUBLIC
 )

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -49,10 +49,10 @@ endif()
 
 iree_bytecode_module(
     name = "tensorlist_test_module",
+    testonly = True,
     src = "tensorlist_test.mlir",
     cc_namespace = "iree::modules::tensorlist",
     flags = ["-iree-mlir-to-vm-bytecode-module"],
-    testonly = True,
 )
 
 cc_test(

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -40,7 +40,7 @@ cc_library(
 
 iree_cmake_extra_content(
     content = """
-if (NOT ${IREE_BUILD_COMPILER} OR NOT ${IREE_BUILD_TESTS})
+if (NOT ${IREE_BUILD_COMPILER})
   return()
 endif()
 """,
@@ -52,6 +52,7 @@ iree_bytecode_module(
     src = "tensorlist_test.mlir",
     cc_namespace = "iree::modules::tensorlist",
     flags = ["-iree-mlir-to-vm-bytecode-module"],
+    testonly = True,
 )
 
 cc_test(

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -34,7 +34,7 @@ iree_cc_library(
   PUBLIC
 )
 
-if (NOT ${IREE_BUILD_COMPILER} OR NOT ${IREE_BUILD_TESTS})
+if (NOT ${IREE_BUILD_COMPILER})
   return()
 endif()
 
@@ -47,6 +47,7 @@ iree_bytecode_module(
     "iree::modules::tensorlist"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
+  TESTONLY
   PUBLIC
 )
 

--- a/iree/tools/compilation.bzl
+++ b/iree/tools/compilation.bzl
@@ -23,7 +23,9 @@ def iree_bytecode_module(
         flags = ["-iree-mlir-to-vm-bytecode-module"],
         translate_tool = "//iree/tools:iree-translate",
         cc_namespace = None,
-        visibility = None):
+        visibility = None,
+        testonly = False,
+        **kwargs):
     native.genrule(
         name = name,
         srcs = [src],
@@ -41,6 +43,8 @@ def iree_bytecode_module(
         tools = [translate_tool],
         message = "Compiling IREE module %s..." % (name),
         output_to_bindir = 1,
+        testonly = testonly,
+        **kwargs
     )
 
     # Embed the module for use in C++. This avoids the need for file IO in

--- a/iree/tools/compilation.bzl
+++ b/iree/tools/compilation.bzl
@@ -23,8 +23,6 @@ def iree_bytecode_module(
         flags = ["-iree-mlir-to-vm-bytecode-module"],
         translate_tool = "//iree/tools:iree-translate",
         cc_namespace = None,
-        visibility = None,
-        testonly = False,
         **kwargs):
     native.genrule(
         name = name,
@@ -43,7 +41,6 @@ def iree_bytecode_module(
         tools = [translate_tool],
         message = "Compiling IREE module %s..." % (name),
         output_to_bindir = 1,
-        testonly = testonly,
         **kwargs
     )
 
@@ -57,6 +54,6 @@ def iree_bytecode_module(
             cc_file_output = "%s.cc" % (name),
             h_file_output = "%s.h" % (name),
             cpp_namespace = cc_namespace,
-            visibility = visibility,
             flatten = True,
+            **kwargs
         )

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -256,10 +256,10 @@ cc_test(
 
 iree_bytecode_module(
     name = "bytecode_module_benchmark_module",
+    testonly = True,
     src = "bytecode_module_benchmark.mlir",
     cc_namespace = "iree::vm",
     flags = ["-iree-vm-ir-to-bytecode-module"],
-    testonly = True,
 )
 
 cc_test(
@@ -275,10 +275,10 @@ cc_test(
 
 iree_bytecode_module(
     name = "bytecode_module_size_benchmark_module",
+    testonly = True,
     src = "bytecode_module_size_benchmark.mlir",
     cc_namespace = "iree::vm",
     flags = ["-iree-vm-ir-to-bytecode-module"],
-    testonly = True,
 )
 
 iree_cmake_extra_content(

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -215,7 +215,7 @@ cc_library(
 
 iree_cmake_extra_content(
     content = """
-if(${IREE_BUILD_COMPILER} AND ${IREE_BUILD_TESTS})
+if(${IREE_BUILD_COMPILER})
 """,
     inline = True,
 )
@@ -259,6 +259,7 @@ iree_bytecode_module(
     src = "bytecode_module_benchmark.mlir",
     cc_namespace = "iree::vm",
     flags = ["-iree-vm-ir-to-bytecode-module"],
+    testonly = True,
 )
 
 cc_test(
@@ -277,6 +278,7 @@ iree_bytecode_module(
     src = "bytecode_module_size_benchmark.mlir",
     cc_namespace = "iree::vm",
     flags = ["-iree-vm-ir-to-bytecode-module"],
+    testonly = True,
 )
 
 iree_cmake_extra_content(

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -177,7 +177,7 @@ iree_cc_library(
   PUBLIC
 )
 
-if(${IREE_BUILD_COMPILER} AND ${IREE_BUILD_TESTS})
+if(${IREE_BUILD_COMPILER})
 
 iree_cc_test(
   NAME
@@ -222,6 +222,7 @@ iree_bytecode_module(
     "iree::vm"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
+  TESTONLY
   PUBLIC
 )
 
@@ -246,6 +247,7 @@ iree_bytecode_module(
     "iree::vm"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
+  TESTONLY
   PUBLIC
 )
 


### PR DESCRIPTION
Also adds the testonly option to the iree_bytecode_modules that are only used for testing