### PR TITLE
Add VMLA support for mixed-type integer matmuls

### DIFF
--- a/iree/compiler/Dialect/VMLA/Transforms/test/pre_conversion_lowering.mlir
+++ b/iree/compiler/Dialect/VMLA/Transforms/test/pre_conversion_lowering.mlir
@@ -2,8 +2,8 @@
 
 // -----
 
-// CHECK-LABEL: func @f
-func @f(%arg0: tensor<3x4xf32>, %arg1: tensor<4x5xf32>) -> tensor<3x5xf32> {
+// CHECK-LABEL: func @dot_general_float
+func @dot_general_float(%arg0: tensor<3x4xf32>, %arg1: tensor<4x5xf32>) -> tensor<3x5xf32> {
   // CHECK: vmla.batch.matmul
   %0 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = {
     lhs_batching_dimensions = dense<[]> : tensor<0xi64>,
@@ -16,8 +16,17 @@ func @f(%arg0: tensor<3x4xf32>, %arg1: tensor<4x5xf32>) -> tensor<3x5xf32> {
 
 // -----
 
-// CHECK-LABEL: func private @f
-func private @f(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-LABEL: func @dot_mixed_element_types
+func @dot_mixed_element_types(%arg0: tensor<2x3xi8>, %arg1: tensor<3x2xi16>) -> tensor<2x2xi32> {
+  // CHECK: vmla.batch.matmul.pseudo %{{[a-zA-Z0-9$._-]+}}, %{{[a-zA-Z0-9$._-]+}} : (tensor<?x?x?xi8>, tensor<?x?x?xi16>) -> tensor<?x?x?xi32>
+  %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<2x3xi8>, tensor<3x2xi16>) -> tensor<2x2xi32>
+  return %0 : tensor<2x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func private @sort
+func private @sort(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
   // CHECK-DAG: [[SORT:%.+]] = vmla.sort.pseudo %arg0
   // CHECK-DAG: [[GATHER:%.+]] = "mhlo.torch_index_select"(%arg0, [[SORT]]) {batch_dims = 0 : i64, dim = 0 : i64}
   %sort = "mhlo.sort"(%arg0) ( {
@@ -32,8 +41,8 @@ func private @f(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
 
 // -----
 
-// CHECK-LABEL: func private @f
-func private @f(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
+// CHECK-LABEL: func private @sort
+func private @sort_2d(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
   // CHECK-DAG: [[SORT:%.+]] = vmla.sort.pseudo %arg0
   // CHECK-DAG: [[GATHER:%.+]] = "mhlo.torch_index_select"(%arg0, [[SORT]]) {batch_dims = 1 : i64, dim = 1 : i64}
   %sort = "mhlo.sort"(%arg0) ( {
@@ -48,8 +57,8 @@ func private @f(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
 
 // -----
 
-// CHECK-LABEL: func @f
-func @f(%arg0: tensor<3xf32>) -> tensor<4x3xf32> {
+// CHECK-LABEL: func @broadcast_in_dim
+func @broadcast_in_dim(%arg0: tensor<3xf32>) -> tensor<4x3xf32> {
   // CHECK: "shapex.ranked_broadcast_in_dim"(%arg0, %rs4_3)
   %0 = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1]> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<4x3xf32>
   return %0 : tensor<4x3xf32>
@@ -57,8 +66,8 @@ func @f(%arg0: tensor<3xf32>) -> tensor<4x3xf32> {
 
 // -----
 
-// CHECK-LABEL: func @f
-func @f(%arg0: tensor<3xf32>) -> tensor<5x6x3xf32> {
+// CHECK-LABEL: func @ranked_broadcast_in_dim
+func @ranked_broadcast_in_dim(%arg0: tensor<3xf32>) -> tensor<5x6x3xf32> {
   // CHECK: "shapex.ranked_broadcast_in_dim"(%arg0, %rs5_6_3)
   %0 = "mhlo.broadcast"(%arg0) {broadcast_sizes = dense<[5, 6]> : tensor<2xi64>} : (tensor<3xf32>) -> tensor<5x6x3xf32>
   return %0 : tensor<5x6x3xf32>
@@ -66,8 +75,8 @@ func @f(%arg0: tensor<3xf32>) -> tensor<5x6x3xf32> {
 
 // -----
 
-// CHECK-LABEL: func private @f
-func private @f(%arg0: tensor<8xcomplex<f32>>) -> tensor<8xcomplex<f32>> {
+// CHECK-LABEL: func private @fft
+func private @fft(%arg0: tensor<8xcomplex<f32>>) -> tensor<8xcomplex<f32>> {
   // CHECK-DAG: [[REAL:%.+]] = "mhlo.real"(%arg0)
   // CHECK-DAG: [[IMAG:%.+]] = "mhlo.imag"(%arg0)
   // CHECK-DAG: [[REAL_OUT:%.+]], [[IMAG_OUT:%.+]] = vmla.fft.pseudo [[REAL]], [[IMAG]]
@@ -78,8 +87,8 @@ func private @f(%arg0: tensor<8xcomplex<f32>>) -> tensor<8xcomplex<f32>> {
 
 // -----
 
-// CHECK-LABEL: func @f
-func @f(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32> {
+// CHECK-LABEL: func @complex_multiply
+func @complex_multiply(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32> {
   // CHECK-NOT: "mhlo.complex"
   %0 = "mhlo.complex"(%arg0, %arg1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xcomplex<f32>>
 

--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -402,6 +402,18 @@ vm.import @batch.matmul.i32i32.i32(
   %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
 )
 
+vm.import @batch.matmul.i8i8.i32(
+  %lhs : !vm.ref<!vmla.buffer>, %lhs_shape : i8 ...,
+  %rhs : !vm.ref<!vmla.buffer>, %rhs_shape : i8 ...,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
+)
+
+vm.import @batch.matmul.i16i16.i32(
+  %lhs : !vm.ref<!vmla.buffer>, %lhs_shape : i16 ...,
+  %rhs : !vm.ref<!vmla.buffer>, %rhs_shape : i16 ...,
+  %dst : !vm.ref<!vmla.buffer>, %dst_shape : i32 ...
+)
+
 //===----------------------------------------------------------------------===//
 // VMLA Ops: reduction
 //===----------------------------------------------------------------------===//

--- a/iree/hal/vmla/op_module.cc
+++ b/iree/hal/vmla/op_module.cc
@@ -1052,6 +1052,14 @@ static const vm::NativeFunction<VMLAModuleState> kVMLAModuleFunctions[] = {
         "batch.matmul.i32i32.i32",
         &VMLAModuleState::BatchMatMul<int32_t, int32_t, int32_t, int32_t>),
 
+    vm::MakeNativeFunction(
+        "batch.matmul.i8i8.i32",
+        &VMLAModuleState::BatchMatMul<int8_t, int8_t, int32_t, int32_t>),
+
+    vm::MakeNativeFunction(
+        "batch.matmul.i16i16.i32",
+        &VMLAModuleState::BatchMatMul<int16_t, int16_t, int32_t, int32_t>),
+
     vm::MakeNativeFunction("conv.f32f32.f32", &VMLAModuleState::ConvF32F32F32)};
 
 // Per-device VMLA module.

--- a/iree/test/e2e/xla_ops/partial/dot_int.mlir
+++ b/iree/test/e2e/xla_ops/partial/dot_int.mlir
@@ -1,7 +1,23 @@
-func @i32() attributes { iree.module.export } {
+func @i32i32.i32() attributes { iree.module.export } {
   %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi32>
   %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi32>
   %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi32>, tensor<4x2xi32>) -> tensor<2x2xi32>
+  check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
+  return
+}
+
+func @i8i8.i32() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi8>
+  %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi8>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi8>, tensor<4x2xi8>) -> tensor<2x2xi32>
+  check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
+  return
+}
+
+func @i16i16.i32() attributes { iree.module.export } {
+  %lhs = iree.unfoldable_constant dense<3> : tensor<2x4xi16>
+  %rhs = iree.unfoldable_constant dense<2> : tensor<4x2xi16>
+  %res = "mhlo.dot"(%lhs, %rhs) : (tensor<2x4xi16>, tensor<4x2xi16>) -> tensor<2x2xi32>
   check.expect_eq_const(%res, dense<24> : tensor<2x2xi32>) : tensor<2x2xi32>
   return
 }


### PR DESCRIPTION
Adds support for i8 x i8 and i16 x i16. In both cases, the accumulator
and destination type is i32. This is the simple case, whereas if the
destination type were smaller, we'd probably want (need?) to do some
rescaling as part of the op. Ruy implements such rescaling, but I think
it would need to come as additional parameters to the op.

Includes adding support in the mhlo.dot[_general] lowering for differing
input/output element types.
