### PR TITLE
Making iree_vm_list_resize work and switching ref cconv behavior

### DIFF
--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -266,8 +266,7 @@ if(${IREE_ENABLE_RUNTIME_TRACING})
     DEPS
       ::core_headers
     DEFINES
-      # TODO(#2114): Change the mode to 2.
-      "IREE_TRACING_MODE=1"
+      "IREE_TRACING_MODE=2"
     PUBLIC
   )
 else()

--- a/iree/modules/hal/hal_module.c
+++ b/iree/modules/hal/hal_module.c
@@ -226,8 +226,8 @@ IREE_VM_ABI_EXPORT(iree_hal_module_ex_submit_and_wait, rr, v) {
   // Block and wait for the semaphore to be signaled (or fail).
   status = iree_hal_semaphore_wait_with_deadline(semaphore, 1ull,
                                                  IREE_TIME_INFINITE_FUTURE);
+  iree_hal_semaphore_release(semaphore);
   if (!iree_status_is_ok(status)) {
-    iree_hal_semaphore_release(semaphore);
     return status;
   }
 

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -125,21 +125,17 @@ Status GetModuleContentsFromFlags(std::string* out_contents) {
 // benchmarking.
 class IREEBenchmark {
  public:
-  IREEBenchmark()
-      : instance_(nullptr),
-        device_(nullptr),
-        hal_module_(nullptr),
-        context_(nullptr),
-        input_module_(nullptr){};
+  IREEBenchmark() = default;
+
   ~IREEBenchmark() {
     IREE_TRACE_SCOPE0("IREEBenchmark::dtor");
 
     // Order matters.
     inputs_.reset();
+    iree_vm_context_release(context_);
     iree_vm_module_release(hal_module_);
     iree_vm_module_release(input_module_);
     iree_hal_device_release(device_);
-    iree_vm_context_release(context_);
     iree_vm_instance_release(instance_);
   };
 
@@ -247,11 +243,11 @@ class IREEBenchmark {
   }
 
   std::string module_data_;
-  iree_vm_instance_t* instance_;
-  iree_hal_device_t* device_;
-  iree_vm_module_t* hal_module_;
-  iree_vm_context_t* context_;
-  iree_vm_module_t* input_module_;
+  iree_vm_instance_t* instance_ = nullptr;
+  iree_hal_device_t* device_ = nullptr;
+  iree_vm_module_t* hal_module_ = nullptr;
+  iree_vm_context_t* context_ = nullptr;
+  iree_vm_module_t* input_module_ = nullptr;
   iree::vm::ref<iree_vm_list_t> inputs_;
 };
 }  // namespace

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -402,8 +402,7 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
       } break;
       case IREE_VM_CCONV_TYPE_REF: {
         uint16_t src_reg = src_reg_list->registers[reg_i++];
-        iree_vm_ref_retain_or_move(
-            src_reg & IREE_REF_REGISTER_MOVE_BIT,
+        iree_vm_ref_assign(
             &caller_registers.ref[src_reg & caller_registers.ref_mask],
             (iree_vm_ref_t*)p);
         p += sizeof(iree_vm_ref_t);
@@ -447,8 +446,7 @@ static void iree_vm_bytecode_populate_import_cconv_arguments(
               } break;
               case IREE_VM_CCONV_TYPE_REF: {
                 uint16_t src_reg = src_reg_list->registers[reg_i++];
-                iree_vm_ref_retain_or_move(
-                    src_reg & IREE_REF_REGISTER_MOVE_BIT,
+                iree_vm_ref_assign(
                     &caller_registers.ref[src_reg & caller_registers.ref_mask],
                     (iree_vm_ref_t*)p);
                 p += sizeof(iree_vm_ref_t);

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -192,9 +192,8 @@ typedef struct {
   // Argument buffer in the format described above.
   // This is only read on beginning the function and need not live beyond that.
   //
-  // Refs contained will be moved into the target function or released if not
-  // needed. Callers must ensure they move or retain arguments when populating
-  // the arguments buffer.
+  // Refs contained are retained by the caller and callees must retain them if
+  // they need them to live beyond the call.
   iree_byte_span_t arguments;
 
   // Storage for the result buffer; assumed undefined and then populated with

--- a/iree/vm/module_abi_packing.h
+++ b/iree/vm/module_abi_packing.h
@@ -362,7 +362,7 @@ template <>
 struct ParamUnpack<opaque_ref> {
   using storage_type = opaque_ref;
   static void Load(Status& status, params_ptr_t& ptr, storage_type& out_param) {
-    iree_vm_ref_move(reinterpret_cast<iree_vm_ref_t*>(ptr), &out_param);
+    iree_vm_ref_retain(reinterpret_cast<iree_vm_ref_t*>(ptr), &out_param);
     ptr += sizeof(iree_vm_ref_t);
   }
 };
@@ -376,7 +376,7 @@ struct ParamUnpack<ref<T>> {
     auto* reg_ptr = reinterpret_cast<iree_vm_ref_t*>(ptr);
     ptr += sizeof(iree_vm_ref_t);
     if (reg_ptr->type == ref_type_descriptor<T>::get()->type) {
-      out_param = vm::assign_ref(reinterpret_cast<T*>(reg_ptr->ptr));
+      out_param = vm::retain_ref(reinterpret_cast<T*>(reg_ptr->ptr));
       memset(reg_ptr, 0, sizeof(*reg_ptr));
     } else if (IREE_UNLIKELY(reg_ptr->type != IREE_VM_REF_TYPE_NULL)) {
       status =
@@ -401,7 +401,7 @@ struct ParamUnpack<const ref<T>> {
     auto* reg_ptr = reinterpret_cast<iree_vm_ref_t*>(ptr);
     ptr += sizeof(iree_vm_ref_t);
     if (reg_ptr->type == ref_type_descriptor<T>::get()->type) {
-      out_param = vm::assign_ref(reinterpret_cast<T*>(reg_ptr->ptr));
+      out_param = vm::retain_ref(reinterpret_cast<T*>(reg_ptr->ptr));
       memset(reg_ptr, 0, sizeof(*reg_ptr));
     } else if (IREE_UNLIKELY(reg_ptr->type != IREE_VM_REF_TYPE_NULL)) {
       status =

--- a/iree/vm/type_def.h
+++ b/iree/vm/type_def.h
@@ -87,6 +87,7 @@ typedef struct {
   { {IREE_VM_VALUE_TYPE_NONE, IREE_VM_REF_TYPE_NULL}, {0}, }
 #define iree_vm_variant_is_value(v) iree_vm_type_def_is_value(&(v).type)
 #define iree_vm_variant_is_ref(v) iree_vm_type_def_is_ref(&(v).type)
+#define iree_vm_variant_is_empty(v) iree_vm_type_def_is_variant(&(v).type)
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
The new C HAL module was the first user of this function - now there
are tests. The new shims also assumed that arguments were not retained
(as doing so requires cleanup) but the dispatch code was double-retaining
them. I'm surprised things worked as well as they did like that o_o

Fixes #4852.

Before:
![image](https://user-images.githubusercontent.com/75337/108114691-fc24e080-704d-11eb-9e5d-68ac9ec35365.png)

After:
![image](https://user-images.githubusercontent.com/75337/108114717-0646df00-704e-11eb-89ac-112fcaa00f51.png)
