### PR TITLE
Add Gradle tasks to configure and make host tools with CMake before compiling the Android Java bindings.

### DIFF
--- a/experimental/bindings/java/build.gradle
+++ b/experimental/bindings/java/build.gradle
@@ -16,6 +16,10 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def cmakeListDir = "${rootDir}/../../../"
+def hostBuildDir = "${cmakeListDir}/../iree-build-host"
+def hostInstallDir = "${hostBuildDir}/install"
+
 android {
     compileSdkVersion 29
 
@@ -25,21 +29,21 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DIREE_BUILD_EXPERIMENTAL_JAVA_BINDINGS=ON',
-                        '-DIREE_HAL_DRIVERS_TO_BUILD=VMLA',
+                arguments "-DIREE_BUILD_EXPERIMENTAL_JAVA_BINDINGS=ON",
+                        "-DIREE_HAL_DRIVERS_TO_BUILD=VMLA",
 
                         // Disable all but the runtime components needed for the
                         // java bindings.
-                        '-DIREE_BUILD_COMPILER=OFF',
-                        '-DIREE_ENABLE_MLIR=OFF',
-                        '-DIREE_BUILD_TESTS=OFF',
-                        '-DIREE_BUILD_SAMPLES=OFF',
-                        '-DIREE_BUILD_PYTHON_BINDINGS=OFF',
+                        "-DIREE_BUILD_COMPILER=OFF",
+                        "-DIREE_ENABLE_MLIR=OFF",
+                        "-DIREE_BUILD_TESTS=OFF",
+                        "-DIREE_BUILD_SAMPLES=OFF",
+                        "-DIREE_BUILD_PYTHON_BINDINGS=OFF",
 
                         // Run the commands at
                         // https://google.github.io/iree/get-started/getting-started-android-cmake#configure-and-build
                         // and update this flag to point to iree-build-host/install/.
-                        '-DIREE_HOST_BINARY_ROOT='
+                        "-DIREE_HOST_BINARY_ROOT=${hostInstallDir}"
             }
         }
     }
@@ -54,8 +58,30 @@ android {
 
     externalNativeBuild {
         cmake {
-            version "3.13.0+"
+            version "3.18.4+"
             path "../../../CMakeLists.txt"
         }
     }
 }
+
+// Task to cmake configure the host
+task cmakeConfigureHost(type: Exec) {
+    doFirst {
+        println "Configuring host tools with cmake..."
+    }
+    workingDir cmakeListDir
+    commandLine "cmake", "-G" , "Ninja",  "-B", hostBuildDir ,  "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++",  "-DCMAKE_INSTALL_PREFIX=${hostInstallDir}", "."
+}
+
+// Task to cmake build the host
+task cmakeBuildHost(type: Exec) {
+    doFirst {
+        println "Building host tools with cmake..."
+    }
+    workingDir cmakeListDir
+    commandLine "cmake", "--build", hostBuildDir, "--target", "install"
+}
+
+// Build host tools before building the app
+preBuild.dependsOn cmakeBuildHost
+cmakeBuildHost.dependsOn cmakeConfigureHost

--- a/experimental/bindings/java/build.gradle
+++ b/experimental/bindings/java/build.gradle
@@ -58,7 +58,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version "3.18.4+"
+            version "3.13.0+"
             path "../../../CMakeLists.txt"
         }
     }
@@ -70,7 +70,14 @@ task cmakeConfigureHost(type: Exec) {
         println "Configuring host tools with cmake..."
     }
     workingDir cmakeListDir
-    commandLine "cmake", "-G" , "Ninja",  "-B", hostBuildDir ,  "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++",  "-DCMAKE_INSTALL_PREFIX=${hostInstallDir}", "."
+    commandLine "cmake",
+            "-G" , "Ninja",
+            "-B", hostBuildDir ,
+            "-DIREE_BUILD_COMPILER=ON",
+            "-DIREE_BUILD_TESTS=OFF ",
+            "-DIREE_BUILD_SAMPLES=OFF",
+            "-DCMAKE_INSTALL_PREFIX=${hostInstallDir}",
+            "."
 }
 
 // Task to cmake build the host

--- a/experimental/bindings/java/build.gradle
+++ b/experimental/bindings/java/build.gradle
@@ -39,10 +39,6 @@ android {
                         "-DIREE_BUILD_TESTS=OFF",
                         "-DIREE_BUILD_SAMPLES=OFF",
                         "-DIREE_BUILD_PYTHON_BINDINGS=OFF",
-
-                        // Run the commands at
-                        // https://google.github.io/iree/get-started/getting-started-android-cmake#configure-and-build
-                        // and update this flag to point to iree-build-host/install/.
                         "-DIREE_HOST_BINARY_ROOT=${hostInstallDir}"
             }
         }

--- a/experimental/bindings/java/build.gradle
+++ b/experimental/bindings/java/build.gradle
@@ -69,6 +69,8 @@ task cmakeConfigureHost(type: Exec) {
     commandLine "cmake",
             "-G" , "Ninja",
             "-B", hostBuildDir ,
+            "-DIREE_TARGET_BACKENDS_TO_BUILD=vmla",
+            "-DIREE_HAL_DRIVERS_TO_BUILD=vmla",
             "-DIREE_BUILD_COMPILER=ON",
             "-DIREE_BUILD_TESTS=OFF ",
             "-DIREE_BUILD_SAMPLES=OFF",


### PR DESCRIPTION
Add Gradle tasks to configure and make host tools with CMake before compiling the Android Java bindings. 