### PR TITLE
Note that libxml2-dev is required for building

### DIFF
--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -51,6 +51,12 @@ We recommend Clang. GCC is not fully supported.
 $ sudo apt install clang
 ```
 
+### Install other dependencies
+
+```shell
+$ sudo apt install libxml2-dev # Required for LLVM
+```
+
 ## Clone and Build
 
 ### Clone


### PR DESCRIPTION
We require this via LLVM for the default build configuration