### PR TITLE
Update getting_started_linux_cmake.md

### DIFF
--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -132,9 +132,9 @@ Then run the compiled module using the `dylib` HAL driver:
 
 ```shell
 $ ./build/iree/tools/iree-run-module -driver=dylib \
-          -input_file=/tmp/simple-llvm_aot.vmfb \
+          -module_file=/tmp/simple-llvm_aot.vmfb \
           -entry_function=abs \
-          -inputs="i32=-5"
+          -function_inputs="i32=-5"
 
 EXEC @abs
 i32=5


### PR DESCRIPTION
It looks like the following option names for iree-run-module got changed since this doc was updated last time: (1) input_file -> module_file and (2) inputs -> function_inputs. This PR updates the iree-run-module example in the doc accordingly.