### PR TITLE
revert the part of PR #4453 about linkopts

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -164,6 +164,11 @@ function(iree_cc_library)
         "$<BUILD_INTERFACE:${IREE_SOURCE_DIR}>"
         "$<BUILD_INTERFACE:${IREE_BINARY_DIR}>"
     )
+    target_link_options(${_NAME}
+      INTERFACE
+        ${IREE_DEFAULT_LINKOPTS}
+        ${_RULE_LINKOPTS}
+    )
     target_link_libraries(${_NAME}
       INTERFACE
         ${_RULE_DEPS}


### PR DESCRIPTION
Linkopts are inherited by dependent rules, thanks @GMNGeoffrey!