### PR TITLE
Importers should print the generic op form.

### DIFF
--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -54,7 +54,7 @@ class TfCompilerTest(tf.test.TestCase):
   def testImportSavedModel(self):
     import_mlir = compile_saved_model(self.smdir,
                                       import_only=True).decode("utf-8")
-    self.assertIn("func @simple_matmul", import_mlir)
+    self.assertIn("sym_name = \"simple_matmul\"", import_mlir)
 
   def testCompileSavedModel(self):
     binary = compile_saved_model(self.smdir,

--- a/integrations/tensorflow/compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/compiler/iree-import-tflite-main.cpp
@@ -113,6 +113,7 @@ int main(int argc, char **argv) {
     }
     OpPrintingFlags printFlags;
     printFlags.enableDebugInfo();
+    printFlags.printGenericOpForm();
     module->print(outputFile->os(), printFlags);
     outputFile->os() << "\n";
     outputFile->keep();

--- a/integrations/tensorflow/compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/compiler/iree-import-xla-main.cpp
@@ -161,6 +161,7 @@ int main(int argc, char **argv) {
     }
     OpPrintingFlags printFlags;
     printFlags.enableDebugInfo();
+    printFlags.printGenericOpForm();
     module->print(outputFile->os(), printFlags);
     outputFile->os() << "\n";
     outputFile->keep();

--- a/integrations/tensorflow/compiler/iree-tf-import-main.cpp
+++ b/integrations/tensorflow/compiler/iree-tf-import-main.cpp
@@ -182,6 +182,7 @@ int main(int argc, char **argv) {
     }
     OpPrintingFlags printFlags;
     printFlags.enableDebugInfo();
+    printFlags.printGenericOpForm();
     module->print(outputFile->os(), printFlags);
     outputFile->os() << "\n";
     outputFile->keep();


### PR DESCRIPTION
* I've just made this non optional for now. Anyone wanting to inspect this can trivially pipe it back through the MLIR API for further work and better output.
* Fixes: #4441