### PR TITLE
Add support for global.i32 ops in the c module target

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/test/add.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/add.mlir
@@ -2,7 +2,7 @@
 
 // CHECK: #include "iree/vm/ops.h"
 vm.module @add_module {
-  // CHECK: iree_status_t add_module_add_1_impl(int32_t v1, int32_t v2, int32_t *out0, int32_t *out1) {
+  // CHECK: iree_status_t add_module_add_1_impl(int32_t v1, int32_t v2, int32_t *out0, int32_t *out1, add_module_state_t* state) {
   vm.func @add_1(%arg0 : i32, %arg1 : i32) -> (i32, i32) {
     // CHECK-NEXT: int32_t v3 = vm_add_i32(v1, v2);
     %0 = vm.add.i32 %arg0, %arg1 : i32

--- a/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
@@ -2,19 +2,19 @@
 
 // CHECK: #include "iree/vm/ops.h"
 vm.module @calling_convention_test {
-  // CHECK: iree_status_t calling_convention_test_no_in_no_return_impl() {
+  // CHECK: iree_status_t calling_convention_test_no_in_no_return_impl(calling_convention_test_state_t* state) {
   vm.func @no_in_no_return() -> () {
     // CHECK-NEXT: return iree_ok_status();
     vm.return
   }
 
-  // CHECK: iree_status_t calling_convention_test_i32_in_no_return_impl(int32_t v1) {
+  // CHECK: iree_status_t calling_convention_test_i32_in_no_return_impl(int32_t v1, calling_convention_test_state_t* state) {
   vm.func @i32_in_no_return(%arg0 : i32) -> () {
     // CHECK-NEXT: return iree_ok_status();
     vm.return
   }
 
-  // CHECK: iree_status_t calling_convention_test_no_in_i32_return_impl(int32_t *out0) {
+  // CHECK: iree_status_t calling_convention_test_no_in_i32_return_impl(int32_t *out0, calling_convention_test_state_t* state) {
   vm.func @no_in_i32_return() -> (i32) {
     // CHECK-NEXT: int32_t v1 = vm_const_i32(32);
     %0 = vm.const.i32 32 : i32
@@ -23,7 +23,7 @@ vm.module @calling_convention_test {
     vm.return %0 : i32
   }
 
-  // CHECK: iree_status_t calling_convention_test_i32_in_i32_return_impl(int32_t v1, int32_t *out0) {
+  // CHECK: iree_status_t calling_convention_test_i32_in_i32_return_impl(int32_t v1, int32_t *out0, calling_convention_test_state_t* state) {
   vm.func @i32_in_i32_return(%arg0 : i32) -> (i32) {
     // CHECK-NEXT: int32_t v2 = vm_const_i32(32);
     %0 = vm.const.i32 32 : i32

--- a/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
@@ -1,0 +1,37 @@
+// RUN: iree-translate -iree-vm-ir-to-c-module %s | IreeFileCheck %s
+
+vm.module @global_ops {
+  // check the generated state struct
+  // CHECK-LABEL: struct global_ops_state_s {
+  // CHECK-NEXT: iree_allocator_t allocator;
+  // CHECK-NEXT: uint8_t rwdata[8];
+  // CHECK-NEXT: };
+
+  vm.global.i32 @c42 42 : i32
+  vm.global.i32 @c107_mut mutable 107 : i32
+
+  vm.export @test_global_load_i32
+  // CHECK-LABEL: iree_status_t global_ops_test_global_load_i32_impl(
+  vm.func @test_global_load_i32() -> i32 {
+    // CHECK-NEXT: int32_t v1 = vm_global_load_i32(state->rwdata, 0);
+    %value = vm.global.load.i32 @c42 : i32
+    vm.return %value : i32
+  }
+
+  vm.export @test_global_store_i32
+  // CHECK-LABEL: iree_status_t global_ops_test_global_store_i32_impl(
+  vm.func @test_global_store_i32() -> i32 {
+    // CHECK-NEXT: int32_t v1 = vm_const_i32(17);
+    %c17 = vm.const.i32 17 : i32
+    // CHECK-NEXT: vm_global_store_i32(state->rwdata, 4, v1);
+    vm.global.store.i32 %c17, @c107_mut : i32
+    // CHECK-NEXT: int32_t v2 = vm_global_load_i32(state->rwdata, 4);
+    %value = vm.global.load.i32 @c107_mut : i32
+    vm.return %value : i32
+  }
+
+  // check state initialization inside the alloc_state function
+  // CHECK-LABEL: static iree_status_t global_ops_alloc_state(
+  // CHECK: vm_global_store_i32(state->rwdata, 0, 42);
+  // CHECK-NEXT: vm_global_store_i32(state->rwdata, 4, 107);
+}

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -656,9 +656,9 @@ iree_status_t iree_vm_bytecode_dispatch(
             module_state->rwdata_storage.data_length);
       }
       int32_t* value = VM_DecResultRegI32("value");
-      const int32_t* global_ptr =
-          (const int32_t*)(module_state->rwdata_storage.data + byte_offset);
-      *value = *global_ptr;
+      const int32_t global_value =
+          vm_global_load_i32(module_state->rwdata_storage.data, byte_offset);
+      *value = global_value;
     });
 
     DISPATCH_OP(CORE, GlobalStoreI32, {
@@ -671,9 +671,8 @@ iree_status_t iree_vm_bytecode_dispatch(
             module_state->rwdata_storage.data_length);
       }
       int32_t value = VM_DecOperandRegI32("value");
-      int32_t* global_ptr =
-          (int32_t*)(module_state->rwdata_storage.data + byte_offset);
-      *global_ptr = value;
+      vm_global_store_i32(module_state->rwdata_storage.data, byte_offset,
+                          value);
     });
 
     DISPATCH_OP(CORE, GlobalLoadIndirectI32, {
@@ -686,9 +685,9 @@ iree_status_t iree_vm_bytecode_dispatch(
             module_state->rwdata_storage.data_length);
       }
       int32_t* value = VM_DecResultRegI32("value");
-      const int32_t* global_ptr =
-          (const int32_t*)(module_state->rwdata_storage.data + byte_offset);
-      *value = *global_ptr;
+      const int32_t global_value =
+          vm_global_load_i32(module_state->rwdata_storage.data, byte_offset);
+      *value = global_value;
     });
 
     DISPATCH_OP(CORE, GlobalStoreIndirectI32, {
@@ -701,9 +700,8 @@ iree_status_t iree_vm_bytecode_dispatch(
             module_state->rwdata_storage.data_length);
       }
       int32_t value = VM_DecOperandRegI32("value");
-      int32_t* global_ptr =
-          (int32_t*)(module_state->rwdata_storage.data + byte_offset);
-      *global_ptr = value;
+      vm_global_store_i32(module_state->rwdata_storage.data, byte_offset,
+                          value);
     });
 
     DISPATCH_OP(CORE, GlobalLoadRef, {

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -18,6 +18,21 @@
 #include <stdint.h>
 
 //===------------------------------------------------------------------===//
+// Globals
+//===------------------------------------------------------------------===//
+
+static inline int32_t vm_global_load_i32(uint8_t* base, uint32_t byte_offset) {
+  const int32_t* global_ptr = (const int32_t*)(base + byte_offset);
+  return *global_ptr;
+}
+
+static inline void vm_global_store_i32(uint8_t* base, uint32_t byte_offset,
+                                       int32_t value) {
+  int32_t* global_ptr = (int32_t*)(base + byte_offset);
+  *global_ptr = value;
+}
+
+//===------------------------------------------------------------------===//
 // Constants
 //===------------------------------------------------------------------===//
 
@@ -120,11 +135,12 @@ static inline int32_t vm_cmp_nz_i32(int32_t operand) {
 //===------------------------------------------------------------------===//
 // Check ops
 // TODO(simon-camp): These macros should be removed once control flow ops are
-// supported in the c module target
+// supported in the c module target.
+// Note that this will fail if message contains a comma
 #define VM_CHECK_EQ(a, b, message)                                          \
   if (a != b) {                                                             \
     return iree_status_allocate(IREE_STATUS_FAILED_PRECONDITION, "<vm>", 0, \
-                                iree_make_cstring_view("message"));         \
+                                iree_make_cstring_view(#message));          \
   }
 
 //===------------------------------------------------------------------===//

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -42,6 +42,7 @@ cc_embed_data(
         ":control_flow_ops.vmfb",
         ":conversion_ops.vmfb",
         ":conversion_ops_i64.vmfb",
+        ":global_ops.vmfb",
         ":list_ops.vmfb",
         ":shift_ops.vmfb",
         ":shift_ops_i64.vmfb",
@@ -97,6 +98,14 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "conversion_ops_i64",
     src = "conversion_ops_i64.mlir",
+    cc_namespace = "iree::vm::test",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "global_ops",
+    src = "global_ops.mlir",
+    cc_namespace = "iree::vm::test",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_embed_data(
     "control_flow_ops.vmfb"
     "conversion_ops.vmfb"
     "conversion_ops_i64.vmfb"
+    "global_ops.vmfb"
     "list_ops.vmfb"
     "shift_ops.vmfb"
     "shift_ops_i64.vmfb"
@@ -118,6 +119,20 @@ iree_bytecode_module(
     conversion_ops_i64
   SRC
     "conversion_ops_i64.mlir"
+  CC_NAMESPACE
+    "iree::vm::test"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    global_ops
+  SRC
+    "global_ops.mlir"
+  CC_NAMESPACE
+    "iree::vm::test"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_test(
     ::assignment_ops_i64_cc
     ::conversion_ops_cc
     ::conversion_ops_i64_cc
+    ::global_ops_cc
     ::shift_ops_cc
     ::shift_ops_i64_cc
 )
@@ -105,6 +106,18 @@ iree_bytecode_module(
     conversion_ops_i64
   SRC
     "../conversion_ops_i64.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    global_ops
+  SRC
+    "../global_ops.mlir"
   CC_NAMESPACE
     "iree::vm::test::emitc"
   FLAGS

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -24,6 +24,7 @@
 #include "iree/vm/test/emitc/assignment_ops_i64.vmfb"
 #include "iree/vm/test/emitc/conversion_ops.vmfb"
 #include "iree/vm/test/emitc/conversion_ops_i64.vmfb"
+#include "iree/vm/test/emitc/global_ops.vmfb"
 #include "iree/vm/test/emitc/shift_ops.vmfb"
 #include "iree/vm/test/emitc/shift_ops_i64.vmfb"
 
@@ -58,6 +59,7 @@ std::vector<TestParams> GetModuleTestParams() {
       {assignment_ops_i64_descriptor_, assignment_ops_i64_create},
       {conversion_ops_descriptor_, conversion_ops_create},
       {conversion_ops_i64_descriptor_, conversion_ops_i64_create},
+      {global_ops_descriptor_, global_ops_create},
       {shift_ops_descriptor_, shift_ops_create},
       {shift_ops_i64_descriptor_, shift_ops_i64_create}};
 

--- a/iree/vm/test/global_ops.mlir
+++ b/iree/vm/test/global_ops.mlir
@@ -1,0 +1,28 @@
+vm.module @global_ops {
+
+  //===--------------------------------------------------------------------===//
+  // global.i32
+  //===--------------------------------------------------------------------===//
+
+  vm.global.i32 @c42 42 : i32
+  vm.global.i32 @c107_mut mutable 107 : i32
+  // TODO(simon-camp): Add test for initializer
+
+  vm.export @test_global_load_i32
+  vm.func @test_global_load_i32() {
+    %actual = vm.global.load.i32 @c42 : i32
+    %expected = vm.const.i32 42 : i32
+    vm.check.eq %actual, %expected, "@c42 != 42" : i32
+    vm.return
+  }
+
+  vm.export @test_global_store_i32
+  vm.func @test_global_store_i32() {
+    %c17 = vm.const.i32 17 : i32
+    vm.global.store.i32 %c17, @c107_mut : i32
+    %actual = vm.global.load.i32 @c107_mut : i32
+    vm.check.eq %actual, %c17, "@c107_mut != 17" : i32
+    vm.return
+  }
+
+}


### PR DESCRIPTION
This adds support for int32 global ops to the c module target.