### PR TITLE
Removing deprecated runtime HAL exports and canonicalizing away others.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/tensor_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/tensor_ops.mlir
@@ -32,7 +32,7 @@ func @tensorLoad(%arg0 : tensor<2x3xi32>) {
   %i1 = constant 1 : index
   // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [
   // CHECK-SAME:   %[[C2]], %[[C3]]
-  // CHECK-SAME: ], element_type = 16777248, indices = [
+  // CHECK-SAME: ], element_type = %c16777248_i32, indices = [
   // CHECK-SAME:   %[[C0]], %[[C1]]
   // CHECK-SAME: ]
   // CHECK-NEXT: = hal.buffer.load %arg0[
@@ -46,7 +46,7 @@ func @tensorLoad(%arg0 : tensor<2x3xi32>) {
 
 // CHECK-LABEL: @tensorLoad1
 func @tensorLoad1(%arg0 : tensor<i1>) {
-  // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [], element_type = 16777217, indices = []
+  // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [], element_type = %c16777217_i32, indices = []
   // CHECK-NEXT: = hal.buffer.load %arg0[
   // CHECK-SAME:   %[[OFF]]
   // CHECK-SAME: ] : i1
@@ -68,7 +68,7 @@ func @tensorStore(%arg0 : tensor<2x3xi32>) {
   %c9 = constant 9 : i32
   // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [
   // CHECK-SAME:   %[[C2]], %[[C3]]
-  // CHECK-SAME: ], element_type = 16777248, indices = [
+  // CHECK-SAME: ], element_type = %c16777248_i32, indices = [
   // CHECK-SAME:   %[[C0]], %[[C1]]
   // CHECK-SAME: ]
   // CHECK-NEXT: hal.buffer.store %[[C9]], %arg0[
@@ -84,7 +84,7 @@ func @tensorStore(%arg0 : tensor<2x3xi32>) {
 func @tensorStore1(%arg0 : tensor<i1>) {
   // CHECK-DAG: %[[C1:.+]] = constant true
   %c1 = constant true
-  // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [], element_type = 16777217, indices = []
+  // CHECK: %[[OFF:.+]] = hal.allocator.compute_offset %allocator, shape = [], element_type = %c16777217_i32, indices = []
   // CHECK-NEXT: hal.buffer.store %[[C1]], %arg0[
   // CHECK-SAME:   %[[OFF]]
   // CHECK-SAME: ] : i1

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
@@ -90,12 +90,6 @@ void populateHALBufferToVMPatterns(MLIRContext *context,
       context, importSymbols, typeConverter, "hal.buffer.subspan");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferFillOp>>(
       context, importSymbols, typeConverter, "hal.buffer.fill");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferReadDataOp>>(
-      context, importSymbols, typeConverter, "hal.buffer.read_data");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferWriteDataOp>>(
-      context, importSymbols, typeConverter, "hal.buffer.write_data");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferCopyDataOp>>(
-      context, importSymbols, typeConverter, "hal.buffer.copy_data");
   patterns.insert<BufferLoadOpConversion>(context, importSymbols, typeConverter,
                                           "hal.buffer.load");
   patterns.insert<BufferStoreOpConversion>(context, importSymbols,

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
@@ -20,90 +20,12 @@
 namespace mlir {
 namespace iree_compiler {
 
-namespace {
-
-// Converts the hal.buffer_view.dims op with variadic results to one of the
-// non-variadic import functions (hal.buffer_view.dims.N). We include N=1-4 as
-// that's the common case. If N>4 we use the N=4 import and then get the
-// remaining dims with hal.buffer_view.dim as that's pretty rare.
-class BufferViewDimsOpConversion
-    : public OpConversionPattern<IREE::HAL::BufferViewDimsOp> {
- public:
-  BufferViewDimsOpConversion(MLIRContext *context, SymbolTable &importSymbols,
-                             TypeConverter &typeConverter,
-                             StringRef importNamePrefix)
-      : OpConversionPattern(context) {
-    importOp1 = importSymbols.lookup<IREE::VM::ImportOp>(
-        (importNamePrefix + ".1").str());
-    importOp2 = importSymbols.lookup<IREE::VM::ImportOp>(
-        (importNamePrefix + ".2").str());
-    importOp3 = importSymbols.lookup<IREE::VM::ImportOp>(
-        (importNamePrefix + ".3").str());
-    importOp4 = importSymbols.lookup<IREE::VM::ImportOp>(
-        (importNamePrefix + ".4").str());
-    assert(importOp1 && importOp2 && importOp3 && importOp4);
-  }
-
-  LogicalResult matchAndRewrite(
-      IREE::HAL::BufferViewDimsOp op, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override {
-    switch (op.getNumResults()) {
-      case 1:
-        rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
-            op, rewriter.getSymbolRefAttr(importOp1),
-            importOp1.getType().getResults(), operands);
-        break;
-      case 2:
-        rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
-            op, rewriter.getSymbolRefAttr(importOp2),
-            importOp2.getType().getResults(), operands);
-        break;
-      case 3:
-        rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
-            op, rewriter.getSymbolRefAttr(importOp3),
-            importOp3.getType().getResults(), operands);
-        break;
-      case 4:
-        rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
-            op, rewriter.getSymbolRefAttr(importOp4),
-            importOp4.getType().getResults(), operands);
-        break;
-      default:
-        SmallVector<Value, 8> dimensions =
-            rewriter
-                .create<IREE::VM::CallOp>(
-                    op.getLoc(), rewriter.getSymbolRefAttr(importOp4),
-                    importOp4.getType().getResults(), operands)
-                .getResults();
-        for (int i = 4; i < op.getNumResults(); ++i) {
-          dimensions.push_back(
-              rewriter.createOrFold<IREE::HAL::BufferViewDimOp>(
-                  op.getLoc(), rewriter.getIndexType(), operands[0],
-                  rewriter.getIntegerAttr(rewriter.getIndexType(), i)));
-        }
-        rewriter.replaceOp(op, dimensions);
-        break;
-    }
-    return success();
-  }
-
- private:
-  mutable IREE::VM::ImportOp importOp1;
-  mutable IREE::VM::ImportOp importOp2;
-  mutable IREE::VM::ImportOp importOp3;
-  mutable IREE::VM::ImportOp importOp4;
-};
-
-}  // namespace
-
 void populateHALBufferViewToVMPatterns(MLIRContext *context,
                                        SymbolTable &importSymbols,
                                        TypeConverter &typeConverter,
                                        OwningRewritePatternList &patterns) {
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewCreateOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.create");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewSubviewOp>>(
-      context, importSymbols, typeConverter, "hal.buffer_view.subview");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewBufferOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.buffer");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewByteLengthOp>>(
@@ -112,12 +34,12 @@ void populateHALBufferViewToVMPatterns(MLIRContext *context,
       context, importSymbols, typeConverter, "hal.buffer_view.compute_offset");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewComputeRangeOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.compute_range");
+  patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewElementTypeOp>>(
+      context, importSymbols, typeConverter, "hal.buffer_view.element_type");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewRankOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.rank");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewDimOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.dim");
-  patterns.insert<BufferViewDimsOpConversion>(
-      context, importSymbols, typeConverter, "hal.buffer_view.dims");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewTraceOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.trace");
 }

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferViewOps.cpp
@@ -30,10 +30,6 @@ void populateHALBufferViewToVMPatterns(MLIRContext *context,
       context, importSymbols, typeConverter, "hal.buffer_view.buffer");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewByteLengthOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.byte_length");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewComputeOffsetOp>>(
-      context, importSymbols, typeConverter, "hal.buffer_view.compute_offset");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewComputeRangeOp>>(
-      context, importSymbols, typeConverter, "hal.buffer_view.compute_range");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewElementTypeOp>>(
       context, importSymbols, typeConverter, "hal.buffer_view.element_type");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferViewRankOp>>(

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
@@ -5,7 +5,8 @@ func @allocatorComputeSizeFoldsAway(%arg0 : !hal.allocator) -> index {
   // CHECK: %c4194304 = vm.const.i32 4194304 : i32
   // CHECK-NOT: hal.allocator.compute_size
   %c1024 = constant 1024 : index
-  %0 = hal.allocator.compute_size %arg0, shape=[%c1024, %c1024], element_type=32
+  %c32_i32 = constant 32 : i32
+  %0 = hal.allocator.compute_size %arg0, shape=[%c1024, %c1024], element_type=%c32_i32
   return %0 : index
 }
 

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_ops.mlir
@@ -23,42 +23,6 @@ func @buffer_fill(%arg0 : !hal.buffer) {
 
 // -----
 
-// CHECK-LABEL: @buffer_read_data
-func @buffer_read_data(%arg0 : !hal.buffer, %arg1 : !iree.mutable_byte_buffer) {
-  %c42 = constant 42 : index
-  %c42_0 = constant 42 : index
-  %c42_1 = constant 42 : index
-  // CHECK: vm.call @hal.buffer.read_data(%arg0, %c42, %arg1, %c42_0, %c42_1) : (!vm.ref<!hal.buffer>, i32, !vm.ref<!iree.mutable_byte_buffer>, i32, i32) -> ()
-  hal.buffer.read_data %arg0, %c42, %arg1, %c42_0, %c42_1 : !iree.mutable_byte_buffer
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @buffer_write_data
-func @buffer_write_data(%arg0 : !hal.buffer, %arg1 : !iree.mutable_byte_buffer) {
-  %c42 = constant 42 : index
-  %c42_0 = constant 42 : index
-  %c42_1 = constant 42 : index
-  // CHECK: vm.call @hal.buffer.write_data(%arg1, %c42, %arg0, %c42_0, %c42_1) : (!vm.ref<!iree.mutable_byte_buffer>, i32, !vm.ref<!hal.buffer>, i32, i32) -> ()
-  hal.buffer.write_data %arg1, %c42, %arg0, %c42_0, %c42_1 : !iree.mutable_byte_buffer
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @buffer_copy_data
-func @buffer_copy_data(%arg0 : !hal.buffer, %arg1 : !hal.buffer) {
-  %c42 = constant 42 : index
-  %c42_0 = constant 42 : index
-  %c42_1 = constant 42 : index
-  // CHECK: vm.call @hal.buffer.copy_data(%arg0, %c42, %arg1, %c42_0, %c42_1) : (!vm.ref<!hal.buffer>, i32, !vm.ref<!hal.buffer>, i32, i32) -> ()
-  hal.buffer.copy_data %arg0, %c42, %arg1, %c42_0, %c42_1
-  return
-}
-
-// -----
-
 // CHECK-LABEL: @buffer_load
 func @buffer_load(%arg0 : !hal.buffer) -> (i8, i16, i32) {
   %c42 = constant 42 : index

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_view_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_view_ops.mlir
@@ -1,26 +1,14 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK-LABEL: @buffer_view_dims_lt4
-func @buffer_view_dims_lt4(%arg0 : !hal.buffer_view) {
-  // CHECK-NEXT: %{{.+}} = vm.call @hal.buffer_view.dims.1(%arg0) : (!vm.ref<!hal.buffer_view>) -> i32
-  %0 = hal.buffer_view.dims %arg0 : index
-  // CHECK-NEXT: %{{.+}}:2 = vm.call @hal.buffer_view.dims.2(%arg0) : (!vm.ref<!hal.buffer_view>) -> (i32, i32)
-  %1, %2 = hal.buffer_view.dims %arg0 : index, index
-  // CHECK-NEXT: %{{.+}}:3 = vm.call @hal.buffer_view.dims.3(%arg0) : (!vm.ref<!hal.buffer_view>) -> (i32, i32, i32)
-  %3, %4, %5 = hal.buffer_view.dims %arg0 : index, index, index
-  // CHECK-NEXT: %{{.+}}:4 = vm.call @hal.buffer_view.dims.4(%arg0) : (!vm.ref<!hal.buffer_view>) -> (i32, i32, i32, i32)
-  %6, %7, %8, %9 = hal.buffer_view.dims %arg0 : index, index, index, index
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @buffer_view_dims_gt4
-func @buffer_view_dims_gt4(%arg0 : !hal.buffer_view) -> (index, index, index, index, index, index) {
-  // CHECK: %0:4 = vm.call @hal.buffer_view.dims.4(%arg0)
-  // CHECK: %1 = vm.call @hal.buffer_view.dim(%arg0, %c4)
-  // CHECK: %2 = vm.call @hal.buffer_view.dim(%arg0, %c5)
-  %0, %1, %2, %3, %4, %5 = hal.buffer_view.dims %arg0 : index, index, index, index, index, index
-  // CHECK-NEXT: vm.return %0#0, %0#1, %0#2, %0#3, %1, %2
-  return %0, %1, %2, %3, %4, %5 : index, index, index, index, index, index
+// CHECK-LABEL: func @buffer_view_dims
+// CHECK-SAME: %[[VIEW:.+]]: !vm.ref<!hal.buffer_view>
+func @buffer_view_dims(%arg0 : !hal.buffer_view) -> (index, index, index) {
+  // CHECK-DAG: %[[D0:.+]] = vm.call @hal.buffer_view.dim(%[[VIEW]], %zero)
+  // CHECK-DAG: %[[D1:.+]] = vm.call @hal.buffer_view.dim(%[[VIEW]], %c1)
+  // CHECK-DAG: %[[D2:.+]] = vm.call @hal.buffer_view.dim(%[[VIEW]], %c2)
+  %0 = hal.buffer_view.dim %arg0, 0 : index
+  %1 = hal.buffer_view.dim %arg0, 1 : index
+  %2 = hal.buffer_view.dim %arg0, 2 : index
+  // CHECK-NEXT: vm.return %[[D0]], %[[D1]], %[[D2]]
+  return %0, %1, %2 : index, index, index
 }

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -414,6 +414,7 @@ def HAL_OrdinalAttr : SignlessIntegerAttrBase<
 
 def HAL_ExecutableDataAttr : SignlessIntElementsAttr<8>;
 
+def HAL_ElementType : TypeAlias<I32>;
 def HAL_ElementTypeAttr : SignlessIntegerAttrBase<
   I32, "element type attribute">;
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -360,9 +360,16 @@ static LogicalResult verifyVariableStoreIndirectOp(
 void AllocatorComputeSizeOp::build(OpBuilder &builder, OperationState &state,
                                    Value allocator, ValueRange shape,
                                    int32_t elementType) {
+  build(builder, state, allocator, shape,
+        builder.createOrFold<ConstantIntOp>(state.location, elementType, 32));
+}
+
+void AllocatorComputeSizeOp::build(OpBuilder &builder, OperationState &state,
+                                   Value allocator, ValueRange shape,
+                                   Value elementType) {
   state.addOperands({allocator});
   state.addOperands(shape);
-  state.addAttribute("element_type", builder.getI32IntegerAttr(elementType));
+  state.addOperands(elementType);
   state.addTypes({builder.getIndexType()});
 }
 
@@ -378,9 +385,17 @@ void AllocatorComputeSizeOp::getAsmResultNames(
 void AllocatorComputeOffsetOp::build(OpBuilder &builder, OperationState &state,
                                      Value allocator, ValueRange shape,
                                      int32_t elementType, ValueRange indices) {
+  build(builder, state, allocator, shape,
+        builder.createOrFold<ConstantIntOp>(state.location, elementType, 32),
+        indices);
+}
+
+void AllocatorComputeOffsetOp::build(OpBuilder &builder, OperationState &state,
+                                     Value allocator, ValueRange shape,
+                                     Value elementType, ValueRange indices) {
   state.addOperands({allocator});
   state.addOperands(shape);
-  state.addAttribute("element_type", builder.getI32IntegerAttr(elementType));
+  state.addOperands(elementType);
   state.addOperands(indices);
   state.addTypes({builder.getIndexType()});
 }
@@ -398,9 +413,18 @@ void AllocatorComputeRangeOp::build(OpBuilder &builder, OperationState &state,
                                     Value allocator, ValueRange shape,
                                     int32_t elementType, ValueRange indices,
                                     ValueRange lengths) {
+  build(builder, state, allocator, shape,
+        builder.createOrFold<ConstantIntOp>(state.location, elementType, 32),
+        indices, lengths);
+}
+
+void AllocatorComputeRangeOp::build(OpBuilder &builder, OperationState &state,
+                                    Value allocator, ValueRange shape,
+                                    Value elementType, ValueRange indices,
+                                    ValueRange lengths) {
   state.addOperands({allocator});
   state.addOperands(shape);
-  state.addAttribute("element_type", builder.getI32IntegerAttr(elementType));
+  state.addOperands(elementType);
   state.addOperands(indices);
   state.addOperands(lengths);
   state.addTypes({builder.getIndexType(), builder.getIndexType()});

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -533,8 +533,15 @@ void BufferViewConstOp::getAsmResultNames(
 void BufferViewCreateOp::build(OpBuilder &builder, OperationState &state,
                                Value buffer, int32_t elementType,
                                ValueRange shape) {
-  state.addOperands({buffer});
-  state.addAttribute("element_type", builder.getI32IntegerAttr(elementType));
+  build(builder, state, buffer,
+        builder.createOrFold<ConstantIntOp>(state.location, elementType, 32),
+        shape);
+}
+
+void BufferViewCreateOp::build(OpBuilder &builder, OperationState &state,
+                               Value buffer, Value elementType,
+                               ValueRange shape) {
+  state.addOperands({buffer, elementType});
   state.addOperands(shape);
   state.addTypes({BufferViewType::get(builder.getContext())});
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -314,7 +314,7 @@ def HAL_AllocatorComputeSizeOp : HAL_PureOp<"allocator.compute_size", [
   let arguments = (ins
     HAL_Allocator:$allocator,
     HAL_Shape:$shape,
-    HAL_ElementTypeAttr:$element_type
+    HAL_ElementType:$element_type
   );
   let results = (outs
     HAL_DeviceSize:$result
@@ -327,7 +327,9 @@ def HAL_AllocatorComputeSizeOp : HAL_PureOp<"allocator.compute_size", [
 
   let builders = [
     OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
-      "int32_t":$elementSize)>,
+      "int32_t":$elementType)>,
+    OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
+      "Value":$elementType)>,
   ];
 
   let hasCanonicalizer = 1;
@@ -346,7 +348,7 @@ def HAL_AllocatorComputeOffsetOp : HAL_PureOp<"allocator.compute_offset", [
   let arguments = (ins
     HAL_Allocator:$allocator,
     HAL_Shape:$shape,
-    HAL_ElementTypeAttr:$element_type,
+    HAL_ElementType:$element_type,
     HAL_Dims:$indices
   );
 
@@ -362,6 +364,8 @@ def HAL_AllocatorComputeOffsetOp : HAL_PureOp<"allocator.compute_offset", [
   let builders = [
     OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
       "int32_t":$elementType, "ValueRange":$indices)>,
+    OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
+      "Value":$elementType, "ValueRange":$indices)>,
   ];
 
   let hasCanonicalizer = 1;
@@ -380,7 +384,7 @@ def HAL_AllocatorComputeRangeOp : HAL_PureOp<"allocator.compute_range", [
   let arguments = (ins
     HAL_Allocator:$allocator,
     HAL_Shape:$shape,
-    HAL_ElementTypeAttr:$element_type,
+    HAL_ElementType:$element_type,
     HAL_Dims:$indices,
     HAL_Dims:$lengths
   );
@@ -399,6 +403,8 @@ def HAL_AllocatorComputeRangeOp : HAL_PureOp<"allocator.compute_range", [
   let builders = [
     OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
       "int32_t":$elementType, "ValueRange":$indices, "ValueRange":$lengths)>,
+    OpBuilderDAG<(ins "Value":$allocator, "ValueRange":$shape,
+      "Value":$elementType, "ValueRange":$indices, "ValueRange":$lengths)>,
   ];
 
   let hasCanonicalizer = 1;
@@ -836,6 +842,8 @@ def HAL_BufferViewComputeOffsetOp : HAL_PureOp<"buffer_view.compute_offset", [
   let builders = [
     OpBuilderDAG<(ins "Value":$bufferView, "ValueRange":$indices)>,
   ];
+
+  let hasCanonicalizer = 1;
 }
 
 def HAL_BufferViewComputeRangeOp : HAL_PureOp<"buffer_view.compute_range", [
@@ -868,6 +876,8 @@ def HAL_BufferViewComputeRangeOp : HAL_PureOp<"buffer_view.compute_range", [
     OpBuilderDAG<(ins "Value":$bufferView, "ValueRange":$indices,
       "ValueRange":$lengths)>,
   ];
+
+  let hasCanonicalizer = 1;
 }
 
 def HAL_BufferViewElementTypeOp : HAL_PureOp<"buffer_view.element_type"> {

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -715,7 +715,7 @@ def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
 
   let arguments = (ins
     HAL_Buffer:$buffer,
-    HAL_ElementTypeAttr:$element_type,
+    HAL_ElementType:$element_type,
     HAL_Shape:$shape
   );
   let results = (outs
@@ -730,6 +730,8 @@ def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilderDAG<(ins "Value":$buffer, "int32_t":$elementType,
+                  "ValueRange":$shape)>,
+    OpBuilderDAG<(ins "Value":$buffer, "Value":$elementType,
                   "ValueRange":$shape)>,
   ];
 }
@@ -757,6 +759,8 @@ def HAL_BufferViewSubviewOp : HAL_PureOp<"buffer_view.subview", [
     $buffer_view `,` `indices` `=` `[` $indices `]` `,` `lengths` `=` `[`
     $lengths `]` `:` type($result) attr-dict
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def HAL_BufferViewBufferOp : HAL_PureOp<"buffer_view.buffer", [
@@ -866,6 +870,22 @@ def HAL_BufferViewComputeRangeOp : HAL_PureOp<"buffer_view.compute_range", [
   ];
 }
 
+def HAL_BufferViewElementTypeOp : HAL_PureOp<"buffer_view.element_type"> {
+  let summary = [{buffer view element type query}];
+  let description = [{
+    Returns the element type of the buffer view.
+  }];
+
+  let arguments = (ins
+    HAL_BufferView:$buffer_view
+  );
+  let results = (outs
+    HAL_ElementType:$result
+  );
+
+  let assemblyFormat = [{$buffer_view attr-dict `:` type($result)}];
+}
+
 def HAL_BufferViewRankOp : HAL_PureOp<"buffer_view.rank"> {
   let summary = [{buffer view rank query}];
   let description = [{
@@ -913,6 +933,8 @@ def HAL_BufferViewDimsOp : HAL_PureOp<"buffer_view.dims"> {
   );
 
   let assemblyFormat = [{$buffer_view attr-dict `:` type($result)}];
+
+  let hasCanonicalizer = 1;
 }
 
 def HAL_BufferViewTraceOp : HAL_Op<"buffer_view.trace", []> {

--- a/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -54,9 +54,11 @@ IntegerAttr getElementTypeAttr(Type type);
 
 // Returns the total bit count of elements of the given type.
 size_t getElementBitCount(IntegerAttr elementType);
+Value getElementBitCount(Location loc, Value elementType, OpBuilder &builder);
 
 // Returns the rounded-up byte count of elements of the given type.
 size_t getElementByteCount(IntegerAttr elementType);
+Value getElementByteCount(Location loc, Value elementType, OpBuilder &builder);
 
 //===----------------------------------------------------------------------===//
 // Object types

--- a/iree/compiler/Dialect/HAL/IR/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/allocator_ops.mlir
@@ -6,8 +6,9 @@
 func @allocator_compute_size() -> index {
   %0 = "test_hal.allocator"() : () -> !hal.allocator
   %1:2 = "test_hal.shape"() : () -> (index, index)
-  // CHECK: %[[SZ:.+]] = hal.allocator.compute_size %0, shape = [%1#0, %1#1], element_type = 32
-  %sz = hal.allocator.compute_size %0, shape = [%1#0, %1#1], element_type = 32
+  %c32_i32 = constant 32 : i32
+  // CHECK: %[[SZ:.+]] = hal.allocator.compute_size %0, shape = [%1#0, %1#1], element_type = %c32_i32
+  %sz = hal.allocator.compute_size %0, shape = [%1#0, %1#1], element_type = %c32_i32
   // CHECK-NEXT: return %[[SZ]]
   return %sz : index
 }
@@ -19,8 +20,9 @@ func @allocator_compute_offset() -> index {
   %0 = "test_hal.allocator"() : () -> !hal.allocator
   %1:2 = "test_hal.shape"() : () -> (index, index)
   %2:2 = "test_hal.indices"() : () -> (index, index)
-  // CHECK: %off = hal.allocator.compute_offset %0, shape = [%1#0, %1#1], element_type = 32, indices = [%2#0, %2#1]
-  %off = hal.allocator.compute_offset %0, shape = [%1#0, %1#1], element_type = 32, indices = [%2#0, %2#1]
+  %c32_i32 = constant 32 : i32
+  // CHECK: %off = hal.allocator.compute_offset %0, shape = [%1#0, %1#1], element_type = %c32_i32, indices = [%2#0, %2#1]
+  %off = hal.allocator.compute_offset %0, shape = [%1#0, %1#1], element_type = %c32_i32, indices = [%2#0, %2#1]
   return %off : index
 }
 
@@ -32,8 +34,9 @@ func @allocator_compute_range() -> (index, index) {
   %1:2 = "test_hal.shape"() : () -> (index, index)
   %2:2 = "test_hal.indices"() : () -> (index, index)
   %3:2 = "test_hal.lengths"() : () -> (index, index)
-  // CHECK: %off, %len = hal.allocator.compute_range %0, shape = [%1#0, %1#1], element_type = 32, indices = [%2#0, %2#1], lengths = [%3#0, %3#1]
-  %off, %len = hal.allocator.compute_range %0, shape = [%1#0, %1#1], element_type = 32, indices = [%2#0, %2#1], lengths=[%3#0, %3#1]
+  %c32_i32 = constant 32 : i32
+  // CHECK: %off, %len = hal.allocator.compute_range %0, shape = [%1#0, %1#1], element_type = %c32_i32, indices = [%2#0, %2#1], lengths = [%3#0, %3#1]
+  %off, %len = hal.allocator.compute_range %0, shape = [%1#0, %1#1], element_type = %c32_i32, indices = [%2#0, %2#1], lengths=[%3#0, %3#1]
   return %off, %len : index, index
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
-// CHECK-LABEL: @expand_buffer_view_const
+// CHECK-LABEL: func @expand_buffer_view_const
 func @expand_buffer_view_const() -> !hal.buffer_view {
   %0 = "test_hal.allocator"() : () -> !hal.allocator
   //      CHECK: [[CONST:%.+]] = iree.byte_buffer.constant : !iree.byte_buffer = dense<[4, 1, 2]> : tensor<3xi32>
-  // CHECK-NEXT: [[BUFFER:%.+]] = hal.allocator.map {{.+}}, "HostVisible|HostCoherent", Transfer, [[CONST]][%c0, %c-1] : !iree.byte_buffer -> !hal.buffer
-  // CHECK-NEXT: [[VIEW:%.+]] = hal.buffer_view.create [[BUFFER]], element_type = 16777248, shape = [%c3] : !hal.buffer_view
+  //      CHECK: [[BUFFER:%.+]] = hal.allocator.map {{.+}}, "HostVisible|HostCoherent", Transfer, [[CONST]][%c0, %c-1] : !iree.byte_buffer -> !hal.buffer
+  //      CHECK: [[VIEW:%.+]] = hal.buffer_view.create [[BUFFER]], element_type = %c16777248_i32, shape = [%c3] : !hal.buffer_view
   %view = hal.buffer_view.const %0, "HostVisible|HostCoherent", Transfer : !hal.buffer_view = dense<[4, 1, 2]> : tensor<3xi32>
   // CHECK-NEXT: return [[VIEW]]
   return %view : !hal.buffer_view
@@ -13,13 +13,54 @@ func @expand_buffer_view_const() -> !hal.buffer_view {
 
 // -----
 
-// CHECK-LABEL: @skip_buffer_view_buffer
+// CHECK-LABEL: func @expand_buffer_view_subview
+func @expand_buffer_view_subview(
+  // CHECK-SAME: %[[VIEW:.+]]: !hal.buffer_view,
+  %view : !hal.buffer_view,
+  // CHECK-SAME: %[[INDEX0:.+]]: index, %[[INDEX1:.+]]: index, %[[LENGTH0:.+]]: index, %[[LENGTH1:.+]]: index
+  %index0 : index, %index1 : index, %length0 : index, %length1 : index
+) -> !hal.buffer_view {
+  //      CHECK: %[[OFFSET:.+]], %[[LENGTH:.+]] = hal.buffer_view.compute_range
+  // CHECK-SAME:     %[[VIEW]],
+  // CHECK-SAME:     indices = [%[[INDEX0]], %[[INDEX1]]],
+  // CHECK-SAME:     lengths = [%[[LENGTH0]], %[[LENGTH1]]]
+  //      CHECK: %[[BUFFER:.+]] = hal.buffer_view.buffer %[[VIEW]] : !hal.buffer
+  // CHECK-NEXT: %[[SUBSPAN:.+]] = hal.buffer.subspan %[[BUFFER]], %[[OFFSET]], %[[LENGTH]] : !hal.buffer
+  //      CHECK: %[[ELEMENT_TYPE:.+]] = hal.buffer_view.element_type %[[VIEW]]
+  //      CHECK: %[[SUBVIEW:.+]] = hal.buffer_view.create
+  // CHECK-SAME:     %[[SUBSPAN]],
+  // CHECK-SAME:     element_type = %[[ELEMENT_TYPE]],
+  // CHECK-SAME:     shape = [%[[LENGTH0]], %[[LENGTH1]]] : !hal.buffer_view
+  %subview = hal.buffer_view.subview %view,
+                                     indices = [%index0, %index1],
+                                     lengths = [%length0, %length1] : !hal.buffer_view
+  // CHECK-NEXT: return %[[SUBVIEW]]
+  return %subview : !hal.buffer_view
+}
+
+// -----
+
+// CHECK-LABEL: func @skip_buffer_view_buffer
 func @skip_buffer_view_buffer() -> !hal.buffer {
   // CHECK: %[[BUFFER:.+]] = "test_hal.buffer"
   %0 = "test_hal.buffer"() : () -> !hal.buffer
   %1:2 = "test_hal.shape"() : () -> (index, index)
-  %2 = hal.buffer_view.create %0, element_type = 32, shape = [%1#0, %1#1] : !hal.buffer_view
+  %c32 = constant 32 : i32
+  %2 = hal.buffer_view.create %0, element_type = %c32, shape = [%1#0, %1#1] : !hal.buffer_view
   %3 = hal.buffer_view.buffer %2 : !hal.buffer
   // CHECK: return %[[BUFFER]]
   return %3 : !hal.buffer
+}
+
+// -----
+
+// CHECK-LABEL: func @expand_buffer_view_dims
+// CHECK-SAME: %[[VIEW:.+]]: !hal.buffer_view
+func @expand_buffer_view_dims(%arg0 : !hal.buffer_view) -> (index, index, index) {
+  // CHECK-DAG: %[[D0:.+]] = hal.buffer_view.dim %[[VIEW]], 0 : index
+  // CHECK-DAG: %[[D1:.+]] = hal.buffer_view.dim %[[VIEW]], 1 : index
+  // CHECK-DAG: %[[D2:.+]] = hal.buffer_view.dim %[[VIEW]], 2 : index
+  %0, %1, %2 = hal.buffer_view.dims %arg0 : index, index, index
+  // CHECK-NEXT: return %[[D0]], %[[D1]], %[[D2]]
+  return %0, %1, %2 : index, index, index
 }

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize -cse %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: func @expand_buffer_view_const
 func @expand_buffer_view_const() -> !hal.buffer_view {
@@ -20,13 +20,11 @@ func @expand_buffer_view_subview(
   // CHECK-SAME: %[[INDEX0:.+]]: index, %[[INDEX1:.+]]: index, %[[LENGTH0:.+]]: index, %[[LENGTH1:.+]]: index
   %index0 : index, %index1 : index, %length0 : index, %length1 : index
 ) -> !hal.buffer_view {
-  //      CHECK: %[[OFFSET:.+]], %[[LENGTH:.+]] = hal.buffer_view.compute_range
-  // CHECK-SAME:     %[[VIEW]],
-  // CHECK-SAME:     indices = [%[[INDEX0]], %[[INDEX1]]],
-  // CHECK-SAME:     lengths = [%[[LENGTH0]], %[[LENGTH1]]]
+  //      CHECK: = hal.buffer_view.dim %[[VIEW]], 1 : index
+  //      CHECK: %[[ELEMENT_TYPE:.+]] = hal.buffer_view.element_type %[[VIEW]] : i32
+  // << A BUNCH OF MATH >>
   //      CHECK: %[[BUFFER:.+]] = hal.buffer_view.buffer %[[VIEW]] : !hal.buffer
-  // CHECK-NEXT: %[[SUBSPAN:.+]] = hal.buffer.subspan %[[BUFFER]], %[[OFFSET]], %[[LENGTH]] : !hal.buffer
-  //      CHECK: %[[ELEMENT_TYPE:.+]] = hal.buffer_view.element_type %[[VIEW]]
+  // CHECK-NEXT: %[[SUBSPAN:.+]] = hal.buffer.subspan %[[BUFFER]], %{{.+}}, %{{.+}} : !hal.buffer
   //      CHECK: %[[SUBVIEW:.+]] = hal.buffer_view.create
   // CHECK-SAME:     %[[SUBSPAN]],
   // CHECK-SAME:     element_type = %[[ELEMENT_TYPE]],
@@ -50,6 +48,47 @@ func @skip_buffer_view_buffer() -> !hal.buffer {
   %3 = hal.buffer_view.buffer %2 : !hal.buffer
   // CHECK: return %[[BUFFER]]
   return %3 : !hal.buffer
+}
+
+// -----
+
+// CHECK-LABEL: func @buffer_view_compute_offset
+// CHECK-SAME: %[[VIEW:.+]]: !hal.buffer_view
+func @buffer_view_compute_offset(%arg0 : !hal.buffer_view) -> index {
+  // CHECK: %[[INDICES:.+]]:2 = "test_hal.indices"() : () -> (index, index)
+  %0:2 = "test_hal.indices"() : () -> (index, index)
+  // CHECK: %[[D0:.+]] = hal.buffer_view.dim %[[VIEW]], 1 : index
+  // CHECK: %[[TYPE:.+]] = hal.buffer_view.element_type %[[VIEW]] : i32
+  // CHECK: %[[T0:.+]] = muli %[[INDICES]]#0, %[[D0]] : index
+  // CHECK: %[[T1:.+]] = addi %[[T0]], %[[INDICES]]#1 : index
+  // CHECK: %[[T2:.+]] = index_cast %[[TYPE]] : i32 to index
+  // CHECK: %[[T3:.+]] = and %[[T2]], %c255 : index
+  // CHECK: %[[T4:.+]] = addi %[[T3]], %c8 : index
+  // CHECK: %[[T5:.+]] = subi %[[T4]], %c1 : index
+  // CHECK: %[[T6:.+]] = divi_unsigned %[[T5]], %c8 : index
+  // CHECK: %[[T7:.+]] = muli %[[T1]], %[[T6]] : index
+  %off = hal.buffer_view.compute_offset %arg0, indices = [%0#0, %0#1]
+  // CHECK: return %[[T7]]
+  return %off : index
+}
+
+// -----
+
+// CHECK-LABEL: func @buffer_view_compute_range
+// CHECK-SAME: %[[VIEW:.+]]: !hal.buffer_view
+func @buffer_view_compute_range(%arg0 : !hal.buffer_view) -> (index, index) {
+  %0:2 = "test_hal.indices"() : () -> (index, index)
+  %1:2 = "test_hal.lengths"() : () -> (index, index)
+  // Testing things like this is brittle :/
+  // Since the canonicalizers are taking these buffer view ops to allocator ops
+  // the testing there should cover with the checks here just to make sure the
+  // right values from the buffer view are passed in.
+  //      CHECK: = hal.buffer_view.dim %[[VIEW]], 1 : index
+  //      CHECK: = hal.buffer_view.element_type %[[VIEW]] : i32
+  // << A BUNCH OF MATH >>
+  %off, %len = hal.buffer_view.compute_range %arg0, indices = [%0#0, %0#1], lengths = [%1#0, %1#1]
+  // CHECK: return
+  return %off, %len : index, index
 }
 
 // -----

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_view_ops.mlir
@@ -16,9 +16,10 @@ func @buffer_view_const() -> !hal.buffer_view {
 
 // CHECK-LABEL: @buffer_view_create
 func @buffer_view_create(%arg0 : !hal.buffer) -> !hal.buffer_view {
+  %c32 = constant 32 : i32
   %0:2 = "test_hal.shape"() : () -> (index, index)
-  // CHECK: %view = hal.buffer_view.create %arg0, element_type = 32, shape = [%0#0, %0#1] : !hal.buffer_view
-  %view = hal.buffer_view.create %arg0, element_type = 32, shape = [%0#0, %0#1] : !hal.buffer_view
+  // CHECK: %view = hal.buffer_view.create %arg0, element_type = %c32_i32, shape = [%0#0, %0#1] : !hal.buffer_view
+  %view = hal.buffer_view.create %arg0, element_type = %c32, shape = [%0#0, %0#1] : !hal.buffer_view
   return %view : !hal.buffer_view
 }
 

--- a/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/public_abi_generation.mlir
@@ -31,7 +31,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
   // CHECK-DAG: %[[R0:.+]] = call @staticTwoArg(%[[BUFFER0]], %[[BUFFER1]])
   // CHECK-DAG: %[[C5:.+]] = constant 5 : index
   // CHECK-DAG: %[[C6:.+]] = constant 6 : index
-  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], element_type = 16777280, shape = [%[[C5]], %[[C6]]] : !hal.buffer_view
+  // CHECK-DAG: %[[VIEW:.+]] = hal.buffer_view.create %[[R0]], element_type = %c16777280_i32, shape = [%[[C5]], %[[C6]]] : !hal.buffer_view
   // CHECK-DAG: hal.semaphore.signal %[[ARG4]], value = %[[ARG5]]
   // CHECK: return %[[VIEW]]
   return %arg1 : !hal.buffer
@@ -71,7 +71,7 @@ func @staticTwoArg(%arg0 : !hal.buffer, %arg1 : !hal.buffer) -> !hal.buffer
 // CHECK-DAG: %[[DIM0:.+]] = hal.buffer_view.dim %[[ARG2]], 0 : index
 // CHECK-DAG: %[[DIM1:.+]] = hal.buffer_view.dim %[[ARG2]], 1 : index
 // CHECK-DAG: %[[RESULT:.+]]:3 = call @dynamicTwoDims(%[[BUFFER]], %[[DIM0]], %[[DIM1]])
-// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, element_type = 50331680, shape = [%[[RESULT]]#1, %[[RESULT]]#2] : !hal.buffer_view
+// CHECK-DAG: %[[RESULT_VIEW:.+]] = hal.buffer_view.create %[[RESULT]]#0, element_type = %c50331680_i32, shape = [%[[RESULT]]#1, %[[RESULT]]#2] : !hal.buffer_view
 // CHECK-DAG: hal.semaphore.signal %[[ARG3]], value = %[[ARG4]]
 // CHECK: return %[[RESULT_VIEW]]
 // A new function with $sync suffix based on buffer_view should be generated.

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -55,39 +55,15 @@ vm.import @buffer.subspan(
   %length : i32
 ) -> !vm.ref<!hal.buffer>
 
+// DEPRECATED: this will be removed in future versions and replaced with
+// transfer queue operations by the compiler.
+//
 // Fills the target buffer with the given repeating value.
 vm.import @buffer.fill(
   %target_buffer : !vm.ref<!hal.buffer>,
   %target_offset : i32,
   %length : i32,
   %pattern : i32
-)
-
-// Reads a block of byte data from the resource at the given offset.
-vm.import @buffer.read_data(
-  %source_buffer : !vm.ref<!hal.buffer>,
-  %source_offset : i32,
-  %target_buffer : !vm.ref<!iree.mutable_byte_buffer>,
-  %target_offset : i32,
-  %length : i32
-)
-
-// Writes a block of byte data into the resource at the given offset.
-vm.import @buffer.write_data(
-  %target_buffer : !vm.ref<!hal.buffer>,
-  %target_offset : i32,
-  %source_buffer : !vm.ref<!iree.byte_buffer>,
-  %source_offset : i32,
-  %length : i32
-)
-
-// Copies data from the provided source_buffer into the buffer.
-vm.import @buffer.copy_data(
-  %source_buffer : !vm.ref<!hal.buffer>,
-  %source_offset : i32,
-  %target_buffer : !vm.ref<!hal.buffer>,
-  %target_offset : i32,
-  %length : i32
 )
 
 // Loads a value from a buffer by mapping it.

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -117,15 +117,6 @@ vm.import @buffer_view.create(
 ) -> !vm.ref<!hal.buffer_view>
 attributes {nosideeffects}
 
-// Returns a view into a buffer. The buffer is not copied and both the original
-// and sliced references must be synchronized.
-vm.import @buffer_view.subview(
-  %buffer_view : !vm.ref<!hal.buffer_view>,
-  %indices : i32 ...,
-  %lengths : i32 ...
-) -> !vm.ref<!hal.buffer_view>
-attributes {nosideeffects}
-
 // Returns the backing buffer of the buffer view.
 vm.import @buffer_view.buffer(
   %buffer_view : !vm.ref<!hal.buffer_view>
@@ -153,6 +144,12 @@ vm.import @buffer_view.compute_range(
 ) -> (i32, i32)
 attributes {nosideeffects}
 
+// Returns the element type of the buffer view.
+vm.import @buffer_view.element_type(
+  %buffer_view : !vm.ref<!hal.buffer_view>,
+) -> i32
+attributes {nosideeffects}
+
 // Returns the rank of the buffer view.
 vm.import @buffer_view.rank(
   %buffer_view : !vm.ref<!hal.buffer_view>,
@@ -164,24 +161,6 @@ vm.import @buffer_view.dim(
   %buffer_view : !vm.ref<!hal.buffer_view>,
   %index : i32
 ) -> i32
-attributes {nosideeffects}
-
-// Returns N dimension values.
-vm.import @buffer_view.dims.1(
-  %buffer_view : !vm.ref<!hal.buffer_view>
-) -> (i32)
-attributes {nosideeffects}
-vm.import @buffer_view.dims.2(
-  %buffer_view : !vm.ref<!hal.buffer_view>
-) -> (i32, i32)
-attributes {nosideeffects}
-vm.import @buffer_view.dims.3(
-  %buffer_view : !vm.ref<!hal.buffer_view>
-) -> (i32, i32, i32)
-attributes {nosideeffects}
-vm.import @buffer_view.dims.4(
-  %buffer_view : !vm.ref<!hal.buffer_view>
-) -> (i32, i32, i32, i32)
 attributes {nosideeffects}
 
 // Prints out the content of buffer views.

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -129,21 +129,6 @@ vm.import @buffer_view.byte_length(
 ) -> i32
 attributes {nosideeffects}
 
-// Computes an element byte offset within a buffer.
-vm.import @buffer_view.compute_offset(
-  %buffer_view : !vm.ref<!hal.buffer_view>,
-  %indices : i32 ...
-) -> i32
-attributes {nosideeffects}
-
-// Computes a byte range within a buffer for one or more elements.
-vm.import @buffer_view.compute_range(
-  %buffer_view : !vm.ref<!hal.buffer_view>,
-  %indices : i32 ...,
-  %lengths : i32 ...
-) -> (i32, i32)
-attributes {nosideeffects}
-
 // Returns the element type of the buffer view.
 vm.import @buffer_view.element_type(
   %buffer_view : !vm.ref<!hal.buffer_view>,

--- a/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/Modules/TensorList/Conversion/test/convert_to_hal.mlir
@@ -3,12 +3,14 @@
 
 // CHECK: @Reserve
 func @Reserve(%arg0: tensor<0xi32>, %arg1: tensor<i32>) -> !tensorlist.list {
-  // CHECK: [[VIEW0:%.+]] = hal.buffer_view.create %arg0, element_type = 16777248, shape = [%c0]
-  // CHECK: [[VIEW1:%.+]] = hal.buffer_view.create %arg1, element_type = 16777248, shape = []
-  // CHECK: [[LIST:%.+]] = "tensorlist.Reserve"(%view, %view_0) {element_type = 50331680 : i32}
+  // CHECK: %c16777248_i32 = constant 16777248 : i32
+  // CHECK: %[[VIEW0:.+]] = hal.buffer_view.create %arg0, element_type = %c16777248_i32, shape = [%c0]
+  // CHECK: %c16777248_i32_0 = constant 16777248 : i32
+  // CHECK: %[[VIEW1:.+]] = hal.buffer_view.create %arg1, element_type = %c16777248_i32_0, shape = []
+  // CHECK: %[[LIST:.+]] = "tensorlist.Reserve"(%[[VIEW0]], %[[VIEW1]]) {element_type = 50331680 : i32}
   %0 = "tensorlist.Reserve.Tensor"(%arg0, %arg1) {element_type = f32} : (tensor<0xi32>, tensor<i32>) -> !tensorlist.list
 
-  // CHECK: return [[LIST]]
+  // CHECK: return %[[LIST]]
   return %0 : !tensorlist.list
 }
 

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -289,30 +289,6 @@ class HALModuleState final {
     return OkStatus();
   }
 
-  Status BufferReadData(const vm::ref<iree_hal_buffer_t>& source_buffer,
-                        int32_t source_offset,
-                        const vm::ref<iree_vm_rw_byte_buffer_t>& target_buffer,
-                        int32_t target_offset, int32_t length) {
-    IREE_TRACE_SCOPE0("HALModuleState::BufferReadData");
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "BufferReadData");
-  }
-
-  Status BufferWriteData(const vm::ref<iree_hal_buffer_t>& target_buffer,
-                         int32_t target_offset,
-                         const vm::ref<iree_vm_ro_byte_buffer_t>& source_buffer,
-                         int32_t source_offset, int32_t length) {
-    IREE_TRACE_SCOPE0("HALModuleState::BufferWriteData");
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "BufferWriteData");
-  }
-
-  Status BufferCopyData(const vm::ref<iree_hal_buffer_t>& source_buffer,
-                        int32_t source_offset,
-                        const vm::ref<iree_hal_buffer_t>& target_buffer,
-                        int32_t target_offset, int32_t length) {
-    IREE_TRACE_SCOPE0("HALModuleState::BufferCopyData");
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "BufferCopyData");
-  }
-
   StatusOr<int32_t> BufferLoad(const vm::ref<iree_hal_buffer_t>& source_buffer,
                                int32_t source_offset, int32_t length) {
     IREE_TRACE_SCOPE0("HALModuleState::BufferLoad");
@@ -749,10 +725,6 @@ static const vm::NativeFunction<HALModuleState> kHALModuleFunctions[] = {
                            &HALModuleState::BufferAllocator),
     vm::MakeNativeFunction("buffer.subspan", &HALModuleState::BufferSubspan),
     vm::MakeNativeFunction("buffer.fill", &HALModuleState::BufferFill),
-    vm::MakeNativeFunction("buffer.read_data", &HALModuleState::BufferReadData),
-    vm::MakeNativeFunction("buffer.write_data",
-                           &HALModuleState::BufferWriteData),
-    vm::MakeNativeFunction("buffer.copy_data", &HALModuleState::BufferCopyData),
     vm::MakeNativeFunction("buffer.load", &HALModuleState::BufferLoad),
     vm::MakeNativeFunction("buffer.store", &HALModuleState::BufferStore),
 

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -375,29 +375,6 @@ class HALModuleState final {
     return iree_hal_buffer_view_byte_length(buffer_view.get());
   }
 
-  StatusOr<int32_t> BufferViewComputeOffset(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view,
-      absl::Span<const int32_t> indices) {
-    iree_device_size_t offset = 0;
-    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_compute_offset(
-        buffer_view.get(), indices.data(), indices.size(), &offset));
-    return offset;
-  }
-
-  StatusOr<std::tuple<int32_t, int32_t>> BufferViewComputeRange(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view,
-      absl::Span<const int32_t> start_indices,
-      absl::Span<const int32_t> lengths) {
-    iree_device_size_t start_offset = 0;
-    iree_device_size_t subspan_length = 0;
-    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_compute_range(
-        buffer_view.get(), start_indices.data(), start_indices.size(),
-        lengths.data(), lengths.size(), &start_offset, &subspan_length));
-    return std::make_tuple<int32_t, int32_t>(
-        static_cast<int32_t>(start_offset),
-        static_cast<int32_t>(subspan_length));
-  }
-
   StatusOr<int32_t> BufferViewElementType(
       const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
     return static_cast<int32_t>(
@@ -785,10 +762,6 @@ static const vm::NativeFunction<HALModuleState> kHALModuleFunctions[] = {
                            &HALModuleState::BufferViewBuffer),
     vm::MakeNativeFunction("buffer_view.byte_length",
                            &HALModuleState::BufferViewByteLength),
-    vm::MakeNativeFunction("buffer_view.compute_offset",
-                           &HALModuleState::BufferViewComputeOffset),
-    vm::MakeNativeFunction("buffer_view.compute_range",
-                           &HALModuleState::BufferViewComputeRange),
     vm::MakeNativeFunction("buffer_view.element_type",
                            &HALModuleState::BufferViewElementType),
     vm::MakeNativeFunction("buffer_view.rank", &HALModuleState::BufferViewRank),

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -365,17 +365,6 @@ class HALModuleState final {
     return std::move(buffer_view);
   }
 
-  StatusOr<vm::ref<iree_hal_buffer_view_t>> BufferViewSubview(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view,
-      absl::Span<const int32_t> indices, absl::Span<const int32_t> lengths) {
-    vm::ref<iree_hal_buffer_view_t> new_buffer_view;
-    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_subview(
-                             buffer_view.get(), indices.data(), indices.size(),
-                             lengths.data(), lengths.size(), &new_buffer_view),
-                         "failed to create subview");
-    return std::move(new_buffer_view);
-  }
-
   StatusOr<vm::ref<iree_hal_buffer_t>> BufferViewBuffer(
       const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
     return vm::retain_ref(iree_hal_buffer_view_buffer(buffer_view.get()));
@@ -409,6 +398,12 @@ class HALModuleState final {
         static_cast<int32_t>(subspan_length));
   }
 
+  StatusOr<int32_t> BufferViewElementType(
+      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
+    return static_cast<int32_t>(
+        iree_hal_buffer_view_element_type(buffer_view.get()));
+  }
+
   StatusOr<int32_t> BufferViewRank(
       const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
     return static_cast<int32_t>(
@@ -419,36 +414,6 @@ class HALModuleState final {
       const vm::ref<iree_hal_buffer_view_t>& buffer_view, int32_t index) {
     return static_cast<int32_t>(
         iree_hal_buffer_view_shape_dim(buffer_view.get(), index));
-  }
-
-  template <size_t N>
-  StatusOr<std::array<int32_t, N>> BufferViewDimsN(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
-    std::array<int32_t, N> value;
-    iree_host_size_t rank = 0;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_buffer_view_shape(buffer_view.get(), N, value.data(), &rank));
-    return value;
-  }
-
-  StatusOr<std::array<int32_t, 1>> BufferViewDims1(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
-    return BufferViewDimsN<1>(buffer_view);
-  }
-
-  StatusOr<std::array<int32_t, 2>> BufferViewDims2(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
-    return BufferViewDimsN<2>(buffer_view);
-  }
-
-  StatusOr<std::array<int32_t, 3>> BufferViewDims3(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
-    return BufferViewDimsN<3>(buffer_view);
-  }
-
-  StatusOr<std::array<int32_t, 4>> BufferViewDims4(
-      const vm::ref<iree_hal_buffer_view_t>& buffer_view) {
-    return BufferViewDimsN<4>(buffer_view);
   }
 
   Status BufferViewTrace(
@@ -816,8 +781,6 @@ static const vm::NativeFunction<HALModuleState> kHALModuleFunctions[] = {
 
     vm::MakeNativeFunction("buffer_view.create",
                            &HALModuleState::BufferViewCreate),
-    vm::MakeNativeFunction("buffer_view.subview",
-                           &HALModuleState::BufferViewSubview),
     vm::MakeNativeFunction("buffer_view.buffer",
                            &HALModuleState::BufferViewBuffer),
     vm::MakeNativeFunction("buffer_view.byte_length",
@@ -826,16 +789,10 @@ static const vm::NativeFunction<HALModuleState> kHALModuleFunctions[] = {
                            &HALModuleState::BufferViewComputeOffset),
     vm::MakeNativeFunction("buffer_view.compute_range",
                            &HALModuleState::BufferViewComputeRange),
+    vm::MakeNativeFunction("buffer_view.element_type",
+                           &HALModuleState::BufferViewElementType),
     vm::MakeNativeFunction("buffer_view.rank", &HALModuleState::BufferViewRank),
     vm::MakeNativeFunction("buffer_view.dim", &HALModuleState::BufferViewDim),
-    vm::MakeNativeFunction("buffer_view.dims.1",
-                           &HALModuleState::BufferViewDims1),
-    vm::MakeNativeFunction("buffer_view.dims.2",
-                           &HALModuleState::BufferViewDims2),
-    vm::MakeNativeFunction("buffer_view.dims.3",
-                           &HALModuleState::BufferViewDims3),
-    vm::MakeNativeFunction("buffer_view.dims.4",
-                           &HALModuleState::BufferViewDims4),
     vm::MakeNativeFunction("buffer_view.trace",
                            &HALModuleState::BufferViewTrace),
 


### PR DESCRIPTION
Long time pending cleanup - at some point I switched the hal.allocator.compute_* to be done in IR and TODO'ed getting rid of the buffer view variants. This required changing some op attributes to operands which is a good change for generality anyway. The read/write/copy buffer ops have also been dropped as they were never implemented and staging buffers are the reliable (and more efficient) way and that's something we control on the compiler-side.