### PR TITLE
Remove workaround for TF dependency issues

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -70,14 +70,9 @@ tf_cc_binary(
         "@org_tensorflow//tensorflow/compiler/mlir:init_mlir",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:convert_graphdef",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_dialect_passes",
         "@org_tensorflow//tensorflow/core/platform:errors",
-    ] + select({
-        "@org_tensorflow//tensorflow:oss": [],
-        "//conditions:default": [
-            # TODO: Enable this for all builds once dependency bug is fixed.
-            "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_dialect_passes",  # Note: always_links in random foo that makes constant folding work
-        ],
-    }),
+    ],
 )
 
 tf_cc_binary(


### PR DESCRIPTION
AFAICT all the CIs are already building with this, but this breaks tests when running
locally.