### PR TITLE
Let iree_cc_library mirror Bazel cc_library more faithfully.

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -164,16 +164,6 @@ function(iree_cc_library)
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
     )
-    target_compile_options(${_NAME}
-      INTERFACE
-        ${IREE_DEFAULT_COPTS}
-        ${_RULE_COPTS}
-    )
-    target_link_options(${_NAME}
-      INTERFACE
-        ${IREE_DEFAULT_LINKOPTS}
-        ${_RULE_LINKOPTS}
-    )
     target_link_libraries(${_NAME}
       INTERFACE
         ${_RULE_DEPS}


### PR DESCRIPTION
In Bazel, in cc_library, copts and linkopts apply only to the library
itself, not its dependents. In a header-only cc_library, copts and linkopts
are ignored.

Note: I checked locally by adding a `if()` with a `message()` in this CMake code: there are currently no `INTERFACES` with `COPTS` or `LINKOPTS`.