### PR TITLE
Force CPU benchmark to run on single thread.

### DIFF
--- a/build_tools/mako/benchmark_modules_on_android.sh
+++ b/build_tools/mako/benchmark_modules_on_android.sh
@@ -89,6 +89,7 @@ EOF
 function run_and_log {
   local mako_log="$1"
   local target="$2"
+  extra_flags=()
   case "${target}" in
     "vulkan-spirv")
       TAG='vlk'
@@ -98,6 +99,10 @@ function run_and_log {
       ;;
     "dylib-llvm-aot")
       TAG='cpu'
+      # TODO(hanchung): Figure out a better way to customize extra flags for
+      # different benchmarking targets. This forces all dylib targets use single
+      # thread.
+      extra_flags+=('--dylib_worker_count=1')
       ;;
     *)
       echo "Unrecognized target '${target}'"
@@ -112,6 +117,7 @@ function run_and_log {
     "--flagfile=${DEVICE_ROOT}/flagfile" \
     "--module_file=${DEVICE_ROOT}/${model}-${target}.vmfb" \
     "--driver=${driver}" \
+    "${extra_flags[@]}" \
     --benchmark_repetitions=10 | tee "${test_out}"
   while read -r ms; do
     append_mako_sample "${mako_log}" "${ms}" "${TAG}"


### PR DESCRIPTION
In the past, we only could run CPU on single thread. After 8d74bfa
landed, we are able to run on multiple threads, and it's turned on by
default. The PR forces it to run on single thread to keep the same
behavior.

Fixes https://github.com/google/iree/issues/4686