### PR TITLE
Add pass manager CL options to iree-import-tflite.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char **argv) {
   // Register any command line options.
   registerAsmPrinterCLOptions();
   registerMLIRContextCLOptions();
+  registerPassManagerCLOptions();
   cl::ParseCommandLineOptions(argc, argv);
 
   // Initialize dialects.


### PR DESCRIPTION
* When this tool was first created, it didn't run any passes, and I think this is why I didn't add the CL options. Or I just forgot. Either way - fixed now.
* Fixes #4847