### PR TITLE
Enable SGD training tests

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -68,4 +68,4 @@ cd ../iree-build/
 ninja
 
 echo "Testing with CTest"
-ctest -R 'tensorflow_e2e|bindings/python'
+ctest -R 'tensorflow_e2e|bindings/python|integrations/tensorflow/'

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -68,4 +68,4 @@ cd ../iree-build/
 ninja
 
 echo "Testing with CTest"
-ctest -R 'tensorflow_e2e|bindings/python'
+ctest -R 'tensorflow_e2e|bindings/python|integrations/tensorflow/'

--- a/integrations/tensorflow/e2e/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/CMakeLists.txt
@@ -138,3 +138,5 @@ function(add_all_e2e_tests pattern)
 endfunction()
 
 add_all_e2e_tests("*_test.py")
+
+add_subdirectory(keras)

--- a/integrations/tensorflow/e2e/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(keras)
+
 # Special cases to exclude from automatically expanding targets for all
 # backends.
 set(SPECIAL_CASES
@@ -138,5 +140,3 @@ function(add_all_e2e_tests pattern)
 endfunction()
 
 add_all_e2e_tests("*_test.py")
-
-add_subdirectory(keras)

--- a/integrations/tensorflow/e2e/keras/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integrations/tensorflow/e2e/keras/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(train)

--- a/integrations/tensorflow/e2e/keras/train/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/train/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integrations/tensorflow/e2e/keras/train/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/train/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(REFERENCE_BACKEND tf)
+
+function(add_e2e_test filename target_backend labels)
+  iree_package_ns(_PACKAGE_NS)
+  string(REPLACE "::" "/" _PACKAGE_PATH ${_PACKAGE_NS})
+  string(REPLACE ".py" "" _name ${filename})
+
+  set(_name "${_PACKAGE_PATH}/${_name}__${target_backend}")
+  add_test(
+    NAME
+      ${_name}
+    WORKING_DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND
+      "${Python3_EXECUTABLE}" -B
+      "${CMAKE_CURRENT_SOURCE_DIR}/${filename}"
+      "--reference_backend=${REFERENCE_BACKEND}"
+      "--target_backends=${target_backend}"
+  )
+  set_property(TEST ${_name} PROPERTY LABELS "${labels}")
+  set_property(TEST ${_name} PROPERTY ENVIRONMENT
+      "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python")
+endfunction()
+
+add_e2e_test(regression_training_test.py tf "")
+add_e2e_test(regression_training_test.py iree_vmla "")
+add_e2e_test(regression_training_test.py iree_llvmaot "driver=dylib")
+add_e2e_test(regression_training_test.py iree_vulkan "driver=vulkan")
+
+add_e2e_test(classification_training_test.py tf "")
+add_e2e_test(classification_training_test.py iree_vmla "")
+add_e2e_test(classification_training_test.py iree_llvmaot "driver=dylib")
+add_e2e_test(classification_training_test.py iree_vulkan "driver=vulkan")


### PR DESCRIPTION
- Explicitly convert inputs to `f32`.
- Compare model weights and biases across backends.
- Add CMake configuration for testing in OSS.

I am adding these tests in OSS before we figure out the long-term structure for the e2e CMake build since they cannot be enabled internally at this time.