### PR TITLE
Force push when synchronizing submodules

### DIFF
--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Sets submodule state to the one specified in SUBMODULE_VERSIONS
+# Edits the HEAD commit to use the submodule state specified in SUBMODULE_VERSIONS
+# WARNING: rewrites history!
 
 name: Synchronize Submodules
 
@@ -29,6 +30,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          # Get all history. We're force-pushing here and will otherwise drop
+          # all the branch history
+          fetch-depth: 0
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
       - name: Checking submodule state
@@ -40,10 +44,7 @@ jobs:
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"
           git config --local user.name "Submodule Synchronize Action"
-          git commit -am "Synchronize submodules"
+          git commit --amend -a --no-edit
       - name: Pushing changes
         if: env.has_diff == 'true'
-        uses: ad-m/github-push-action@v0.5.0
-        with:
-          github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
-          branch: ${{ github.ref }}
+        run: git push -f origin ${{ github.ref }}

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -20,6 +20,7 @@ name: Synchronize Submodules
 on:
   push:
     branches:
+      # Do not add this to human branches like main. It rewrites history!
       - google
 
 jobs:

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
           # Get all history. We're force-pushing here and will otherwise drop
-          # all the branch history
+          # all the branch history. This takes a whopping 2 seconds. I think
+          # we'll live.
           fetch-depth: 0
       - name: Initializing submodules
         run: ./scripts/git/submodule_versions.py init
@@ -48,3 +49,11 @@ jobs:
       - name: Pushing changes
         if: env.has_diff == 'true'
         run: git push -f origin ${{ github.ref }}
+
+  check:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v2
+      - name: Checking submodules
+        run: ./scripts/git/submodule_versions.py check

--- a/.github/workflows/synchronize_submodules.yml
+++ b/.github/workflows/synchronize_submodules.yml
@@ -34,8 +34,8 @@ jobs:
           # all the branch history. This takes a whopping 2 seconds. I think
           # we'll live.
           fetch-depth: 0
-      - name: Initializing submodules
-        run: ./scripts/git/submodule_versions.py init
+      - name: Importing submodules from SUBMODULE_VERSIONS
+        run: ./scripts/git/submodule_versions.py import
       - name: Checking submodule state
         run: |
           echo "has_diff=false" >> $GITHUB_ENV


### PR DESCRIPTION
Instead of adding a new commit that fixes up the submodules, rewrite
the HEAD commit so that they are correct. This action was originally
intended for rare cases where Copybara messed up integrations. These
"rare cases" now happen multiple times a day and are cluttering the
repository history with useless commits. We have already decided it's
ok to rewrite the google branch history to fix up Copybara failures to
create merge commits, so this doesn't change things much. It also
us to expand this action to create those merge commits as well.

Somewhat incidentally, I noticed that this action doesn't actually need
to initialize the submodules themselves. It only really deals in
hashes, which are already recorded. Dropping this makes it ~10x faster.

This has a couple disadvantages:
- If multiple commits are pushed and an intermediate one is the one
  that introduces a submodule diff, the changes will get erroneously
  attributed to the current HEAD commit. The rate of pushes to this
  branch is pretty low, so I don't think that will happen to
  frequently. I can work on some more complex logic that walks the
  history instead.
- If someone is trying to track the google branch, rewriting history
  more frequently will make things difficult for them. This branch is
  only intended for the export from google source control, so the only
  people who should care about it are build cops and maybe googlers,
  and I think the inconvenience will be minor.
- There will be some lag time between when a commit is exported and
  when it can be safely merged into the main branch. This action runs
  in about 10 seconds and quickly reports a failure (plus you can see
  the pending status as well), so I think this isn't likely to happen.

Tested:
Ran this on my fork. Initially pushed a cherry-picked version of
https://github.com/google/iree/commit/78170d0a58fe
![screenshot](https://user-images.githubusercontent.com/5732088/103966637-1dbcaf00-5115-11eb-9077-6192d23d5820.png).
The check action failed on this, marking it with an "x"
(https://github.com/GMNGeoffrey/iree/runs/1666244136) and the
synchronize action fixed it up
(https://github.com/GMNGeoffrey/iree/runs/1666187868)
with the final result being
https://github.com/GMNGeoffrey/iree/commit/ec9e72364088.