### PR TITLE
Use stack allocation on CPU side for Linalg on tensors path.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -100,7 +100,15 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
   // HLO -> Linalg on buffers.
   if (clEnableLLVMLinalgOnTensors) {
     nestedModulePM.addPass(createLinalgVectorizePass());
-    addLinalgBufferizePasses(nestedModulePM);
+    // Use stack allocation on CPU side.
+    WorkgroupMemoryAllocationFn allocationFn =
+        [](OpBuilder &builder, Location loc, ArrayRef<Value> dynamicSizes,
+           MemRefType allocationType) {
+          MemRefType allocType = MemRefType::get(
+              allocationType.getShape(), allocationType.getElementType());
+          return builder.create<AllocaOp>(loc, allocType, dynamicSize);
+        };
+    addLinalgBufferizePasses(nestedModulePM, allocationFn);
     nestedModulePM.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
   } else {
     // Propagates dynamic shapes computation on tensors.

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -106,7 +106,7 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager) {
            MemRefType allocationType) {
           MemRefType allocType = MemRefType::get(
               allocationType.getShape(), allocationType.getElementType());
-          return builder.create<AllocaOp>(loc, allocType, dynamicSize);
+          return builder.create<AllocaOp>(loc, allocType, dynamicSizes);
         };
     addLinalgBufferizePasses(nestedModulePM, allocationFn);
     nestedModulePM.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));


### PR DESCRIPTION
Using heap allocations without a free leads to memory leaks. Only
stack allocations are allowed with dispatch regions on CPU side.