### PR TITLE
Add missing dep on HLOToLinalg

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -50,6 +50,7 @@ cc_library(
     ],
     deps = [
         "//iree/base:signature_mangle",
+        "//iree/compiler/Conversion/HLOToLinalg",
         "//iree/compiler/Conversion/HLOToLinalg:HLOToLinalgOnTensors",
         "//iree/compiler/Dialect/Flow/Analysis",
         "//iree/compiler/Dialect/Flow/Conversion",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRTransforms
     iree::base::signature_mangle
+    iree::compiler::Conversion::HLOToLinalg
     iree::compiler::Conversion::HLOToLinalg::HLOToLinalgOnTensors
     iree::compiler::Dialect::Flow::Analysis
     iree::compiler::Dialect::Flow::Conversion


### PR DESCRIPTION
`iree/compiler/Dialect/Flow/Transforms/Passes.cpp` calls
`addHLOToLinalgOnTensorsPasses()`. This function is declared in
`iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h`,
belonging to the target HLOToLinalgOnTensors. However, it is defined in
`iree/compiler/Conversion/HLOToLinalg/Passes.cpp`, belonging to the
target HLOToLinalg. This blocks updating the iree submodule in
https://github.com/iml130/iree-template-cpp.