### PR TITLE
Adapt mhlo.pad lowering to Linalg on tensors.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/test/pad.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -canonicalize %s | IreeFileCheck %s
 
 module {
   func @pad_cst() {
@@ -18,13 +18,16 @@ module {
     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
   }
 }
-// CHECK_LABEL: @pad_cst
-//   CHECK-DAG: %[[CST:.+]] = constant 0.000000e+00 : f32
-//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
-//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
-//       CHECK: linalg.fill(%[[OUT]], %[[CST]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
-//       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])
+// CHECK-LABEL: func @pad_cst
+//   CHECK-DAG: %[[PAD:.+]] = constant 0.000000e+00 : f32
+//   CHECK-DAG: %[[C4:.+]] = constant 4 : index
+//   CHECK-DAG: %[[C2:.+]] = constant 2 : index
+//   CHECK-DAG: %[[C5:.+]] = constant 5 : index
+//   CHECK-DAG: %[[C3:.+]] = constant 3 : index
+//   CHECK-DAG: %[[IN:.+]] = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<12x4xf32>
+//       CHECK: linalg.pad_tensor %[[IN]] low[%[[C4]], %[[C5]]] high[%[[C2]], %[[C3]]]
+//       CHECK:  linalg.yield %[[PAD]] : f32
+//       CHECK: } : tensor<12x4xf32> to tensor<18x12xf32>
 
 // -----
 
@@ -47,14 +50,17 @@ module {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
   }
 }
-// CHECK_LABEL: @pad_memref
-//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
-//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
-//   CHECK-DAG: %[[PAD_BUF:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
-//       CHECK: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<f32>
-//       CHECK: linalg.fill(%[[OUT]], %[[PAD_VAL]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
-//       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])
+// CHECK-LABEL: func @pad_memref
+//   CHECK-DAG: %[[C4:.+]] = constant 4 : index
+//   CHECK-DAG: %[[C2:.+]] = constant 2 : index
+//   CHECK-DAG: %[[C5:.+]] = constant 5 : index
+//   CHECK-DAG: %[[C3:.+]] = constant 3 : index
+//   CHECK-DAG: %[[IN1:.+]] = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<12x4xf32>
+//   CHECK-DAG: %[[IN2:.+]] = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<f32>
+//   CHECK-DAG: %[[PAD:.+]] = tensor.extract %[[IN2]][] : tensor<f32>
+//       CHECK: linalg.pad_tensor %[[IN1]] low[%[[C4]], %[[C5]]] high[%[[C2]], %[[C3]]]
+//       CHECK:  linalg.yield %[[PAD]] : f32
+//       CHECK: } : tensor<12x4xf32> to tensor<18x12xf32>
 
 // -----
 
@@ -76,34 +82,28 @@ module {
     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
   }
 }
-// CHECK_LABEL: @pad_no_op
-//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<12x4xf32>
-//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
-//   CHECK: linalg.copy(%[[IN]], %[[OUT]])
+// CHECK-LABEL: func @pad_no_op
+//   CHECK-NOT:   linalg.pad_tensor
 
 // -----
 
 module {
   func @cst_pad_cst() {
     %c0 = constant 0 : index
-    %0 = constant dense<1.0> : tensor<12x4xf32>
+    %0 = constant dense<1.0> : tensor<1xf32>
     %1 = constant dense<0.0> : tensor<f32>
     %2 = "mhlo.pad"(%0, %1) {
-      edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
-      edge_padding_low = dense<[4, 5]> : tensor<2xi64>,
-      interior_padding = dense<0> : tensor<2xi64>
-    } : (tensor<12x4xf32>, tensor<f32>) -> tensor<18x12xf32>
-    hal.interface.store.tensor %2, @legacy_io::@ret0, offset = %c0 : tensor<18x12xf32>
+      edge_padding_high = dense<[1]> : tensor<1xi64>,
+      edge_padding_low = dense<[2]> : tensor<1xi64>,
+      interior_padding = dense<0> : tensor<1xi64>
+    } : (tensor<1xf32>, tensor<f32>) -> tensor<4xf32>
+    hal.interface.store.tensor %2, @legacy_io::@ret0, offset = %c0 : tensor<4xf32>
     return
   }
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
     hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer", access="Write"
   }
 }
-// CHECK_LABEL: @cst_pad_cst
-//   CHECK-DAG: %[[ZERO:.+]] = constant 0.000000e+00 : f32
-//   CHECK-DAG: %[[ONE:.+]] = constant 1.000000e+00 : f32
-//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
-//       CHECK: linalg.fill(%[[OUT]], %[[ZERO]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
-//       CHECK: linalg.fill(%[[SUBVIEW]], %[[ONE]])
+// CHECK-LABEL: func @cst_pad_cst
+//       CHECK:   constant dense<[0.000000e+00, 0.000000e+00, 1.000000e+00, 0.000000e+00]> : tensor<4xf32>
+//   CHECK-NOT:   linalg.pad_tensor

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor.mlir
@@ -1,0 +1,64 @@
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
+
+module  {
+  func @pad_cst() {
+    %c0 = constant 0 : index
+    %cst = constant 0.000000e+00 : f32
+    %c4 = constant 4 : index
+    %c2 = constant 2 : index
+    %c5 = constant 5 : index
+    %c3 = constant 3 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<12x4xf32>
+    %1 = linalg.pad_tensor %0 low[%c4, %c5] high[%c2, %c3]  {
+    ^bb0(%arg0: index, %arg1: index):  // no predecessors
+      linalg.yield %cst : f32
+    } : tensor<12x4xf32> to tensor<18x12xf32>
+    hal.interface.store.tensor %1, @legacy_io::@ret0, offset = %c0 : tensor<18x12xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
+  }
+}
+// CHECK-LABEL: @pad_cst
+//   CHECK-DAG: %[[CST:.+]] = constant 0.000000e+00 : f32
+//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
+//       CHECK: linalg.fill(%[[OUT]], %[[CST]])
+//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
+//       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])
+
+// -----
+
+module  {
+  func @pad_memref() {
+    %c0 = constant 0 : index
+    %c4 = constant 4 : index
+    %c2 = constant 2 : index
+    %c5 = constant 5 : index
+    %c3 = constant 3 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<12x4xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<f32>
+    %2 = tensor.extract %1[] : tensor<f32>
+    %3 = linalg.pad_tensor %0 low[%c4, %c5] high[%c2, %c3]  {
+    ^bb0(%arg0: index, %arg1: index):  // no predecessors
+      linalg.yield %2 : f32
+    } : tensor<12x4xf32> to tensor<18x12xf32>
+    hal.interface.store.tensor %3, @legacy_io::@ret0, offset = %c0 : tensor<18x12xf32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}
+// CHECK-LABEL: @pad_memref
+//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
+//   CHECK-DAG: %[[PAD_BUF:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
+//       CHECK: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<f32>
+//       CHECK: linalg.fill(%[[OUT]], %[[PAD_VAL]])
+//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
+//       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])

--- a/iree/test/e2e/xla_ops/pad.mlir
+++ b/iree/test/e2e/xla_ops/pad.mlir
@@ -20,19 +20,3 @@ func @pad_no_op() attributes { iree.module.export } {
   check.expect_eq(%res, %input) : tensor<2x3xi32>
   return
 }
-
-func @pad_with_interior_padding() attributes { iree.module.export } {
-  %input = iree.unfoldable_constant dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
-  %c0 = iree.unfoldable_constant dense<0> : tensor<i32>
-  %res = "mhlo.pad"(%input, %c0) {
-    edge_padding_low = dense<[0, 1]> : tensor<2xi64>,
-    edge_padding_high = dense<[1, 5]> : tensor<2xi64>,
-    interior_padding = dense<[1, 2]> : tensor<2xi64>
-  } : (tensor<2x3xi32>, tensor<i32>) -> tensor<4x13xi32>
-  check.expect_eq_const(%res, dense<[
-      [0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 4, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]> : tensor<4x13xi32>) : tensor<4x13xi32>
-  return
-}


### PR DESCRIPTION
- Lower mhlo.pad to linalg.pad_tensor
- Lower linalg.pad_tensor to fill + subview + copy
- Drop support for interior padding cases.

Fixes https://github.com/google/iree/issues/1604

This depends on https://reviews.llvm.org/D96343