### PR TITLE
Revert "Make IREE TF integrations use TF toolchains"

### DIFF
--- a/integrations/tensorflow/.bazelrc
+++ b/integrations/tensorflow/.bazelrc
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Import the TF bazelrc config
-try-import %workspace%/../../third_party/tensorflow/.bazelrc
+# Import the main bazelrc config. This is in a separate file so that it's
+# possible to turn off all user bazelrc options by specifying
+# `--nosystem_rc --nohome_rc --noworkspace_rc --bazelrc=build_tools/bazel/iree.bazelrc`
+try-import %workspace%/../../build_tools/bazel/iree.bazelrc
 
-# Linking in the TF shared object with tf_cc_binary in non-monolithic mode
-# violates TF's visibility restrictions. We can investigate fixing this
-# upstream. In the meantime, this is easier.
-build --nocheck_visibility
-# Disk cache is incompatible with remote execution and caching.
-build:rbe --disk_cache=''
+# Run the configure_bazel.py script to generate.
+try-import %workspace%/../../configured.bazelrc
 
 # The user.bazelrc file is not checked in but available for local mods.
 # Always keep this at the end of the file so that user flags override.
-try-import %workspace%/user.bazelrc
+try-import %workspace%/../../user.bazelrc

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Links in the TF shared object if --config=monolithic is not set. If this gets
-# borked you'll end up with a ton of undefined symbols errors.
-load("@org_tensorflow//tensorflow:tensorflow.bzl", "tf_cc_binary")
-
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 
-tf_cc_binary(
+cc_binary(
     name = "iree-tf-opt",
     srcs = ["iree-tf-opt-main.cpp"],
     deps = [
@@ -40,7 +36,7 @@ tf_cc_binary(
     ],
 )
 
-tf_cc_binary(
+cc_binary(
     name = "iree-opt-tflite",
     srcs = ["iree-opt-tflite-main.cpp"],
     deps = [
@@ -57,7 +53,7 @@ tf_cc_binary(
     ],
 )
 
-tf_cc_binary(
+cc_binary(
     name = "iree-tf-import",
     srcs = ["iree-tf-import-main.cpp"],
     deps = [
@@ -80,7 +76,7 @@ tf_cc_binary(
     }),
 )
 
-tf_cc_binary(
+cc_binary(
     name = "iree-import-tflite",
     srcs = ["iree-import-tflite-main.cpp"],
     deps = [
@@ -95,7 +91,7 @@ tf_cc_binary(
     ],
 )
 
-tf_cc_binary(
+cc_binary(
     name = "iree-import-xla",
     srcs = ["iree-import-xla-main.cpp"],
     deps = [


### PR DESCRIPTION
This breaks local Bazel builds with mysterious missing cppmap
dependency errors. It didn't break any bots because the only bot that
invokes this does so through a weird CMake wrapper that uses its own
bazelrc.

Reverts google/iree#4711