### PR TITLE
Add a new option for address sanitization with assertion message  (unimplemented feature yet)

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
@@ -66,6 +66,8 @@ std::unique_ptr<llvm::TargetMachine> createTargetMachine(
 LogicalResult runLLVMIRPasses(const LLVMTargetOptions &options,
                               llvm::TargetMachine *machine,
                               llvm::Module *module) {
+  if(options.addressSanitizer)
+    assert(false && "Address Sanitization feature has not been implemented yet.");
   llvm::LoopAnalysisManager loopAnalysisManager;
   llvm::FunctionAnalysisManager functionAnalysisManager;
   llvm::CGSCCAnalysisManager cGSCCAnalysisManager;

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -34,7 +34,7 @@ LLVMTargetOptions getDefaultLLVMTargetOptions() {
   {
     llvm::SubtargetFeatures features;
     llvm::StringMap<bool> hostFeatures;
-    if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
+    	if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
       for (auto &feature : hostFeatures) {
         features.AddFeature(feature.first(), feature.second);
       }
@@ -106,6 +106,13 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       llvm::cl::desc("Generate and embed debug information (DWARF, PDB, etc)"),
       llvm::cl::init(llvmTargetOptions.debugSymbols));
   llvmTargetOptions.debugSymbols = clDebugSymbols;
+
+  static llvm::cl::opt<bool> clAddressSanitizer(
+      "iree-llvm-address-sanitizer",
+      llvm::cl::desc("Turn on address sanitization to detect memory violations"),
+      llvm::cl::init(llvmTargetOptions.addressSanitizer));
+//  if(clAddressSanitizer)
+  llvmTargetOptions.addressSanitizer = clAddressSanitizer;
 
   static llvm::cl::opt<bool> clLinkStatic(
       "iree-llvm-link-static",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -38,6 +38,7 @@ struct LLVMTargetOptions {
   // information is valid) it may significantly change the output program
   // and benchmarking
   bool debugSymbols = true;
+  bool addressSanitizer = false;
 
   // Link any required runtime libraries into the produced binaries statically.
   // This increases resulting binary size but enables the binaries to be used on


### PR DESCRIPTION
Added a new option -iree-llvm-address-sanitizer to iree-translate, but it's feature is not implemented yet.
Assertion error occurs when the new option is turned on from debug mode. On release mode, it ignores the option since it is not implemented yet.