### PR TITLE
Update docs following LLVM AOT linker cleanup.

### DIFF
--- a/bindings/python/pyiree/jax/README.md
+++ b/bindings/python/pyiree/jax/README.md
@@ -61,10 +61,6 @@ import jax.numpy as jnp
 import flax
 from flax import linen as nn
 
-import os
-# Configure the linker to target Android.
-os.environ["IREE_LLVMAOT_LINKER_PATH"] = "${ANDROID_NDK?}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++ -static-libstdc++"
-
 
 class MLP(nn.Module):
 
@@ -85,7 +81,6 @@ apply_args = [{"params": params}, image]
 options = dict(target_backends=["dylib-llvm-aot"],
                extra_args=["--iree-llvm-target-triple=aarch64-linux-android"])
 
-# This will throw a compilation error if IREE_LLVMAOT_LINKER_PATH is not set.
 compiled_binary = iree.jax.aot(MLP().apply, *apply_args, **options)
 
 with open("/tmp/mlp_apply.vmfb", "wb") as f:

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -109,8 +109,8 @@ $ ../iree-build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
 
 ### LLVM Ahead-of-Time (AOT) backend
 
-To compile IREE LLVM AOT module we need to set the AOT linker path environment
-variable:
+If you want to manually specify the linker used, set the
+`IREE_LLVMAOT_LINKER_PATH` environment variable to the path of the linker:
 
 ```shell
 $ export IREE_LLVMAOT_LINKER_PATH=ld.lld-10

--- a/docs/get_started/getting_started_riscv_cmake.md
+++ b/docs/get_started/getting_started_riscv_cmake.md
@@ -98,7 +98,7 @@ Set the AOT linker path environment variable:
 
 ```shell
 # Still in "build-riscv" folder
-$ export IREE_LLVMAOT_LINKER_PATH="$HOME/riscv/toolchain/clang/linux/RISCV/bin/clang++ -static-libstdc++ -O3"
+$ export IREE_LLVMAOT_LINKER_PATH="$HOME/riscv/toolchain/clang/linux/RISCV/bin/clang++"
 ```
 
 Translate a source MLIR into an IREE module:


### PR DESCRIPTION
Redo of https://github.com/google/iree/pull/4761 after GitHub silliness.

Note that the `docs/get_started/getting_started_riscv_cmake.md` changes slightly overlap with https://github.com/google/iree/pull/4940.

Fixes https://github.com/google/iree/issues/4606 (now that https://github.com/google/iree/pull/4719 is also merged)