### PR TITLE
Swapping `[]` -> `CD` and `.` -> `_` in the VM calling convention.

### DIFF
--- a/bindings/python/pyiree/rt/function_abi.cc
+++ b/bindings/python/pyiree/rt/function_abi.cc
@@ -573,7 +573,11 @@ void FunctionAbi::RawUnpack(absl::Span<const Description> descs,
   py::object this_object =
       py::cast(this, py::return_value_policy::take_ownership);
   if (descs.size() != f_results.size() || descs.size() != py_results.size()) {
-    throw RaiseValueError("Mismatched RawUnpack() result arity");
+    std::string s = std::string("Mismatched RawUnpack() result arity; descs=") +
+                    std::to_string(descs.size()) +
+                    ", f_results=" + std::to_string(f_results.size()) +
+                    ", py_results=" + std::to_string(py_results.size());
+    throw RaiseValueError(s.c_str());
   }
   for (size_t i = 0, e = descs.size(); i < e; ++i) {
     const Description& desc = descs[i];

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -78,16 +78,7 @@ static LogicalResult printShim(IREE::VM::FuncOp &funcOp,
   if (!callingConvention) {
     return funcOp.emitError("Couldn't create calling convention string");
   }
-  auto s = callingConvention.getValue();
-  output << "call_";
-  if (s.size() == 0) {
-    output << "0_";
-  } else {
-    std::replace(s.begin(), s.end(), '.', '_');
-    output << s;
-  }
-  output << "_shim";
-
+  output << "call_" << callingConvention.getValue() << "_shim";
   return success();
 }
 

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -200,6 +200,8 @@ static iree_status_t iree_vm_bytecode_external_enter(
   const uint8_t* p = arguments.data;
   for (iree_host_size_t i = 0; i < cconv_arguments.size; ++i) {
     switch (cconv_arguments.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32: {
         uint16_t dst_reg = i32_reg++;
         memcpy(&callee_registers.i32[dst_reg & callee_registers.i32_mask], p,
@@ -241,6 +243,8 @@ static iree_status_t iree_vm_bytecode_external_leave(
   for (iree_host_size_t i = 0; i < cconv_results.size; ++i) {
     uint16_t src_reg = src_reg_list->registers[i];
     switch (cconv_results.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32: {
         memcpy(p, &callee_registers->i32[src_reg & callee_registers->i32_mask],
                sizeof(int32_t));
@@ -380,6 +384,8 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
   for (iree_host_size_t i = 0, seg_i = 0, reg_i = 0; i < cconv_arguments.size;
        ++i, ++seg_i) {
     switch (cconv_arguments.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32: {
         memcpy(p,
                &caller_registers.i32[src_reg_list->registers[reg_i++] &
@@ -423,6 +429,8 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
                ++i) {
             // TODO(benvanik): share with switch above.
             switch (cconv_arguments.data[i]) {
+              case IREE_VM_CCONV_TYPE_VOID:
+                break;
               case IREE_VM_CCONV_TYPE_INT32: {
                 memcpy(p,
                        &caller_registers.i32[src_reg_list->registers[reg_i++] &
@@ -484,6 +492,8 @@ static iree_status_t iree_vm_bytecode_issue_import_call(
        ++i) {
     uint16_t dst_reg = dst_reg_list->registers[i];
     switch (cconv_results.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32:
         memcpy(&caller_registers.i32[dst_reg & caller_registers.i32_mask], p,
                sizeof(int32_t));

--- a/iree/vm/bytecode_module_benchmark.cc
+++ b/iree/vm/bytecode_module_benchmark.cc
@@ -44,7 +44,7 @@ static iree_status_t native_import_module_add_1(
 
 static const iree_vm_native_export_descriptor_t
     native_import_module_exports_[] = {
-        {iree_make_cstring_view("add_1"), iree_make_cstring_view("0i.i"), 0,
+        {iree_make_cstring_view("add_1"), iree_make_cstring_view("0i_i"), 0,
          NULL},
 };
 static const iree_vm_native_function_ptr_t native_import_module_funcs_[] = {

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -35,7 +35,7 @@ iree_vm_function_call_get_cconv_fragments(
                             "unsupported cconv version %c", cconv.data[0]);
   }
   iree_string_view_t cconv_body = iree_string_view_substr(cconv, 1, INTPTR_MAX);
-  if (iree_string_view_split(cconv_body, '.', out_arguments, out_results) ==
+  if (iree_string_view_split(cconv_body, '_', out_arguments, out_results) ==
       -1) {
     *out_arguments = cconv_body;
   }
@@ -57,6 +57,8 @@ iree_vm_function_call_compute_cconv_fragment_size(
   for (iree_host_size_t i = 0, seg_i = 0; i < cconv_fragment.size;
        ++i, ++seg_i) {
     switch (cconv_fragment.data[i]) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32:
         required_size += sizeof(int32_t);
         break;
@@ -80,6 +82,8 @@ iree_vm_function_call_compute_cconv_fragment_size(
                         cconv_fragment.data[i] != IREE_VM_CCONV_TYPE_SPAN_END;
              ++i) {
           switch (cconv_fragment.data[i]) {
+            case IREE_VM_CCONV_TYPE_VOID:
+              break;
             case IREE_VM_CCONV_TYPE_INT32:
               span_size += sizeof(int32_t);
               break;
@@ -118,11 +122,13 @@ iree_vm_function_call_release(iree_vm_function_call_t* call,
   uint8_t* p = call->arguments.data;
   for (iree_host_size_t i = 1; i < cconv.size; ++i) {
     char c = cconv.data[i];
-    if (c == '.') {
+    if (c == '_') {
       // Switch to results.
       p = call->results.data;
     }
     switch (c) {
+      case IREE_VM_CCONV_TYPE_VOID:
+        break;
       case IREE_VM_CCONV_TYPE_INT32:
         p += sizeof(int32_t);
         break;

--- a/iree/vm/native_module_test.h
+++ b/iree/vm/native_module_test.h
@@ -101,8 +101,8 @@ static iree_status_t module_a_sub_1(iree_vm_stack_t* stack, module_a_t* module,
 }
 
 static const iree_vm_native_export_descriptor_t module_a_exports_[] = {
-    {iree_make_cstring_view("add_1"), iree_make_cstring_view("0i.i"), 0, NULL},
-    {iree_make_cstring_view("sub_1"), iree_make_cstring_view("0i.i"), 0, NULL},
+    {iree_make_cstring_view("add_1"), iree_make_cstring_view("0i_i"), 0, NULL},
+    {iree_make_cstring_view("sub_1"), iree_make_cstring_view("0i_i"), 0, NULL},
 };
 static const iree_vm_native_function_ptr_t module_a_funcs_[] = {
     {(iree_vm_native_function_shim_t)call_shim_i32_i32,
@@ -257,7 +257,7 @@ static const iree_vm_reflection_attr_t module_b_entry_attrs_[] = {
     {iree_make_cstring_view("key1"), iree_make_cstring_view("value1")},
 };
 static const iree_vm_native_export_descriptor_t module_b_exports_[] = {
-    {iree_make_cstring_view("entry"), iree_make_cstring_view("0i.i"),
+    {iree_make_cstring_view("entry"), iree_make_cstring_view("0i_i"),
      IREE_ARRAYSIZE(module_b_entry_attrs_), module_b_entry_attrs_},
 };
 static_assert(IREE_ARRAYSIZE(module_b_funcs_) ==

--- a/iree/vm/shims.h
+++ b/iree/vm/shims.h
@@ -19,22 +19,21 @@
 #include "iree/vm/stack.h"
 
 // see Calling convetion in module.h
-// We use the same format but replace '.' by '_'
 // Variadic arguments are not supported
 
-// 0.
-typedef iree_status_t (*call_0__t)(iree_vm_stack_t* stack, void* module_ptr,
-                                   void* module_state);
+// 0v_v
+typedef iree_status_t (*call_0v_v_t)(iree_vm_stack_t* stack, void* module_ptr,
+                                     void* module_state);
 
-static iree_status_t call_0__shim(iree_vm_stack_t* stack,
-                                  const iree_vm_function_call_t* call,
-                                  call_0__t target_fn, void* module,
-                                  void* module_state,
-                                  iree_vm_execution_result_t* out_result) {
+static iree_status_t call_0v_v_shim(iree_vm_stack_t* stack,
+                                    const iree_vm_function_call_t* call,
+                                    call_0v_v_t target_fn, void* module,
+                                    void* module_state,
+                                    iree_vm_execution_result_t* out_result) {
   return target_fn(stack, module, module_state);
 }
 
-// 0i.i
+// 0i_i
 typedef iree_status_t (*call_0i_i_t)(iree_vm_stack_t* stack, void* module_ptr,
                                      void* module_state, int32_t arg0,
                                      int32_t* res0);
@@ -56,7 +55,8 @@ static iree_status_t call_0i_i_shim(iree_vm_stack_t* stack,
 
   return target_fn(stack, module, module_state, args->arg0, &results->ret0);
 }
-// 0ii.i
+
+// 0ii_i
 typedef iree_status_t (*call_0ii_i_t)(iree_vm_stack_t* stack, void* module_ptr,
                                       void* module_state, int32_t arg0,
                                       int32_t arg1, int32_t* res0);


### PR DESCRIPTION
This makes it easier to write simple 1:1 shim functions/wrappers without needing to special case characters or void/empty args/results.

Progress on #4736.