### PR TITLE
Allow benchmark pipeline to be run on presubmit

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
@@ -24,7 +24,6 @@ steps:
       - "build=true"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
-    branches: "main"
     artifact_paths: "model-artifacts.tgz"
 
   - wait
@@ -45,7 +44,6 @@ steps:
       - "queue=benchmark-android"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
-    branches: "main"
     artifact_paths: "mako-*.log"
     timeout_in_minutes: "15"
 
@@ -65,7 +63,6 @@ steps:
       - "queue=benchmark-android"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
-    branches: "main"
     artifact_paths: "mako-*.log"
     timeout_in_minutes: "15"
 


### PR DESCRIPTION
The GitHub configuration for the pipeline in the BuildKite GUI still
only triggers automatically on pushes to `main`, but this allows
manually triggering on pull requests (using the somewhat esoteric
BuildKite method of setting branch to `pull/<pr_number>/head`) or other
branches and actually having something run. The final step to upload
to Mako is still skipped, to avoid polluting the dashboard.

Tested:
Ran the benchmark pipeline on presubmit for this PR.