### PR TITLE
Extend bazel_to_cmake to preserve specially marked CMakeLists.txt sec…

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -163,9 +163,19 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
   if not os.path.isfile(build_file_path):
     return Status.NO_BUILD_FILE
 
+  preserve_lines = []
   if os.path.isfile(cmakelists_file_path):
-    with open(cmakelists_file_path) as f:
+    with open(cmakelists_file_path, "rt") as f:
+      found_preserve_marker = False
       for i, line in enumerate(f):
+        # Accumulate all lines on and after the special preserve marker.
+        if (not found_preserve_marker and
+            re.match(r"^### CMAKE PRESERVE ###\s*$", line)):
+          found_preserve_marker = True
+        if found_preserve_marker:
+          preserve_lines.append(line)
+          continue
+
         if EDIT_BLOCKING_PATTERN.search(line):
           if verbosity >= 1:
             log(f"Skipped. line {i + 1}: '{line.strip()}' prevents edits.",
@@ -185,6 +195,9 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
       if write_files:
         with open(cmakelists_file_path, "wt") as cmakelists_file:
           cmakelists_file.write(converted_text)
+          if preserve_lines:
+            cmakelists_file.write("\n")
+            cmakelists_file.write("".join(preserve_lines))
       else:
         print(converted_text, end="")
     except (NameError, NotImplementedError) as e:

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -52,17 +52,6 @@ cc_library(
         "DispatchConfig.h",
         "Passes.h",
     ],
-    copts = [
-        # FIXME: https://github.com/google/iree/issues/4919
-        # The O2 default release optimization level is causing an unknown
-        # issue on GCC 10.2.1 (and 9.x).
-        # It would be best to not set this globally but bazel to cmake goo is
-        # unfathomable. (Ideally, I would like to set a property on just the
-        # source file with the issue on the CMake side).
-        # Given that this is blocking releases, will just proceed with this
-        # for now.
-        "-O1",
-    ],
     deps = [
         "//iree/base:signature_mangle",
         "//iree/compiler/Conversion/HLOToHLO",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -5,8 +5,6 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     Transforms
-  COPTS
-    "-O1"
   HDRS
     "DestructiveUpdateUtils.h"
     "DispatchConfig.h"
@@ -72,3 +70,13 @@ iree_cc_library(
     tensorflow::mlir_hlo
   PUBLIC
 )
+
+### CMAKE PRESERVE ###
+
+# FIXME: https://github.com/google/iree/issues/4919
+# The O2 default release optimization level is causing an unknown
+# issue on GCC 10.2.1 (and 9.x). This needs to be root-caused but just
+# carving out to unblock releases.
+set_source_files_properties(
+  DispatchLinalgOnTensors.cpp
+  PROPERTIES COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-O1>)


### PR DESCRIPTION
…tions.

* Uses this to properly scope an optimization level to just the source file/affected compiler.
* Progress on #4919