### PR TITLE
Include pffft.h without directory prefix

### DIFF
--- a/build_tools/third_party/pffft/BUILD.overlay
+++ b/build_tools/third_party/pffft/BUILD.overlay
@@ -13,7 +13,6 @@ cc_library(
         "pffft.h",
     ],
     deps =  [":pffft_internal"],
-    include_prefix = "third_party/pffft",
 )
 
 cc_library(

--- a/build_tools/third_party/pffft/CMakeLists.txt
+++ b/build_tools/third_party/pffft/CMakeLists.txt
@@ -25,6 +25,8 @@ external_cc_library(
     "pffft.c"
   HDRS
     "pffft.h"
+  INCLUDES
+    ${PFFFT_ROOT}
 )
 
 external_cc_library(

--- a/iree/hal/vmla/op_kernels_fft.h
+++ b/iree/hal/vmla/op_kernels_fft.h
@@ -37,7 +37,7 @@
 #include "absl/types/span.h"
 #include "iree/base/logging.h"
 #include "iree/base/status.h"
-#include "third_party/pffft/pffft.h"
+#include "pffft.h"
 
 namespace iree {
 namespace hal {


### PR DESCRIPTION
This is more portable to our google internal source control, where
pffft has a slightly weird directory path.