### PR TITLE
Add e2e tests that also exercise fusion.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -113,8 +113,10 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
     passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
     passManager.addNestedPass<FuncOp>(createCSEPass());
     passManager.addPass(createCopyRemovalPass());
-    passManager.addPass(createBufferHoistingPass());
-    passManager.addPass(createBufferLoopHoistingPass());
+    // passManager.addPass(createBufferHoistingPass());
+    // TODO(nicolasvasilache): bug in buffer loop hoisting with
+    // dynamic_linalg_matmul_on_tensors_fuse_0.mlir
+    // passManager.addPass(createBufferLoopHoistingPass());
     passManager.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
   } else {
     passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
@@ -70,6 +70,8 @@ static LogicalResult convertToDispatchOp(DispatchWorkgroupsOp regionOp,
   SmallVector<Value, 4> newOperands;
   for (auto operand : regionOp.operands()) {
     newOperands.push_back(operand);
+  }
+  for (auto operand : regionOp.operands()) {
     if (operand.getType().isa<TensorType>()) {
       insertDynamicShapeDimOperands(regionOp, operand, newOperands, builder);
     }

--- a/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_0.mlir
+++ b/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_0.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-run-mlir %s -export-all -iree-hal-target-backends=dylib-llvm-aot -iree-flow-dispatch-linalg-on-tensors -iree-flow-dispatch-linalg-on-tensors-tile-sizes="1,1" -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="2x3xf32=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]"  -function-input="3x4xf32=[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]"  -function-input="2x4xf32=[[1000.0, 1000.0, 1000.0, 1000.0], [1000.0, 1000.0, 1000.0, 1000.0]]" | IreeFileCheck %s
+
+// CHECK: EXEC @main
+// CHECK: 2x4xf32=[985 982 979 976][985 982 979 976]
+func @main(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %AA = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%A : tensor<?x?xf32>) {
+    ^bb0(%b: f32):
+      // TODO(nicolasvasilache): The constant ends up being hoisted and turns
+      // into a pushconstant. But pushconstants must be integers, so we use
+      // sitofp to temporarily circumvent the problem.
+      %im1 = constant -1 : i32
+      %fm1 = sitofp %im1: i32 to f32
+      linalg.yield %fm1 : f32
+    } -> tensor<?x?xf32>
+  %D = linalg.matmul ins(%AA, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}

--- a/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_1.mlir
+++ b/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_1.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-run-mlir %s -export-all -iree-hal-target-backends=dylib-llvm-aot -iree-flow-dispatch-linalg-on-tensors -iree-flow-dispatch-linalg-on-tensors-tile-sizes="1,1" -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="2x3xf32=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]"  -function-input="3x4xf32=[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]"  -function-input="2x4xf32=[[1000.0, 1000.0, 1000.0, 1000.0], [1000.0, 1000.0, 1000.0, 1000.0]]" | IreeFileCheck %s
+
+// CHECK: EXEC @main
+// CHECK: 2x4xf32=[994 994 994 994][985 985 985 985]
+func @main(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %BB = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%B : tensor<?x?xf32>) {
+    ^bb0(%b: f32):
+      // TODO(nicolasvasilache): The constant ends up being hoisted and turns
+      // into a pushconstant. But pushconstants must be integers, so we use
+      // sitofp to temporarily circumvent the problem.
+      %im1 = constant -1 : i32
+      %fm1 = sitofp %im1: i32 to f32
+      linalg.yield %fm1 : f32
+    } -> tensor<?x?xf32>
+  %D = linalg.matmul ins(%A, %BB: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}

--- a/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_2.mlir
+++ b/iree/test/e2e/regression/dynamic_linalg_matmul_on_tensors_fuse_2.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-run-mlir %s -export-all -iree-hal-target-backends=dylib-llvm-aot -iree-flow-dispatch-linalg-on-tensors -iree-flow-dispatch-linalg-on-tensors-tile-sizes="1,1" -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="2x3xf32=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]"  -function-input="3x4xf32=[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]"  -function-input="2x4xf32=[[1000.0, 1000.0, 1000.0, 1000.0], [1000.0, 1000.0, 1000.0, 1000.0]]" | IreeFileCheck %s
+
+// CHECK: EXEC @main
+// CHECK: 2x4xf32=[37 43 49 55][82 97 112 127]
+func @main(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C: tensor<?x?xf32>)
+  -> tensor<?x?xf32> attributes {iree.module.export}
+{
+  %CC = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"] }
+    outs(%C : tensor<?x?xf32>) {
+    ^bb0(%c: f32):
+      // TODO(nicolasvasilache): The constant ends up being hoisted and turns
+      // into a pushconstant. But pushconstants must be integers, so we use
+      // sitofp to temporarily circumvent the problem.
+      %im1 = constant -1 : i32
+      %fm1 = sitofp %im1: i32 to f32
+      linalg.yield %fm1 : f32
+    } -> tensor<?x?xf32>
+  %D = linalg.matmul ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+                    outs(%CC: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %D: tensor<?x?xf32>
+}


### PR DESCRIPTION
A bug is exhibited in core buffer hoisting passes, so we temporarily disable them.

PiperOrigin-RevId: 351352838