### PR TITLE
Avoid unnecessary intermediate memory allocation by preprocessing linalg operations.

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -276,9 +276,7 @@ static LogicalResult convertSubTensorOp(
   b.setInsertionPoint(op);
   Location loc = op.getLoc();
   Value srcTensor = op.source();
-  RankedTensorType srcTensorType = op.getSourceType();
   Value resultTensor = op.result();
-  RankedTensorType resultTensorType = op.getType();
   Value inputBuffer = bvm.lookup(srcTensor);
   MemRefType inputBufferType = inputBuffer.getType().cast<MemRefType>();
 

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -25,8 +25,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
-#include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
 #include "iree/compiler/Conversion/Common/Passes.h"
+#include "iree/compiler/Conversion/Common/Transforms.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -47,6 +47,13 @@
 namespace mlir {
 namespace iree_compiler {
 
+static MemRefType getMemrefTypeForTensor(RankedTensorType tensorType,
+                                         ArrayRef<AffineMap> layout = {},
+                                         unsigned memorySpace = 0) {
+  return MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
+                         layout, memorySpace);
+}
+
 // Transfer all `dim` ops on `tensor` to `memref`.
 static void transferShapeOpsToMemref(OpBuilder &b, Value tensor, Value memref,
                                      BlockAndValueMapping &bvm) {
@@ -65,17 +72,6 @@ static void transferShapeOpsToMemref(OpBuilder &b, Value tensor, Value memref,
       bvm.map(flowTieShapeOp.getResult(), tieShapeOp.getResult());
       continue;
     }
-  }
-}
-
-// TODO(ravishankarm): Marker added to copy op to hook into rest of the
-// codegen. Mostly need to kill markers (or at least assume that default marker
-// is workgroup marker on the linalg on tensors path.
-static void createCopyOp(OpBuilder &b, Location loc, Value source, Value dest,
-                         StringRef marker = "") {
-  auto op = b.create<linalg::CopyOp>(loc, source, dest);
-  if (!marker.empty()) {
-    setMarker(op, marker);
   }
 }
 
@@ -141,7 +137,7 @@ static LogicalResult allocateBuffersForResults(
     // manually defined ops specifically.
     if (!isa<linalg::FillOp>(op.getOperation()) &&
         op.payloadUsesValueFromOutputOperandIndex(resultIndex)) {
-      createCopyOp(b, loc, bvm.lookup(outTensor), alloc, getMarkerOrNull(op));
+      b.create<linalg::CopyOp>(loc, bvm.lookup(outTensor), alloc);
     }
   }
   for (auto it : llvm::zip(op->getResults(), resultBuffers)) {
@@ -166,8 +162,7 @@ static void finalizeBufferAllocation(OpBuilder &b, linalg::LinalgOp op,
     Value resultValue = result.value();
     Value resultBuffer = bvm.lookup(resultValue);
     if (resultBuffer != outputs[result.index()]) {
-      createCopyOp(b, loc, outputs[result.index()], resultBuffer,
-                   getMarkerOrNull(op));
+      b.create<linalg::CopyOp>(loc, outputs[result.index()], resultBuffer);
     }
   }
 }
@@ -207,6 +202,42 @@ LogicalResult convertAnyLinalgOp(OpBuilder &b,
   return success();
 }
 
+/// Avoids creating an allocation if the result tensor can just be aliased to
+/// use the same buffer (`inputBuffer`) that `srcTensor` is mapped to. This can
+/// be done if `srcTensor` has a single use, which is the operation which is
+/// being converted to buffers.
+/// Note that the mapping for `srcTensor` need not be mapped to `inputBuffer`
+/// directly. It could also be mapped to an alias of the `inputBuffer.
+static LogicalResult createAliasingBufferOrAllocationForResult(
+    OpBuilder &b, Location loc, WorkgroupMemoryAllocationFn allocationFn,
+    Value srcTensor, Value inputBuffer, Value resultTensor,
+    ArrayRef<Value> allocationDynamicDims, BlockAndValueMapping &bvm) {
+  // Case 1 : If result tensor is already mapped to a buffer just copy the
+  // value.
+  if (Value outputBuffer = bvm.lookupOrNull(resultTensor)) {
+    if (inputBuffer != outputBuffer) {
+      b.create<linalg::CopyOp>(loc, inputBuffer, outputBuffer);
+    }
+    return success();
+  }
+  // Case 2: If the input tensor has only one use (this operation, then no need
+  // to create a copy either.
+  if (srcTensor.hasOneUse()) {
+    bvm.map(resultTensor, inputBuffer);
+    return success();
+  }
+  // Fallback is to create an allocation and copy the output.
+  MemRefType inputBufferType = inputBuffer.getType().cast<MemRefType>();
+  assert(allocationDynamicDims.size() ==
+         static_cast<size_t>(inputBufferType.getRank()));
+  Value alloc = allocationFn(
+      b, loc, SmallVector<int64_t, 4>(inputBufferType.getRank(), -1),
+      inputBufferType.getElementType(), allocationDynamicDims);
+  b.create<linalg::CopyOp>(loc, inputBuffer, alloc);
+  bvm.map(resultTensor, alloc);
+  return success();
+}
+
 /// Converts a `linalg.tensor_reshape` operation to a `linalg.reshape`
 /// operation.
 static LogicalResult convertTensorReshapeOp(
@@ -220,41 +251,59 @@ static LogicalResult convertTensorReshapeOp(
   Value resultTensor = op.result();
   RankedTensorType resultTensorType = op.getResultType();
   Value inputBuffer = bvm.lookup(srcTensor);
+  MemRefType inputBufferType = inputBuffer.getType().cast<MemRefType>();
   // Create the reshape op.
-  auto reshapeSrcType =
-      MemRefType::get(srcTensorType.getShape(), srcTensorType.getElementType());
+  auto reshapeSrcType = getMemrefTypeForTensor(
+      srcTensorType, {}, inputBufferType.getMemorySpace());
   Value reshapeSrc = b.create<MemRefCastOp>(loc, inputBuffer, reshapeSrcType);
-  auto reshapeResultType = MemRefType::get(resultTensorType.getShape(),
-                                           resultTensorType.getElementType());
+  auto reshapeResultType = getMemrefTypeForTensor(
+      resultTensorType, {}, inputBufferType.getMemorySpace());
   Value bufferReshape = b.create<linalg::ReshapeOp>(
       loc, reshapeResultType, reshapeSrc, op.reassociation());
+  auto allocationDynamicSizes = linalg::getReshapeOutputShapeFromInputShape(
+      b, loc, inputBuffer, resultTensorType.getShape(),
+      op.getReassociationMaps());
+  return createAliasingBufferOrAllocationForResult(
+      b, loc, allocationFn, srcTensor, bufferReshape, resultTensor,
+      allocationDynamicSizes, bvm);
+}
 
-  // Case 1: If the output tensor has already been mapped to a different buffer,
-  // need to copy.
-  if (Value outputBuffer = bvm.lookupOrNull(resultTensor)) {
-    if (inputBuffer != outputBuffer) {
-      createCopyOp(b, loc, bufferReshape, outputBuffer, getMarkerOrNull(op));
-    }
-    bvm.map(resultTensor, bufferReshape);
-    return success();
-  }
-  // Case 2: If the input tensor has only one use (this operation, then no need
-  // to create a copy either.
-  if (srcTensor.hasOneUse()) {
-    bvm.map(resultTensor, bufferReshape);
-    return success();
-  }
-  // Fallback is to create an allocation and copy the output.
-  // Compute the shape of the new tensor based on shape of the input tensor.
-  SmallVector<Value, 4> dynamicDims =
-      linalg::getReshapeOutputShapeFromInputShape(b, loc, inputBuffer,
-                                                  resultTensorType.getShape(),
-                                                  op.getReassociationMaps());
-  Value alloc = allocationFn(b, loc, resultTensorType.getShape(),
-                             resultTensorType.getElementType(), dynamicDims);
-  createCopyOp(b, loc, bufferReshape, alloc, getMarkerOrNull(op));
-  bvm.map(resultTensor, alloc);
-  return success();
+/// Converts a `subtensor` operation to a `subview` operation.
+static LogicalResult convertSubTensorOp(
+    OpBuilder &b, WorkgroupMemoryAllocationFn allocationFn, SubTensorOp op,
+    BlockAndValueMapping &bvm) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(op);
+  Location loc = op.getLoc();
+  Value srcTensor = op.source();
+  RankedTensorType srcTensorType = op.getSourceType();
+  Value resultTensor = op.result();
+  RankedTensorType resultTensorType = op.getType();
+  Value inputBuffer = bvm.lookup(srcTensor);
+  MemRefType inputBufferType = inputBuffer.getType().cast<MemRefType>();
+
+  auto extractFromI64ArrayAttr = [](ArrayAttr attr) {
+    return llvm::to_vector<4>(llvm::map_range(attr, [](Attribute a) -> int64_t {
+      return a.cast<IntegerAttr>().getInt();
+    }));
+  };
+  auto subViewResultType = SubViewOp::inferResultType(
+      inputBufferType, extractFromI64ArrayAttr(op.static_offsets()),
+      extractFromI64ArrayAttr(op.static_sizes()),
+      extractFromI64ArrayAttr(op.static_strides()));
+  auto subViewOp =
+      b.create<SubViewOp>(loc, subViewResultType, inputBuffer, op.offsets(),
+                          op.sizes(), op.strides(), op.static_offsets(),
+                          op.static_sizes(), op.static_strides());
+  auto allocationDynamicSizes = llvm::to_vector<4>(
+      llvm::map_range(subViewOp.getOrCreateRanges(b, loc), [](Range range) {
+        assert(matchPattern(range.stride, m_One()) &&
+               "unhandled non-unit stride");
+        return range.size;
+      }));
+  return createAliasingBufferOrAllocationForResult(
+      b, loc, allocationFn, srcTensor, subViewOp, resultTensor,
+      allocationDynamicSizes, bvm);
 }
 
 static LogicalResult convertTransferOp(OpBuilder &b,
@@ -309,13 +358,6 @@ static SmallVector<int64_t, 4> extractFromI64ArrayAttr(Attribute attr) {
       [](Attribute a) -> int64_t { return a.cast<IntegerAttr>().getInt(); }));
 }
 
-static MemRefType getMemrefTypeForTensor(
-    RankedTensorType tensorType, ArrayRef<AffineMap> affineMapComposition = {},
-    unsigned memorySpace = 0) {
-  return MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
-                         affineMapComposition, memorySpace);
-}
-
 LogicalResult convertInterfaceLoadTensorOp(
     OpBuilder &b, IREE::Flow::DispatchInputLoadOp loadOp,
     BlockAndValueMapping &bvm) {
@@ -347,8 +389,9 @@ static Operation *getInsertionPointForReplacementStoreOp(
     if (!insertAfter || insertAfter->isBeforeInBlock(definingOp))
       insertAfter = definingOp;
   }
-  // All defining ops are outside of the block, so just insertBefore
-  if (!insertAfter) return insertBefore;
+  // All defining ops are outside of the block, so just insert at the start of
+  // the block.
+  if (!insertAfter) return &(op->getBlock()->front());
   if (insertAfter->isBeforeInBlock(insertBefore))
     return insertAfter->getNextNode();
   return nullptr;
@@ -383,6 +426,24 @@ LogicalResult preProcessConvertInterfaceStoreTensorOp(
       createSubviewOp(b, storeOp.getLoc(), bvm.lookup(storeOp.target()),
                       storeOp.offsets(), storeOp.sizes(), storeOp.strides());
   bvm.map(storeOp.value(), subview);
+  return success();
+}
+
+/// Pre process linalg operations (on tensors) so that if the result of the
+/// linalg operation is mapped to a buffer, the out is mapped to the same buffer
+/// to make this an inplace update.
+LogicalResult preProcessLinalgOps(OpBuilder &b, linalg::LinalgOp op,
+                                  BlockAndValueMapping &bvm) {
+  if (!op.hasTensorSemantics()) return success();
+  for (auto en :
+       llvm::zip(op.getOperation()->getResults(), op.getOutputTensors())) {
+    Value resultTensor = std::get<0>(en);
+    Value outTensor = std::get<1>(en);
+    Value resultBuffer = bvm.lookupOrNull(resultTensor);
+    if (resultBuffer && outTensor.hasOneUse()) {
+      bvm.map(outTensor, resultBuffer);
+    }
+  }
   return success();
 }
 
@@ -472,6 +533,24 @@ void LinalgBufferizePass::runOnFunction() {
           .wasInterrupted()) {
     return signalPassFailure();
   }
+
+  /// Walk the linalg operations backwards (if they are all in the same basic
+  /// block) to propagate buffer usage backwards to reduce the need for
+  /// allocation. This works for simple cases where all the linalg operations
+  /// are within the same basic block. Fallback is to create a separate
+  /// allocation for the output.
+  {
+    SmallVector<linalg::LinalgOp, 4> linalgOps;
+    SmallVector<Operation *, 4> tiledLoops;
+    if (succeeded(getLinalgOps(funcOp, linalgOps, tiledLoops))) {
+      for (linalg::LinalgOp op : llvm::reverse(linalgOps)) {
+        if (failed(preProcessLinalgOps(b, op, bvm))) {
+          return signalPassFailure();
+        }
+      }
+    }
+  }
+
   auto conversionDispatch = [&](Operation *op) -> WalkResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
         .Case<IREE::Flow::DispatchInputLoadOp>(
@@ -484,6 +563,9 @@ void LinalgBufferizePass::runOnFunction() {
             })
         .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
           return convertAnyLinalgOp(b, allocationFn, linalgOp, bvm);
+        })
+        .Case<SubTensorOp>([&](SubTensorOp subTensorOp) {
+          return convertSubTensorOp(b, allocationFn, subTensorOp, bvm);
         })
         .Case<linalg::TensorReshapeOp>([&](linalg::TensorReshapeOp reshapeOp) {
           return convertTensorReshapeOp(b, allocationFn, reshapeOp, bvm);

--- a/iree/compiler/Conversion/Common/Transforms.h
+++ b/iree/compiler/Conversion/Common/Transforms.h
@@ -53,6 +53,11 @@ void applyCanonicalizationPatternsForTiling(MLIRContext *context,
 /// `scf.for` operations in the function return the linalg operations in the
 /// body of the function if it has a single basic block. Return failure in all
 /// other cases.
+///
+/// TODO(ravishankarm) This methods also adds the "workgroup" marker to all ops
+/// within the loop. The marker is the way to tie into rest of the
+/// codegen. Refactor the downstream passes and get rid of the markers once and
+/// for all.
 LogicalResult getLinalgOps(FuncOp funcOp,
                            SmallVectorImpl<linalg::LinalgOp> &linalgOps,
                            SmallVectorImpl<Operation *> &tiledLoops);

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -93,6 +93,7 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
+//   CHECK-DAG:       %[[RESULT:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
 //   CHECK-DAG:       %[[LHS:.+]] = subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
 //   CHECK-DAG:       %[[RHS:.+]] = subview %[[TENSOR_RHS]][0, %[[IV1]]] [3, 1] [1, 1]
 //       CHECK:       %[[ALLOC:.+]] = alloc() : memref<1x3xf32>
@@ -100,7 +101,6 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //  CHECK-SAME:         ins(%[[LHS]] :
 //  CHECK-SAME:         outs(%[[ALLOC]]
 //   CHECK-DAG:       %[[INIT:.+]] = subview %[[TENSOR_INIT]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
-//   CHECK-DAG:       %[[RESULT:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
 //       CHECK:       linalg.copy(%[[INIT]], %[[RESULT]])
 //       CHECK:       linalg.matmul
 //  CHECK-SAME:         ins(%[[ALLOC]], %[[RHS]]
@@ -151,18 +151,16 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
+//   CHECK-DAG:       %[[RESULT:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
 //   CHECK-DAG:       %[[LHS:.+]] = subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
 //   CHECK-DAG:       %[[RHS:.+]] = subview %[[TENSOR_RHS]][0, %[[IV1]]] [3, 1] [1, 1]
 //   CHECK-DAG:       %[[INIT:.+]] = subview %[[TENSOR_INIT]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
-//       CHECK:       %[[ALLOC:.+]] = alloc() : memref<1x1xf32>
 //       CHECK:       linalg.generic
 //  CHECK-SAME:         ins(%[[INIT]] :
-//  CHECK-SAME:         outs(%[[ALLOC]]
-//   CHECK-DAG:       %[[RESULT:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
+//  CHECK-SAME:         outs(%[[RESULT]]
 //       CHECK:       linalg.matmul
 //  CHECK-SAME:         ins(%[[LHS]], %[[RHS]]
-//  CHECK-SAME:         outs(%[[ALLOC]]
-//       CHECK:       linalg.copy(%[[ALLOC]], %[[RESULT]])
+//  CHECK-SAME:         outs(%[[RESULT]]
 
 // -----
 
@@ -418,7 +416,7 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //       CHECK:   %[[RESHAPE:.+]] = linalg.reshape %[[ARG0V]] [#[[MAP1]]]
 //   CHECK-DAG:   linalg.copy(%[[RESHAPE]], %[[RET1V]])
 //   CHECK-DAG:   linalg.generic
-//  CHECK-SAME:     ins(%[[RESHAPE]] : memref<3x4xi32>)
+//  CHECK-SAME:     ins(%[[RET1V]] : memref<3x4xi32, #[[MAP0]]>)
 //  CHECK-SAME:     outs(%[[RET0V]] : memref<3x4xi32, #[[MAP0]]>)
 
 
@@ -464,3 +462,60 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //  CHECK-SAME:     outs(%[[ALLOC]] : memref<3x4xi32>)
 //       CHECK:   %[[RESULT:.+]] = linalg.reshape %[[ALLOC]] [#[[MAP1]]]
 //       CHECK:   linalg.copy(%[[RESULT]], %[[RET0V]])
+
+// -----
+
+func @dot_general_lowering() {
+  %cst = constant 0.000000e+00 : f32
+  %c3 = constant 3 : index
+  %c0 = constant 0 : index
+  %c2 = constant 2 : index
+  %c1 = constant 1 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.input<1x1x2xf32>
+  %1 = hal.interface.binding.subspan @legacy_io::@arg1[%c0] : !flow.dispatch.input<2x3xf32>
+  %2 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<1x3xf32>
+  %3 = flow.dispatch.input.load %0 : !flow.dispatch.input<1x1x2xf32> -> tensor<1x1x2xf32>
+  %4 = linalg.tensor_reshape %3 [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d2)>] : tensor<1x1x2xf32> into tensor<1x2xf32>
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %5 = muli %workgroup_size_y, %workgroup_id_y : index
+  %6 = muli %workgroup_size_y, %workgroup_count_y : index
+  scf.for %arg0 = %5 to %c1 step %6 {
+    %7 = muli %workgroup_size_x, %workgroup_id_x : index
+    %8 = muli %workgroup_size_x, %workgroup_count_x : index
+    scf.for %arg1 = %7 to %c3 step %8 {
+      %9 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 1)>(%arg0)[%workgroup_size_y]
+      %10 = subtensor %4[%arg0, 0] [%9, 2] [1, 1] : tensor<1x2xf32> to tensor<?x2xf32>
+      %11 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 3)>(%arg1)[%workgroup_size_x]
+      %12 = flow.dispatch.input.load %1, offsets = [%c0, %arg1], sizes = [%c2, %11], strides = [%c1, %c1] : !flow.dispatch.input<2x3xf32> -> tensor<2x?xf32>
+      %13 = linalg.init_tensor [%9, %11] : tensor<?x?xf32>
+      %14 = linalg.fill(%13, %cst) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+      %15 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%10, %12 : tensor<?x2xf32>, tensor<2x?xf32>) outs(%14 : tensor<?x?xf32>) -> tensor<?x?xf32>
+      flow.dispatch.output.store %15, %2, offsets = [%arg0, %arg1], sizes = [%9, %11], strides = [%c1, %c1] : tensor<?x?xf32> -> !flow.dispatch.output<1x3xf32>
+    }
+  }
+  return
+}
+hal.interface @legacy_io attributes {sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @arg1, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @dot_general_lowering()
+//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @legacy_io::@arg0
+//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @legacy_io::@arg1
+//   CHECK-DAG:   %[[RESHAPE_LHS:.+]] = linalg.reshape %[[LHS]]
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
+//       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
+//       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
+//   CHECK-DAG:       %[[LHS_TILE:.+]] = subview %[[RESHAPE_LHS]][%[[IV0]], 0]
+//   CHECK-DAG:       %[[RESULT_TILE:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]]
+//   CHECK-DAG:       %[[RHS_TILE:.+]] = subview %[[RHS]][0, %[[IV1]]]
+//       CHECK:       linalg.fill(%[[RESULT_TILE]], %{{.+}})
+//       CHECK:       linalg.matmul
+//  CHECK-SAME:         ins(%[[LHS_TILE]], %[[RHS_TILE]]
+//  CHECK-SAME:         outs(%[[RESULT_TILE]]

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -154,7 +154,7 @@ iree_check_single_backend_test_suite(
         "divide.mlir",
         # https://github.com/google/iree/issues/4079
         "dot.mlir",
-        # "dot_general.mlir",
+        "dot_general.mlir",
         "exponential.mlir",
         "exponential_minus_one.mlir",
         "floor.mlir",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -147,6 +147,7 @@ iree_check_single_backend_test_suite(
     "cosine.mlir"
     "divide.mlir"
     "dot.mlir"
+    "dot_general.mlir"
     "exponential.mlir"
     "exponential_minus_one.mlir"
     "floor.mlir"


### PR DESCRIPTION
If all linalg operations are in a basic block some basic propagation
of buffers to use can allow computing the result of linalg operations
in place when converted to buffers. This eliminates majority of
intermediate stack allocations that were introduced by bufferization
for IREEs use cases.

Also adding support for lowering subtensor operation.

This enables running dot_general through linalg on tensors path.