### PR TITLE
Add scripting to update mlir-hlo to match LLVM commit

### DIFF
--- a/.github/workflows/update_llvm_dependent_submodules.yml
+++ b/.github/workflows/update_llvm_dependent_submodules.yml
@@ -42,6 +42,7 @@ jobs:
           echo "LLVM_SHA=$(git submodule status third_party/llvm-project | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
           echo "TF_SHA=$(git submodule status third_party/tensorflow | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
           echo "LLVM_BAZEL_SHA=$(git submodule status third_party/llvm-bazel | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
+          echo "MLIR_HLO_SHA=$(git submodule status third_party/mlir_hlo | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
       - name: Creating Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
@@ -56,6 +57,8 @@ jobs:
               [${{ env.LLVM_BAZEL_SHA }}](https://github.com/google/llvm-bazel/commit/${{ env.LLVM_BAZEL_SHA }})
             - TensorFlow to
             [${{ env.TF_SHA }}](https://github.com/tensorflow/tensorflow/commit/${{ env.TF_SHA }})
+            - MLIR-HLO to
+            [${{ env.MLIR_HLO_SHA }}](https://github.com/tensorflow/mlir-hlo/commit/${MLIR_HLO_SHA?})
 
             `./scripts/git/update_to_llvm_syncpoint.py`
 

--- a/scripts/git/update_llvm_dependent_submodules.sh
+++ b/scripts/git/update_llvm_dependent_submodules.sh
@@ -46,6 +46,7 @@ bash -c "${CMD?}"
 LLVM_SHA="$(git submodule status third_party/llvm-project | awk '{print $1}' | cut -c -12)"
 LLVM_BAZEL_SHA="$(git submodule status third_party/llvm-bazel | awk '{print $1}' | cut -c -12)"
 TF_SHA="$(git submodule status third_party/tensorflow | awk '{print $1}' | cut -c -12)"
+MLIR_HLO_SHA="$(git submodule status third_party/mlir_hlo | awk '{print $1}' | cut -c -12)"
 
 TITLE="Synchronize submodules with LLVM at llvm/llvm-project@${LLVM_SHA?}"
 BODY="$(cat <<-EOF
@@ -55,6 +56,8 @@ Updates LLVM dependencies to match
   [${LLVM_BAZEL_SHA?}](https://github.com/google/llvm-bazel/commit/${LLVM_BAZEL_SHA?})
 - TensorFlow to
   [${TF_SHA?}](https://github.com/tensorflow/tensorflow/commit/${TF_SHA?})
+- MLIR-HLO to
+  [${MLIR_HLO_SHA?}](https://github.com/tensorflow/mlir-hlo/commit/${MLIR_HLO_SHA?})
 
 \`${CMD?}\`
 EOF


### PR DESCRIPTION
This updates the MLIR-HLO submodule in a similar manner to the TF
submodule, just with slightly less parsing because the LLVM commit
information is in its own file.