### PR TITLE
Add region to `hal.executable.entry_point` that computes number of  workgroups.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
@@ -35,7 +35,8 @@ namespace iree_compiler {
 
 namespace {
 struct LinalgTileAndDistributePass
-    : public PassWrapper<LinalgTileAndDistributePass, OperationPass<ModuleOp>> {
+    : public PassWrapper<LinalgTileAndDistributePass,
+                         OperationPass<IREE::HAL::ExecutableTargetOp>> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, IREE::HAL::HALDialect, AffineDialect,
                     scf::SCFDialect>();
@@ -74,9 +75,63 @@ Optional<Value> allocateThreadLocalMemory(OpBuilder &b, SubViewOp subview,
   return buffer;
 }
 
+/// Given the tile sizes to use add a region to the entry point operation that
+/// describes the maximum number of workgroups for a given workload. For now it
+/// is computed as (workload + tilesize - 1) / tilesize along each dimension and
+/// restricted to be 3D dimensional.
+static LogicalResult initNumWorkgroupsRegion(OpBuilder &builder, FuncOp funcOp,
+                                             ArrayRef<int64_t> tileSizes) {
+  auto targetOp =
+      funcOp.getOperation()->getParentOfType<IREE::HAL::ExecutableTargetOp>();
+  IREE::HAL::ExecutableEntryPointOp entryPointOp = nullptr;
+  for (auto op : targetOp.getOps<IREE::HAL::ExecutableEntryPointOp>()) {
+    if (op.sym_name() == funcOp.getName()) {
+      entryPointOp = op;
+      break;
+    }
+  }
+  if (!entryPointOp)
+    return funcOp.emitOpError("unable to find corresponding entry point op");
+  if (entryPointOp.getBody())
+    return entryPointOp.emitOpError("cannot override num_workgroups_region");
+  Location loc = entryPointOp.getLoc();
+
+  OpBuilder::InsertionGuard guard(builder);
+  // Create the cloned operation but with a single region.
+  builder.setInsertionPoint(entryPointOp);
+  auto clonedOp = builder.create<IREE::HAL::ExecutableEntryPointOp>(
+      loc, entryPointOp.sym_nameAttr(), entryPointOp.ordinalAttr(),
+      entryPointOp.interfaceAttr(), entryPointOp.signatureAttr(),
+      entryPointOp.workgroup_sizeAttr(), 1);
+  Region *region = clonedOp.getBody();
+  Block *entryBlock = new Block();
+  region->push_back(entryBlock);
+  builder.setInsertionPointToStart(entryBlock);
+  // Add 3 index arguments for the workload.
+  auto indexType = builder.getIndexType();
+  SmallVector<BlockArgument, 4> workload = llvm::to_vector<4>(
+      entryBlock->addArguments({indexType, indexType, indexType}));
+  // Make the number of workgroups workload / tile size.
+  SmallVector<Value, 4> yieldValues;
+  Value one = builder.create<ConstantIndexOp>(loc, 1);
+  assert(tileSizes.size() <= 3 &&
+         "expected only three tile size values for num workgroups computation");
+  for (auto ts : llvm::enumerate(llvm::reverse(tileSizes))) {
+    Value tsVal = builder.create<ConstantIndexOp>(loc, ts.value());
+    Value tsMinusOne = builder.create<SubIOp>(loc, tsVal, one);
+    Value num = builder.create<AddIOp>(loc, workload[ts.index()], tsMinusOne);
+    yieldValues.push_back(builder.create<SignedDivIOp>(loc, num, tsVal));
+  }
+  yieldValues.resize(3, one);
+  builder.create<IREE::HAL::YieldOp>(loc, yieldValues);
+  entryPointOp.erase();
+  return success();
+}
+
 void LinalgTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  ModuleOp module = getOperation();
+  IREE::HAL::ExecutableTargetOp targetOp = getOperation();
+  ModuleOp module = targetOp.getInnerModule();
 
   for (FuncOp funcOp : module.getOps<FuncOp>()) {
     if (!isEntryPoint(funcOp)) continue;
@@ -155,6 +210,13 @@ void LinalgTileAndDistributePass::runOnOperation() {
       }
       if (failed(materializeStaticLaunchInformation(
               funcOp, workloadPerWorkgroup.getValue()))) {
+        funcOp.emitOpError("failed to set tile size to constant value");
+        return signalPassFailure();
+      }
+      OpBuilder builder(funcOp.getContext());
+      if (failed(initNumWorkgroupsRegion(builder, funcOp,
+                                         *workloadPerWorkgroup))) {
+        funcOp.emitOpError("failed to update number of workgroups");
         return signalPassFailure();
       }
     }
@@ -163,7 +225,8 @@ void LinalgTileAndDistributePass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> createLinalgTileAndDistributePass() {
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createLinalgTileAndDistributePass() {
   return std::make_unique<LinalgTileAndDistributePass>();
 }
 

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -50,65 +50,68 @@ void addLinalgToLLVMPasses(OpPassManager &passManager) {
   // Distribute linalg op among a 3d grid of parallel threads. Tile each
   // workgroup thread memory then vectorize the linalg op.
   passManager.addPass(createLinalgTileAndDistributePass());
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   if (!clEnableLLVMLinalgOnTensors) {
-    passManager.addPass(createLegalizeNumWorkgroupsFnPass());
+    nestedModulePM.addPass(createLegalizeNumWorkgroupsFnPass());
   }
   // Linalg.ConvOp -> (Img2Col packing + matmul).
   // After convolution is tiled and distributed among workgroups its converted
   // before vectorize workgroup workload.
   if (convImg2ColConversion) {
-    passManager.addNestedPass<FuncOp>(createConvImg2ColMatmulConversionPass());
+    nestedModulePM.addNestedPass<FuncOp>(
+        createConvImg2ColMatmulConversionPass());
   }
 
-  passManager.addNestedPass<FuncOp>(
+  nestedModulePM.addNestedPass<FuncOp>(
       createLinalgTileAndVectorizeWorkgroupsPass());
-  passManager.addNestedPass<FuncOp>(createPlanConvLoopOrderPass());
+  nestedModulePM.addNestedPass<FuncOp>(createPlanConvLoopOrderPass());
 
   // Linalg -> SCF
-  passManager.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
+  nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<FuncOp>(createCSEPass());
 
   // SCF -> STD
-  passManager.addNestedPass<FuncOp>(createLowerToCFGPass());
-  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<FuncOp>(createLowerToCFGPass());
+  nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<FuncOp>(createCSEPass());
 
   // (HAL, IREE, Linalg, STD) -> LLVM
-  // OpPassManager& llvmPassManager = passManager.nest<ModuleOp>();
+  // OpPassManager& llvmPassManager = nestedModulePM.nest<ModuleOp>();
   if (clEnableLLVMLinalgOnTensors) {
-    passManager.addPass(createConvertToLLVM2Pass());
+    nestedModulePM.addPass(createConvertToLLVM2Pass());
   } else {
-    passManager.addPass(createConvertToLLVMPass());
+    nestedModulePM.addPass(createConvertToLLVMPass());
   }
-  passManager.addPass(createCanonicalizerPass());
-  passManager.addPass(createCSEPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
 
   // Approximate llvm.intr.exp with a 4-th order ploynmial in range[0, ln2].
   if (fastExpConversion) {
-    passManager.addPass(createFastExpApproximationConversionPass());
+    nestedModulePM.addPass(createFastExpApproximationConversionPass());
   }
 }
 
 void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   if (!clEnableLLVMLinalgOnTensors)
-    passManager.addPass(createDeclareNumWorkgroupsFnPass());
+    nestedModulePM.addPass(createDeclareNumWorkgroupsFnPass());
 
-  passManager.addPass(createInlinerPass());
+  nestedModulePM.addPass(createInlinerPass());
 
   // HLO -> Linalg on buffers.
   if (clEnableLLVMLinalgOnTensors) {
-    passManager.addPass(createLinalgVectorizePass());
-    passManager.addPass(createLinalgLLVMBufferizePass());
-    passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    passManager.addNestedPass<FuncOp>(createCSEPass());
-    passManager.addNestedPass<FuncOp>(createRemoveDeadMemAllocsPass());
-    passManager.addPass(createCopyRemovalPass());
-    // passManager.addPass(createBufferHoistingPass());
+    nestedModulePM.addPass(createLinalgVectorizePass());
+    nestedModulePM.addPass(createLinalgLLVMBufferizePass());
+    nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
+    nestedModulePM.addNestedPass<FuncOp>(createCSEPass());
+    nestedModulePM.addNestedPass<FuncOp>(createRemoveDeadMemAllocsPass());
+    nestedModulePM.addPass(createCopyRemovalPass());
+    // nestedModulePM.addPass(createBufferHoistingPass());
     // TODO(nicolasvasilache): bug in buffer loop hoisting with
     // dynamic_linalg_matmul_on_tensors_fuse_0.mlir
-    // passManager.addPass(createBufferLoopHoistingPass());
-    passManager.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
+    // nestedModulePM.addPass(createBufferLoopHoistingPass());
+    nestedModulePM.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
   } else {
     // Propagates dynamic shapes computation on tensors.
     passManager.addNestedPass<FuncOp>(Shape::createTieDynamicShapesPass());

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -114,13 +114,13 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
     nestedModulePM.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
   } else {
     // Propagates dynamic shapes computation on tensors.
-    passManager.addNestedPass<FuncOp>(Shape::createTieDynamicShapesPass());
-    passManager.addNestedPass<FuncOp>(
+    nestedModulePM.addNestedPass<FuncOp>(Shape::createTieDynamicShapesPass());
+    nestedModulePM.addNestedPass<FuncOp>(
         Shape::createMaterializeShapeCalculationsPass());
-    passManager.addNestedPass<FuncOp>(
+    nestedModulePM.addNestedPass<FuncOp>(
         Shape::createHoistShapeCalculationsPass());
-    passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
-    addHLOToLinalgOnBuffersPasses(passManager);
+    nestedModulePM.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
+    addHLOToLinalgOnBuffersPasses(nestedModulePM);
   }
   // Linalg -> LLVM passes.
   addLinalgToLLVMPasses(passManager);

--- a/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
@@ -1,10 +1,24 @@
-// RUN: iree-opt -iree-codegen-llvm-linalg-tile-and-distribute -iree-codegen-linalg-to-llvm-workgroups-vectorization-pass -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-linalg-tile-and-distribute)),hal.executable(hal.executable.target(module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
 
-func @matmul_128x128x128(%arg0 : memref<128x128xf32>, %arg1: memref<128x128xf32>, %arg2: memref<128x128xf32>) {
-    linalg.matmul ins(%arg0, %arg1 : memref<128x128xf32>, memref<128x128xf32>) outs(%arg2 : memref<128x128xf32>)
-    return
+hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
+  hal.interface @legacy_io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @llvm_aot, filter="dylib*" {
+    hal.executable.entry_point @dynamic_matmul attributes {
+      interface = @legacy_io, ordinal = 0 : i32,
+      signature = (!flow.dispatch.input<?x?xf32>, !flow.dispatch.input<?x?xf32>,
+        !flow.dispatch.output<?x?xf32>) -> ()}
+    module {
+      func @matmul_128x128x128(%arg0 : memref<128x128xf32>, %arg1: memref<128x128xf32>, %arg2: memref<128x128xf32>) {
+        linalg.matmul ins(%arg0, %arg1 : memref<128x128xf32>, memref<128x128xf32>) outs(%arg2 : memref<128x128xf32>)
+        return
+      }
+    }
+  }
 }
-// CHECK: #[[MAP0:map.*]] =  affine_map<()[s0] -> (s0 * 64)>
 // CHECK-LABEL: func @matmul_128x128x128
 // CHECK-SAME: (%[[ARG0:.+]]: memref<128x128xf32>, %[[ARG1:.+]]: memref<128x128xf32>, %[[ARG2:.+]]: memref<128x128xf32>)
 // CHECK-DaG: %[[WORKGROUP_TILE_X:.+]] = hal.interface.workgroup.id[0] : index

--- a/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
@@ -154,7 +154,7 @@ hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
 //       CHECK:     %[[T1:.+]] = divi_signed %[[T0]], %[[C4]]
 //       CHECK:     %[[T2:.+]] = addi %[[ARG1]], %[[C1]]
 //       CHECK:     %[[T3:.+]] = divi_signed %[[T2]], %[[C2]]
-//       CHECK:     hal.yield %[[T1]], %[[T3]], %[[C1]]
+//       CHECK:     hal.return %[[T1]], %[[T3]], %[[C1]]
 //   CHECK-NOT:   hal.interface.workgroup.size
 //   CHECK-DAG:   %[[C2:.+]] = constant 2
 //   CHECK-DAG:   %[[C4:.+]] = constant 4

--- a/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
@@ -1,8 +1,23 @@
-// RUN: iree-opt --iree-codegen-llvm-linalg-tile-and-distribute -iree-llvm-tile-size=2,4,1 -cse -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-linalg-tile-and-distribute))" -iree-llvm-tile-size=2,4,1 -cse -canonicalize -split-input-file %s | IreeFileCheck %s
 
-func @dynamic_matmul(%lhs: memref<?x?xf32>, %rhs: memref<?x?xf32>, %result: memref<?x?xf32>) {
-  linalg.matmul ins(%lhs, %rhs : memref<?x?xf32>, memref<?x?xf32>) outs(%result : memref<?x?xf32>)
-  return
+hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
+  hal.interface @legacy_io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @llvm_aot, filter="dylib*" {
+    hal.executable.entry_point @dynamic_matmul attributes {
+      interface = @legacy_io, ordinal = 0 : i32,
+      signature = (!flow.dispatch.input<?x?xf32>, !flow.dispatch.input<?x?xf32>,
+        !flow.dispatch.output<?x?xf32>) -> ()}
+    module {
+      func @dynamic_matmul(%lhs: memref<?x?xf32>, %rhs: memref<?x?xf32>, %result: memref<?x?xf32>) {
+        linalg.matmul ins(%lhs, %rhs : memref<?x?xf32>, memref<?x?xf32>) outs(%result : memref<?x?xf32>)
+        return
+      }
+    }
+  }
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (2, s0 * -2 + s1)>
@@ -33,9 +48,24 @@ func @dynamic_matmul(%lhs: memref<?x?xf32>, %rhs: memref<?x?xf32>, %result: memr
 
 // -----
 
-func @static_matmul(%lhs: memref<16x4xf32>, %rhs: memref<4x8xf32>, %result: memref<16x8xf32>) {
-  linalg.matmul ins(%lhs, %rhs : memref<16x4xf32>, memref<4x8xf32>) outs(%result : memref<16x8xf32>)
-  return
+hal.executable @static_matmul attributes {sym_visibility = "private"} {
+  hal.interface @legacy_io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @llvm_aot, filter="dylib*" {
+    hal.executable.entry_point @static_matmul attributes {
+      interface = @legacy_io, ordinal = 0 : i32,
+      signature = (!flow.dispatch.input<16x4xf32>, !flow.dispatch.input<4x8xf32>,
+        !flow.dispatch.output<16x8xf32>) -> ()}
+    module {
+      func @static_matmul(%lhs: memref<16x4xf32>, %rhs: memref<4x8xf32>, %result: memref<16x8xf32>) {
+        linalg.matmul ins(%lhs, %rhs : memref<16x4xf32>, memref<4x8xf32>) outs(%result : memref<16x8xf32>)
+        return
+      }
+    }
+  }
 }
 // CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>
@@ -57,45 +87,74 @@ func @static_matmul(%lhs: memref<16x4xf32>, %rhs: memref<4x8xf32>, %result: memr
 
 // -----
 
-func @matmul_tensors() {
-  %c2 = constant 2 : index
-  %c4 = constant 4 : index
-  %c0 = constant 0 : index
-  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : memref<?xi8>
-  %1 = std.view %0[%c0][] : memref<?xi8> to memref<2x3xf32>
-  %2 = hal.interface.binding.subspan @legacy_io::@arg1[%c0] : memref<?xi8>
-  %3 = std.view %2[%c0][] : memref<?xi8> to memref<3x4xf32>
-  %4 = hal.interface.binding.subspan @legacy_io::@arg2[%c0] : memref<?xi8>
-  %5 = std.view %4[%c0][] : memref<?xi8> to memref<2x4xf32>
-  %6 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : memref<?xi8>
-  %7 = std.view %6[%c0][] : memref<?xi8> to memref<2x4xf32>
-  %workgroup_size_x = hal.interface.workgroup.size[0] : index
-  %workgroup_size_y = hal.interface.workgroup.size[1] : index
-  %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
-  %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %8 = muli %workgroup_size_y, %workgroup_id_y : index
-  %9 = muli %workgroup_size_y, %workgroup_count_y : index
-  scf.for %arg0 = %8 to %c2 step %9 {
-    %10 = muli %workgroup_size_x, %workgroup_id_x : index
-    %11 = muli %workgroup_size_x, %workgroup_count_x : index
-    scf.for %arg1 = %10 to %c4 step %11 {
-      %12 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 2)>(%arg0)[%workgroup_size_y]
-      %13 = subview %1[%arg0, 0] [%12, 3] [1, 1] : memref<2x3xf32> to memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>
-      %14 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 4)>(%arg1)[%workgroup_size_x]
-      %15 = subview %3[0, %arg1] [3, %14] [1, 1] : memref<3x4xf32> to memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
-      %16 = subview %5[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
-      %17 = alloc(%12, %14) : memref<?x?xf32>
-      linalg.copy(%16, %17) : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>, memref<?x?xf32>
-      linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%13, %15 : memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>, memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>) outs(%17 : memref<?x?xf32>)
-      %18 = subview %7[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
-      linalg.copy(%17, %18) : memref<?x?xf32>, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
+  hal.interface @legacy_io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @llvm_aot, filter="dylib*" {
+    hal.executable.entry_point @matmul_tensors attributes {
+      interface = @legacy_io, ordinal = 0 : i32,
+      signature = (!flow.dispatch.input<?x?xf32>, !flow.dispatch.input<?x?xf32>,
+        !flow.dispatch.output<?x?xf32>) -> ()}
+    module {
+      func @matmul_tensors() {
+        %c2 = constant 2 : index
+        %c4 = constant 4 : index
+        %c0 = constant 0 : index
+        %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : memref<?xi8>
+        %1 = std.view %0[%c0][] : memref<?xi8> to memref<2x3xf32>
+        %2 = hal.interface.binding.subspan @legacy_io::@arg1[%c0] : memref<?xi8>
+        %3 = std.view %2[%c0][] : memref<?xi8> to memref<3x4xf32>
+        %4 = hal.interface.binding.subspan @legacy_io::@arg2[%c0] : memref<?xi8>
+        %5 = std.view %4[%c0][] : memref<?xi8> to memref<2x4xf32>
+        %6 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : memref<?xi8>
+        %7 = std.view %6[%c0][] : memref<?xi8> to memref<2x4xf32>
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %8 = muli %workgroup_size_y, %workgroup_id_y : index
+        %9 = muli %workgroup_size_y, %workgroup_count_y : index
+        scf.for %arg0 = %8 to %c2 step %9 {
+          %10 = muli %workgroup_size_x, %workgroup_id_x : index
+          %11 = muli %workgroup_size_x, %workgroup_count_x : index
+          scf.for %arg1 = %10 to %c4 step %11 {
+            %12 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 2)>(%arg0)[%workgroup_size_y]
+            %13 = subview %1[%arg0, 0] [%12, 3] [1, 1] : memref<2x3xf32> to memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>
+            %14 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 4)>(%arg1)[%workgroup_size_x]
+            %15 = subview %3[0, %arg1] [3, %14] [1, 1] : memref<3x4xf32> to memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+            %16 = subview %5[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+            %17 = alloc(%12, %14) : memref<?x?xf32>
+            linalg.copy(%16, %17) : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>, memref<?x?xf32>
+            linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%13, %15 : memref<?x3xf32, affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>>, memref<3x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>) outs(%17 : memref<?x?xf32>)
+            %18 = subview %7[%arg0, %arg1] [%12, %14] [1, 1] : memref<2x4xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+            linalg.copy(%17, %18) : memref<?x?xf32>, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>>
+          }
+        }
+        return
+      }
     }
   }
-  return
 }
-// CHECK-LABEL: matmul_tensors
+// CHECK-LABEL: hal.executable @matmul_tensors
+//       CHECK: hal.executable.entry_point @matmul_tensors
+//  CHECK-NEXT:   ^{{[a-zA-Z0-9_]+}}(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:     %[[C2:.+]] = constant 2 : index
+//   CHECK-DAG:     %[[C3:.+]] = constant 3 : index
+//   CHECK-DAG:     %[[C4:.+]] = constant 4 : index
+//       CHECK:     %[[T0:.+]] = addi %[[ARG0]], %[[C3]]
+//       CHECK:     %[[T1:.+]] = divi_signed %[[T0]], %[[C4]]
+//       CHECK:     %[[T2:.+]] = addi %[[ARG1]], %[[C1]]
+//       CHECK:     %[[T3:.+]] = divi_signed %[[T2]], %[[C2]]
+//       CHECK:     hal.yield %[[T1]], %[[T3]], %[[C1]]
 //   CHECK-NOT:   hal.interface.workgroup.size
 //   CHECK-DAG:   %[[C2:.+]] = constant 2
 //   CHECK-DAG:   %[[C4:.+]] = constant 4

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -5,6 +5,8 @@
 // CHECK-LABEL: func @tensor
 func @tensor() -> tensor<2x4xf32> {
   //  CHECK-DAG: %[[C1wg:.*]] = constant 1 : index
+  //  CHECK-DAG: %[[C2wg:.*]] = constant 2 : index
+  //  CHECK-DAG: %[[C4wg:.*]] = constant 4 : index
   //  CHECK-DAG: %[[outerA:.*]] = iree.do_not_optimize{{.*}} : tensor<2x3xf32>
   //  CHECK-DAG: %[[outerB:.*]] = iree.do_not_optimize{{.*}} : tensor<3x4xf32>
   //  CHECK-DAG: %[[outerC:.*]] = iree.do_not_optimize{{.*}} : tensor<2x4xf32>
@@ -15,7 +17,7 @@ func @tensor() -> tensor<2x4xf32> {
   %C = iree.unfoldable_constant dense<1000.0> : tensor<2x4xf32>
 
   // %[[C2]] will be handled by a later RematerializeDispatchConstants
-  //      CHECK: flow.dispatch.workgroups[%[[C1wg]], %[[C1wg]], %[[C1wg]]] (%[[outerA]], %[[outerB]], %[[outerC]]) :
+  //      CHECK: flow.dispatch.workgroups[%[[C4wg]], %[[C2wg]], %[[C1wg]]] (%[[outerA]], %[[outerB]], %[[outerC]]) :
   // CHECK-SAME:    (tensor<2x3xf32>, tensor<3x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32> =
   // CHECK-SAME:    (%[[A:[0-9a-z]*]] : !flow.dispatch.input<2x3xf32>,
   // CHECK-SAME:     %[[B:[0-9a-z]*]] : !flow.dispatch.input<3x4xf32>,

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1354,7 +1354,7 @@ static LogicalResult verifyExecutableEntryPointOp(ExecutableEntryPointOp op) {
   // TODO(ravishankarm): The SingleBlockImplicitTerminator<"HAL::ReturnOp">
   // should generate this check, but it doesnt.
   auto returnOp = dyn_cast<ReturnOp>(region->front().getTerminator());
-  if (!returnOp || returnOp.values().size() != 3) {
+  if (!returnOp || returnOp.operands().size() != 3) {
     return op.emitOpError("expected operation to yield 3 values");
   }
   return success();

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1307,6 +1307,16 @@ static ParseResult parseExecutableEntryPointOp(OpAsmParser &parser,
       failed(parser.parseOptionalAttrDictWithKeyword(result->attributes))) {
     return failure();
   }
+  // For now assume that the workload is at max 3D. So arguments to the region
+  // are workload along x, y and z.
+  std::unique_ptr<Region> region;
+  SmallVector<OpAsmParser::OperandType, 4> regionOperands;
+  SmallVector<Type, 4> regionTypes;
+  OptionalParseResult parseResult =
+      parser.parseOptionalRegion(region, regionOperands, regionTypes);
+  if (!parseResult.hasValue()) return success();
+  if (failed(*parseResult)) return failure();
+  result->addRegion(std::move(region));
   return success();
 }
 
@@ -1316,6 +1326,37 @@ static void printExecutableEntryPointOp(OpAsmPrinter &p,
   p.printSymbolName(op.sym_name());
   p.printOptionalAttrDictWithKeyword(op.getAttrs(),
                                      /*elidedAttrs=*/{"sym_name"});
+  if (op.num_workgroups_region().empty()) return;
+  p.printRegion(op.num_workgroups_region().front());
+}
+
+static LogicalResult verifyExecutableEntryPointOp(ExecutableEntryPointOp op) {
+  Region *region = op.getBody();
+  // When there is no region, nothing to verify.
+  if (!region) return success();
+
+  if (!llvm::hasSingleElement(*region)) {
+    return op.emitOpError() << "expected a single region";
+  }
+  if (region->getNumArguments() != 3) {
+    return op.emitOpError(
+        "expected three arguments for num_workgroups_region for workload along "
+        "x, y, and z");
+  }
+  for (BlockArgument &blockArg : region->getArguments()) {
+    if (!blockArg.getType().isa<IndexType>()) {
+      return op.emitOpError(
+          "expected arguments to num_workgroups_region be index type");
+    }
+  }
+  // Check that the last statement in the block is `hal.yield` operation.
+  // TODO(ravishankarm): The SingleBlockImplicitTerminator<"HAL::YieldOp">
+  // should generate this check, but it doesnt.
+  auto yieldOp = dyn_cast<YieldOp>(region->front().getTerminator());
+  if (!yieldOp || yieldOp.values().size() != 3) {
+    return op.emitOpError("expected operation to yield 3 values");
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1326,8 +1326,8 @@ static void printExecutableEntryPointOp(OpAsmPrinter &p,
   p.printSymbolName(op.sym_name());
   p.printOptionalAttrDictWithKeyword(op.getAttrs(),
                                      /*elidedAttrs=*/{"sym_name"});
-  if (op.num_workgroups_region().empty()) return;
-  p.printRegion(op.num_workgroups_region().front());
+  if (op.workgroup_count_region().empty()) return;
+  p.printRegion(op.workgroup_count_region().front());
 }
 
 static LogicalResult verifyExecutableEntryPointOp(ExecutableEntryPointOp op) {
@@ -1340,20 +1340,21 @@ static LogicalResult verifyExecutableEntryPointOp(ExecutableEntryPointOp op) {
   }
   if (region->getNumArguments() != 3) {
     return op.emitOpError(
-        "expected three arguments for num_workgroups_region for workload along "
+        "expected three arguments for workgroup_count_region for workload "
+        "along "
         "x, y, and z");
   }
   for (BlockArgument &blockArg : region->getArguments()) {
     if (!blockArg.getType().isa<IndexType>()) {
       return op.emitOpError(
-          "expected arguments to num_workgroups_region be index type");
+          "expected arguments to workgroup_count_region be index type");
     }
   }
   // Check that the last statement in the block is `hal.yield` operation.
-  // TODO(ravishankarm): The SingleBlockImplicitTerminator<"HAL::YieldOp">
+  // TODO(ravishankarm): The SingleBlockImplicitTerminator<"HAL::ReturnOp">
   // should generate this check, but it doesnt.
-  auto yieldOp = dyn_cast<YieldOp>(region->front().getTerminator());
-  if (!yieldOp || yieldOp.values().size() != 3) {
+  auto returnOp = dyn_cast<ReturnOp>(region->front().getTerminator());
+  if (!returnOp || returnOp.values().size() != 3) {
     return op.emitOpError("expected operation to yield 3 values");
   }
   return success();

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1840,15 +1840,6 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
   let assemblyFormat = "attr-dict";
 }
 
-def HAL_YieldOp : HAL_Op<"yield", [NoSideEffect, Terminator]> {
-  let summary = [{yield values from within regions in hal ops}];
-  let description = [{
-    Yields values to the immediately enclaosing hal op
-  }];
-  let arguments = (ins Variadic<AnyType>:$values);
-  let assemblyFormat = "$values attr-dict `:` type($values)";
-}
-
 def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     Symbol,
     HasParent<"IREE::HAL::ExecutableTargetOp">,
@@ -1859,7 +1850,7 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
 
-    The optional `num_workgroups_region` region represents the
+    The optional `workgroup_count_region` region represents the
     computation that returns the number of workgroups to use. The
     arguments to the region represents the workload along x, y and
     z. It returns the number of workgroups along x, y, and z.
@@ -1879,7 +1870,7 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size
   );
 
-  let regions = (region VariadicRegion<SizedRegion<1>>:$num_workgroups_region);
+  let regions = (region VariadicRegion<SizedRegion<1>>:$workgroup_count_region);
 
   let builders = [
     OpBuilderDAG<
@@ -1900,7 +1891,7 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
 
   let extraClassDeclaration = [{
     Region *getBody() {
-      auto regions = num_workgroups_region();
+      auto regions = workgroup_count_region();
       if (!regions.empty()) return &regions.front();
       return nullptr;
     }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1840,14 +1840,35 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
   let assemblyFormat = "attr-dict";
 }
 
+def HAL_YieldOp : HAL_Op<"yield", [NoSideEffect, Terminator]> {
+  let summary = [{yield values from within regions in hal ops}];
+  let description = [{
+    Yields values to the immediately enclaosing hal op
+  }];
+  let arguments = (ins Variadic<AnyType>:$values);
+  let assemblyFormat = "$values attr-dict `:` type($values)";
+}
+
 def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     Symbol,
     HasParent<"IREE::HAL::ExecutableTargetOp">,
+    IsolatedFromAbove
   ]> {
   let summary = [{executable entry point declaration}];
   let description = [{
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
+
+    The optional `num_workgroups_region` region represents the
+    computation that returns the number of workgroups to use. The
+    arguments to the region represents the workload along x, y and
+    z. It returns the number of workgroups along x, y, and z.
+
+    TODO(ravishankarm): In reality there is no need to define what the
+    arguments represent. They could be any values that are needed to
+    compute the number of workgroups. Its unclear what these are in
+    general and how to plumb them through. So for now just accepting
+    the workload along x, y, and z.
   }];
 
   let arguments = (ins
@@ -1857,6 +1878,37 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     TypeAttr:$signature,
     OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size
   );
+
+  let regions = (region VariadicRegion<SizedRegion<1>>:$num_workgroups_region);
+
+  let builders = [
+    OpBuilderDAG<
+      (ins "::llvm::StringRef":$sym_name, "::llvm::APInt":$ordinal,
+        "::llvm::StringRef":$interface,"::mlir::TypeAttr":$signature,
+        "::mlir::ArrayAttr":$workgroup_size),
+       [{build($_builder, $_state, sym_name, ordinal, interface, signature,
+            workgroup_size, 0);}]>,
+    OpBuilderDAG<
+      (ins "::mlir::StringAttr":$sym_name, "::mlir::IntegerAttr":$ordinal,
+        "::mlir::FlatSymbolRefAttr":$interface, "::mlir::TypeAttr":$signature,
+        "::mlir::ArrayAttr":$workgroup_size),
+      [{build($_builder, $_state, sym_name, ordinal, interface, signature,
+          workgroup_size, 0);}]>
+  ];
+
+  let verifier = [{ return verifyExecutableEntryPointOp(*this); }];
+
+  let extraClassDeclaration = [{
+    Region *getBody() {
+      auto regions = num_workgroups_region();
+      if (!regions.empty()) return &regions.front();
+      return nullptr;
+    }
+    Block* getBlock() {
+      if (Region *region = getBody()) return &region->front();
+      return nullptr;
+    }
+  }];
 }
 
 def HAL_ExecutableTargetOp : HAL_Op<"executable.target", [

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -52,7 +52,7 @@ hal.executable @ex_with_workgroup_count_region {
       workgroup_size = [4 : index, 1 : index, 1 : index]
     } {
     ^bb0(%arg0: index, %arg1: index, %arg2: index):
-      hal.yield %arg0, %arg1, %arg2 : index, index, index
+      hal.return %arg0, %arg1, %arg2 : index, index, index
     }
   }
   // CHECK-DAG: hal.interface @interface

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -36,6 +36,43 @@ hal.executable @ex {
 
 // -----
 
+// CHECK-LABEL: @ex_with_num_workgroups_region
+hal.executable @ex_with_num_workgroups_region {
+  // CHECK: hal.executable.target @backend, filter="backend"
+  hal.executable.target @backend, filter="backend" {
+    // CHECK-DAG: hal.executable.entry_point @entry0 attributes {
+    // CHECK-SAME:     interface = @interface
+    // CHECK-SAME:     ordinal = 0 : i32
+    // CHECK-SAME:     signature = (tensor<4xf32>) -> tensor<4xf32>
+    // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
+    hal.executable.entry_point @entry0 attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [4 : index, 1 : index, 1 : index]
+    } {
+    ^bb0(%arg0: index, %arg1: index, %arg2: index):
+      hal.yield %arg0, %arg1, %arg2 : index, index, index
+    }
+  }
+  // CHECK-DAG: hal.interface @interface
+  hal.interface @interface {
+    // CHECK-NEXT: hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+    // CHECK-NEXT: hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+    hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  // CHECK: hal.executable.binary
+  hal.executable.binary attributes {
+    // CHECK-SAME: data = dense<1> : vector<128xi8>,
+    data = dense<1> : vector<128xi8>,
+    // CHECK-SAME: format = 1230128453 : i32
+    format = 1230128453 : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @ex_with_source
 hal.executable @ex_with_source {
   // CHECK-NEXT: hal.executable.binary

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -63,7 +63,7 @@ hal.executable @ex_with_num_workgroups_region {
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
   // CHECK: hal.executable.binary
-  hal.executable.binary attributes {
+  hal.executable.binary @backend_binary attributes {
     // CHECK-SAME: data = dense<1> : vector<128xi8>,
     data = dense<1> : vector<128xi8>,
     // CHECK-SAME: format = 1230128453 : i32

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -36,8 +36,8 @@ hal.executable @ex {
 
 // -----
 
-// CHECK-LABEL: @ex_with_num_workgroups_region
-hal.executable @ex_with_num_workgroups_region {
+// CHECK-LABEL: @ex_with_workgroup_count_region
+hal.executable @ex_with_workgroup_count_region {
   // CHECK: hal.executable.target @backend, filter="backend"
   hal.executable.target @backend, filter="backend" {
     // CHECK-DAG: hal.executable.entry_point @entry0 attributes {

--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -62,7 +62,8 @@ void SPIRVTargetBackend::declareTargetOpsForEnv(
 
 void SPIRVTargetBackend::buildTranslationPassPipeline(
     OpPassManager &passManager) {
-  buildSPIRVTransformPassPipeline(passManager, spvCodeGenOptions_);
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+  buildSPIRVTransformPassPipeline(nestedModulePM, spvCodeGenOptions_);
 }
 
 LogicalResult SPIRVTargetBackend::recordDispatch(

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -271,7 +271,7 @@ static std::array<Value, 3> calculateDispatchWorkgroupCountFromRegion(
   auto returnOp = cast<IREE::HAL::ReturnOp>(body->getTerminator());
   // Verifier of EntryPointOp checks that the return has 3 values.
   SmallVector<Value, 4> count = llvm::to_vector<4>(llvm::map_range(
-      returnOp.values(), [&bvm](Value v) { return bvm.lookup(v); }));
+      returnOp.operands(), [&bvm](Value v) { return bvm.lookup(v); }));
   return {count[0], count[1], count[2]};
 }
 

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -268,10 +268,10 @@ static std::array<Value, 3> calculateDispatchWorkgroupCountFromRegion(
   for (Operation &op : body->without_terminator()) {
     builder.clone(op, bvm);
   }
-  auto yieldOp = cast<IREE::HAL::YieldOp>(body->getTerminator());
-  // Verifier of EntryPointOp checks that the yield has 3 values.
+  auto returnOp = cast<IREE::HAL::ReturnOp>(body->getTerminator());
+  // Verifier of EntryPointOp checks that the return has 3 values.
   SmallVector<Value, 4> count = llvm::to_vector<4>(llvm::map_range(
-      yieldOp.values(), [&bvm](Value v) { return bvm.lookup(v); }));
+      returnOp.values(), [&bvm](Value v) { return bvm.lookup(v); }));
   return {count[0], count[1], count[2]};
 }
 

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -247,10 +247,43 @@ std::array<Value, 3> TargetBackend::calculateDispatchWorkgroupSize(
   };
 }
 
+static std::array<Value, 3> calculateDispatchWorkgroupCountFromRegion(
+    Location loc, IREE::HAL::ExecutableEntryPointOp entryPointOp,
+    ValueRange workload, OpBuilder &builder) {
+  Block *body = entryPointOp.getBlock();
+  if (workload.size() != body->getNumArguments()) {
+    ::mlir::emitError(loc,
+                      "mismatch in number of workload values provided during "
+                      "lowering to HAL and provided");
+    return {
+        builder.createOrFold<mlir::ConstantIndexOp>(loc, 1),
+        builder.createOrFold<mlir::ConstantIndexOp>(loc, 1),
+        builder.createOrFold<mlir::ConstantIndexOp>(loc, 1),
+    };
+  }
+  BlockAndValueMapping bvm;
+  for (auto args : llvm::zip(workload, body->getArguments())) {
+    bvm.map(std::get<1>(args), std::get<0>(args));
+  }
+  for (Operation &op : body->without_terminator()) {
+    builder.clone(op, bvm);
+  }
+  auto yieldOp = cast<IREE::HAL::YieldOp>(body->getTerminator());
+  // Verifier of EntryPointOp checks that the yield has 3 values.
+  SmallVector<Value, 4> count = llvm::to_vector<4>(llvm::map_range(
+      yieldOp.values(), [&bvm](Value v) { return bvm.lookup(v); }));
+  return {count[0], count[1], count[2]};
+}
+
 std::array<Value, 3> TargetBackend::calculateDispatchWorkgroupCount(
     Location loc, IREE::HAL::ExecutableOp executableOp,
     IREE::HAL::ExecutableEntryPointOp entryPointOp, ValueRange workload,
     OpBuilder &builder) {
+  Region *region = entryPointOp.getBody();
+  if (region) {
+    return calculateDispatchWorkgroupCountFromRegion(loc, entryPointOp,
+                                                     workload, builder);
+  }
   auto workgroupSize = calculateDispatchWorkgroupSize(
       loc, executableOp, entryPointOp, workload, builder);
   return calculateDispatchWorkgroupCount(loc, workload, workgroupSize, builder);

--- a/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
@@ -55,14 +55,15 @@ class VMLATargetBackend final : public TargetBackend {
   }
 
   void buildTranslationPassPipeline(OpPassManager &passManager) override {
-    IREE::VMLA::buildVMLATransformPassPipeline(passManager);
+    OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+    IREE::VMLA::buildVMLATransformPassPipeline(nestedModulePM);
 
     // TODO(#614): remove this when the std->vm conversion isn't looking for
     // iree.module.export.
-    passManager.addPass(IREE::VM::createMarkPublicSymbolsExportedPass());
+    nestedModulePM.addPass(IREE::VM::createMarkPublicSymbolsExportedPass());
 
     IREE::VM::buildVMTransformPassPipeline(
-        passManager, IREE::VM::getTargetOptionsFromFlags());
+        nestedModulePM, IREE::VM::getTargetOptionsFromFlags());
   }
 
   LogicalResult linkExecutables(mlir::ModuleOp moduleOp) override {

--- a/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -40,7 +40,8 @@ class TranslateExecutablesPass
     for (auto &targetBackend :
          matchTargetBackends(executableOptions_.targets)) {
       auto pm = std::make_unique<OpPassManager>(
-          ModuleOp::getOperationName(), OpPassManager::Nesting::Implicit);
+          IREE::HAL::ExecutableTargetOp::getOperationName(),
+          OpPassManager::Nesting::Implicit);
       targetBackend->buildTranslationPassPipeline(*pm);
       pipelines_.push_back({std::move(targetBackend), std::move(pm)});
     }
@@ -65,8 +66,7 @@ class TranslateExecutablesPass
               targetOp.target_backend_filter().str())) {
         continue;
       }
-      if (failed(
-              runPipeline(*pipeline.passManager, targetOp.getInnerModule()))) {
+      if (failed(runPipeline(*pipeline.passManager, targetOp))) {
         targetOp.emitError() << "failed to run translation of source "
                                 "executable to target executable for backend "
                              << targetOp.target_backend_filter();


### PR DESCRIPTION
While the code-generated through the linalg on tensors path works for
any number of workgroups used by the runtime, there is advantage to
expose the maximum number of workgroups that are actually needed to
perform the entire computation represented by the
`flow.dispatch.workgroup`. The runtime can then chose to
underprovision based on resource availability.
This is done by adding a region to `hal.executable.entry_point` op
that returns the maximum number of workgroups given the workload of
the dispatched computation.
Current implementation limitations are that it is assumed that the
workload is described in terms of [x, y, z]. Due to this only those
dispatch regions in flow dialect that have workload described in terms
of [x, y, z] are handled.

A consequence of allowing backends to specify number of workgroups is
that the translation pipeline now needs the entire
`hal.executable.target` operation for translation.

The Linalg on tensors path is adapted to use this which enables use of
multi-core CPU.