### PR TITLE
[codegen] Enable vectorizing convolution with output height != 1

### DIFF
--- a/iree/compiler/Conversion/LinalgToVector/VectorizeConv.cpp
+++ b/iree/compiler/Conversion/LinalgToVector/VectorizeConv.cpp
@@ -43,7 +43,6 @@ namespace {
 /// - Output: NHoWoCo format
 /// - For output:
 ///   - N must be 1.
-///   - Ho must be 1.
 ///   - Co must be a multiple of 4.
 /// - For filter:
 ///   - Hf must be 1.
@@ -84,12 +83,8 @@ struct VectorizeLinalgConv : OpRewritePattern<linalg::ConvOp> {
       return failure();
     }
 
-    // The output batch and height dimensions should be 1. If not, other
-    // patterns can generate parallel loops can distribute them.
-    if (outputViewOp.getStaticSize(0) != 1 ||
-        outputViewOp.getStaticSize(1) != 1) {
-      return failure();
-    }
+    // The output batch dimension should be 1.
+    if (outputViewOp.getStaticSize(0) != 1) return failure();
 
     // We addtionally expect the filter height/width dimensions are both 1 to
     // simplify vectorization. Other patterns can generate loops to create 1x1
@@ -103,13 +98,18 @@ struct VectorizeLinalgConv : OpRewritePattern<linalg::ConvOp> {
     int64_t numOutputChannels = filterViewOp.getStaticSize(3);
     if (numInputChannels != 4 || numOutputChannels % 4 != 0) return failure();
 
+    int64_t numOutputHeights = outputViewOp.getStaticSize(1);
     int64_t numOutputWidths = outputViewOp.getStaticSize(2);
+    int64_t heightStride = convOp.getStride(0);
     int64_t widthStride = convOp.getStride(1);
 
-    // This invocation handles a batch of (numOutputWidths * numOutputChannels).
+    // This invocation handles a batch of
+    // (numOutputHeights * numOutputWidths * numOutputChannels).
     LLVM_DEBUG({
+      llvm::dbgs() << "# output height: " << numOutputHeights << "\n";
       llvm::dbgs() << "# output width: " << numOutputWidths << "\n";
       llvm::dbgs() << "# output channels: " << numOutputChannels << "\n";
+      llvm::dbgs() << "height stride: " << heightStride << "\n";
       llvm::dbgs() << "width stride: " << widthStride << "\n";
     });
 
@@ -120,7 +120,7 @@ struct VectorizeLinalgConv : OpRewritePattern<linalg::ConvOp> {
     auto filterVectorType =
         VectorType::get({numInputChannels, numOutputChannels}, elementType);
     auto vector1x4Type = VectorType::get({1, 4}, elementType);
-    Value zero = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value zero = rewriter.createOrFold<ConstantIndexOp>(loc, 0);
 
     // Load the entire filter subview.
     SmallVector<Value, 4> filterIndices(4, zero);
@@ -158,41 +158,48 @@ struct VectorizeLinalgConv : OpRewritePattern<linalg::ConvOp> {
         {getParallelIteratorTypeName(), getParallelIteratorTypeName(),
          getReductionIteratorTypeName()});
 
-    // Compute the (numOutputWidths * numOutputChannels) batch. We only
-    // contribute numInputChannels accumulation along the reduction dimension.
-    // So read in the result from the output, compose a chain of
-    // numInputChannels vector dot operations, and then write out.
-    for (int ow = 0; ow < numOutputWidths; ++ow) {
-      // Read in the input vector for these 4 input channels a a batch. The
-      // input vector are used for computing all output channels so data can
-      // be reused.
-      SmallVector<Value, 4> inputIndices(4, zero);
-      inputIndices[2] = rewriter.create<ConstantIndexOp>(loc, ow * widthStride);
-      Value inputVector = rewriter.create<vector::TransferReadOp>(
-          loc, vector1x4Type, inputViewOp, inputIndices);
+    // Compute the (numOutputHeights * numOutputWidths * numOutputChannels)
+    // batch. We only contribute numInputChannels accumulation along the
+    // reduction dimension. So read in the result from the output, compose a
+    // chain of numInputChannels vector dot operations, and then write out.
+    for (int oh = 0; oh < numOutputHeights; ++oh) {
+      for (int ow = 0; ow < numOutputWidths; ++ow) {
+        // Read in the input vector for these 4 input channels a a batch. The
+        // input vector are used for computing all output channels so data can
+        // be reused.
+        SmallVector<Value, 4> inputIndices(4, zero);
+        inputIndices[1] =
+            rewriter.createOrFold<ConstantIndexOp>(loc, oh * heightStride);
+        inputIndices[2] =
+            rewriter.createOrFold<ConstantIndexOp>(loc, ow * widthStride);
+        Value inputVector = rewriter.create<vector::TransferReadOp>(
+            loc, vector1x4Type, inputViewOp, inputIndices);
 
-      for (int oc = 0; oc < numOutputChannels / 4; ++oc) {
-        // Read in the initial value for this output vector.
-        SmallVector<Value, 4> outputIndices(4, zero);
-        outputIndices[2] = rewriter.create<ConstantIndexOp>(loc, ow);
-        outputIndices[3] = rewriter.create<ConstantIndexOp>(loc, oc * 4);
-        Value outputVector = rewriter.create<vector::TransferReadOp>(
-            loc, vector1x4Type, outputViewOp, outputIndices);
+        for (int oc = 0; oc < numOutputChannels / 4; ++oc) {
+          // Read in the initial value for this output vector.
+          SmallVector<Value, 4> outputIndices(4, zero);
+          outputIndices[1] = rewriter.createOrFold<ConstantIndexOp>(loc, oh);
+          outputIndices[2] = rewriter.createOrFold<ConstantIndexOp>(loc, ow);
+          outputIndices[3] =
+              rewriter.createOrFold<ConstantIndexOp>(loc, oc * 4);
+          Value outputVector = rewriter.create<vector::TransferReadOp>(
+              loc, vector1x4Type, outputViewOp, outputIndices);
 
-        // Peform a chain of dot product and accumulation.
-        for (int i = 0; i < numInputChannels; ++i) {
-          auto inputSlice = rewriter.create<vector::ExtractStridedSliceOp>(
-              loc, inputVector, /*offsets=*/ArrayRef<int64_t>({0, i}),
-              /*sizes=*/ArrayRef<int64_t>({1, 1}),
-              /*strides=*/ArrayRef<int64_t>({1, 1}));
-          outputVector = rewriter.create<vector::ContractionOp>(
-              loc, inputSlice, filterVectors[i][oc], outputVector, indexingMaps,
-              iterators);
+          // Peform a chain of dot product and accumulation.
+          for (int i = 0; i < numInputChannels; ++i) {
+            auto inputSlice = rewriter.create<vector::ExtractStridedSliceOp>(
+                loc, inputVector, /*offsets=*/ArrayRef<int64_t>({0, i}),
+                /*sizes=*/ArrayRef<int64_t>({1, 1}),
+                /*strides=*/ArrayRef<int64_t>({1, 1}));
+            outputVector = rewriter.create<vector::ContractionOp>(
+                loc, inputSlice, filterVectors[i][oc], outputVector,
+                indexingMaps, iterators);
+          }
+
+          // Write out the output vector.
+          rewriter.create<vector::TransferWriteOp>(loc, outputVector,
+                                                   outputViewOp, outputIndices);
         }
-
-        // Write out the output vector.
-        rewriter.create<vector::TransferWriteOp>(loc, outputVector,
-                                                 outputViewOp, outputIndices);
       }
     }
 

--- a/iree/compiler/Conversion/LinalgToVector/test/vectorize_linalg_conv.mlir
+++ b/iree/compiler/Conversion/LinalgToVector/test/vectorize_linalg_conv.mlir
@@ -1,10 +1,10 @@
 // RUN: iree-opt -split-input-file -iree-codegen-vectorize-linalg-conv -canonicalize -cse %s | IreeFileCheck %s
 
-func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, %output: memref<1x1x4x4xf32>) {
+func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x2x2x4xf32>, %output: memref<1x2x2x4xf32>) {
   %0 = subview %filter[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<1x1x4x4xf32> to memref<1x1x4x4xf32>
-  %1 = subview %input[0, 0, 0, 0] [1, 1, 7, 4] [1, 1, 1, 1]  : memref<1x1x7x4xf32> to memref<1x1x7x4xf32>
-  %2 = subview %output[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<1x1x4x4xf32> to memref<1x1x4x4xf32>
-  linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [2, 2]} : memref<1x1x4x4xf32>, memref<1x1x7x4xf32>, memref<1x1x4x4xf32>
+  %1 = subview %input[0, 0, 0, 0] [1, 2, 2, 4] [1, 1, 1, 1]  : memref<1x2x2x4xf32> to memref<1x2x2x4xf32>
+  %2 = subview %output[0, 0, 0, 0] [1, 2, 2, 4] [1, 1, 1, 1]  : memref<1x2x2x4xf32> to memref<1x2x2x4xf32>
+  linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [1, 1]} : memref<1x1x4x4xf32>, memref<1x2x2x4xf32>, memref<1x2x2x4xf32>
   return
 }
 
@@ -14,8 +14,8 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 
 // CHECK: func @vectorize_conv
 // CHECK-SAME: %[[FILTER_ARG:.+]]: memref<1x1x4x4xf32>,
-// CHECK-SAME: %[[INPUT_ARG:.+]]: memref<1x1x7x4xf32>,
-// CHECK-SAME: %[[OUTPUT_ARG:.+]]: memref<1x1x4x4xf32>
+// CHECK-SAME: %[[INPUT_ARG:.+]]: memref<1x2x2x4xf32>,
+// CHECK-SAME: %[[OUTPUT_ARG:.+]]: memref<1x2x2x4xf32>
 
 // CHECK: %[[FLOAT_ZERO:.+]] = constant 0.000000e+00 : f32
 // CHECK: %[[FILTER:.+]] = subview %[[FILTER_ARG]]
@@ -30,8 +30,8 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 // CHECK: %[[FILTER_3:.+]] = vector.extract_strided_slice %[[FILTER_VECTOR]] {offsets = [3, 0], sizes = [1, 4], strides = [1, 1]} : vector<4x4xf32> to vector<1x4xf32>
 
 // Handle batch #0
-// CHECK: %[[INPUT_0:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x7x4xf32>, vector<1x4xf32>
-// CHECK: %[[OUTPUT_0:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x4x4xf32>, vector<1x4xf32>
+// CHECK: %[[INPUT_0:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
+// CHECK: %[[OUTPUT_0:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
 // CHECK: %[[INPUT_0_0:.+]] = vector.extract_strided_slice %[[INPUT_0]] {offsets = [0, 0], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_0:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_0_0]], %[[FILTER_0]], %[[OUTPUT_0]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_0_1:.+]] = vector.extract_strided_slice %[[INPUT_0]] {offsets = [0, 1], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
@@ -40,11 +40,11 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 // CHECK: %[[DOT_2:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_0_2]], %[[FILTER_2]], %[[DOT_1]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_0_3:.+]] = vector.extract_strided_slice %[[INPUT_0]] {offsets = [0, 3], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_3:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_0_3]], %[[FILTER_3]], %[[DOT_2]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
-// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c0, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x1x4x4xf32>
+// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c0, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x2x2x4xf32>
 
 // Handle batch #1
-// CHECK: %[[INPUT_1:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c2, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x7x4xf32>, vector<1x4xf32>
-// CHECK: %[[OUTPUT_1:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c1, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x4x4xf32>, vector<1x4xf32>
+// CHECK: %[[INPUT_1:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c1, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
+// CHECK: %[[OUTPUT_1:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c1, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
 // CHECK: %[[INPUT_1_0:.+]] = vector.extract_strided_slice %[[INPUT_1]] {offsets = [0, 0], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_0:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_1_0]], %[[FILTER_0]], %[[OUTPUT_1]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_1_1:.+]] = vector.extract_strided_slice %[[INPUT_1]] {offsets = [0, 1], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
@@ -53,11 +53,11 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 // CHECK: %[[DOT_2:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_1_2]], %[[FILTER_2]], %[[DOT_1]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_1_3:.+]] = vector.extract_strided_slice %[[INPUT_1]] {offsets = [0, 3], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_3:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_1_3]], %[[FILTER_3]], %[[DOT_2]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
-// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c1, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x1x4x4xf32>
+// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c1, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x2x2x4xf32>
 
 // Handle batch #2
-// CHECK: %[[INPUT_2:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c4, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x7x4xf32>, vector<1x4xf32>
-// CHECK: %[[OUTPUT_2:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c2, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x4x4xf32>, vector<1x4xf32>
+// CHECK: %[[INPUT_2:.+]] = vector.transfer_read %[[INPUT]][%c0, %c1, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
+// CHECK: %[[OUTPUT_2:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c1, %c0, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
 // CHECK: %[[INPUT_2_0:.+]] = vector.extract_strided_slice %[[INPUT_2]] {offsets = [0, 0], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_0:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_2_0]], %[[FILTER_0]], %[[OUTPUT_2]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_2_1:.+]] = vector.extract_strided_slice %[[INPUT_2]] {offsets = [0, 1], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
@@ -66,11 +66,11 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 // CHECK: %[[DOT_2:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_2_2]], %[[FILTER_2]], %[[DOT_1]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_2_3:.+]] = vector.extract_strided_slice %[[INPUT_2]] {offsets = [0, 3], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_3:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_2_3]], %[[FILTER_3]], %[[DOT_2]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
-// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c2, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x1x4x4xf32>
+// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c1, %c0, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x2x2x4xf32>
 
 // Handle batch #3
-// CHECK: %[[INPUT_3:.+]] = vector.transfer_read %[[INPUT]][%c0, %c0, %c6, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x7x4xf32>, vector<1x4xf32>
-// CHECK: %[[OUTPUT_3:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c0, %c3, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x1x4x4xf32>, vector<1x4xf32>
+// CHECK: %[[INPUT_3:.+]] = vector.transfer_read %[[INPUT]][%c0, %c1, %c1, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
+// CHECK: %[[OUTPUT_3:.+]] = vector.transfer_read %[[OUTPUT]][%c0, %c1, %c1, %c0], %[[FLOAT_ZERO]] {masked = [false, false]} : memref<1x2x2x4xf32>, vector<1x4xf32>
 // CHECK: %[[INPUT_3_0:.+]] = vector.extract_strided_slice %[[INPUT_3]] {offsets = [0, 0], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_0:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_3_0]], %[[FILTER_0]], %[[OUTPUT_3]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_3_1:.+]] = vector.extract_strided_slice %[[INPUT_3]] {offsets = [0, 1], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
@@ -79,7 +79,7 @@ func @vectorize_conv(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, 
 // CHECK: %[[DOT_2:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_3_2]], %[[FILTER_2]], %[[DOT_1]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
 // CHECK: %[[INPUT_3_3:.+]] = vector.extract_strided_slice %[[INPUT_3]] {offsets = [0, 3], sizes = [1, 1], strides = [1, 1]} : vector<1x4xf32> to vector<1x1xf32>
 // CHECK: %[[DOT_3:.+]] = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} %[[INPUT_3_3]], %[[FILTER_3]], %[[DOT_2]] : vector<1x1xf32>, vector<1x4xf32> into vector<1x4xf32>
-// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c0, %c3, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x1x4x4xf32>
+// CHECK: vector.transfer_write %[[DOT_3]], %[[OUTPUT]][%c0, %c1, %c1, %c0] {masked = [false, false]} : vector<1x4xf32>, memref<1x2x2x4xf32>
 
 // -----
 
@@ -90,18 +90,6 @@ func @do_not_vectorize_conv_with_non_1_batch(%filter: memref<1x1x4x4xf32>, %inpu
   %2 = subview %output[0, 0, 0, 0] [2, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<2x1x4x4xf32>
   // CHECK: linalg.conv
   linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [2, 2]} : memref<1x1x4x4xf32>, memref<2x1x7x4xf32>, memref<2x1x4x4xf32>
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func @do_not_vectorize_conv_with_non_1_output_height
-func @do_not_vectorize_conv_with_non_1_output_height(%filter: memref<1x1x4x4xf32>, %input: memref<1x3x7x4xf32>, %output: memref<1x2x4x4xf32>) {
-  %0 = subview %filter[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<1x1x4x4xf32> to memref<1x1x4x4xf32>
-  %1 = subview %input[0, 0, 0, 0] [1, 3, 7, 4] [1, 1, 1, 1]  : memref<1x3x7x4xf32> to memref<1x3x7x4xf32>
-  %2 = subview %output[0, 0, 0, 0] [1, 2, 4, 4] [1, 1, 1, 1]  : memref<1x2x4x4xf32> to memref<1x2x4x4xf32>
-  // CHECK: linalg.conv
-  linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [2, 2]} : memref<1x1x4x4xf32>, memref<1x3x7x4xf32>, memref<1x2x4x4xf32>
   return
 }
 


### PR DESCRIPTION
The previous restriction is artificial, just to get started.
Allowing conv with output height != 1 will allow us to support
more cases.