### PR TITLE
Globally disable RTTI and exceptions in IREE.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -166,6 +166,11 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unused-variable"
     "-Wno-undef"
     "-fvisibility=hidden"
+    # NOTE: The RTTI setting must match what LLVM was compiled with (defaults
+    # to RTTI disabled).
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>"
+
   MSVC_OR_CLANG_CL
     # Exclude a bunch of rarely-used APIs, such as crypto/DDE/shell.
     # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
@@ -203,17 +208,11 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # https://docs.microsoft.com/en-us/cpp/c-runtime-library/secure-template-overloads
     "/D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES"
 
-    # Configure exception handling for standard C++ behavior.
-    # - /EHs enables C++ catch-style exceptions
-    # - /EHc breaks unwinding across extern C boundaries, dramatically reducing
-    #   unwind table size and associated exception handling overhead as the
-    #   compiler can assume no exception will ever be thrown within any function
-    #   annotated with extern "C".
-    # https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model
-    #
-    # TODO(benvanik): figure out if we need /EHs - we don't use exceptions in
-    # the runtime and I'm pretty sure LLVM doesn't use them either.
-    "/EHsc"
+    # Configure RTTI generation.
+    # - /GR - Enable generation of RTTI (default)
+    # - /GR- - Disables generation of RTTI
+    # https://docs.microsoft.com/en-us/cpp/build/reference/gr-enable-run-time-type-information?view=msvc-160
+    "/GR-"
 
     # Default max section count is 64k, which is woefully inadequate for some of
     # the insanely bloated tablegen outputs LLVM/MLIR produces. This cranks it
@@ -417,7 +416,6 @@ set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
 set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
 set(LLVM_APPEND_VC_REV OFF CACHE BOOL "" FORCE)
 set(LLVM_ENABLE_IDE ON CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_RTTI ON CACHE BOOL "" FORCE)
 
 # TODO(ataei): Use optional build time targets selection for LLVMAOT.
 set(LLVM_TARGETS_TO_BUILD "WebAssembly;X86;ARM;AArch64;RISCV" CACHE STRING "" FORCE)

--- a/iree/compiler/Dialect/HAL/Target/MetalSPIRV/SPIRVToMSL.cpp
+++ b/iree/compiler/Dialect/HAL/Target/MetalSPIRV/SPIRVToMSL.cpp
@@ -19,6 +19,9 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+
+// Disable exception handling in favor of assertions.
+#define SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
 #include "third_party/spirv_cross/spirv_msl.hpp"
 
 #define DEBUG_TYPE "spirv-to-msl"

--- a/iree/vm/list_test.cc
+++ b/iree/vm/list_test.cc
@@ -47,9 +47,10 @@ IREE_VM_DEFINE_TYPE_ADAPTERS(test_b, B);
 namespace {
 
 template <typename T>
-static void RegisterRefType(iree_vm_ref_type_descriptor_t* descriptor) {
+static void RegisterRefType(iree_vm_ref_type_descriptor_t* descriptor,
+                            const char* type_name) {
   if (descriptor->type == IREE_VM_REF_TYPE_NULL) {
-    descriptor->type_name = iree_make_cstring_view(typeid(T).name());
+    descriptor->type_name = iree_make_cstring_view(type_name);
     descriptor->offsetof_counter = T::offsetof_counter();
     descriptor->destroy = T::DirectDestroy;
     IREE_CHECK_OK(iree_vm_ref_register_type(descriptor));
@@ -57,8 +58,8 @@ static void RegisterRefType(iree_vm_ref_type_descriptor_t* descriptor) {
 }
 
 static void RegisterRefTypes() {
-  RegisterRefType<A>(&test_a_descriptor);
-  RegisterRefType<B>(&test_b_descriptor);
+  RegisterRefType<A>(&test_a_descriptor, "AType");
+  RegisterRefType<B>(&test_b_descriptor, "BType");
 }
 
 template <typename T, typename V>

--- a/iree/vm/module_abi_packing.h
+++ b/iree/vm/module_abi_packing.h
@@ -357,8 +357,7 @@ struct ParamUnpack<ref<T>> {
       status = InvalidArgumentErrorBuilder(IREE_LOC)
                << "Parameter contains a reference to the wrong type; have "
                << iree_vm_ref_type_name(reg_ptr->type).data << " but expected "
-               << ref_type_descriptor<T>::get()->type_name.data << " ("
-               << typeid(storage_type).name() << ")";
+               << ref_type_descriptor<T>::get()->type_name.data;
     } else {
       out_param = {};
     }
@@ -379,8 +378,7 @@ struct ParamUnpack<const ref<T>> {
       status = InvalidArgumentErrorBuilder(IREE_LOC)
                << "Parameter contains a reference to the wrong type; have "
                << iree_vm_ref_type_name(reg_ptr->type).data << " but expected "
-               << ref_type_descriptor<T>::get()->type_name.data << " ("
-               << typeid(storage_type).name() << ")";
+               << ref_type_descriptor<T>::get()->type_name.data;
     } else {
       out_param = {};
     }
@@ -406,8 +404,7 @@ struct ParamUnpack<absl::string_view> {
                << "Parameter contains a reference to the wrong type; have "
                << iree_vm_ref_type_name(reg_ptr->type).data << " but expected "
                << ref_type_descriptor<iree_vm_ro_byte_buffer_t>::get()
-                      ->type_name.data
-               << " (" << typeid(storage_type).name() << ")";
+                      ->type_name.data;
     } else {
       // NOTE: empty string is allowed here!
       out_param = {};

--- a/iree/vm/ref_test.cc
+++ b/iree/vm/ref_test.cc
@@ -52,12 +52,12 @@ struct ref_object_c_t {
 };
 
 template <typename T>
-static iree_vm_ref_t MakeRef() {
+static iree_vm_ref_t MakeRef(const char* type_name) {
   // Safe to do multiple times, so we do it to ensure the tests don't care what
   // order they run in/don't need to preregister types.
   static iree_vm_ref_type_descriptor_t descriptor = {0};
   if (descriptor.type == IREE_VM_REF_TYPE_NULL) {
-    descriptor.type_name = iree_make_cstring_view(typeid(T).name());
+    descriptor.type_name = iree_make_cstring_view(type_name);
     descriptor.offsetof_counter = T::offsetof_counter();
     descriptor.destroy = T::DirectDestroy;
     IREE_CHECK_OK(iree_vm_ref_register_type(&descriptor));
@@ -79,8 +79,7 @@ static iree_vm_ref_type_t kCTypeID = IREE_VM_REF_TYPE_NULL;
 static void RegisterTypeC() {
   static iree_vm_ref_type_descriptor_t descriptor = {0};
   if (descriptor.type == IREE_VM_REF_TYPE_NULL) {
-    descriptor.type_name =
-        iree_make_cstring_view(typeid(ref_object_c_t).name());
+    descriptor.type_name = iree_make_cstring_view("CType");
     descriptor.offsetof_counter = offsetof(ref_object_c_t, ref_object.counter);
     descriptor.destroy =
         +[](void* ptr) { delete reinterpret_cast<ref_object_c_t*>(ptr); };
@@ -92,8 +91,8 @@ static void RegisterTypeC() {
 // Tests type registration and lookup.
 TEST(VMRefTest, TypeRegistration) {
   RegisterTypeC();
-  ASSERT_NE(nullptr, iree_vm_ref_lookup_registered_type(iree_make_cstring_view(
-                         typeid(ref_object_c_t).name())));
+  ASSERT_NE(nullptr, iree_vm_ref_lookup_registered_type(
+                         iree_make_cstring_view("CType")));
   ASSERT_EQ(nullptr, iree_vm_ref_lookup_registered_type(
                          iree_make_cstring_view("asodjfaoisdjfaoisdfj")));
 }
@@ -121,7 +120,7 @@ TEST(VMRefTest, WrappingSubclassedRefObject) {
   };
 
   static iree_vm_ref_type_descriptor_t descriptor;
-  descriptor.type_name = iree_make_cstring_view(typeid(BaseType).name());
+  descriptor.type_name = iree_make_cstring_view("BaseType");
   descriptor.offsetof_counter = BaseType::offsetof_counter();
   descriptor.destroy = BaseType::DirectDestroy;
   IREE_ASSERT_OK(iree_vm_ref_register_type(&descriptor));
@@ -170,7 +169,7 @@ TEST(VMRefTest, CheckNull) {
 
 // Tests type checks.
 TEST(VMRefTest, Check) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   IREE_EXPECT_OK(iree_vm_ref_check(&a_ref, A::kTypeID));
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         ::iree::Status(iree_vm_ref_check(&a_ref, B::kTypeID)));
@@ -186,7 +185,7 @@ TEST(VMRefTest, RetainNull) {
 
 // Tests that retaining into itself only increments the count.
 TEST(VMRefTest, RetainIntoSelf) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_retain(&a_ref, &a_ref);
   EXPECT_EQ(2, ReadCounter(&a_ref));
@@ -199,8 +198,8 @@ TEST(VMRefTest, RetainIntoSelf) {
 
 // Tests that retaining into out_ref releases the existing contents.
 TEST(VMRefTest, RetainReleasesExisting) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
-  iree_vm_ref_t b_ref = MakeRef<B>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
+  iree_vm_ref_t b_ref = MakeRef<B>("BType");
   iree_vm_ref_retain(&a_ref, &b_ref);
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref, &b_ref));
   EXPECT_EQ(2, ReadCounter(&a_ref));
@@ -218,7 +217,7 @@ TEST(VMRefTest, RetainCheckedNull) {
 
 // Tests that types are verified and retains fail if types don't match.
 TEST(VMRefTest, RetainChecked) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   IREE_EXPECT_OK(iree_vm_ref_retain_checked(&a_ref_0, A::kTypeID, &a_ref_1));
   iree_vm_ref_release(&a_ref_0);
@@ -235,7 +234,7 @@ TEST(VMRefTest, RetainOrMoveNull) {
 
 // Tests that is_move=false increments the ref count.
 TEST(VMRefTest, RetainOrMoveRetaining) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   iree_vm_ref_retain_or_move(/*is_move=*/0, &a_ref_0, &a_ref_1);
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref_0, &a_ref_1));
@@ -246,7 +245,7 @@ TEST(VMRefTest, RetainOrMoveRetaining) {
 
 // Tests that is_move=true does not increment the ref count.
 TEST(VMRefTest, RetainOrMoveMoving) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   iree_vm_ref_retain_or_move(/*is_move=*/1, &a_ref_0, &a_ref_1);
   IREE_EXPECT_OK(iree_vm_ref_check(&a_ref_0, IREE_VM_REF_TYPE_NULL));
@@ -255,7 +254,7 @@ TEST(VMRefTest, RetainOrMoveMoving) {
 
 // Tests that retaining into itself just increments the ref count.
 TEST(VMRefTest, RetainOrMoveRetainingIntoSelf) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_retain_or_move(/*is_move=*/0, &a_ref, &a_ref);
   EXPECT_EQ(2, ReadCounter(&a_ref));
@@ -268,7 +267,7 @@ TEST(VMRefTest, RetainOrMoveRetainingIntoSelf) {
 
 // Tests that moving into itself is a no-op.
 TEST(VMRefTest, RetainOrMoveMovingIntoSelf) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   iree_vm_ref_retain_or_move(/*is_move=*/1, &a_ref, &a_ref);
   IREE_EXPECT_OK(iree_vm_ref_check(&a_ref, A::kTypeID));
   iree_vm_ref_release(&a_ref);
@@ -276,8 +275,8 @@ TEST(VMRefTest, RetainOrMoveMovingIntoSelf) {
 
 // Tests that retaining into out_ref releases the existing contents.
 TEST(VMRefTest, RetainOrMoveRetainingReleasesExisting) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
-  iree_vm_ref_t b_ref = MakeRef<B>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
+  iree_vm_ref_t b_ref = MakeRef<B>("BType");
   iree_vm_ref_retain_or_move(/*is_move=*/0, &a_ref, &b_ref);
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref, &b_ref));
   EXPECT_EQ(2, ReadCounter(&a_ref));
@@ -287,8 +286,8 @@ TEST(VMRefTest, RetainOrMoveRetainingReleasesExisting) {
 
 // Tests that moving into out_ref releases the existing contents.
 TEST(VMRefTest, RetainOrMoveMovingReleasesExisting) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
-  iree_vm_ref_t b_ref = MakeRef<B>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
+  iree_vm_ref_t b_ref = MakeRef<B>("BType");
   iree_vm_ref_retain_or_move(/*is_move=*/1, &a_ref, &b_ref);
   EXPECT_EQ(0, iree_vm_ref_equal(&a_ref, &b_ref));
   EXPECT_EQ(1, ReadCounter(&b_ref));
@@ -308,7 +307,7 @@ TEST(VMRefTest, RetainOrMoveCheckedNull) {
 // Tests that retains/moves work when types match.
 TEST(VMRefTest, RetainOrMoveCheckedMatch) {
   // Retain.
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   IREE_EXPECT_OK(iree_vm_ref_retain_or_move_checked(
       /*is_move=*/0, &a_ref_0, A::kTypeID, &a_ref_1));
@@ -318,7 +317,7 @@ TEST(VMRefTest, RetainOrMoveCheckedMatch) {
   iree_vm_ref_release(&a_ref_1);
 
   // Move.
-  iree_vm_ref_t b_ref_0 = MakeRef<B>();
+  iree_vm_ref_t b_ref_0 = MakeRef<B>("BType");
   iree_vm_ref_t b_ref_1 = {0};
   IREE_EXPECT_OK(iree_vm_ref_retain_or_move_checked(
       /*is_move=*/1, &b_ref_0, B::kTypeID, &b_ref_1));
@@ -330,7 +329,7 @@ TEST(VMRefTest, RetainOrMoveCheckedMatch) {
 // Tests that types are verified and retains/moves fail if types don't match.
 TEST(VMRefTest, RetainOrMoveCheckedMismatch) {
   // Retain.
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         ::iree::Status(iree_vm_ref_retain_or_move_checked(
@@ -340,7 +339,7 @@ TEST(VMRefTest, RetainOrMoveCheckedMismatch) {
   iree_vm_ref_release(&a_ref_0);
 
   // Move.
-  iree_vm_ref_t b_ref_0 = MakeRef<B>();
+  iree_vm_ref_t b_ref_0 = MakeRef<B>("BType");
   iree_vm_ref_t b_ref_1 = {0};
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         ::iree::Status(iree_vm_ref_retain_or_move_checked(
@@ -352,15 +351,15 @@ TEST(VMRefTest, RetainOrMoveCheckedMismatch) {
 // Tests that existing references are released when being overwritten.
 TEST(VMRefTest, RetainOrMoveCheckedReleasesExistingNull) {
   iree_vm_ref_t null_ref = {0};
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   IREE_EXPECT_OK(iree_vm_ref_retain_or_move_checked(
       /*is_move=*/0, &null_ref, A::kTypeID, &a_ref));
 }
 
 // Tests that existing references are released when being overwritten.
 TEST(VMRefTest, RetainOrMoveCheckedReleasesExisting) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
-  iree_vm_ref_t a_ref_1 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
+  iree_vm_ref_t a_ref_1 = MakeRef<A>("AType");
   IREE_EXPECT_OK(iree_vm_ref_retain_or_move_checked(
       /*is_move=*/1, &a_ref_0, A::kTypeID, &a_ref_1));
   iree_vm_ref_release(&a_ref_1);
@@ -375,7 +374,7 @@ TEST(VMRefTest, AssignNull) {
 
 // Tests that assigning does not reset the source ref nor inc the ref count.
 TEST(VMRefTest, Assign) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   iree_vm_ref_assign(&a_ref_0, &a_ref_1);
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref_0, &a_ref_1));
@@ -385,7 +384,7 @@ TEST(VMRefTest, Assign) {
 
 // Tests that assigning into itself is a no-op.
 TEST(VMRefTest, AssignSelf) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   iree_vm_ref_assign(&a_ref, &a_ref);
   EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_release(&a_ref);
@@ -393,8 +392,8 @@ TEST(VMRefTest, AssignSelf) {
 
 // Tests that assigning into out_ref releases the existing contents.
 TEST(VMRefTest, AssignReleasesExisting) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
-  iree_vm_ref_t b_ref = MakeRef<B>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
+  iree_vm_ref_t b_ref = MakeRef<B>("BType");
   iree_vm_ref_assign(&a_ref, &b_ref);
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref, &b_ref));
   EXPECT_EQ(1, ReadCounter(&a_ref));
@@ -411,7 +410,7 @@ TEST(VMRefTest, MovingNull) {
 
 // Tests that moving resets the source ref.
 TEST(VMRefTest, MovingResetsSource) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
   iree_vm_ref_t a_ref_1 = {0};
   iree_vm_ref_move(&a_ref_0, &a_ref_1);
   IREE_EXPECT_OK(iree_vm_ref_check(&a_ref_0, IREE_VM_REF_TYPE_NULL));
@@ -420,7 +419,7 @@ TEST(VMRefTest, MovingResetsSource) {
 
 // Tests that moving into itself is a no-op.
 TEST(VMRefTest, MovingIntoSelf) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   iree_vm_ref_move(&a_ref, &a_ref);
   IREE_EXPECT_OK(iree_vm_ref_check(&a_ref, A::kTypeID));
   iree_vm_ref_release(&a_ref);
@@ -428,8 +427,8 @@ TEST(VMRefTest, MovingIntoSelf) {
 
 // Tests that moving into out_ref releases the existing contents.
 TEST(VMRefTest, MovingReleasesExisting) {
-  iree_vm_ref_t a_ref_0 = MakeRef<A>();
-  iree_vm_ref_t a_ref_1 = MakeRef<A>();
+  iree_vm_ref_t a_ref_0 = MakeRef<A>("AType");
+  iree_vm_ref_t a_ref_1 = MakeRef<A>("AType");
   iree_vm_ref_move(&a_ref_0, &a_ref_1);
   iree_vm_ref_release(&a_ref_1);
 }
@@ -445,7 +444,7 @@ TEST(VMRefTest, EqualityNull) {
 
 // Tests comparing with self and against null.
 TEST(VMRefTest, EqualitySelfOrNull) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
   iree_vm_ref_t null_ref = {0};
   EXPECT_EQ(1, iree_vm_ref_equal(&a_ref, &a_ref));
   EXPECT_EQ(0, iree_vm_ref_equal(&a_ref, &null_ref));
@@ -455,8 +454,8 @@ TEST(VMRefTest, EqualitySelfOrNull) {
 
 // Tests comparing between different types.
 TEST(VMRefTest, EqualityDifferentTypes) {
-  iree_vm_ref_t a_ref = MakeRef<A>();
-  iree_vm_ref_t b_ref = MakeRef<B>();
+  iree_vm_ref_t a_ref = MakeRef<A>("AType");
+  iree_vm_ref_t b_ref = MakeRef<B>("BType");
   EXPECT_EQ(0, iree_vm_ref_equal(&a_ref, &b_ref));
   EXPECT_EQ(0, iree_vm_ref_equal(&b_ref, &a_ref));
   iree_vm_ref_release(&b_ref);


### PR DESCRIPTION
* Enables them for python bindings.
* Configures SPIRV-Cross to use assertions instead.
* Fix a number of non load bearing typeid() name lookups in the VM.