### PR TITLE
Implement custom attribute type for vm ordinal counts

### DIFF
--- a/iree/compiler/Dialect/VM/IR/BUILD
+++ b/iree/compiler/Dialect/VM/IR/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "VMOpInterface.cpp.inc",
         "VMOps.cpp",
         "VMOps.cpp.inc",
+        "VMStructs.cpp.inc",
         "VMTypes.cpp",
     ],
     hdrs = [
@@ -47,6 +48,7 @@ cc_library(
         "VMOpInterface.h.inc",
         "VMOps.h",
         "VMOps.h.inc",
+        "VMStructs.h.inc",
         "VMTraits.h",
         "VMTypes.h",
     ],
@@ -55,6 +57,7 @@ cc_library(
         ":VMOpEncoderGen",
         ":VMOpInterfaceGen",
         ":VMOpsGen",
+        ":VMStructsGen",
         "//iree/compiler/Dialect/IREE/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ControlFlowInterfaces",
@@ -127,6 +130,21 @@ gentbl(
         ("-gen-op-interface-defs", "VMOpInterface.cpp.inc"),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "VMBase.td",
+    td_srcs = [
+        ":td_files",
+        "//iree/compiler/Dialect/IREE/IR:td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl(
+    name = "VMStructsGen",
+    tbl_outs = [
+        ("-gen-iree-struct-attr-decls", "VMStructs.h.inc"),
+        ("-gen-iree-struct-attr-defs", "VMStructs.cpp.inc"),
+    ],
+    tblgen = "//iree/tools:iree-tblgen",
     td_file = "VMBase.td",
     td_srcs = [
         ":td_files",

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "VMOpInterface.h.inc"
     "VMOps.h"
     "VMOps.h.inc"
+    "VMStructs.h.inc"
     "VMTraits.h"
     "VMTypes.h"
   SRCS
@@ -35,6 +36,7 @@ iree_cc_library(
     "VMOpInterface.cpp.inc"
     "VMOps.cpp"
     "VMOps.cpp.inc"
+    "VMStructs.cpp.inc"
     "VMTypes.cpp"
   DEPS
     LLVMSupport
@@ -88,6 +90,18 @@ iree_tablegen_library(
   OUTS
     -gen-op-interface-decls VMOpInterface.h.inc
     -gen-op-interface-defs VMOpInterface.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    VMStructsGen
+  TD_FILE
+    "VMBase.td"
+  OUTS
+    -gen-iree-struct-attr-decls VMStructs.h.inc
+    -gen-iree-struct-attr-defs VMStructs.cpp.inc
+  TBLGEN
+    IREE
 )
 
 iree_tablegen_doc(

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -643,4 +643,23 @@ class VM_ConstIntValueAttr<I type> : Attr<
   let constBuilderCall = "$0";
 }
 
+//===----------------------------------------------------------------------===//
+// VM structs
+//===----------------------------------------------------------------------===//
+
+def VM_OrdinalCountsAttr :
+  IREE_StructAttr<"ordinal_counts",
+                  "OrdinalCountsAttr",
+                  VM_Dialect, [
+    IREE_StructFieldAttr<"import_funcs", I32Attr>,
+    IREE_StructFieldAttr<"export_funcs", I32Attr>,
+    IREE_StructFieldAttr<"internal_funcs", I32Attr>,
+    IREE_StructFieldAttr<"global_bytes", I32Attr>,
+    IREE_StructFieldAttr<"global_refs", I32Attr>,
+    IREE_StructFieldAttr<"rodatas", I32Attr>,
+    IREE_StructFieldAttr<"rwdatas", I32Attr>,
+  ]> {
+  let cppNamespace = "mlir::iree_compiler::IREE::VM";
+}
+
 #endif  // IREE_DIALECT_VM_BASE

--- a/iree/compiler/Dialect/VM/IR/VMDialect.h
+++ b/iree/compiler/Dialect/VM/IR/VMDialect.h
@@ -32,6 +32,12 @@ class VMDialect : public Dialect {
   explicit VMDialect(MLIRContext *context);
   static StringRef getDialectNamespace() { return "vm"; }
 
+  /// Parses an attribute registered to this dialect.
+  Attribute parseAttribute(DialectAsmParser &parser, Type type) const override;
+
+  /// Prints an attribute registered to this dialect.
+  void printAttribute(Attribute attr, DialectAsmPrinter &p) const override;
+
   /// Parses a type registered to this dialect.
   Type parseType(DialectAsmParser &parser) const override;
 

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -42,7 +42,7 @@ def VM_ModuleOp : VM_Op<"module", [
   let arguments = (ins
     StrAttr:$sym_name,
     // TODO(benvanik): add compatibility and versioning attributes.
-    OptionalAttr<DictionaryAttr>:$ordinal_counts
+    OptionalAttr<VM_OrdinalCountsAttr>:$ordinal_counts
   );
 
   let regions = (region SizedRegion<1>:$body);

--- a/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -14,12 +14,15 @@
 
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
 
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/TypeSupport.h"
 
 // Order matters:
 #include "iree/compiler/Dialect/VM/IR/VMEnums.cpp.inc"
+#include "iree/compiler/Dialect/VM/IR/VMStructs.cpp.inc"
 
 namespace mlir {
 namespace iree_compiler {
@@ -119,6 +122,57 @@ RefType RefType::getChecked(Type objectType, Location location) {
 }
 
 Type RefType::getObjectType() { return getImpl()->objectType; }
+
+//===----------------------------------------------------------------------===//
+// Attribute printing and parsing
+//===----------------------------------------------------------------------===//
+
+Attribute OrdinalCountsAttr::parse(DialectAsmParser &p) {
+  Type i32 = p.getBuilder().getIntegerType(32);
+  IntegerAttr importFuncsAttr;
+  IntegerAttr exportFuncsAttr;
+  IntegerAttr internalFuncsAttr;
+  IntegerAttr globalBytesAttr;
+  IntegerAttr globalRefsAttr;
+  IntegerAttr rodatasAttr;
+  IntegerAttr rwdatasAttr;
+  if (failed(p.parseLess()) || failed(p.parseKeyword("import_funcs")) ||
+      failed(p.parseEqual()) ||
+      failed(p.parseAttribute(importFuncsAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("export_funcs")) ||
+      failed(p.parseEqual()) ||
+      failed(p.parseAttribute(exportFuncsAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("internal_funcs")) ||
+      failed(p.parseEqual()) ||
+      failed(p.parseAttribute(internalFuncsAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("global_bytes")) ||
+      failed(p.parseEqual()) ||
+      failed(p.parseAttribute(globalBytesAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("global_refs")) ||
+      failed(p.parseEqual()) || failed(p.parseAttribute(globalRefsAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("rodatas")) ||
+      failed(p.parseEqual()) || failed(p.parseAttribute(rodatasAttr, i32)) ||
+      failed(p.parseComma()) || failed(p.parseKeyword("rwdatas")) ||
+      failed(p.parseEqual()) || failed(p.parseAttribute(rwdatasAttr, i32)) ||
+      failed(p.parseGreater())) {
+    return {};
+  }
+  return get(importFuncsAttr, exportFuncsAttr, internalFuncsAttr,
+             globalBytesAttr, globalRefsAttr, rodatasAttr, rwdatasAttr);
+}
+
+void OrdinalCountsAttr::print(DialectAsmPrinter &p) const {
+  auto &os = p.getStream();
+  os << getKindName() << "<";
+  os << "import_funcs = " << import_funcs() << ", ";
+  os << "export_funcs = " << export_funcs() << ", ";
+  os << "internal_funcs = " << internal_funcs() << ", ";
+  os << "global_bytes = " << global_bytes() << ", ";
+  os << "global_refs = " << global_refs() << ", ";
+  os << "rodatas = " << rodatas() << ", ";
+  os << "rwdatas = " << rwdatas();
+  os << ">";
+}
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/IR/VMTypes.h
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.h
@@ -19,12 +19,14 @@
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 
 // Order matters.
 #include "iree/compiler/Dialect/VM/IR/VMEnums.h.inc"
+#include "iree/compiler/Dialect/VM/IR/VMStructs.h.inc"
 
 namespace mlir {
 namespace iree_compiler {

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -279,29 +279,17 @@ static LogicalResult buildFlatBufferModule(BytecodeTargetOptions targetOptions,
     return moduleOp.emitError() << "ordinal_counts attribute not found. The "
                                    "OrdinalAllocationPass must be run before.";
   }
-  DictionaryAttr ordinalCounts = moduleOp.ordinal_counts().getValue();
+  OrdinalCountsAttr ordinalCounts = moduleOp.ordinal_counts().getValue();
 
   // Find all structural ops in the module.
   std::vector<IREE::VM::ImportOp> importFuncOps;
   std::vector<IREE::VM::ExportOp> exportFuncOps;
   std::vector<IREE::VM::FuncOp> internalFuncOps;
   std::vector<IREE::VM::RodataOp> rodataOps;
-  importFuncOps.resize(ordinalCounts.get("import_funcs")
-                           .dyn_cast<IntegerAttr>()
-                           .getValue()
-                           .getLimitedValue());
-  exportFuncOps.resize(ordinalCounts.get("export_funcs")
-                           .dyn_cast<IntegerAttr>()
-                           .getValue()
-                           .getLimitedValue());
-  internalFuncOps.resize(ordinalCounts.get("internal_funcs")
-                             .dyn_cast<IntegerAttr>()
-                             .getValue()
-                             .getLimitedValue());
-  rodataOps.resize(ordinalCounts.get("rodatas")
-                       .dyn_cast<IntegerAttr>()
-                       .getValue()
-                       .getLimitedValue());
+  importFuncOps.resize(ordinalCounts.import_funcs());
+  exportFuncOps.resize(ordinalCounts.export_funcs());
+  internalFuncOps.resize(ordinalCounts.internal_funcs());
+  rodataOps.resize(ordinalCounts.rodatas());
 
   for (auto &op : moduleOp.getBlock().getOperations()) {
     if (auto funcOp = dyn_cast<IREE::VM::FuncOp>(op)) {
@@ -458,14 +446,8 @@ static LogicalResult buildFlatBufferModule(BytecodeTargetOptions targetOptions,
   auto importFuncsRef = fbb.createOffsetVecDestructive(importFuncRefs);
   auto typesRef = fbb.createOffsetVecDestructive(typeRefs);
 
-  int32_t globalRefs = ordinalCounts.get("global_refs")
-                           .dyn_cast<IntegerAttr>()
-                           .getValue()
-                           .getLimitedValue();
-  int32_t globalBytes = ordinalCounts.get("global_bytes")
-                            .dyn_cast<IntegerAttr>()
-                            .getValue()
-                            .getLimitedValue();
+  int32_t globalRefs = ordinalCounts.global_refs();
+  int32_t globalBytes = ordinalCounts.global_bytes();
 
   iree_vm_ModuleStateDef_ref_t moduleStateDef = 0;
   if (globalBytes || globalRefs) {

--- a/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -78,7 +78,7 @@ class OrdinalAllocationPass
     // Assign byte offset values to primitive globals, ensuring that we meet
     // natural alignment requirements on each size type.
     int nextGlobalBytesOrdinal = 0;
-    size_t globalBytes = 0;
+    int globalBytes = 0;
     for (auto sizeGlobalOps : llvm::enumerate(primitiveGlobalOps)) {
       size_t storageSize = sizeGlobalOps.index();
       if (sizeGlobalOps.value().empty()) continue;
@@ -88,26 +88,14 @@ class OrdinalAllocationPass
         globalOp->setAttr("ordinal",
                           builder.getI32IntegerAttr(nextGlobalBytesOrdinal));
         nextGlobalBytesOrdinal += storageSize;
-        globalBytes =
-            std::max(globalBytes, nextGlobalBytesOrdinal + storageSize);
+        globalBytes = std::max(globalBytes, nextGlobalBytesOrdinal);
       }
     }
 
     // Assign ordinal counts to module op.
-    getOperation().ordinal_countsAttr(builder.getDictionaryAttr(
-        {{builder.getIdentifier("import_funcs"),
-          builder.getI32IntegerAttr(nextImportOrdinal)},
-         {builder.getIdentifier("export_funcs"),
-          builder.getI32IntegerAttr(nextExportOrdinal)},
-         {builder.getIdentifier("internal_funcs"),
-          builder.getI32IntegerAttr(nextFuncOrdinal)},
-         {builder.getIdentifier("global_bytes"),
-          builder.getI32IntegerAttr(globalBytes)},
-         {builder.getIdentifier("global_refs"),
-          builder.getI32IntegerAttr(nextGlobalRefOrdinal)},
-         {builder.getIdentifier("rodatas"),
-          builder.getI32IntegerAttr(nextRodataOrdinal)},
-         {builder.getIdentifier("rwdatas"), builder.getI32IntegerAttr(0)}}));
+    getOperation().ordinal_countsAttr(OrdinalCountsAttr::get(
+        nextImportOrdinal, nextExportOrdinal, nextFuncOrdinal, globalBytes,
+        nextGlobalRefOrdinal, nextRodataOrdinal, 0, &getContext()));
 
     SymbolTable symbolTable(getOperation());
 

--- a/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
@@ -1,6 +1,17 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation)' %s | IreeFileCheck %s
+// check the parser for vm.module.ordinal_counts
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation)' %s | iree-opt | IreeFileCheck %s
 
 // CHECK-LABEL: @global_address_propagation
+  // CHECK-SAME: attributes {ordinal_counts = #vm.ordinal_counts<
+  // CHECK-SAME: import_funcs = 0,
+  // CHECK-SAME: export_funcs = 0,
+  // CHECK-SAME: internal_funcs = 1,
+  // CHECK-SAME: global_bytes = 8,
+  // CHECK-SAME: global_refs = 0,
+  // CHECK-SAME: rodatas = 0,
+  // CHECK-SAME: rwdatas = 0
+  // CHECK-SAME: >}
 vm.module @global_address_propagation {
   // CHECK-DAG: vm.global.i32 @g0 mutable : i32 attributes {ordinal = 0 : i32}
   vm.global.i32 @g0 mutable : i32


### PR DESCRIPTION
This is a follow up on #4805 and replaces the dictionary attribute with a dedicated struct attribute.

This also fixes an issue in the calculation of the module state size introduced in #4805.