### PR TITLE
Add VMLA support for integer matmul

### DIFF
--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -396,6 +396,18 @@ vm.import @batch.matmul.f32f32.f32(
   %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
 )
 
+vm.import @batch.matmul.i32i32.i32(
+  %lhs : !vm.ref<!vmla.buffer>, %lhs_shape : i32 ...,
+  %rhs : !vm.ref<!vmla.buffer>, %rhs_shape : i32 ...,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
+)
+
+vm.import @batch.matmul.i8i8.i8(
+  %lhs : !vm.ref<!vmla.buffer>, %lhs_shape : i8 ...,
+  %rhs : !vm.ref<!vmla.buffer>, %rhs_shape : i8 ...,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i8 ...
+)
+
 //===----------------------------------------------------------------------===//
 // VMLA Ops: reduction
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -402,12 +402,6 @@ vm.import @batch.matmul.i32i32.i32(
   %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
 )
 
-vm.import @batch.matmul.i8i8.i8(
-  %lhs : !vm.ref<!vmla.buffer>, %lhs_shape : i8 ...,
-  %rhs : !vm.ref<!vmla.buffer>, %rhs_shape : i8 ...,
-  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i8 ...
-)
-
 //===----------------------------------------------------------------------===//
 // VMLA Ops: reduction
 //===----------------------------------------------------------------------===//

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@com_google_ruy//ruy",
         "@com_google_ruy//ruy:context",
+        "@com_google_ruy//ruy:reference_mul",
         "@pffft",
     ],
 )

--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -50,7 +50,6 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@com_google_ruy//ruy",
         "@com_google_ruy//ruy:context",
-        "@com_google_ruy//ruy:reference_mul",
         "@pffft",
     ],
 )

--- a/iree/hal/vmla/op_kernels.h
+++ b/iree/hal/vmla/op_kernels.h
@@ -393,28 +393,28 @@ struct MatMul {
 
   static std::unique_ptr<RuntimeState> CreateRuntimeState();
 
-  template <typename T, typename ACC>
+  template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
   struct Buffers {
     ShapeSpan lhs_shape;
-    absl::Span<const T> lhs_buffer;
+    absl::Span<const LhsEl> lhs_buffer;
     ShapeSpan rhs_shape;
-    absl::Span<const T> rhs_buffer;
+    absl::Span<const RhsEl> rhs_buffer;
     ShapeSpan dst_shape;
-    absl::Span<T> dst_buffer;
+    absl::Span<DstEl> dst_buffer;
 
     // Optional bias buffer.
-    absl::Span<const ACC> bias_buffer;
+    absl::Span<const AccumEl> bias_buffer;
 
     // Fixed-point multiplier mantissa/exponent. May be a single value (for
     // uniform quantization) or one element per row of the destination matrix
     // for per-channel.
-    absl::Span<const ACC> multiplier_mantissa_buffer;
+    absl::Span<const AccumEl> multiplier_mantissa_buffer;
     absl::Span<const int32_t> multiplier_exponent_buffer;
   };
 
-  template <typename T, typename ACC>
+  template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
   static Status Execute(RuntimeState* runtime_state,
-                        const Buffers<T, ACC>& buffers);
+                        const Buffers<LhsEl, RhsEl, AccumEl, DstEl>& buffers);
 };
 
 struct RuntimeState {

--- a/iree/hal/vmla/op_kernels_ruy.h
+++ b/iree/hal/vmla/op_kernels_ruy.h
@@ -22,7 +22,6 @@
 #include "iree/base/status.h"
 #include "ruy/context.h"
 #include "ruy/mul_params.h"
-#include "ruy/reference_mul.h"
 #include "ruy/ruy.h"
 
 namespace iree {
@@ -103,25 +102,21 @@ Status MatMul::Execute(RuntimeState* runtime_state,
   lhs.set_data(buffers.lhs_buffer.data());
   ruy::MakeSimpleLayout(buffers.lhs_shape[0], buffers.lhs_shape[1],
                         ruy::Order::kRowMajor, lhs.mutable_layout());
-  std::cerr << "LHS=\n" << lhs << "\n";
 
   ruy::Matrix<RhsEl> rhs;
   rhs.set_data(buffers.rhs_buffer.data());
   ruy::MakeSimpleLayout(buffers.rhs_shape[1], buffers.rhs_shape[0],
                         ruy::Order::kColMajor, rhs.mutable_layout());
-  std::cerr << "RHS=\n" << rhs << "\n";
 
   ruy::Matrix<DstEl> dst;
   dst.set_data(buffers.dst_buffer.data());
   ruy::MakeSimpleLayout(buffers.dst_shape[1], buffers.dst_shape[0],
                         ruy::Order::kColMajor, dst.mutable_layout());
-  std::cerr << "DST=\n" << dst << "\n";
 
   ruy::MulParams<AccumEl, DstEl> mul_params;
   MakeRuyMulParams(buffers, &mul_params);
 
-  ruy::ReferenceMul(lhs, rhs, mul_params, &dst);
-  std::cerr << "DST=\n" << dst << "\n";
+  ruy::Mul(lhs, rhs, mul_params, &runtime_state->context, &dst);
 
   return OkStatus();
 }

--- a/iree/hal/vmla/op_kernels_ruy.h
+++ b/iree/hal/vmla/op_kernels_ruy.h
@@ -22,6 +22,7 @@
 #include "iree/base/status.h"
 #include "ruy/context.h"
 #include "ruy/mul_params.h"
+#include "ruy/reference_mul.h"
 #include "ruy/ruy.h"
 
 namespace iree {
@@ -119,7 +120,7 @@ Status MatMul::Execute(RuntimeState* runtime_state,
   ruy::MulParams<AccumEl, DstEl> mul_params;
   MakeRuyMulParams(buffers, &mul_params);
 
-  ruy::Mul(lhs, rhs, mul_params, &runtime_state->context, &dst);
+  ruy::ReferenceMul(lhs, rhs, mul_params, &dst);
   std::cerr << "DST=\n" << dst << "\n";
 
   return OkStatus();

--- a/iree/hal/vmla/op_kernels_ruy.h
+++ b/iree/hal/vmla/op_kernels_ruy.h
@@ -41,12 +41,14 @@ inline std::unique_ptr<MatMul::RuntimeState> MatMul::CreateRuntimeState() {
 }
 
 // Floating-point case.
-template <typename ACC, typename T>
+template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
 struct MakeRuyMulParamsImpl {
-  static_assert(std::is_floating_point<ACC>::value, "");
-  static_assert(std::is_floating_point<T>::value, "");
-  static void Run(const MatMul::Buffers<T, ACC>& buffers,
-                  ruy::MulParams<ACC, T>* mul_params) {
+  static_assert(std::is_floating_point<LhsEl>::value, "");
+  static_assert(std::is_floating_point<RhsEl>::value, "");
+  static_assert(std::is_floating_point<AccumEl>::value, "");
+  static_assert(std::is_floating_point<DstEl>::value, "");
+  static void Run(const MatMul::Buffers<LhsEl, RhsEl, AccumEl, DstEl>& buffers,
+                  ruy::MulParams<AccumEl, DstEl>* mul_params) {
     mul_params->set_bias(buffers.bias_buffer.data());
   }
 };
@@ -54,10 +56,10 @@ struct MakeRuyMulParamsImpl {
 // Integer quantized case with downquantization to a destination T narrower than
 // int32.
 template <typename T>
-struct MakeRuyMulParamsImpl<std::int32_t, T> {
+struct MakeRuyMulParamsImpl<T, T, std::int32_t, T> {
   static_assert(std::is_integral<T>::value, "");
   static_assert(sizeof(T) < sizeof(std::int32_t), "");
-  static void Run(const MatMul::Buffers<T, std::int32_t>& buffers,
+  static void Run(const MatMul::Buffers<T, T, std::int32_t, T>& buffers,
                   ruy::MulParams<std::int32_t, T>* mul_params) {
     mul_params->set_bias(buffers.bias_buffer.data());
     if (buffers.multiplier_mantissa_buffer.size() == 1) {
@@ -77,41 +79,48 @@ struct MakeRuyMulParamsImpl<std::int32_t, T> {
 // Raw integer case with int32 destination. This case does not support any
 // output operation besides bias-addition.
 template <>
-struct MakeRuyMulParamsImpl<std::int32_t, std::int32_t> {
-  static void Run(const MatMul::Buffers<std::int32_t, std::int32_t>& buffers,
+struct MakeRuyMulParamsImpl<std::int32_t, std::int32_t, std::int32_t,
+                            std::int32_t> {
+  static void Run(const MatMul::Buffers<std::int32_t, std::int32_t,
+                                        std::int32_t, std::int32_t>& buffers,
                   ruy::MulParams<std::int32_t, std::int32_t>* mul_params) {
     mul_params->set_bias(buffers.bias_buffer.data());
   }
 };
 
-template <typename ACC, typename T>
-void MakeRuyMulParams(const MatMul::Buffers<T, ACC>& buffers,
-                      ruy::MulParams<ACC, T>* mul_params) {
-  MakeRuyMulParamsImpl<ACC, T>::Run(buffers, mul_params);
+template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
+void MakeRuyMulParams(
+    const MatMul::Buffers<LhsEl, RhsEl, AccumEl, DstEl>& buffers,
+    ruy::MulParams<AccumEl, DstEl>* mul_params) {
+  MakeRuyMulParamsImpl<LhsEl, RhsEl, AccumEl, DstEl>::Run(buffers, mul_params);
 }
 
-template <typename T, typename ACC>
+template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
 Status MatMul::Execute(RuntimeState* runtime_state,
-                       const Buffers<T, ACC>& buffers) {
-  ruy::Matrix<T> lhs;
+                       const Buffers<LhsEl, RhsEl, AccumEl, DstEl>& buffers) {
+  ruy::Matrix<LhsEl> lhs;
   lhs.set_data(buffers.lhs_buffer.data());
   ruy::MakeSimpleLayout(buffers.lhs_shape[0], buffers.lhs_shape[1],
                         ruy::Order::kRowMajor, lhs.mutable_layout());
+  std::cerr << "LHS=\n" << lhs << "\n";
 
-  ruy::Matrix<T> rhs;
+  ruy::Matrix<RhsEl> rhs;
   rhs.set_data(buffers.rhs_buffer.data());
   ruy::MakeSimpleLayout(buffers.rhs_shape[1], buffers.rhs_shape[0],
                         ruy::Order::kColMajor, rhs.mutable_layout());
+  std::cerr << "RHS=\n" << rhs << "\n";
 
-  ruy::Matrix<T> dst;
+  ruy::Matrix<DstEl> dst;
   dst.set_data(buffers.dst_buffer.data());
   ruy::MakeSimpleLayout(buffers.dst_shape[1], buffers.dst_shape[0],
                         ruy::Order::kColMajor, dst.mutable_layout());
+  std::cerr << "DST=\n" << dst << "\n";
 
-  ruy::MulParams<ACC, T> mul_params;
+  ruy::MulParams<AccumEl, DstEl> mul_params;
   MakeRuyMulParams(buffers, &mul_params);
 
   ruy::Mul(lhs, rhs, mul_params, &runtime_state->context, &dst);
+  std::cerr << "DST=\n" << dst << "\n";
 
   return OkStatus();
 }

--- a/iree/hal/vmla/op_module.cc
+++ b/iree/hal/vmla/op_module.cc
@@ -745,13 +745,11 @@ class VMLAModuleState final {
   // VMLA Ops: GEMM/GEMV
   //===--------------------------------------------------------------------===//
 
-  Status BatchMatMulF32F32F32(const vm::ref<Buffer>& lhs,
-                              iree_vmla_shape_t lhs_shape,
-                              const vm::ref<Buffer>& rhs,
-                              iree_vmla_shape_t rhs_shape,
-                              const vm::ref<Buffer>& dst,
-                              iree_vmla_shape_t dst_shape) {
-    IREE_TRACE_SCOPE0("VMLAModuleState::BatchMatMulF32F32F32");
+  template <typename LhsEl, typename RhsEl, typename AccumEl, typename DstEl>
+  Status BatchMatMul(const vm::ref<Buffer>& lhs, iree_vmla_shape_t lhs_shape,
+                     const vm::ref<Buffer>& rhs, iree_vmla_shape_t rhs_shape,
+                     const vm::ref<Buffer>& dst, iree_vmla_shape_t dst_shape) {
+    IREE_TRACE_SCOPE0("VMLAModuleState::BatchMatMul");
     // Compiler guarantees. Here for documentation purposes.
     assert(lhs_shape.size() == 3 && rhs_shape.size() == 3 &&
            dst_shape.size() == 3);
@@ -766,12 +764,13 @@ class VMLAModuleState final {
     size_t lhs_batch_stride = kernels::GetElementCount(lhs_batch_element_shape);
     size_t rhs_batch_stride = kernels::GetElementCount(rhs_batch_element_shape);
     size_t dst_batch_stride = kernels::GetElementCount(dst_batch_element_shape);
-    float* lhs_batch_base = lhs->As<float>().data();
-    float* rhs_batch_base = rhs->As<float>().data();
-    float* dst_batch_base = dst->As<float>().data();
+    std::cerr << lhs_batch_stride << "\n";
+    LhsEl* lhs_batch_base = lhs->As<LhsEl>().data();
+    RhsEl* rhs_batch_base = rhs->As<RhsEl>().data();
+    DstEl* dst_batch_base = dst->As<DstEl>().data();
     int32_t batch_dim = lhs_shape[0];
     for (int i = 0; i < batch_dim; i++) {
-      kernels::MatMul::Buffers<float, float> buffers;
+      kernels::MatMul::Buffers<LhsEl, RhsEl, AccumEl, DstEl> buffers;
       buffers.lhs_buffer = absl::MakeSpan(lhs_batch_base + i * lhs_batch_stride,
                                           lhs_batch_stride);
       buffers.lhs_shape = lhs_batch_element_shape2;
@@ -1046,8 +1045,18 @@ static const vm::NativeFunction<VMLAModuleState> kVMLAModuleFunctions[] = {
     vm::MakeNativeFunction("pooling.max.i32", &VMLAModuleState::PoolingMaxI32),
     vm::MakeNativeFunction("pooling.max.f32", &VMLAModuleState::PoolingMaxF32),
 
-    vm::MakeNativeFunction("batch.matmul.f32f32.f32",
-                           &VMLAModuleState::BatchMatMulF32F32F32),
+    vm::MakeNativeFunction(
+        "batch.matmul.f32f32.f32",
+        &VMLAModuleState::BatchMatMul<float, float, float, float>),
+
+    vm::MakeNativeFunction(
+        "batch.matmul.i32i32.i32",
+        &VMLAModuleState::BatchMatMul<int32_t, int32_t, int32_t, int32_t>),
+
+    vm::MakeNativeFunction(
+        "batch.matmul.i8i8.i8",
+        // Note that accumulator is still i32
+        &VMLAModuleState::BatchMatMul<int8_t, int8_t, int32_t, int8_t>),
 
     vm::MakeNativeFunction("conv.f32f32.f32", &VMLAModuleState::ConvF32F32F32)};
 

--- a/iree/hal/vmla/op_module.cc
+++ b/iree/hal/vmla/op_module.cc
@@ -764,7 +764,6 @@ class VMLAModuleState final {
     size_t lhs_batch_stride = kernels::GetElementCount(lhs_batch_element_shape);
     size_t rhs_batch_stride = kernels::GetElementCount(rhs_batch_element_shape);
     size_t dst_batch_stride = kernels::GetElementCount(dst_batch_element_shape);
-    std::cerr << lhs_batch_stride << "\n";
     LhsEl* lhs_batch_base = lhs->As<LhsEl>().data();
     RhsEl* rhs_batch_base = rhs->As<RhsEl>().data();
     DstEl* dst_batch_base = dst->As<DstEl>().data();
@@ -1052,11 +1051,6 @@ static const vm::NativeFunction<VMLAModuleState> kVMLAModuleFunctions[] = {
     vm::MakeNativeFunction(
         "batch.matmul.i32i32.i32",
         &VMLAModuleState::BatchMatMul<int32_t, int32_t, int32_t, int32_t>),
-
-    vm::MakeNativeFunction(
-        "batch.matmul.i8i8.i8",
-        // Note that accumulator is still i32
-        &VMLAModuleState::BatchMatMul<int8_t, int8_t, int32_t, int8_t>),
 
     vm::MakeNativeFunction("conv.f32f32.f32", &VMLAModuleState::ConvF32F32F32)};
 

--- a/iree/test/e2e/xla_ops/dot.mlir
+++ b/iree/test/e2e/xla_ops/dot.mlir
@@ -1,12 +1,4 @@
-func @dot_passthrough() attributes { iree.module.export } {
-  %lhs = iree.unfoldable_constant dense<[[0.3, 0.5]]> : tensor<1x2xf32>
-  %rhs = iree.unfoldable_constant  dense<[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]> : tensor<2x3xf32>
-  %res = "mhlo.dot"(%lhs, %rhs) {precision_config = ["DEFAULT", "DEFAULT"]} : (tensor<1x2xf32>, tensor<2x3xf32>) -> tensor<1x3xf32>
-  check.expect_almost_eq_const(%res, dense<[[0.23, 0.31, 0.39]]> : tensor<1x3xf32>) : tensor<1x3xf32>
-  return
-}
-
-func @gemm() attributes { iree.module.export } {
+func @f32() attributes { iree.module.export } {
   %lhs = iree.unfoldable_constant dense<[
     [15.0, 14.0, 13.0],
     [12.0, 11.0, 10.0],
@@ -17,7 +9,7 @@ func @gemm() attributes { iree.module.export } {
     [15.0, 14.0, 13.0, 12.0, 11.0],
     [10.0, 09.0, 08.0, 07.0, 06.0],
     [05.0, 04.0, 03.0, 02.0, 01.0]]> : tensor<3x5xf32>
-  %res = "mhlo.dot"(%lhs, %rhs) {precision_config = ["DEFAULT", "DEFAULT"]} : (tensor<5x3xf32>, tensor<3x5xf32>) -> tensor<5x5xf32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<5x3xf32>, tensor<3x5xf32>) -> tensor<5x5xf32>
   check.expect_almost_eq_const(%res, dense<[
     [430.0, 388.0, 346.0, 304.0, 262.0],
     [340.0, 307.0, 274.0, 241.0, 208.0],
@@ -27,7 +19,7 @@ func @gemm() attributes { iree.module.export } {
   return
 }
 
-func @large_matmul() attributes { iree.module.export } {
+func @large() attributes { iree.module.export } {
   %lhs = iree.unfoldable_constant dense<1.0> : tensor<32x1024xf32>
   %rhs = iree.unfoldable_constant dense<0.4> : tensor<1024x64xf32>
   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<32x1024xf32>, tensor<1024x64xf32>) -> tensor<32x64xf32>

--- a/iree/test/e2e/xla_ops/partial/BUILD
+++ b/iree/test/e2e/xla_ops/partial/BUILD
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests of end-to-end IREE support for support of specific subsets of ops in the
+# XLA HLO dialect. This is for cases where some variation (e.g. tensor element
+# types) of an op is not supported on all backends. When the test is supported
+# on all backends it should be moved into the corresponding op test in the main
+# xla_ops direcotry. Each test file should have a name matching the
+# corresponding XLA HLO op with a suffix indicating the subset it tests. Only
+# the functionality of that op should be tessted (though it may make use of
+# other ops where necessary). Tests should be written using the IREE Check
+# framework and should always pass on the reference VMLA backend. See
+# https://google.github.io/iree/TestingGuide#iree-core-end-to-end-tests.
+
+load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_vmla_vmla",
+    srcs = glob(["*.mlir"]),
+    driver = "vmla",
+    target_backend = "vmla",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_metal-spirv_metal",
+    srcs = [
+    ],
+    driver = "metal",
+    target_backend = "metal-spirv",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_vulkan-spirv_vulkan",
+    srcs = [
+    ],
+    driver = "vulkan",
+    target_backend = "vulkan-spirv",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_dylib-llvm-aot_dylib",
+    srcs = [
+    ],
+    driver = "dylib",
+    target_backend = "dylib-llvm-aot",
+)
+
+test_suite(
+    name = "check",
+    tests = [
+        ":check_dylib-llvm-aot_dylib",
+        ":check_metal-spirv_metal",
+        ":check_vmla_vmla",
+        ":check_vulkan-spirv_vulkan",
+    ],
+)

--- a/iree/test/e2e/xla_ops/partial/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/partial/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
+iree_check_single_backend_test_suite(
+  NAME
+    check_vmla_vmla
+  SRCS
+    "${_GLOB_X_MLIR}"
+  TARGET_BACKEND
+    "vmla"
+  DRIVER
+    "vmla"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_metal-spirv_metal
+  TARGET_BACKEND
+    "metal-spirv"
+  DRIVER
+    "metal"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_vulkan-spirv_vulkan
+  TARGET_BACKEND
+    "vulkan-spirv"
+  DRIVER
+    "vulkan"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_dylib-llvm-aot_dylib
+  TARGET_BACKEND
+    "dylib-llvm-aot"
+  DRIVER
+    "dylib"
+)

--- a/iree/test/e2e/xla_ops/partial/dot_int.mlir
+++ b/iree/test/e2e/xla_ops/partial/dot_int.mlir
@@ -1,15 +1,7 @@
-// func @i32() attributes { iree.module.export } {
-//   %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi32>
-//   %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi32>
-//   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi32>, tensor<4x2xi32>) -> tensor<2x2xi32>
-//   check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
-//   return
-// }
-
-func @i8() attributes { iree.module.export } {
-  %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi8>
-  %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi8>
-  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi8>, tensor<4x2xi8>) -> tensor<2x2xi8>
-  check.expect_eq_const(%res, dense<24> : tensor<2x2xi8>) : tensor<2x2xi8>
+func @i32() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi32>
+  %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi32>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi32>, tensor<4x2xi32>) -> tensor<2x2xi32>
+  check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
   return
 }

--- a/iree/test/e2e/xla_ops/partial/dot_int.mlir
+++ b/iree/test/e2e/xla_ops/partial/dot_int.mlir
@@ -1,0 +1,15 @@
+// func @i32() attributes { iree.module.export } {
+//   %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi32>
+//   %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi32>
+//   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi32>, tensor<4x2xi32>) -> tensor<2x2xi32>
+//   check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
+//   return
+// }
+
+func @i8() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi8>
+  %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi8>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi8>, tensor<4x2xi8>) -> tensor<2x2xi8>
+  check.expect_eq_const(%res, dense<24> : tensor<2x2xi8>) : tensor<2x2xi8>
+  return
+}


### PR DESCRIPTION
Just i32i32.i32 for now. Other cases proved to be far more complicated
than expected. This includes making our template parameters indicate
the full versatility of ruy's matmul.