### PR TITLE
Drop WHOLEARCHIVE leftovers

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -67,7 +67,7 @@ include(CMakeParseArguments)
 function(iree_cc_library)
   cmake_parse_arguments(
     _RULE
-    "PUBLIC;TESTONLY;SHARED;WHOLEARCHIVE"
+    "PUBLIC;TESTONLY;SHARED"
     "NAME"
     "HDRS;TEXTUAL_HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS;INCLUDES"
     ${ARGN}

--- a/iree/tools/android/run_module_app/CMakeLists.txt
+++ b/iree/tools/android/run_module_app/CMakeLists.txt
@@ -49,5 +49,4 @@ iree_cc_library(
     "-landroid"
     "-llog"
   SHARED
-  WHOLEARCHIVE
 )


### PR DESCRIPTION
Linking as whole archive is neither necessary any more nor supported.