### PR TITLE
Forking UnixLinkerTool into AndroidLinkerTool.

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -70,6 +70,17 @@ function(iree_check_test)
   set(_MODULE_NAME "${_RULE_NAME}_module")
 
   if(ANDROID)
+    # Android's CMake toolchain defines some variables that we can use to infer
+    # the appropriate target triple from the configured settings:
+    # https://developer.android.com/ndk/guides/cmake#android_platform
+    #
+    # In typical CMake fashion, the various strings are pretty fuzzy and can
+    # have multiple values like "latest", "android-25"/"25"/"android-N-MR1".
+    #
+    # From looking at the toolchain file, ANDROID_PLATFORM_LEVEL seems like it
+    # should pretty consistently be just a number we can use for target triple.
+    set(_TARGET_TRIPLE "aarch64-none-linux-android${ANDROID_PLATFORM_LEVEL}")
+
     iree_bytecode_module(
       NAME
         "${_MODULE_NAME}"
@@ -78,8 +89,7 @@ function(iree_check_test)
       FLAGS
         "-iree-mlir-to-vm-bytecode-module"
         "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
-        # TODO(ataei): Get target from arguments passed to build
-        "--iree-llvm-target-triple=aarch64-none-linux-android30"
+        "--iree-llvm-target-triple=${_TARGET_TRIPLE}"
         ${_RULE_COMPILER_FLAGS}
       TESTONLY
     )

--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -50,8 +50,6 @@ if [[ -z "${model}" ]]; then
   exit 1
 fi
 
-export IREE_LLVMAOT_LINKER_PATH="${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++ -static-libstdc++ -O3"
-
 IFS=',' read -ra targets_array <<< "$targets"
 for target in "${targets_array[@]}"
 do
@@ -60,7 +58,7 @@ do
   extra_flags=()
   case "${target}" in
     "dylib-llvm-aot")
-      extra_flags+=('--iree-llvm-target-triple=aarch64-linux-android')
+      extra_flags+=('--iree-llvm-target-triple=aarch64-none-linux-android29')
       ;;
     *)
       ;;

--- a/build_tools/mako/compile_android_modules.sh
+++ b/build_tools/mako/compile_android_modules.sh
@@ -58,6 +58,10 @@ do
   extra_flags=()
   case "${target}" in
     "dylib-llvm-aot")
+      # Note: this should match the phones the benchmarks will be run on.
+      # We could pass it in as an option or query the min/max in $ANDROID_NDK,
+      # but that will only be worth it if this script is used in different
+      # environments or for benchmarking on different phones.
       extra_flags+=('--iree-llvm-target-triple=aarch64-none-linux-android29')
       ;;
     *)

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
@@ -1,0 +1,198 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/Host.h"
+
+#define DEBUG_TYPE "llvmaot-linker"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+using llvm::Triple;
+
+// Returns the canonical host name for the Android NDK prebuilt versions:
+//   https://developer.android.com/ndk/guides/other_build_systems
+//
+// If we want to support self-built variants we'll need an env var (or just make
+// the user set IREE_LLVMAOT_LINKER_PATH).
+static const char *getNDKHostPlatform() {
+  auto hostTriple = Triple(llvm::sys::getProcessTriple());
+  if (hostTriple.isOSLinux() && hostTriple.getArch() == Triple::x86_64) {
+    return "linux-x86_64";
+  } else if (hostTriple.isMacOSX() && hostTriple.getArch() == Triple::x86_64) {
+    return "darwin-x86_64";
+  } else if (hostTriple.isOSWindows() &&
+             hostTriple.getArch() == Triple::x86_64) {
+    return "windows-x86_64";
+  } else if (hostTriple.isOSWindows() && hostTriple.getArch() == Triple::x86) {
+    return "windows";
+  } else {
+    llvm::errs()
+        << "No (known) Android NDK prebuilt name for this host platform ('"
+        << hostTriple.str() << "')";
+    return "";
+  }
+}
+
+// Returns the canonical target name for the Android NDK prebuilt versions.
+static const char *getNDKTargetPlatform(const Triple &targetTriple) {
+  switch (targetTriple.getArch()) {
+    case Triple::arm:
+      return "armv7a";
+    case Triple::aarch64:
+      return "aarch64";
+    case Triple::x86:
+      return "i686";
+    case Triple::x86_64:
+      return "x86_64";
+    default:
+      llvm::errs()
+          << "No (known) Android NDK prebuilt name for this target platform ('"
+          << targetTriple.str() << "')";
+      return "";
+  }
+}
+
+// Android linker using the Android NDK toolchain.
+class AndroidLinkerTool : public LinkerTool {
+ public:
+  using LinkerTool::LinkerTool;
+
+  std::string getToolPath() const override {
+    auto toolPath = LinkerTool::getToolPath();
+    if (!toolPath.empty()) return toolPath;
+
+    // ANDROID_NDK must be set for us to infer the tool path.
+    char *androidNDKPath = std::getenv("ANDROID_NDK");
+    if (!androidNDKPath) return toolPath;
+
+    // Extract the Android version from the `android30` like triple piece.
+    unsigned androidEnv[3];
+    targetTriple.getEnvironmentVersion(androidEnv[0], androidEnv[1],
+                                       androidEnv[2]);
+    unsigned androidVersion = androidEnv[0];  // like '30'
+
+    // Select prebuilt toolchain based on both host and target
+    // architecture/platform:
+    //   https://developer.android.com/ndk/guides/other_build_systems
+    return llvm::Twine(androidNDKPath)
+        .concat("/toolchains/llvm/prebuilt/")
+        .concat(getNDKHostPlatform())
+        .concat("/bin/")
+        .concat(getNDKTargetPlatform(targetTriple))
+        .concat("-linux-android")
+        .concat(std::to_string(androidVersion))
+        .concat("-clang")
+        .str();
+  }
+
+  LogicalResult configureModule(llvm::Module *llvmModule,
+                                ArrayRef<StringRef> entryPointNames) override {
+    for (auto &func : *llvmModule) {
+      // Enable frame pointers to ensure that stack unwinding works, e.g. in
+      // Tracy. In principle this could also be achieved by enabling unwind
+      // tables, but we tried that and that didn't work in Tracy (which uses
+      // libbacktrace), while enabling frame pointers worked.
+      // https://github.com/google/iree/issues/3957
+      func.addFnAttr("frame-pointer", "all");
+
+      // -ffreestanding-like behavior.
+      func.addFnAttr("no-builtins");
+    }
+
+    // TODO(benvanik): switch to executable libraries w/ internal functions.
+    for (auto entryPointName : entryPointNames) {
+      auto *entryPointFn = llvmModule->getFunction(entryPointName);
+      entryPointFn->setLinkage(
+          llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+      entryPointFn->setVisibility(
+          llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
+    }
+
+    return success();
+  }
+
+  Optional<Artifacts> linkDynamicLibrary(
+      StringRef libraryName, ArrayRef<Artifact> objectFiles) override {
+    Artifacts artifacts;
+
+    // Create the shared object name; if we only have a single input object we
+    // can just reuse that.
+    if (objectFiles.size() == 1) {
+      artifacts.libraryFile =
+          Artifact::createVariant(objectFiles.front().path, "so");
+    } else {
+      artifacts.libraryFile = Artifact::createTemporary(libraryName, "so");
+    }
+    artifacts.libraryFile.close();
+
+    SmallVector<std::string, 8> flags = {
+        getToolPath(),
+
+        // Avoids including any libc/startup files that initialize the CRT as
+        // we don't use any of that. Our shared libraries must be freestanding.
+        "-nostdlib",  // -nodefaultlibs + -nostartfiles
+
+        // Statically link all dependencies so we don't have any runtime deps.
+        // We cannot have any imports in the module we produce.
+        // "-static",
+
+        // HACK: we insert mallocs and junk. This is *not good*.
+        // We should be statically linking and not require anything from libc.
+        "-shared",
+        "-lc",
+
+        // Currently we are emitting calls to libm (expf, cosf, etc). We ideally
+        // should not be doing this - those functions are all generally terrible
+        // and indicate some extremely non-optimal code paths.
+        "-lm",
+
+        "-o " + artifacts.libraryFile.path,
+    };
+
+    // Strip debug information (only, no relocations) when not requested.
+    if (!targetOptions.debugSymbols) {
+      flags.push_back("-Wl,--strip-debug");
+    }
+
+    // Link all input objects. Note that we are not linking whole-archive as
+    // we want to allow dropping of unused codegen outputs.
+    for (auto &objectFile : objectFiles) {
+      flags.push_back(objectFile.path);
+    }
+
+    auto commandLine = llvm::join(flags, " ");
+    if (failed(runLinkCommand(commandLine))) return llvm::None;
+    return artifacts;
+  }
+};
+
+std::unique_ptr<LinkerTool> createAndroidLinkerTool(
+    Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+  assert(targetTriple.isAndroid() &&
+         "only use the AndroidLinkerTool for Android targets");
+  return std::make_unique<AndroidLinkerTool>(targetTriple, targetOptions);
+}
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
@@ -21,12 +21,12 @@ package(
 cc_library(
     name = "LinkerTools_internal",
     srcs = [
+        "AndroidLinkerTool.cpp",
         "LinkerTools.cpp",
         "UnixLinkerTool.cpp",
         "WindowsLinkerTool.cpp",
     ],
     deps = [
-        "//iree/base:core_headers",
         "//iree/compiler/Dialect/HAL/Target/LLVM:LinkerTool_hdrs",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
   NAME
     LinkerTools_internal
   SRCS
+    "AndroidLinkerTool.cpp"
     "LinkerTools.cpp"
     "UnixLinkerTool.cpp"
     "WindowsLinkerTool.cpp"
@@ -25,7 +26,6 @@ iree_cc_library(
     LLVMCore
     LLVMSupport
     MLIRSupport
-    iree::base::core_headers
     iree::compiler::Dialect::HAL::Target::LLVM::LinkerTool_hdrs
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
@@ -23,6 +23,8 @@ namespace HAL {
 // createMacLinkerTool using ld64.lld
 // createWasmLinkerTool wasm-ld
 
+std::unique_ptr<LinkerTool> createAndroidLinkerTool(
+    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createUnixLinkerTool(
     llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createWindowsLinkerTool(
@@ -31,7 +33,10 @@ std::unique_ptr<LinkerTool> createWindowsLinkerTool(
 // static
 std::unique_ptr<LinkerTool> LinkerTool::getForTarget(
     llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
-  if (targetTriple.isOSWindows() || targetTriple.isWindowsMSVCEnvironment()) {
+  if (targetTriple.isAndroid()) {
+    return createAndroidLinkerTool(targetTriple, targetOptions);
+  } else if (targetTriple.isOSWindows() ||
+             targetTriple.isWindowsMSVCEnvironment()) {
     return createWindowsLinkerTool(targetTriple, targetOptions);
   }
   return createUnixLinkerTool(targetTriple, targetOptions);

--- a/iree/tools/iree-check-module-main.cc
+++ b/iree/tools/iree-check-module-main.cc
@@ -60,7 +60,7 @@ class CheckModuleTest : public ::testing::Test {
                            iree_vm_function_t function)
       : instance_(instance), modules_(modules), function_(function) {}
   void SetUp() override {
-    IREE_ASSERT_OK(iree_vm_context_create_with_modules(
+    IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, modules_.data(), modules_.size(), iree_allocator_system(),
         &context_));
   }


### PR DESCRIPTION
There's some common things between them but that's mostly incidental at
this point. Once we have some more platforms working we can see if there
are attributes/etc we can apply everywhere (ensuring they're ignored when
not used on a particular tool/etc). For now, this stuff is whack-a-mole
and having them shared makes it harder to iterate on any one target.

With this our .so's for android end up with no imports and strictly the
functions we generate - an unstripped simple_mul is <500 bytes (most of
which is the source path names and junk in .comment).

Progress on #4606 - needs testing, script updates, and checks that things
like tracy still have symbols.