### PR TITLE
Get remote name in a more portable way in gh scripting

### DIFF
--- a/scripts/git/update_llvm_dependent_submodules.sh
+++ b/scripts/git/update_llvm_dependent_submodules.sh
@@ -75,6 +75,6 @@ if [[ -z "$(which gh)" ]]; then
   exit 1
 fi
 
-# Workaround https://github.com/cli/cli/issues/1820
-GITHUB_USERNAME="$(gh config get -h github.com user)"
-gh pr create --base="${BASE_BRANCH?}" --head="${GITHUB_USERNAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"
+# Extract the GitHub owner of the fork from either an ssh or https GitHub URL.
+FORK_NAME="$(git remote get-url ${FORK_REMOTE?} | sed 's|.*[/:]\([A-Za-z]*\)/iree\(.git\)\?|\1|')"
+gh pr create --base="${BASE_BRANCH?}" --head="${FORK_NAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"


### PR DESCRIPTION
This respects the existing `FORK_REMOTE` env variable and doesn't
require a `gh` config setting that some people have been having issues
with.

The syntax for specifying the remote here is a pain to work with, see
https://github.com/cli/cli/issues/1985