### PR TITLE
Revert removing explicit linker path in compile_android_modules.sh.

### DIFF
--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -50,6 +50,8 @@ if [[ -z "${model}" ]]; then
   exit 1
 fi
 
+export IREE_LLVMAOT_LINKER_PATH="${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++ -static-libstdc++ -O3"
+
 IFS=',' read -ra targets_array <<< "$targets"
 for target in "${targets_array[@]}"
 do


### PR DESCRIPTION
Attempted fix for failing iree-android-benchmark runs: https://buildkite.com/iree/iree-android-benchmark/builds/1733#3de7c616-bd4d-45d2-8dc1-50a51fbdd047, failing after https://github.com/google/iree/pull/4584.

cc @hanhanW 