### PR TITLE
Reordering/simplifying some HAL APIs.

### DIFF
--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -677,8 +677,8 @@ void FunctionAbi::AllocateResults(absl::Span<const Description> descs,
                 desc.scalar.type)]);
         iree_hal_buffer_view_t* buffer_view;
         CheckApiStatus(
-            iree_hal_buffer_view_create(raw_buffer, dims.data(), dims.size(),
-                                        element_type, &buffer_view),
+            iree_hal_buffer_view_create(raw_buffer, element_type, dims.data(),
+                                        dims.size(), &buffer_view),
             "Error allocating buffer_view");
         iree_hal_buffer_release(raw_buffer);
         iree_vm_ref_t buffer_view_ref =
@@ -765,8 +765,8 @@ void FunctionAbi::PackBuffer(const RawSignatureParser::Description& desc,
   std::copy(py_view.shape, py_view.shape + py_view.ndim, dims.begin());
   iree_hal_buffer_view_t* buffer_view;
   CheckApiStatus(
-      iree_hal_buffer_view_create(raw_buffer, dims.data(), dims.size(),
-                                  element_type, &buffer_view),
+      iree_hal_buffer_view_create(raw_buffer, element_type, dims.data(),
+                                  dims.size(), &buffer_view),
       "Error allocating buffer_view");
   iree_hal_buffer_release(raw_buffer);
   iree_vm_ref_t buffer_view_ref = iree_hal_buffer_view_move_ref(buffer_view);

--- a/bindings/python/pyiree/rt/hal.h
+++ b/bindings/python/pyiree/rt/hal.h
@@ -108,8 +108,8 @@ class HalBuffer : public ApiRefCounted<HalBuffer, iree_hal_buffer_t> {
     iree_hal_element_type_t element_type = iree_hal_make_element_type(
         IREE_HAL_ELEMENT_TYPE_NONE, element_size * 8);
     CheckApiStatus(
-        iree_hal_buffer_view_create(raw_ptr(), shape.s.data(), shape.s.size(),
-                                    element_type, &bv),
+        iree_hal_buffer_view_create(raw_ptr(), element_type, shape.s.data(),
+                                    shape.s.size(), &bv),
         "Error creating buffer view");
     return HalBufferView::CreateRetained(bv);
   }

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -924,12 +924,15 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
 def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", []> {
   let summary = [{trace value(s) operation}];
   let description = [{
-    Trace point for dispatchable functions.
+    Traces out to a runtime trace sink (console, log file, etc) the given
+    tensors and titles them with the given key. The key is informational only
+    and useful for titling/marking specific sets of tensors for easier
+    searching.
   }];
 
   let arguments = (ins
-    Variadic<FLOW_Tensor>:$operands,
-    StrAttr:$trace_info
+    StrAttr:$key,
+    Variadic<FLOW_Tensor>:$operands
   );
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";

--- a/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -52,14 +52,16 @@ class InjectDispatchTracingPass
       // Input tensors:
       OpBuilder builder(dispatchOp);
       builder.create<TensorTraceOp>(
-          dispatchOp.getLoc(), filterTensorValues(dispatchOp.operands()),
-          builder.getStringAttr(entryPointName + " inputs"));
+          dispatchOp.getLoc(),
+          builder.getStringAttr(entryPointName + " inputs"),
+          filterTensorValues(dispatchOp.operands()));
 
       // Output tensors:
       builder.setInsertionPointAfter(dispatchOp);
       builder.create<TensorTraceOp>(
-          dispatchOp.getLoc(), filterTensorValues(dispatchOp.results()),
-          builder.getStringAttr(entryPointName + " outputs"));
+          dispatchOp.getLoc(),
+          builder.getStringAttr(entryPointName + " outputs"),
+          filterTensorValues(dispatchOp.results()));
     }
   }
 };

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -72,8 +72,8 @@ LogicalResult convertToDispatchOp(DispatchRegionOp regionOp,
   };
   if (traceDispatchTensors) {
     std::string str = "Input for " + std::string(outlinedFuncOp.getName());
-    builder.create<TensorTraceOp>(regionOp.getLoc(), getTensorTypeArgs(newArgs),
-                                  builder.getStringAttr(str));
+    builder.create<TensorTraceOp>(regionOp.getLoc(), builder.getStringAttr(str),
+                                  getTensorTypeArgs(newArgs));
   }
 
   // Create the dispatch op to the executable function.
@@ -83,9 +83,8 @@ LogicalResult convertToDispatchOp(DispatchRegionOp regionOp,
 
   if (traceDispatchTensors) {
     std::string str = "Output for " + std::string(outlinedFuncOp.getName());
-    builder.create<TensorTraceOp>(regionOp.getLoc(),
-                                  getTensorTypeArgs(dispatchOp.getResults()),
-                                  builder.getStringAttr(str));
+    builder.create<TensorTraceOp>(regionOp.getLoc(), builder.getStringAttr(str),
+                                  getTensorTypeArgs(dispatchOp.getResults()));
   }
 
   // Replace uses of the existing results with the new results.

--- a/iree/compiler/Dialect/Flow/Transforms/test/inject_dispatch_tracing.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/inject_dispatch_tracing.mlir
@@ -4,10 +4,10 @@
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<4xf32>)
 func @singleDispatch(%arg0: tensor<4xf32>) -> tensor<4xf32> {
   %c4 = constant 4 : index
-  //      CHECK: flow.tensor.trace {trace_info = "ex::entry0 inputs"} %[[ARG0]] : tensor<4xf32>
+  //      CHECK: flow.tensor.trace {key = "ex::entry0 inputs"} %[[ARG0]] : tensor<4xf32>
   // CHECK-NEXT: %[[RET0:.+]] = flow.dispatch @ex::@entry0[%c4] (%[[ARG0]]) : (tensor<4xf32>) -> tensor<4xf32>
   %0 = flow.dispatch @ex::@entry0[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK-NEXT: flow.tensor.trace {trace_info = "ex::entry0 outputs"} %[[RET0]] : tensor<4xf32>
+  // CHECK-NEXT: flow.tensor.trace {key = "ex::entry0 outputs"} %[[RET0]] : tensor<4xf32>
   // CHECK-NEXT: return %[[RET0]]
   return %0 : tensor<4xf32>
 }
@@ -19,15 +19,15 @@ func @singleDispatch(%arg0: tensor<4xf32>) -> tensor<4xf32> {
 func @multiDispatch(%arg0: tensor<4xf32>) -> tensor<4xf32> {
   %c4 = constant 4 : index
 
-  //     CHECK: flow.tensor.trace {trace_info = "ex::entry0 inputs"} %[[ARG0]] : tensor<4xf32>
+  //     CHECK: flow.tensor.trace {key = "ex::entry0 inputs"} %[[ARG0]] : tensor<4xf32>
   // CHECK-NEXT: %[[RET0:.+]] = flow.dispatch @ex::@entry0[%c4] (%[[ARG0]]) : (tensor<4xf32>) -> tensor<4xf32>
   %0 = flow.dispatch @ex::@entry0[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK-NEXT: flow.tensor.trace {trace_info = "ex::entry0 outputs"} %[[RET0]] : tensor<4xf32>
+  // CHECK-NEXT: flow.tensor.trace {key = "ex::entry0 outputs"} %[[RET0]] : tensor<4xf32>
 
-  //     CHECK: flow.tensor.trace {trace_info = "ex::entry1 inputs"} %[[RET0]] : tensor<4xf32>
+  //     CHECK: flow.tensor.trace {key = "ex::entry1 inputs"} %[[RET0]] : tensor<4xf32>
   // CHECK-NEXT: %[[RET1:.+]] = flow.dispatch @ex::@entry1[%c4] (%[[RET0]]) : (tensor<4xf32>) -> tensor<4xf32>
   %1 = flow.dispatch @ex::@entry1[%c4] (%0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK-NEXT: flow.tensor.trace {trace_info = "ex::entry1 outputs"} %[[RET1]] : tensor<4xf32>
+  // CHECK-NEXT: flow.tensor.trace {key = "ex::entry1 outputs"} %[[RET1]] : tensor<4xf32>
 
   // CHECK: return %[[RET1]]
   return %1 : tensor<4xf32>

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -239,19 +239,13 @@ static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
 // Records a full execution barrier that forces visibility of all buffers.
 static void recordFullExecutionBarrier(Value commandBuffer, Location loc,
                                        ConversionPatternRewriter &rewriter) {
-  auto memoryBarrier =
-      rewriter
-          .create<IREE::HAL::MakeMemoryBarrierOp>(
-              loc, IREE::HAL::AccessScopeBitfield::DispatchWrite,
-              IREE::HAL::AccessScopeBitfield::DispatchRead)
-          .getResult();
   rewriter.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
       loc, commandBuffer,
       IREE::HAL::ExecutionStageBitfield::CommandRetire |
           IREE::HAL::ExecutionStageBitfield::Dispatch,
       IREE::HAL::ExecutionStageBitfield::CommandIssue |
           IREE::HAL::ExecutionStageBitfield::Dispatch,
-      ArrayRef<Value>{memoryBarrier}, ArrayRef<Value>{});
+      IREE::HAL::ExecutionBarrierFlagBitfield::None);
 }
 
 static void recordPushConstants(Value device, Value commandBuffer,

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
@@ -150,7 +150,7 @@ class TensorTraceOpConversion
       bufferViews.emplace_back(adaptor.getBufferView());
     }
     rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewTraceOp>(
-        traceOp, bufferViews, traceOp.trace_infoAttr());
+        traceOp, traceOp.keyAttr(), bufferViews);
     return success();
   }
 };

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -22,14 +22,8 @@ func @command_buffer_begin_end(%arg0 : !hal.command_buffer) {
 
 // CHECK-LABEL: @command_buffer_execution_barrier
 func @command_buffer_execution_barrier(%arg0 : !hal.command_buffer, %arg1 : !hal.buffer) {
-  %c100 = constant 100 : index
-  %c200 = constant 200 : index
-  %memory_barrier = hal.make_memory_barrier "HostRead|HostWrite", "MemoryRead|MemoryWrite" : tuple<i32, i32>
-  // TODO(benvanik): buffer barriers.
-  // %buffer_barrier = hal.make_buffer_barrier "HostRead|HostWrite", "MemoryRead|MemoryWrite", %0, %1, %2 : tuple<i32, i32, !vm.ref<!hal.buffer>, i32, i32>
-  // CHECK: vm.call.variadic @hal.command_buffer.execution_barrier(%arg0, %c1, %c2, [%c192, %c768], []) : (!vm.ref<!hal.command_buffer>, i32, i32, i32 ..., i32 ...)
-  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess",
-      memory_barriers=[%memory_barrier, %memory_barrier]
+  // CHECK: vm.call @hal.command_buffer.execution_barrier(%arg0, %c1, %c2, %zero) : (!vm.ref<!hal.command_buffer>, i32, i32, i32)
+  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", "None"
   return
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -186,6 +186,16 @@ def HAL_ExecutionStageBitfieldAttr :
   let cppNamespace = "mlir::iree_compiler::IREE::HAL";
 }
 
+def HAL_ExecutionBarrierFlag_None : BitEnumAttrCase<"None", 0x0000>;
+def HAL_ExecutionBarrierFlag_Reserved : BitEnumAttrCase<"Reserved", 0x0001>;
+def HAL_ExecutionBarrierFlagBitfieldAttr :
+    BitEnumAttr<"ExecutionBarrierFlagBitfield", "valid ExecutionBarrierFlag", [
+      HAL_ExecutionBarrierFlag_None,
+      HAL_ExecutionBarrierFlag_Reserved,
+    ]> {
+  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+}
+
 def HAL_AccessScope_None : BitEnumAttrCase<"None", 0x0000>;
 def HAL_AccessScope_IndirectCommandRead : BitEnumAttrCase<"IndirectCommandRead", 0x0001>;
 def HAL_AccessScope_ConstantRead : BitEnumAttrCase<"ConstantRead", 0x0002>;

--- a/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -388,8 +388,8 @@ struct ExpandBufferViewConstOp : public OpRewritePattern<BufferViewConstOp> {
       }
     }
 
-    rewriter.replaceOpWithNewOp<BufferViewCreateOp>(op, buffer, shape,
-                                                    elementType.getValue());
+    rewriter.replaceOpWithNewOp<BufferViewCreateOp>(
+        op, buffer, elementType.getValue(), shape);
     return success();
   }
 };

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -531,11 +531,11 @@ void BufferViewConstOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 
 void BufferViewCreateOp::build(OpBuilder &builder, OperationState &state,
-                               Value buffer, ValueRange shape,
-                               int32_t elementType) {
+                               Value buffer, int32_t elementType,
+                               ValueRange shape) {
   state.addOperands({buffer});
-  state.addOperands(shape);
   state.addAttribute("element_type", builder.getI32IntegerAttr(elementType));
+  state.addOperands(shape);
   state.addTypes({BufferViewType::get(builder.getContext())});
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2556,23 +2556,24 @@ def HAL_ExecutableLayoutCreateOp : HAL_PureOp<"executable_layout.create", [
     %set0 = hal.descriptor_set_layout.create ...
     %set1 = hal.descriptor_set_layout.create ...
     %layout = hal.executable_layout.create %device,
-                                           set_layouts = [%set0, %set1],
-                                           push_constants = 3 : !hal.executable_layout
+                                           push_constants = 3,
+                                           set_layouts = [%set0, %set1] : !hal.executable_layout
     ```
   }];
 
   let arguments = (ins
     HAL_Device:$device,
-    Variadic<HAL_DescriptorSetLayout>:$set_layouts,
-    I32Attr:$push_constants
+    I32Attr:$push_constants,
+    Variadic<HAL_DescriptorSetLayout>:$set_layouts
   );
   let results = (outs
     HAL_ExecutableLayout:$result
   );
 
   let assemblyFormat = [{
-    $device `,` `set_layouts` `=` `[` $set_layouts `]` `,`
-    `push_constants` `=` $push_constants
+    $device `,`
+    `push_constants` `=` $push_constants `,`
+    `set_layouts` `=` `[` $set_layouts `]`
     attr-dict-with-keyword `:` type($result)
   }];
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -918,12 +918,14 @@ def HAL_BufferViewDimsOp : HAL_PureOp<"buffer_view.dims"> {
 def HAL_BufferViewTraceOp : HAL_Op<"buffer_view.trace", []> {
   let summary = [{trace value(s) operation}];
   let description = [{
-    Trace point for dispatchable functions.
+    Traces out to a runtime trace sink (console, log file, etc) the given buffer
+    views and titles them with the given key. The key is informational only and
+    useful for titling/marking specific sets of buffers for easier searching.
   }];
 
   let arguments = (ins
-    Variadic<HAL_BufferView>:$operands,
-    StrAttr:$trace_info
+    StrAttr:$key,
+    Variadic<HAL_BufferView>:$operands
   );
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1008,30 +1008,20 @@ def HAL_CommandBufferDeviceOp : HAL_PureOp<"command_buffer.device"> {
   let hasCanonicalizer = 1;
 }
 
-def HAL_CommandBufferExecutionBarrierOp : HAL_Op<"command_buffer.execution_barrier", [
-    AttrSizedOperandSegments,
-  ]> {
+def HAL_CommandBufferExecutionBarrierOp : HAL_Op<"command_buffer.execution_barrier"> {
   let summary = [{command buffer execution barrier recording operation}];
   let description = [{
-    Defines a memory dependency between commands recorded before and after the
-    barrier.
+    Defines an execution dependency between all commands recorded before the
+    barrier and all commands recorded after the barrier. Only the stages
+    provided will be affected.
   }];
 
   let arguments = (ins
     HAL_CommandBuffer:$command_buffer,
     HAL_ExecutionStageBitfieldAttr:$source_stage_mask,
     HAL_ExecutionStageBitfieldAttr:$target_stage_mask,
-    Variadic<HAL_MemoryBarrier>:$memory_barriers,
-    Variadic<HAL_BufferBarrier>:$buffer_barriers
+    HAL_ExecutionBarrierFlagBitfieldAttr:$flags
   );
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilderDAG<(ins "Value":$commandBuffer,
-      "IREE::HAL::ExecutionStageBitfield":$sourceStageMask,
-      "IREE::HAL::ExecutionStageBitfield":$targetStageMask,
-      "ValueRange":$memoryBarriers, "ValueRange":$bufferBarriers)>,
-  ];
 }
 
 // TODO(benvanik): event ops.

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -715,22 +715,22 @@ def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
 
   let arguments = (ins
     HAL_Buffer:$buffer,
-    HAL_Shape:$shape,
-    HAL_ElementTypeAttr:$element_type
+    HAL_ElementTypeAttr:$element_type,
+    HAL_Shape:$shape
   );
   let results = (outs
     HAL_BufferView:$result
   );
 
   let assemblyFormat = [{
-    $buffer `,` `shape` `=` `[` $shape `]` `,` `element_type` `=` $element_type
+    $buffer `,` `element_type` `=` $element_type `,` `shape` `=` `[` $shape `]`
     `:` type($result) attr-dict
   }];
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilderDAG<(ins "Value":$buffer, "ValueRange":$shape,
-      "int32_t":$elementType)>,
+    OpBuilderDAG<(ins "Value":$buffer, "int32_t":$elementType,
+                  "ValueRange":$shape)>,
   ];
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -5,7 +5,7 @@ func @expand_buffer_view_const() -> !hal.buffer_view {
   %0 = "test_hal.allocator"() : () -> !hal.allocator
   //      CHECK: [[CONST:%.+]] = iree.byte_buffer.constant : !iree.byte_buffer = dense<[4, 1, 2]> : tensor<3xi32>
   // CHECK-NEXT: [[BUFFER:%.+]] = hal.allocator.map {{.+}}, "HostVisible|HostCoherent", Transfer, [[CONST]][%c0, %c-1] : !iree.byte_buffer -> !hal.buffer
-  // CHECK-NEXT: [[VIEW:%.+]] = hal.buffer_view.create [[BUFFER]], shape = [%c3], element_type = 16777248 : !hal.buffer_view
+  // CHECK-NEXT: [[VIEW:%.+]] = hal.buffer_view.create [[BUFFER]], element_type = 16777248, shape = [%c3] : !hal.buffer_view
   %view = hal.buffer_view.const %0, "HostVisible|HostCoherent", Transfer : !hal.buffer_view = dense<[4, 1, 2]> : tensor<3xi32>
   // CHECK-NEXT: return [[VIEW]]
   return %view : !hal.buffer_view
@@ -18,7 +18,7 @@ func @skip_buffer_view_buffer() -> !hal.buffer {
   // CHECK: %[[BUFFER:.+]] = "test_hal.buffer"
   %0 = "test_hal.buffer"() : () -> !hal.buffer
   %1:2 = "test_hal.shape"() : () -> (index, index)
-  %2 = hal.buffer_view.create %0, shape = [%1#0, %1#1], element_type = 32 : !hal.buffer_view
+  %2 = hal.buffer_view.create %0, element_type = 32, shape = [%1#0, %1#1] : !hal.buffer_view
   %3 = hal.buffer_view.buffer %2 : !hal.buffer
   // CHECK: return %[[BUFFER]]
   return %3 : !hal.buffer

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
@@ -17,8 +17,8 @@ func @buffer_view_const() -> !hal.buffer_view {
 // CHECK-LABEL: @buffer_view_create
 func @buffer_view_create(%arg0 : !hal.buffer) -> !hal.buffer_view {
   %0:2 = "test_hal.shape"() : () -> (index, index)
-  // CHECK: %view = hal.buffer_view.create %arg0, shape = [%0#0, %0#1], element_type = 32 : !hal.buffer_view
-  %view = hal.buffer_view.create %arg0, shape=[%0#0, %0#1], element_type=32 : !hal.buffer_view
+  // CHECK: %view = hal.buffer_view.create %arg0, element_type = 32, shape = [%0#0, %0#1] : !hal.buffer_view
+  %view = hal.buffer_view.create %arg0, element_type = 32, shape = [%0#0, %0#1] : !hal.buffer_view
   return %view : !hal.buffer_view
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -53,23 +53,8 @@ func @command_buffer_device(%arg0 : !hal.command_buffer) {
 
 // CHECK-LABEL: @command_buffer_execution_barrier
 func @command_buffer_execution_barrier(%arg0 : !hal.command_buffer) {
-  %0 = "test_hal.buffer"() : () -> !hal.buffer
-  %1 = "test_hal.offset"() : () -> index
-  %2 = "test_hal.length"() : () -> index
-  %memory_barrier = hal.make_memory_barrier "HostRead|HostWrite", "MemoryRead|MemoryWrite" : tuple<i32, i32>
-  %buffer_barrier = hal.make_buffer_barrier "HostRead|HostWrite", "MemoryRead|MemoryWrite", %0, %1, %2 : tuple<i32, i32, !hal.buffer, index, index>
-  // CHECK: hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess"
-  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess"
-  // CHECK-NEXT: hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", memory_barriers=[%memory_barrier, %memory_barrier]
-  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess",
-      memory_barriers=[%memory_barrier, %memory_barrier]
-  // CHECK-NEXT: hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", buffer_barriers=[%buffer_barrier, %buffer_barrier]
-  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess",
-      buffer_barriers=[%buffer_barrier, %buffer_barrier]
-  // CHECK-NEXT: hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", memory_barriers=[%memory_barrier, %memory_barrier], buffer_barriers=[%buffer_barrier, %buffer_barrier]
-  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess",
-      memory_barriers=[%memory_barrier, %memory_barrier],
-      buffer_barriers=[%buffer_barrier, %buffer_barrier]
+  // CHECK: hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", "None"
+  hal.command_buffer.execution_barrier %arg0, "CommandIssue", "CommandProcess", "None"
   return
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -115,7 +115,7 @@ func @executable_create(%device : !hal.device, %layout0 : !hal.executable_layout
 
 // CHECK-LABEL: @executable_layout_create
 func @executable_layout_create(%arg0 : !hal.device, %arg1 : !hal.descriptor_set_layout) {
-  // CHECK: hal.executable_layout.create %arg0, set_layouts = [%arg1], push_constants = 1 : !hal.executable_layout
-  %executable_layout = hal.executable_layout.create %arg0, set_layouts = [%arg1], push_constants = 1 : !hal.executable_layout
+  // CHECK: hal.executable_layout.create %arg0, push_constants = 1, set_layouts = [%arg1] : !hal.executable_layout
+  %executable_layout = hal.executable_layout.create %arg0, push_constants = 1, set_layouts = [%arg1] : !hal.executable_layout
   return
 }

--- a/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/SPIRVCommon/SPIRVTarget.cpp
@@ -32,13 +32,10 @@ namespace HAL {
 // Records a full execution barrier that forces visibility of all buffers.
 static void recordFullExecutionBarrier(Value commandBuffer, Location loc,
                                        OpBuilder &builder) {
-  Value memoryBarrier = builder.create<IREE::HAL::MakeMemoryBarrierOp>(
-      loc, IREE::HAL::AccessScopeBitfield::DispatchWrite,
-      IREE::HAL::AccessScopeBitfield::DispatchRead);
   builder.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
       loc, commandBuffer, IREE::HAL::ExecutionStageBitfield::Dispatch,
       IREE::HAL::ExecutionStageBitfield::Dispatch,
-      ArrayRef<Value>{memoryBarrier}, ArrayRef<Value>{});
+      IREE::HAL::ExecutionBarrierFlagBitfield::None);
 }
 
 SPIRVTargetBackend::SPIRVTargetBackend(SPIRVCodegenOptions options)

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -173,7 +173,7 @@ class MaterializeResourceCachesPass
     }
     auto deviceValue = blockBuilder.createOrFold<ExSharedDeviceOp>(loc);
     auto layoutValue = blockBuilder.createOrFold<ExecutableLayoutCreateOp>(
-        loc, layoutType, deviceValue, setLayoutValues, pushConstantsAttr);
+        loc, layoutType, deviceValue, pushConstantsAttr, setLayoutValues);
     blockBuilder.create<mlir::ReturnOp>(loc, layoutValue);
 
     return variableOp;

--- a/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PublicAbiGeneration.cpp
@@ -205,7 +205,7 @@ LogicalResult generateAsynchronousBody(
 
         // Build buffer_view.
         funcResults.push_back(builder.create<BufferViewCreateOp>(
-            loc, nextCallResult, dimValues, *elementType));
+            loc, nextCallResult, *elementType, dimValues));
         break;
       }
       case RawSignatureParser::Type::kScalar: {

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -26,7 +26,7 @@ func @descriptorSetLayoutLookup(%arg0 : !hal.device) -> !hal.descriptor_set_layo
 // CHECK-NEXT: func private @_executable_layout_0_initializer() -> !hal.executable_layout {
 // CHECK-NEXT:   %0 = hal.variable.load @_descriptor_set_layout_0 : !hal.descriptor_set_layout
 // CHECK-NEXT:   %dev = hal.ex.shared_device : !hal.device
-// CHECK-NEXT:   %executable_layout = hal.executable_layout.create %dev, set_layouts = [%0], push_constants = 0 : !hal.executable_layout
+// CHECK-NEXT:   %executable_layout = hal.executable_layout.create %dev, push_constants = 0, set_layouts = [%0] : !hal.executable_layout
 // CHECK-NEXT:   return %executable_layout : !hal.executable_layout
 // CHECK-NEXT: }
 
@@ -53,7 +53,7 @@ func @exeLayoutLookup(%arg0 : !hal.device) -> !hal.executable_layout {
 // CHECK-NEXT:   %0 = hal.variable.load @_descriptor_set_layout_0 : !hal.descriptor_set_layout
 // CHECK-NEXT:   %1 = hal.variable.load @_descriptor_set_layout_1 : !hal.descriptor_set_layout
 // CHECK-NEXT:   %dev = hal.ex.shared_device : !hal.device
-// CHECK-NEXT:   %executable_layout = hal.executable_layout.create %dev, set_layouts = [%0, %1], push_constants = 0 : !hal.executable_layout
+// CHECK-NEXT:   %executable_layout = hal.executable_layout.create %dev, push_constants = 0, set_layouts = [%0, %1] : !hal.executable_layout
 // CHECK-NEXT:   return %executable_layout : !hal.executable_layout
 // CHECK-NEXT: }
 

--- a/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
@@ -31,7 +31,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
   // CHECK-DAG: %[[R0:.+]] = call @staticTwoArg(%[[BUFFER0]], %[[BUFFER1]])
   // CHECK-DAG: %[[C5:.+]] = constant 5 : index
   // CHECK-DAG: %[[C6:.+]] = constant 6 : index
-  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], shape = [%[[C5]], %[[C6]]], element_type = 16777280 : !hal.buffer_view
+  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], element_type = 16777280, shape = [%[[C5]], %[[C6]]] : !hal.buffer_view
   // CHECK-DAG: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
   // CHECK: return %[[VIEW]]
   return %arg1 : !hal.buffer
@@ -71,7 +71,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
 // CHECK-DAG: %[[DIM0:.+]] = hal.buffer_view.dim %[[ARG2]], 0 : index
 // CHECK-DAG: %[[DIM1:.+]] = hal.buffer_view.dim %[[ARG2]], 1 : index
 // CHECK-DAG: %[[RESULT:.+]]:3 = call @dynamicTwoDims(%[[BUFFER]], %[[DIM0]], %[[DIM1]])
-// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, shape = [%[[RESULT]]#1, %[[RESULT]]#2], element_type = 50331680 : !hal.buffer_view
+// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, element_type = 50331680, shape = [%[[RESULT]]#1, %[[RESULT]]#2] : !hal.buffer_view
 // CHECK-DAG: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
 // CHECK: return %[[RESULT_VIEW]]
 // A new function with $sync suffix based on buffer_view should be generated.

--- a/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
+++ b/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
@@ -166,7 +166,7 @@ Value TensorRewriteAdaptor::getBufferView() {
     auto shapeDims = getShapeDims();
     if (!shapeDims) return {};
     return rewriter_.createOrFold<IREE::HAL::BufferViewCreateOp>(
-        loc_, newValue_, *shapeDims, getElementType());
+        loc_, newValue_, getElementType(), *shapeDims);
   }
 }
 

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -358,8 +358,8 @@ attributes {nosideeffects}
 // required size.
 vm.import @executable_layout.create(
   %device : !vm.ref<!hal.device>,
-  %set_layouts : !vm.ref<!hal.descriptor_set_layout>...,
-  %push_constants : i32
+  %push_constants : i32,
+  %set_layouts : !vm.ref<!hal.descriptor_set_layout>...
 ) -> !vm.ref<!hal.executable_layout>
 attributes {nosideeffects}
 

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -212,15 +212,14 @@ vm.import @command_buffer.end(
   %command_buffer : !vm.ref<!hal.command_buffer>
 )
 
-// Defines a memory dependency between commands recorded before and after the
-// barrier.
+// Defines an execution dependency between all commands recorded before the
+// barrier and all commands recorded after the barrier. Only the stages provided
+// will be affected.
 vm.import @command_buffer.execution_barrier(
   %command_buffer : !vm.ref<!hal.command_buffer>,
   %source_stage_mask : i32,
   %target_stage_mask : i32,
-  // TODO(benvanik): tuple types.
-  %memory_barriers : i32 ...,
-  %buffer_barriers : i32 ...
+  %flags : i32
 )
 
 // Fills the target buffer with the given repeating value.

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -112,8 +112,8 @@ vm.import @buffer.store(
 // Creates a reference to a buffer with a particular shape and element type.
 vm.import @buffer_view.create(
   %buffer : !vm.ref<!hal.buffer>,
-  %shape : i32 ...,
-  %element_type : i32
+  %element_type : i32,
+  %shape : i32 ...
 ) -> !vm.ref<!hal.buffer_view>
 attributes {nosideeffects}
 

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -184,10 +184,10 @@ vm.import @buffer_view.dims.4(
 ) -> (i32, i32, i32, i32)
 attributes {nosideeffects}
 
-// Prints out the content of buffers.
+// Prints out the content of buffer views.
 vm.import @buffer_view.trace(
-  %operands : !vm.ref<!hal.buffer_view> ...,
-  %trace_info : !vm.ref<!iree.byte_buffer>
+  %key : !vm.ref<!iree.byte_buffer>,
+  %operands : !vm.ref<!hal.buffer_view> ...
 )
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_to_hal.mlir
@@ -3,8 +3,8 @@
 
 // CHECK: @Reserve
 func @Reserve(%arg0: tensor<0xi32>, %arg1: tensor<i32>) -> !tensorlist.list {
-  // CHECK: [[VIEW0:%.+]] = hal.buffer_view.create %arg0, shape = [%c0], element_type = 16777248
-  // CHECK: [[VIEW1:%.+]] = hal.buffer_view.create %arg1, shape = [], element_type = 16777248
+  // CHECK: [[VIEW0:%.+]] = hal.buffer_view.create %arg0, element_type = 16777248, shape = [%c0]
+  // CHECK: [[VIEW1:%.+]] = hal.buffer_view.create %arg1, element_type = 16777248, shape = []
   // CHECK: [[LIST:%.+]] = "tensorlist.Reserve"(%view, %view_0) {element_type = 50331680 : i32}
   %0 = "tensorlist.Reserve.Tensor"(%arg0, %arg1) {element_type = f32} : (tensor<0xi32>, tensor<i32>) -> !tensorlist.list
 

--- a/iree/hal/buffer_view.c
+++ b/iree/hal/buffer_view.c
@@ -30,8 +30,8 @@ struct iree_hal_buffer_view_s {
 };
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_create(
-    iree_hal_buffer_t* buffer, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_buffer_t* buffer, iree_hal_element_type_t element_type,
+    const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
     iree_hal_buffer_view_t** out_buffer_view) {
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_ASSERT_ARGUMENT(out_buffer_view);
@@ -115,8 +115,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_subview(
       buffer_view->buffer, start_offset, subview_length, &subview_buffer));
 
   iree_status_t status =
-      iree_hal_buffer_view_create(subview_buffer, lengths, lengths_count,
-                                  buffer_view->element_type, out_buffer_view);
+      iree_hal_buffer_view_create(subview_buffer, buffer_view->element_type,
+                                  lengths, lengths_count, out_buffer_view);
   iree_hal_buffer_release(subview_buffer);
   return status;
 }

--- a/iree/hal/buffer_view.cc
+++ b/iree/hal/buffer_view.cc
@@ -128,8 +128,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_parse(
   }
 
   // Wrap and pass ownership of the buffer to the buffer view.
-  status = iree_hal_buffer_view_create(buffer, shape.data(), shape.size(),
-                                       element_type, out_buffer_view);
+  status = iree_hal_buffer_view_create(buffer, element_type, shape.data(),
+                                       shape.size(), out_buffer_view);
   iree_hal_buffer_release(buffer);
   return status;
 }

--- a/iree/hal/buffer_view.h
+++ b/iree/hal/buffer_view.h
@@ -126,8 +126,8 @@ typedef struct iree_hal_buffer_view_s iree_hal_buffer_view_t;
 // Creates a buffer view with the given |buffer|.
 // |out_buffer_view| must be released by the caller.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_create(
-    iree_hal_buffer_t* buffer, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_buffer_t* buffer, iree_hal_element_type_t element_type,
+    const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
     iree_hal_buffer_view_t** out_buffer_view);
 
 // Creates a buffer view referencing a subview of the given |buffer_view|.

--- a/iree/hal/command_buffer.c
+++ b/iree/hal/command_buffer.c
@@ -69,6 +69,7 @@ iree_hal_command_buffer_execution_barrier(
     iree_hal_command_buffer_t* command_buffer,
     iree_hal_execution_stage_t source_stage_mask,
     iree_hal_execution_stage_t target_stage_mask,
+    iree_hal_execution_barrier_flags_t flags,
     iree_host_size_t memory_barrier_count,
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,
@@ -76,7 +77,7 @@ iree_hal_command_buffer_execution_barrier(
   IREE_ASSERT_ARGUMENT(command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(command_buffer, execution_barrier)(
-      command_buffer, source_stage_mask, target_stage_mask,
+      command_buffer, source_stage_mask, target_stage_mask, flags,
       memory_barrier_count, memory_barriers, buffer_barrier_count,
       buffer_barriers);
   IREE_TRACE_ZONE_END(z0);

--- a/iree/hal/command_buffer.h
+++ b/iree/hal/command_buffer.h
@@ -83,6 +83,14 @@ enum iree_hal_execution_stage_e {
 };
 typedef uint32_t iree_hal_execution_stage_t;
 
+// Bitfield specifying flags controlling an execution dependency.
+//
+// Maps to VkDependencyFlags.
+enum iree_hal_execution_barrier_flags_e {
+  IREE_HAL_EXECUTION_BARRIER_FLAG_NONE = 0,
+};
+typedef uint32_t iree_hal_execution_barrier_flags_t;
+
 // Bitfield specifying which scopes will access memory and how.
 //
 // Maps to VkAccessFlagBits.
@@ -223,6 +231,7 @@ iree_hal_command_buffer_execution_barrier(
     iree_hal_command_buffer_t* command_buffer,
     iree_hal_execution_stage_t source_stage_mask,
     iree_hal_execution_stage_t target_stage_mask,
+    iree_hal_execution_barrier_flags_t flags,
     iree_host_size_t memory_barrier_count,
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,
@@ -434,6 +443,7 @@ typedef struct {
       iree_hal_command_buffer_t* command_buffer,
       iree_hal_execution_stage_t source_stage_mask,
       iree_hal_execution_stage_t target_stage_mask,
+      iree_hal_execution_barrier_flags_t flags,
       iree_host_size_t memory_barrier_count,
       const iree_hal_memory_barrier_t* memory_barriers,
       iree_host_size_t buffer_barrier_count,

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -168,6 +168,7 @@ static iree_status_t iree_hal_validating_command_buffer_execution_barrier(
     iree_hal_command_buffer_t* base_command_buffer,
     iree_hal_execution_stage_t source_stage_mask,
     iree_hal_execution_stage_t target_stage_mask,
+    iree_hal_execution_barrier_flags_t flags,
     iree_host_size_t memory_barrier_count,
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,
@@ -182,7 +183,7 @@ static iree_status_t iree_hal_validating_command_buffer_execution_barrier(
 
   return iree_hal_command_buffer_execution_barrier(
       command_buffer->target_command_buffer, source_stage_mask,
-      target_stage_mask, memory_barrier_count, memory_barriers,
+      target_stage_mask, flags, memory_barrier_count, memory_barriers,
       buffer_barrier_count, buffer_barriers);
 }
 

--- a/iree/hal/cts/executable_layout_test.cc
+++ b/iree/hal/cts/executable_layout_test.cc
@@ -26,8 +26,8 @@ class ExecutableLayoutTest : public CtsTestBase {};
 TEST_P(ExecutableLayoutTest, CreateWithNoLayouts) {
   iree_hal_executable_layout_t* executable_layout;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
-      device_, /*set_layout_count=*/0, NULL,
-      /*push_constants=*/0, &executable_layout));
+      device_, /*push_constants=*/0, /*set_layout_count=*/0, NULL,
+      &executable_layout));
 
   iree_hal_executable_layout_release(executable_layout);
 }
@@ -37,8 +37,8 @@ TEST_P(ExecutableLayoutTest, CreateWithPushConstants) {
   // Note: The Vulkan maxPushConstantsSize limit must be at least 128 bytes:
   // https://www.khronos.org/registry/vulkan/specs/1.2/html/vkspec.html#limits-minmax
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
-      device_, /*set_layout_count=*/0, NULL,
-      /*push_constants=*/5, &executable_layout));
+      device_, /*push_constants=*/5, /*set_layout_count=*/0, NULL,
+      &executable_layout));
 
   iree_hal_executable_layout_release(executable_layout);
 }
@@ -58,8 +58,8 @@ TEST_P(ExecutableLayoutTest, CreateWithOneLayout) {
 
   iree_hal_executable_layout_t* executable_layout;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
-      device_, /*set_layout_count=*/1, &descriptor_set_layout,
-      /*push_constants=*/0, &executable_layout));
+      device_, /*push_constants=*/0, /*set_layout_count=*/1,
+      &descriptor_set_layout, &executable_layout));
 
   iree_hal_executable_layout_release(executable_layout);
   iree_hal_descriptor_set_layout_release(descriptor_set_layout);
@@ -93,8 +93,8 @@ TEST_P(ExecutableLayoutTest, CreateWithTwoLayouts) {
 
   iree_hal_executable_layout_t* executable_layout;
   IREE_ASSERT_OK(iree_hal_executable_layout_create(
-      device_, IREE_ARRAYSIZE(descriptor_set_layouts), descriptor_set_layouts,
-      /*push_constants=*/0, &executable_layout));
+      device_, /*push_constants=*/0, IREE_ARRAYSIZE(descriptor_set_layouts),
+      descriptor_set_layouts, &executable_layout));
 
   iree_hal_executable_layout_release(executable_layout);
   iree_hal_descriptor_set_layout_release(descriptor_set_layouts[0]);

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -265,9 +265,9 @@ typedef struct {
       iree_hal_executable_cache_t** out_executable_cache);
 
   iree_status_t(IREE_API_PTR* create_executable_layout)(
-      iree_hal_device_t* device, iree_host_size_t set_layout_count,
+      iree_hal_device_t* device, iree_host_size_t push_constants,
+      iree_host_size_t set_layout_count,
       iree_hal_descriptor_set_layout_t** set_layouts,
-      iree_host_size_t push_constants,
       iree_hal_executable_layout_t** out_executable_layout);
 
   iree_status_t(IREE_API_PTR* create_semaphore)(

--- a/iree/hal/executable_layout.c
+++ b/iree/hal/executable_layout.c
@@ -25,9 +25,9 @@
 IREE_HAL_API_RETAIN_RELEASE(executable_layout);
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_create(
-    iree_hal_device_t* device, iree_host_size_t set_layout_count,
+    iree_hal_device_t* device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);
@@ -36,7 +36,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_create(
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device,
                                                   create_executable_layout)(
-      device, set_layout_count, set_layouts, push_constants,
+      device, push_constants, set_layout_count, set_layouts,
       out_executable_layout);
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/iree/hal/executable_layout.h
+++ b/iree/hal/executable_layout.h
@@ -54,9 +54,9 @@ typedef struct iree_hal_executable_layout_s iree_hal_executable_layout_t;
 // The returned executable layout can be used by multiple executables with the
 // same compatible resource binding layouts.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_create(
-    iree_hal_device_t* device, iree_host_size_t set_layout_count,
+    iree_hal_device_t* device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants,
     iree_hal_executable_layout_t** out_executable_layout);
 
 // Retains the given |executable_layout| for the caller.

--- a/iree/hal/local/local_executable_layout.c
+++ b/iree/hal/local/local_executable_layout.c
@@ -27,9 +27,9 @@ iree_hal_local_executable_layout_t* iree_hal_local_executable_layout_cast(
 }
 
 iree_status_t iree_hal_local_executable_layout_create(
-    iree_host_size_t set_layout_count,
+    iree_host_size_t push_constants, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants, iree_allocator_t host_allocator,
+    iree_allocator_t host_allocator,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);
   IREE_ASSERT_ARGUMENT(out_executable_layout);

--- a/iree/hal/local/local_executable_layout.h
+++ b/iree/hal/local/local_executable_layout.h
@@ -41,9 +41,9 @@ typedef struct {
 } iree_hal_local_executable_layout_t;
 
 iree_status_t iree_hal_local_executable_layout_create(
-    iree_host_size_t set_layout_count,
+    iree_host_size_t push_constants, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants, iree_allocator_t host_allocator,
+    iree_allocator_t host_allocator,
     iree_hal_executable_layout_t** out_executable_layout);
 
 iree_hal_local_executable_layout_t* iree_hal_local_executable_layout_cast(

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -384,6 +384,7 @@ static iree_status_t iree_hal_task_command_buffer_execution_barrier(
     iree_hal_command_buffer_t* base_command_buffer,
     iree_hal_execution_stage_t source_stage_mask,
     iree_hal_execution_stage_t target_stage_mask,
+    iree_hal_execution_barrier_flags_t flags,
     iree_host_size_t memory_barrier_count,
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -247,12 +247,12 @@ static iree_status_t iree_hal_task_device_create_executable_cache(
 }
 
 static iree_status_t iree_hal_task_device_create_executable_layout(
-    iree_hal_device_t* base_device, iree_host_size_t set_layout_count,
+    iree_hal_device_t* base_device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants,
     iree_hal_executable_layout_t** out_executable_layout) {
   return iree_hal_local_executable_layout_create(
-      set_layout_count, set_layouts, push_constants,
+      push_constants, set_layout_count, set_layouts,
       iree_hal_device_host_allocator(base_device), out_executable_layout);
 }
 

--- a/iree/hal/string_util_test.cc
+++ b/iree/hal/string_util_test.cc
@@ -430,7 +430,7 @@ struct BufferView final
                                      iree_hal_element_type_t element_type) {
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_create(
-        buffer, shape.data(), shape.size(), element_type, &buffer_view);
+        buffer, element_type, shape.data(), shape.size(), &buffer_view);
     IREE_RETURN_IF_ERROR(std::move(status));
     return std::move(buffer_view);
   }

--- a/iree/hal/vulkan/direct_command_buffer.cc
+++ b/iree/hal/vulkan/direct_command_buffer.cc
@@ -256,6 +256,7 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_execution_barrier(
     iree_hal_command_buffer_t* base_command_buffer,
     iree_hal_execution_stage_t source_stage_mask,
     iree_hal_execution_stage_t target_stage_mask,
+    iree_hal_execution_barrier_flags_t flags,
     iree_host_size_t memory_barrier_count,
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,

--- a/iree/hal/vulkan/native_executable_layout.cc
+++ b/iree/hal/vulkan/native_executable_layout.cc
@@ -41,9 +41,9 @@ iree_hal_vulkan_native_executable_layout_cast(
 
 static iree_status_t iree_hal_vulkan_create_pipeline_layout(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_host_size_t set_layout_count,
+    iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constant_count, VkPipelineLayout* out_handle) {
+    VkPipelineLayout* out_handle) {
   VkDescriptorSetLayout* set_layout_handles =
       (VkDescriptorSetLayout*)iree_alloca(set_layout_count *
                                           sizeof(VkDescriptorSetLayout));
@@ -82,9 +82,8 @@ static void iree_hal_vulkan_destroy_pipeline_layout(
 
 iree_status_t iree_hal_vulkan_native_executable_layout_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_host_size_t set_layout_count,
+    iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);
@@ -94,9 +93,9 @@ iree_status_t iree_hal_vulkan_native_executable_layout_create(
 
   VkPipelineLayout handle = VK_NULL_HANDLE;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_vulkan_create_pipeline_layout(logical_device,
-                                                 set_layout_count, set_layouts,
-                                                 push_constant_count, &handle));
+      z0, iree_hal_vulkan_create_pipeline_layout(
+              logical_device, push_constant_count, set_layout_count,
+              set_layouts, &handle));
 
   iree_hal_vulkan_native_executable_layout_t* executable_layout = NULL;
   iree_host_size_t total_size =

--- a/iree/hal/vulkan/native_executable_layout.h
+++ b/iree/hal/vulkan/native_executable_layout.h
@@ -30,9 +30,8 @@ extern "C" {
 // descriptor set layouts.
 iree_status_t iree_hal_vulkan_native_executable_layout_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_host_size_t set_layout_count,
+    iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout);
 
 // Returns the native VkPipelineLayout handle for the executable layout.

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -879,13 +879,13 @@ static iree_status_t iree_hal_vulkan_device_create_executable_cache(
 }
 
 static iree_status_t iree_hal_vulkan_device_create_executable_layout(
-    iree_hal_device_t* base_device, iree_host_size_t set_layout_count,
+    iree_hal_device_t* base_device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t** set_layouts,
-    iree_host_size_t push_constants,
     iree_hal_executable_layout_t** out_executable_layout) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
   return iree_hal_vulkan_native_executable_layout_create(
-      device->logical_device, set_layout_count, set_layouts, push_constants,
+      device->logical_device, push_constants, set_layout_count, set_layouts,
       out_executable_layout);
 }
 

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -97,7 +97,7 @@ class CheckTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_buffer_write_data(
         buffer.get(), 0, contents.data(), contents.size() * sizeof(int32_t)));
     IREE_ASSERT_OK(iree_hal_buffer_view_create(
-        buffer.get(), shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_SINT_32,
+        buffer.get(), IREE_HAL_ELEMENT_TYPE_SINT_32, shape.data(), shape.size(),
         &*out_buffer_view));
   }
 
@@ -119,8 +119,8 @@ class CheckTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_buffer_write_data(buffer.get(), 0, contents.data(),
                                               contents.size() * sizeof(float)));
     IREE_ASSERT_OK(iree_hal_buffer_view_create(
-        buffer.get(), shape.data(), shape.size(),
-        IREE_HAL_ELEMENT_TYPE_FLOAT_32, &*out_buffer_view));
+        buffer.get(), IREE_HAL_ELEMENT_TYPE_FLOAT_32, shape.data(),
+        shape.size(), &*out_buffer_view));
   }
 
   void CreateFloat64BufferView(absl::Span<const double> contents,
@@ -141,8 +141,8 @@ class CheckTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_buffer_write_data(
         buffer.get(), 0, contents.data(), contents.size() * sizeof(double)));
     IREE_ASSERT_OK(iree_hal_buffer_view_create(
-        buffer.get(), shape.data(), shape.size(),
-        IREE_HAL_ELEMENT_TYPE_FLOAT_64, &*out_buffer_view));
+        buffer.get(), IREE_HAL_ELEMENT_TYPE_FLOAT_64, shape.data(),
+        shape.size(), &*out_buffer_view));
   }
 
   Status Invoke(absl::string_view function_name) {

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -355,12 +355,12 @@ class HALModuleState final {
   //===--------------------------------------------------------------------===//
 
   StatusOr<vm::ref<iree_hal_buffer_view_t>> BufferViewCreate(
-      const vm::ref<iree_hal_buffer_t>& buffer, absl::Span<const int32_t> shape,
-      iree_hal_element_type_t element_type) {
+      const vm::ref<iree_hal_buffer_t>& buffer,
+      iree_hal_element_type_t element_type, absl::Span<const int32_t> shape) {
     vm::ref<iree_hal_buffer_view_t> buffer_view;
     IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_create(buffer.get(), shape.data(), shape.size(),
-                                    element_type, &buffer_view),
+        iree_hal_buffer_view_create(buffer.get(), element_type, shape.data(),
+                                    shape.size(), &buffer_view),
         "failed to create buffer view");
     return std::move(buffer_view);
   }

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -719,9 +719,8 @@ class HALModuleState final {
   //===--------------------------------------------------------------------===//
 
   StatusOr<vm::ref<iree_hal_executable_layout_t>> ExecutableLayoutCreate(
-      const vm::ref<iree_hal_device_t>& device,
-      absl::Span<const vm::ref<iree_hal_descriptor_set_layout_t>> set_layouts,
-      int32_t push_constants) {
+      const vm::ref<iree_hal_device_t>& device, int32_t push_constants,
+      absl::Span<const vm::ref<iree_hal_descriptor_set_layout_t>> set_layouts) {
     iree_hal_descriptor_set_layout_t** set_layouts_ptr =
         (iree_hal_descriptor_set_layout_t**)iree_alloca(
             sizeof(set_layouts_ptr[0]) * set_layouts.size());
@@ -731,7 +730,7 @@ class HALModuleState final {
 
     vm::ref<iree_hal_executable_layout_t> executable_layout;
     IREE_RETURN_IF_ERROR(iree_hal_executable_layout_create(
-        device.get(), set_layouts.size(), set_layouts_ptr, push_constants,
+        device.get(), push_constants, set_layouts.size(), set_layouts_ptr,
         &executable_layout));
     return std::move(executable_layout);
   }

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -503,14 +503,12 @@ class HALModuleState final {
       const vm::ref<iree_hal_command_buffer_t>& command_buffer,
       iree_hal_execution_stage_t source_stage_mask,
       iree_hal_execution_stage_t target_stage_mask,
-      absl::Span<const int32_t> memory_barriers,
-      absl::Span<const int32_t> buffer_barriers) {
-    // TODO(benvanik): decode barriers.
+      iree_hal_execution_barrier_flags_t flags) {
     iree_hal_memory_barrier_t global_barrier;
     global_barrier.source_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE;
     global_barrier.target_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ;
     return iree_hal_command_buffer_execution_barrier(
-        command_buffer.get(), source_stage_mask, target_stage_mask, 1,
+        command_buffer.get(), source_stage_mask, target_stage_mask, flags, 1,
         &global_barrier, 0, nullptr);
   }
 

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -452,9 +452,9 @@ class HALModuleState final {
   }
 
   Status BufferViewTrace(
-      absl::Span<const vm::ref<iree_hal_buffer_view_t>> buffer_views,
-      absl::string_view trace_info) {
-    fprintf(stderr, "=== %s ===\n", std::string(trace_info).c_str());
+      absl::string_view key,
+      absl::Span<const vm::ref<iree_hal_buffer_view_t>> buffer_views) {
+    fprintf(stderr, "=== %s ===\n", std::string(key).c_str());
     for (auto& view : buffer_views) {
       std::string result_str(4096, '\0');
       iree_status_t status;

--- a/iree/modules/strings/strings_module_test.cc
+++ b/iree/modules/strings/strings_module_test.cc
@@ -123,7 +123,7 @@ class StringsModuleTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_buffer_write_data(buffer.get(), 0, contents.data(),
                                               contents.size() * sizeof(T)));
     IREE_ASSERT_OK(iree_hal_buffer_view_create(
-        buffer.get(), shape.data(), shape.size(), E, &*out_buffer_view));
+        buffer.get(), E, shape.data(), shape.size(), &*out_buffer_view));
   }
 
   void TestStringTensorToString(

--- a/iree/modules/tensorlist/native_module.cc
+++ b/iree/modules/tensorlist/native_module.cc
@@ -113,8 +113,8 @@ class TensorList final : public iree::vm::RefObject<TensorList> {
 
       iree_hal_buffer_view_t* slice = nullptr;
       IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
-          subview_buffer.get(), element_shape.data(), element_shape.size(),
-          iree_hal_buffer_view_element_type(tensor.get()), &slice));
+          subview_buffer.get(), iree_hal_buffer_view_element_type(tensor.get()),
+          element_shape.data(), element_shape.size(), &slice));
       list->SetItem(i, slice);
     }
     return list;
@@ -173,9 +173,9 @@ class TensorList final : public iree::vm::RefObject<TensorList> {
       result_shape.push_back(dim);
     }
     vm::ref<iree_hal_buffer_view_t> result_view;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_create(result_buffer.get(), result_shape.data(),
-                                    result_shape.size(), type, &result_view));
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
+        result_buffer.get(), type, result_shape.data(), result_shape.size(),
+        &result_view));
     return std::move(result_view);
   }
 
@@ -246,9 +246,9 @@ class TensorList final : public iree::vm::RefObject<TensorList> {
       result_shape.push_back(dim);
     }
     vm::ref<iree_hal_buffer_view_t> result_view;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_create(result_buffer.get(), result_shape.data(),
-                                    result_shape.size(), type, &result_view));
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
+        result_buffer.get(), type, result_shape.data(), result_shape.size(),
+        &result_view));
 
     return std::move(result_view);
   }

--- a/iree/modules/tensorlist/tensorlist_test.cc
+++ b/iree/modules/tensorlist/tensorlist_test.cc
@@ -172,8 +172,8 @@ class TensorListModulesTest : public ::testing::Test {
     IREE_ASSERT_OK(iree_hal_buffer_write_data(buffer.get(), 0, contents.data(),
                                               contents.size() * sizeof(float)));
     IREE_ASSERT_OK(iree_hal_buffer_view_create(
-        buffer.get(), shape.data(), shape.size(),
-        IREE_HAL_ELEMENT_TYPE_FLOAT_32, &*out_buffer_view));
+        buffer.get(), IREE_HAL_ELEMENT_TYPE_FLOAT_32, shape.data(),
+        shape.size(), &*out_buffer_view));
   }
 
   iree_hal_device_t* device_ = nullptr;

--- a/iree/samples/custom_modules/dialect/test/conversion.mlir
+++ b/iree/samples/custom_modules/dialect/test/conversion.mlir
@@ -20,12 +20,13 @@
 
 // CHECK-LABEL: @tensorToMessage
 func @tensorToMessage(%tensor : tensor<2x4xf32>) {
-  // CHECK-DAG: [[TYPE:%.+]] = vm.const.i32 50331680 : i32
-  // CHECK-DAG: [[DIM0:%.+]] = vm.const.i32 2 : i32
-  // CHECK-DAG: [[DIM1:%.+]] = vm.const.i32 4 : i32
-  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(%arg0, [
-  // CHECK-SAME:     [[DIM0]], [[DIM1]]
-  // CHECK-SAME: ], [[TYPE]])
+  //  CHECK-DAG: [[TYPE:%.+]] = vm.const.i32 50331680 : i32
+  //  CHECK-DAG: [[DIM0:%.+]] = vm.const.i32 2 : i32
+  //  CHECK-DAG: [[DIM1:%.+]] = vm.const.i32 4 : i32
+  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(
+  // CHECK-SAME:     %arg0, [[TYPE]], [
+  // CHECK-SAME:       [[DIM0]], [[DIM1]]
+  // CHECK-SAME:     ])
   // CHECK-NEXT: [[MSG:%.+]] = vm.call @custom.buffer_to_message([[VIEW]]) : (!vm.ref<!hal.buffer_view>) -> !vm.ref<!custom.message>
   %0 = "custom.tensor_to_message"(%tensor) : (tensor<2x4xf32>) -> !custom.message
   %c1 = constant 1 : i32
@@ -38,10 +39,11 @@ func @tensorToMessage(%tensor : tensor<2x4xf32>) {
 
 // CHECK-LABEL: @dynamicTensorToMessage
 func @dynamicTensorToMessage(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index) {
-  // CHECK-DAG: [[TYPE:%.+]] = vm.const.i32 50331680 : i32
-  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(%arg0, [
-  // CHECK-SAME:     %arg1, %arg2
-  // CHECK-SAME: ], [[TYPE]])
+  //  CHECK-DAG: [[TYPE:%.+]] = vm.const.i32 50331680 : i32
+  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(
+  // CHECK-SAME:     %arg0, [[TYPE]], [
+  // CHECK-SAME:       %arg1, %arg2
+  // CHECK-SAME:     ])
   // CHECK-NEXT: [[MSG:%.+]] = vm.call @custom.buffer_to_message([[VIEW]]) : (!vm.ref<!hal.buffer_view>) -> !vm.ref<!custom.message>
   %shape = shapex.make_ranked_shape %arg1, %arg2 : (index, index) -> !shapex.ranked_shape<[?, ?]>
   %shaped_tensor = shapex.tie_shape %arg0, %shape : tensor<?x?xf32>, !shapex.ranked_shape<[?, ?]>
@@ -57,8 +59,8 @@ func @dynamicTensorToMessage(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : ind
 // CHECK-LABEL: @dynamicTensorToMessage2
 func @dynamicTensorToMessage2(%arg0 : tensor<?x?xf32>, %arg1: !shapex.ranked_shape<[?, ?]> {iree.reflection = {}}) {
   // CHECK-DAG: [[TYPE:%.+]] = vm.const.i32 50331680 : i32
-  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(%arg0,
-  // CHECK-SAME: [%arg1, %arg2], [[TYPE]])
+  // CHECK-NEXT: [[VIEW:%.+]] = vm.call.variadic @hal.buffer_view.create(%arg0, [[TYPE]],
+  // CHECK-SAME: [%arg1, %arg2])
   // CHECK-NEXT: [[MSG:%.+]] = vm.call @custom.buffer_to_message([[VIEW]]) : (!vm.ref<!hal.buffer_view>) -> !vm.ref<!custom.message>
   %shaped_tensor = shapex.tie_shape %arg0, %arg1 : tensor<?x?xf32>, !shapex.ranked_shape<[?, ?]>
   %0 = "custom.tensor_to_message"(%shaped_tensor) : (tensor<?x?xf32>) -> !custom.message

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -396,11 +396,11 @@ extern "C" int iree_main(int argc, char** argv) {
         iree_hal_buffer_view_t* input0_buffer_view = nullptr;
         iree_hal_buffer_view_t* input1_buffer_view = nullptr;
         IREE_CHECK_OK(iree_hal_buffer_view_create(
-            input0_buffer, /*shape=*/&kElementCount, /*shape_rank=*/1,
-            IREE_HAL_ELEMENT_TYPE_FLOAT_32, &input0_buffer_view));
+            input0_buffer, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+            /*shape=*/&kElementCount, /*shape_rank=*/1, &input0_buffer_view));
         IREE_CHECK_OK(iree_hal_buffer_view_create(
-            input1_buffer, /*shape=*/&kElementCount, /*shape_rank=*/1,
-            IREE_HAL_ELEMENT_TYPE_FLOAT_32, &input1_buffer_view));
+            input1_buffer, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+            /*shape=*/&kElementCount, /*shape_rank=*/1, &input1_buffer_view));
         iree_hal_buffer_release(input0_buffer);
         iree_hal_buffer_release(input1_buffer);
         // Marshal inputs through a VM variant list.


### PR DESCRIPTION
These simplify and improve the ability to optimize the cross-module calling by keeping variadic args at the end. I'd like to enforce this as a requirement (same rule as C) and future PRs will whittle away at the ops remaining that use multiple variadic arguments.
Progress on #4736.