### PR TITLE
Adding a new arena type with a shared thread-safe block pool.

### DIFF
--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default implementations for HAL types that use the host resources.
+# These are generally just wrappers around host heap memory and host threads.
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+# TODO(benvanik): replace iree/base/arena.h with this one. We still want the
+# old-style arena for pure stack use; we may be able to do that with a change
+# to block pool that allows for on-stack initialization (iree_stack_arena_t
+# that has storage for one block inside itself and then dynamically allocates
+# new ones if needed). That way we have only one arena implementation and can
+# easily use the iree_allocator_t interface without worry.
+cc_library(
+    name = "arena",
+    srcs = ["arena.c"],
+    hdrs = ["arena.h"],
+    deps = [
+        "//iree/base:api",
+        "//iree/base:core_headers",
+    ],
+)

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_cc_library(
+  NAME
+    arena
+  HDRS
+    "arena.h"
+  SRCS
+    "arena.c"
+  DEPS
+    iree::base::api
+    iree::base::core_headers
+  PUBLIC
+)

--- a/iree/hal/local/arena.c
+++ b/iree/hal/local/arena.c
@@ -1,0 +1,181 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/arena.h"
+
+#include "iree/base/alignment.h"
+
+//===----------------------------------------------------------------------===//
+// iree_arena_block_pool_t
+//===----------------------------------------------------------------------===//
+
+void iree_arena_block_pool_initialize(iree_host_size_t total_block_size,
+                                      iree_allocator_t block_allocator,
+                                      iree_arena_block_pool_t* out_block_pool) {
+  memset(out_block_pool, 0, sizeof(*out_block_pool));
+  out_block_pool->total_block_size = total_block_size;
+  out_block_pool->usable_block_size =
+      total_block_size - sizeof(iree_arena_block_t);
+  out_block_pool->block_allocator = block_allocator;
+  iree_atomic_arena_block_slist_initialize(&out_block_pool->available_slist);
+}
+
+void iree_arena_block_pool_deinitialize(iree_arena_block_pool_t* block_pool) {
+  // Since all blocks must have been released we can just reuse trim (today) as
+  // it doesn't retain any blocks.
+  iree_arena_block_pool_trim(block_pool);
+  iree_atomic_arena_block_slist_deinitialize(&block_pool->available_slist);
+}
+
+void iree_arena_block_pool_trim(iree_arena_block_pool_t* block_pool) {
+  iree_arena_block_t* head = NULL;
+  iree_atomic_arena_block_slist_flush(
+      &block_pool->available_slist,
+      IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO, &head, NULL);
+  while (head) {
+    void* ptr = (uint8_t*)head - block_pool->usable_block_size;
+    head = head->next;
+    iree_allocator_free(block_pool->block_allocator, ptr);
+  }
+}
+
+iree_status_t iree_arena_block_pool_acquire(iree_arena_block_pool_t* block_pool,
+                                            iree_arena_block_t** out_block) {
+  iree_arena_block_t* block =
+      iree_atomic_arena_block_slist_pop(&block_pool->available_slist);
+
+  if (!block) {
+    // No blocks available; allocate one now.
+    // Note that it's possible for there to be a race here where one thread
+    // releases a block to the pool while we are trying to acquire one - in that
+    // case we may end up allocating a block when perhaps we didn't need to but
+    // that's fine - it's just one block and the contention means there's likely
+    // to be a need for more anyway.
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        block_pool->block_allocator, block_pool->total_block_size, &block));
+  }
+
+  block->next = NULL;
+  *out_block = block;
+  return iree_ok_status();
+}
+
+void iree_arena_block_pool_release(iree_arena_block_pool_t* block_pool,
+                                   iree_arena_block_t* block_head,
+                                   iree_arena_block_t* block_tail) {
+  iree_atomic_arena_block_slist_concat(&block_pool->available_slist, block_head,
+                                       block_tail);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_arena_allocator_t
+//===----------------------------------------------------------------------===//
+
+void iree_arena_initialize(iree_arena_block_pool_t* block_pool,
+                           iree_arena_allocator_t* out_arena) {
+  memset(out_arena, 0, sizeof(*out_arena));
+  out_arena->block_pool = block_pool;
+}
+
+void iree_arena_deinitialize(iree_arena_allocator_t* arena) {
+  iree_arena_reset(arena);
+}
+
+void iree_arena_reset(iree_arena_allocator_t* arena) {
+  if (arena->allocation_head != NULL) {
+    iree_arena_oversized_allocation_t* head = arena->allocation_head;
+    do {
+      void* ptr = (void*)head;
+      head = head->next;
+      iree_allocator_free(arena->block_pool->block_allocator, ptr);
+    } while (head);
+    arena->allocation_head = NULL;
+  }
+  if (arena->block_head != NULL) {
+    iree_arena_block_pool_release(arena->block_pool, arena->block_head,
+                                  arena->block_tail);
+    arena->block_head = NULL;
+    arena->block_tail = NULL;
+  }
+}
+
+iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
+                                  iree_host_size_t byte_length,
+                                  void** out_ptr) {
+  *out_ptr = NULL;
+
+  iree_arena_block_pool_t* block_pool = arena->block_pool;
+
+  if (byte_length > block_pool->usable_block_size) {
+    // Oversized allocation that can't be handled by the block pool. We'll
+    // allocate directly from the system allocator and track it ourselves for
+    // freeing during reset.
+    iree_host_size_t allocation_size =
+        sizeof(iree_arena_oversized_allocation_t) + byte_length;
+    iree_arena_oversized_allocation_t* allocation = NULL;
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        block_pool->block_allocator, allocation_size, (void**)&allocation));
+    allocation->next = arena->allocation_head;
+    arena->allocation_head = allocation;
+    arena->total_allocation_size += allocation_size;
+    arena->used_allocation_size += byte_length;
+    *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
+    return iree_ok_status();
+  }
+
+  // Pad length allocated so that each pointer bump is always ending at an
+  // aligned address and the next allocation will start aligned.
+  iree_host_size_t aligned_length = iree_align(byte_length, iree_max_align_t);
+
+  // Check to see if the current block (if any) has space - if not, get another.
+  if (arena->block_head == NULL ||
+      arena->block_bytes_remaining < aligned_length) {
+    iree_arena_block_t* block = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_arena_block_pool_acquire(arena->block_pool, &block));
+    block->next = arena->block_head;
+    arena->block_head = block;
+    if (!arena->block_tail) arena->block_tail = block;
+    arena->total_allocation_size += block_pool->total_block_size;
+    arena->block_bytes_remaining = block_pool->usable_block_size;
+  }
+
+  // Slice out the allocation from the current block.
+  void* ptr = (uint8_t*)arena->block_head - arena->block_bytes_remaining;
+  arena->block_bytes_remaining -= aligned_length;
+  arena->used_allocation_size += aligned_length;
+  *out_ptr = ptr;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_arena_allocate_thunk(void* self,
+                                               iree_allocation_mode_t mode,
+                                               iree_host_size_t byte_length,
+                                               void** out_ptr) {
+  iree_arena_allocator_t* arena = (iree_arena_allocator_t*)self;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate(arena, byte_length, out_ptr));
+  if (mode & IREE_ALLOCATION_MODE_ZERO_CONTENTS) {
+    memset(*out_ptr, 0, byte_length);
+  }
+  return iree_ok_status();
+}
+
+iree_allocator_t iree_arena_allocator(iree_arena_allocator_t* arena) {
+  iree_allocator_t v = {
+      .self = arena,
+      .alloc = (iree_allocator_alloc_fn_t)iree_arena_allocate,
+      .free = NULL,
+  };
+  return v;
+}

--- a/iree/hal/local/arena.h
+++ b/iree/hal/local/arena.h
@@ -1,0 +1,155 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_ARENA_H_
+#define IREE_HAL_LOCAL_ARENA_H_
+
+#include "iree/base/api.h"
+#include "iree/base/atomic_slist.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_arena_block_pool_t
+//===----------------------------------------------------------------------===//
+
+// NOTE: this struct is at the *end* of allocated blocks such that we don't mess
+// with alignment - byte 0 of a block is always byte 0 of the allocation from
+// the system. We can do this as all blocks have the same size so computing the
+// footer offset from a pointer is easy.
+typedef struct iree_arena_block_s {
+  struct iree_arena_block_s* next;
+} iree_arena_block_t;
+
+// An atomic approximately LIFO singly-linked list.
+IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_atomic_arena_block, iree_arena_block_t,
+                                offsetof(iree_arena_block_t, next));
+
+// A simple atomic fixed-size block pool.
+// Blocks are allocated from the system as required and kept in the pool to
+// satisfy future requests. Blocks are all of a uniform size specified when the
+// pool is created. It's recommended that power-of-two sizes are used for the
+// blocks so that the underlying allocator is more likely to bucket them
+// appropriately.
+//
+// Thread-safe; multiple threads may acquire and release blocks from the pool.
+// The underlying allocator must also be thread-safe.
+typedef struct {
+  // Block size, in bytes. All blocks in the available_slist will have this
+  // byte size which includes the iree_arena_block_t footer.
+  iree_host_size_t total_block_size;
+  // Block size, in bytes, of the usable bytes within a block.
+  iree_host_size_t usable_block_size;
+  // Allocator used for allocating/freeing each allocation block.
+  iree_allocator_t block_allocator;
+  // Linked list of free blocks (LIFO).
+  iree_atomic_arena_block_slist_t available_slist;
+} iree_arena_block_pool_t;
+
+// Initializes a new block pool in |out_block_pool|.
+// |block_allocator| will be used to allocate and free blocks for the pool.
+// Each block allocated will be |total_block_size| but have a slightly smaller
+// usable size due to the tracking overhead. Prefer powers of two.
+void iree_arena_block_pool_initialize(iree_host_size_t total_block_size,
+                                      iree_allocator_t block_allocator,
+                                      iree_arena_block_pool_t* out_block_pool);
+
+// Deinitializes a block pool and frees all allocations.
+// All blocks that were acquired from the pool must have already been released
+// back to it.
+void iree_arena_block_pool_deinitialize(iree_arena_block_pool_t* block_pool);
+
+// Trims the pool by freeing unused blocks back to the allocator.
+// Acquired blocks are not freed and remain valid.
+void iree_arena_block_pool_trim(iree_arena_block_pool_t* block_pool);
+
+// Acquires a single block from the pool and returns it in |out_block|.
+// The block may be either a new allocation with undefined contents or a reused
+// prior allocation with undefined contents.
+iree_status_t iree_arena_block_pool_acquire(iree_arena_block_pool_t* block_pool,
+                                            iree_arena_block_t** out_block);
+
+// Releases one or more blocks back to the block pool.
+// Any blocks chained in |block_head| will also be released allowing for
+// low-overhead resets when the blocks are already tracked in linked lists.
+void iree_arena_block_pool_release(iree_arena_block_pool_t* block_pool,
+                                   iree_arena_block_t* block_head,
+                                   iree_arena_block_t* block_tail);
+
+//===----------------------------------------------------------------------===//
+// iree_arena_allocator_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_arena_oversized_allocation_s {
+  struct iree_arena_oversized_allocation_s* next;
+} iree_arena_oversized_allocation_t;
+
+// A lightweight bump-pointer arena allocator using a shared block pool.
+// As allocations are made from the arena and block capacity is exhausted new
+// blocks will be acquired from the pool. Upon being reset all blocks will be
+// released back to the pool for reuse by either the same arena in the future or
+// other arenas sharing the same pool.
+//
+// The size of each allocated block used by the arena is inherited from the
+// block pool. Allocations from the arena may exceed the block size but will
+// incur additional allocation overhead as the block pool is bypassed and the
+// system allocator is directly used to service the request.
+//
+// Thread-compatible; the shared block pool is thread-safe and may be used by
+// arenas on multiple threads but each arena must only be used by a single
+// thread.
+typedef struct {
+  // Fixed-size block pool used to acquire new blocks for the arena.
+  iree_arena_block_pool_t* block_pool;
+  // Total bytes allocated to the arena from the block pool or system allocator.
+  iree_host_size_t total_allocation_size;
+  // Total bytes allocated from the arena; the utilization of the arena can be
+  // checked with `used_allocation_size / total_allocation_size`.
+  iree_host_size_t used_allocation_size;
+  // Linked list of oversized allocations made directly from the system
+  // allocator used by the block pool.
+  iree_arena_oversized_allocation_t* allocation_head;
+  // Linked list of allocated blocks maintained so that reset can release them.
+  iree_arena_block_t* block_head;
+  iree_arena_block_t* block_tail;
+  // The number of bytes remaining in the block pointed to by block_head.
+  iree_host_size_t block_bytes_remaining;
+} iree_arena_allocator_t;
+
+// Initializes an arena that will use |block_pool| for allocating blocks as
+// needed.
+void iree_arena_initialize(iree_arena_block_pool_t* block_pool,
+                           iree_arena_allocator_t* out_arena);
+
+// Deinitializes the arena and returns allocated blocks to the parent pool.
+void iree_arena_deinitialize(iree_arena_allocator_t* arena);
+
+// Resets the entire arena and returns allocated blocks to the parent pool.
+void iree_arena_reset(iree_arena_allocator_t* arena);
+
+// Allocates |byte_length| contiguous bytes from the arena.
+iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
+                                  iree_host_size_t byte_length, void** out_ptr);
+
+// Returns an iree_allocator_t that allocates from the given |arena|.
+// Frees are ignored as arenas can only be reset as a whole.
+iree_allocator_t iree_arena_allocator(iree_arena_allocator_t* arena);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_ARENA_H_


### PR DESCRIPTION
This will be used to provide storage for command buffers and other
builder types (submissions/etc) in the local HAL backend.