### PR TITLE
Make IREE TF integrations use TF toolchains

### DIFF
--- a/integrations/tensorflow/.bazelrc
+++ b/integrations/tensorflow/.bazelrc
@@ -15,8 +15,10 @@
 # Import the TF bazelrc config
 try-import %workspace%/../../third_party/tensorflow/.bazelrc
 
-# Non-monolithic builds are basically broken outside of the TF repository
-build --config=monolithic
+# Linking in the TF shared object with tf_cc_binary in non-monolithic mode
+# violates TF's visibility restrictions. We can investigate fixing this
+# upstream. In the meantime, this is easier.
+build --nocheck_visibility
 # Disk cache is incompatible with remote execution and caching.
 build:rbe --disk_cache=''
 

--- a/integrations/tensorflow/.bazelrc
+++ b/integrations/tensorflow/.bazelrc
@@ -17,6 +17,8 @@ try-import %workspace%/../../third_party/tensorflow/.bazelrc
 
 # Non-monolithic builds are basically broken outside of the TF repository
 build --config=monolithic
+# Disk cache is incompatible with remote execution and caching.
+build:rbe --disk_cache=''
 
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.

--- a/integrations/tensorflow/.bazelrc
+++ b/integrations/tensorflow/.bazelrc
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Import the main bazelrc config. This is in a separate file so that it's
-# possible to turn off all user bazelrc options by specifying
-# `--nosystem_rc --nohome_rc --noworkspace_rc --bazelrc=build_tools/bazel/iree.bazelrc`
-try-import %workspace%/../../build_tools/bazel/iree.bazelrc
+# Import the TF bazelrc config
+try-import %workspace%/../../third_party/tensorflow/.bazelrc
 
-# Run the configure_bazel.py script to generate.
-try-import %workspace%/../../configured.bazelrc
+# Non-monolithic builds are basically broken outside of the TF repository
+build --config=monolithic
 
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.
-try-import %workspace%/../../user.bazelrc
+try-import %workspace%/user.bazelrc

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Links in the TF shared object if --config=monolithic is not set. If this gets
+# borked you'll end up with a ton of undefined symbols errors.
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "tf_cc_binary")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
-cc_binary(
+tf_cc_binary(
     name = "iree-tf-opt",
     srcs = ["iree-tf-opt-main.cpp"],
     deps = [
@@ -36,7 +40,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+tf_cc_binary(
     name = "iree-opt-tflite",
     srcs = ["iree-opt-tflite-main.cpp"],
     deps = [
@@ -53,7 +57,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+tf_cc_binary(
     name = "iree-tf-import",
     srcs = ["iree-tf-import-main.cpp"],
     deps = [
@@ -76,7 +80,7 @@ cc_binary(
     }),
 )
 
-cc_binary(
+tf_cc_binary(
     name = "iree-import-tflite",
     srcs = ["iree-import-tflite-main.cpp"],
     deps = [
@@ -91,7 +95,7 @@ cc_binary(
     ],
 )
 
-cc_binary(
+tf_cc_binary(
     name = "iree-import-xla",
     srcs = ["iree-import-xla-main.cpp"],
     deps = [


### PR DESCRIPTION
This makes it possible to build the IREE TF integrations using TF's
toolchains and RBE instance (given the appropriate permissions):

```shell
~/src/iree/integrations/tensorflow$ bazel build \
  --config=rbe_linux_cuda_clang_py36 \
  --config=tensorflow_testing_rbe_linux \
  ...
```

This allows building our TF integrations in an only moderately-absurd
amount of time on my workstation (10 minutes for a clean build):
https://source.cloud.google.com/results/invocations/6ffa186a-4b52-46c6-b49c-194281ea405d

and decently fast rebuilds (20s after `bazel clean`):
https://source.cloud.google.com/results/invocations/246478f0-5b6b-4ad3-94f8-49e7e435936e

It also works in monolithic mode (`--config=monolithic`).

This does not yet change how any CI is configured. It just makes the
configs available.

This also allows us to delete all TF and python configuration from our
main bazelrc, since it is no longer used in the integrations.