### PR TITLE
Relocate integer arithmetic ops from dispatcher

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -436,10 +436,10 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
     output << "#include \"" << include << "\"\n";
   };
 
-  printInclude("iree/vm/c_funcs.h");
   printInclude("iree/vm/context.h");
   printInclude("iree/vm/instance.h");
   printInclude("iree/vm/native_module.h");
+  printInclude("iree/vm/ops.h");
   printInclude("iree/vm/ref.h");
   printInclude("iree/vm/shims.h");
   printInclude("iree/vm/stack.h");

--- a/iree/compiler/Dialect/VM/Target/C/test/add.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/add.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-translate -iree-vm-ir-to-c-module %s | IreeFileCheck %s
 
-// CHECK: #include "iree/vm/c_funcs.h"
+// CHECK: #include "iree/vm/ops.h"
 vm.module @add_module {
   // CHECK: iree_status_t add_module_add_1_impl(int32_t v1, int32_t v2, int32_t *out0, int32_t *out1) {
   vm.func @add_1(%arg0 : i32, %arg1 : i32) -> (i32, i32) {

--- a/iree/compiler/Dialect/VM/Target/C/test/empty_module.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/empty_module.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-translate -iree-vm-ir-to-c-module %s | IreeFileCheck %s
 
-// CHECK: #include "iree/vm/c_funcs.h"
+// CHECK: #include "iree/vm/ops.h"
 vm.module @empty_module {
 }

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -186,7 +186,7 @@ cc_library(
         "bytecode_module.h",
     ],
     deps = [
-        ":c_funcs",
+        ":ops",
         ":vm",
         "//iree/base:api",
         "//iree/base:core_headers",
@@ -298,13 +298,13 @@ endif()
 )
 
 #===------------------------------------------------------------------------===#
-# Common VM c functions
+# Common VM op implementations
 #===------------------------------------------------------------------------===#
 
 cc_library(
-    name = "c_funcs",
+    name = "ops",
     hdrs = [
-        "c_funcs.h",
+        "ops.h",
     ],
 )
 

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -186,6 +186,7 @@ cc_library(
         "bytecode_module.h",
     ],
     deps = [
+        ":c_funcs",
         ":vm",
         "//iree/base:api",
         "//iree/base:core_headers",
@@ -297,7 +298,7 @@ endif()
 )
 
 #===------------------------------------------------------------------------===#
-# Emit-C modules
+# Common VM c functions
 #===------------------------------------------------------------------------===#
 
 cc_library(

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -168,7 +168,7 @@ iree_cc_library(
     "bytecode_module_impl.h"
     "generated/bytecode_op_table.h"
   DEPS
-    ::c_funcs
+    ::ops
     ::vm
     iree::base::api
     iree::base::core_headers
@@ -266,9 +266,9 @@ endif()
 
 iree_cc_library(
   NAME
-    c_funcs
+    ops
   HDRS
-    "c_funcs.h"
+    "ops.h"
   PUBLIC
 )
 

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -168,6 +168,7 @@ iree_cc_library(
     "bytecode_module_impl.h"
     "generated/bytecode_op_table.h"
   DEPS
+    ::c_funcs
     ::vm
     iree::base::api
     iree::base::core_headers

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -18,6 +18,7 @@
 #include "iree/base/tracing.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_dispatch_util.h"
+#include "iree/vm/c_funcs.h"
 
 //===----------------------------------------------------------------------===//
 // Register remapping utilities
@@ -975,32 +976,32 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Native integer arithmetic
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CORE_UNARY_ALU_I32(op_name, type, op) \
-  DISPATCH_OP(CORE, op_name, {                            \
-    int32_t operand = VM_DecOperandRegI32("operand");     \
-    int32_t* result = VM_DecResultRegI32("result");       \
-    *result = (int32_t)(op((type)operand));               \
+#define DISPATCH_OP_CORE_UNARY_ALU_I32(op_name, type, op_func) \
+  DISPATCH_OP(CORE, op_name, {                                 \
+    int32_t operand = VM_DecOperandRegI32("operand");          \
+    int32_t* result = VM_DecResultRegI32("result");            \
+    *result = (int32_t)(op_func((type)operand));               \
   });
 
-#define DISPATCH_OP_CORE_BINARY_ALU_I32(op_name, type, op) \
-  DISPATCH_OP(CORE, op_name, {                             \
-    int32_t lhs = VM_DecOperandRegI32("lhs");              \
-    int32_t rhs = VM_DecOperandRegI32("rhs");              \
-    int32_t* result = VM_DecResultRegI32("result");        \
-    *result = (int32_t)(((type)lhs)op((type)rhs));         \
+#define DISPATCH_OP_CORE_BINARY_ALU_I32(op_name, type, op_func) \
+  DISPATCH_OP(CORE, op_name, {                                  \
+    int32_t lhs = VM_DecOperandRegI32("lhs");                   \
+    int32_t rhs = VM_DecOperandRegI32("rhs");                   \
+    int32_t* result = VM_DecResultRegI32("result");             \
+    *result = (int32_t)(op_func((type)lhs, (type)rhs));         \
   });
 
-    DISPATCH_OP_CORE_BINARY_ALU_I32(AddI32, int32_t, +);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(SubI32, int32_t, -);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(MulI32, int32_t, *);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32S, int32_t, /);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32U, uint32_t, /);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32S, int32_t, %);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32U, uint32_t, %);
-    DISPATCH_OP_CORE_UNARY_ALU_I32(NotI32, uint32_t, ~);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(AndI32, uint32_t, &);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(OrI32, uint32_t, |);
-    DISPATCH_OP_CORE_BINARY_ALU_I32(XorI32, uint32_t, ^);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(AddI32, int32_t, vm_add_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(SubI32, int32_t, vm_sub_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(MulI32, int32_t, vm_mul_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32S, int32_t, vm_div_i32s);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32U, uint32_t, vm_div_i32u);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32S, int32_t, vm_rem_i32s);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32U, uint32_t, vm_rem_i32u);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(NotI32, uint32_t, vm_not_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(AndI32, uint32_t, vm_and_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(OrI32, uint32_t, vm_or_i32);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(XorI32, uint32_t, vm_xor_i32);
 
     //===------------------------------------------------------------------===//
     // Casting and type conversion/emulation

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -18,7 +18,7 @@
 #include "iree/base/tracing.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_dispatch_util.h"
-#include "iree/vm/c_funcs.h"
+#include "iree/vm/ops.h"
 
 //===----------------------------------------------------------------------===//
 // Register remapping utilities

--- a/iree/vm/c_funcs.h
+++ b/iree/vm/c_funcs.h
@@ -17,8 +17,21 @@
 
 #include <stdint.h>
 
-// Arithmetic ops
-inline int32_t vm_add_i32(int32_t a, int32_t b) { return a + b; }
+//===------------------------------------------------------------------===//
+// Native integer arithmetic
+//===------------------------------------------------------------------===//
+
+int32_t vm_add_i32(int32_t lhs, int32_t rhs) { return lhs + rhs; }
+int32_t vm_sub_i32(int32_t lhs, int32_t rhs) { return lhs - rhs; }
+int32_t vm_mul_i32(int32_t lhs, int32_t rhs) { return lhs * rhs; }
+int32_t vm_div_i32s(int32_t lhs, int32_t rhs) { return lhs / rhs; }
+uint32_t vm_div_i32u(uint32_t lhs, uint32_t rhs) { return lhs / rhs; }
+int32_t vm_rem_i32s(int32_t lhs, int32_t rhs) { return lhs % rhs; }
+uint32_t vm_rem_i32u(uint32_t lhs, uint32_t rhs) { return lhs % rhs; }
+uint32_t vm_not_i32(uint32_t operand) { return ~operand; }
+int32_t vm_and_i32(int32_t lhs, int32_t rhs) { return lhs & rhs; }
+int32_t vm_or_i32(int32_t lhs, int32_t rhs) { return lhs | rhs; }
+int32_t vm_xor_i32(int32_t lhs, int32_t rhs) { return lhs ^ rhs; }
 
 // Check ops
 // TODO(simon-camp): These macros should be removed once control flow ops are

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IREE_VM_C_FUNCS_H_
-#define IREE_VM_C_FUNCS_H_
+#ifndef IREE_VM_OPS_H_
+#define IREE_VM_OPS_H_
 
 #include <stdint.h>
 
@@ -48,4 +48,4 @@ inline int32_t vm_cmp_ne_i32(int32_t a, int32_t b) { return a != b ? 1 : 0; }
 // Const ops
 inline int32_t vm_const_i32(int32_t a) { return a; }
 
-#endif  // IREE_VM_C_FUNCS_H_
+#endif  // IREE_VM_OPS_H_

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -21,17 +21,19 @@
 // Native integer arithmetic
 //===------------------------------------------------------------------===//
 
-int32_t vm_add_i32(int32_t lhs, int32_t rhs) { return lhs + rhs; }
-int32_t vm_sub_i32(int32_t lhs, int32_t rhs) { return lhs - rhs; }
-int32_t vm_mul_i32(int32_t lhs, int32_t rhs) { return lhs * rhs; }
-int32_t vm_div_i32s(int32_t lhs, int32_t rhs) { return lhs / rhs; }
-uint32_t vm_div_i32u(uint32_t lhs, uint32_t rhs) { return lhs / rhs; }
-int32_t vm_rem_i32s(int32_t lhs, int32_t rhs) { return lhs % rhs; }
-uint32_t vm_rem_i32u(uint32_t lhs, uint32_t rhs) { return lhs % rhs; }
-uint32_t vm_not_i32(uint32_t operand) { return ~operand; }
-int32_t vm_and_i32(int32_t lhs, int32_t rhs) { return lhs & rhs; }
-int32_t vm_or_i32(int32_t lhs, int32_t rhs) { return lhs | rhs; }
-int32_t vm_xor_i32(int32_t lhs, int32_t rhs) { return lhs ^ rhs; }
+static inline int32_t vm_add_i32(int32_t lhs, int32_t rhs) { return lhs + rhs; }
+static inline int32_t vm_sub_i32(int32_t lhs, int32_t rhs) { return lhs - rhs; }
+static inline int32_t vm_mul_i32(int32_t lhs, int32_t rhs) { return lhs * rhs; }
+// clang-format off
+static inline int32_t vm_div_i32s(int32_t lhs, int32_t rhs) { return lhs / rhs; }
+static inline uint32_t vm_div_i32u(uint32_t lhs, uint32_t rhs) { return lhs / rhs; }
+static inline int32_t vm_rem_i32s(int32_t lhs, int32_t rhs) { return lhs % rhs;}
+static inline uint32_t vm_rem_i32u(uint32_t lhs, uint32_t rhs) { return lhs % rhs; }
+// clang-format on
+static inline uint32_t vm_not_i32(uint32_t operand) { return ~operand; }
+static inline int32_t vm_and_i32(int32_t lhs, int32_t rhs) { return lhs & rhs; }
+static inline int32_t vm_or_i32(int32_t lhs, int32_t rhs) { return lhs | rhs; }
+static inline int32_t vm_xor_i32(int32_t lhs, int32_t rhs) { return lhs ^ rhs; }
 
 // Check ops
 // TODO(simon-camp): These macros should be removed once control flow ops are


### PR DESCRIPTION
This moves the native integer arithmetic ops from the bytecode
dispatcher to a header. The header only implementations can be used
within the dispatcher as well as by EmitC emitted code, avoiding to
duplicate the implementations.