### PR TITLE
Extend i64 VM/EmitC support

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -136,6 +136,36 @@ void populateVMToCPatterns(MLIRContext *context,
   patterns.insert<CallOpConversion<IREE::VM::CheckEQOp>>(context,
                                                          "VM_CHECK_EQ");
 
+  // ExtI64: Constants{shift_ops_descriptor_, shift_ops_create}};
+  patterns.insert<CallOpConversion<IREE::VM::ConstI64Op>>(context,
+                                                          "vm_const_i64");
+
+  // ExtI64: Conditional assignment ops
+  patterns.insert<CallOpConversion<IREE::VM::SelectI64Op>>(context,
+                                                           "vm_select_i64");
+  // ExtI64: Native integer arithmetic ops
+  patterns.insert<CallOpConversion<IREE::VM::AddI64Op>>(context, "vm_add_i64");
+  patterns.insert<CallOpConversion<IREE::VM::SubI64Op>>(context, "vm_sub_i64");
+  patterns.insert<CallOpConversion<IREE::VM::MulI64Op>>(context, "vm_mul_i64");
+  patterns.insert<CallOpConversion<IREE::VM::DivI64SOp>>(context,
+                                                         "vm_div_i64s");
+  patterns.insert<CallOpConversion<IREE::VM::DivI64UOp>>(context,
+                                                         "vm_div_i64u");
+  patterns.insert<CallOpConversion<IREE::VM::RemI64SOp>>(context,
+                                                         "vm_rem_i64s");
+  patterns.insert<CallOpConversion<IREE::VM::RemI64UOp>>(context,
+                                                         "vm_rem_i64u");
+  patterns.insert<CallOpConversion<IREE::VM::NotI64Op>>(context, "vm_not_i64");
+  patterns.insert<CallOpConversion<IREE::VM::AndI64Op>>(context, "vm_and_i64");
+  patterns.insert<CallOpConversion<IREE::VM::OrI64Op>>(context, "vm_or_i64");
+  patterns.insert<CallOpConversion<IREE::VM::XorI64Op>>(context, "vm_xor_i64");
+
+  // ExtI64: Native bitwise shift and rotate ops
+  patterns.insert<CallOpConversion<IREE::VM::ShlI64Op>>(context, "vm_shl_i64");
+  patterns.insert<CallOpConversion<IREE::VM::ShrI64SOp>>(context,
+                                                         "vm_shr_i64s");
+  patterns.insert<CallOpConversion<IREE::VM::ShrI64UOp>>(context,
+                                                         "vm_shr_i64u");
 }
 
 namespace IREE {
@@ -205,6 +235,29 @@ class ConvertVMToEmitCPass
     // support for control flow ops has landed in the c module target
     target.addIllegalOp<IREE::VM::CheckEQOp>();
 
+    // ExtI64: Constants
+    target.addIllegalOp<IREE::VM::ConstI64Op>();
+
+    // ExtI64: Conditional assignment ops
+    target.addIllegalOp<IREE::VM::SelectI64Op>();
+
+    // ExtI64: Native integer arithmetic ops
+    target.addIllegalOp<IREE::VM::AddI64Op>();
+    target.addIllegalOp<IREE::VM::SubI64Op>();
+    target.addIllegalOp<IREE::VM::MulI64Op>();
+    target.addIllegalOp<IREE::VM::DivI64SOp>();
+    target.addIllegalOp<IREE::VM::DivI64UOp>();
+    target.addIllegalOp<IREE::VM::RemI64SOp>();
+    target.addIllegalOp<IREE::VM::RemI64UOp>();
+    target.addIllegalOp<IREE::VM::NotI64Op>();
+    target.addIllegalOp<IREE::VM::AndI64Op>();
+    target.addIllegalOp<IREE::VM::OrI64Op>();
+    target.addIllegalOp<IREE::VM::XorI64Op>();
+
+    // ExtI64: Native bitwise shift and rotate ops
+    target.addIllegalOp<IREE::VM::ShlI64Op>();
+    target.addIllegalOp<IREE::VM::ShrI64SOp>();
+    target.addIllegalOp<IREE::VM::ShrI64UOp>();
 
     if (failed(
             applyFullConversion(getOperation(), target, std::move(patterns)))) {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -136,7 +136,7 @@ void populateVMToCPatterns(MLIRContext *context,
   patterns.insert<CallOpConversion<IREE::VM::CheckEQOp>>(context,
                                                          "VM_CHECK_EQ");
 
-  // ExtI64: Constants{shift_ops_descriptor_, shift_ops_create}};
+  // ExtI64: Constants
   patterns.insert<CallOpConversion<IREE::VM::ConstI64Op>>(context,
                                                           "vm_const_i64");
 

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -1,0 +1,120 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @add_i64
+vm.module @my_module {
+  vm.func @add_i64(%arg0: i64, %arg1: i64) {
+    // CHECK-NEXT: %0 = emitc.call "vm_add_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.add.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @sub_i64
+vm.module @my_module {
+  vm.func @sub_i64(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_sub_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.sub.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @mul_i64
+vm.module @my_module {
+  vm.func @mul_i64(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_mul_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.mul.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @div_i64_s
+vm.module @my_module {
+  vm.func @div_i64_s(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_div_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.div.i64.s %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @div_i64_u
+vm.module @my_module {
+  vm.func @div_i64_u(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_div_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.div.i64.u %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @rem_i64_s
+vm.module @my_module {
+  vm.func @rem_i64_s(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_rem_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.rem.i64.s %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @rem_i64_u
+vm.module @my_module {
+  vm.func @rem_i64_u(%arg0: i64, %arg1: i64) {
+    // CHECK: %0 = emitc.call "vm_rem_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.rem.i64.u %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @not_i64
+vm.module @my_module {
+  vm.func @not_i64(%arg0 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_not_i64"(%arg0) {args = [0 : index]} : (i64) -> i64
+    %0 = vm.not.i64 %arg0 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @and_i64
+vm.module @my_module {
+  vm.func @and_i64(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_and_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.and.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @or_i64
+vm.module @my_module {
+  vm.func @or_i64(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_or_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.or.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @xor_i64
+vm.module @my_module {
+  vm.func @xor_i64(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_xor_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    %0 = vm.xor.i64 %arg0, %arg1 : i64
+    vm.return %0 : i64
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @select_i32
+vm.module @my_module {
+  vm.func @select_i32(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
+    // CHECK: %0 = emitc.call "vm_select_i32"(%arg0, %arg1, %arg2) {args = [0 : index, 1 : index, 2 : index]} : (i32, i32, i32) -> i32
+    %0 = vm.select.i32 %arg0, %arg1, %arg2 : i32
+    vm.return %0 : i32
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @select_i64
+vm.module @my_module {
+  vm.func @select_i64(%arg0 : i32, %arg1 : i64, %arg2 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_select_i64"(%arg0, %arg1, %arg2) {args = [0 : index, 1 : index, 2 : index]} : (i32, i64, i64) -> i64
+    %0 = vm.select.i64 %arg0, %arg1, %arg2 : i64
+    vm.return %0 : i64
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK: vm.module @module {
+vm.module @module {
+  // CHECK-LABEL: vm.func @const_i64
+  vm.func @const_i64() {
+    // CHECK-NEXT: %0 = emitc.call "vm_const_i64"() {args = [0]} : () -> i64
+    %0 = vm.const.i64 0 : i64
+    // CHECK-NEXT: %1 = emitc.call "vm_const_i64"() {args = [2]} : () -> i64
+    %1 = vm.const.i64 2 : i64
+    // CHECK-NEXT: %2 = emitc.call "vm_const_i64"() {args = [-2]} : () -> i64
+    %2 = vm.const.i64 -2 : i64
+    // CHECK-NEXT: vm.return
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @shl_i64
+vm.module @my_module {
+  vm.func @shl_i64(%arg0 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_shl_i64"(%arg0) {args = [0 : index, 2 : i8]} : (i64) -> i64
+    %0 = vm.shl.i64 %arg0, 2 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @shr_i64_s
+vm.module @my_module {
+  vm.func @shr_i64_s(%arg0 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_shr_i64s"(%arg0) {args = [0 : index, 2 : i8]} : (i64) -> i64
+    %0 = vm.shr.i64.s %arg0, 2 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @shr_i64_u
+vm.module @my_module {
+  vm.func @shr_i64_u(%arg0 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_shr_i64u"(%arg0) {args = [0 : index, 2 : i8]} : (i64) -> i64
+    %0 = vm.shr.i64.u %arg0, 2 : i64
+    vm.return %0 : i64
+  }
+}

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1360,7 +1360,7 @@ iree_status_t iree_vm_bytecode_dispatch(
         int64_t true_value = VM_DecOperandRegI64("true_value");
         int64_t false_value = VM_DecOperandRegI64("false_value");
         int64_t* result = VM_DecResultRegI64("result");
-        *result = condition ? true_value : false_value;
+        *result = vm_select_i64(condition, true_value, false_value);
       });
 
       DISPATCH_OP(EXT_I64, SwitchI64, {
@@ -1381,32 +1381,17 @@ iree_status_t iree_vm_bytecode_dispatch(
       // ExtI64: Native integer arithmetic
       //===----------------------------------------------------------------===//
 
-#define DISPATCH_OP_EXT_I64_UNARY_ALU_I64(op_name, type, op) \
-  DISPATCH_OP(EXT_I64, op_name, {                            \
-    int64_t operand = VM_DecOperandRegI64("operand");        \
-    int64_t* result = VM_DecResultRegI64("result");          \
-    *result = (int64_t)(op((type)operand));                  \
-  });
-
-#define DISPATCH_OP_EXT_I64_BINARY_ALU_I64(op_name, type, op) \
-  DISPATCH_OP(EXT_I64, op_name, {                             \
-    int64_t lhs = VM_DecOperandRegI64("lhs");                 \
-    int64_t rhs = VM_DecOperandRegI64("rhs");                 \
-    int64_t* result = VM_DecResultRegI64("result");           \
-    *result = (int64_t)(((type)lhs)op((type)rhs));            \
-  });
-
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(AddI64, int64_t, +);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(SubI64, int64_t, -);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(MulI64, int64_t, *);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(DivI64S, int64_t, /);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(DivI64U, uint64_t, /);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(RemI64S, int64_t, %);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(RemI64U, uint64_t, %);
-      DISPATCH_OP_EXT_I64_UNARY_ALU_I64(NotI64, uint64_t, ~);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(AndI64, uint64_t, &);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(OrI64, uint64_t, |);
-      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(XorI64, uint64_t, ^);
+      DISPATCH_OP_EXT_I64_BINARY_I64(AddI64, vm_add_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(SubI64, vm_sub_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(MulI64, vm_mul_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(DivI64S, vm_div_i64s);
+      DISPATCH_OP_EXT_I64_BINARY_I64(DivI64U, vm_div_i64u);
+      DISPATCH_OP_EXT_I64_BINARY_I64(RemI64S, vm_rem_i64s);
+      DISPATCH_OP_EXT_I64_BINARY_I64(RemI64U, vm_rem_i64u);
+      DISPATCH_OP_EXT_I64_UNARY_I64(NotI64, vm_not_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(AndI64, vm_and_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(OrI64, vm_or_i64);
+      DISPATCH_OP_EXT_I64_BINARY_I64(XorI64, vm_xor_i64);
 
       //===----------------------------------------------------------------===//
       // ExtI64: Casting and type conversion/emulation
@@ -1427,17 +1412,17 @@ iree_status_t iree_vm_bytecode_dispatch(
       // ExtI64: Native bitwise shifts and rotates
       //===----------------------------------------------------------------===//
 
-#define DISPATCH_OP_EXT_I64_SHIFT_I64(op_name, type, op) \
-  DISPATCH_OP(EXT_I64, op_name, {                        \
-    int64_t operand = VM_DecOperandRegI64("operand");    \
-    int8_t amount = VM_DecConstI8("amount");             \
-    int64_t* result = VM_DecResultRegI64("result");      \
-    *result = (int64_t)(((type)operand)op amount);       \
+#define DISPATCH_OP_EXT_I64_SHIFT_I64(op_name, op_func) \
+  DISPATCH_OP(EXT_I64, op_name, {                       \
+    int64_t operand = VM_DecOperandRegI64("operand");   \
+    int8_t amount = VM_DecConstI8("amount");            \
+    int64_t* result = VM_DecResultRegI64("result");     \
+    *result = op_func(operand, amount);                 \
   });
 
-      DISPATCH_OP_EXT_I64_SHIFT_I64(ShlI64, int64_t, <<);
-      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64S, int64_t, >>);
-      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64U, uint64_t, >>);
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShlI64, vm_shl_i64);
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64S, vm_shr_i64s);
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64U, vm_shr_i64u);
 
       //===----------------------------------------------------------------===//
       // ExtI64: Comparison ops

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -377,4 +377,19 @@ static const int kRegSize = sizeof(uint16_t);
     *result = op_func(lhs, rhs);                      \
   });
 
+#define DISPATCH_OP_EXT_I64_UNARY_I64(op_name, op_func) \
+  DISPATCH_OP(EXT_I64, op_name, {                       \
+    int64_t operand = VM_DecOperandRegI64("operand");   \
+    int64_t* result = VM_DecResultRegI64("result");     \
+    *result = op_func(operand);                         \
+  });
+
+#define DISPATCH_OP_EXT_I64_BINARY_I64(op_name, op_func) \
+  DISPATCH_OP(EXT_I64, op_name, {                        \
+    int64_t lhs = VM_DecOperandRegI64("lhs");            \
+    int64_t rhs = VM_DecOperandRegI64("rhs");            \
+    int64_t* result = VM_DecResultRegI64("result");      \
+    *result = op_func(lhs, rhs);                         \
+  });
+
 #endif  // IREE_VM_BYTECODE_DISPATCH_UTIL_H_

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -64,22 +64,22 @@ static inline int32_t vm_xor_i32(int32_t lhs, int32_t rhs) { return lhs ^ rhs; }
 
 static inline int32_t vm_trunc_i32i8(int32_t operand) {
   return (uint8_t)((uint32_t)operand);
-};
+}
 static inline int32_t vm_trunc_i32i16(int32_t operand) {
   return (uint16_t)((uint32_t)operand);
-};
+}
 static inline int32_t vm_ext_i8i32s(int32_t operand) {
   return (int32_t)((int8_t)operand);
-};
+}
 static inline int32_t vm_ext_i8i32u(int32_t operand) {
   return (uint32_t)((uint8_t)operand);
-};
+}
 static inline int32_t vm_ext_i16i32s(int32_t operand) {
   return (int32_t)((int16_t)operand);
-};
+}
 static inline int32_t vm_ext_i16i32u(int32_t operand) {
   return (uint32_t)((uint16_t)operand);
-};
+}
 
 //===------------------------------------------------------------------===//
 // Native bitwise shifts and rotates
@@ -87,13 +87,13 @@ static inline int32_t vm_ext_i16i32u(int32_t operand) {
 
 static inline int32_t vm_shl_i32(int32_t operand, int8_t amount) {
   return (int32_t)(operand << amount);
-};
+}
 static inline int32_t vm_shr_i32s(int32_t operand, int8_t amount) {
   return (int32_t)(operand >> amount);
-};
+}
 static inline int32_t vm_shr_i32u(int32_t operand, int8_t amount) {
   return (int32_t)(((uint32_t)operand) >> amount);
-};
+}
 
 //===------------------------------------------------------------------===//
 // Comparison ops
@@ -169,17 +169,17 @@ static inline int64_t vm_or_i64(int64_t lhs, int64_t rhs) { return lhs | rhs; }
 static inline int64_t vm_xor_i64(int64_t lhs, int64_t rhs) { return lhs ^ rhs; }
 
 //===------------------------------------------------------------------===//
-// Native bitwise shifts and rotates
+// ExtI64: Native bitwise shifts and rotates
 //===------------------------------------------------------------------===//
 
 static inline int64_t vm_shl_i64(int64_t operand, int8_t amount) {
   return (int64_t)(operand << amount);
-};
+}
 static inline int64_t vm_shr_i64s(int64_t operand, int8_t amount) {
   return (int64_t)(operand >> amount);
-};
+}
 static inline int64_t vm_shr_i64u(int64_t operand, int8_t amount) {
-  return (int64_t)(((uint32_t)operand) >> amount);
-};
+  return (int64_t)(((uint64_t)operand) >> amount);
+}
 
 #endif  // IREE_VM_OPS_H_

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -127,5 +127,59 @@ static inline int32_t vm_cmp_nz_i32(int32_t operand) {
                                 iree_make_cstring_view("message"));         \
   }
 
+//===------------------------------------------------------------------===//
+// ExtI64: Constants
+//===------------------------------------------------------------------===//
+
+static inline int64_t vm_const_i64(int64_t a) { return a; }
+
+//===------------------------------------------------------------------===//
+// ExtI64: Conditional assignment
+//===------------------------------------------------------------------===//
+
+static inline int64_t vm_select_i64(int32_t condition, int64_t true_value,
+                                    int64_t false_value) {
+  return condition ? true_value : false_value;
+}
+
+//===------------------------------------------------------------------===//
+// ExtI64: Native integer arithmetic ops
+//===------------------------------------------------------------------===//
+
+static inline int64_t vm_add_i64(int64_t lhs, int64_t rhs) { return lhs + rhs; }
+static inline int64_t vm_sub_i64(int64_t lhs, int64_t rhs) { return lhs - rhs; }
+static inline int64_t vm_mul_i64(int64_t lhs, int64_t rhs) { return lhs * rhs; }
+static inline int64_t vm_div_i64s(int64_t lhs, int64_t rhs) {
+  return lhs / rhs;
+}
+static inline int64_t vm_div_i64u(int64_t lhs, int64_t rhs) {
+  return (int64_t)(((uint64_t)lhs) / ((uint64_t)rhs));
+}
+static inline int64_t vm_rem_i64s(int64_t lhs, int64_t rhs) {
+  return lhs % rhs;
+}
+static inline int64_t vm_rem_i64u(int64_t lhs, int64_t rhs) {
+  return (int64_t)(((uint64_t)lhs) % ((uint64_t)rhs));
+}
+static inline int64_t vm_not_i64(int64_t operand) {
+  return (int64_t)(~((uint64_t)operand));
+}
+static inline int64_t vm_and_i64(int64_t lhs, int64_t rhs) { return lhs & rhs; }
+static inline int64_t vm_or_i64(int64_t lhs, int64_t rhs) { return lhs | rhs; }
+static inline int64_t vm_xor_i64(int64_t lhs, int64_t rhs) { return lhs ^ rhs; }
+
+//===------------------------------------------------------------------===//
+// Native bitwise shifts and rotates
+//===------------------------------------------------------------------===//
+
+static inline int64_t vm_shl_i64(int64_t operand, int8_t amount) {
+  return (int64_t)(operand << amount);
+};
+static inline int64_t vm_shr_i64s(int64_t operand, int8_t amount) {
+  return (int64_t)(operand >> amount);
+};
+static inline int64_t vm_shr_i64u(int64_t operand, int8_t amount) {
+  return (int64_t)(((uint32_t)operand) >> amount);
+};
 
 #endif  // IREE_VM_OPS_H_

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -31,9 +31,12 @@ iree_cc_test(
     iree::vm::ops
     iree::vm::shims
     ::arithmetic_ops_cc
+    ::arithmetic_ops_i64_cc
     ::assignment_ops_cc
+    ::assignment_ops_i64_cc
     ::conversion_ops_cc
     ::shift_ops_cc
+    ::shift_ops_i64_cc
 )
 
 iree_bytecode_module(
@@ -50,9 +53,33 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
+    arithmetic_ops_i64
+  SRC
+    "../arithmetic_ops_i64.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
     assignment_ops
   SRC
     "../assignment_ops.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    assignment_ops_i64
+  SRC
+    "../assignment_ops_i64.mlir"
   CC_NAMESPACE
     "iree::vm::test::emitc"
   FLAGS
@@ -77,6 +104,18 @@ iree_bytecode_module(
     shift_ops
   SRC
     "../shift_ops.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    shift_ops_i64
+  SRC
+    "../shift_ops_i64.mlir"
   CC_NAMESPACE
     "iree::vm::test::emitc"
   FLAGS

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -19,9 +19,12 @@
 #include "iree/testing/gtest.h"
 #include "iree/vm/api.h"
 #include "iree/vm/test/emitc/arithmetic_ops.vmfb"
+#include "iree/vm/test/emitc/arithmetic_ops_i64.vmfb"
 #include "iree/vm/test/emitc/assignment_ops.vmfb"
+#include "iree/vm/test/emitc/assignment_ops_i64.vmfb"
 #include "iree/vm/test/emitc/conversion_ops.vmfb"
 #include "iree/vm/test/emitc/shift_ops.vmfb"
+#include "iree/vm/test/emitc/shift_ops_i64.vmfb"
 
 namespace {
 
@@ -49,9 +52,12 @@ std::vector<TestParams> GetModuleTestParams() {
   // TODO(simon-camp): get these automatically
   std::vector<ModuleDescription> modules = {
       {arithmetic_ops_descriptor_, arithmetic_ops_create},
+      {arithmetic_ops_i64_descriptor_, arithmetic_ops_i64_create},
       {assignment_ops_descriptor_, assignment_ops_create},
+      {assignment_ops_i64_descriptor_, assignment_ops_i64_create},
       {conversion_ops_descriptor_, conversion_ops_create},
-      {shift_ops_descriptor_, shift_ops_create}};
+      {shift_ops_descriptor_, shift_ops_create},
+      {shift_ops_i64_descriptor_, shift_ops_i64_create}};
 
   for (size_t i = 0; i < modules.size(); i++) {
     iree_vm_native_module_descriptor_t descriptor = modules[i].descriptor;


### PR DESCRIPTION
* Adds support (and tests!) to convert i64 integer arithmetics,
  assignment, const and shift ops from VM to EmitC. In addition to the
  `vm.module(iree-convert-vm-to-emitc` pipeline tests, this also extends
  the module test (`iree-vm-ir-to-c-module`).
* Adds common ExtI64 dispatch op macros
* Refactors the bytcode dispatcher to use shared implementations