### PR TITLE
Add logic for better ordering of fusion.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -36,6 +36,20 @@
 
 #define DEBUG_TYPE "iree-flow-dispatch-linalg-on-tensors"
 
+static llvm::cl::list<int64_t> clLinalgOnTensorsTileSizes(
+    "iree-flow-dispatch-linalg-on-tensors-tile-sizes",
+    llvm::cl::desc("Comma-separated list of tile sizes for tiling on tensors"),
+    llvm::cl::CommaSeparated);
+
+// TODO(ravishankarm): Remove this option after addressing fusion.
+static llvm::cl::opt<bool> clLinalgOnTensorsEnableForceFusion(
+    "iree-flow-dispatch-linalg-on-tensors-enable-fusion-always",
+    llvm::cl::desc("Option to force fuse linalg operations on tensors"),
+    llvm::cl::init(false));
+
+static const char kRootOpAttr[] = "__root_op__";
+static const char kFusionGroupAttr[] = "__fused_op__";
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
@@ -84,22 +98,8 @@ struct DispatchLinalgOnTensorsPass
                     AffineDialect, scf::SCFDialect, ShapeDialect>();
   }
   DispatchLinalgOnTensorsPass() = default;
-  DispatchLinalgOnTensorsPass(ArrayRef<int64_t> sizes,
-                              bool enableFusion = false) {
-    this->tileSizes = sizes;
-    this->enableFusion = enableFusion;
-  };
   DispatchLinalgOnTensorsPass(const DispatchLinalgOnTensorsPass &pass) {}
   void runOnOperation() override;
-
- private:
-  ListOption<int64_t> tileSizes{
-      *this, "tile-sizes", llvm::cl::desc("Set tile sizes to use"),
-      llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated};
-  Option<bool> enableFusion{
-      *this, "enable-fusion",
-      llvm::cl::desc("Enable fusion on linalg on tensors path"),
-      llvm::cl::init(false)};
 };
 
 /// Returns the number of consecutive outer loops that are "parallel". This is a
@@ -179,23 +179,28 @@ static IREE::Flow::DispatchWorkgroupsOp buildOperandLessFlowDispatchWorkgroupOp(
 //
 // TODO(nicolasvasilache: This implementation jumps an abstraction gap as it
 // knows that `clonedLinalgOp` has been tiled into `tiledLinalgOp`. In the case
-// of `out` tensors, this allows calling into a `fuseProducerOfTensor` to which
-// we provide the producer by construction. This avoids an analysis that would
-// need to reconstruct a destructive update from the loop nest + operations in
-// order to get the producer of an `out` tensor.
+// where a `rootOp`, i.e. the untiled original operation used to create the
+// dispatch region, can be fused with its producer, this allows calling into a
+// `fuseProducerOfTensor` to which we provide the producer by construction. This
+// avoids an analysis that would need to reconstruct a destructive update from
+// the loop nest + operations in order to get the producer of an `out` tensor.
 // In the future, this analysis should be implemented in core but for now it is
 // IREE-only.
-static Optional<linalg::FusionInfo> pullInFirstProducerOf(
+static void pullInProducersInSameGroup(
     PatternRewriter &rewriter, IREE::Flow::DispatchWorkgroupsOp dispatchOp,
-    ValueRange shapedOperands, linalg::TiledLinalgOp &tiledLinalgOp) {
+    ValueRange shapedOperands, linalg::TiledLinalgOp &tiledLinalgOp,
+    int64_t groupNum) {
   // Scoped within DispatchWorkgroupOp.
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPointToStart(&dispatchOp.getRegion().front());
   for (auto en : llvm::enumerate(shapedOperands)) {
-    if (auto linalgOp = en.value().getDefiningOp<linalg::LinalgOp>()) {
-      Operation *clonedOpToFuse = rewriter.clone(*linalgOp);
+    if (auto producer = en.value().getDefiningOp<linalg::LinalgOp>()) {
+      IntegerAttr opGroupNum =
+          producer.getOperation()->getAttrOfType<IntegerAttr>(kFusionGroupAttr);
+      if (!opGroupNum || opGroupNum.getInt() != groupNum) continue;
+      Operation *clonedOpToFuse = rewriter.clone(*producer);
       static_cast<PatternRewriterWithScopedReplaceOp &>(rewriter)
-          .replaceOpWithinScope(linalgOp, clonedOpToFuse->getResults(),
+          .replaceOpWithinScope(producer, clonedOpToFuse->getResults(),
                                 &dispatchOp.getRegion().front());
       // TODO: this is incorrect on general pattern failures, try pattern within
       // pattern.
@@ -204,12 +209,12 @@ static Optional<linalg::FusionInfo> pullInFirstProducerOf(
           rewriter, clonedOpToFuse->getResult(opResult.getResultNumber()),
           tiledLinalgOp.op.getShapedOpOperand(en.index()));
       if (!maybeFusionInfo.hasValue()) {
-        rewriter.replaceOp(clonedOpToFuse, linalgOp->getResults());
+        rewriter.replaceOp(clonedOpToFuse, producer->getResults());
       }
-      return maybeFusionInfo;
+      maybeFusionInfo->fusedProducer.getOperation()->removeAttr(
+          kFusionGroupAttr);
     }
   }
-  return llvm::None;
 }
 
 // Add tie_shape for all outputs. This provides necessary information for
@@ -262,18 +267,15 @@ struct TileAndDistributeOnTensorsPattern
   using Base = linalg::LinalgBaseTilingPattern;
   TileAndDistributeOnTensorsPattern(linalg::LinalgTilingOptions options,
                                     linalg::LinalgTransformationFilter marker,
-                                    bool enableFusion,
                                     PatternBenefit benefit = 1)
-      : Base(options, marker, benefit), enableFusion(enableFusion) {}
+      : Base(options, marker, benefit) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-    if (!linalgOp || !linalgOp.hasTensorSemantics()) return failure();
-
-    // TODO(ravishankarm): Until fusion is handled properly, only tile and
-    // distribute for matmul operations.
-    if (enableFusion && !isa<linalg::MatmulOp>(op)) return failure();
+    if (!linalgOp) return failure();
+    IntegerAttr rootOpAttr = op->getAttrOfType<IntegerAttr>(kRootOpAttr);
+    if (!rootOpAttr) return failure();
 
     linalg::LinalgOp clonedLinalgOp;
     IREE::Flow::DispatchWorkgroupsOp dispatchOp =
@@ -296,20 +298,30 @@ struct TileAndDistributeOnTensorsPattern
     SmallVector<Value, 4> shapedOperands(clonedLinalgOp.getShapedOperands());
     rewriter.replaceOp(clonedLinalgOp, tiledLinalgOp.tensorResults);
 
-    pullInFirstProducerOf(rewriter, dispatchOp, shapedOperands, tiledLinalgOp);
+    pullInProducersInSameGroup(rewriter, dispatchOp, shapedOperands,
+                               tiledLinalgOp, rootOpAttr.getInt());
 
+    tiledLinalgOp.op.getOperation()->removeAttr(kRootOpAttr);
     SmallVector<Value, 4> shapedResults =
         createDispatchTieShapeOp(rewriter, linalgOp, dispatchOp);
     rewriter.replaceOp(op, shapedResults);
     return success();
   }
-
-  const bool enableFusion;
 };
 
 template <typename OpTy>
 static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
   return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
+}
+
+bool isAlwaysClonedIntoDispatchOp(Operation *op) {
+  if (isa<linalg::InitTensorOp>(op)) {
+    return true;
+  }
+  if (auto constantOp = dyn_cast<ConstantOp>(op)) {
+    return constantOp.getResult().getType().isIntOrFloat();
+  }
+  return false;
 }
 
 // After outlining in dispatch region we can rewrite the dispatch ops with
@@ -338,13 +350,14 @@ static void legalizeDispatchWorkgroupOperands(
   // be pulled into the dispatch region
   BlockAndValueMapping map;
   for (Value operand : valuesSet) {
-    auto initTensorOp = operand.getDefiningOp<linalg::InitTensorOp>();
-    if (!initTensorOp) continue;
-    auto clonedOp =
-        cast<linalg::InitTensorOp>(b.clone(*initTensorOp.getOperation(), map));
+    Operation *definingOp = operand.getDefiningOp();
+    if (!definingOp || !isAlwaysClonedIntoDispatchOp(definingOp) ||
+        definingOp->getNumResults() != 1)
+      continue;
+    auto clonedOp = b.clone(*definingOp, map);
     auto outsideUses = getUsesOfValueOutsideOfDispatchOp(operand);
     operand.replaceAllUsesExcept(
-        clonedOp.getResult(),
+        clonedOp->getResult(0),
         SmallPtrSet<Operation *, 8>(outsideUses.begin(), outsideUses.end()));
   }
 
@@ -390,6 +403,75 @@ static void legalizeDispatchWorkgroupOperands(
   dispatchOp.operandsMutable().assign(valuesDefinedAbove);
 }
 
+/// Checks if the `producer` can be fused into the dispatch region of the
+/// `consumer`.
+// TODO(ravishankarm): For now this is doing only some limited fusion. Ideally
+// the way we create the dispatches itself should account for data access
+// pattern within the consumer and producer. So probably need to do a pre-pass
+// to decide what to fuse and then do the fusion. For now just use a simple
+// default scheme to get the ball rolling.
+static bool isProducerFusableWithConsumer(linalg::LinalgOp producer,
+                                          linalg::LinalgOp consumer) {
+  if (clLinalgOnTensorsEnableForceFusion) return true;
+  // Fuse if the dependence from producer to consumer is to the `outs` operand
+  // of the consumer and the producer is a parallel operation
+  llvm::DenseSet<Value> producerResults(producer.getOperation()->result_begin(),
+                                        producer.getOperation()->result_end());
+  auto isProducerResultValue = [&producerResults](OpOperand &operand) -> bool {
+    return producerResults.count(operand.get());
+  };
+  auto isElementWiseParallelOp = [](linalg::LinalgOp op) -> bool {
+    return llvm::all_of(op.iterator_types(), [](Attribute attr) {
+      return attr.cast<StringAttr>().getValue() ==
+             toString(IteratorType::Parallel);
+    });
+  };
+  return llvm::none_of(consumer.getInputOpOperands(), isProducerResultValue) &&
+         llvm::any_of(consumer.getOutputOpOperands(), isProducerResultValue) &&
+         isElementWiseParallelOp(producer);
+}
+
+/// For a given block partition the LinalgOps in the block into fusable
+/// groups. All analysis of what to fuse happens here. For now this is just
+/// hard-wiring from basic heuristic but this could be adapted to have 1) better
+/// heuristics and 2) use a search approach to decide what all should be fused.
+static void decideFusableLinalgOps(FuncOp funcOp) {
+  unsigned numRootOps = 0;
+  MLIRContext *context = funcOp.getContext();
+  OpBuilder builder(context);
+  for (Block &block : funcOp) {
+    auto linalgOps = block.getOps<linalg::LinalgOp>();
+
+    // Start with a root operation. Everything will be "fused with it".
+    for (linalg::LinalgOp linalgOp : linalgOps) {
+      Operation *op = linalgOp.getOperation();
+      if (op->hasAttr(kRootOpAttr) || op->hasAttr(kFusionGroupAttr)) continue;
+      // For now only matmul op as root.
+      if (!isa<linalg::MatmulOp>(op)) continue;
+      unsigned currGroupNum = numRootOps++;
+      op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(currGroupNum));
+      for (auto operand : linalgOp.getShapedOperands()) {
+        auto producer = operand.getDefiningOp<linalg::LinalgOp>();
+        if (!producer) continue;
+        Operation *producerOp = producer.getOperation();
+        if (!producerOp->hasAttr(kRootOpAttr) &&
+            !producerOp->hasAttr(kFusionGroupAttr) &&
+            isProducerFusableWithConsumer(producer, op)) {
+          producerOp->setAttr(kFusionGroupAttr,
+                              builder.getI64IntegerAttr(currGroupNum));
+        }
+      }
+    }
+
+    // Finally whatever is not marked for fusion becomes a root operation.
+    for (linalg::LinalgOp linalgOp : linalgOps) {
+      Operation *op = linalgOp.getOperation();
+      if (op->hasAttr(kRootOpAttr) || op->hasAttr(kFusionGroupAttr)) continue;
+      op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(numRootOps++));
+    }
+  }
+}
+
 void DispatchLinalgOnTensorsPass::runOnOperation() {
   FuncOp funcOp = getOperation();
   // `isEntryPoint` functions are the ones that are marked public.
@@ -397,6 +479,8 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
 
   MLIRContext *context = funcOp->getContext();
   context->allowUnregisteredDialects(true);
+
+  decideFusableLinalgOps(funcOp);
 
   // Distribution strategy along at most 3 dimensions with WorkgroupIdOp in
   // range [0, WorkgroupSizeOp).
@@ -418,6 +502,28 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
       {linalg::DistributionMethod::Cyclic, linalg::DistributionMethod::Cyclic,
        linalg::DistributionMethod::Cyclic}};
 
+  auto tileSizeFn = [&](OpBuilder &builder,
+                        Operation *op) -> SmallVector<Value, 4> {
+    auto numTiledLoops = getNumTilableLoops(cast<linalg::LinalgOp>(op));
+    SmallVector<Value, 4> useTileSizes(numTiledLoops);
+    if (!clLinalgOnTensorsTileSizes.empty()) {
+      SmallVector<int64_t, 2> tileSizes(clLinalgOnTensorsTileSizes.begin(),
+                                        clLinalgOnTensorsTileSizes.end());
+      useTileSizes.resize(std::min<size_t>(tileSizes.size(), numTiledLoops));
+      return llvm::to_vector<4>(llvm::map_range(
+          ArrayRef<int64_t>(tileSizes).take_front(
+              std::min<size_t>(tileSizes.size(), numTiledLoops)),
+          [&](int64_t t) -> Value {
+            return builder.create<ConstantIndexOp>(op->getLoc(), t);
+          }));
+    }
+    for (size_t dim = 0; dim < numTiledLoops; ++dim) {
+      useTileSizes[numTiledLoops - dim - 1] =
+          buildFlowWorkgroupInfoOp<Flow::DispatchWorkgroupSizeOp>(builder, dim);
+    }
+    return useTileSizes;
+  };
+
   // Use the workgroup size as a proxy for tile size here. At the flow level
   // this represents the "workload" per processors and is not necessarily tied
   // to the workgroup size specified by the backend.
@@ -426,36 +532,14 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
       linalg::LinalgTilingOptions()
           .setDistributionOptions(workgroupDistributionOptions)
           .setLoopType(linalg::LinalgTilingLoopType::Loops)
-          .setTileSizeComputationFunction(
-              [&](OpBuilder &builder, Operation *op) -> SmallVector<Value, 4> {
-                auto numTiledLoops =
-                    getNumTilableLoops(cast<linalg::LinalgOp>(op));
-                SmallVector<Value, 4> useTileSizes(numTiledLoops);
-                if (!tileSizes.empty()) {
-                  useTileSizes.resize(
-                      std::min<size_t>(tileSizes.size(), numTiledLoops));
-                  return llvm::to_vector<4>(llvm::map_range(
-                      ArrayRef<int64_t>(tileSizes).take_front(
-                          std::min<size_t>(tileSizes.size(), numTiledLoops)),
-                      [&](int64_t t) -> Value {
-                        return builder.create<ConstantIndexOp>(op->getLoc(), t);
-                      }));
-                }
-                for (size_t dim = 0; dim < numTiledLoops; ++dim) {
-                  useTileSizes[numTiledLoops - dim - 1] =
-                      buildFlowWorkgroupInfoOp<Flow::DispatchWorkgroupSizeOp>(
-                          builder, dim);
-                }
-                return useTileSizes;
-              });
+          .setTileSizeComputationFunction(tileSizeFn);
   assert(linalgTilingOptions.distribution.hasValue());
 
   patterns.insert<TileAndDistributeOnTensorsPattern>(
       linalgTilingOptions,
       // TODO(nicolavasilache): use refactored `getWorkgroupMarker()`
-      linalg::LinalgTransformationFilter(ArrayRef<Identifier>(),
-                                         Identifier::get("workgroup", context)),
-      enableFusion);
+      linalg::LinalgTransformationFilter(
+          ArrayRef<Identifier>(), Identifier::get("workgroup", context)));
 
   // Add canonicalization patterns.
   linalg::populateLinalgTilingCanonicalizationPatterns(patterns, context);
@@ -496,9 +580,8 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createDispatchLinalgOnTensorsPass(
-    ArrayRef<int64_t> sizes, bool enableFusion) {
-  return std::make_unique<DispatchLinalgOnTensorsPass>(sizes, enableFusion);
+std::unique_ptr<OperationPass<FuncOp>> createDispatchLinalgOnTensorsPass() {
+  return std::make_unique<DispatchLinalgOnTensorsPass>();
 }
 
 static PassRegistration<DispatchLinalgOnTensorsPass> pass(

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -273,7 +273,7 @@ struct TileAndDistributeOnTensorsPattern
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-    if (!linalgOp) return failure();
+    if (!linalgOp || !linalgOp.hasTensorSemantics()) return failure();
     IntegerAttr rootOpAttr = op->getAttrOfType<IntegerAttr>(kRootOpAttr);
     if (!rootOpAttr) return failure();
 
@@ -314,6 +314,8 @@ static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
   return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
 }
 
+/// Returns true if an operation is to always be cloned into the dispatch region
+/// when its value is used within it.
 bool isAlwaysClonedIntoDispatchOp(Operation *op) {
   if (isa<linalg::InitTensorOp>(op)) {
     return true;

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -33,17 +33,6 @@ static llvm::cl::opt<bool> clEnableLinalgOnTensorsDispatch(
         "Enable use of Linalg on tensors for dispatch region creation"),
     llvm::cl::init(false));
 
-static llvm::cl::list<int64_t> clLinalgOnTensorsTileSizes(
-    "iree-flow-dispatch-linalg-on-tensors-tile-sizes",
-    llvm::cl::desc("Comma-separated list of tile sizes for tiling on tensors"),
-    llvm::cl::CommaSeparated);
-
-// TODO(ravishankarm): Remove this option after addressing fusion.
-static llvm::cl::opt<bool> clLinalgOnTensorsEnableFusion(
-    "iree-flow-dispatch-linalg-on-tensors-enable-fusion",
-    llvm::cl::desc("Enable fusion on linalg on tensors path"),
-    llvm::cl::init(false));
-
 // TODO(benvanik): change to a pipeline option.
 static llvm::cl::opt<bool> clTraceDispatchTensors(
     "iree-flow-trace-dispatch-tensors2",
@@ -80,8 +69,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
     passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
     passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
     addHLOToLinalgOnTensorsPasses(passManager);
-    passManager.addNestedPass<FuncOp>(createDispatchLinalgOnTensorsPass(
-        clLinalgOnTensorsTileSizes, clLinalgOnTensorsEnableFusion));
+    passManager.addNestedPass<FuncOp>(createDispatchLinalgOnTensorsPass());
   }
 
   // Run passes to remove shape constraints. HLO lowering inserts them, but they

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -105,8 +105,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createExpandVariableDynamicDimsPass();
 
 /// Pass to perform dispatch of Linalg on tensor ops by tiling and distribution.
 /// A dispatch region is created for each tiled loop nest.
-std::unique_ptr<OperationPass<FuncOp>> createDispatchLinalgOnTensorsPass(
-    ArrayRef<int64_t> sizes = {}, bool enableFusion = false);
+std::unique_ptr<OperationPass<FuncOp>> createDispatchLinalgOnTensorsPass();
 
 // Analyzes a module to identify which functions are dispatchable.
 // This information is cached on the module and is used by other FuncOp-scoped

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass='tile-sizes=1,2 enable-fusion=true' -canonicalize -cse %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -iree-flow-dispatch-linalg-on-tensors-tile-sizes="1,2" -iree-flow-dispatch-linalg-on-tensors-enable-fusion-always -canonicalize -cse %s | IreeFileCheck %s
 
 // CHECK-DAG: #[[$MAP:.*]] = affine_map<(d0) -> (2, -d0 + 4)>
 

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -88,6 +88,48 @@ func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
 
 // -----
 
+func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %zero = constant 0.0 : f32
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %M = dim %A, %c0 : tensor<?x?xf32>
+  %N = dim %B, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}
+//       CHECK:   func @fuse_fill_with_producer
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+//       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
+//       CHECK:        scf.for
+//       CHECK:          scf.for
+//   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+//   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
+//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
+//  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+//       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
+//       CHECK:          flow.return
+//       CHECK:        }
+
+// -----
+
 func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %zero = constant 0.0 : f32
   %one = constant 1.0 : f32
@@ -138,65 +180,32 @@ func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf
 //       CHECK:          flow.return
 //       CHECK:        }
 //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
-//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-//       CHECK:          %[[ZERO:.+]] = constant 0.0
-//       CHECK:          scf.for
-//       CHECK:            scf.for
-//   CHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
-//   CHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
-//   CHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
-//       CHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-//       CHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
-//  CHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
-//       CHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
-//       CHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
-//       CHECK:          flow.return
-//       CHECK:        }
+//       CHECK:       %[[ZERO:.+]] = constant 0.0
+//       CHECK:       scf.for
+//       CHECK:         scf.for
+//       CHECK:            %[[INIT_TILE_2:.+]] = linalg.init_tensor
+//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE_2]], %[[ZERO]])
+//       CHECK:            linalg.matmul
+//       CHECK:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
 
-// -----
-
-func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %zero = constant 0.0 : f32
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
-  %M = dim %A, %c0 : tensor<?x?xf32>
-  %N = dim %B, %c1 : tensor<?x?xf32>
-  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
-  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
-  %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
-    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %2 : tensor<?x?xf32>
-}
-//       CHECK:   func @fuse_fill_with_producer
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-//       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
-//       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
-//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
-//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-//       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
-//       CHECK:        scf.for
-//       CHECK:          scf.for
-//   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
-//   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
-//   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
-//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-//       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
-//  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
-//  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
-//       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
-//       CHECK:          flow.return
-//       CHECK:        }
+// The following CHECK* sems to hit a segfault with FileCheck. For now using a simpler check.
+//  NOCHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
+//  NOCHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  NOCHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  NOCHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       NOCHECK:          %[[ZERO:.+]] = constant 0.0
+//       NOCHECK:          scf.for
+//       NOCHECK:            scf.for
+//   NOCHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
+//   NOCHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   NOCHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
+//       NOCHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       NOCHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
+//  NOCHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//       NOCHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
+//       NOCHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
+//       NOCHECK:          flow.return
+//       NOCHECK:        }

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -85,3 +85,118 @@ func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
 // CHECK-SAME:         ins(%[[V1]], %[[V2]] : tensor<?x?xf32>, tensor<?xf32>)
 // CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
 //      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]], offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[D0]], %[[D1]]]
+
+// -----
+
+func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %zero = constant 0.0 : f32
+  %one = constant 1.0 : f32
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %M = dim %A, %c0 : tensor<?x?xf32>
+  %N = dim %B, %c1 : tensor<?x?xf32>
+  %K = dim %A, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %2 = linalg.init_tensor [%M, %K] : tensor<?x?xf32>
+  %3 = linalg.generic
+    {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                      affine_map<(d0, d1) -> (d0, d1)>],
+     iterator_types = ["parallel", "parallel"]}
+    ins(%A : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
+    ^bb0(%arg0 : f32, %arg1 : f32):
+      %4 = addf %arg0, %one : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?xf32>
+  %4 = linalg.matmul ins(%3, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %4 : tensor<?x?xf32>
+}
+//      CHECK: func @two_dispatches
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+//   CHECK-DAG:     %[[K:.+]] = dim %[[ARG0]], %[[C1]]
+//       CHECK:     %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[K]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[M]], %[[K]], %[[ARG0]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:          %[[ONE:.+]] = constant 1.0
+//       CHECK:          scf.for
+//       CHECK:            scf.for
+//   CHECK-DAG:              %[[INPUT_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+//       CHECK:              %[[INIT_TILE:.+]] = linalg.init_tensor
+//       CHECK:              %[[RESULT_TILE:.+]] = linalg.generic
+//  CHECK-SAME:                ins(%[[INPUT_TILE]] : tensor<?x?xf32>)
+//  CHECK-SAME:                outs(%[[INIT_TILE]] : tensor<?x?xf32>)
+//       CHECK:              flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG5]]
+//       CHECK:          flow.return
+//       CHECK:        }
+//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:          %[[ZERO:.+]] = constant 0.0
+//       CHECK:          scf.for
+//       CHECK:            scf.for
+//   CHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
+//   CHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   CHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
+//       CHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       CHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
+//  CHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//       CHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
+//       CHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
+//       CHECK:          flow.return
+//       CHECK:        }
+
+// -----
+
+func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %zero = constant 0.0 : f32
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %M = dim %A, %c0 : tensor<?x?xf32>
+  %N = dim %B, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}
+//       CHECK:   func @fuse_fill_with_producer
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+//       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
+//       CHECK:        scf.for
+//       CHECK:          scf.for
+//   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+//   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
+//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
+//  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+//       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
+//       CHECK:          flow.return
+//       CHECK:        }

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -193,7 +193,6 @@ iree_check_single_backend_test_suite(
     compiler_flags = [
         "-iree-flow-dispatch-linalg-on-tensors",
         "-iree-codegen-llvm-experimental-linalg-on-tensors",
-        "-iree-flow-dispatch-linalg-on-tensors-enable-fusion",
     ],
     driver = "dylib",
     target_backend = "dylib-llvm-aot",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -167,5 +167,4 @@ iree_check_single_backend_test_suite(
   COMPILER_FLAGS
     "-iree-flow-dispatch-linalg-on-tensors"
     "-iree-codegen-llvm-experimental-linalg-on-tensors"
-    "-iree-flow-dispatch-linalg-on-tensors-enable-fusion"
 )


### PR DESCRIPTION
This PR adds support for controlling what fusion are performed during tile and distribute. A prepass of the operations (post elementwise fusion) is done to figure out which operations to fuse. The prepass computes a fusion group, each group having a single root. Once the root operation is tiled and distributed, all the producers that are part of the fusion group are pulled into the dispatch region as well. For now a basic heuristic is used to find the fusion groups, but these could be computed through any means, even an external search approach.