### PR TITLE
Fix vm.list.get.i64 in the interpreter

### DIFF
--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1360,7 +1360,7 @@ iree_status_t iree_vm_bytecode_dispatch(
         iree_vm_value_t value;
         IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
             list, index, IREE_VM_VALUE_TYPE_I64, &value));
-        *result = value.i32;
+        *result = value.i64;
       });
 
       DISPATCH_OP(EXT_I64, ListSetI64, {

--- a/iree/vm/test/list_ops.mlir
+++ b/iree/vm/test/list_ops.mlir
@@ -32,6 +32,24 @@ vm.module @list_ops {
   }
 
   //===--------------------------------------------------------------------===//
+  // vm.list.* with I64 types
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_i64
+  vm.func @test_i64() {
+    %capacity = vm.const.i32 42 : i32
+    %index = vm.const.i32 41 : i32
+    %max_int_plus_1 = vm.const.i64 2147483648 : i64
+    %list = vm.list.alloc %capacity : (i32) -> !vm.list<i64>
+    %sz = vm.list.size %list : (!vm.list<i64>) -> i32
+    vm.list.resize %list, %capacity : (!vm.list<i64>, i32)
+    vm.list.set.i64 %list, %index, %max_int_plus_1 : (!vm.list<i64>, i32, i64)
+    %v = vm.list.get.i64 %list, %index : (!vm.list<i64>, i32) -> i64
+    vm.check.eq %v, %max_int_plus_1 : i64
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
   // vm.list.* with ref types
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
I stumbled upon this while scrolling through the code.