### PR TITLE
Fix relative path error in Android getting started

### DIFF
--- a/docs/get_started/getting_started_android_cmake.md
+++ b/docs/get_started/getting_started_android_cmake.md
@@ -81,7 +81,7 @@ Build the runtime using the Android NDK toolchain:
 ```shell
 $ cmake -G Ninja -B ../iree-build-android/ \
   -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK?}/build/cmake/android.toolchain.cmake" \
-  -DIREE_HOST_BINARY_ROOT=../iree-build-host/install \
+  -DIREE_HOST_BINARY_ROOT=$(realpath ../iree-build-host/install) \
   -DANDROID_ABI="arm64-v8a" \
   -DANDROID_PLATFORM=android-29 \
   -DIREE_BUILD_COMPILER=OFF \


### PR DESCRIPTION
The command as written was causing the following error on my system:

```
ninja: error: 'iree/base/iree-build-host/install/bin/generate_cc_embed_data', needed by 'iree/base/testing/dynamic_library_test_library_embed.cc', missing and no known rule to make it
```