### PR TITLE
Convert mhlo.const -> const when running ConvertHLOToLinalgOnTensorsPass

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -215,12 +215,23 @@ struct ConvertHLOToLinalgOnTensorsPass
   }
 };
 
+/// Convert mhlo.constant op into std.const.
+struct ConstOpConversion : public OpRewritePattern<mhlo::ConstOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mhlo::ConstOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ConstantOp>(op, op.value());
+    return success();
+  }
+};
+
 }  // namespace
 
 void populateHLOToLinalgOnTensorsConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns) {
   mhlo::populateHLOToLinalgConversionPattern(context, &patterns);
-  patterns.insert<TorchIndexSelectOpConversion, SliceOpConversion>(context);
+  patterns.insert<TorchIndexSelectOpConversion, SliceOpConversion,
+                  ConstOpConversion>(context);
 }
 
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass() {

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -139,7 +139,7 @@ iree_check_single_backend_test_suite(
     srcs = [
         "abs.mlir",
         "add.mlir",
-        # "batch_norm_inference.mlir",
+        "batch_norm_inference.mlir",
         "broadcast.mlir",
         "broadcast_add.mlir",
         "broadcast_in_dim.mlir",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -137,6 +137,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "abs.mlir"
     "add.mlir"
+    "batch_norm_inference.mlir"
     "broadcast.mlir"
     "broadcast_add.mlir"
     "broadcast_in_dim.mlir"


### PR DESCRIPTION
- mhlo.const -> const
- Enable batch_norm_inference for linalg-on-tensors pass