### PR TITLE
Bump CMake minimum to 3.13.4 and remove dead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.13)
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required(VERSION 3.13.4)
 # Allow target_link_libraries() from other directories (since 3.13):
 #   https://cmake.org/cmake/help/v3.13/policy/CMP0079.html
 if(POLICY CMP0079)


### PR DESCRIPTION
The upstream CMake minimum was bumped with llvm/llvm-project@afa1afd.
This allows to remove dead code setting policies to NEW, see the
upstream commit llvm/llvm-project@480643a.