### PR TITLE
Fixed tflite import tools dialect registration

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   registry.insert<StandardOpsDialect>();
 
   // Convert the Module proto into MLIR.
-  MLIRContext context;
+  MLIRContext context(registry);
   context.loadAllAvailableDialects();
 
   // Load input buffer.


### PR DESCRIPTION
LLVM integrate removed dialect registration from the tflite import tool.