### PR TITLE
Retain the backing device with python mapped array memory.

### DIFF
--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -570,6 +570,8 @@ void FunctionAbi::RawPack(absl::Span<const Description> descs,
 void FunctionAbi::RawUnpack(absl::Span<const Description> descs,
                             VmVariantList& f_results,
                             absl::Span<py::object> py_results) {
+  py::object this_object =
+      py::cast(this, py::return_value_policy::take_ownership);
   if (descs.size() != f_results.size() || descs.size() != py_results.size()) {
     throw RaiseValueError("Mismatched RawUnpack() result arity");
   }
@@ -618,7 +620,7 @@ void FunctionAbi::RawUnpack(absl::Span<const Description> descs,
             desc.buffer.scalar_type,
             absl::MakeConstSpan(reinterpret_cast<int*>(dims.data()),
                                 dims.size()),
-            std::move(buffer));
+            std::move(buffer), this_object);
         break;
       }
       case RawSignatureParser::Type::kRefObject:

--- a/bindings/python/pyiree/rt/host_types.h
+++ b/bindings/python/pyiree/rt/host_types.h
@@ -46,7 +46,7 @@ class HostTypeFactory {
   // available for use immediately.
   virtual py::object CreateImmediateNdarray(
       AbiConstants::ScalarType element_type, absl::Span<const int> dims,
-      HalBuffer buffer);
+      HalBuffer buffer, py::object parent_keep_alive);
 
   // TODO(laurenzo): Add a CreateDelayedNdarray() which is conditioned on
   // a semaphore. This is actually what should be used for async results.


### PR DESCRIPTION
* Fixes #3381
* While many programs didn't suffer from this, any time references to the array memory escape to the generational collector, a subsequent collection has a high likelihood of freeing the device prior to the buffer allocated against it.
* JAX internally seems to have a heuristic that caches a bunch of things and manually invokes the generational gc.
* There were many other things I would like to improve about this code but I held off and just did a targeted bug fix.
* The prior attempt (#3450) failed because with multiple results, it would have tried to get a weak reference to a tuple, which is not permitted. This more manual intervention stitches the keep-alive onto the actual objects that need it.