### PR TITLE
Add support for dynamic shapes in IREE on Linalg on tensors.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -65,6 +65,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
         "@llvm-project//mlir:StandardToSPIRV",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
         "@llvm-project//mlir:VectorToLLVM",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRStandardOpsTransforms
     MLIRStandardToLLVM
     MLIRStandardToSPIRV
+    MLIRSupport
     MLIRTransforms
     MLIRVector
     MLIRVectorToLLVM

--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgRewriteDestructiveUpdatesPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgRewriteDestructiveUpdatesPass.cpp
@@ -69,6 +69,9 @@ static bool hasDestructiveUpdateSubTensorUses(
       writes.push_back(subTensorInsertOp);
       continue;
     }
+    if (auto dimOp = dyn_cast<DimOp>(u.getOwner())) {
+      continue;
+    }
     LLVM_DEBUG(llvm::dbgs() << "found non-destructive update pattern use: "
                             << *(u.getOwner()) << "\n");
     return false;

--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -74,6 +74,9 @@ static bool hasDestructiveUpdateSubTensorUses(
       writes.push_back(subTensorInsertOp);
       continue;
     }
+    if (auto dimOp = dyn_cast<DimOp>(u.getOwner())) {
+      continue;
+    }
     LLVM_DEBUG(llvm::dbgs() << "found non-destructive update pattern use: "
                             << *(u.getOwner()) << "\n");
     return false;

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -208,9 +208,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // Outline the dispatch regions into their own functions wrapped in
   // executables. This separates sequencer functions performing dispatches from
   // dispatchees.
-  if (!clEnableLinalgOnTensorsDispatch) {
-    passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
-  }
+  passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
   passManager.addPass(IREE::Flow::createOutlineDispatchRegions2Pass());
 
   // Cleanup identity ops that clutter up the IR and canonicalize.

--- a/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors.mlir
+++ b/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-run-mlir %s -export-all -iree-hal-target-backends=dylib-llvm-aot  -iree-flow-dispatch-linalg-on-tensors -iree-flow-dispatch-linalg-on-tensors-tile-sizes="1,1" -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="2x3xf32=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]"  -function-input="3x4xf32=[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]"  -function-input="2x4xf32=[[1000.0, 1000.0, 1000.0, 1000.0], [1000.0, 1000.0, 1000.0, 1000.0]]" | IreeFileCheck %s
+
+// CHECK: EXEC @main
+// CHECK: 2x4xf32=[1038 1044 1050 1056][1083 1098 1113 1128]
+func @main(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %D = linalg.matmul ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}


### PR DESCRIPTION
This revision pipes dynamic shapes through IREE on tensors all the way to LLVM.
Peculiarities of TieShapeOp require some genuflexions to traverse IR and recover proper
indices for the memref shapes in bufferization.
This creates an asymmetry that it would be welcome to remove in the future, once we have core support for ranked shapes types and subshape operations as discussed in
https://llvm.discourse.group/t/linalg-and-shapes/2421.

PiperOrigin-RevId: 350429972