### PR TITLE
Use existing script in submodule synchronize action

### DIFF
--- a/.github/workflows/update_llvm_dependent_submodules.yml
+++ b/.github/workflows/update_llvm_dependent_submodules.yml
@@ -33,35 +33,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "google"
+      - name: Setting git config
+        run: |
+          git config --local user.email "iree-github-actions-bot@google.com"
+          git config --local user.name "Submodule Update Action"
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
-      - name: Updating submodules
-        run: ./scripts/git/update_to_llvm_syncpoint.py
-      - name: Calculating SHAs
-        run: |
-          echo "LLVM_SHA=$(git submodule status third_party/llvm-project | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
-          echo "TF_SHA=$(git submodule status third_party/tensorflow | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
-          echo "LLVM_BAZEL_SHA=$(git submodule status third_party/llvm-bazel | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
-          echo "MLIR_HLO_SHA=$(git submodule status third_party/mlir-hlo | awk '{print $1}' | cut -c -12)" >> $GITHUB_ENV
-      - name: Creating Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
+      - name: Updating submodules and creating PR
+        env:
           # Personal token is required to trigger additional automation (e.g. presubmits).
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
-          commit-message: "Synchronize submodules with LLVM at llvm/llvm-project@${{ env.LLVM_SHA }}"
-          title: "Synchronize submodules with LLVM at llvm/llvm-project@${{ env.LLVM_SHA }}"
-          body: |
-            Updates LLVM dependencies to match
-            [${{ env.LLVM_SHA }}](https://github.com/llvm/llvm-project/commit/${{ env.LLVM_SHA }}).
-            - llvm-bazel to
-              [${{ env.LLVM_BAZEL_SHA }}](https://github.com/google/llvm-bazel/commit/${{ env.LLVM_BAZEL_SHA }})
-            - TensorFlow to
-            [${{ env.TF_SHA }}](https://github.com/tensorflow/tensorflow/commit/${{ env.TF_SHA }})
-            - MLIR-HLO to
-            [${{ env.MLIR_HLO_SHA }}](https://github.com/tensorflow/mlir-hlo/commit/${MLIR_HLO_SHA?})
-
-            `./scripts/git/update_to_llvm_syncpoint.py`
-
-            Automated submodule bump from .github/workflows/update_llvm_dependent_submodules.yml
-          committer: "Submodule Update Action <iree-github-actions-bot@google.com>"
-          branch: "auto_submodule_update"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          UPSTREAM_REMOTE: "origin"
+          PR_BRANCH: "auto_submodule_update"
+        run: ./scripts/git/update_llvm_dependent_submodules.sh

--- a/scripts/git/update_llvm_dependent_submodules.sh
+++ b/scripts/git/update_llvm_dependent_submodules.sh
@@ -75,6 +75,6 @@ if [[ -z "$(which gh)" ]]; then
   exit 1
 fi
 
-# Workaround https://github.com/cli/cli/issues/1820
-GITHUB_USERNAME="$(gh config get -h github.com user)"
-gh pr create --base="${BASE_BRANCH?}" --head="${GITHUB_USERNAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"
+# Extract the GitHub owner of the fork from either an ssh or https GitHub URL.
+FORK_NAME="$(git remote get-url ${FORK_REMOTE?} | sed 's|.*[/:]\([A-Za-z]*\)/iree\(.git\)\?|\1|')"
+gh pr create --base="${BASE_BRANCH?}" --head="${FORK_NAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"


### PR DESCRIPTION
This avoids needing to reconfigure the same thing in two different
syntaxes. The `gh` CLI is available on GitHub action runners and
respects the `GITHUB_TOKEN` env variable for auth.

Tested:
Ran on my fork. https://github.com/GMNGeoffrey/iree/actions/runs/453306027 created https://github.com/GMNGeoffrey/iree/pull/66