### PR TITLE
Fixes to enable executing matmul on GPU.

### DIFF
--- a/iree/compiler/Conversion/CodegenUtils/MarkerUtils.cpp
+++ b/iree/compiler/Conversion/CodegenUtils/MarkerUtils.cpp
@@ -57,6 +57,13 @@ StringRef getVectorizeMarker() { return "vectorize"; }
 
 StringRef getDeleteMarker() { return "delete"; }
 
+StringRef getMarkerOrNull(Operation *op) {
+  StringAttr attr = op->getAttrOfType<StringAttr>(
+      linalg::LinalgTransforms::kLinalgTransformMarker);
+  if (!attr) return "";
+  return attr.getValue();
+}
+
 bool hasMarker(Operation *op, ArrayRef<StringRef> marker) {
   StringAttr attr = op->getAttrOfType<StringAttr>(
       linalg::LinalgTransforms::kLinalgTransformMarker);

--- a/iree/compiler/Conversion/CodegenUtils/MarkerUtils.h
+++ b/iree/compiler/Conversion/CodegenUtils/MarkerUtils.h
@@ -57,6 +57,9 @@ StringRef getVectorizeMarker();
 /// a marker that can be used later to delete these operations.
 StringRef getDeleteMarker();
 
+/// Returns the marker set on an operation, or "" if no marker is set
+StringRef getMarkerOrNull(Operation *op);
+
 /// Returns true if an operation has the specified `marker`. When `marker` is
 /// empty, returns true if the operation has any marker.
 bool hasMarker(Operation *, ArrayRef<StringRef> markers = {});

--- a/iree/compiler/Conversion/CodegenUtils/MarkerUtils.h
+++ b/iree/compiler/Conversion/CodegenUtils/MarkerUtils.h
@@ -57,7 +57,7 @@ StringRef getVectorizeMarker();
 /// a marker that can be used later to delete these operations.
 StringRef getDeleteMarker();
 
-/// Returns the marker set on an operation, or "" if no marker is set
+/// Returns the marker set on an operation, or "" if no marker is set.
 StringRef getMarkerOrNull(Operation *op);
 
 /// Returns true if an operation has the specified `marker`. When `marker` is

--- a/iree/compiler/Conversion/LinalgToSPIRV/CodeGenOptionUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CodeGenOptionUtils.cpp
@@ -55,6 +55,11 @@ static llvm::SmallVector<unsigned, 3> getSPIRVWorkgroupSizeClOption() {
   return sizes;
 }
 
+static llvm::cl::opt<bool> clEnableLinalgOnTensorsSPIRV(
+    "iree-codegen-spirv-experimental-linalg-on-tensors",
+    llvm::cl::desc("Enable the linalg on tensors on SPIR-V path"),
+    llvm::cl::init(false));
+
 namespace mlir {
 namespace iree_compiler {
 
@@ -65,6 +70,7 @@ SPIRVCodegenOptions getSPIRVCodegenOptionsFromClOptions() {
   options.enableVectorization = clEnableVectorization;
   options.useWorkgroupMemory = clUseWorkgroupMemory;
   options.vectorizeMemref = clVectorizeMemref;
+  options.useLinalgOnTensors = clEnableLinalgOnTensorsSPIRV;
   return options;
 }
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/CodeGenOptionUtils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/CodeGenOptionUtils.h
@@ -37,6 +37,7 @@ struct SPIRVCodegenOptions {
   bool enableVectorization = false;
   bool useWorkgroupMemory = false;
   bool vectorizeMemref = false;
+  bool useLinalgOnTensors = false;
 };
 
 // Returns SPIR-V CodeGen options from command-line options.

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -637,6 +637,9 @@ struct MapLinalgOpToLocalInvocationId : public OpConversionPattern<LinalgOpTy> {
   }
 
  private:
+  /// In cases where we know by construction that the iteration space is always
+  /// less than the number of local invocations within a workgroup, the
+  /// loop-control overhead can be reduced to just a single if-statement.
   bool optimizeControlFlow;
 };
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -450,8 +450,13 @@ static LogicalResult mapToWorkgroups(ConversionPatternRewriter &rewriter,
 }
 
 /// Distributes scf.parallel to workitems using local invocation ID.
-static LogicalResult mapToLocalInvocationId(ConversionPatternRewriter &rewriter,
-                                            scf::ParallelOp pLoopOp) {
+static LogicalResult mapToLocalInvocationId(
+    ConversionPatternRewriter &rewriter, scf::ParallelOp pLoopOp,
+    bool useCyclicDistribution = false) {
+  if (useCyclicDistribution) {
+    return distributeCyclicallyToProcessors<gpu::ThreadIdOp, gpu::BlockDimOp>(
+        rewriter, pLoopOp);
+  }
   return distributeSingleIterationPerProcessor<gpu::ThreadIdOp,
                                                gpu::BlockDimOp>(rewriter,
                                                                 pLoopOp);
@@ -505,16 +510,21 @@ static Optional<int64_t> getLinearizedCopySize(linalg::CopyOp copyOp) {
 
 namespace {
 /// Pass to convert from tiled and fused linalg ops into gpu.func.
-struct ConvertToGPUPass
+class ConvertToGPUPass
     : public PassWrapper<ConvertToGPUPass, OperationPass<ModuleOp>> {
-  ConvertToGPUPass() = default;
-  ConvertToGPUPass(const ConvertToGPUPass &pass) {}
+ public:
+  ConvertToGPUPass(const SPIRVCodegenOptions &passOptions)
+      : options(passOptions) {}
+  ConvertToGPUPass(const ConvertToGPUPass &pass) : options(pass.options) {}
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<AffineDialect, gpu::GPUDialect, scf::SCFDialect,
                     ShapeDialect>();
   }
   void runOnOperation() override;
+
+ private:
+  SPIRVCodegenOptions options;
 };
 
 struct SerializeParallelLoopPattern
@@ -532,7 +542,7 @@ struct SerializeParallelLoopPattern
 template <typename LinalgOpTy>
 static LogicalResult mapLinalgOpToLocalInvocationIdImpl(
     LinalgOpTy linalgOp, ArrayRef<Value> operands,
-    ConversionPatternRewriter &rewriter) {
+    ConversionPatternRewriter &rewriter, bool optimizeControlFlow) {
   // Check for marker that specifies that the linalg op is to be partitioned
   // across threads within a workgroup.
   if (!hasMarker(linalgOp)) return failure();
@@ -542,7 +552,7 @@ static LogicalResult mapLinalgOpToLocalInvocationIdImpl(
   if (loops.getValue().empty()) return success();
 
   auto pLoopOp = cast<scf::ParallelOp>(loops.getValue()[0]);
-  return mapToLocalInvocationId(rewriter, pLoopOp);
+  return mapToLocalInvocationId(rewriter, pLoopOp, optimizeControlFlow);
 }
 
 static LogicalResult distributeCopyOp(linalg::CopyOp copyOp,
@@ -580,14 +590,19 @@ static LogicalResult distributeCopyOp(linalg::CopyOp copyOp,
 template <>
 LogicalResult mapLinalgOpToLocalInvocationIdImpl<linalg::CopyOp>(
     linalg::CopyOp copyOp, ArrayRef<Value> operands,
-    ConversionPatternRewriter &rewriter) {
-  if (!hasMarker(copyOp, getCopyToWorkgroupMemoryMarker())) return failure();
+    ConversionPatternRewriter &rewriter, bool optimizeControlFlow) {
+  if (!hasMarker(copyOp,
+                 {getCopyToWorkgroupMemoryMarker(), getWorkgroupMarker()}))
+    return failure();
   Optional<linalg::LinalgLoops> loops =
       linalg::linalgLowerOpToLoops<scf::ParallelOp>(rewriter, copyOp);
   if (!loops) return failure();
   if (loops.getValue().empty()) return success();
 
   auto pLoopOp = cast<scf::ParallelOp>(loops.getValue()[0]);
+  if (hasMarker(copyOp, getWorkgroupMarker())) {
+    return mapToLocalInvocationId(rewriter, pLoopOp, optimizeControlFlow);
+  }
   return distributeCopyOp(copyOp, pLoopOp, rewriter);
 }
 
@@ -595,12 +610,15 @@ LogicalResult mapLinalgOpToLocalInvocationIdImpl<linalg::CopyOp>(
 /// partitioning it to workitems.
 template <typename LinalgOpTy>
 struct MapLinalgOpToLocalInvocationId : public OpConversionPattern<LinalgOpTy> {
-  using OpConversionPattern<LinalgOpTy>::OpConversionPattern;
+  MapLinalgOpToLocalInvocationId(MLIRContext *context, bool optimizeControlFlow,
+                                 PatternBenefit benefit = 1)
+      : OpConversionPattern<LinalgOpTy>(context, benefit),
+        optimizeControlFlow(optimizeControlFlow) {}
   LogicalResult matchAndRewrite(
       LinalgOpTy linalgOp, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    if (failed(
-            mapLinalgOpToLocalInvocationIdImpl(linalgOp, operands, rewriter)))
+    if (failed(mapLinalgOpToLocalInvocationIdImpl(linalgOp, operands, rewriter,
+                                                  optimizeControlFlow)))
       return failure();
 
     // If the `linalgOp` writes to workgroup memory insert barrier after the
@@ -617,6 +635,9 @@ struct MapLinalgOpToLocalInvocationId : public OpConversionPattern<LinalgOpTy> {
     rewriter.eraseOp(linalgOp);
     return success();
   }
+
+ private:
+  bool optimizeControlFlow;
 };
 
 /// Map linalg operation to execute on GPU in parallel by mapping the parallel
@@ -761,7 +782,8 @@ void ConvertToGPUPass::runOnOperation() {
                   MapLinalgOpToLocalInvocationId<linalg::PoolingMaxOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingMinOp>,
                   MapLinalgOpToLocalInvocationId<linalg::PoolingSumOp>,
-                  RemoveLinalgRange, SerializeParallelLoopPattern>(context);
+                  RemoveLinalgRange, SerializeParallelLoopPattern>(
+      context, options.useLinalgOnTensors);
   FrozenRewritePatternList frozenPatterns(std::move(patterns));
 
   for (FuncOp funcOp : getOperation().getOps<FuncOp>()) {
@@ -776,13 +798,16 @@ void ConvertToGPUPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToGPUPass() {
-  return std::make_unique<ConvertToGPUPass>();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertToGPUPass(
+    const SPIRVCodegenOptions &options) {
+  return std::make_unique<ConvertToGPUPass>(options);
 }
 
 static PassRegistration<ConvertToGPUPass> pass(
-    "iree-codegen-convert-to-gpu", "Map tiled linalg and loop ops to GPU",
-    [] { return std::make_unique<ConvertToGPUPass>(); });
+    "iree-codegen-convert-to-gpu", "Map tiled linalg and loop ops to GPU", [] {
+      SPIRVCodegenOptions options = getSPIRVCodegenOptionsFromClOptions();
+      return std::make_unique<ConvertToGPUPass>(options);
+    });
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.h
@@ -40,7 +40,8 @@ createLinalgTileAndFusePass(const SPIRVCodegenOptions &options);
 
 /// Pass to add the synchronizations and attributes needed to lower from PLoops
 /// to GPU dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToGPUPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertToGPUPass(
+    const SPIRVCodegenOptions &options);
 
 /// Pass to perform the final conversion to SPIR-V dialect.
 /// This pass converts remaining interface ops into SPIR-V global variables,

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -59,7 +59,7 @@ inline void registerLinalgToVectorPasses() {
 inline void registerLinalgToSPIRVPasses() {
   static bool init_once = []() {
     // LinalgToSPIRV
-    createConvertToGPUPass();
+    createConvertToGPUPass(SPIRVCodegenOptions());
     createFoldProcessorIDUsesPass();
     createLinalgTileAndFusePass(SPIRVCodegenOptions());
     createSplitDispatchFunctionPass();

--- a/iree/test/e2e/linalg_tensor_ops/BUILD
+++ b/iree/test/e2e/linalg_tensor_ops/BUILD
@@ -39,7 +39,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
-    srcs = ["add.mlir"],  #glob(["*.mlir"]),
+    srcs = glob(["*.mlir"]),
     compiler_flags = [
         "-iree-flow-dispatch-linalg-on-tensors",
         "-iree-codegen-spirv-experimental-linalg-on-tensors",

--- a/iree/test/e2e/linalg_tensor_ops/CMakeLists.txt
+++ b/iree/test/e2e/linalg_tensor_ops/CMakeLists.txt
@@ -29,11 +29,12 @@ iree_check_single_backend_test_suite(
     "-iree-codegen-llvm-experimental-linalg-on-tensors"
 )
 
+file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
 iree_check_single_backend_test_suite(
   NAME
     check_vulkan-spirv_vulkan
   SRCS
-    "add.mlir"
+    "${_GLOB_X_MLIR}"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER


### PR DESCRIPTION
The GPU path needs to 
1) Use the pass manager that works on IREE::HAL::ExecutableTargetOp, so that the LinalgTileAndFuse pass can be run on this op. This allows the pass to set the workgroup count region on the IREE::HAL::EntryPointOp.
2) The `linalg.copy` operation introduced by bufferize pass needs to have the right marker so that the ConvertToGPU pass can distribute the op to within threads in a thread block.

This allows execution of matmul on GPU with the linalg on tensors path.
