### PR TITLE
More fixes after HAL C changes.

### DIFF
--- a/iree/base/internal/file_io_win32.cc
+++ b/iree/base/internal/file_io_win32.cc
@@ -18,6 +18,8 @@
 
 #include <io.h>
 
+#include <atomic>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "iree/base/file_io.h"

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -705,9 +705,9 @@ typedef struct {
   iree_task_dispatch_t task;
   iree_hal_local_executable_t* executable;
   iree_host_size_t ordinal;
-  iree_hal_executable_binding_ptr_t* restrict bindings;
-  iree_device_size_t* restrict binding_lengths;
-  uint32_t* restrict push_constants;
+  iree_hal_executable_binding_ptr_t* IREE_RESTRICT bindings;
+  iree_device_size_t* IREE_RESTRICT binding_lengths;
+  uint32_t* IREE_RESTRICT push_constants;
 } iree_hal_cmd_dispatch_t;
 
 static iree_status_t iree_hal_cmd_dispatch_tile(

--- a/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
+++ b/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
@@ -274,27 +274,32 @@ int iree::IreeMain(int argc, char** argv) {
   // Load symbols from our static `vkGetInstanceProcAddr` for IREE to use.
   iree_hal_vulkan_syms_t* iree_vk_syms = nullptr;
   IREE_CHECK_OK(iree_hal_vulkan_syms_create(
-      reinterpret_cast<void*>(&vkGetInstanceProcAddr), &iree_vk_syms));
+      reinterpret_cast<void*>(&vkGetInstanceProcAddr), iree_allocator_system(),
+      &iree_vk_syms));
   // Create the driver sharing our VkInstance.
   iree_hal_driver_t* iree_vk_driver = nullptr;
-  iree_hal_vulkan_driver_options_t options;
-  options.api_version = VK_API_VERSION_1_0;
-  options.features = static_cast<iree_hal_vulkan_features_t>(
+  iree_string_view_t driver_identifier = iree_make_cstring_view("vulkan");
+  iree_hal_vulkan_driver_options_t driver_options;
+  driver_options.api_version = VK_API_VERSION_1_0;
+  driver_options.requested_features = static_cast<iree_hal_vulkan_features_t>(
       IREE_HAL_VULKAN_FEATURE_ENABLE_DEBUG_UTILS);
   IREE_CHECK_OK(iree_hal_vulkan_driver_create_using_instance(
-      options, iree_vk_syms, g_Instance, &iree_vk_driver));
+      driver_identifier, &driver_options, iree_vk_syms, g_Instance,
+      iree_allocator_system(), &iree_vk_driver));
   // Create a device sharing our VkDevice and queue. This makes capturing with
   // vendor tools easier because we will have sync compute residing in the
   // rendered frame.
+  iree_string_view_t device_identifier = iree_make_cstring_view("vulkan");
   iree_hal_vulkan_queue_set_t compute_queue_set;
   compute_queue_set.queue_family_index = g_QueueFamily;
   compute_queue_set.queue_indices = 1 << 0;
   iree_hal_vulkan_queue_set_t transfer_queue_set;
   transfer_queue_set.queue_indices = 0;
   iree_hal_device_t* iree_vk_device = nullptr;
-  IREE_CHECK_OK(iree_hal_vulkan_driver_wrap_device(
-      iree_vk_driver, g_PhysicalDevice, g_Device, compute_queue_set,
-      transfer_queue_set, &iree_vk_device));
+  IREE_CHECK_OK(iree_hal_vulkan_wrap_device(
+      device_identifier, &driver_options.device_options, iree_vk_syms,
+      g_Instance, g_PhysicalDevice, g_Device, &compute_queue_set,
+      &transfer_queue_set, iree_allocator_system(), &iree_vk_device));
   // Create a HAL module using the HAL device.
   iree_vm_module_t* hal_module = nullptr;
   IREE_CHECK_OK(iree_hal_module_create(iree_vk_device, iree_allocator_system(),


### PR DESCRIPTION
* Use `IREE_RESTRICT` for older MSVC versions.
* Update iree-run-module-vulkan-gui-main.cc
* Include <atomic> for std::atomic use in GetTempFile.

Tested CMake build of `all` (vmla+vulkan only) on my Windows machine, with samples and Vulkan enabled.