### PR TITLE
Skip check tests on host builds when IREE_BUILD_COMPILER is OFF.

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -36,6 +36,12 @@ function(iree_check_test)
     return()
   endif()
 
+  # On the host, only build check tests if the compiler is enabled.
+  # When cross compiling, assume the host tools were already built.
+  if(NOT IREE_BUILD_COMPILER AND NOT CMAKE_CROSSCOMPILING)
+    return()
+  endif()
+
   cmake_parse_arguments(
     _RULE
     ""

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -36,8 +36,21 @@ function(iree_check_test)
     return()
   endif()
 
-  # On the host, only build check tests if the compiler is enabled.
-  # When cross compiling, assume the host tools were already built.
+  # Check tests require (by way of iree_bytecode_module) some tools.
+  #
+  # On the host, we can either build the tools directly, if IREE_BUILD_COMPILER
+  # is enabled, or reuse the tools from an existing build (or binary release).
+  #
+  # In some configurations (e.g. when cross compiling for Android), we can't
+  # always build the tools and may depend on them from a host build.
+  #
+  # For now we enable check tests:
+  #   On the host if IREE_BUILD_COMPILER is set
+  #   Always when cross compiling (assuming host tools exist)
+  #
+  # In the future, we should probably add some orthogonal options that give
+  # more control (such as using tools from a binary release in a runtime-only
+  # host build, or skipping check tests in an Android build).
   if(NOT IREE_BUILD_COMPILER AND NOT CMAKE_CROSSCOMPILING)
     return()
   endif()

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -51,6 +51,7 @@ function(iree_check_test)
   # In the future, we should probably add some orthogonal options that give
   # more control (such as using tools from a binary release in a runtime-only
   # host build, or skipping check tests in an Android build).
+  # TODO(#4662): add flexible configurable options that cover more uses
   if(NOT IREE_BUILD_COMPILER AND NOT CMAKE_CROSSCOMPILING)
     return()
   endif()


### PR DESCRIPTION
I misconfigured this as part of https://github.com/google/iree/pull/4584, leading to issues spotted on https://github.com/google/iree/issues/4617. The flatcc cli is still required for the runtime, which is what I originally filed that issue for, but compiler tools like `iree-translate` should not be.

See also https://github.com/google/iree/blob/7d0108f0d565956c51c446dd52062fa1e50ca4e3/build_tools/cmake/iree_lit_test.cmake#L39-L43