### PR TITLE
Further extend i64 VM/EmitC support

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -160,12 +160,32 @@ void populateVMToCPatterns(MLIRContext *context,
   patterns.insert<CallOpConversion<IREE::VM::OrI64Op>>(context, "vm_or_i64");
   patterns.insert<CallOpConversion<IREE::VM::XorI64Op>>(context, "vm_xor_i64");
 
+  // ExtI64: Casting and type conversion/emulation ops
+  patterns.insert<CallOpConversion<IREE::VM::TruncI64I32Op>>(context,
+                                                             "vm_trunc_i64i32");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI32I64SOp>>(context,
+                                                            "vm_ext_i32i64s");
+  patterns.insert<CallOpConversion<IREE::VM::ExtI32I64UOp>>(context,
+                                                            "vm_ext_i32i64u");
+
   // ExtI64: Native bitwise shift and rotate ops
   patterns.insert<CallOpConversion<IREE::VM::ShlI64Op>>(context, "vm_shl_i64");
   patterns.insert<CallOpConversion<IREE::VM::ShrI64SOp>>(context,
                                                          "vm_shr_i64s");
   patterns.insert<CallOpConversion<IREE::VM::ShrI64UOp>>(context,
                                                          "vm_shr_i64u");
+
+  // ExtI64: Comparison ops
+  patterns.insert<CallOpConversion<IREE::VM::CmpEQI64Op>>(context,
+                                                          "vm_cmp_eq_i64");
+  patterns.insert<CallOpConversion<IREE::VM::CmpNEI64Op>>(context,
+                                                          "vm_cmp_ne_i64");
+  patterns.insert<CallOpConversion<IREE::VM::CmpLTI64SOp>>(context,
+                                                           "vm_cmp_lt_i64s");
+  patterns.insert<CallOpConversion<IREE::VM::CmpLTI64UOp>>(context,
+                                                           "vm_cmp_lt_i64u");
+  patterns.insert<CallOpConversion<IREE::VM::CmpNZI64Op>>(context,
+                                                          "vm_cmp_nz_i64");
 }
 
 namespace IREE {
@@ -254,10 +274,22 @@ class ConvertVMToEmitCPass
     target.addIllegalOp<IREE::VM::OrI64Op>();
     target.addIllegalOp<IREE::VM::XorI64Op>();
 
+    // ExtI64: Casting and type conversion/emulation ops
+    target.addIllegalOp<IREE::VM::TruncI64I32Op>();
+    target.addIllegalOp<IREE::VM::ExtI32I64SOp>();
+    target.addIllegalOp<IREE::VM::ExtI32I64UOp>();
+
     // ExtI64: Native bitwise shift and rotate ops
     target.addIllegalOp<IREE::VM::ShlI64Op>();
     target.addIllegalOp<IREE::VM::ShrI64SOp>();
     target.addIllegalOp<IREE::VM::ShrI64UOp>();
+
+    // ExtI64: Comparison ops
+    target.addIllegalOp<IREE::VM::CmpEQI64Op>();
+    target.addIllegalOp<IREE::VM::CmpNEI64Op>();
+    target.addIllegalOp<IREE::VM::CmpLTI64SOp>();
+    target.addIllegalOp<IREE::VM::CmpLTI64UOp>();
+    target.addIllegalOp<IREE::VM::CmpNZI64Op>();
 
     if (failed(
             applyFullConversion(getOperation(), target, std::move(patterns)))) {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -1,0 +1,58 @@
+// Tests printing and parsing of comparison ops.
+
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @cmp_eq_i64
+  vm.func @cmp_eq_i64(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    %0 = vm.cmp.eq.i64 %arg0, %arg1 : i64
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @cmp_ne_i64
+  vm.func @cmp_ne_i64(%arg0 : i64, %arg1 : i64) {
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    %0 = vm.cmp.ne.i64 %arg0, %arg1 : i64
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @cmp_lt_i64_s
+  vm.func @cmp_lt_i64_s(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    %0 = vm.cmp.lt.i64.s %arg0, %arg1 : i64
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @cmp_lt_i64_u
+  vm.func @cmp_lt_i64_u(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    %0 = vm.cmp.lt.i64.u %arg0, %arg1 : i64
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  // CHECK-LABEL: vm.func @cmp_nz_i64
+  vm.func @cmp_nz_i64(%arg0 : i64) -> i64 {
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i64"(%arg0) {args = [0 : index]} : (i64) -> i32
+    %0 = vm.cmp.nz.i64 %arg0 : i64
+    vm.return
+  }
+}
+
+// -----

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @trunc_i64
+vm.module @my_module {
+  vm.func @trunc_i64(%arg0 : i64) -> i32 {
+    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i64i32"(%arg0) {args = [0 : index]} : (i64) -> i32
+    %0 = vm.trunc.i64.i32 %arg0 : i64 -> i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: vm.func @ext_i64
+vm.module @my_module {
+  vm.func @ext_i64(%arg0 : i32) -> i64 {
+    // CHECK-NEXT: %0 = emitc.call "vm_ext_i32i64s"(%arg0) {args = [0 : index]} : (i32) -> i64
+    %0 = vm.ext.i32.i64.s %arg0 : i32 -> i64
+    // CHECK-NEXT: %1 = emitc.call "vm_ext_i32i64u"(%arg0) {args = [0 : index]} : (i32) -> i64
+    %1 = vm.ext.i32.i64.u %arg0 : i32 -> i64
+    vm.return %1 : i64
+  }
+}

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1400,17 +1400,17 @@ iree_status_t iree_vm_bytecode_dispatch(
       DISPATCH_OP(EXT_I64, TruncI64I32, {
         int64_t operand = VM_DecOperandRegI64("operand");
         int32_t* result = VM_DecResultRegI32("result");
-        *result = (uint32_t)((uint64_t)operand);
+        *result = vm_trunc_i64i32(operand);
       });
       DISPATCH_OP(EXT_I64, ExtI32I64S, {
         int32_t operand = VM_DecOperandRegI32("operand");
         int64_t* result = VM_DecResultRegI64("result");
-        *result = (int64_t)((int32_t)operand);
+        *result = vm_ext_i32i64s(operand);
       });
       DISPATCH_OP(EXT_I64, ExtI32I64U, {
         int32_t operand = VM_DecOperandRegI32("operand");
         int64_t* result = VM_DecResultRegI64("result");
-        *result = (uint64_t)((uint32_t)operand);
+        *result = vm_ext_i32i64u(operand);
       });
 
       //===----------------------------------------------------------------===//
@@ -1433,22 +1433,22 @@ iree_status_t iree_vm_bytecode_dispatch(
       // ExtI64: Comparison ops
       //===----------------------------------------------------------------===//
 
-#define DISPATCH_OP_EXT_I64_CMP_I64(op_name, type, op) \
-  DISPATCH_OP(EXT_I64, op_name, {                      \
-    int64_t lhs = VM_DecOperandRegI64("lhs");          \
-    int64_t rhs = VM_DecOperandRegI64("rhs");          \
-    int32_t* result = VM_DecResultRegI32("result");    \
-    *result = (((type)lhs)op((type)rhs)) ? 1 : 0;      \
+#define DISPATCH_OP_EXT_I64_CMP_I64(op_name, op_func) \
+  DISPATCH_OP(EXT_I64, op_name, {                     \
+    int64_t lhs = VM_DecOperandRegI64("lhs");         \
+    int64_t rhs = VM_DecOperandRegI64("rhs");         \
+    int32_t* result = VM_DecResultRegI32("result");   \
+    *result = op_func(lhs, rhs);                      \
   });
 
-      DISPATCH_OP_EXT_I64_CMP_I64(CmpEQI64, int64_t, ==);
-      DISPATCH_OP_EXT_I64_CMP_I64(CmpNEI64, int64_t, !=);
-      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64S, int64_t, <);
-      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64U, uint64_t, <);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpEQI64, vm_cmp_eq_i64);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpNEI64, vm_cmp_ne_i64);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64S, vm_cmp_lt_i64s);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64U, vm_cmp_lt_i64u);
       DISPATCH_OP(EXT_I64, CmpNZI64, {
         int64_t operand = VM_DecOperandRegI64("operand");
         int32_t* result = VM_DecResultRegI32("result");
-        *result = (operand != 0) ? 1 : 0;
+        *result = vm_cmp_nz_i64(operand);
       });
 #else
       return iree_make_status(IREE_STATUS_UNIMPLEMENTED);

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -169,6 +169,20 @@ static inline int64_t vm_or_i64(int64_t lhs, int64_t rhs) { return lhs | rhs; }
 static inline int64_t vm_xor_i64(int64_t lhs, int64_t rhs) { return lhs ^ rhs; }
 
 //===------------------------------------------------------------------===//
+// ExtI64: Casting and type conversion/emulation
+//===------------------------------------------------------------------===//
+
+static inline int32_t vm_trunc_i64i32(int64_t operand) {
+  return (uint32_t)((uint64_t)operand);
+}
+static inline int64_t vm_ext_i32i64s(int32_t operand) {
+  return (int64_t)((int32_t)operand);
+}
+static inline int64_t vm_ext_i32i64u(int32_t operand) {
+  return (uint64_t)((uint32_t)operand);
+}
+
+//===------------------------------------------------------------------===//
 // ExtI64: Native bitwise shifts and rotates
 //===------------------------------------------------------------------===//
 
@@ -180,6 +194,26 @@ static inline int64_t vm_shr_i64s(int64_t operand, int8_t amount) {
 }
 static inline int64_t vm_shr_i64u(int64_t operand, int8_t amount) {
   return (int64_t)(((uint64_t)operand) >> amount);
+}
+
+//===------------------------------------------------------------------===//
+// ExtI64: Comparison ops
+//===------------------------------------------------------------------===//
+
+static inline int32_t vm_cmp_eq_i64(int64_t lhs, int64_t rhs) {
+  return (lhs == rhs) ? 1 : 0;
+}
+static inline int32_t vm_cmp_ne_i64(int64_t lhs, int64_t rhs) {
+  return (lhs != rhs) ? 1 : 0;
+}
+static inline int32_t vm_cmp_lt_i64s(int64_t lhs, int64_t rhs) {
+  return (lhs < rhs) ? 1 : 0;
+}
+static inline int32_t vm_cmp_lt_i64u(int64_t lhs, int64_t rhs) {
+  return (((uint64_t)lhs) < ((uint64_t)rhs)) ? 1 : 0;
+}
+static inline int32_t vm_cmp_nz_i64(int64_t operand) {
+  return (operand != 0) ? 1 : 0;
 }
 
 #endif  // IREE_VM_OPS_H_

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_test(
     ::assignment_ops_cc
     ::assignment_ops_i64_cc
     ::conversion_ops_cc
+    ::conversion_ops_i64_cc
     ::shift_ops_cc
     ::shift_ops_i64_cc
 )
@@ -92,6 +93,18 @@ iree_bytecode_module(
     conversion_ops
   SRC
     "../conversion_ops.mlir"
+  CC_NAMESPACE
+    "iree::vm::test::emitc"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    conversion_ops_i64
+  SRC
+    "../conversion_ops_i64.mlir"
   CC_NAMESPACE
     "iree::vm::test::emitc"
   FLAGS

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -23,6 +23,7 @@
 #include "iree/vm/test/emitc/assignment_ops.vmfb"
 #include "iree/vm/test/emitc/assignment_ops_i64.vmfb"
 #include "iree/vm/test/emitc/conversion_ops.vmfb"
+#include "iree/vm/test/emitc/conversion_ops_i64.vmfb"
 #include "iree/vm/test/emitc/shift_ops.vmfb"
 #include "iree/vm/test/emitc/shift_ops_i64.vmfb"
 
@@ -56,6 +57,7 @@ std::vector<TestParams> GetModuleTestParams() {
       {assignment_ops_descriptor_, assignment_ops_create},
       {assignment_ops_i64_descriptor_, assignment_ops_i64_create},
       {conversion_ops_descriptor_, conversion_ops_create},
+      {conversion_ops_i64_descriptor_, conversion_ops_i64_create},
       {shift_ops_descriptor_, shift_ops_create},
       {shift_ops_i64_descriptor_, shift_ops_i64_create}};
 


### PR DESCRIPTION
* Adds VM to EmitC conversions (and tests) for comparison and conversion
  ops.
* Adds shared implementations and refactors the bytecode dispatcher to
  use those.