### PR TITLE
Unify patterns in the vm to emitc conversion

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @add_i32
 vm.module @my_module {
   vm.func @add_i32(%arg0: i32, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_add_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.add.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @sub_i32
 vm.module @my_module {
   vm.func @sub_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_sub_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_sub_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @mul_i32
 vm.module @my_module {
   vm.func @mul_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_mul_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_mul_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.mul.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i32_s
 vm.module @my_module {
   vm.func @div_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32s"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_div_i32s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.div.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i32_u
 vm.module @my_module {
   vm.func @div_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32u"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_div_i32u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.div.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i32_s
 vm.module @my_module {
   vm.func @rem_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32s"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_rem_i32s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.rem.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i32_u
 vm.module @my_module {
   vm.func @rem_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32u"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_rem_i32u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.rem.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_not_i32"(%arg0) : (i32) -> i32
+    // CHECK: %0 = emitc.call "vm_not_i32"(%arg0) {args = [0 : index]} : (i32) -> i32
     %0 = vm.not.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @and_i32
 vm.module @my_module {
   vm.func @and_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_and_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_and_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.and.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @or_i32
 vm.module @my_module {
   vm.func @or_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_or_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_or_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.or.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @xor_i32
 vm.module @my_module {
   vm.func @xor_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_xor_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_xor_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.xor.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/compare.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/compare.mlir
@@ -4,7 +4,7 @@
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_ne_i32
   vm.func @cmp_ne_i32(%arg0 : i32, %arg1 : i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i32"(%arg0, %arg1) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
     %0 = vm.cmp.ne.i32 %arg0, %arg1 : i32
     // CHECK-NEXT: vm.return
     vm.return


### PR DESCRIPTION
This generalizes the conversion pattern to handle op attributes.