### PR TITLE
Add basic support for fusion in dispatch region formation.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM2.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM2.cpp
@@ -262,10 +262,12 @@ class ConvertHALInterfaceLoadConstant : public ConvertToLLVMPattern {
         llvmFuncOp.getArgument(kIndexPushConstant), llvmPushConstantOffset);
     Value llvmPushConstantValue =
         rewriter.create<LLVM::LoadOp>(loc, llvmPushConstantOffsetAddr);
-    Value indexValue = rewriter.create<LLVM::ZExtOp>(
-        loc, llvmTypeConverter->convertType(rewriter.getIndexType()),
-        llvmPushConstantValue);
-    rewriter.replaceOp(op, indexValue);
+    if (interfaceLoadConstantOp.result().getType().isIndex()) {
+      llvmPushConstantValue = rewriter.create<LLVM::ZExtOp>(
+          loc, llvmTypeConverter->convertType(rewriter.getIndexType()),
+          llvmPushConstantValue);
+    }
+    rewriter.replaceOp(op, llvmPushConstantValue);
     return success();
   }
 };

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1,35 +1,38 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass='tile-sizes=1,2' -cse %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass='tile-sizes=1,2' -canonicalize -cse %s | IreeFileCheck %s
 
 // CHECK-DAG: #[[$MAP:.*]] = affine_map<(d0) -> (2, -d0 + 4)>
 
 // CHECK-LABEL: func @tensor
 func @tensor() -> tensor<2x4xf32> {
+  //  CHECK-DAG: %[[C2outer:.*]] = constant 2 : index
   //  CHECK-DAG: %[[C1wg:.*]] = constant 1 : index
-  //  CHECK-DAG: %[[outerA:.*]] = iree.unfoldable_constant {{.*}} : tensor<2x3xf32>
-  //  CHECK-DAG: %[[outerB:.*]] = iree.unfoldable_constant {{.*}} : tensor<3x4xf32>
-  //  CHECK-DAG: %[[outerC:.*]] = iree.unfoldable_constant {{.*}} : tensor<2x4xf32>
+  //  CHECK-DAG: %[[outerA:.*]] = iree.do_not_optimize{{.*}} : tensor<2x3xf32>
+  //  CHECK-DAG: %[[outerB:.*]] = iree.do_not_optimize{{.*}} : tensor<3x4xf32>
+  //  CHECK-DAG: %[[outerC:.*]] = iree.do_not_optimize{{.*}} : tensor<2x4xf32>
   %A = iree.unfoldable_constant dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf32>
   %B = iree.unfoldable_constant dense<[[1.0, 2.0, 3.0, 4.0],
                        [5.0, 6.0, 7.0, 8.0],
                        [9.0, 10.0, 11.0, 12.0]]> : tensor<3x4xf32>
   %C = iree.unfoldable_constant dense<1000.0> : tensor<2x4xf32>
 
-  //      CHECK: flow.dispatch.workgroups[%[[C1wg]], %[[C1wg]], %[[C1wg]]] (%[[outerA]], %[[outerB]], %[[outerC]]) :
-  // CHECK-SAME:    (tensor<2x3xf32>, tensor<3x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32> =
-  // CHECK-SAME:    (%[[A:[0-9a-z]*]] : !flow.dispatch.input<2x3xf32>,
+  // %[[C2]] will be handled by a later RematerializeDispatchConstants
+  //      CHECK: flow.dispatch.workgroups[%[[C1wg]], %[[C1wg]], %[[C1wg]]] (%[[C2outer]], %[[outerA]], %[[outerB]], %[[outerC]]) :
+  // CHECK-SAME:    (index, tensor<2x3xf32>, tensor<3x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32> =
+  // CHECK-SAME:    (%[[C2:[0-9a-z]*]] : index,
+  // CHECK-SAME:     %[[A:[0-9a-z]*]] : !flow.dispatch.input<2x3xf32>,
   // CHECK-SAME:     %[[B:[0-9a-z]*]] : !flow.dispatch.input<3x4xf32>,
   // CHECK-SAME:     %[[C:[0-9a-z]*]] : !flow.dispatch.input<2x4xf32>,
   // CHECK-SAME:     %[[OUT:[0-9a-z]*]] : !flow.dispatch.output<2x4xf32>) {
   //  CHECK-DAG:   %[[C0:.*]] = constant 0 : index
   //  CHECK-DAG:   %[[C1:.*]] = constant 1 : index
-  //  CHECK-DAG:   %[[C2:.*]] = constant 2 : index
+  //  CHECK-DAG:   %[[C2inner:.*]] = constant 2 : index
   //  CHECK-DAG:   %[[C3:.*]] = constant 3 : index
   //  CHECK-DAG:   %[[C4:.*]] = constant 4 : index
   //  CHECK-DAG:   %[[bix:.*]] = flow.dispatch.workgroup.id[0] : index
   //  CHECK-DAG:   %[[bdx:.*]] = flow.dispatch.workgroup.count[0] : index
   //  CHECK-DAG:   %[[biy:.*]] = flow.dispatch.workgroup.id[1] : index
   //  CHECK-DAG:   %[[bdy:.*]] = flow.dispatch.workgroup.count[1] : index
-  //      CHECK:   scf.for %[[I:.*]] = %[[biy]] to %[[C2]] step %[[bdy]] {
+  //      CHECK:   scf.for %[[I:.*]] = %[[biy]] to %[[C2inner]] step %[[bdy]] {
   // CHECK-NEXT:     %[[bix_scaled:.*]] = muli %[[bix]], %[[C2]] : index
   // CHECK-NEXT:     %[[bdx_scaled:.*]] = muli %[[bdx]], %[[C2]] : index
   // CHECK-NEXT:     scf.for %[[J:.*]] = %[[bix_scaled]] to %[[C4]] step %[[bdx_scaled]] {
@@ -41,10 +44,10 @@ func @tensor() -> tensor<2x4xf32> {
   //
   // Canonicalizations not yet powerful enough here.
   // CHECK-NEXT:       %[[MIN_J:.*]] = affine.min{{.*}}(%[[J]])
-  // CHECK-NEXT:       %[[BB:.*]] = flow.dispatch.input.load %arg1,
+  // CHECK-NEXT:       %[[BB:.*]] = flow.dispatch.input.load %[[B]],
   // CHECK-SAME:         offsets = [%[[C0]], %[[J]]], sizes = [%[[C3]], %[[MIN_J]]], strides = [%[[C1]], %[[C1]]] :
   // CHECK-SAME:           !flow.dispatch.input<3x4xf32> -> tensor<3x?xf32>
-  // CHECK-NEXT:       %[[CC:.*]] = flow.dispatch.input.load %arg2,
+  // CHECK-NEXT:       %[[CC:.*]] = flow.dispatch.input.load %[[C]],
   // CHECK-SAME:         offsets = [%[[I]], %[[J]]], sizes = [%[[MIN_I]], %[[MIN_J]]], strides = [%[[C1]], %[[C1]]] :
   // CHECK-SAME:           !flow.dispatch.input<2x4xf32> -> tensor<?x?xf32>
   // CHECK-NEXT:       %[[RES:.*]] = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%[[AA]], %[[BB]] :
@@ -58,4 +61,117 @@ func @tensor() -> tensor<2x4xf32> {
   %E = linalg.matmul ins(%A, %B: tensor<2x3xf32>, tensor<3x4xf32>)
                     outs(%C: tensor<2x4xf32>) -> tensor<2x4xf32>
   return %E : tensor<2x4xf32>
+}
+
+// CHECK-LABEL: func @tensor2
+func @tensor2(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %f12 = constant 12.0 : f32
+
+  // linalg.generic is fused inside the dispatch region and becomes a noop.
+  // CHECK-NOT: generic
+  %AA = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%A : tensor<?x?xf32>) {
+    ^bb0(%a: f32):
+      linalg.yield %f12 : f32
+    } -> tensor<?x?xf32>
+
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:  scf.for
+  // CHECK:    scf.for
+  // CHECK:      %[[AA:.*]] = linalg.generic
+  // CHECK:      linalg.matmul{{.*}} ins(%[[AA]], %{{.}}
+  %D = linalg.matmul ins(%AA, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func @tensor3
+func @tensor3(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %f12 = constant 12.0 : f32
+
+  // linalg.generic is fused inside the dispatch region and becomes a noop.
+  // CHECK-NOT: generic
+  %BB = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%B : tensor<?x?xf32>) {
+    ^bb0(%b: f32):
+      linalg.yield %f12 : f32
+    } -> tensor<?x?xf32>
+
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:  scf.for
+  // CHECK:    scf.for
+  // CHECK:      %[[BB:.*]] = linalg.generic{{.*}}
+  // CHECK:      linalg.matmul{{.*}} ins(%{{.*}}, %[[BB]]
+  %D = linalg.matmul ins(%A, %BB: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}
+
+
+// CHECK-LABEL: func @tensor4
+func @tensor4(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %f12 = constant 12.0 : f32
+
+  // linalg.generic is fused inside the dispatch region and becomes dead.
+  // CHECK-NOT: generic
+  %CC = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%C : tensor<?x?xf32>) {
+    ^bb0(%c: f32):
+      linalg.yield %f12 : f32
+    } -> tensor<?x?xf32>
+
+  //     CHECK: flow.dispatch.workgroups
+  // CHECK-NOT:   generic
+  //     CHECK:   scf.for
+  //     CHECK:     scf.for
+  //     CHECK:       %[[CC:.*]] = linalg.generic
+  //     CHECK:       linalg.matmul{{.*}} outs(%[[CC]]
+  %D = linalg.matmul ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%CC: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func @tensor5
+func @tensor5(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> (tensor<?x?xf32>, tensor<?x?xf32>) attributes {iree.module.export}
+{
+  %f12 = constant 12.0 : f32
+
+  // linalg.generic is fused inside the dispatch region and becomes a noop but
+  // there is still a use.
+  // CHECK: %[[origCC:.*]] = linalg.generic
+  %CC = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%C : tensor<?x?xf32>) {
+    ^bb0(%c: f32):
+      linalg.yield %f12 : f32
+    } -> tensor<?x?xf32>
+
+  //     CHECK: %[[D:.*]] = flow.dispatch.workgroups
+  // Check origCC is not an operand of flow.dispatch.workgroups
+  // CHECK-NOT: %[[origCC]],
+  // CHECK-NOT:   linalg.generic
+  //     CHECK:   scf.for
+  //     CHECK:     scf.for
+  //     CHECK:       %[[CC:.*]] = linalg.generic
+  //     CHECK:       linalg.matmul{{.*}} outs(%[[CC]]
+  %D = linalg.matmul ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%CC: tensor<?x?xf32>) -> tensor<?x?xf32>
+
+  // CHECK: %[[retD:.*]] = shapex.tie_shape %[[D]]
+  // CHECK: return %[[retD]], %[[origCC]]
+  return %D, %CC: tensor<?x?xf32>, tensor<?x?xf32>
 }


### PR DESCRIPTION
This revision shows how to enable fusion incrementally in the context of dispatch region formation on linalg on tensors.
The dispatch pattern is temporarily modified to only apply to MatmulOp and is extended to only fuse the first producer.

This is meant to be refactored and extended in real-world scenarios, the current revision exercises proper DispatchWorkgroupOp operand and BBarg formation in the context of fusion.

PiperOrigin-RevId: 351352845