### PR TITLE
Re-add dropped printIncludes

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -430,6 +430,8 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
   };
 
   printInclude("iree/vm/api.h");
+  printInclude("iree/vm/ops.h");
+  printInclude("iree/vm/shims.h");
   output << "\n";
 
   printModuleComment(moduleOp, output);


### PR DESCRIPTION
Dropped with commit d5219c9, but required by targets created via EmitC.