### PR TITLE
Revert "Disable benchmark on phone with ADB auth issues"

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
@@ -29,8 +29,6 @@ steps:
   - wait
 
   - label: "benchmark on snapdragon-855 (adreno-640) (Pixel 4)"
-    # TODO(#4861): Re-enable when phone is fixed
-    skip: "Phone is borked. See https://github.com/google/iree/issues/4861"
     commands:
       - "buildkite-agent artifact download --step build model-artifacts.tgz ./"
       - "tar xzvf model-artifacts.tgz"


### PR DESCRIPTION
The phone has been poked and is fixed.

Reverts https://github.com/google/iree/pull/4862
This reverts commit 646e999b1f499a26d7793d238f87d7231defa6fd.

Part of https://github.com/google/iree/issues/4861