### PR TITLE
Make bazel_to_cmake quieter by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v2
       - name: Running bazel_to_cmake
-        run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py
+        run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py --verbosity=2
       - name: Checking Diff
         run: git diff --exit-code
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -70,9 +70,8 @@ def parse_arguments():
       "-v",
       type=int,
       default=0,
-      help=
-      "Specify verbosity level where higher verbosity emits more logging. (Default 0)"
-  )
+      help="Specify verbosity level where higher verbosity emits more logging."
+      " (Default 0)")
 
   # Specify only one of these (defaults to --root_dir=iree).
   group = parser.add_mutually_exclusive_group()
@@ -146,7 +145,7 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
     raise FileNotFoundError(f"Cannot find directory '{directory_path}'")
 
   rel_dir_path = repo_relpath(directory_path)
-  if verbosity > 0:
+  if verbosity >= 1:
     log(f"Processing {rel_dir_path}")
 
   skip_file_path = os.path.join(directory_path, ".skip_bazel_to_cmake")
@@ -169,7 +168,7 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
         if line.startswith("# Copyright"):
           copyright_line = line.rstrip()
         if EDIT_BLOCKING_PATTERN.search(line):
-          if verbosity > 0:
+          if verbosity >= 1:
             log(f"Skipped. line {i + 1}: '{line.strip()}' prevents edits.",
                 indent=2)
           return Status.SKIPPED
@@ -200,7 +199,7 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
           f"Reason: `{type(e).__name__}: {e}`",
           indent=2)
       return Status.FAILED
-  if verbosity > 1:
+  if verbosity >= 2:
     log(
         f"Successfly generated {rel_cmakelists_file_path}"
         f" from {rel_build_file_path}",

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -71,7 +71,10 @@ def parse_arguments():
       type=int,
       default=0,
       help="Specify verbosity level where higher verbosity emits more logging."
-      " (Default 0)")
+      " 0 (default): Only output errors and summary statistics."
+      " 1: Also output the name of each directory as it's being processed and"
+      " whether the directory is skipped."
+      " 2: Also output when conversion was successful.")
 
   # Specify only one of these (defaults to --root_dir=iree).
   group = parser.add_mutually_exclusive_group()

--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -62,9 +62,17 @@ def parse_arguments():
                       default=False)
   parser.add_argument(
       "--allow_partial_conversion",
-      help="Generates partial files, ignoring errors during conversion",
+      help="Generates partial files, ignoring errors during conversion.",
       action="store_true",
       default=False)
+  parser.add_argument(
+      "--verbosity",
+      "-v",
+      type=int,
+      default=0,
+      help=
+      "Specify verbosity level where higher verbosity emits more logging. (Default 0)"
+  )
 
   # Specify only one of these (defaults to --root_dir=iree).
   group = parser.add_mutually_exclusive_group()
@@ -106,12 +114,17 @@ def log(string, *args, indent=0, **kwargs):
         file=sys.stderr)
 
 
-def convert_directories(directories, write_files, allow_partial_conversion):
+def convert_directories(directories, write_files, allow_partial_conversion,
+                        verbosity):
   failure_dirs = []
   skip_count = 0
   success_count = 0
   for directory in directories:
-    status = convert_directory(directory, write_files, allow_partial_conversion)
+    status = convert_directory(
+        directory,
+        write_files=write_files,
+        allow_partial_conversion=allow_partial_conversion,
+        verbosity=verbosity)
     if status == Status.FAILED:
       failure_dirs.append(repo_relpath(directory))
     elif status == Status.SKIPPED:
@@ -127,32 +140,38 @@ def convert_directories(directories, write_files, allow_partial_conversion):
     sys.exit(1)
 
 
-def convert_directory(directory_path, write_files, allow_partial_conversion):
+def convert_directory(directory_path, write_files, allow_partial_conversion,
+                      verbosity):
   if not os.path.isdir(directory_path):
     raise FileNotFoundError(f"Cannot find directory '{directory_path}'")
+
+  rel_dir_path = repo_relpath(directory_path)
+  if verbosity > 0:
+    log(f"Processing {rel_dir_path}")
 
   skip_file_path = os.path.join(directory_path, ".skip_bazel_to_cmake")
   build_file_path = os.path.join(directory_path, "BUILD")
   cmakelists_file_path = os.path.join(directory_path, "CMakeLists.txt")
+
+  rel_cmakelists_file_path = repo_relpath(cmakelists_file_path)
+  rel_build_file_path = repo_relpath(build_file_path)
 
   if os.path.isfile(skip_file_path):
     return Status.SKIPPED
   if not os.path.isfile(build_file_path):
     return Status.NO_BUILD_FILE
 
-  rel_cmakelists_file_path = repo_relpath(cmakelists_file_path)
-  log(f"{rel_cmakelists_file_path}...", end="")
-
-  cmake_file_exists = os.path.isfile(cmakelists_file_path)
   copyright_line = f"# Copyright {datetime.date.today().year} Google LLC"
   write_allowed = write_files
-  if cmake_file_exists:
+  if os.path.isfile(cmakelists_file_path):
     with open(cmakelists_file_path) as f:
       for i, line in enumerate(f):
         if line.startswith("# Copyright"):
           copyright_line = line.rstrip()
         if EDIT_BLOCKING_PATTERN.search(line):
-          log(f"\n  Skipped. line {i + 1}: '{line.strip()}' prevents edits. ")
+          if verbosity > 0:
+            log(f"Skipped. line {i + 1}: '{line.strip()}' prevents edits.",
+                indent=2)
           return Status.SKIPPED
 
   with open(build_file_path, "rt") as build_file:
@@ -169,19 +188,23 @@ def convert_directory(directory_path, write_files, allow_partial_conversion):
         print(converted_text, end="")
     except (NameError, NotImplementedError) as e:
       log(
-          f"\nERROR.\n"
+          f"ERROR generating {rel_dir_path}.\n"
           f"Missing a rule handler in bazel_to_cmake_converter.py?\n"
           f"Reason: `{type(e).__name__}: {e}`",
           indent=2)
       return Status.FAILED
     except KeyError as e:
       log(
-          f"\nERROR.\n"
+          f"ERROR generating {rel_dir_path}.\n"
           f"Missing a conversion in bazel_to_cmake_targets.py?\n"
           f"Reason: `{type(e).__name__}: {e}`",
           indent=2)
       return Status.FAILED
-  log(f"Success")
+  if verbosity > 1:
+    log(
+        f"Successfly generated {rel_cmakelists_file_path}"
+        f" from {rel_build_file_path}",
+        indent=2)
   return Status.SUCCEEDED
 
 
@@ -195,10 +218,14 @@ def main(args):
     root_directory_path = os.path.join(repo_root, args.root_dir)
     log(f"Converting directory tree rooted at: {root_directory_path}")
     convert_directories((root for root, _, _ in os.walk(root_directory_path)),
-                        write_files, args.allow_partial_conversion)
+                        write_files=write_files,
+                        allow_partial_conversion=args.allow_partial_conversion,
+                        verbosity=args.verbosity)
   elif args.dir:
-    convert_directories([os.path.join(repo_root, args.dir)], write_files,
-                        args.allow_partial_conversion)
+    convert_directories([os.path.join(repo_root, args.dir)],
+                        write_files=write_files,
+                        allow_partial_conversion=args.allow_partial_conversion,
+                        verbosity=args.verbosity)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the normal case, this should give the user all the info they need
without spilling across their terminal. Verbosity control is still
present to allow more info when desired. In particular, I left the
GitHub action at the previous verbosity, since that's run in a
non-interactive environment.

Example output from various verbosity levels is at
https://gist.github.com/GMNGeoffrey/76c91ce79a9277ca205ac2eaedfb3fa4

Fixes https://github.com/google/iree/issues/4282 