### PR TITLE
Added missing DialectRegistry to MLIRContext constructor.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   registry.insert<StandardOpsDialect>();
 
   // Convert the Module proto into MLIR.
-  MLIRContext context;
+  MLIRContext context(registry);
   registry.loadAll(&context);
 
   // Load input buffer.


### PR DESCRIPTION
Missing argument prevented the added MLIR Dialects to be added to the tflite tool.