### PR TITLE
Annotate XLA imported module @main functions with iree.module.export.

### DIFF
--- a/bindings/python/tests/compiler_xla_test.py
+++ b/bindings/python/tests/compiler_xla_test.py
@@ -36,6 +36,7 @@ class CompilerTest(unittest.TestCase):
     text = compile_file(path, import_only=True).decode("utf-8")
     logging.info("%s", text)
     self.assertIn("mhlo.constant", text)
+    self.assertIn("iree.module.export", text)
 
   def testCompileBinaryPbFile(self):
     path = os.path.join(os.path.dirname(__file__), "testdata", "xla_sample.pb")

--- a/integrations/tensorflow/compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/compiler/iree-import-xla-main.cpp
@@ -27,6 +27,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/FileUtilities.h"
 #include "tensorflow/compiler/mlir/xla/hlo_to_mlir_hlo.h"
 #include "tensorflow/compiler/xla/service/hlo.pb.h"
@@ -151,6 +152,19 @@ int main(int argc, char **argv) {
                  << status.ToString() << "\n";
     return 2;
   }
+
+  // Find the entry function an annotate it as exported.
+  // Note that the XLA importer always produced an MLIR module with a @main
+  // function.
+  std::string entryName = "main";
+  SymbolTable symbolTable(module.get());
+  Operation *mainFunc = symbolTable.lookup(entryName);
+  if (!mainFunc) {
+    llvm::errs() << "Unable to find main function '" << entryName
+                 << "' in converted module.\n";
+    return 3;
+  }
+  mainFunc->setAttr("iree.module.export", UnitAttr::get(&context));
 
   // Save.
   auto saveToFile = [&](llvm::StringRef savePath) -> LogicalResult {


### PR DESCRIPTION
* We would like to eliminate the need to do this, but it makes the setup work for now.
* Fixes #4444