### PR TITLE
Turn -Wunused-variable back on

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -142,7 +142,6 @@ build:generic_clang --copt=-Wtautological-overlap-compare
 build:generic_clang --copt=-Wthread-safety
 build:generic_clang --copt=-Wthread-safety-beta
 build:generic_clang --copt=-Wunused-comparison
-build:generic_clang --copt=-Wno-unused-variable
 build:generic_clang --copt=-Wvla
 
 ###############################################################################

--- a/iree/task/executor.c
+++ b/iree/task/executor.c
@@ -673,9 +673,6 @@ iree_task_t* iree_task_executor_try_steal_task(
     iree_task_queue_t* local_task_queue) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  const int worker_count = executor->worker_count;
-  iree_task_worker_t* workers = executor->workers;
-
   // Limit the workers we will steal from to the ones that are currently live
   // and not idle.
   iree_task_affinity_set_t victim_mask =

--- a/iree/task/list_test.cc
+++ b/iree/task/list_test.cc
@@ -187,8 +187,6 @@ TEST(TaskListTest, PrependEmpty) {
 
   auto task0 = AcquireNopTask(pool, scope, 0);
   auto task1 = AcquireNopTask(pool, scope, 1);
-  auto task2 = AcquireNopTask(pool, scope, 2);
-  auto task3 = AcquireNopTask(pool, scope, 3);
 
   iree_task_list_push_back(&list_a, task0);
   iree_task_list_push_back(&list_a, task1);


### PR DESCRIPTION
This is turned on in the internal build configuration and having it off
here means we only hit those failures on integrate.