### PR TITLE
Use iree_cmake_extra_content to set compiler flags

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake.py
@@ -163,19 +163,9 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
   if not os.path.isfile(build_file_path):
     return Status.NO_BUILD_FILE
 
-  preserve_lines = []
   if os.path.isfile(cmakelists_file_path):
-    with open(cmakelists_file_path, "rt") as f:
-      found_preserve_marker = False
+    with open(cmakelists_file_path) as f:
       for i, line in enumerate(f):
-        # Accumulate all lines on and after the special preserve marker.
-        if (not found_preserve_marker and
-            re.match(r"^### CMAKE PRESERVE ###\s*$", line)):
-          found_preserve_marker = True
-        if found_preserve_marker:
-          preserve_lines.append(line)
-          continue
-
         if EDIT_BLOCKING_PATTERN.search(line):
           if verbosity >= 1:
             log(f"Skipped. line {i + 1}: '{line.strip()}' prevents edits.",
@@ -195,9 +185,6 @@ def convert_directory(directory_path, write_files, allow_partial_conversion,
       if write_files:
         with open(cmakelists_file_path, "wt") as cmakelists_file:
           cmakelists_file.write(converted_text)
-          if preserve_lines:
-            cmakelists_file.write("\n")
-            cmakelists_file.write("".join(preserve_lines))
       else:
         print(converted_text, end="")
     except (NameError, NotImplementedError) as e:

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -52,6 +52,17 @@ cc_library(
         "DispatchConfig.h",
         "Passes.h",
     ],
+    copts = [
+        # FIXME: https://github.com/google/iree/issues/4919
+        # The O2 default release optimization level is causing an unknown
+        # issue on GCC 10.2.1 (and 9.x).
+        # It would be best to not set this globally but bazel to cmake goo is
+        # unfathomable. (Ideally, I would like to set a property on just the
+        # source file with the issue on the CMake side).
+        # Given that this is blocking releases, will just proceed with this
+        # for now.
+        "-O1",
+    ],
     deps = [
         "//iree/base:signature_mangle",
         "//iree/compiler/Conversion/HLOToHLO",

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
@@ -101,7 +103,7 @@ iree_cmake_extra_content(
     content = """
 set_property(SOURCE
   DispatchLinalgOnTensors.cpp
-  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize)
+  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
 """,
     inline = True,
 )

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -52,17 +52,6 @@ cc_library(
         "DispatchConfig.h",
         "Passes.h",
     ],
-    copts = [
-        # FIXME: https://github.com/google/iree/issues/4919
-        # The O2 default release optimization level is causing an unknown
-        # issue on GCC 10.2.1 (and 9.x).
-        # It would be best to not set this globally but bazel to cmake goo is
-        # unfathomable. (Ideally, I would like to set a property on just the
-        # source file with the issue on the CMake side).
-        # Given that this is blocking releases, will just proceed with this
-        # for now.
-        "-O1",
-    ],
     deps = [
         "//iree/base:signature_mangle",
         "//iree/compiler/Conversion/HLOToHLO",
@@ -103,4 +92,16 @@ cc_library(
         "@mlir-hlo//:mhlo_to_mhlo_lowering_patterns",
         "@mlir-hlo//:unfuse_batch_norm",
     ],
+)
+
+# TODO(#4919): For an unknown reason, GCC's devirtualization optimization wreaks
+# havoc on this file. Needs to be further root caused. Seems to affect both 9.x
+# and 10.x.
+iree_cmake_extra_content(
+    content = """
+set_property(SOURCE
+  DispatchLinalgOnTensors.cpp
+  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize)
+""",
+    inline = True,
 )

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -5,8 +5,6 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     Transforms
-  COPTS
-    "-O1"
   HDRS
     "DestructiveUpdateUtils.h"
     "DispatchConfig.h"
@@ -72,3 +70,7 @@ iree_cc_library(
     tensorflow::mlir_hlo
   PUBLIC
 )
+
+set_property(SOURCE
+  DispatchLinalgOnTensors.cpp
+  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize)

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -5,6 +5,8 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     Transforms
+  COPTS
+    "-O1"
   HDRS
     "DestructiveUpdateUtils.h"
     "DispatchConfig.h"
@@ -70,13 +72,3 @@ iree_cc_library(
     tensorflow::mlir_hlo
   PUBLIC
 )
-
-### CMAKE PRESERVE ###
-
-# FIXME: https://github.com/google/iree/issues/4919
-# The O2 default release optimization level is causing an unknown
-# issue on GCC 10.2.1 (and 9.x). This needs to be root-caused but just
-# carving out to unblock releases.
-set_source_files_properties(
-  DispatchLinalgOnTensors.cpp
-  PROPERTIES COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-O1>)

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -73,4 +73,4 @@ iree_cc_library(
 
 set_property(SOURCE
   DispatchLinalgOnTensors.cpp
-  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize)
+  PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -74,8 +74,9 @@ iree_cc_library(
 ### CMAKE PRESERVE ###
 
 # FIXME: https://github.com/google/iree/issues/4919
-# For an unknown reason, GCC's devirtualization optimization wreaks havoc on
-# this file. Needs to be further root caused. Seems to affect both 9.x and 10.x.
+# The O2 default release optimization level is causing an unknown
+# issue on GCC 10.2.1 (and 9.x). This needs to be root-caused but just
+# carving out to unblock releases.
 set_source_files_properties(
   DispatchLinalgOnTensors.cpp
-  PROPERTIES COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
+  PROPERTIES COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-O1>)


### PR DESCRIPTION
This reverts commit eac0c0490e52f93454c6a64460db794f8c3329a6.
This reverts commit c7d964e8d4ec5e9672db149b71f9db36b131163a.