### PR TITLE
Fix deps on renamed target iree::vm::ops

### DIFF
--- a/iree/samples/emitc_modules/CMakeLists.txt
+++ b/iree/samples/emitc_modules/CMakeLists.txt
@@ -39,8 +39,8 @@ if(${IREE_ENABLE_EMITC})
       iree::testing::gtest
       iree::testing::gtest_main
       iree::vm
-      iree::vm::c_funcs
       iree::vm::cc
+      iree::vm::ops
       iree::vm::shims
   )
 endif()

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -28,7 +28,7 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
     iree::vm::cc
-    iree::vm::c_funcs
+    iree::vm::ops
     iree::vm::shims
     ::arithmetic_ops_cc
 )


### PR DESCRIPTION
Follow up to #4658. Some deps to the renamed target `iree::vm::ops` were not properly updated.