### PR TITLE
Add necessary linker flag to jax-android example

### DIFF
--- a/bindings/python/pyiree/jax/README.md
+++ b/bindings/python/pyiree/jax/README.md
@@ -44,11 +44,10 @@ runtime environments like Android.
 
 Install the Android NDK according to the
 [Android Getting Started](https://google.github.io/iree/get-started/getting-started-android-cmake)
-doc, and then ensure the following environment variables are set:
+doc, and then ensure the following environment variable is set:
 
 ```shell
 export ANDROID_NDK=# NDK install location
-export IREE_LLVMAOT_LINKER_PATH="${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++"
 ```
 
 The code below assumes that you have `flax` installed.
@@ -61,6 +60,10 @@ import jax
 import jax.numpy as jnp
 import flax
 from flax import linen as nn
+
+import os
+# Configure the linker to target Android.
+os.environ["IREE_LLVMAOT_LINKER_PATH"] = "${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++ -static-libstdc++"
 
 
 class MLP(nn.Module):


### PR DESCRIPTION
Compilation completes without error without `-static-libstdc++`, but `iree-run-module` gives the following error when attempting to run the `.vmfb` on device:

```
F iree/tools/iree-run-module-main.cc:163] Check failed: ::iree::IsOk(_status163) iree/iree/base/dynamic_library_posix.cc:47: UNAVAILABLE
```

Also moved setting `IREE_LLVMAOT_LINKER_PATH` so that it doesn't persist in the environment to cause future host build/compilation errors.