### PR TITLE
Avoid running slow benchmarks as part of testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,7 @@ include(iree_python)
 include(iree_lit_test)
 include(iree_add_all_subdirs)
 include(iree_check_test)
+include(iree_run_binary_test)
 
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/build_tools/cmake/iree_run_binary_test.cmake
+++ b/build_tools/cmake/iree_run_binary_test.cmake
@@ -1,0 +1,111 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeParseArguments)
+
+# iree_run_binary_test()
+#
+# Creates a test that runs the specified binary with the specified arguments.
+#
+# Mirrors the bzl function of the same name.
+#
+# Parameters:
+# NAME: name of target
+# ARGS: arguments passed to the test binary.
+# TEST_BINARY: binary target to run as the test.
+# LABELS: Additional labels to apply to the test. The package path is added
+#     automatically.
+#
+# Note: the DATA argument is not supported because CMake doesn't have a good way
+# to specify a data dependency for a test.
+#
+#
+# Usage:
+# iree_cc_binary(
+#   NAME
+#     requires_args_to_run
+#   ...
+# )
+# iree_run_binary_test(
+#   NAME
+#     requires_args_to_run_test
+#   ARGS
+#    --do-the-right-thing
+#   TEST_BINARY
+#     ::requires_args_to_run
+# )
+
+function(iree_run_binary_test)
+  if(NOT IREE_BUILD_TESTS)
+    return()
+  endif()
+
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;TEST_BINARY"
+    "ARGS;LABELS"
+    ${ARGN}
+  )
+
+  # Prefix the test with the package name, so we get: iree_package_name
+  iree_package_name(_PACKAGE_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
+  set(_TEST_NAME "${_PACKAGE_PATH}/${_RULE_NAME}")
+
+  string(REGEX REPLACE "^::" "${_PACKAGE_NS}::" _TEST_BINARY_TARGET ${_RULE_TEST_BINARY})
+  string(REPLACE "::" "_" _TEST_BINARY_EXECUTABLE ${_TEST_BINARY_TARGET})
+
+  if(ANDROID)
+    set(_ANDROID_REL_DIR "${_PACKAGE_PATH}/${_RULE_NAME}")
+    set(_ANDROID_ABS_DIR "/data/local/tmp/${_ANDROID_REL_DIR}")
+
+    # Define a custom target for pushing and running the test on Android device.
+    set(_TEST_NAME ${_TEST_NAME}_on_android_device)
+    add_test(
+      NAME
+        ${_TEST_NAME}
+      COMMAND
+        "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_android_test.${IREE_HOST_SCRIPT_EXT}"
+        "${_ANDROID_REL_DIR}/${_NAME}"
+        ${_RULE_ARGS}
+    )
+    # Use environment variables to instruct the script to push artifacts
+    # onto the Android device before running the test. This needs to match
+    # with the expectation of the run_android_test.{sh|bat|ps1} script.
+    set(
+      _ENVIRONMENT_VARS
+        TEST_ANDROID_ABS_DIR=${_ANDROID_ABS_DIR}
+        TEST_EXECUTABLE=$<TARGET_FILE:${_TEST_BINARY_EXECUTABLE}>
+        TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir
+    )
+    set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
+  else()
+    add_test(
+      NAME
+        ${_TEST_NAME}
+      COMMAND
+        "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
+        "$<TARGET_FILE:${_TEST_BINARY_EXECUTABLE}>"
+        ${_RULE_ARGS}
+    )
+    set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_NAME}_test_tmpdir")
+    iree_add_test_environment_properties(${_TEST_NAME})
+  endif()
+
+  list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
+  set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
+endfunction()

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -15,6 +15,7 @@
 # Common types and utilities used in the IREE codebase.
 
 load("//build_tools/bazel:iree_flatcc.bzl", "iree_flatbuffer_c_library")
+load("//build_tools/bazel:run_binary_test.bzl", "run_binary_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -379,14 +380,21 @@ cc_library(
     ],
 )
 
-cc_test(
+cc_binary(
     name = "synchronization_benchmark",
+    testonly = True,
     srcs = ["synchronization_benchmark.cc"],
     deps = [
         ":synchronization",
         "//iree/testing:benchmark_main",
         "@com_google_benchmark//:benchmark",
     ],
+)
+
+run_binary_test(
+    name = "synchronization_benchmark_test",
+    args = ["--benchmark_min_time=0"],
+    test_binary = ":synchronization_benchmark",
 )
 
 cc_test(

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -406,7 +406,7 @@ iree_cc_library(
   PUBLIC
 )
 
-iree_cc_test(
+iree_cc_binary(
   NAME
     synchronization_benchmark
   SRCS
@@ -415,6 +415,16 @@ iree_cc_test(
     ::synchronization
     benchmark
     iree::testing::benchmark_main
+  TESTONLY
+)
+
+iree_run_binary_test(
+  NAME
+    synchronization_benchmark_test
+  TEST_BINARY
+    ::synchronization_benchmark
+  ARGS
+    "--benchmark_min_time=0"
 )
 
 iree_cc_test(

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -14,6 +14,7 @@
 
 load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
 load("//iree/tools:compilation.bzl", "iree_bytecode_module")
+load("//build_tools/bazel:run_binary_test.bzl", "run_binary_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -238,8 +239,9 @@ cc_test(
     ],
 )
 
-cc_test(
+cc_binary(
     name = "bytecode_module_benchmark",
+    testonly = True,
     srcs = ["bytecode_module_benchmark.cc"],
     deps = [
         ":bytecode_module",
@@ -252,6 +254,12 @@ cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_benchmark//:benchmark",
     ],
+)
+
+run_binary_test(
+    name = "bytecode_module_benchmark_test",
+    args = ["--benchmark_min_time=0"],
+    test_binary = ":bytecode_module_benchmark",
 )
 
 iree_bytecode_module(

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -196,7 +196,7 @@ iree_cc_test(
     iree::vm::test::all_bytecode_modules_cc
 )
 
-iree_cc_test(
+iree_cc_binary(
   NAME
     bytecode_module_benchmark
   SRCS
@@ -211,6 +211,16 @@ iree_cc_test(
     iree::base::api
     iree::base::logging
     iree::testing::benchmark_main
+  TESTONLY
+)
+
+iree_run_binary_test(
+  NAME
+    "bytecode_module_benchmark_test"
+  ARGS
+    "--benchmark_min_time=0"
+  TEST_BINARY
+    ::bytecode_module_benchmark
 )
 
 iree_bytecode_module(


### PR DESCRIPTION
It's good to test that these benchmarks run. It's really annoying to run
a billion iterations of them every time you try to run tests. This
literally takes longer than all the other tests combined. Instead, make
these binaries and invoke them for testing with
`--min_benchmark_time=0`.

This introduces CMake and Bazel -> CMake support for `run_binary_test`,
which runs the specified executable target with the specified args.
Punted on support for data dependencies, since these are not required
for this use case and I think we still haven't figured out how to do
that for CMake tests.
