### PR TITLE
Abstracting out LLVM HAL ABI use to HALDispatchABI utility.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -41,8 +41,6 @@ cc_library(
         "//iree/compiler/Conversion/HLOToHLO",
         "//iree/compiler/Conversion/HLOToLinalg",
         "//iree/compiler/Conversion/LLVMToLLVM",
-        "//iree/compiler/Dialect/Flow/IR",
-        "//iree/compiler/Dialect/Flow/Transforms",
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
         "//iree/compiler/Dialect/IREE/IR",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -55,8 +55,6 @@ iree_cc_library(
     iree::compiler::Conversion::HLOToHLO
     iree::compiler::Conversion::HLOToLinalg
     iree::compiler::Conversion::LLVMToLLVM
-    iree::compiler::Dialect::Flow::IR
-    iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::IREE::IR

--- a/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/ConvertToLLVM.cpp
@@ -14,7 +14,6 @@
 
 #include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
 #include "iree/compiler/Conversion/LinalgToLLVM/Passes.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEDialect.h"
@@ -45,89 +44,237 @@ namespace iree_compiler {
 
 namespace {
 
-static constexpr int kIndexPackedBuffer = 0;
-static constexpr int kIndexPushConstant = 1;
-static constexpr int kIndexWorkGroupId = 2;
-static constexpr int kIndexWorkGroupCount = 3;
-static constexpr int kIndexWorkGroupSize = 4;
+// NOTE: HALDispatchABI and the associated conversion patterns should live under
+// iree/compiler/Dialect/HAL/Target/LLVM/ instead of here as they have nothing
+// to do with linalg. If we need to use the patterns in this conversion we can
+// expose a populate*Patterns() function to access them without needing them
+// defined here.
 
-// Return the index type: i32.
-static Type getIndexTy(MLIRContext *context) {
-  return IntegerType::get(context, 32);
-}
-
-// func foo(%packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>,
-//          %push_constant: !llvm.ptr<i32>,
-//          workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//          workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//          workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
-static SmallVector<Type, 5> getABITypes(MLIRContext *context) {
-  auto indexTy = getIndexTy(context);
-  return SmallVector<Type, 5>{
-      // %packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>
-      LLVM::LLVMPointerType::get(
-          LLVM::LLVMPointerType::get(IntegerType::get(context, 8))),
-      // %push_constant: !llvm.ptr<i32>
-      LLVM::LLVMPointerType::get(indexTy),
-      // %workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>
-      LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3)),
-      // %workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>
-      LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3)),
-      // %workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>
-      LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3))};
-}
-
-// Convert to an LLVMFuncOp form with LLVM types. This implements an ABI that is
-// compatible with IREE and which cannot be represented in std atm.
-// Since it cannot be represented in std, this is an IREE-specific conversion.
-// The conversion rewrites the argument-less and return-less function:
-//
-// ```
-//    func @foo() { ... }
-// ```
-//
-// into:
-//
-// ```
-//    llvm.func foo(%packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>,
-//                  %push_constant: !llvm.ptr<i32>,
-//                  workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//                  workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//                  workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
-// ```
-//
-// Bump the benefit of the pattern to 100 to pick this pattern instead of a
-// competing pattern inserted by `populateStdToLLVMConversionPatterns`.
-class ConvertFunc : public ConvertToLLVMPattern {
+// Utility for accessing the IREE HAL dispatch function ABI values.
+// All accesses should route through this vs directly manipulating LLVM function
+// arguments so that we can adjust the ABI over time and support multiple
+// versions in the same compiled output.
+class HALDispatchABI {
  public:
-  explicit ConvertFunc(MLIRContext *context, LLVMTypeConverter &converter)
+  static constexpr int kIndexPackedBuffer = 0;
+  static constexpr int kIndexPushConstant = 1;
+  static constexpr int kIndexWorkGroupId = 2;
+  static constexpr int kIndexWorkGroupCount = 3;
+  static constexpr int kIndexWorkGroupSize = 4;
+
+  // Returns the types of the LLVM function inputs for the ABI.
+  // This matches the signature of `iree_hal_executable_dispatch_v0_t` in
+  // `iree/hal/local/executable_library.h`.
+  static SmallVector<Type, 5> getInputTypes(MLIRContext *context) {
+    // func foo(%packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>,
+    //          %push_constant: !llvm.ptr<i32>,
+    //          workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>,
+    //          workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
+    //          workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
+    auto indexTy = IntegerType::get(context, 32);
+    return SmallVector<Type, 5>{
+        // %packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>
+        LLVM::LLVMPointerType::get(
+            LLVM::LLVMPointerType::get(IntegerType::get(context, 8))),
+        // %push_constant: !llvm.ptr<i32>
+        LLVM::LLVMPointerType::get(indexTy),
+        // %workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>
+        LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3)),
+        // %workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>
+        LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3)),
+        // %workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>
+        LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(indexTy, 3))};
+  }
+
+  explicit HALDispatchABI(LLVM::LLVMFuncOp &funcOp,
+                          LLVMTypeConverter *typeConverter)
+      : funcOp(funcOp), typeConverter(typeConverter) {}
+
+  // Loads the workgroup_id[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupID(Location loc, int32_t dim, Type resultType,
+                        OpBuilder &builder) {
+    auto xyzArrayPtr = funcOp.getArgument(kIndexWorkGroupId);
+    auto xyzArrayValue = builder.createOrFold<LLVM::LoadOp>(loc, xyzArrayPtr);
+    auto dimValue = builder.createOrFold<LLVM::ExtractValueOp>(
+        loc, builder.getIntegerType(32), xyzArrayValue,
+        builder.getI32ArrayAttr({dim}));
+    return castValueToType(loc, dimValue, resultType, builder);
+  }
+
+  // Loads the workgroup_count[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupCount(Location loc, int32_t dim, Type resultType,
+                           OpBuilder &builder) {
+    auto xyzArrayPtr = funcOp.getArgument(kIndexWorkGroupCount);
+    auto xyzArrayValue = builder.createOrFold<LLVM::LoadOp>(loc, xyzArrayPtr);
+    auto dimValue = builder.createOrFold<LLVM::ExtractValueOp>(
+        loc, builder.getIntegerType(32), xyzArrayValue,
+        builder.getI32ArrayAttr({dim}));
+    return castValueToType(loc, dimValue, resultType, builder);
+  }
+
+  // Loads the workgroup_size[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupSize(Location loc, int32_t dim, Type resultType,
+                          OpBuilder &builder) {
+    auto xyzArrayPtr = funcOp.getArgument(kIndexWorkGroupSize);
+    auto xyzArrayValue = builder.createOrFold<LLVM::LoadOp>(loc, xyzArrayPtr);
+    auto dimValue = builder.createOrFold<LLVM::ExtractValueOp>(
+        loc, builder.getIntegerType(32), xyzArrayValue,
+        builder.getI32ArrayAttr({dim}));
+    return castValueToType(loc, dimValue, resultType, builder);
+  }
+
+  // Returns the total push constant count as an index-converted type.
+  Value loadPushConstantCount(Location loc, OpBuilder &builder) {
+    // TODO(#3580): switch to the executable_library ABI.
+    assert(false && "not yet implemented");
+    return {};
+  }
+
+  // Loads a push constant at |offset| and casts it to |resultType|.
+  Value loadPushConstant(Location loc, int64_t offset, Type resultType,
+                         OpBuilder &builder) {
+    Value offsetValue = builder.create<LLVM::DialectCastOp>(
+        loc, typeConverter->convertType(builder.getIndexType()),
+        builder.create<ConstantIndexOp>(loc, offset));
+    Value pushConstantPtrValue = builder.create<LLVM::GEPOp>(
+        loc, funcOp.getArgument(kIndexPushConstant).getType(),
+        funcOp.getArgument(kIndexPushConstant), offsetValue);
+    Value pushConstantValue =
+        builder.create<LLVM::LoadOp>(loc, pushConstantPtrValue);
+    return castValueToType(loc, pushConstantValue, resultType, builder);
+  }
+
+  // Returns the total binding count as an index-converted type.
+  Value loadBindingCount(Location loc, OpBuilder &builder) {
+    // TODO(#3580): switch to the executable_library ABI.
+    assert(false && "not yet implemented");
+    return {};
+  }
+
+  // Loads the base pointer of the binding |ordinal| as an `i8**`.
+  // Equivalent to:
+  //   int8_t** base_ptr = &state->binding_ptrs[ordinal];
+  Value loadBindingPtr(Location loc, int64_t ordinal, OpBuilder &builder) {
+    Value ordinalValue = builder.createOrFold<LLVM::DialectCastOp>(
+        loc, typeConverter->convertType(builder.getIndexType()),
+        builder.create<ConstantIndexOp>(loc, ordinal));
+    return builder.createOrFold<LLVM::GEPOp>(
+        loc, funcOp.getArgument(kIndexPackedBuffer).getType(),
+        funcOp.getArgument(kIndexPackedBuffer), ordinalValue);
+  }
+
+  // Loads the byte length of the binding |ordinal| as an index-converted type.
+  Value loadBindingLength(Location loc, int64_t ordinal, OpBuilder &builder) {
+    // TODO(#3580): switch to the executable_library ABI.
+    assert(false && "not yet implemented");
+    return {};
+  }
+
+  // Loads a binding as a constructed MemRefDescriptor.
+  // |baseOffset| can optionally adjust the base byte offset of the buffer.
+  MemRefDescriptor loadBinding(Location loc, int64_t ordinal,
+                               Value baseOffsetValue, MemRefType memRefType,
+                               OpBuilder &builder) {
+    // Load the base buffer pointer in the appropriate type (f32*, etc).
+    Value opaqueBasePtrValue = loadBindingPtr(loc, ordinal, builder);
+    Value basePtrValue = builder.create<LLVM::LoadOp>(loc, opaqueBasePtrValue);
+
+    // Adjust by baseOffset (if needed).
+    if (baseOffsetValue) {
+      basePtrValue = builder.createOrFold<LLVM::GEPOp>(
+          loc, basePtrValue.getType(), basePtrValue, baseOffsetValue);
+    }
+
+    // NOTE: if we wanted to check the range was in bounds here would be the
+    // place to do it.
+
+    // Cast to the desired memref element type.
+    auto elementType = typeConverter->convertType(memRefType.getElementType());
+    Value typedPtrValue = builder.createOrFold<LLVM::BitcastOp>(
+        loc,
+        LLVM::LLVMPointerType::get(elementType, memRefType.getMemorySpace()),
+        basePtrValue);
+
+    // Construct the MemRefDescriptor type based on the information we have.
+    // NOTE: we could use the binding length to clamp this/check that the
+    // requested range is valid.
+    if (memRefType.hasStaticShape()) {
+      return MemRefDescriptor::fromStaticShape(builder, loc, *typeConverter,
+                                               memRefType, typedPtrValue);
+    } else {
+      auto desc = MemRefDescriptor::undef(
+          builder, loc, typeConverter->convertType(memRefType));
+      desc.setAllocatedPtr(builder, loc, typedPtrValue);
+      desc.setAlignedPtr(builder, loc, typedPtrValue);
+      return desc;
+    }
+  }
+
+ private:
+  Value castValueToType(Location loc, Value value, Type resultType,
+                        OpBuilder &builder) {
+    // NOTE: we should handle more cases here (and proper sign extension).
+    if (value.getType() == resultType) return value;
+    return builder.createOrFold<LLVM::ZExtOp>(loc, resultType, value);
+  }
+
+  LLVM::LLVMFuncOp funcOp;
+  LLVMTypeConverter *typeConverter;
+};
+
+/// Converts Standard MLIR FuncOps to LLVMFuncOps matching the IREE HAL ABI.
+/// This is an IREE-specific conversion that assumes the input function is
+/// `() -> ()` and that hal.interface.* ops are used to access all state.
+///
+/// Source function:
+///
+/// ```
+/// func @foo() {
+///   %0 = hal.interface.binding.subspan ...
+/// }
+/// ```
+///
+/// into:
+///
+/// ```
+/// llvm.func foo(%state: !llvm.ptr<!...>,
+///               %workgroup_id : !llvm.ptr<!llvm.array<i32, 3>>) {
+///   %0 = <GEP/loads to access binding in %state>
+/// }
+/// ```
+///
+/// See `iree/hal/local/executable_library.h` for more information.
+///
+/// NOTE: we bump the benefit of the pattern to 100 to pick this pattern instead
+/// of a competing pattern inserted by `populateStdToLLVMConversionPatterns`.
+class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertHALEntryPointFuncOp(MLIRContext *context,
+                                      LLVMTypeConverter &converter)
       : ConvertToLLVMPattern(mlir::FuncOp::getOperationName(), context,
                              converter, 100) {}
 
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto funcOp = cast<FuncOp>(op);
-    FunctionType fnType = funcOp.getType();
-    (void)fnType;
-    if (!funcOp.isPublic()) return failure();
+    auto stdFuncOp = cast<FuncOp>(op);
+    if (!stdFuncOp.isPublic()) return failure();
+    FunctionType fnType = stdFuncOp.getType();
+    if (fnType.getNumInputs() != 0 || fnType.getNumResults() != 0) {
+      op->emitWarning() << "public functions on executables must be () -> ()";
+      return failure();
+    }
 
-    // illegal FuncOp must have 0 inputs.
-    assert(fnType.getNumInputs() == 0 && fnType.getNumResults() == 0);
-
-    // func foo(%packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>,
-    //          %push_constant: !llvm.ptr<i32>,
-    //          workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-    //          workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-    //          workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
+    // Convert the function signature to take the HAL ABI LLVM pointers.
     TypeConverter::SignatureConversion signatureConverter(/*numOrigInputs=*/0);
     MLIRContext *context = rewriter.getContext();
-    SmallVector<Type, 5> llvmInputTypes = getABITypes(context);
-    signatureConverter.addInputs(llvmInputTypes);
+    auto abiInputTypes = HALDispatchABI::getInputTypes(context);
+    signatureConverter.addInputs(abiInputTypes);
 
-    // Construct newFunc with all attributes except return type & symbol name.
+    // Copy all attributes onto the LLVM function except the ones handled by
+    // MLIR implicitly.
     SmallVector<NamedAttribute, 4> funcAttrs;
-    for (auto attr : funcOp.getAttrs()) {
+    for (auto attr : stdFuncOp.getAttrs()) {
       if (attr.first == SymbolTable::getSymbolAttrName() ||
           attr.first == mlir::impl::getTypeAttrName()) {
         continue;
@@ -135,103 +282,197 @@ class ConvertFunc : public ConvertToLLVMPattern {
       funcAttrs.push_back(attr);
     }
 
+    // Clone the function as an LLVMFuncOp and convert all interior types.
     auto llvmFuncType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(rewriter.getContext()), llvmInputTypes);
-    auto newFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
-        funcOp.getLoc(), funcOp.getName(), llvmFuncType,
+        LLVM::LLVMVoidType::get(rewriter.getContext()), abiInputTypes);
+    auto llvmFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+        stdFuncOp.getLoc(), stdFuncOp.getName(), llvmFuncType,
         LLVM::Linkage::External, funcAttrs);
-
-    // Copy all of funcOp's operations into newFuncOp's body and perform region
-    // type conversion.
-    rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
-                                newFuncOp.end());
-    if (failed(rewriter.convertRegionTypes(&newFuncOp.getBody(), *typeConverter,
-                                           &signatureConverter)))
+    rewriter.inlineRegionBefore(stdFuncOp.getBody(), llvmFuncOp.getBody(),
+                                llvmFuncOp.end());
+    if (failed(rewriter.convertRegionTypes(
+            &llvmFuncOp.getBody(), *typeConverter, &signatureConverter))) {
       return failure();
+    }
 
-    rewriter.eraseOp(funcOp);
+    rewriter.eraseOp(stdFuncOp);
     return success();
   }
 };
 
-/// Returns the IREE::HAL::InterfaceBindingOp from an interface op.
-// TODO(ravishankarm) : Copy of similar method in LinalgToSPIRV path. Consider
-// combining them.
-IREE::HAL::InterfaceBindingOp getBindingOp(Operation *op) {
-  if (auto placeholderOp = dyn_cast<IREE::PlaceholderOp>(op)) {
-    return cast<IREE::HAL::InterfaceBindingOp>(
-        SymbolTable::lookupNearestSymbolFrom(
-            op, op->getAttrOfType<SymbolRefAttr>("binding")));
-  }
-  if (auto bindingSubspanOp =
-          dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(op)) {
-    return bindingSubspanOp.queryBindingOp();
-  }
-  llvm_unreachable("unknown interface binding op");
-}
-
-// Assumes the enclosing FuncOp has been converted to IREE-compatible ABI:
-// ```
-//    llvm.func foo(%packed_buffer_args: !llvm.ptr<!llvm.ptr<i8>>,
-//                  %push_constant: !llvm.ptr<i32>,
-//                  workgroup_id[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//                  workgroup_count[3]: !llvm.ptr<!llvm.array<i32, 3>>,
-//                  workgroup_size[3]: !llvm.ptr<!llvm.array<i32, 3>>)
-// ```
-//
-// Rewrites BindingOp into the proper memref descriptor extracted from
-// `packed_buffer_args`.
-template <typename BindingOp>
-class ConvertBindingOp : public ConvertToLLVMPattern {
+/// Rewrites hal.interface.workgroup.id to ops loading from the ABI structs.
+///
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+class ConvertHALInterfaceWorkgroupIDOp : public ConvertToLLVMPattern {
  public:
-  explicit ConvertBindingOp(MLIRContext *context, LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(BindingOp::getOperationName(), context,
+  explicit ConvertHALInterfaceWorkgroupIDOp(MLIRContext *context,
+                                            LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(
+            IREE::HAL::InterfaceWorkgroupIDOp::getOperationName(), context,
+            converter) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupIDOp>(op)
+                      .dimension()
+                      .getZExtValue();
+    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    rewriter.replaceOp(
+        op, abi.loadWorkgroupID(op->getLoc(), dim, resultType, rewriter));
+    return success();
+  }
+};
+
+/// Rewrites hal.interface.workgroup.size to ops loading from the ABI structs.
+///
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+class ConvertHALInterfaceWorkgroupSizeOp : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertHALInterfaceWorkgroupSizeOp(MLIRContext *context,
+                                              LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(
+            IREE::HAL::InterfaceWorkgroupSizeOp::getOperationName(), context,
+            converter) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupSizeOp>(op)
+                      .dimension()
+                      .getZExtValue();
+    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    rewriter.replaceOp(
+        op, abi.loadWorkgroupSize(op->getLoc(), dim, resultType, rewriter));
+    return success();
+  }
+};
+
+/// Rewrites hal.interface.workgroup.count to ops loading from the ABI structs.
+///
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+class ConvertHALInterfaceWorkgroupCountOp : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertHALInterfaceWorkgroupCountOp(MLIRContext *context,
+                                               LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(
+            IREE::HAL::InterfaceWorkgroupCountOp::getOperationName(), context,
+            converter) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupCountOp>(op)
+                      .dimension()
+                      .getZExtValue();
+    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    rewriter.replaceOp(
+        op, abi.loadWorkgroupCount(op->getLoc(), dim, resultType, rewriter));
+    return success();
+  }
+};
+
+/// Rewrites hal.interface.load.constant to ops loading from the ABI structs.
+///
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+class ConvertHALInterfaceLoadConstant : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertHALInterfaceLoadConstant(MLIRContext *context,
+                                           LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(
+            IREE::HAL::InterfaceLoadConstantOp::getOperationName(), context,
+            converter) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    auto loadConstantOp = cast<IREE::HAL::InterfaceLoadConstantOp>(op);
+    int64_t offset = loadConstantOp.offset().getZExtValue();
+    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    rewriter.replaceOp(
+        op, abi.loadPushConstant(op->getLoc(), offset, resultType, rewriter));
+    return success();
+  }
+};
+
+/// Rewrites hal.interface.binding.subspan to ops loading from the ABI structs.
+///
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertHALInterfaceBindingSubspanOp(MLIRContext *context,
+                                               LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(
+            IREE::HAL::InterfaceBindingSubspanOp::getOperationName(), context,
+            converter) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    auto interfaceBindingOp =
+        cast<IREE::HAL::InterfaceBindingSubspanOp>(op).queryBindingOp();
+    IREE::HAL::InterfaceBindingSubspanOpAdaptor newOperands(operands);
+    MemRefType memRefType = op->getResult(0).getType().cast<MemRefType>();
+    auto memRefDesc =
+        abi.loadBinding(op->getLoc(), interfaceBindingOp.binding(),
+                        newOperands.byte_offset(), memRefType, rewriter);
+    rewriter.replaceOp(op, {memRefDesc});
+    return success();
+  }
+};
+
+/// DEPRECATED: delete this as soon as linalg on buffers and iree.placeholder
+/// are gone.
+class ConvertLegacyPlaceholderOp : public ConvertToLLVMPattern {
+ public:
+  explicit ConvertLegacyPlaceholderOp(MLIRContext *context,
+                                      LLVMTypeConverter &converter)
+      : ConvertToLLVMPattern(IREE::PlaceholderOp::getOperationName(), context,
                              converter) {}
 
   LogicalResult matchAndRewrite(
       Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    // Bail until nested under an LLVMFuncOp.
     auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
     if (!llvmFuncOp) return failure();
-    assert(llvmFuncOp.getNumArguments() > 0);
+    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
+    auto interfaceBindingOp = cast<IREE::HAL::InterfaceBindingOp>(
+        SymbolTable::lookupNearestSymbolFrom(
+            op, op->getAttrOfType<SymbolRefAttr>("binding")));
+    MemRefType memRefType = op->getResult(0).getType().cast<MemRefType>();
+    auto memRefDesc =
+        abi.loadBinding(op->getLoc(), interfaceBindingOp.binding(),
+                        /*baseOffset=*/{}, memRefType, rewriter);
+    rewriter.replaceOp(op, {memRefDesc});
+    return success();
+  }
+};
 
-    auto llvmTypeConverter = getTypeConverter();
-    Location loc = op->getLoc();
-    MemRefType memrefType = op->getResult(0).getType().dyn_cast<MemRefType>();
-    auto elementType = typeConverter->convertType(memrefType.getElementType());
-
-    // Fetch the interface binding op and extract the buffer index from void**.
-    auto interfaceBindingOp = getBindingOp(op);
-    Value bufferIndex =
-        rewriter.create<ConstantIndexOp>(loc, interfaceBindingOp.binding());
-    Value llvmBufferIndex = rewriter.create<LLVM::DialectCastOp>(
-        loc, llvmTypeConverter->convertType(bufferIndex.getType()),
-        bufferIndex);
-    Value llvmBufferBasePtrAddr = rewriter.create<LLVM::GEPOp>(
-        loc, llvmFuncOp.getArgument(kIndexPackedBuffer).getType(),
-        llvmFuncOp.getArgument(kIndexPackedBuffer), llvmBufferIndex);
-
-    Value packedBuffersArgsPtrCasted = rewriter.create<LLVM::BitcastOp>(
-        loc,
-        LLVM::LLVMPointerType::get(LLVM::LLVMPointerType::get(
-            elementType, memrefType.getMemorySpace())),
-        llvmBufferBasePtrAddr);
-
-    Value llvmBufferBasePtr =
-        rewriter.create<LLVM::LoadOp>(loc, packedBuffersArgsPtrCasted);
-    if (memrefType.hasStaticShape()) {
-      auto desc = MemRefDescriptor::fromStaticShape(
-          rewriter, loc, *getTypeConverter(), memrefType, llvmBufferBasePtr);
-      rewriter.replaceOp(op, {desc});
-    } else {
-      auto desc = MemRefDescriptor::undef(
-          rewriter, loc, typeConverter->convertType(memrefType));
-      desc.setAllocatedPtr(rewriter, loc, llvmBufferBasePtr);
-      desc.setAlignedPtr(rewriter, loc, llvmBufferBasePtr);
-      rewriter.replaceOp(op, {desc});
-    }
-
+class RemoveHALInterfaceOpPattern : public ConvertToLLVMPattern {
+ public:
+  explicit RemoveHALInterfaceOpPattern(MLIRContext *context,
+                                       LLVMTypeConverter &typeconverter)
+      : ConvertToLLVMPattern(IREE::HAL::InterfaceOp::getOperationName(),
+                             context, typeconverter) {}
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -304,90 +545,6 @@ class ConvertTieShapePattern : public ConvertToLLVMPattern {
     rewriter.replaceOp(tieShapeOp, {sourceMemRef});
     return success();
   }
-};  // namespace iree_compiler
-
-class ConvertHALInterfaceLoadConstant : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceLoadConstant(MLIRContext *context,
-                                           LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceLoadConstantOp::getOperationName(), context,
-            converter) {}
-
-  LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override {
-    // Bail until nested under an LLVMFuncOp.
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-
-    assert(llvmFuncOp.getNumArguments() > 0);
-
-    auto llvmTypeConverter = getTypeConverter();
-    Location loc = op->getLoc();
-    auto interfaceLoadConstantOp = cast<IREE::HAL::InterfaceLoadConstantOp>(op);
-    Value pushConstantOffset = rewriter.create<ConstantIndexOp>(
-        loc, interfaceLoadConstantOp.offset().getSExtValue());
-    Value llvmPushConstantOffset = rewriter.create<LLVM::DialectCastOp>(
-        loc, llvmTypeConverter->convertType(pushConstantOffset.getType()),
-        pushConstantOffset);
-    Value llvmPushConstantOffsetAddr = rewriter.create<LLVM::GEPOp>(
-        loc, llvmFuncOp.getArgument(kIndexPushConstant).getType(),
-        llvmFuncOp.getArgument(kIndexPushConstant), llvmPushConstantOffset);
-    Value llvmPushConstantValue =
-        rewriter.create<LLVM::LoadOp>(loc, llvmPushConstantOffsetAddr);
-    if (interfaceLoadConstantOp.result().getType().isIndex()) {
-      llvmPushConstantValue = rewriter.create<LLVM::ZExtOp>(
-          loc, llvmTypeConverter->convertType(rewriter.getIndexType()),
-          llvmPushConstantValue);
-    }
-    rewriter.replaceOp(op, llvmPushConstantValue);
-    return success();
-  }
-};
-
-class RemoveInterfaceOpPattern : public ConvertToLLVMPattern {
- public:
-  explicit RemoveInterfaceOpPattern(MLIRContext *context,
-                                    LLVMTypeConverter &typeconverter)
-      : ConvertToLLVMPattern(IREE::HAL::InterfaceOp::getOperationName(),
-                             context, typeconverter) {}
-  LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override {
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
-
-// ArgIndex hardcodes knowledge of argument position of `Op` in the
-// IREE-compatible ABI.
-template <typename Op, int ArgIndex>
-class ConvertWorkgroupInfoOpPattern : public ConvertToLLVMPattern {
- public:
-  explicit ConvertWorkgroupInfoOpPattern(MLIRContext *context,
-                                         LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(Op::getOperationName(), context, converter) {}
-
-  LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override {
-    auto newFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    // Bail until enclosing FuncOp has been converted.
-    if (!newFuncOp) return failure();
-
-    Location loc = op->getLoc();
-    auto xyzArrayPtr = newFuncOp.getArgument(ArgIndex);
-    auto xyzArrayValue = rewriter.createOrFold<LLVM::LoadOp>(loc, xyzArrayPtr);
-    auto dimValue = rewriter.createOrFold<LLVM::ExtractValueOp>(
-        loc, getIndexTy(op->getContext()), xyzArrayValue,
-        rewriter.getI32ArrayAttr(ArrayRef<int>(
-            op->getAttrOfType<IntegerAttr>("dimension").getInt())));
-
-    rewriter.replaceOpWithNewOp<LLVM::ZExtOp>(
-        op, typeConverter->convertType(op->getResult(0).getType()), dimValue);
-    return success();
-  }
 };
 
 struct ConvertToLLVMPass
@@ -439,19 +596,16 @@ void ConvertToLLVMPass::runOnOperation() {
 
   // clang-format off
   patterns.insert<
-      ConvertBindingOp<IREE::HAL::InterfaceBindingSubspanOp>,
-      ConvertBindingOp<IREE::PlaceholderOp>,
-    ConvertFunc,
-    ConvertTieShapePattern,
-    RemoveMakeRankedShape,
-    RemoveInterfaceOpPattern,
+    ConvertHALEntryPointFuncOp,
+    ConvertHALInterfaceWorkgroupIDOp,
+    ConvertHALInterfaceWorkgroupSizeOp,
+    ConvertHALInterfaceWorkgroupCountOp,
     ConvertHALInterfaceLoadConstant,
-    ConvertWorkgroupInfoOpPattern<
-      IREE::HAL::InterfaceWorkgroupIDOp, kIndexWorkGroupId>,
-    ConvertWorkgroupInfoOpPattern<
-      IREE::HAL::InterfaceWorkgroupCountOp, kIndexWorkGroupCount>,
-    ConvertWorkgroupInfoOpPattern<
-      IREE::HAL::InterfaceWorkgroupSizeOp, kIndexWorkGroupSize>
+    ConvertHALInterfaceBindingSubspanOp,
+    ConvertLegacyPlaceholderOp,
+    RemoveHALInterfaceOpPattern,
+    ConvertTieShapePattern,
+    RemoveMakeRankedShape
   >(&getContext(), converter);
   // clang-format on
 
@@ -461,7 +615,7 @@ void ConvertToLLVMPass::runOnOperation() {
   target.addLegalOp<ModuleOp, ModuleTerminatorOp, IREE::HAL::InterfaceOp,
                     IREE::HAL::InterfaceBindingOp, IREE::HAL::InterfaceEndOp>();
   target.addIllegalDialect<ShapeDialect, StandardOpsDialect, IREEDialect,
-                           IREE::HAL::HALDialect, IREE::Flow::FlowDialect>();
+                           IREE::HAL::HALDialect>();
 
   // Don't apply patterns to private function (e.g num_workgroups func).
   target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
@@ -469,8 +623,7 @@ void ConvertToLLVMPass::runOnOperation() {
     return true;
   });
   target.addDynamicallyLegalDialect<ShapeDialect, StandardOpsDialect,
-                                    IREEDialect, IREE::HAL::HALDialect,
-                                    IREE::Flow::FlowDialect>(
+                                    IREEDialect, IREE::HAL::HALDialect>(
       [&](Operation *op) {
         auto funcParent = op->getParentOfType<FuncOp>();
         if (!funcParent) return false;

--- a/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
@@ -12,7 +12,7 @@ func @convert_dynamic_shape() {
   %8 = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<?x?xf32>
   %9 = shapex.tie_shape %8, %3 : memref<?x?xf32>, !shapex.ranked_shape<[?,?]>
   store %7, %8[%c0, %c0] : memref<?x?xf32>
-  return 
+  return
 }
 hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
@@ -21,8 +21,8 @@ hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = 
 // CHECK: llvm.func @convert_dynamic_shape(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_ID:.+]]: !llvm.ptr<array<3 x i32>>, %[[WORKGROUP_COUNT:.+]]: !llvm.ptr<array<3 x i32>>, %[[WORKGROUP_SIZE:.+]]: !llvm.ptr<array<3 x i32>>) {
 // CHECK: %[[CONST0:.+]] = llvm.mlir.constant(0 : index) : i64
 // CHECK: %[[MEMREF0_PTR_PTR:.+]] = llvm.getelementptr %[[ARG0]][%[[CONST0]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
-// CHECK: %[[MEMREF0_PTR_PTR_F32:.+]] = llvm.bitcast %[[MEMREF0_PTR_PTR]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<ptr<f32>>
-// CHECK: %[[MEMREF0_BASE_PTR:.+]] = llvm.load %[[MEMREF0_PTR_PTR_F32]] : !llvm.ptr<ptr<f32>>
+// CHECK: %[[MEMREF0_PTR:.+]] = llvm.load %[[MEMREF0_PTR_PTR]] : !llvm.ptr<ptr<i8>>
+// CHECK: %[[MEMREF0_BASE_PTR:.+]] = llvm.bitcast %[[MEMREF0_PTR]] : !llvm.ptr<i8> to !llvm.ptr<f32>
 // CHECK: %[[MEMREF_DESC:.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_1:.+]] = llvm.insertvalue %[[MEMREF0_BASE_PTR]], %[[MEMREF_DESC]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_2:.+]] = llvm.insertvalue %[[MEMREF0_BASE_PTR]], %[[MEMREF0_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
@@ -47,10 +47,10 @@ hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = 
 // CHECK: %[[MEMREF0_00_PTR:.+]] = llvm.getelementptr %[[MEMREF0_BASE_PTR_1]][%[[MEMREF0_00_OFFSET]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: %[[MEMREF0_00:.+]] = llvm.load %[[MEMREF0_00_PTR]] : !llvm.ptr<f32>
 // CHECK: %[[MEMREF1_PTR_PTR:.+]] = llvm.getelementptr %[[ARG0]][%[[CONST1]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
-// CHECK: %[[MEMREF1_PTR_PTR_F32:.+]] = llvm.bitcast %[[MEMREF1_PTR_PTR]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<ptr<f32>>
-// CHECK: %[[MEMREF1_PTR_BASE:.+]] = llvm.load %[[MEMREF1_PTR_PTR_F32]] : !llvm.ptr<ptr<f32>>
-// CHECK: %[[MEMREF1_0:.+]] = llvm.insertvalue %[[MEMREF1_PTR_BASE]], %[[MEMREF_DESC]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
-// CHECK: %[[MEMREF1_1:.+]] = llvm.insertvalue %[[MEMREF1_PTR_BASE]], %[[MEMREF1_0]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK: %[[MEMREF1_PTR:.+]] = llvm.load %[[MEMREF1_PTR_PTR]] : !llvm.ptr<ptr<i8>>
+// CHECK: %[[MEMREF1_BASE_PTR:.+]] = llvm.bitcast %[[MEMREF1_PTR]] : !llvm.ptr<i8> to !llvm.ptr<f32>
+// CHECK: %[[MEMREF1_0:.+]] = llvm.insertvalue %[[MEMREF1_BASE_PTR]], %[[MEMREF_DESC]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK: %[[MEMREF1_1:.+]] = llvm.insertvalue %[[MEMREF1_BASE_PTR]], %[[MEMREF1_0]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF1_BASE:.+]] = llvm.extractvalue %[[MEMREF1_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF1_STRIDE_0:.+]] = llvm.extractvalue %[[MEMREF1_1]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF1_00_OFFSET:.+]] = llvm.mul %[[CONST0]], %[[MEMREF1_STRIDE_0]]  : i64
@@ -81,8 +81,8 @@ hal.interface @legacy_io2 attributes {push_constants = 1 : i32, sym_visibility =
 // CHECK: llvm.func @convert_dynamic_shape2(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_ID:.+]]: !llvm.ptr<array<3 x i32>>, %[[WORKGROUP_COUNT:.+]]: !llvm.ptr<array<3 x i32>>, %[[WORKGROUP_SIZE:.+]]: !llvm.ptr<array<3 x i32>>) {
 // CHECK: %[[CONST0:.+]] = llvm.mlir.constant(0 : index) : i64
 // CHECK: %[[MEMREF0_PTR_PTR:.+]] = llvm.getelementptr %[[ARG0]][%[[CONST0]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
-// CHECK: %[[MEMREF0_PTR_PTR_F32:.+]] = llvm.bitcast %[[MEMREF0_PTR_PTR]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<ptr<f32>>
-// CHECK: %[[MEMREF0_BASE_PTR:.+]] = llvm.load %[[MEMREF0_PTR_PTR_F32]] : !llvm.ptr<ptr<f32>>
+// CHECK: %[[MEMREF0_PTR:.+]] = llvm.load %[[MEMREF0_PTR_PTR]] : !llvm.ptr<ptr<i8>>
+// CHECK: %[[MEMREF0_BASE_PTR:.+]] = llvm.bitcast %[[MEMREF0_PTR]] : !llvm.ptr<i8> to !llvm.ptr<f32>
 // CHECK: %[[MEMREF_DESC:.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_1:.+]] = llvm.insertvalue %[[MEMREF0_BASE_PTR]], %[[MEMREF_DESC]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_2:.+]] = llvm.insertvalue %[[MEMREF0_BASE_PTR]], %[[MEMREF0_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
@@ -98,15 +98,15 @@ hal.interface @legacy_io2 attributes {push_constants = 1 : i32, sym_visibility =
 // CHECK: %[[MEMREF0_SIZE_1:.+]] = llvm.extractvalue %[[MEMREF0_5]][3, 1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_STRIDE_0:.+]] = llvm.mul %[[MEMREF0_STRIDE_1]], %[[MEMREF0_SIZE_1]]  : i64
 // CHECK: %[[MEMREF0_6:.+]] = llvm.insertvalue %[[MEMREF0_STRIDE_0]], %[[MEMREF0_5]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
-// CHECK: %[[MEMREF0_BASE_PTR:.+]] = llvm.extractvalue %[[MEMREF0_6]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK: %[[MEMREF0_BASE_PTR_1:.+]] = llvm.extractvalue %[[MEMREF0_6]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_STRIDE_0_0:.+]] = llvm.extractvalue %[[MEMREF0_6]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF0_00_ADDRS:.+]] = llvm.mul %[[CONST0]], %[[MEMREF0_STRIDE_0_0]]  : i64
 // CHECK: %[[MEMREF0_00_INDEX:.+]] = llvm.add %[[MEMREF0_00_ADDRS]], %[[CONST0]]  : i64
 // CHECK: %[[MEMREF0_00_PTR:.+]] = llvm.getelementptr %19[%[[MEMREF0_00_INDEX]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: %[[MEMREF0_00:.+]] = llvm.load %[[MEMREF0_00_PTR]] : !llvm.ptr<f32>
-// CHECK: %[[MEMREF1_BASE_PTR_PTR:.+]] = llvm.getelementptr %[[ARG0]][%[[CONST1]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
-// CHECK: %[[MEMREF1_BASE_PTR_PTR_F32:.+]] = llvm.bitcast %[[MEMREF1_BASE_PTR_PTR]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<ptr<f32>>
-// CHECK: %[[MEMREF1_BASE_PTR:.+]] = llvm.load %[[MEMREF1_BASE_PTR_PTR_F32]] : !llvm.ptr<ptr<f32>>
+// CHECK: %[[MEMREF1_PTR_PTR:.+]] = llvm.getelementptr %[[ARG0]][%[[CONST1]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
+// CHECK: %[[MEMREF1_PTR:.+]] = llvm.load %[[MEMREF1_PTR_PTR]] : !llvm.ptr<ptr<i8>>
+// CHECK: %[[MEMREF1_BASE_PTR:.+]] = llvm.bitcast %[[MEMREF1_PTR]] : !llvm.ptr<i8> to !llvm.ptr<f32>
 // CHECK: %[[MEMREF1_1:.+]] = llvm.insertvalue %[[MEMREF1_BASE_PTR]], %[[MEMREF_DESC]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF1_2:.+]] = llvm.insertvalue %[[MEMREF1_BASE_PTR]], %[[MEMREF1_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK: %[[MEMREF1_3:.+]] = llvm.insertvalue %[[CONST2]], %[[MEMREF1_2]][3, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>

--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_bindings.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_bindings.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
+
+// CHECK-LABEL: llvm.func @binding_ptrs
+func @binding_ptrs() {
+  // CHECK-DAG: %[[C72:.+]] = llvm.mlir.constant(72 : index) : i64
+  %c72 = constant 72 : index
+  // CHECK-DAG: %[[C1:.+]] = llvm.mlir.constant(1 : index) : i64
+  // CHECK: %[[ARRAY_PTR:.+]] = llvm.getelementptr %arg0[%[[C1]]] : (!llvm.ptr<ptr<i8>>, i64) -> !llvm.ptr<ptr<i8>>
+  // CHECK: %[[BASE_PTR_I8:.+]] = llvm.load %[[ARRAY_PTR]] : !llvm.ptr<ptr<i8>>
+  // CHECK: %[[BUFFER_I8:.+]] = llvm.getelementptr %[[BASE_PTR_I8]][%[[C72]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
+  // CHECK: %[[BUFFER_F32:.+]] = llvm.bitcast %[[BUFFER_I8]] : !llvm.ptr<i8> to !llvm.ptr<f32>
+  // CHECK: %[[DESC_A:.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK: %[[DESC_B:.+]] = llvm.insertvalue %[[BUFFER_F32]], %[[DESC_A]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK: %[[DESC_C:.+]] = llvm.insertvalue %[[BUFFER_F32]], %[[DESC_B]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+  %memref = hal.interface.binding.subspan @io::@ret0[%c72] : memref<?xf32>
+  // CHECK: "test.sink"(%[[DESC_C]])
+  "test.sink"(%memref) : (memref<?xf32>) -> ()
+  return
+}
+hal.interface @io attributes {push_constants = 2 : i32, sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
+}

--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_constants.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_constants.mlir
@@ -1,0 +1,13 @@
+// RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
+
+// CHECK-LABEL: llvm.func @constant_values
+func @constant_values() {
+  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : index) : i64
+  // CHECK: %[[VPTR:.+]] = llvm.getelementptr %arg1[%[[C1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+  // CHECK: %[[V32:.+]] = llvm.load %[[VPTR]] : !llvm.ptr<i32>
+  // CHECK: %[[V64:.+]] = llvm.zext %[[V32]] : i32 to i64
+  %v1 = hal.interface.load.constant offset = 1 : index
+  // CHECK-NEXT: "test.sink"(%[[V64]])
+  "test.sink"(%v1) : (index) -> ()
+  return
+}

--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_workgroup_info.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_workgroup_info.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
+
+// CHECK-LABEL: llvm.func @workgroup_id
+func @workgroup_id() {
+  // CHECK: %[[PTR:.+]] = llvm.load %arg2 : !llvm.ptr<array<3 x i32>>
+  // CHECK: %[[Z32:.+]] = llvm.extractvalue %[[PTR]][2 : i32] : !llvm.array<3 x i32>
+  // CHECK: %[[Z64:.+]] = llvm.zext %[[Z32]] : i32 to i64
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  // CHECK-NEXT: "test.sink"(%[[Z64]])
+  "test.sink"(%workgroup_id_z) : (index) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @workgroup_size
+func @workgroup_size() {
+  // CHECK: %[[PTR:.+]] = llvm.load %arg4 : !llvm.ptr<array<3 x i32>>
+  // CHECK: %[[Z32:.+]] = llvm.extractvalue %[[PTR]][2 : i32] : !llvm.array<3 x i32>
+  // CHECK: %[[Z64:.+]] = llvm.zext %[[Z32]] : i32 to i64
+  %workgroup_size_z = hal.interface.workgroup.size[2] : index
+  // CHECK-NEXT: "test.sink"(%[[Z64]])
+  "test.sink"(%workgroup_size_z) : (index) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @workgroup_count
+func @workgroup_count() {
+  // CHECK: %[[PTR:.+]] = llvm.load %arg3 : !llvm.ptr<array<3 x i32>>
+  // CHECK: %[[Z32:.+]] = llvm.extractvalue %[[PTR]][2 : i32] : !llvm.array<3 x i32>
+  // CHECK: %[[Z64:.+]] = llvm.zext %[[Z32]] : i32 to i64
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  // CHECK-NEXT: "test.sink"(%[[Z64]])
+  "test.sink"(%workgroup_count_z) : (index) -> ()
+  return
+}


### PR DESCRIPTION
This will make it possible to version the ABI independent of the lowerings.
The initial work here is strictly to refactor the accesses - future changes will
change the ABI to match that described in #3580.

Progress on #3580.