### PR TITLE
 Add an optional promot workgroup memory to stack memory step.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndVectorizePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndVectorizePass.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Conversion/StandardToSPIRV/StandardToSPIRV.h"
 #include "mlir/Dialect/Linalg/Transforms/CodegenStrategy.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -26,6 +27,13 @@
 
 namespace mlir {
 namespace iree_compiler {
+
+// TODO(ataei): Use pass options instead of global llvm flags.
+static llvm::cl::opt<bool> clEnablePromoteWorkgroupToFullTiles(
+    "iree-codegen-llvm-promote-workgroup-to-full-tiles",
+    llvm::cl::desc("Enable promoting wokgroup memory to full tiles allocated "
+                   "on the stack."),
+    llvm::cl::init(false));
 
 namespace {
 template <typename LinalgOpTy>
@@ -61,10 +69,79 @@ struct TileAndVectorizeWorkgroups
 };
 }  // namespace
 
+namespace {
+/// Pattern to promote all matmul operands to memory.
+struct PromoteMatmulSubviewsPattern
+    : public linalg::LinalgPromotionPattern<linalg::MatmulOp> {
+  PromoteMatmulSubviewsPattern(MLIRContext *context,
+                               linalg::LinalgPromotionOptions options,
+                               linalg::LinalgTransformationFilter marker,
+                               PatternBenefit benefit = 1)
+      : linalg::LinalgPromotionPattern<linalg::MatmulOp>(
+            context,
+            options.setOperandsToPromote({0, 1, 2})
+                .setUseFullTileBuffersByDefault(true),
+            marker, benefit) {}
+};
+}  // namespace
+
+namespace {
+
+// TODO(ataei): Refactor this into a common utility with LinalgToSPIRV.
+Optional<Value> allocateWorkgroupMemoryOnStack(
+    OpBuilder &b, SubViewOp subview, ArrayRef<Value> boundingSubViewSize,
+    OperationFolder *folder) {
+  // Allocate the memory into the entry block of the parent FuncOp. This better
+  // aligns with the semantics of this memory which is available at the entry of
+  // the function.
+  OpBuilder::InsertionGuard guard(b);
+  FuncOp funcOp = subview->getParentOfType<FuncOp>();
+  if (!funcOp) {
+    subview.emitError("expected op to be within std.func");
+    return llvm::None;
+  }
+  b.setInsertionPointToStart(&(*funcOp.getBody().begin()));
+  // The bounding subview size is expected to be constant. This specified the
+  // shape of the allocation.
+  SmallVector<int64_t, 2> shape = llvm::to_vector<2>(
+      llvm::map_range(boundingSubViewSize, [](Value v) -> int64_t {
+        APInt value;
+        if (matchPattern(v, m_ConstantInt(&value))) return value.getSExtValue();
+        return -1;
+      }));
+  if (llvm::any_of(shape, [](int64_t v) { return v == -1; })) return {};
+  MemRefType allocType =
+      MemRefType::get(shape, subview.getType().getElementType(), {});
+  Value buffer = b.create<AllocaOp>(subview.getLoc(), allocType);
+  return buffer;
+}
+
+LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer) {
+  MemRefType bufferType = buffer.getType().dyn_cast<MemRefType>();
+  if (!bufferType) return failure();
+  return success();
+}
+
+}  // namespace
+
 void TileAndVectorizeWorkgroups::runOnFunction() {
   auto funcOp = getOperation();
   MLIRContext *context = &getContext();
   CPUKernelDispatch cpuKernelDispatch;
+
+  // Promotes workgroups subviews to a full-tile allocated on the stack.
+  if (clEnablePromoteWorkgroupToFullTiles) {
+    OwningRewritePatternList promotionPatterns;
+    promotionPatterns.insert<PromoteMatmulSubviewsPattern>(
+        context,
+        linalg::LinalgPromotionOptions().setAllocationDeallocationFns(
+            allocateWorkgroupMemoryOnStack, deallocateWorkgroupMemory),
+        linalg::LinalgTransformationFilter(
+            Identifier::get(getWorkgroupMarker(), context),
+            Identifier::get(getWorkgroupMemoryMarker(), context)));
+    ViewOp::getCanonicalizationPatterns(promotionPatterns, context);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(promotionPatterns));
+  }
 
   // Workgroup first level of tiling.
   {
@@ -80,7 +157,10 @@ void TileAndVectorizeWorkgroups::runOnFunction() {
                   cpuKernelDispatch, builder, operation);
             }),
         linalg::LinalgTransformationFilter(
-            Identifier::get(getWorkgroupMarker(), context),
+            Identifier::get(clEnablePromoteWorkgroupToFullTiles
+                                ? getWorkgroupMemoryMarker()
+                                : getWorkgroupMarker(),
+                            context),
             Identifier::get(getWorkgroupL1TileMarker(), context)));
 
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(l1patterns));
@@ -120,7 +200,8 @@ void TileAndVectorizeWorkgroups::runOnFunction() {
   // Apply vectorization patterns.
   {
     OwningRewritePatternList vectorizationPatterns;
-    linalg::insertVectorizationPatterns<linalg::ContractionOpInterface>(
+    linalg::insertVectorizationPatterns<linalg::ContractionOpInterface,
+                                        linalg::CopyOp, linalg::FillOp>(
         vectorizationPatterns, context, linalg::LinalgVectorizationOptions(),
         linalg::LinalgTransformationFilter(
             Identifier::get(getVectorizeMarker(), context)));
@@ -157,8 +238,8 @@ void TileAndVectorizeWorkgroups::runOnFunction() {
     OwningRewritePatternList vectorToLoopsPatterns;
     populateVectorToSCFConversionPatterns(vectorToLoopsPatterns, context,
                                           vectorToSCFOptions);
-    // Hosit hierarchical tiling indexing and other loop invariant transfer ops
-    // computation.
+    // Hosit hierarchical tiling indexing and other loop invariant transfer
+    // ops computation.
     linalg::hoistViewAllocOps(funcOp);
     linalg::hoistRedundantVectorTransfers(funcOp);
 

--- a/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
@@ -1,7 +1,7 @@
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-linalg-tile-and-distribute)),hal.executable(hal.executable.target(module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
-
 // TODO(GH-4901): Convert these tests back to use dynamic shapes when linalg on tensors becomes default.
-hal.executable @matmul_128x128x128 attributes {sym_visibility = "private"} {
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-linalg-tile-and-distribute)),hal.executable(hal.executable.target(module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-linalg-tile-and-distribute)),hal.executable(hal.executable.target(module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file -iree-codegen-llvm-promote-workgroup-to-full-tiles -cse %s | IreeFileCheck %s -check-prefix=CHECK-PROMOTED
+hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
   hal.interface @legacy_io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
@@ -47,3 +47,36 @@ hal.executable @matmul_128x128x128 attributes {sym_visibility = "private"} {
 // CHECK:                    %[[VEC_b_1:.+]] = vector.transfer_read %[[ARG1]]
 // CHECK:                    %[[VEC_B_2:.+]] = vector.transfer_read %[[ARG1]]
 // CHECK:                    %[[VEC_B_3:.+]] = vector.transfer_read %[[ARG1]]
+
+
+// CHECK-PROMOTED: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 64)>
+// CHECK-PROMOTED: #[[MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>
+// CHECK-PROMOTED: func @matmul_128x128x128
+// CHECK-PROMOTED: (%[[ARG0:.+]]: memref<128x128xf32>, %[[ARG1:.+]]: memref<128x128xf32>, %[[ARG2:.+]]: memref<128x128xf32>) {
+// CHECK-PROMOTED: %[[KDIM_SIZE:.+]] = constant 128 : index
+// CHECK-PROMOTED: %[[WORGKROUP_SIZE:.+]] = constant 64 : index
+// CHECK-PROMOTED: %[[VECTOR_SIZE:.+]] = constant 4 : index
+// CHECK-PROMOTED: %[[L1_SIZE:.+]] = constant 32 : index
+// CHECK-PROMOTED: %[[START:.+]] = constant 0 : index
+// CHECK-PROMOTED: %[[C1:.+]] = constant 1 : index
+// CHECK-PROMOTED: %[[C1:.+]] = constant 2 : index
+// CHECK-PROMOTED: %[[C1:.+]] = constant 3 : index
+// CHECK-PROMOTED: %[[A_PROMOTED_TILE:.+]] = alloca() : memref<64x64xf32>
+// CHECK-PROMOTED: %[[B_PROMOTED_TILE:.+]] = alloca() : memref<128x64xf32>
+// CHECK-PROMOTED: %[[C_PROMOTED_TILE:.+]] = alloca() : memref<64x128xf32>
+// CHECK-PROMOTED: %[[WORKGROUP_TILE_X:.+]] = hal.interface.workgroup.id[0] : index
+// CHECK-PROMOTED: %[[WORKGROUP_TILE_Y:.+]] = hal.interface.workgroup.id[1] : index
+// CHECK-PROMOTED: %[[WORKGROUP_ID_Y_INDEX:.+]] = affine.apply #[[MAP0]]()[%[[WORKGROUP_TILE_Y]]]
+// CHECK-PROMOTED: %[[A_TILE:.+]] = subview %[[ARG0]][%[[WORKGROUP_ID_Y_INDEX]], 0] [64, 128] [1, 1] : memref<128x128xf32> to memref<64x128xf32, #[[MAP1]]>
+// CHECK-PROMOTED: %[[WORKGROUP_ID_X_INDEX:.+]] = affine.apply #[[MAP0]]()[%[[WORKGROUP_TILE_X]]]
+// CHECK-PROMOTED: %[[B_TILE:.+]] = subview %[[ARG1]][0, %[[WORKGROUP_ID_X_INDEX]]] [128, 64] [1, 1] : memref<128x128xf32> to memref<128x64xf32, #[[MAP1]]>
+// CHECK-PROMOTED: %[[C_TILE:.+]] = subview %[[ARG2]][%[[WORKGROUP_ID_Y_INDEX]], %[[WORKGROUP_ID_X_INDEX]]] [64, 64] [1, 1] : memref<128x128xf32> to memref<64x64xf32, #[[MAP1]]>
+// CHECK-PROMOTED:     scf.for {{.*}} = %[[START]] to %[[WORGKROUP_SIZE]] step %[[L1_SIZE]] {
+// CHECK-PROMOTED:       scf.for {{.*}} = %[[START]] to %[[WORGKROUP_SIZE]] step %[[L1_SIZE]] {
+// CHECK-PROMOTED:         scf.for {{.*}} = %[[START]] to %[[KDIM_SIZE]] step %[[L1_SIZE]] {
+// CHECK-PROMOTED:           scf.for {{.*}} = %[[START]] to %[[L1_SIZE]] step %[[VECTOR_SIZE]] {
+// CHECK-PROMOTED:             scf.for {{.*}} = %[[START]] to %[[L1_SIZE]] step %[[VECTOR_SIZE]] {
+// CHECK-PROMOTED:               %[[VEC_C_0:.+]] = vector.transfer_read %[[C_PROMOTED_TILE]]
+// CHECK-PROMOTED:               %[[VEC_C_1:.+]] = vector.transfer_read %[[C_PROMOTED_TILE]]
+// CHECK-PROMOTED:               %[[VEC_C_2:.+]] = vector.transfer_read %[[C_PROMOTED_TILE]]
+// CHECK-PROMOTED:               %[[VEC_C_3:.+]] = vector.transfer_read %[[C_PROMOTED_TILE]]


### PR DESCRIPTION
This improves and the performance of matmuls for linalg on tensors (1.3x slower comparing to linalg-on-buffers pass)

IR snippet: https://gist.github.com/asaadaldien/efb712e4b1cc7ab4620b3a22809f0a74

This PR:
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_dot_384x128x128/process_time/real_time      0.529 ms        0.528 ms         1335
```
Baseline linalg-on-buffers:
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_dot_384x128x128/process_time/real_time      0.396 ms        0.395 ms         1779

```
linalg-on-buffers + promotion:
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_dot_384x128x128/process_time/real_time      0.473 ms        0.472 ms         1481

```