### PR TITLE
Reenable tests on Pixel 4

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
@@ -29,8 +29,6 @@ steps:
   - wait
 
   - label: "benchmark on snapdragon-855 (adreno-640) (Pixel 4)"
-    # TODO(#4861): Re-enable when phone is fixed
-    skip: "Phone is borked. See https://github.com/google/iree/issues/4861"
     commands:
       - "buildkite-agent artifact download --step build model-artifacts.tgz ./"
       - "tar xzvf model-artifacts.tgz"


### PR DESCRIPTION
This phone has been fixed.
    
Reverts "Disable benchmark on phone with ADB auth issues (#4862)"
This reverts commit 646e999b1f499a26d7793d238f87d7231defa6fd.

Reverts "[buildkite] Disable lost Pixel 4 (#4868)"
Partially reverts commit 69d4a32217a945436af153250f015e5060267f57,
preserving the relocation of existing "skip" directives.

Fixes https://github.com/google/iree/issues/4861