### PR TITLE
Android build fixes for HAL rewrite branch.

### DIFF
--- a/iree/base/wait_handle_impl.h
+++ b/iree/base/wait_handle_impl.h
@@ -52,7 +52,9 @@
 // TODO(benvanik): EPOLL on android/linux/bsd/etc.
 // TODO(benvanik): KQUEUE on mac/ios.
 // KQUEUE is not implemented yet. Use POLL for mac/ios
-#if !defined(IREE_PLATFORM_APPLE) && !defined(__EMSCRIPTEN__)
+// Android ppoll requires API version >= 21
+#if !defined(IREE_PLATFORM_APPLE) && !defined(__EMSCRIPTEN__) && \
+    (!defined(__ANDROID_API__) || __ANDROID_API__ >= 21)
 #define IREE_WAIT_API IREE_WAIT_API_PPOLL
 #else
 #define IREE_WAIT_API IREE_WAIT_API_POLL

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <inttypes.h>
+
 #include "iree/base/tracing.h"
 #include "iree/hal/allocator.h"
 #include "iree/hal/command_buffer.h"
@@ -293,7 +295,8 @@ static iree_status_t iree_hal_validating_command_buffer_fill_buffer(
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "fill offset and/or length do not match the natural alignment of the "
-        "fill value (target_offset=%zu, length=%zu, pattern_length=%zu)",
+        "fill value (target_offset=%" PRIu64 ", length=%" PRIu64
+        ", pattern_length=%zu)",
         target_offset, length, pattern_length);
   }
 

--- a/iree/hal/local/local_executable.h
+++ b/iree/hal/local/local_executable.h
@@ -31,7 +31,7 @@ typedef struct {
   iree_hal_vec3_t workgroup_count;
   iree_hal_executable_push_constants_ptr_t push_constants;
   const iree_hal_executable_binding_ptr_t* bindings;
-  const iree_host_size_t* binding_lengths;
+  const iree_device_size_t* binding_lengths;
 } iree_hal_local_executable_call_t;
 
 typedef struct {

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -706,7 +706,7 @@ typedef struct {
   iree_hal_local_executable_t* executable;
   iree_host_size_t ordinal;
   iree_hal_executable_binding_ptr_t* IREE_RESTRICT bindings;
-  iree_host_size_t* IREE_RESTRICT binding_lengths;
+  iree_device_size_t* IREE_RESTRICT binding_lengths;
   uint32_t* IREE_RESTRICT push_constants;
 } iree_hal_cmd_dispatch_t;
 
@@ -793,7 +793,7 @@ static iree_status_t iree_hal_task_command_buffer_build_dispatch(
   // kept valid for the duration they may be in use.
   cmd->bindings = (iree_hal_executable_binding_ptr_t*)cmd_ptr;
   cmd_ptr += used_binding_count * sizeof(*cmd->bindings);
-  cmd->binding_lengths = (iree_host_size_t*)cmd_ptr;
+  cmd->binding_lengths = (iree_device_size_t*)cmd_ptr;
   cmd_ptr += used_binding_count * sizeof(*cmd->binding_lengths);
   iree_host_size_t binding_base = 0;
   for (iree_host_size_t i = 0; i < used_binding_count; ++i) {

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -706,7 +706,7 @@ typedef struct {
   iree_hal_local_executable_t* executable;
   iree_host_size_t ordinal;
   iree_hal_executable_binding_ptr_t* IREE_RESTRICT bindings;
-  iree_device_size_t* IREE_RESTRICT binding_lengths;
+  iree_host_size_t* IREE_RESTRICT binding_lengths;
   uint32_t* IREE_RESTRICT push_constants;
 } iree_hal_cmd_dispatch_t;
 
@@ -793,7 +793,7 @@ static iree_status_t iree_hal_task_command_buffer_build_dispatch(
   // kept valid for the duration they may be in use.
   cmd->bindings = (iree_hal_executable_binding_ptr_t*)cmd_ptr;
   cmd_ptr += used_binding_count * sizeof(*cmd->bindings);
-  cmd->binding_lengths = (iree_device_size_t*)cmd_ptr;
+  cmd->binding_lengths = (iree_host_size_t*)cmd_ptr;
   cmd_ptr += used_binding_count * sizeof(*cmd->binding_lengths);
   iree_host_size_t binding_base = 0;
   for (iree_host_size_t i = 0; i < used_binding_count; ++i) {


### PR DESCRIPTION
Unfortunately not caught by any of our open source builds.

---

```
typedef size_t iree_host_size_t;
typedef uint64_t iree_device_size_t;
```

`iree_device_size_t` should use `% " PRIu64 "` instead of `%zu`

---

`ppoll` is available since Android API 21 (or 28 for `ppoll64`? seeing conflicting docs)

---

`iree_hal_buffer_calculate_range` outputs into a `iree_device_size_t`, which isn't directly compatible with

```
typedef struct {
  uint8_t* data;
  iree_host_size_t data_length;
} iree_byte_span_t;
```