### PR TITLE
Add EmitC support for conversion ops

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -89,6 +89,20 @@ void populateVMToCPatterns(MLIRContext *context,
   patterns.insert<CallOpConversion<IREE::VM::OrI32Op>>(context, "vm_or_i32");
   patterns.insert<CallOpConversion<IREE::VM::XorI32Op>>(context, "vm_xor_i32");
 
+  // Casting and type conversion/emulation ops
+  patterns.insert<CallOpConversion<IREE::VM::TruncI32I8Op>>(context,
+                                                            "vm_trunc_i32i8");
+  patterns.insert<CallOpConversion<IREE::VM::TruncI32I16Op>>(context,
+                                                             "vm_trunc_i32i16");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI8I32SOp>>(context,
+                                                           "vm_ext_i8i32s");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI8I32UOp>>(context,
+                                                           "vm_ext_i8i32u");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI16I32SOp>>(context,
+                                                            "vm_ext_i16i32s");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI16I32UOp>>(context,
+                                                            "vm_ext_i16i32u");
+
   // Native bitwise shift and rotate ops
   patterns.insert<CallOpConversion<IREE::VM::ShlI32Op>>(context, "vm_shl_i32");
   patterns.insert<CallOpConversion<IREE::VM::ShrI32SOp>>(context,
@@ -146,6 +160,14 @@ class ConvertVMToEmitCPass
     target.addIllegalOp<IREE::VM::AndI32Op>();
     target.addIllegalOp<IREE::VM::OrI32Op>();
     target.addIllegalOp<IREE::VM::XorI32Op>();
+
+    // Casting and type conversion/emulation ops
+    target.addIllegalOp<IREE::VM::TruncI32I8Op>();
+    target.addIllegalOp<IREE::VM::TruncI32I16Op>();
+    target.addIllegalOp<IREE::VM::ExtI8I32SOp>();
+    target.addIllegalOp<IREE::VM::ExtI8I32UOp>();
+    target.addIllegalOp<IREE::VM::ExtI16I32SOp>();
+    target.addIllegalOp<IREE::VM::ExtI16I32UOp>();
 
     // Native bitwise shift and rotate ops
     target.addIllegalOp<IREE::VM::ShlI32Op>();

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @trunc
+vm.module @my_module {
+  vm.func @trunc(%arg0 : i32) -> i32 {
+    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i32i8"(%arg0) {args = [0 : index]} : (i32) -> i32
+    %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
+    // CHECK-NEXT: %1 = emitc.call "vm_trunc_i32i16"(%0) {args = [0 : index]} : (i32) -> i32
+    %1 = vm.trunc.i32.i16 %0 : i32 -> i32
+    vm.return %1 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: vm.func @ext
+vm.module @my_module {
+  vm.func @ext(%arg0 : i32) -> i32 {
+    // CHECK-NEXT: %0 = emitc.call "vm_ext_i8i32s"(%arg0) {args = [0 : index]} : (i32) -> i32
+    %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
+    // CHECK-NEXT: %1 = emitc.call "vm_ext_i8i32u"(%0) {args = [0 : index]} : (i32) -> i32
+    %1 = vm.ext.i8.i32.u %0 : i32 -> i32
+    // CHECK-NEXT: %2 = emitc.call "vm_ext_i16i32s"(%1) {args = [0 : index]} : (i32) -> i32
+    %2 = vm.ext.i16.i32.s %1 : i32 -> i32
+    // CHECK-NEXT: %3 = emitc.call "vm_ext_i16i32u"(%2) {args = [0 : index]} : (i32) -> i32
+    %3 = vm.ext.i16.i32.u %2 : i32 -> i32
+    vm.return %3 : i32
+  }
+}

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -976,6 +976,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Native integer arithmetic
     //===------------------------------------------------------------------===//
 
+// TODO: unify macros, eg. DISPATCH_OP_CORE_UNARY_I32
 #define DISPATCH_OP_CORE_UNARY_ALU_I32(op_name, op_func) \
   DISPATCH_OP(CORE, op_name, {                           \
     int32_t operand = VM_DecOperandRegI32("operand");    \
@@ -1007,19 +1008,12 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Casting and type conversion/emulation
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CORE_CAST_I32(op_name, op_func)   \
-  DISPATCH_OP(CORE, op_name, {                        \
-    int32_t operand = VM_DecOperandRegI32("operand"); \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = op_func(operand);                       \
-  });
-
-    DISPATCH_OP_CORE_CAST_I32(TruncI32I8, vm_trunc_i32i8);
-    DISPATCH_OP_CORE_CAST_I32(TruncI32I16, vm_trunc_i32i16);
-    DISPATCH_OP_CORE_CAST_I32(ExtI8I32S, vm_ext_i8i32s);
-    DISPATCH_OP_CORE_CAST_I32(ExtI8I32U, vm_ext_i8i32u);
-    DISPATCH_OP_CORE_CAST_I32(ExtI16I32S, vm_ext_i16i32s);
-    DISPATCH_OP_CORE_CAST_I32(ExtI16I32U, vm_ext_i16i32u);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(TruncI32I8, vm_trunc_i32i8);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(TruncI32I16, vm_trunc_i32i16);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(ExtI8I32S, vm_ext_i8i32s);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(ExtI8I32U, vm_ext_i8i32u);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(ExtI16I32S, vm_ext_i16i32s);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(ExtI16I32U, vm_ext_i16i32u);
 
     //===------------------------------------------------------------------===//
     // Native bitwise shifts and rotates

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1007,19 +1007,19 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Casting and type conversion/emulation
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CORE_CAST_I32(op_name, src_type, dst_type) \
-  DISPATCH_OP(CORE, op_name, {                                 \
-    int32_t operand = VM_DecOperandRegI32("operand");          \
-    int32_t* result = VM_DecResultRegI32("result");            \
-    *result = (dst_type)((src_type)operand);                   \
+#define DISPATCH_OP_CORE_CAST_I32(op_name, op_func)   \
+  DISPATCH_OP(CORE, op_name, {                        \
+    int32_t operand = VM_DecOperandRegI32("operand"); \
+    int32_t* result = VM_DecResultRegI32("result");   \
+    *result = op_func(operand);                       \
   });
 
-    DISPATCH_OP_CORE_CAST_I32(TruncI32I8, uint32_t, uint8_t);
-    DISPATCH_OP_CORE_CAST_I32(TruncI32I16, uint32_t, uint16_t);
-    DISPATCH_OP_CORE_CAST_I32(ExtI8I32S, int8_t, int32_t);
-    DISPATCH_OP_CORE_CAST_I32(ExtI8I32U, uint8_t, uint32_t);
-    DISPATCH_OP_CORE_CAST_I32(ExtI16I32S, int16_t, int32_t);
-    DISPATCH_OP_CORE_CAST_I32(ExtI16I32U, uint16_t, uint32_t);
+    DISPATCH_OP_CORE_CAST_I32(TruncI32I8, vm_trunc_i32i8);
+    DISPATCH_OP_CORE_CAST_I32(TruncI32I16, vm_trunc_i32i16);
+    DISPATCH_OP_CORE_CAST_I32(ExtI8I32S, vm_ext_i8i32s);
+    DISPATCH_OP_CORE_CAST_I32(ExtI8I32U, vm_ext_i8i32u);
+    DISPATCH_OP_CORE_CAST_I32(ExtI16I32S, vm_ext_i16i32s);
+    DISPATCH_OP_CORE_CAST_I32(ExtI16I32U, vm_ext_i16i32u);
 
     //===------------------------------------------------------------------===//
     // Native bitwise shifts and rotates

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -44,6 +44,29 @@ static inline int32_t vm_or_i32(int32_t lhs, int32_t rhs) { return lhs | rhs; }
 static inline int32_t vm_xor_i32(int32_t lhs, int32_t rhs) { return lhs ^ rhs; }
 
 //===------------------------------------------------------------------===//
+// Casting and type conversion/emulation
+//===------------------------------------------------------------------===//
+
+static inline int32_t vm_trunc_i32i8(int32_t operand) {
+  return (uint8_t)((uint32_t)operand);
+};
+static inline int32_t vm_trunc_i32i16(int32_t operand) {
+  return (uint16_t)((uint32_t)operand);
+};
+static inline int32_t vm_ext_i8i32s(int32_t operand) {
+  return (int32_t)((int8_t)operand);
+};
+static inline int32_t vm_ext_i8i32u(int32_t operand) {
+  return (uint32_t)((uint8_t)operand);
+};
+static inline int32_t vm_ext_i16i32s(int32_t operand) {
+  return (int32_t)((int16_t)operand);
+};
+static inline int32_t vm_ext_i16i32u(int32_t operand) {
+  return (uint32_t)((uint16_t)operand);
+};
+
+//===------------------------------------------------------------------===//
 // Native bitwise shifts and rotates
 //===------------------------------------------------------------------===//
 

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -38,6 +38,7 @@ cc_embed_data(
         ":arithmetic_ops_i64.vmfb",
         ":comparison_ops.vmfb",
         ":control_flow_ops.vmfb",
+        ":conversion_ops.vmfb",
         ":list_ops.vmfb",
         ":shift_ops.vmfb",
     ],
@@ -68,6 +69,12 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "control_flow_ops",
     src = "control_flow_ops.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "conversion_ops",
+    src = "conversion_ops.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_embed_data(
     "arithmetic_ops_i64.vmfb"
     "comparison_ops.vmfb"
     "control_flow_ops.vmfb"
+    "conversion_ops.vmfb"
     "list_ops.vmfb"
     "shift_ops.vmfb"
   CC_FILE_OUTPUT
@@ -73,6 +74,16 @@ iree_bytecode_module(
     control_flow_ops
   SRC
     "control_flow_ops.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    conversion_ops
+  SRC
+    "conversion_ops.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/conversion_ops.mlir
+++ b/iree/vm/test/conversion_ops.mlir
@@ -1,0 +1,28 @@
+vm.module @conversion_ops {
+
+  //===----------------------------------------------------------------------===//
+  // Casting and type conversion/emulation
+  //===----------------------------------------------------------------------===//
+
+  // TODO: The CModuleTarget enforces exports to be ordered.
+  vm.export @test_trunc_i32_i16
+  vm.export @test_trunc_i32_i8
+
+  vm.func @test_trunc_i32_i8() {
+    %c1 = vm.const.i32 2147483647 : i32
+    %c1dno = iree.do_not_optimize(%c1) : i32
+    %v = vm.trunc.i32.i8 %c1dno : i32 -> i32
+    %c2 = vm.const.i32 255 : i32
+    vm.check.eq %v, %c2, "truncate unsigned i32 to unsigned i8" : i32
+    vm.return
+  }
+
+    vm.func @test_trunc_i32_i16() {
+    %c1 = vm.const.i32 2147483647 : i32
+    %c1dno = iree.do_not_optimize(%c1) : i32
+    %v = vm.trunc.i32.i16 %c1dno : i32 -> i32
+    %c2 = vm.const.i32 65535 : i32
+    vm.check.eq %v, %c2, "truncate unsigned i32 to unsigned i16" : i32
+    vm.return
+  }
+}

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_test(
     iree::vm::ops
     iree::vm::shims
     ::arithmetic_ops_cc
+    ::conversion_ops_cc
     ::shift_ops_cc
 )
 
@@ -39,6 +40,18 @@ iree_bytecode_module(
     arithmetic_ops
   SRC
     "../arithmetic_ops.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    conversion_ops
+  SRC
+    "../conversion_ops.mlir"
   CC_NAMESPACE
     "iree::vm::test::emitc"
   FLAGS

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -19,6 +19,7 @@
 #include "iree/testing/gtest.h"
 #include "iree/vm/api.h"
 #include "iree/vm/test/emitc/arithmetic_ops.vmfb"
+#include "iree/vm/test/emitc/conversion_ops.vmfb"
 #include "iree/vm/test/emitc/shift_ops.vmfb"
 
 namespace {
@@ -47,6 +48,7 @@ std::vector<TestParams> GetModuleTestParams() {
   // TODO(simon-camp): get these automatically
   std::vector<ModuleDescription> modules = {
       {arithmetic_ops_descriptor_, arithmetic_ops_create},
+      {conversion_ops_descriptor_, conversion_ops_create},
       {shift_ops_descriptor_, shift_ops_create}};
 
   for (size_t i = 0; i < modules.size(); i++) {


### PR DESCRIPTION
Further adds tests for `vm.trunc` ops to the VM.

Co-authored-by: Marius Brehler <marius.brehler@iml.fraunhofer.de>