### PR TITLE
Bump benefit of pattern to convert from func -> llvm.func in ConvertToLLVM2

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM2.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM2.cpp
@@ -95,11 +95,14 @@ static SmallVector<Type, 5> getABITypes(MLIRContext *context) {
 //                  workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
 //                  workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
 // ```
+//
+// Bump the benefit of the pattern to 100 to pick this pattern instead of a
+// competing pattern inserted by `populateStdToLLVMConversionPatterns`.
 class ConvertFunc : public ConvertToLLVMPattern {
  public:
   explicit ConvertFunc(MLIRContext *context, LLVMTypeConverter &converter)
       : ConvertToLLVMPattern(mlir::FuncOp::getOperationName(), context,
-                             converter) {}
+                             converter, 100) {}
 
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,


### PR DESCRIPTION
Bumping the pattern makes the pattern in IREE trigger before a similar
pattern in MLIR core that is added to the pattern list by
`populateStdToLLVMConversionPatterns`.

Fixes #4409