### PR TITLE
Disabling failing reverse linalg-on-tensors test.

### DIFF
--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -173,7 +173,7 @@ iree_check_single_backend_test_suite(
         # "reduce_window.mlir",
         "remainder.mlir",
         # "reshape.mlir",
-        "reverse.mlir",
+        # "reverse.mlir",
         "rsqrt.mlir",
         "select.mlir",
         "sine.mlir",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -158,7 +158,7 @@ iree_check_single_backend_test_suite(
     "multiply.mlir"
     "negate.mlir"
     "remainder.mlir"
-    "reverse.mlir"
+    # "reverse.mlir"
     "rsqrt.mlir"
     "select.mlir"
     "sine.mlir"

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -158,7 +158,6 @@ iree_check_single_backend_test_suite(
     "multiply.mlir"
     "negate.mlir"
     "remainder.mlir"
-    # "reverse.mlir"
     "rsqrt.mlir"
     "select.mlir"
     "sine.mlir"


### PR DESCRIPTION
Reverse results in an iree-translate compiler crash during compilation.