### PR TITLE
Canonicalize `std.dim` into `flow.dispatch.shape` when relevant.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/BUILD
@@ -55,6 +55,7 @@ cc_library(
         "//iree/compiler/Dialect/Shape/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:SideEffects",
         "@llvm-project//mlir:StandardOps",
@@ -77,6 +78,7 @@ gentbl(
         "//iree/compiler/Dialect/Shape/IR:td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
+        "@llvm-project//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
     ],
 )
 
@@ -94,6 +96,7 @@ gentbl(
         "//iree/compiler/Dialect/Shape/IR:td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
+        "@llvm-project//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
     ],
 )
 
@@ -112,6 +115,7 @@ gentbl(
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
+        "@llvm-project//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
     ],
 )
 
@@ -129,5 +133,6 @@ iree_tablegen_doc(
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
+        "@llvm-project//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
     ],
 )

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRIR
+    MLIRInferTypeOpInterface
     MLIRParser
     MLIRSideEffectInterfaces
     MLIRStandard

--- a/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
@@ -54,6 +54,7 @@ FlowDialect::FlowDialect(MLIRContext *context)
   addOperations<
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.cpp.inc"
       >();
+  context->getOrLoadDialect("shapex");
 }
 
 Operation *FlowDialect::materializeConstant(OpBuilder &builder, Attribute value,

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -735,6 +735,17 @@ void DispatchShapeOp::getAsmResultNames(
   setNameFn(result(), "shape");
 }
 
+LogicalResult DispatchShapeOp::inferReturnTypes(
+    MLIRContext *context, Optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  auto dispatchTensorType = operands[0].getType().cast<DispatchTensorType>();
+  auto shape = dispatchTensorType.getShape();
+  auto rankedShapeType = Shape::RankedShapeType::get(shape, context);
+  inferredReturnTypes.assign({rankedShapeType});
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // flow.executable
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.h
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.h
@@ -28,6 +28,7 @@
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -18,6 +18,7 @@
 include "iree/compiler/Dialect/Flow/IR/FlowBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class FLOW_PureOp<string mnemonic, list<OpTrait> traits = []> :
@@ -450,6 +451,7 @@ def FLOW_DispatchWorkgroupSizeOp : FLOW_PureOp<"dispatch.workgroup.size", [
 
 def FLOW_DispatchShapeOp : FLOW_PureOp<"dispatch.shape", [
     DeclareOpInterfaceMethods<OpAsmOpInterface>,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]> {
   let summary = [{returns the shape of a dispatch region input/output tensor}];
   let description = [{
@@ -522,6 +524,8 @@ def FLOW_DispatchInputLoadOp : FLOW_PureOp<"dispatch.input.load", [
     ( `,` `strides` `=` `[` $strides^ `]` )?
     `:` type($source) `->` type($result) attr-dict-with-keyword
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def FLOW_DispatchOutputStoreOp : FLOW_Op<"dispatch.output.store", [

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -53,3 +53,18 @@ func @workgroupRankFolding(%arg0 : tensor<?x4xf32>) -> tensor<4x?xf32> {
   }
   return %0 : tensor<4x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @convertDimOfDispatchInputLoadToDispatchShape
+// CHECK-SAME:    %[[ARG:.*]]: !flow.dispatch.input<?xf32>) {
+func @convertDimOfDispatchInputLoadToDispatchShape(%arg0: !flow.dispatch.input<?xf32>) {
+  // CHECK-NEXT: %[[RANKED_SHAPE:.*]] = flow.dispatch.shape %[[ARG]]
+  // CHECK-NEXT: %[[DIM:.*]] = shapex.ranked_dim %[[RANKED_SHAPE]][0]
+  // CHECK-NEXT: "test.sink"(%[[DIM]]) : (index) -> ()
+  %tensor = flow.dispatch.input.load %arg0 : !flow.dispatch.input<?xf32> -> tensor<?xf32>
+  %c0 = constant 0 : index
+  %dim = dim %tensor, %c0 : tensor<?xf32>
+  "test.sink"(%dim) : (index) -> ()
+  return
+}


### PR DESCRIPTION
Linalg tends to create `std.dim` ops because it is upstream code.
However, inside a `flow.dispatch.workgroups` region, we should be using
`flow.dispatch.shape` to get the shape of the dispatch tensors.

This plays nicer with the way that flow.dispatch.workgroups is meant to
be used, and results in much nicer IR as it lets everything fold away.

Example IR before/after this change, as seen by the
LinalgLLVMBufferizePass
https://gist.github.com/silvasean/60b80d442cde72ca4a39f6198a7075dc

The new code results in no dim ops at the LinalgLLVMBufferizePass, so we
can consider removing support for them there. I don't do that in this
patch since I'm not sure if there are other considerations in flight.
I believe that by running dim op canonicalization to a fixed point we
can guarantee that they always go away by construction before that pass.