### PR TITLE
Adapt dispatch region creation to always clone metadata-like/simple operations

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -384,7 +384,7 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
 
   llvm::SetVector<Value> valuesDefinedAbove;
   llvm::SmallVector<Operation *, 4> clonedOps;
-  getUsedValuesDefinedAboveAfterCloningOps(dispatchOp.body(), b,
+  getUsedValuesDefinedAboveAfterCloningOps(dispatchOp.body(),
                                            valuesDefinedAbove, clonedOps);
 
   BlockAndValueMapping map;

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -607,7 +607,7 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   // After outlining in dispatch region we can rewrite the dispatch ops with
   // proper captures.
   if (funcOp
-          .walk([&](IREE::Flow::DispatchWorkgroupsOp op) {
+          .walk([&](IREE::Flow::DispatchWorkgroupsOp op) -> WalkResult {
             return legalizeDispatchWorkgroupOperands(op);
           })
           .wasInterrupted()) {

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -353,8 +353,15 @@ void getUsedValuesDefinedAboveAfterCloningOps(
   }
   // The cloned operations form a DAG. Return the cloned operations in reverse
   // so the leaves come first, and can be cloned in-order into the dispatch
-  // region.
+  // region. Do the same for `valuesDefinedAbove` to keep return values
+  // consistent with order gotten from `mlir::getUsedValuesDefinedAbove` (more
+  // for a convention that correctness)
   clonedOps = llvm::to_vector<4>(llvm::reverse(clonedOps));
+  llvm::SetVector<Value> reverseValuesDefinedAbove;
+  for (auto value : llvm::reverse(valuesDefinedAbove)) {
+    reverseValuesDefinedAbove.insert(value);
+  }
+  std::swap(reverseValuesDefinedAbove, valuesDefinedAbove);
 }
 
 /// Returns a valid insertion point for an operation based on the values used.

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -317,7 +317,7 @@ static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
 /// Returns true if an operation is to always be cloned into the dispatch region
 /// when its value is used within it.
 bool isAlwaysClonedIntoDispatchOp(Operation *op) {
-  if (isa<linalg::InitTensorOp>(op)) {
+  if (isa<linalg::InitTensorOp, linalg::TensorReshapeOp>(op)) {
     return true;
   }
   if (auto constantOp = dyn_cast<ConstantOp>(op)) {
@@ -326,48 +326,77 @@ bool isAlwaysClonedIntoDispatchOp(Operation *op) {
   return false;
 }
 
+/// Computes the values that will be eventually be used within the dispatch
+/// workgroup op but defined outside the op after all clonable operations are
+/// cloned into the region. Returns (by reference) the clonable operations too.
+void getUsedValuesDefinedAboveAfterCloningOps(
+    Region &region, OpBuilder &b, llvm::SetVector<Value> &valuesDefinedAbove,
+    llvm::SetVector<Operation *> &clonedOps) {
+  mlir::getUsedValuesDefinedAbove(region, valuesDefinedAbove);
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPointToStart(&region.front());
+  llvm::SetVector<Operation *> tempClonedOps;
+  for (Value operand : valuesDefinedAbove) {
+    Operation *definingOp = operand.getDefiningOp();
+    if (!definingOp || !isAlwaysClonedIntoDispatchOp(definingOp)) continue;
+    clonedOps.insert(definingOp);
+    // Temporarily clone this operation. This is just so that when the values
+    // defined from above is recomputed, we get the actual values that need to
+    // be captured as arguments. Fairly hacky, but anything more sophisticated
+    // will require computing multiple backward slices. These ops will be
+    // removed after the used values defined from above are recomputed and
+    // reinserted at the right position.
+    auto clonedOp = b.clone(*definingOp);
+    tempClonedOps.insert(clonedOp);
+  }
+
+  // Recompute the values captured from outside.
+  valuesDefinedAbove.clear();
+  mlir::getUsedValuesDefinedAbove(region, valuesDefinedAbove);
+
+  // Prune the set of values that are defined by cloned operations.
+  for (auto clonedOp : clonedOps) {
+    for (Value result : clonedOp->getResults()) {
+      valuesDefinedAbove.remove(result);
+    }
+  }
+
+  // Remove the temporarily cloned operations.
+  for (auto tempClonedOp : tempClonedOps) {
+    tempClonedOp->erase();
+  }
+}
+
+static Operation *getInsertionPoint(Block &block, ArrayRef<Value> usedValues) {
+  Operation *insertAfter = &block.front();
+  for (auto value : usedValues) {
+    Operation *definingOp = value.getDefiningOp();
+    if (!definingOp) continue;
+    if (definingOp->getBlock() != &block) return nullptr;
+    if (insertAfter->isBeforeInBlock(definingOp)) {
+      insertAfter = definingOp;
+    }
+  }
+  return insertAfter->getNextNode();
+}
+
 // After outlining in dispatch region we can rewrite the dispatch ops with
 // proper captures.
 // A later RematerializeDispatchConstants should be called to avoid passing
 // unnecessary constant arguments.
-static void legalizeDispatchWorkgroupOperands(
+static LogicalResult legalizeDispatchWorkgroupOperands(
     IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   Location loc = dispatchOp.getLoc();
   Block &block = dispatchOp.body().front();
   unsigned numOldBBArgs = block.getNumArguments();
   OpBuilder b = OpBuilder::atBlockBegin(&block);
 
-  llvm::SetVector<Value> valuesSet;
-  mlir::getUsedValuesDefinedAbove(dispatchOp.body(), valuesSet);
+  llvm::SetVector<Value> valuesDefinedAbove;
+  llvm::SetVector<Operation *> clonedOps;
+  getUsedValuesDefinedAboveAfterCloningOps(dispatchOp.body(), b,
+                                           valuesDefinedAbove, clonedOps);
 
-  auto getUsesOfValueOutsideOfDispatchOp =
-      [&](Value v) -> SmallVector<Operation *, 4> {
-    SmallVector<Operation *, 4> res;
-    for (Operation *user : v.getUsers())
-      if (!dispatchOp->isAncestor(user)) res.push_back(user);
-    return res;
-  };
-
-  // Go through the captured values and check for any `init_tensor`. These can
-  // be pulled into the dispatch region
   BlockAndValueMapping map;
-  for (Value operand : valuesSet) {
-    Operation *definingOp = operand.getDefiningOp();
-    if (!definingOp || !isAlwaysClonedIntoDispatchOp(definingOp) ||
-        definingOp->getNumResults() != 1)
-      continue;
-    auto clonedOp = b.clone(*definingOp, map);
-    auto outsideUses = getUsesOfValueOutsideOfDispatchOp(operand);
-    operand.replaceAllUsesExcept(
-        clonedOp->getResult(0),
-        SmallPtrSet<Operation *, 8>(outsideUses.begin(), outsideUses.end()));
-  }
-
-  // Recompute the values captured from outside.
-  valuesSet.clear();
-  mlir::getUsedValuesDefinedAbove(dispatchOp.body(), valuesSet);
-  ValueRange valuesDefinedAbove{valuesSet.getArrayRef()};
-
   // Replace valuesDefinedAbove by new BB args (including the op's operands).
   for (Value operand : valuesDefinedAbove) {
     if (auto rt = operand.getType().dyn_cast<RankedTensorType>()) {
@@ -378,7 +407,6 @@ static void legalizeDispatchWorkgroupOperands(
     }
 
     Value bbArg = block.getArguments().back();
-    auto uses = getUsesOfValueOutsideOfDispatchOp(operand);
     Value repl = bbArg;
     if (bbArg.getType().isa<IREE::Flow::DispatchInputType>()) {
       repl = b.create<IREE::Flow::DispatchInputLoadOp>(loc, operand.getType(),
@@ -387,22 +415,59 @@ static void legalizeDispatchWorkgroupOperands(
       // TODO(nicolasvasilache): do something useful.
       continue;
     }
-    operand.replaceAllUsesExcept(
-        repl, SmallPtrSet<Operation *, 8>(uses.begin(), uses.end()));
+    map.map(operand, repl);
   }
 
-  // Reinsert and replace old BB args.
-  for (BlockArgument ba : block.getArguments().take_front(numOldBBArgs)) {
-    block.addArgument(ba.getType());
-    ba.replaceAllUsesWith(block.getArguments().back());
+  // The only existing argument are for the outputs. Just need to add a new
+  // argument for the outpts and remap the value to use the new argument.
+  for (auto ba : block.getArguments().take_front(numOldBBArgs)) {
+    assert(ba.getType().isa<IREE::Flow::DispatchOutputType>());
+    map.map(ba, block.addArgument(ba.getType()));
+  }
+
+  auto getUsesOfValueOutsideOfDispatchOp =
+      [&](Value v) -> SmallPtrSet<Operation *, 4> {
+    SmallPtrSet<Operation *, 4> res;
+    for (Operation *user : v.getUsers())
+      if (!dispatchOp->isAncestor(user)) res.insert(user);
+    return res;
+  };
+  // Replace all uses of mapped values within the dispatch op to the new value.
+  for (Value value : valuesDefinedAbove) {
+    auto uses = getUsesOfValueOutsideOfDispatchOp(value);
+    value.replaceAllUsesExcept(map.lookup(value), uses);
+  }
+
+  // Clone the marked operations.
+  for (Operation *op : clonedOps) {
+    SmallVector<Value, 2> clonedOpOperands = llvm::to_vector<2>(llvm::map_range(
+        op->getOperands(), [&map](Value v) { return map.lookup(v); }));
+    Operation *insertionPoint = getInsertionPoint(block, clonedOpOperands);
+    if (!insertionPoint) {
+      return op->emitOpError(
+          "failed to clone operation into dispatch workgroup op");
+    }
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(insertionPoint);
+    Operation *clonedOp = b.clone(*op, map);
+    for (Value result : op->getResults()) {
+      auto uses = getUsesOfValueOutsideOfDispatchOp(result);
+      result.replaceAllUsesExcept(map.lookup(result), uses);
+    }
+  }
+
+  for (Value ba : block.getArguments().take_front(numOldBBArgs)) {
+    ba.replaceAllUsesWith(map.lookup(ba));
   }
 
   // Drop old BB args.
   block.eraseArguments(
       llvm::to_vector<4>(llvm::seq<unsigned>(0, numOldBBArgs)));
 
-  // Set the operands.
-  dispatchOp.operandsMutable().assign(valuesDefinedAbove);
+  // Set the values captured from above as the new operands.
+  dispatchOp.operandsMutable().assign(llvm::to_vector<4>(valuesDefinedAbove));
+
+  return success();
 }
 
 /// Checks if the `producer` can be fused into the dispatch region of the
@@ -550,7 +615,15 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
 
   // After outlining in dispatch region we can rewrite the dispatch ops with
   // proper captures.
-  funcOp.walk(legalizeDispatchWorkgroupOperands);
+  if (funcOp
+          .walk([&](IREE::Flow::DispatchWorkgroupsOp op) {
+            return succeeded(legalizeDispatchWorkgroupOperands(op))
+                       ? WalkResult::advance()
+                       : WalkResult::interrupt();
+          })
+          .wasInterrupted()) {
+    return signalPassFailure();
+  }
 
   // Rewrite destructive updates and ensure no remaining store remains to the
   // full output.

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -1,216 +1,216 @@
-// // RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -canonicalize -cse %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -canonicalize -cse %s | IreeFileCheck %s
 
-// func @tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
-//              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
-//   %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
-//     outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
-//   return %1 : tensor<?x?xf32>
-// }
-// //      CHECK: func @tensor
-// // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// //      CHECK:   flow.dispatch.workgroups
-// // CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[ARG2]])
-// // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// // CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// // CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// // CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
-// //  CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-// //  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
-// //  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
-// //  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
-// //  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
-// //  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
-// //  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
-// //      CHECK:     %[[OFFSET_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGID_Y]]
-// //      CHECK:     %[[STEP_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGCOUNT_Y]]
-// //      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
-// // CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
-// //      CHECK:       %[[OFFSET_X:.+]] = muli %[[WGSIZE_X]], %[[WGID_X]]
-// //      CHECK:       %[[STEP_X:.+]] = muli %[[WGSIZE_X]], %[[WGCOUNT_X]]
-// //      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
-// // CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
-// //      CHECK:         %[[LHS:.+]] = flow.dispatch.input.load %[[ARG3]]
-// // CHECK-SAME:           offsets = [%[[ARG7]], %[[C0]]]
-// //      CHECK:         %[[RHS:.+]] = flow.dispatch.input.load %[[ARG4]]
-// // CHECK-SAME:           offsets = [%[[C0]], %[[ARG8]]]
-// //      CHECK:         %[[INIT:.+]] = flow.dispatch.input.load %[[ARG5]]
-// // CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
-// //      CHECK:         %[[RESULT:.+]] = linalg.matmul
-// // CHECK-SAME:           ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
-// // CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
-// //      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]]
-// // CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
+func @tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
+             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: func @tensor
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//      CHECK:   flow.dispatch.workgroups
+// CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
+//  CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+//  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+//  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
+//  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
+//  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
+//  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
+//      CHECK:     %[[OFFSET_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGID_Y]]
+//      CHECK:     %[[STEP_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGCOUNT_Y]]
+//      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
+// CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
+//      CHECK:       %[[OFFSET_X:.+]] = muli %[[WGSIZE_X]], %[[WGID_X]]
+//      CHECK:       %[[STEP_X:.+]] = muli %[[WGSIZE_X]], %[[WGCOUNT_X]]
+//      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
+// CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
+//      CHECK:         %[[LHS:.+]] = flow.dispatch.input.load %[[ARG3]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[C0]]]
+//      CHECK:         %[[RHS:.+]] = flow.dispatch.input.load %[[ARG4]]
+// CHECK-SAME:           offsets = [%[[C0]], %[[ARG8]]]
+//      CHECK:         %[[INIT:.+]] = flow.dispatch.input.load %[[ARG5]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
+//      CHECK:         %[[RESULT:.+]] = linalg.matmul
+// CHECK-SAME:           ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
+//      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]]
+// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
 
-// // -----
+// -----
 
-// func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
-//   %c0 = constant 0 : index
-//   %c1 = constant 1 : index
-//   %d0 = dim %A, %c0 : tensor<?x?xf32>
-//   %d1 = dim %A, %c1 : tensor<?x?xf32>
-//   %0 = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
-//   %1 = linalg.generic {
-//     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-//                      affine_map<(d0, d1) -> (d1)>,
-//                      affine_map<(d0, d1) -> (d0, d1)>],
-//     iterator_types = ["parallel", "parallel"]}
-//     ins (%A, %B: tensor<?x?xf32>, tensor<?xf32>)
-//     outs (%0 : tensor<?x?xf32>) {
-//       ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
-//         %2 = addf %arg0, %arg1 : f32
-//         linalg.yield %2 : f32
-//     } -> tensor<?x?xf32>
-//   return %1 : tensor<?x?xf32>
-// }
-// //      CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d0 - d1)>
-// //      CHECK: func @generic_op
-// //      CHECK:   flow.dispatch.workgroups
-// // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]] : index
-// // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : index
-// // CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// // CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?xf32>
-// // CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
-// //  CHECK-DAG:     %[[WG_SIZE_X:.+]] = flow.dispatch.workgroup.size[0]
-// //  CHECK-DAG:     %[[WG_SIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
-// //      CHECK:     scf.for %[[IV0:[a-zA-Z0-9_]+]]
-// //      CHECK:       scf.for %[[IV1:.[a-zA-Z0-9_]+]]
-// //      CHECK:       %[[V1:.+]] = flow.dispatch.input.load %[[ARG4]]
-// //      CHECK:       %[[V2:.+]] = flow.dispatch.input.load %[[ARG5]]
-// //      CHECK:       %[[D0:.+]] = affine.min #[[MAP1]](%[[ARG2]], %[[IV0]], %[[WG_SIZE_Y]])
-// //      CHECK:       %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG3]], %[[IV1]], %[[WG_SIZE_X]])
-// //      CHECK:       %[[INIT:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
-// //      CHECK:       %[[RESULT:.+]] = linalg.generic
-// // CHECK-SAME:         ins(%[[V1]], %[[V2]] : tensor<?x?xf32>, tensor<?xf32>)
-// // CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
-// //      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]], offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[D0]], %[[D1]]]
+func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %d0 = dim %A, %c0 : tensor<?x?xf32>
+  %d1 = dim %A, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins (%A, %B: tensor<?x?xf32>, tensor<?xf32>)
+    outs (%0 : tensor<?x?xf32>) {
+      ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
+        %2 = addf %arg0, %arg1 : f32
+        linalg.yield %2 : f32
+    } -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d0 - d1)>
+//      CHECK: func @generic_op
+//      CHECK:   flow.dispatch.workgroups
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?xf32>
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : index
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : index
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
+//  CHECK-DAG:     %[[WG_SIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+//  CHECK-DAG:     %[[WG_SIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+//      CHECK:     scf.for %[[IV0:[a-zA-Z0-9_]+]]
+//      CHECK:       scf.for %[[IV1:.[a-zA-Z0-9_]+]]
+//      CHECK:       %[[V1:.+]] = flow.dispatch.input.load %[[ARG2]]
+//      CHECK:       %[[V2:.+]] = flow.dispatch.input.load %[[ARG3]]
+//      CHECK:       %[[D0:.+]] = affine.min #[[MAP1]](%[[ARG4]], %[[IV0]], %[[WG_SIZE_Y]])
+//      CHECK:       %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG5]], %[[IV1]], %[[WG_SIZE_X]])
+//      CHECK:       %[[INIT:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
+//      CHECK:       %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:         ins(%[[V1]], %[[V2]] : tensor<?x?xf32>, tensor<?xf32>)
+// CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
+//      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]], offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[D0]], %[[D1]]]
 
-// // -----
+// -----
 
-// func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
-//   %zero = constant 0.0 : f32
-//   %c0 = constant 0 : index
-//   %c1 = constant 1 : index
-//   %M = dim %A, %c0 : tensor<?x?xf32>
-//   %N = dim %B, %c1 : tensor<?x?xf32>
-//   %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
-//   %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
-//   %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
-//     outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
-//   return %2 : tensor<?x?xf32>
-// }
-// //       CHECK:   func @fuse_fill_with_producer
-// //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// //   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-// //   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-// //       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
-// //       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
-// //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-// //  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
-// //  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-// //  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-// //  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-// //       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
-// //       CHECK:        scf.for
-// //       CHECK:          scf.for
-// //   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
-// //   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
-// //   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
-// //       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-// //       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
-// //  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
-// //  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
-// //       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
-// //       CHECK:          flow.return
-// //       CHECK:        }
+func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %zero = constant 0.0 : f32
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %M = dim %A, %c0 : tensor<?x?xf32>
+  %N = dim %B, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}
+//       CHECK:   func @fuse_fill_with_producer
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+//       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
+//       CHECK:        scf.for
+//       CHECK:          scf.for
+//   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+//   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
+//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
+//  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+//       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
+//       CHECK:          flow.return
+//       CHECK:        }
 
-// // -----
+// -----
 
-// func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
-//   %zero = constant 0.0 : f32
-//   %one = constant 1.0 : f32
-//   %c0 = constant 0 : index
-//   %c1 = constant 1 : index
-//   %M = dim %A, %c0 : tensor<?x?xf32>
-//   %N = dim %B, %c1 : tensor<?x?xf32>
-//   %K = dim %A, %c1 : tensor<?x?xf32>
-//   %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
-//   %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
-//   %2 = linalg.init_tensor [%M, %K] : tensor<?x?xf32>
-//   %3 = linalg.generic
-//     {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-//                       affine_map<(d0, d1) -> (d0, d1)>],
-//      iterator_types = ["parallel", "parallel"]}
-//     ins(%A : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
-//     ^bb0(%arg0 : f32, %arg1 : f32):
-//       %4 = addf %arg0, %one : f32
-//       linalg.yield %4 : f32
-//     } -> tensor<?x?xf32>
-//   %4 = linalg.matmul ins(%3, %B : tensor<?x?xf32>, tensor<?x?xf32>)
-//     outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
-//   return %4 : tensor<?x?xf32>
-// }
-// //      CHECK: func @two_dispatches
-// //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// //   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-// //   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-// //   CHECK-DAG:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
-// //   CHECK-DAG:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
-// //   CHECK-DAG:     %[[K:.+]] = dim %[[ARG0]], %[[C1]]
-// //       CHECK:     %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[K]], %[[M]], %[[C1]]]
-// //  CHECK-SAME:       (%[[M]], %[[K]], %[[ARG0]])
-// //  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-// //  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-// //  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-// //       CHECK:          %[[ONE:.+]] = constant 1.0
-// //       CHECK:          scf.for
-// //       CHECK:            scf.for
-// //   CHECK-DAG:              %[[INPUT_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
-// //       CHECK:              %[[INIT_TILE:.+]] = linalg.init_tensor
-// //       CHECK:              %[[RESULT_TILE:.+]] = linalg.generic
-// //  CHECK-SAME:                ins(%[[INPUT_TILE]] : tensor<?x?xf32>)
-// //  CHECK-SAME:                outs(%[[INIT_TILE]] : tensor<?x?xf32>)
-// //       CHECK:              flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG5]]
-// //       CHECK:          flow.return
-// //       CHECK:        }
-// //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-// //       CHECK:       %[[ZERO:.+]] = constant 0.0
-// //       CHECK:       scf.for
-// //       CHECK:         scf.for
-// //       CHECK:            %[[INIT_TILE_2:.+]] = linalg.init_tensor
-// //       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE_2]], %[[ZERO]])
-// //       CHECK:            linalg.matmul
-// //       CHECK:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %zero = constant 0.0 : f32
+  %one = constant 1.0 : f32
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %M = dim %A, %c0 : tensor<?x?xf32>
+  %N = dim %B, %c1 : tensor<?x?xf32>
+  %K = dim %A, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %2 = linalg.init_tensor [%M, %K] : tensor<?x?xf32>
+  %3 = linalg.generic
+    {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                      affine_map<(d0, d1) -> (d0, d1)>],
+     iterator_types = ["parallel", "parallel"]}
+    ins(%A : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
+    ^bb0(%arg0 : f32, %arg1 : f32):
+      %4 = addf %arg0, %one : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?xf32>
+  %4 = linalg.matmul ins(%3, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %4 : tensor<?x?xf32>
+}
+//      CHECK: func @two_dispatches
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+//   CHECK-DAG:     %[[K:.+]] = dim %[[ARG0]], %[[C1]]
+//       CHECK:     %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[K]], %[[M]], %[[C1]]]
+//  CHECK-SAME:       (%[[ARG0]], %[[M]], %[[K]])
+//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : index
+//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       CHECK:          %[[ONE:.+]] = constant 1.0
+//       CHECK:          scf.for
+//       CHECK:            scf.for
+//   CHECK-DAG:              %[[INPUT_TILE:.+]] = flow.dispatch.input.load %[[ARG2]]
+//       CHECK:              %[[INIT_TILE:.+]] = linalg.init_tensor
+//       CHECK:              %[[RESULT_TILE:.+]] = linalg.generic
+//  CHECK-SAME:                ins(%[[INPUT_TILE]] : tensor<?x?xf32>)
+//  CHECK-SAME:                outs(%[[INIT_TILE]] : tensor<?x?xf32>)
+//       CHECK:              flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG5]]
+//       CHECK:          flow.return
+//       CHECK:        }
+//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+//       CHECK:       %[[ZERO:.+]] = constant 0.0
+//       CHECK:       scf.for
+//       CHECK:         scf.for
+//       CHECK:            %[[INIT_TILE_2:.+]] = linalg.init_tensor
+//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE_2]], %[[ZERO]])
+//       CHECK:            linalg.matmul
+//       CHECK:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
 
-// // The following CHECK* sems to hit a segfault with FileCheck. For now using a simpler check.
-// //  NOCHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
-// //  NOCHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-// //  NOCHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-// //  NOCHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  NOCHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  NOCHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// //  NOCHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-// //       NOCHECK:          %[[ZERO:.+]] = constant 0.0
-// //       NOCHECK:          scf.for
-// //       NOCHECK:            scf.for
-// //   NOCHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
-// //   NOCHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
-// //   NOCHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
-// //       NOCHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-// //       NOCHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
-// //  NOCHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
-// //       NOCHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
-// //       NOCHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
-// //       NOCHECK:          flow.return
-// //       NOCHECK:        }
+// The following CHECK* sems to hit a segfault with FileCheck. For now using a simpler check.
+//  NOCHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
+//  NOCHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+//  NOCHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+//  NOCHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+//  NOCHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+//       NOCHECK:          %[[ZERO:.+]] = constant 0.0
+//       NOCHECK:          scf.for
+//       NOCHECK:            scf.for
+//   NOCHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
+//   NOCHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
+//   NOCHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
+//       NOCHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+//       NOCHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
+//  NOCHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
+//       NOCHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
+//       NOCHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
+//       NOCHECK:          flow.return
+//       NOCHECK:        }
 
-// // -----
+// -----
 
 func @dot_general_lower() attributes {iree.module.export} {
   %cst = constant dense<[[[3.000000e-01, 5.000000e-01]]]> : tensor<1x1x2xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -1,216 +1,216 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -canonicalize -cse %s | IreeFileCheck %s
+// // RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -canonicalize -cse %s | IreeFileCheck %s
 
-func @tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
-             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
-    outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %1 : tensor<?x?xf32>
-}
-//      CHECK: func @tensor
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//      CHECK:   flow.dispatch.workgroups
-// CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[ARG2]])
-// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
-//  CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-//  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
-//  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
-//  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
-//  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
-//  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
-//  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
-//      CHECK:     %[[OFFSET_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGID_Y]]
-//      CHECK:     %[[STEP_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGCOUNT_Y]]
-//      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
-// CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
-//      CHECK:       %[[OFFSET_X:.+]] = muli %[[WGSIZE_X]], %[[WGID_X]]
-//      CHECK:       %[[STEP_X:.+]] = muli %[[WGSIZE_X]], %[[WGCOUNT_X]]
-//      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
-// CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
-//      CHECK:         %[[LHS:.+]] = flow.dispatch.input.load %[[ARG3]]
-// CHECK-SAME:           offsets = [%[[ARG7]], %[[C0]]]
-//      CHECK:         %[[RHS:.+]] = flow.dispatch.input.load %[[ARG4]]
-// CHECK-SAME:           offsets = [%[[C0]], %[[ARG8]]]
-//      CHECK:         %[[INIT:.+]] = flow.dispatch.input.load %[[ARG5]]
-// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
-//      CHECK:         %[[RESULT:.+]] = linalg.matmul
-// CHECK-SAME:           ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
-// CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
-//      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]]
-// CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
+// func @tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
+//              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+//   %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+//     outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+//   return %1 : tensor<?x?xf32>
+// }
+// //      CHECK: func @tensor
+// // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// //      CHECK:   flow.dispatch.workgroups
+// // CHECK-SAME:     (%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// // CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// // CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// // CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
+// //  CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// //  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+// //  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+// //  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
+// //  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
+// //  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
+// //  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
+// //      CHECK:     %[[OFFSET_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGID_Y]]
+// //      CHECK:     %[[STEP_Y:.+]] = muli %[[WGSIZE_Y]], %[[WGCOUNT_Y]]
+// //      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
+// // CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
+// //      CHECK:       %[[OFFSET_X:.+]] = muli %[[WGSIZE_X]], %[[WGID_X]]
+// //      CHECK:       %[[STEP_X:.+]] = muli %[[WGSIZE_X]], %[[WGCOUNT_X]]
+// //      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
+// // CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
+// //      CHECK:         %[[LHS:.+]] = flow.dispatch.input.load %[[ARG3]]
+// // CHECK-SAME:           offsets = [%[[ARG7]], %[[C0]]]
+// //      CHECK:         %[[RHS:.+]] = flow.dispatch.input.load %[[ARG4]]
+// // CHECK-SAME:           offsets = [%[[C0]], %[[ARG8]]]
+// //      CHECK:         %[[INIT:.+]] = flow.dispatch.input.load %[[ARG5]]
+// // CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
+// //      CHECK:         %[[RESULT:.+]] = linalg.matmul
+// // CHECK-SAME:           ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// // CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
+// //      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]]
+// // CHECK-SAME:           offsets = [%[[ARG7]], %[[ARG8]]]
 
-// -----
+// // -----
 
-func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
-  %d0 = dim %A, %c0 : tensor<?x?xf32>
-  %d1 = dim %A, %c1 : tensor<?x?xf32>
-  %0 = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
-  %1 = linalg.generic {
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-                     affine_map<(d0, d1) -> (d1)>,
-                     affine_map<(d0, d1) -> (d0, d1)>],
-    iterator_types = ["parallel", "parallel"]}
-    ins (%A, %B: tensor<?x?xf32>, tensor<?xf32>)
-    outs (%0 : tensor<?x?xf32>) {
-      ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
-        %2 = addf %arg0, %arg1 : f32
-        linalg.yield %2 : f32
-    } -> tensor<?x?xf32>
-  return %1 : tensor<?x?xf32>
-}
-//      CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d0 - d1)>
-//      CHECK: func @generic_op
-//      CHECK:   flow.dispatch.workgroups
-// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]] : index
-// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : index
-// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?xf32>
-// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
-//  CHECK-DAG:     %[[WG_SIZE_X:.+]] = flow.dispatch.workgroup.size[0]
-//  CHECK-DAG:     %[[WG_SIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
-//      CHECK:     scf.for %[[IV0:[a-zA-Z0-9_]+]]
-//      CHECK:       scf.for %[[IV1:.[a-zA-Z0-9_]+]]
-//      CHECK:       %[[V1:.+]] = flow.dispatch.input.load %[[ARG4]]
-//      CHECK:       %[[V2:.+]] = flow.dispatch.input.load %[[ARG5]]
-//      CHECK:       %[[D0:.+]] = affine.min #[[MAP1]](%[[ARG2]], %[[IV0]], %[[WG_SIZE_Y]])
-//      CHECK:       %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG3]], %[[IV1]], %[[WG_SIZE_X]])
-//      CHECK:       %[[INIT:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
-//      CHECK:       %[[RESULT:.+]] = linalg.generic
-// CHECK-SAME:         ins(%[[V1]], %[[V2]] : tensor<?x?xf32>, tensor<?xf32>)
-// CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
-//      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]], offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[D0]], %[[D1]]]
+// func @generic_op(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
+//   %c0 = constant 0 : index
+//   %c1 = constant 1 : index
+//   %d0 = dim %A, %c0 : tensor<?x?xf32>
+//   %d1 = dim %A, %c1 : tensor<?x?xf32>
+//   %0 = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
+//   %1 = linalg.generic {
+//     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+//                      affine_map<(d0, d1) -> (d1)>,
+//                      affine_map<(d0, d1) -> (d0, d1)>],
+//     iterator_types = ["parallel", "parallel"]}
+//     ins (%A, %B: tensor<?x?xf32>, tensor<?xf32>)
+//     outs (%0 : tensor<?x?xf32>) {
+//       ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
+//         %2 = addf %arg0, %arg1 : f32
+//         linalg.yield %2 : f32
+//     } -> tensor<?x?xf32>
+//   return %1 : tensor<?x?xf32>
+// }
+// //      CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d0 - d1)>
+// //      CHECK: func @generic_op
+// //      CHECK:   flow.dispatch.workgroups
+// // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]] : index
+// // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]] : index
+// // CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// // CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?xf32>
+// // CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>
+// //  CHECK-DAG:     %[[WG_SIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+// //  CHECK-DAG:     %[[WG_SIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+// //      CHECK:     scf.for %[[IV0:[a-zA-Z0-9_]+]]
+// //      CHECK:       scf.for %[[IV1:.[a-zA-Z0-9_]+]]
+// //      CHECK:       %[[V1:.+]] = flow.dispatch.input.load %[[ARG4]]
+// //      CHECK:       %[[V2:.+]] = flow.dispatch.input.load %[[ARG5]]
+// //      CHECK:       %[[D0:.+]] = affine.min #[[MAP1]](%[[ARG2]], %[[IV0]], %[[WG_SIZE_Y]])
+// //      CHECK:       %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG3]], %[[IV1]], %[[WG_SIZE_X]])
+// //      CHECK:       %[[INIT:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
+// //      CHECK:       %[[RESULT:.+]] = linalg.generic
+// // CHECK-SAME:         ins(%[[V1]], %[[V2]] : tensor<?x?xf32>, tensor<?xf32>)
+// // CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
+// //      CHECK:         flow.dispatch.output.store %[[RESULT]], %[[ARG6]], offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[D0]], %[[D1]]]
 
-// -----
+// // -----
 
-func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %zero = constant 0.0 : f32
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
-  %M = dim %A, %c0 : tensor<?x?xf32>
-  %N = dim %B, %c1 : tensor<?x?xf32>
-  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
-  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
-  %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
-    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %2 : tensor<?x?xf32>
-}
-//       CHECK:   func @fuse_fill_with_producer
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-//       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
-//       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
-//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-//  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
-//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-//       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
-//       CHECK:        scf.for
-//       CHECK:          scf.for
-//   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
-//   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
-//   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
-//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-//       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
-//  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
-//  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
-//       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
-//       CHECK:          flow.return
-//       CHECK:        }
+// func @fuse_fill_with_producer(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+//   %zero = constant 0.0 : f32
+//   %c0 = constant 0 : index
+//   %c1 = constant 1 : index
+//   %M = dim %A, %c0 : tensor<?x?xf32>
+//   %N = dim %B, %c1 : tensor<?x?xf32>
+//   %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+//   %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+//   %2 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+//     outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+//   return %2 : tensor<?x?xf32>
+// }
+// //       CHECK:   func @fuse_fill_with_producer
+// //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// //   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// //   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// //       CHECK:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+// //       CHECK:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+// //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+// //  CHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]])
+// //  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+// //  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+// //  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  CHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+// //       CHECK:        %[[ZERO:.+]] = constant 0.000000e+00 : f32
+// //       CHECK:        scf.for
+// //       CHECK:          scf.for
+// //   CHECK-DAG:            %[[LHS_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+// //   CHECK-DAG:            %[[RHS_TILE:.+]] = flow.dispatch.input.load %[[ARG5]]
+// //   CHECK-DAG:            %[[INIT_TILE:.+]] = linalg.init_tensor
+// //       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+// //       CHECK:            %[[RESULT_TILE:.+]] = linalg.matmul
+// //  CHECK-SAME:              ins(%[[LHS_TILE]], %[[RHS_TILE]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// //  CHECK-SAME:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+// //       CHECK:            flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG6]]
+// //       CHECK:          flow.return
+// //       CHECK:        }
 
-// -----
+// // -----
 
-func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %zero = constant 0.0 : f32
-  %one = constant 1.0 : f32
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
-  %M = dim %A, %c0 : tensor<?x?xf32>
-  %N = dim %B, %c1 : tensor<?x?xf32>
-  %K = dim %A, %c1 : tensor<?x?xf32>
-  %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
-  %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
-  %2 = linalg.init_tensor [%M, %K] : tensor<?x?xf32>
-  %3 = linalg.generic
-    {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-                      affine_map<(d0, d1) -> (d0, d1)>],
-     iterator_types = ["parallel", "parallel"]}
-    ins(%A : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
-    ^bb0(%arg0 : f32, %arg1 : f32):
-      %4 = addf %arg0, %one : f32
-      linalg.yield %4 : f32
-    } -> tensor<?x?xf32>
-  %4 = linalg.matmul ins(%3, %B : tensor<?x?xf32>, tensor<?x?xf32>)
-    outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %4 : tensor<?x?xf32>
-}
-//      CHECK: func @two_dispatches
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
-//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-//   CHECK-DAG:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
-//   CHECK-DAG:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
-//   CHECK-DAG:     %[[K:.+]] = dim %[[ARG0]], %[[C1]]
-//       CHECK:     %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[K]], %[[M]], %[[C1]]]
-//  CHECK-SAME:       (%[[M]], %[[K]], %[[ARG0]])
-//  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-//  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-//       CHECK:          %[[ONE:.+]] = constant 1.0
-//       CHECK:          scf.for
-//       CHECK:            scf.for
-//   CHECK-DAG:              %[[INPUT_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
-//       CHECK:              %[[INIT_TILE:.+]] = linalg.init_tensor
-//       CHECK:              %[[RESULT_TILE:.+]] = linalg.generic
-//  CHECK-SAME:                ins(%[[INPUT_TILE]] : tensor<?x?xf32>)
-//  CHECK-SAME:                outs(%[[INIT_TILE]] : tensor<?x?xf32>)
-//       CHECK:              flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG5]]
-//       CHECK:          flow.return
-//       CHECK:        }
-//       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
-//       CHECK:       %[[ZERO:.+]] = constant 0.0
-//       CHECK:       scf.for
-//       CHECK:         scf.for
-//       CHECK:            %[[INIT_TILE_2:.+]] = linalg.init_tensor
-//       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE_2]], %[[ZERO]])
-//       CHECK:            linalg.matmul
-//       CHECK:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
+// func @two_dispatches(%A : tensor<?x?xf32>, %B : tensor<?x?xf32>) -> tensor<?x?xf32> {
+//   %zero = constant 0.0 : f32
+//   %one = constant 1.0 : f32
+//   %c0 = constant 0 : index
+//   %c1 = constant 1 : index
+//   %M = dim %A, %c0 : tensor<?x?xf32>
+//   %N = dim %B, %c1 : tensor<?x?xf32>
+//   %K = dim %A, %c1 : tensor<?x?xf32>
+//   %0 = linalg.init_tensor [%M, %N] : tensor<?x?xf32>
+//   %1 = linalg.fill(%0, %zero) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+//   %2 = linalg.init_tensor [%M, %K] : tensor<?x?xf32>
+//   %3 = linalg.generic
+//     {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+//                       affine_map<(d0, d1) -> (d0, d1)>],
+//      iterator_types = ["parallel", "parallel"]}
+//     ins(%A : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
+//     ^bb0(%arg0 : f32, %arg1 : f32):
+//       %4 = addf %arg0, %one : f32
+//       linalg.yield %4 : f32
+//     } -> tensor<?x?xf32>
+//   %4 = linalg.matmul ins(%3, %B : tensor<?x?xf32>, tensor<?x?xf32>)
+//     outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+//   return %4 : tensor<?x?xf32>
+// }
+// //      CHECK: func @two_dispatches
+// //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// //   CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// //   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// //   CHECK-DAG:     %[[M:.+]] = dim %[[ARG0]], %[[C0]]
+// //   CHECK-DAG:     %[[N:.+]] = dim %[[ARG1]], %[[C1]]
+// //   CHECK-DAG:     %[[K:.+]] = dim %[[ARG0]], %[[C1]]
+// //       CHECK:     %[[RESULT1:.+]] = flow.dispatch.workgroups[%[[K]], %[[M]], %[[C1]]]
+// //  CHECK-SAME:       (%[[M]], %[[K]], %[[ARG0]])
+// //  CHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+// //  CHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+// //  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+// //       CHECK:          %[[ONE:.+]] = constant 1.0
+// //       CHECK:          scf.for
+// //       CHECK:            scf.for
+// //   CHECK-DAG:              %[[INPUT_TILE:.+]] = flow.dispatch.input.load %[[ARG4]]
+// //       CHECK:              %[[INIT_TILE:.+]] = linalg.init_tensor
+// //       CHECK:              %[[RESULT_TILE:.+]] = linalg.generic
+// //  CHECK-SAME:                ins(%[[INPUT_TILE]] : tensor<?x?xf32>)
+// //  CHECK-SAME:                outs(%[[INIT_TILE]] : tensor<?x?xf32>)
+// //       CHECK:              flow.dispatch.output.store %[[RESULT_TILE]], %[[ARG5]]
+// //       CHECK:          flow.return
+// //       CHECK:        }
+// //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
+// //       CHECK:       %[[ZERO:.+]] = constant 0.0
+// //       CHECK:       scf.for
+// //       CHECK:         scf.for
+// //       CHECK:            %[[INIT_TILE_2:.+]] = linalg.init_tensor
+// //       CHECK:            %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE_2]], %[[ZERO]])
+// //       CHECK:            linalg.matmul
+// //       CHECK:              outs(%[[FILL_TILE]] : tensor<?x?xf32>)
 
-// The following CHECK* sems to hit a segfault with FileCheck. For now using a simpler check.
-//  NOCHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
-//  NOCHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
-//  NOCHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
-//  NOCHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  NOCHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  NOCHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
-//  NOCHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
-//       NOCHECK:          %[[ZERO:.+]] = constant 0.0
-//       NOCHECK:          scf.for
-//       NOCHECK:            scf.for
-//   NOCHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
-//   NOCHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
-//   NOCHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
-//       NOCHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
-//       NOCHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
-//  NOCHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
-//       NOCHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
-//       NOCHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
-//       NOCHECK:          flow.return
-//       NOCHECK:        }
+// // The following CHECK* sems to hit a segfault with FileCheck. For now using a simpler check.
+// //  NOCHECK-SAME:       (%[[M]], %[[N]], %[[ARG0]], %[[ARG1]], %[[RESULT1]])
+// //  NOCHECK-SAME:       (%[[ARG2:[a-zA-Z0-9_]+]] : index
+// //  NOCHECK-SAME:        %[[ARG3:[a-zA-Z0-9_]+]] : index
+// //  NOCHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  NOCHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  NOCHECK-SAME:        %[[ARG6:[a-zA-Z0-9_]+]] : !flow.dispatch.input<?x?xf32>
+// //  NOCHECK-SAME:        %[[ARG7:[a-zA-Z0-9_]+]] : !flow.dispatch.output<?x?xf32>) {
+// //       NOCHECK:          %[[ZERO:.+]] = constant 0.0
+// //       NOCHECK:          scf.for
+// //       NOCHECK:            scf.for
+// //   NOCHECK-DAG:              %[[LHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG6]]
+// //   NOCHECK-DAG:              %[[RHS_TILE_2:.+]] = flow.dispatch.input.load %[[ARG5]]
+// //   NOCHECK-DAG:              %[[INIT_TILE_2:.+]] = linalg.init_tensor
+// //       NOCHECK:              %[[FILL_TILE:.+]] = linalg.fill(%[[INIT_TILE]], %[[ZERO]])
+// //       NOCHECK:              %[[RESULT_TILE_2:.++]]] = linalg.matmul
+// //  NOCHECK-SAME:                ins(%[[LHS_TILE_2]], %[[RHS_TILE_2]] : tensor<?x?xf32>, tensor<?x?xf32>)
+// //       NOCHECK:                outs(%[[FILL_TILE_2]] : tensor<?x?xf32>)
+// //       NOCHECK:              flow.dispatch.output.store %[[RESULT_TILE_2]], %[[ARG7]]
+// //       NOCHECK:          flow.return
+// //       NOCHECK:        }
 
-// -----
+// // -----
 
 func @dot_general_lower() attributes {iree.module.export} {
   %cst = constant dense<[[[3.000000e-01, 5.000000e-01]]]> : tensor<1x1x2xf32>


### PR DESCRIPTION
Operations like linalg.tensor_reshape and linalg.init_tensor need to
be cloned within the created dispatch region operation always. This
makes the logic of legalizing the flow.dispatch.workgroups op more
involved since it needs to account for
1) The values that are defined outside of the dispatch region needs to
   account for operations that will be cloned.
2) The cloned operations need to be inserted at the point where it can
   use the mapped values from within the dispatch op for its operations.