### PR TITLE
Disable clang-format in template type list

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -1277,19 +1277,26 @@ struct ConvertHLOToLinalgOnBuffersPass
 void populateHLOToLinalgOnBuffersConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns,
     TensorToBufferMap const &resultTensorToBufferMap) {
-  patterns.insert<ConvOpConversion, DepthwiseConvOpConversion,
-                  ConcatenateOpConversion, FillOpOnTensorConversion,
-                  InitTensorOpConversion,
-                  LinalgOpOnTensorConversion<linalg::GenericOp>,
-                  LinalgOpOnTensorConversion<linalg::IndexedGenericOp>,
-                  NamedOpConversion<linalg::ConvInputNWCFilterWCFOp>,
-                  NamedOpConversion<linalg::ConvInputNHWCFilterHWCFOp>,
-                  NamedOpConversion<linalg::ConvInputNDHWCFilterDHWCFOp>,
-                  NamedOpConversion<linalg::MatmulOp>,
-                  NamedOpConversion<linalg::BatchMatmulOp>,
-                  PadTensorOpConversion, ReduceWindowOpConversion,
-                  SubTensorOpConversion, TensorReshapeOpConversion>(
-      context, resultTensorToBufferMap);
+  patterns.insert<
+      // clang-format off
+      ConvOpConversion,
+      DepthwiseConvOpConversion,
+      ConcatenateOpConversion,
+      FillOpOnTensorConversion,
+      InitTensorOpConversion,
+      LinalgOpOnTensorConversion<linalg::GenericOp>,
+      LinalgOpOnTensorConversion<linalg::IndexedGenericOp>,
+      NamedOpConversion<linalg::ConvInputNWCFilterWCFOp>,
+      NamedOpConversion<linalg::ConvInputNHWCFilterHWCFOp>,
+      NamedOpConversion<linalg::ConvInputNDHWCFilterDHWCFOp>,
+      NamedOpConversion<linalg::MatmulOp>,
+      NamedOpConversion<linalg::BatchMatmulOp>,
+      PadTensorOpConversion,
+      ReduceWindowOpConversion,
+      SubTensorOpConversion,
+      TensorReshapeOpConversion
+      // clang-format on
+      >(context, resultTensorToBufferMap);
 
   // Prefer lowering to named Linalg dpethwise convolution when possible.
   patterns.insert<DepthwiseConvOpConversion>(context, resultTensorToBufferMap,


### PR DESCRIPTION
Put one template argument per line instead. Merge conflicts here are
annoying to resolve and diffs are hard to read. It's also just easier
to read this way anyway. This is commonly done upstream for the same
reasons. I wonder if we could find a clang-format option to format
template type lists one per line after they spill over.