### PR TITLE
Integrate Linalg on tensors path to rest of CPU backend (Part 1)

### DIFF
--- a/iree/compiler/Conversion/Common/BUILD
+++ b/iree/compiler/Conversion/Common/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "DeclareNumWorkgroupsFnPass.cpp",
         "LaunchConfig.cpp",
         "LegalizeNumWorkgroupsFnPass.cpp",
+        "RemoveDeadMemAllocsPass.cpp",
         "Transforms.cpp",
         "VectorTransferOptimization.cpp",
     ],

--- a/iree/compiler/Conversion/Common/BUILD
+++ b/iree/compiler/Conversion/Common/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",

--- a/iree/compiler/Conversion/Common/CMakeLists.txt
+++ b/iree/compiler/Conversion/Common/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
     MLIRLinalgTransforms
     MLIRPass
     MLIRSCFToStandard
+    MLIRSideEffectInterfaces
     MLIRStandard
     MLIRTransforms
     MLIRVector

--- a/iree/compiler/Conversion/Common/CMakeLists.txt
+++ b/iree/compiler/Conversion/Common/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "DeclareNumWorkgroupsFnPass.cpp"
     "LaunchConfig.cpp"
     "LegalizeNumWorkgroupsFnPass.cpp"
+    "RemoveDeadMemAllocsPass.cpp"
     "Transforms.cpp"
     "VectorTransferOptimization.cpp"
   DEPS

--- a/iree/compiler/Conversion/Common/LaunchConfig.cpp
+++ b/iree/compiler/Conversion/Common/LaunchConfig.cpp
@@ -79,6 +79,34 @@ ArrayRef<int64_t> LaunchConfig::getTileSizes(Operation *op,
   return t[level];
 }
 
+Optional<SmallVector<int64_t, 4>> LaunchConfig::getWorkgroupTileSizes(
+    unsigned numWorkgroupDims) const {
+  // The first level of tile + fuse happens at the flow level. So here need to
+  // just get the tile sizes that are decided by the launch config.  Check the
+  // tile sizes of all the operations and make sure they match upto
+  // `numWorkgroupDims`.
+  // TODO(ravishankarm): Not a great way of doing this. An alternative is to use
+  // a "rootOperation" and just return the tile sizes of the root
+  // operation. Currently the LaunchConfig has no concept of root operation, so
+  // avoiding this for now. Revisit if this doesnt work.
+  Optional<SmallVector<int64_t, 4>> workgroupTileSizes = llvm::None;
+  for (auto &it : tileSizes) {
+    TileSizesListTypeRef opTileSizesList(it.second);
+    if (opTileSizesList.empty()) return llvm::None;
+    ArrayRef<int64_t> opFirstLevelTileSize(opTileSizesList.front());
+    if (opFirstLevelTileSize.size() < numWorkgroupDims) return llvm::None;
+    opFirstLevelTileSize = opFirstLevelTileSize.take_front(numWorkgroupDims);
+    if (workgroupTileSizes) {
+      if (workgroupTileSizes.getValue() != opFirstLevelTileSize) {
+        return llvm::None;
+      }
+    } else {
+      workgroupTileSizes = llvm::to_vector<4>(opFirstLevelTileSize);
+    }
+  }
+  return workgroupTileSizes;
+}
+
 void LaunchConfig::setTileSizes(Operation *op, TileSizesListType vTileSizes) {
   tileSizes[getOrSetNewKey(op, tileSizes.size())] = vTileSizes;
 }
@@ -116,46 +144,7 @@ void LaunchConfig::setVectorize(bool enableVectorize) {
 LogicalResult propogateRootOperationLaunchConfig(
     LaunchConfig &config, linalg::LinalgOp rootOperation,
     const linalg::LinalgDependenceGraph &dependenceGraph) {
-  // Check the dependencies going into and out of the root operation. For now
-  // only the following dependencies are supported
-  // - WAW dependencies going into the root operation.
-  // - RAW dependencies going out of the root operation.
-  // - WAW dependencies going out of the root operation.
-  // i.e. there are no RAW dependences going into the root operation.
-  auto inRAWDependencies = dependenceGraph.getDependencesInto(
-      rootOperation, linalg::LinalgDependenceGraph::RAW);
-  if (!inRAWDependencies.empty()) {
-    return rootOperation.getOperation()->emitError(
-        "unhandled fusion of root operation with producer");
-  }
   auto dependences = dependenceGraph.getDependentOperations(rootOperation);
-  unsigned numOuterParallel = getNumOuterParallelLoops(rootOperation);
-
-  // Check that for all dependences into and out of the root operation,
-  // - The result expressions of the indexing maps of the fused view in the
-  //   producer and consumer must match for the parallel loops.
-  for (auto dependence :
-       dependenceGraph.getDependentOperations(rootOperation)) {
-    unsigned viewIndex = dependence.indexingOpView->getOperandNumber();
-    AffineMap indexingMap = rootOperation.getIndexingMap(viewIndex);
-    linalg::LinalgOp fusedOp =
-        cast<linalg::LinalgOp>(dependence.dependentOpView->getOwner());
-    unsigned fusedViewIndex = dependence.dependentOpView->getOperandNumber();
-    AffineMap fusedIndexingMap = fusedOp.getIndexingMap(fusedViewIndex);
-    if (indexingMap.getNumResults() < numOuterParallel ||
-        fusedIndexingMap.getNumResults() < numOuterParallel ||
-        !llvm::all_of(
-            llvm::seq<unsigned>(0, numOuterParallel),
-            [&indexingMap, fusedIndexingMap](unsigned i) {
-              return indexingMap.getResult(i).isa<AffineDimExpr>() &&
-                     fusedIndexingMap.getResult(i).isa<AffineDimExpr>() &&
-                     indexingMap.getResult(i) == fusedIndexingMap.getResult(i);
-            })) {
-      return rootOperation.getOperation()->emitError(
-          "unhandled fusion of root operation with all operations in the "
-          "dispatch region");
-    }
-  }
   // The dependent operations get the same tile size information as the root
   // operation. To propogate that information, just use the same key as the root
   // operation.

--- a/iree/compiler/Conversion/Common/LaunchConfig.cpp
+++ b/iree/compiler/Conversion/Common/LaunchConfig.cpp
@@ -96,12 +96,10 @@ Optional<SmallVector<int64_t, 4>> LaunchConfig::getWorkgroupTileSizes(
     ArrayRef<int64_t> opFirstLevelTileSize(opTileSizesList.front());
     if (opFirstLevelTileSize.size() < numWorkgroupDims) return llvm::None;
     opFirstLevelTileSize = opFirstLevelTileSize.take_front(numWorkgroupDims);
-    if (workgroupTileSizes) {
-      if (workgroupTileSizes.getValue() != opFirstLevelTileSize) {
-        return llvm::None;
-      }
-    } else {
+    if (!workgroupTileSizes) {
       workgroupTileSizes = llvm::to_vector<4>(opFirstLevelTileSize);
+    } else if (workgroupTileSizes.getValue() != opFirstLevelTileSize) {
+      return llvm::None;
     }
   }
   return workgroupTileSizes;

--- a/iree/compiler/Conversion/Common/LaunchConfig.h
+++ b/iree/compiler/Conversion/Common/LaunchConfig.h
@@ -78,6 +78,14 @@ class LaunchConfig {
   /// Returns the number of subgroups to use.
   ArrayRef<int64_t> getNumSubgroups() const { return numSubgroups; }
 
+  /// First level of tiling (and fusion) happens in the Flow dialect with
+  /// dynamic tile sizes and represented at flow.dispatch.workgroup.size. The
+  /// launch config information is used to set the tile size to a static value
+  /// as decided here. Return the static value to use.
+  /// Returns llvm::None if the assumption here is violated.
+  Optional<SmallVector<int64_t, 4>> getWorkgroupTileSizes(
+      unsigned numWorkgroupDims) const;
+
   /// Returns true if tile sizes have been computed for the operation. If tile
   /// sizes arent set, it implies operation is not to be tiled.
   bool hasTileSizes(Operation *op, size_t level = 0) const {

--- a/iree/compiler/Conversion/Common/Passes.h
+++ b/iree/compiler/Conversion/Common/Passes.h
@@ -23,6 +23,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createLegalizeNumWorkgroupsFnPass();
 /// each entry point function. The function is defined, but is populated later.
 std::unique_ptr<OperationPass<ModuleOp>> createDeclareNumWorkgroupsFnPass();
 
+/// Pass to remove operations that have allocate semantics but have no
+/// uses. These arent removed by CSE.
+std::unique_ptr<OperationPass<>> createRemoveDeadMemAllocsPass();
+
 /// Pass to optimize vector transfer_read and transfer_write.
 std::unique_ptr<FunctionPass> createVectorTransferOptimizationPass();
 

--- a/iree/compiler/Conversion/Common/Passes.h
+++ b/iree/compiler/Conversion/Common/Passes.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Pass/Pass.h"
+
 namespace mlir {
 namespace iree_compiler {
 

--- a/iree/compiler/Conversion/Common/RemoveDeadMemAllocsPass.cpp
+++ b/iree/compiler/Conversion/Common/RemoveDeadMemAllocsPass.cpp
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//===-RemoveDeadMemAllocsPass.cpp - Pass to remove dead alloc-like ops ----===//
+//
+// Pass to remove operations with Allocate MemoryEffects when the allocations
+// are dead.
+//
+//===----------------------------------------------------------------------===//
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct RemoveDeadMemAllocs : RewritePattern {
+  RemoveDeadMemAllocs(PatternBenefit benefit = 1)
+      : RewritePattern(benefit, MatchAnyOpTypeTag()) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
+    if (!memEffect || !memEffect.hasEffect<MemoryEffects::Allocate>())
+      return failure();
+    if (!op->use_empty()) return failure();
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct RemoveDeadMemAllocsPass
+    : public PassWrapper<RemoveDeadMemAllocsPass, OperationPass<>> {
+  void runOnOperation() override {
+    OwningRewritePatternList patterns;
+    patterns.insert<RemoveDeadMemAllocs>();
+    applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<>> createRemoveDeadMemAllocsPass() {
+  return std::make_unique<RemoveDeadMemAllocsPass>();
+}
+
+static PassRegistration<RemoveDeadMemAllocsPass> pass(
+    "iree-codegen-remove-dead-mem-allocs",
+    "Remove operations with Allocate semantics that have no uses",
+    [] { return std::make_unique<RemoveDeadMemAllocsPass>(); });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/Common/RemoveDeadMemAllocsPass.cpp
+++ b/iree/compiler/Conversion/Common/RemoveDeadMemAllocsPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@
 // are dead.
 //
 //===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Conversion/Common/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
@@ -34,8 +35,9 @@ struct RemoveDeadMemAllocs : RewritePattern {
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-    if (!memEffect || !memEffect.hasEffect<MemoryEffects::Allocate>())
+    if (!memEffect || !memEffect.hasEffect<MemoryEffects::Allocate>()) {
       return failure();
+    }
     if (!op->use_empty()) return failure();
     rewriter.eraseOp(op);
     return success();

--- a/iree/compiler/Conversion/Common/Transforms.cpp
+++ b/iree/compiler/Conversion/Common/Transforms.cpp
@@ -25,6 +25,7 @@
 #include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
 #include "iree/compiler/Conversion/CodegenUtils/MatmulCodegenStrategy.h"
 #include "iree/compiler/Conversion/Common/Attributes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
@@ -194,6 +195,81 @@ static Optional<linalg::TiledAndFusedLinalgOps> tileAndFuseLinalgOps(
   setMarker(tiledAndFusedOps->op, getWorkgroupMarker());
 
   return tiledAndFusedOps;
+}
+
+LogicalResult getLinalgOps(FuncOp funcOp,
+                           SmallVectorImpl<linalg::LinalgOp> &linalgOps,
+                           SmallVectorImpl<Operation *> &tiledLoops) {
+  Region &region = funcOp.body();
+  if (!llvm::hasSingleElement(region)) {
+    return funcOp.emitError("unable dispatch function with multiple blocks");
+  }
+  Block *body = &region.front();
+  auto forOps = body->getOps<scf::ForOp>();
+  while (!forOps.empty()) {
+    if (!llvm::hasSingleElement(forOps)) return failure();
+    scf::ForOp forOp = *(forOps.begin());
+    tiledLoops.push_back(forOp.getOperation());
+    body = forOp.getBody();
+    forOps = body->getOps<scf::ForOp>();
+  }
+  linalgOps = llvm::to_vector<4>(body->getOps<linalg::LinalgOp>());
+  return success();
+}
+
+namespace {
+static size_t kMaxHALDimensions = 3;
+
+/// Sets the flow.dispatch.workgroup_size operation to the constant value passed
+/// in as `tileSizes`. The number of entries in `tileSizes` is at least as much
+/// as the dimensionality of the workgroup. It is assumed that the inner-most
+/// loop is mapped to the fastest varying dimension in
+/// flow.dispatch.workgroup_size.
+class SetWorkgroupSizePattern
+    : public OpRewritePattern<IREE::HAL::InterfaceWorkgroupSizeOp> {
+ public:
+  SetWorkgroupSizePattern(MLIRContext *context, ArrayRef<int64_t> tileSizesRef,
+                          PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit),
+        tileSizes(
+            llvm::to_vector<4>(tileSizesRef.size() > kMaxHALDimensions
+                                   ? tileSizesRef.take_front(kMaxHALDimensions)
+                                   : tileSizesRef)) {}
+
+  LogicalResult matchAndRewrite(
+      IREE::HAL::InterfaceWorkgroupSizeOp workgroupSizeOp,
+      PatternRewriter &rewriter) const override {
+    int64_t dim = workgroupSizeOp.dimension().getSExtValue();
+    if (dim >= tileSizes.size()) {
+      return workgroupSizeOp.emitRemark(
+          "expected at least as many static tile sizes as the workgroup "
+          "dimensionality");
+    }
+    rewriter.replaceOpWithNewOp<ConstantIndexOp>(
+        workgroupSizeOp, tileSizes[tileSizes.size() - 1 - dim]);
+    return success();
+  }
+
+ private:
+  SmallVector<int64_t, 4> tileSizes;
+};
+}  // namespace
+
+LogicalResult materializeStaticLaunchInformation(
+    FuncOp funcOp, const LaunchConfig &launchConfig, unsigned numTiledLoops) {
+  OwningRewritePatternList patterns;
+  Optional<SmallVector<int64_t, 4>> workgroupTileSizes =
+      launchConfig.getWorkgroupTileSizes(numTiledLoops);
+  if (!workgroupTileSizes) {
+    return funcOp.emitError(
+        "unable to find static values to use for flow.dispatch.workgroup_size");
+  }
+  patterns.insert<SetWorkgroupSizePattern>(funcOp.getContext(),
+                                           workgroupTileSizes.getValue());
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    return failure();
+  }
+  return success();
 }
 
 LogicalResult tileAndFuseLinalgBufferOps(

--- a/iree/compiler/Conversion/Common/Transforms.cpp
+++ b/iree/compiler/Conversion/Common/Transforms.cpp
@@ -25,7 +25,6 @@
 #include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
 #include "iree/compiler/Conversion/CodegenUtils/MatmulCodegenStrategy.h"
 #include "iree/compiler/Conversion/Common/Attributes.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"

--- a/iree/compiler/Conversion/Common/Transforms.h
+++ b/iree/compiler/Conversion/Common/Transforms.h
@@ -34,6 +34,37 @@ namespace iree_compiler {
 void applyCanonicalizationPatternsForTiling(MLIRContext *context,
                                             Operation *op);
 
+/// Assuming that `funcOp` contains a single nested scf.for that represented the
+/// tiled+fused+distributed loops with the distribution being across workgroups,
+/// i.e.
+///
+/// scf.for ... {
+///   ...
+///   scf.for ... {
+///     ...
+///     linalg.
+///     ...
+///     linalg.
+///     ...
+///   }
+/// }
+///
+/// return the list of linalg operations in the functions. If there are no
+/// `scf.for` operations in the function return the linalg operations in the
+/// body of the function if it has a single basic block. Return failure in all
+/// other cases.
+LogicalResult getLinalgOps(FuncOp funcOp,
+                           SmallVectorImpl<linalg::LinalgOp> &linalgOps,
+                           SmallVectorImpl<Operation *> &tiledLoops);
+
+/// Using linalg on tensors for dispatch region creation does first-level of
+/// tile (fuse and distribute) during dispatch region formation and dynamic tile
+/// sizes represented as `flow.dispatch.workgroup_size`. These get mapped to
+/// static tile sizes based on target architecture and computations in the
+/// dispatch region. Replace the dynamic tile size with static tiles.
+LogicalResult materializeStaticLaunchInformation(
+    FuncOp funcOp, const LaunchConfig &launchConfig, unsigned numTiledLoops);
+
 struct TileAndFuseOptions {
   linalg::LinalgLoopDistributionOptions distributionOptions;
   linalg::AllocBufferCallbackFn allocationFn = nullptr;

--- a/iree/compiler/Conversion/Common/Transforms.h
+++ b/iree/compiler/Conversion/Common/Transforms.h
@@ -49,7 +49,7 @@ void applyCanonicalizationPatternsForTiling(MLIRContext *context,
 ///   }
 /// }
 ///
-/// return the list of linalg operations in the functions. If there are no
+/// Returns the list of linalg operations in the functions. If there are no
 /// `scf.for` operations in the function return the linalg operations in the
 /// body of the function if it has a single basic block. Return failure in all
 /// other cases.

--- a/iree/compiler/Conversion/Common/test/BUILD
+++ b/iree/compiler/Conversion/Common/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-iree_add_all_subdirs()
+# Tests for common transforms.
 
-file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
-iree_check_single_backend_test_suite(
-  NAME
-    check_llvm-ir_llvm
-  SRCS
-    "${_GLOB_X_MLIR}"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  DRIVER
-    "dylib"
-  COMPILER_FLAGS
-    "-iree-flow-dispatch-linalg-on-tensors"
-    "-iree-codegen-llvm-experimental-linalg-on-tensors"
+load("//iree:lit_test.bzl", "iree_lit_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_lit_test_suite(
+    name = "lit",
+    srcs = glob(["*.mlir"]),
+    data = [
+        "//iree/tools:IreeFileCheck",
+        "//iree/tools:iree-opt",
+    ],
 )

--- a/iree/compiler/Conversion/Common/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/Common/test/CMakeLists.txt
@@ -15,16 +15,12 @@
 iree_add_all_subdirs()
 
 file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
-iree_check_single_backend_test_suite(
+iree_lit_test_suite(
   NAME
-    check_llvm-ir_llvm
+    lit
   SRCS
     "${_GLOB_X_MLIR}"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  DRIVER
-    "dylib"
-  COMPILER_FLAGS
-    "-iree-flow-dispatch-linalg-on-tensors"
-    "-iree-codegen-llvm-experimental-linalg-on-tensors"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-opt
 )

--- a/iree/compiler/Conversion/Common/test/remove_dead_allocs.mlir
+++ b/iree/compiler/Conversion/Common/test/remove_dead_allocs.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-opt %s -iree-codegen-remove-dead-mem-allocs -split-input-file | IreeFileCheck %s
+
+func @alloc_remove(%arg0: index, %arg1: index) {
+  %0 = alloc(%arg0, %arg1) : memref<?x?xf32>
+  return
+}
+// CHECK-LABEL: func @alloc_remove
+//  CHECK-NEXT:   return
+
+// -----
+
+func @alloc_keep(%arg0: index, %arg1: index) -> memref<?x?xf32> {
+  %0 = alloc(%arg0, %arg1) : memref<?x?xf32>
+  return %0 : memref<?x?xf32>
+}
+// CHECK-LABEL: func @alloc_keep
+//  CHECK-NEXT:   %[[ALLOC:.+]] = alloc
+//  CHECK-NEXT:   return %[[ALLOC]]
+

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
@@ -181,10 +181,9 @@ Optional<LaunchConfig> initCPULaunchConfig(
       return llvm::None;                                                     \
     }                                                                        \
     rootOperation = linalgOp;                                                \
-    config.setTileSizes(                                                     \
-        op,                                                                  \
-        TileOpParameters::getSizes<opType, TilingLevel::WorkGroupTiles>(op), \
-        0);                                                                  \
+    auto opTileSizes =                                                       \
+        TileOpParameters::getSizes<opType, TilingLevel::WorkGroupTiles>(op); \
+    config.setTileSizes(op, opTileSizes, 0);                                 \
     continue;                                                                \
   }
 

--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
@@ -46,81 +46,6 @@ struct LinalgTileAndDistributePass
 };
 }  // namespace
 
-namespace {
-template <typename LinalgOpTy>
-struct TileToCPUThreads : public linalg::LinalgBaseTilingPattern {
-  using Base = linalg::LinalgBaseTilingPattern;
-  TileToCPUThreads(MLIRContext *context,
-                   const linalg::LinalgDependenceGraph &dependenceGraph,
-                   const CPUKernelDispatch &cpuKernelDispatch,
-                   linalg::LinalgTilingOptions options,
-                   linalg::LinalgMarker marker, PatternBenefit benefit = 1)
-      : Base(LinalgOpTy::getOperationName(), context, options, marker, benefit),
-        cpuKernelDispatch(cpuKernelDispatch) {}
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    // Find the parent FuncOp before tiling. If tiling succeeds, the op will be
-    // erased.
-    FuncOp funcOp = op->getParentOfType<FuncOp>();
-    linalg::TiledLinalgOp tiledLinalgOp;
-    if (!funcOp ||
-        failed(Base::matchAndRewriteBase(op, rewriter, tiledLinalgOp)) ||
-        !tiledLinalgOp.tensorResults.empty() ||
-        (funcOp->getAttr(getNumWorkgroupsFnAttrName()) &&
-         failed(createNumWorkgroupsFromResultShape(
-             rewriter, cast<linalg::LinalgOp>(op), funcOp,
-             getNumWorkgroupsFnAttrName(),
-             cpuKernelDispatch.getTileSizes<TilingLevel::WorkGroupTiles>(
-                 op))))) {
-      return failure();
-    }
-    rewriter.eraseOp(op);
-    return success();
-  }
-  CPUKernelDispatch cpuKernelDispatch;
-};
-
-template <typename LinalgOpTy>
-struct TileAndFuseToCPUThreads
-    : public linalg::LinalgTileAndFusePattern<LinalgOpTy> {
-  using Base = linalg::LinalgTileAndFusePattern<LinalgOpTy>;
-  TileAndFuseToCPUThreads(MLIRContext *context,
-                          const linalg::LinalgDependenceGraph &dependenceGraph,
-                          const CPUKernelDispatch &cpuKernelDispatch,
-                          linalg::LinalgTilingOptions tilingOptions,
-                          linalg::LinalgMarker marker,
-                          PatternBenefit benefit = 1)
-      : Base(context, dependenceGraph, tilingOptions,
-             linalg::LinalgFusionOptions().setIndicesToFuse({2}), marker,
-             marker,
-             linalg::LinalgMarker(ArrayRef<Identifier>(),
-                                  Identifier::get(getDeleteMarker(), context)),
-             benefit),
-        dependenceGraph(dependenceGraph),
-        cpuKernelDispatch(cpuKernelDispatch) {}
-
-  virtual LogicalResult matchAndRewrite(Operation *op,
-                                        PatternRewriter &rewriter) const {
-    FuncOp funcOp = op->getParentOfType<FuncOp>();
-    linalg::LinalgOp linalgOp = cast<linalg::LinalgOp>(op);
-    if (!funcOp || !dependenceGraph.hasDependentOperations(linalgOp) ||
-        failed(Base::matchAndRewrite(op, rewriter)) ||
-        failed(createNumWorkgroupsFromResultShape(
-            rewriter, cast<linalg::LinalgOp>(op), funcOp,
-            getNumWorkgroupsFnAttrName().str(),
-            cpuKernelDispatch.getTileSizes<TilingLevel::WorkGroupTiles>(op)))) {
-      return failure();
-    }
-    return success();
-  }
-
-  const linalg::LinalgDependenceGraph &dependenceGraph;
-  CPUKernelDispatch cpuKernelDispatch;
-};
-
-}  // namespace
-
 Optional<Value> allocateThreadLocalMemory(OpBuilder &b, SubViewOp subview,
                                           ArrayRef<Value> boundingSubViewSize,
                                           OperationFolder *folder) {
@@ -153,45 +78,18 @@ void LinalgTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
   ModuleOp module = getOperation();
 
-  static linalg::LinalgLoopDistributionOptions workgroupDistributionOptions = {
-      [](OpBuilder &builder, Location loc, ArrayRef<Range> parallelLoopRanges) {
-        auto numParallelDims = parallelLoopRanges.size();
-        SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
-        for (size_t dim = 0;
-             dim < std::min(numParallelDims, static_cast<size_t>(3)); ++dim) {
-          procInfo[numParallelDims - dim - 1] = {
-              builder.createOrFold<IREE::HAL::InterfaceWorkgroupIDOp>(
-                  loc, builder.getIndexType(), APInt(64, dim)),
-              builder.createOrFold<IREE::HAL::InterfaceWorkgroupCountOp>(
-                  loc, builder.getIndexType(), APInt(64, dim)),
-          };
-        }
-        return procInfo;
-      },
-      {linalg::DistributionMethod::CyclicNumProcsEqNumIters,
-       linalg::DistributionMethod::CyclicNumProcsEqNumIters,
-       linalg::DistributionMethod::CyclicNumProcsEqNumIters}};
-
   for (FuncOp funcOp : module.getOps<FuncOp>()) {
     if (!isEntryPoint(funcOp)) continue;
 
-    Region &body = funcOp.getBody();
-    if (!llvm::hasSingleElement(body.getBlocks())) {
-      funcOp.emitError("unhandled dispatch function with multiple blocks");
+    SmallVector<linalg::LinalgOp, 4> linalgOps;
+    SmallVector<Operation *, 4> tiledLoops;
+    if (failed(getLinalgOps(funcOp, linalgOps, tiledLoops))) {
       return signalPassFailure();
     }
-    Block &block = body.front();
-    auto linalgOps = block.getOps<linalg::LinalgOp>();
-    if (linalgOps.empty()) continue;
-
-    SmallVector<linalg::LinalgOp, 4> linalgOpsVec =
-        llvm::to_vector<4>(llvm::map_range(linalgOps, [](Operation *op) {
-          return cast<linalg::LinalgOp>(op);
-        }));
     linalg::Aliases aliases;
-    linalg::LinalgDependenceGraph dependenceGraph(aliases, linalgOpsVec);
+    linalg::LinalgDependenceGraph dependenceGraph(aliases, linalgOps);
     Optional<LaunchConfig> launchConfigOpt =
-        initCPULaunchConfig(context, dependenceGraph, linalgOpsVec);
+        initCPULaunchConfig(context, dependenceGraph, linalgOps);
     if (!launchConfigOpt) {
       funcOp.emitError("unable to find launch configuration");
       return signalPassFailure();
@@ -215,11 +113,39 @@ void LinalgTileAndDistributePass::runOnOperation() {
       }
     });
 
-    TileAndFuseOptions tileAndFuseOptions = {workgroupDistributionOptions,
-                                             allocateThreadLocalMemory};
-    if (failed(tileAndFuseLinalgBufferOps(funcOp, linalgOpsVec, dependenceGraph,
-                                          launchConfig, tileAndFuseOptions))) {
-      return signalPassFailure();
+    if (tiledLoops.empty()) {
+      linalg::LinalgLoopDistributionOptions workgroupDistributionOptions = {
+          [](OpBuilder &builder, Location loc,
+             ArrayRef<Range> parallelLoopRanges) {
+            auto numParallelDims = parallelLoopRanges.size();
+            SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
+            for (size_t dim = 0;
+                 dim < std::min(numParallelDims, static_cast<size_t>(3));
+                 ++dim) {
+              procInfo[numParallelDims - dim - 1] = {
+                  builder.createOrFold<IREE::HAL::InterfaceWorkgroupIDOp>(
+                      loc, builder.getIndexType(), APInt(64, dim)),
+                  builder.createOrFold<IREE::HAL::InterfaceWorkgroupCountOp>(
+                      loc, builder.getIndexType(), APInt(64, dim)),
+              };
+            }
+            return procInfo;
+          },
+          {linalg::DistributionMethod::CyclicNumProcsEqNumIters,
+           linalg::DistributionMethod::CyclicNumProcsEqNumIters,
+           linalg::DistributionMethod::CyclicNumProcsEqNumIters}};
+      TileAndFuseOptions tileAndFuseOptions = {workgroupDistributionOptions,
+                                               allocateThreadLocalMemory};
+      if (failed(tileAndFuseLinalgBufferOps(funcOp, linalgOps, dependenceGraph,
+                                            launchConfig,
+                                            tileAndFuseOptions))) {
+        return signalPassFailure();
+      }
+    } else {
+      if (failed(materializeStaticLaunchInformation(funcOp, launchConfig,
+                                                    tiledLoops.size()))) {
+        return signalPassFailure();
+      }
     }
 
     launchConfig.finalize(funcOp);

--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
@@ -119,9 +119,9 @@ void LinalgTileAndDistributePass::runOnOperation() {
              ArrayRef<Range> parallelLoopRanges) {
             auto numParallelDims = parallelLoopRanges.size();
             SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
-            for (size_t dim = 0;
-                 dim < std::min(numParallelDims, static_cast<size_t>(3));
-                 ++dim) {
+            for (size_t dim = 0,
+                        e = std::min(numParallelDims, static_cast<size_t>(3));
+                 dim < e; ++dim) {
               procInfo[numParallelDims - dim - 1] = {
                   builder.createOrFold<IREE::HAL::InterfaceWorkgroupIDOp>(
                       loc, builder.getIndexType(), APInt(64, dim)),

--- a/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
@@ -54,3 +54,58 @@ func @static_matmul(%lhs: memref<16x4xf32>, %rhs: memref<4x8xf32>, %result: memr
 //     CHECK:    %[[RHS_SUBVIEW:.+]] = subview %[[RHS]][%[[K]], %[[J]]] [1, 4] [1, 1]  : memref<4x8xf32> to memref<1x4xf32, #[[MAP3]]>
 //     CHECK:    %[[RESULT_SUBVIEW:.+]] = subview %[[RESULT]][%[[I]], %[[J]]] [2, 4] [1, 1]  : memref<16x8xf32> to memref<2x4xf32, #[[MAP3]]>
 //     CHECK:    linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]] : memref<2x1xf32, #[[MAP1]]>, memref<1x4xf32, #[[MAP3]]>) outs(%4 : memref<2x4xf32, #[[MAP3]]>)
+
+// ----
+
+func @matmul_tensors() {
+  %c2 = constant 2 : index
+  %c4 = constant 4 : index
+  %c0 = constant 0 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : memref<?xi8>
+  %1 = std.view %0[%c0][] : memref<?xi8> to memref<2x3xf32>
+  %2 = hal.interface.binding.subspan @legacy_io::@arg1[%c0] : memref<?xi8>
+  %3 = std.view %2[%c0][] : memref<?xi8> to memref<3x4xf32>
+  %4 = hal.interface.binding.subspan @legacy_io::@arg2[%c0] : memref<?xi8>
+  %5 = std.view %4[%c0][] : memref<?xi8> to memref<2x4xf32>
+  %6 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : memref<?xi8>
+  %7 = std.view %6[%c0][] : memref<?xi8> to memref<2x4xf32>
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %8 = muli %workgroup_size_y, %workgroup_id_y : index
+  %9 = muli %workgroup_size_y, %workgroup_count_y : index
+  scf.for %arg0 = %8 to %c2 step %9 {
+    %10 = muli %workgroup_size_x, %workgroup_id_x : index
+    %11 = muli %workgroup_size_x, %workgroup_count_x : index
+    scf.for %arg1 = %10 to %c4 step %11 {
+      %12 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 2)>(%arg0)[%workgroup_size_y]
+      %13 = subview %1[%arg0, 0] [%12, 3] [1, 1] : memref<2x3xf32> to memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>
+      %14 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 4)>(%arg1)[%workgroup_size_x]
+      %15 = subview %3[0, %arg1] [3, %14] [1, 1] : memref<3x4xf32> to memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+      %16 = subview %5[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+      %17 = alloc(%12, %14) : memref<?x?xf32>
+      linalg.copy(%16, %17) : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>, memref<?x?xf32>
+      linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%13, %15 : memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>, memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>) outs(%17 : memref<?x?xf32>)
+      %18 = subview %7[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+      linalg.copy(%17, %18) : memref<?x?xf32>, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+    }
+  }
+  return
+}
+// CHECK-LABEL: matmul_tensors
+//   CHECK-NOT:   hal.interface.workgroup.size
+//   CHECK-DAG:   %[[C2:.+]] = constant 2
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[WGID_X:.+]] = hal.interface.workgroup.id[0]
+//   CHECK-DAG:   %[[WGID_Y:.+]] = hal.interface.workgroup.id[1]
+//   CHECK-DAG:   %[[WGCOUNT_X:.+]] = hal.interface.workgroup.count[0]
+//   CHECK-DAG:   %[[WGCOUNT_Y:.+]] = hal.interface.workgroup.count[1]
+//       CHECK:   %[[OFFSET_Y:.+]] = muli %[[WGID_Y]], %[[C2]]
+//       CHECK:   %[[STEP_Y:.+]] = muli %[[WGCOUNT_Y]], %[[C2]]
+//       CHECK:   scf.for %{{.+}} = %[[OFFSET_Y]] to %[[C2]] step %[[STEP_Y]]
+//       CHECK:     %[[OFFSET_X:.+]] = muli %[[WGID_X]], %[[C4]]
+//       CHECK:     %[[STEP_X:.+]] = muli %[[WGCOUNT_X]], %[[C4]]
+//       CHECK:     scf.for %{{.+}} = %[[OFFSET_X]] to %[[C4]] step %[[STEP_X]]

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -436,7 +436,16 @@ def FLOW_DispatchWorkgroupSizeOp : FLOW_PureOp<"dispatch.workgroup.size", [
   let arguments = (ins IndexAttr:$dimension);
   let results = (outs FLOW_Dim:$result);
 
+  let builders = [
+    OpBuilderDAG<(ins "unsigned":$dim),
+    [{
+      build($_builder, $_state, $_builder.getIndexType(), $_builder.getIndexAttr(dim));
+    }]>,
+  ];
+
   let assemblyFormat = "`[` $dimension `]` attr-dict `:` type($result)";
+
+  let verifier = [{ return verifyDispatchWorkgroupInfoOp(*this); }];
 }
 
 def FLOW_DispatchShapeOp : FLOW_PureOp<"dispatch.shape", [

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -61,6 +61,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
 
   // Frontload linalg-on-tensors transformations and dispatch region creation.
   if (clEnableLinalgOnTensorsDispatch) {
+    addHLOToLinalgOnTensorsPasses(passManager);
     passManager.addNestedPass<FuncOp>(
         createDispatchLinalgOnTensorsPass(clLinalgOnTensorsTileSizes));
   }
@@ -184,10 +185,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // Convert into our expected input and (hopefully) some flow ops.
   passManager.addNestedPass<FuncOp>(
       IREE::Flow::createPrePartitioningConversionPass());
-
-  if (clEnableLinalgOnTensorsDispatch) {
-    addHLOToLinalgOnTensorsPasses(passManager);
-  }
 
   // First perform module-level analysis that following passes will use to query
   // per-function dispatchability information. We run this first so that it only

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -4,7 +4,6 @@
 
 // CHECK-LABEL: func @tensor
 func @tensor() -> tensor<2x4xf32> {
-  //  CHECK-DAG: %[[C2outer:.*]] = constant 2 : index
   //  CHECK-DAG: %[[C1wg:.*]] = constant 1 : index
   //  CHECK-DAG: %[[outerA:.*]] = iree.do_not_optimize{{.*}} : tensor<2x3xf32>
   //  CHECK-DAG: %[[outerB:.*]] = iree.do_not_optimize{{.*}} : tensor<3x4xf32>
@@ -16,23 +15,22 @@ func @tensor() -> tensor<2x4xf32> {
   %C = iree.unfoldable_constant dense<1000.0> : tensor<2x4xf32>
 
   // %[[C2]] will be handled by a later RematerializeDispatchConstants
-  //      CHECK: flow.dispatch.workgroups[%[[C1wg]], %[[C1wg]], %[[C1wg]]] (%[[C2outer]], %[[outerA]], %[[outerB]], %[[outerC]]) :
-  // CHECK-SAME:    (index, tensor<2x3xf32>, tensor<3x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32> =
-  // CHECK-SAME:    (%[[C2:[0-9a-z]*]] : index,
-  // CHECK-SAME:     %[[A:[0-9a-z]*]] : !flow.dispatch.input<2x3xf32>,
+  //      CHECK: flow.dispatch.workgroups[%[[C1wg]], %[[C1wg]], %[[C1wg]]] (%[[outerA]], %[[outerB]], %[[outerC]]) :
+  // CHECK-SAME:    (tensor<2x3xf32>, tensor<3x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32> =
+  // CHECK-SAME:    (%[[A:[0-9a-z]*]] : !flow.dispatch.input<2x3xf32>,
   // CHECK-SAME:     %[[B:[0-9a-z]*]] : !flow.dispatch.input<3x4xf32>,
   // CHECK-SAME:     %[[C:[0-9a-z]*]] : !flow.dispatch.input<2x4xf32>,
   // CHECK-SAME:     %[[OUT:[0-9a-z]*]] : !flow.dispatch.output<2x4xf32>) {
   //  CHECK-DAG:   %[[C0:.*]] = constant 0 : index
   //  CHECK-DAG:   %[[C1:.*]] = constant 1 : index
-  //  CHECK-DAG:   %[[C2inner:.*]] = constant 2 : index
+  //  CHECK-DAG:   %[[C2:.*]] = constant 2 : index
   //  CHECK-DAG:   %[[C3:.*]] = constant 3 : index
   //  CHECK-DAG:   %[[C4:.*]] = constant 4 : index
   //  CHECK-DAG:   %[[bix:.*]] = flow.dispatch.workgroup.id[0] : index
   //  CHECK-DAG:   %[[bdx:.*]] = flow.dispatch.workgroup.count[0] : index
   //  CHECK-DAG:   %[[biy:.*]] = flow.dispatch.workgroup.id[1] : index
   //  CHECK-DAG:   %[[bdy:.*]] = flow.dispatch.workgroup.count[1] : index
-  //      CHECK:   scf.for %[[I:.*]] = %[[biy]] to %[[C2inner]] step %[[bdy]] {
+  //      CHECK:   scf.for %[[I:.*]] = %[[biy]] to %[[C2]] step %[[bdy]] {
   // CHECK-NEXT:     %[[bix_scaled:.*]] = muli %[[bix]], %[[C2]] : index
   // CHECK-NEXT:     %[[bdx_scaled:.*]] = muli %[[bdx]], %[[C2]] : index
   // CHECK-NEXT:     scf.for %[[J:.*]] = %[[bix_scaled]] to %[[C4]] step %[[bdx_scaled]] {

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -canonicalize -cse %s | IreeFileCheck %s
+
+func @tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
+             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: func @tensor
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//      CHECK:   flow.dispatch.workgroups
+// CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
+//  CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+//  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+//  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
+//  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
+//  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
+//  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
+//      CHECK:     %[[OFFSET_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGID_Y]]
+//      CHECK:     %[[STEP_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGCOUNT_Y]]
+//      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
+// CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
+//      CHECK:       %[[OFFSET_X:.+]] = muli %[[WGSIZE_X]], %[[WGID_X]]
+//      CHECK:       %[[STEP_X:.+]] = muli %[[WGSIZE_X]], %[[WGCOUNT_X]]
+//      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
+// CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
+//      CHECK:         %[[LHS:.+]] = flow.dispatch.input.load %[[ARG3]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[C0]]]
+//      CHECK:         %[[RHS:.+]] = flow.dispatch.input.load %[[ARG4]]
+// CHECK-SAME:           offsets = [%[[C0]], %[[ARG8]]]
+//      CHECK:         %[[INIT:.+]] = flow.dispatch.input.load %[[ARG5]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
+//      CHECK:         %[[RESULT:.+]] = linalg.matmul
+// CHECK-SAME:           ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
+//      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -543,8 +543,7 @@ def HAL_BufferAllocatorOp : HAL_PureOp<"buffer.allocator", [
 // TODO(benvanik): clone buffer op.
 
 def HAL_BufferSubspanOp : HAL_PureOp<"buffer.subspan", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface>,
-  ]> {
+    DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
   let summary = [{buffer subspan operation}];
   let description = [{
     Returns a reference to a subspan of the buffer.
@@ -2178,7 +2177,8 @@ def HAL_InterfaceLoadConstantOp : HAL_PureOp<"interface.load.constant"> {
   }];
 }
 
-def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan"> {
+def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
+    MemoryEffects<[MemAlloc]>]> {
   let summary = [{returns an alias to a subspan of interface binding data}];
   let description = [{
     // TODO(benvanik): add description
@@ -2190,7 +2190,7 @@ def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan"> {
     Optional<HAL_DeviceSize>:$byte_length
   );
   let results = (outs
-    AnyType:$result
+    Res<AnyType, "", [MemAlloc]>:$result
   );
 
   let assemblyFormat = [{

--- a/iree/test/e2e/linalg_tensor_ops/BUILD
+++ b/iree/test/e2e/linalg_tensor_ops/BUILD
@@ -31,7 +31,6 @@ iree_check_single_backend_test_suite(
     srcs = glob(["*.mlir"]),
     compiler_flags = [
         "-iree-flow-dispatch-linalg-on-tensors",
-        "-iree-flow-dispatch-linalg-on-tensors-tile-sizes=1,1",
         "-iree-codegen-llvm-experimental-linalg-on-tensors",
     ],
     driver = "dylib",


### PR DESCRIPTION
Current implementation of the Linalg on tensors path is only tested
with static tile sizes specified at command line. In this PR
- Use `flow.dispatch.workgroup.size` to represent the dynamic tile
  size used
- After conversion to HAL, where `flow.dispatch.workgroup.size` gets
  replaced by `hal.interface.workgroup.size`, use LaunchConfig to set
  the value of `hal.interface.workgroup.size` to a static value.
- This effectively replace the first level of tiling done by the
  existing codegen paths. The rest of the codegen can then be used
  with this path.
Also included all minor fixes needed to plumb everything through.