### PR TITLE
Add missing deps

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -60,6 +60,7 @@ cc_library(
         "//iree/compiler/Dialect/Shape/Transforms",
         "@com_google_absl//absl/strings",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:StandardOps",

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "TranslateExecutables.cpp"
   DEPS
     LLVMSupport
+    MLIRAffineToStandard
     MLIRIR
     MLIRPass
     MLIRStandard

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -317,6 +317,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRSCFTransforms
       MLIRPass
       MLIRSupport
+      MLIRTargetLLVMIR
       MLIRTranslation
       iree::compiler::Conversion::init_conversions
       iree::compiler::Dialect::VM::Target::Bytecode
@@ -363,6 +364,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRParser
       MLIRPass
       MLIRSupport
+      MLIRTargetLLVMIR
       absl::flags
       absl::span
       absl::strings


### PR DESCRIPTION
* Calling `registerLLVMDialectTranslation()`, added with ce85ce5, makes
  a dep on MLIRTargetLLVMIR mandatory.
* With `createLowerAffinePass()` added as pass as part of db62c35, a
  dependency on MLIRAffineToStandard is required.