### PR TITLE
make it build again on macos

### DIFF
--- a/iree/base/threading_darwin.c
+++ b/iree/base/threading_darwin.c
@@ -52,7 +52,6 @@ static void iree_thread_set_name(const char* name) {
   pthread_setname_np(name);
   IREE_TRACE_SET_THREAD_NAME(name);
   IREE_TRACE_ZONE_END(z0);
-  return rc;
 }
 
 static void* iree_thread_start_routine(void* param) {

--- a/iree/hal/drivers/CMakeLists.txt
+++ b/iree/hal/drivers/CMakeLists.txt
@@ -28,6 +28,11 @@ if(${IREE_HAL_DRIVER_VULKAN})
   list(APPEND IREE_HAL_DRIVER_MODULES iree::hal::vulkan::registration)
 endif()
 
+if(APPLE)
+  find_library(Metal Metal)
+  find_library(Foundation Foundation)
+endif()
+
 iree_cc_library(
   NAME
     drivers
@@ -39,5 +44,7 @@ iree_cc_library(
     iree::base::api
     iree::base::tracing
     ${IREE_HAL_DRIVER_MODULES}
+    $<$<PLATFORM_ID:Darwin>:${Metal}>
+    $<$<PLATFORM_ID:Darwin>:${Foundation}>
   PUBLIC
 )

--- a/iree/hal/metal/BUILD.bazel
+++ b/iree/hal/metal/BUILD.bazel
@@ -50,7 +50,10 @@ objc_library(
         "metal_pipeline_cache.mm",
         "metal_shared_event.mm",
     ],
-    sdk_frameworks = ["Metal"],
+    sdk_frameworks = [
+        "Metal",
+        "Foundation",
+    ],
     deps = [
         "//iree/base:arena",
         "//iree/base:file_io",


### PR DESCRIPTION
1. remove a trivial copy & paste error in `iree/base/threading_darwin.c`
2. make building with cmake work again (by adding Metal and Foundation)