### PR TITLE
Omit creation of args attribute when not necessary in emitc conversion

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @add_i32
 vm.module @my_module {
   vm.func @add_i32(%arg0: i32, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_add_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.add.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @sub_i32
 vm.module @my_module {
   vm.func @sub_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_sub_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_sub_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @mul_i32
 vm.module @my_module {
   vm.func @mul_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_mul_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_mul_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.mul.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i32_s
 vm.module @my_module {
   vm.func @div_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_div_i32s"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.div.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i32_u
 vm.module @my_module {
   vm.func @div_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_div_i32u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_div_i32u"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.div.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i32_s
 vm.module @my_module {
   vm.func @rem_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_rem_i32s"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.rem.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i32_u
 vm.module @my_module {
   vm.func @rem_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call "vm_rem_i32u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_rem_i32u"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.rem.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_not_i32"(%arg0) {args = [0 : index]} : (i32) -> i32
+    // CHECK: %0 = emitc.call "vm_not_i32"(%arg0) : (i32) -> i32
     %0 = vm.not.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @and_i32
 vm.module @my_module {
   vm.func @and_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_and_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_and_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.and.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @or_i32
 vm.module @my_module {
   vm.func @or_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_or_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_or_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.or.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @xor_i32
 vm.module @my_module {
   vm.func @xor_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_xor_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_xor_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.xor.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @add_i64
 vm.module @my_module {
   vm.func @add_i64(%arg0: i64, %arg1: i64) {
-    // CHECK-NEXT: %0 = emitc.call "vm_add_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK-NEXT: %0 = emitc.call "vm_add_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.add.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: @sub_i64
 vm.module @my_module {
   vm.func @sub_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_sub_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_sub_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.sub.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: @mul_i64
 vm.module @my_module {
   vm.func @mul_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_mul_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_mul_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.mul.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i64_s
 vm.module @my_module {
   vm.func @div_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_div_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_div_i64s"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.div.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: @div_i64_u
 vm.module @my_module {
   vm.func @div_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_div_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_div_i64u"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.div.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i64_s
 vm.module @my_module {
   vm.func @rem_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_rem_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_rem_i64s"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.rem.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: @rem_i64_u
 vm.module @my_module {
   vm.func @rem_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call "vm_rem_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_rem_i64u"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.rem.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: @not_i64
 vm.module @my_module {
   vm.func @not_i64(%arg0 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_not_i64"(%arg0) {args = [0 : index]} : (i64) -> i64
+    // CHECK: %0 = emitc.call "vm_not_i64"(%arg0) : (i64) -> i64
     %0 = vm.not.i64 %arg0 : i64
     vm.return %0 : i64
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: @and_i64
 vm.module @my_module {
   vm.func @and_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_and_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_and_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.and.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: @or_i64
 vm.module @my_module {
   vm.func @or_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_or_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_or_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.or.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: @xor_i64
 vm.module @my_module {
   vm.func @xor_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_xor_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_xor_i64"(%arg0, %arg1) : (i64, i64) -> i64
     %0 = vm.xor.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: vm.func @select_i32
 vm.module @my_module {
   vm.func @select_i32(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
-    // CHECK: %0 = emitc.call "vm_select_i32"(%arg0, %arg1, %arg2) {args = [0 : index, 1 : index, 2 : index]} : (i32, i32, i32) -> i32
+    // CHECK: %0 = emitc.call "vm_select_i32"(%arg0, %arg1, %arg2) : (i32, i32, i32) -> i32
     %0 = vm.select.i32 %arg0, %arg1, %arg2 : i32
     vm.return %0 : i32
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: vm.func @select_i64
 vm.module @my_module {
   vm.func @select_i64(%arg0 : i32, %arg1 : i64, %arg2 : i64) -> i64 {
-    // CHECK: %0 = emitc.call "vm_select_i64"(%arg0, %arg1, %arg2) {args = [0 : index, 1 : index, 2 : index]} : (i32, i64, i64) -> i64
+    // CHECK: %0 = emitc.call "vm_select_i64"(%arg0, %arg1, %arg2) : (i32, i64, i64) -> i64
     %0 = vm.select.i64 %arg0, %arg1, %arg2 : i64
     vm.return %0 : i64
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
@@ -5,7 +5,7 @@
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_eq_i32
   vm.func @cmp_eq_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.cmp.eq.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -16,7 +16,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_ne_i32
   vm.func @cmp_ne_i32(%arg0 : i32, %arg1 : i32) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i32"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i32"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.cmp.ne.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -27,7 +27,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_lt_i32_s
   vm.func @cmp_lt_i32_s(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32s"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.s %arg0, %arg1 : i32
     vm.return
   }
@@ -38,7 +38,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_lt_i32_u
   vm.func @cmp_lt_i32_u(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i32u"(%arg0, %arg1) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.u %arg0, %arg1 : i32
     vm.return
   }
@@ -49,7 +49,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_nz_i32
   vm.func @cmp_nz_i32(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i32"(%arg0) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i32"(%arg0) : (i32) -> i32
     %0 = vm.cmp.nz.i32 %arg0 : i32
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -5,7 +5,7 @@
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_eq_i64
   vm.func @cmp_eq_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_eq_i64"(%arg0, %arg1) : (i64, i64) -> i32
     %0 = vm.cmp.eq.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -16,7 +16,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_ne_i64
   vm.func @cmp_ne_i64(%arg0 : i64, %arg1 : i64) {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i64"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_ne_i64"(%arg0, %arg1) : (i64, i64) -> i32
     %0 = vm.cmp.ne.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -27,7 +27,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_lt_i64_s
   vm.func @cmp_lt_i64_s(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64s"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64s"(%arg0, %arg1) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.s %arg0, %arg1 : i64
     vm.return
   }
@@ -38,7 +38,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_lt_i64_u
   vm.func @cmp_lt_i64_u(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64u"(%arg0, %arg1) {args = [0 : index, 1 : index]} : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_lt_i64u"(%arg0, %arg1) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.u %arg0, %arg1 : i64
     vm.return
   }
@@ -49,7 +49,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: vm.func @cmp_nz_i64
   vm.func @cmp_nz_i64(%arg0 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i64"(%arg0) {args = [0 : index]} : (i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_cmp_nz_i64"(%arg0) : (i64) -> i32
     %0 = vm.cmp.nz.i64 %arg0 : i64
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: vm.func @trunc
 vm.module @my_module {
   vm.func @trunc(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i32i8"(%arg0) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i32i8"(%arg0) : (i32) -> i32
     %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call "vm_trunc_i32i16"(%0) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %1 = emitc.call "vm_trunc_i32i16"(%0) : (i32) -> i32
     %1 = vm.trunc.i32.i16 %0 : i32 -> i32
     vm.return %1 : i32
   }
@@ -16,13 +16,13 @@ vm.module @my_module {
 // CHECK-LABEL: vm.func @ext
 vm.module @my_module {
   vm.func @ext(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_ext_i8i32s"(%arg0) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_ext_i8i32s"(%arg0) : (i32) -> i32
     %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call "vm_ext_i8i32u"(%0) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %1 = emitc.call "vm_ext_i8i32u"(%0) : (i32) -> i32
     %1 = vm.ext.i8.i32.u %0 : i32 -> i32
-    // CHECK-NEXT: %2 = emitc.call "vm_ext_i16i32s"(%1) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %2 = emitc.call "vm_ext_i16i32s"(%1) : (i32) -> i32
     %2 = vm.ext.i16.i32.s %1 : i32 -> i32
-    // CHECK-NEXT: %3 = emitc.call "vm_ext_i16i32u"(%2) {args = [0 : index]} : (i32) -> i32
+    // CHECK-NEXT: %3 = emitc.call "vm_ext_i16i32u"(%2) : (i32) -> i32
     %3 = vm.ext.i16.i32.u %2 : i32 -> i32
     vm.return %3 : i32
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: vm.func @trunc_i64
 vm.module @my_module {
   vm.func @trunc_i64(%arg0 : i64) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i64i32"(%arg0) {args = [0 : index]} : (i64) -> i32
+    // CHECK-NEXT: %0 = emitc.call "vm_trunc_i64i32"(%arg0) : (i64) -> i32
     %0 = vm.trunc.i64.i32 %arg0 : i64 -> i32
     vm.return %0 : i32
   }
@@ -14,9 +14,9 @@ vm.module @my_module {
 // CHECK-LABEL: vm.func @ext_i64
 vm.module @my_module {
   vm.func @ext_i64(%arg0 : i32) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call "vm_ext_i32i64s"(%arg0) {args = [0 : index]} : (i32) -> i64
+    // CHECK-NEXT: %0 = emitc.call "vm_ext_i32i64s"(%arg0) : (i32) -> i64
     %0 = vm.ext.i32.i64.s %arg0 : i32 -> i64
-    // CHECK-NEXT: %1 = emitc.call "vm_ext_i32i64u"(%arg0) {args = [0 : index]} : (i32) -> i64
+    // CHECK-NEXT: %1 = emitc.call "vm_ext_i32i64u"(%arg0) : (i32) -> i64
     %1 = vm.ext.i32.i64.u %arg0 : i32 -> i64
     vm.return %1 : i64
   }


### PR DESCRIPTION
This doesn't change any functionality, but makes the generated IR much easier to read.