### PR TITLE
Make Cuda status comment correct

### DIFF
--- a/iree/hal/cuda/status_util.h
+++ b/iree/hal/cuda/status_util.h
@@ -40,7 +40,7 @@ extern "C" {
                        __VA_ARGS__)
 
 // IREE_IGNORE_ERROR but implicitly converts the CUresult return value to a
-// ::util::Status and checks that it is OkStatus.
+// Status.
 //
 // Usage:
 //   CUDA_IGNORE_ERROR(cuDoThing(...));


### PR DESCRIPTION
`::util::Status` does not exist and this does not check for OkStatus