### PR TITLE
Fix type mismatch between definition and declaration.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -61,7 +61,7 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createLinalgTileAndDistributeOnTensorsPass();
 
 /// Pass to perform linalg on tensor bufferization.
-std::unique_ptr<OperationPass<FuncOp>> createLinalgLLVMBufferizePass();
+std::unique_ptr<FunctionPass> createLinalgLLVMBufferizePass();
 
 /// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the


### PR DESCRIPTION
 This is potentially causing windows build failure.