### PR TITLE
Adapt mhlo.concatenate lowering to Linalg on tensors

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -425,62 +425,6 @@ LogicalResult ConvOpConversion::apply(
 }
 
 //===----------------------------------------------------------------------===//
-// mhlo.concatenate conversion patterns and utility functions.
-//===----------------------------------------------------------------------===//
-
-namespace {
-/// Converts a mhlo.concatenate op to subview ops + linalg.copy/fill ops.
-class ConcatenateOpConversion
-    : public ConvertToLinalgBufferOp<ConcatenateOpConversion,
-                                     mhlo::ConcatenateOp> {
- public:
-  using ConvertToLinalgBufferOp<ConcatenateOpConversion,
-                                mhlo::ConcatenateOp>::ConvertToLinalgBufferOp;
-  LogicalResult apply(mhlo::ConcatenateOp op, ArrayRef<Value> inputBuffers,
-                      ArrayRef<Value> resultBuffers,
-                      ConversionPatternRewriter &rewriter) const;
-};
-}  // namespace
-
-LogicalResult ConcatenateOpConversion::apply(
-    mhlo::ConcatenateOp op, ArrayRef<Value> inputBuffers,
-    ArrayRef<Value> resultBuffers, ConversionPatternRewriter &rewriter) const {
-  Location loc = op.getLoc();
-  int dim = op.dimension();
-  int rank = inputBuffers[0].getType().cast<ShapedType>().getRank();
-  SmallVector<Value, 3> offsets, sizes, strides;
-  for (int i = 0; i < rank; ++i) {
-    offsets.push_back(rewriter.create<ConstantIndexOp>(loc, 0));
-    Value size = rewriter.create<DimOp>(loc, resultBuffers[0], i);
-    sizes.push_back(size);
-    strides.push_back(rewriter.create<ConstantIndexOp>(loc, 1));
-  }
-
-  Value accBound = rewriter.create<ConstantIndexOp>(loc, 0);
-  for (auto inBuf : inputBuffers) {
-    offsets[dim] = accBound;
-    if (auto cstOp = inBuf.getDefiningOp<ConstantOp>()) {
-      sizes[dim] = rewriter.create<ConstantIndexOp>(
-          loc, cstOp.getType().cast<ShapedType>().getShape()[dim]);
-      auto subViewOp = rewriter.create<SubViewOp>(loc, resultBuffers[0],
-                                                  offsets, sizes, strides);
-      auto inputConstAttr =
-          cstOp.valueAttr().cast<DenseElementsAttr>().getSplatValue();
-      Value cstVal = rewriter.create<ConstantOp>(loc, inputConstAttr);
-      rewriter.create<linalg::FillOp>(loc, subViewOp, cstVal);
-    } else {
-      sizes[dim] = rewriter.create<DimOp>(loc, inBuf, dim);
-      auto subViewOp = rewriter.create<SubViewOp>(loc, resultBuffers[0],
-                                                  offsets, sizes, strides);
-      rewriter.create<linalg::CopyOp>(loc, inBuf, subViewOp);
-    }
-    accBound = rewriter.create<AddIOp>(loc, accBound, sizes[dim]);
-  }
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // linalg.pad_tensor conversion patterns and utility functions.
 //===----------------------------------------------------------------------===//
 
@@ -550,6 +494,27 @@ struct SubTensorOpConversion
         rewriter.create<SubViewOp>(loc, inputBuffers[0], op.getMixedOffsets(),
                                    op.getMixedSizes(), op.getMixedStrides());
     rewriter.create<linalg::CopyOp>(loc, subViewOp, resultBuffers[0]);
+    return success();
+  }
+};
+}  // namespace
+
+namespace {
+/// Converts subtensor_insert operation to subview + linalg.copy
+struct SubTensorInsertOpConversion
+    : public ConvertToLinalgBufferOp<SubTensorInsertOpConversion,
+                                     SubTensorInsertOp> {
+  using ConvertToLinalgBufferOp<SubTensorInsertOpConversion,
+                                SubTensorInsertOp>::ConvertToLinalgBufferOp;
+
+  LogicalResult apply(SubTensorInsertOp op, ArrayRef<Value> inputBuffers,
+                      ArrayRef<Value> resultBuffers,
+                      ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto subViewOp =
+        rewriter.create<SubViewOp>(loc, resultBuffers[0], op.getMixedOffsets(),
+                                   op.getMixedSizes(), op.getMixedStrides());
+    rewriter.create<linalg::CopyOp>(loc, inputBuffers[0], subViewOp);
     return success();
   }
 };
@@ -1083,6 +1048,11 @@ static LogicalResult propagateBufferUsedForResultTensor(
       resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
       continue;
     }
+    if (auto subTensorInsertOp = tensor.getDefiningOp<SubTensorInsertOp>()) {
+      tensor = subTensorInsertOp.dest();
+      resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
+      continue;
+    }
     break;
   }
   return success();
@@ -1182,7 +1152,6 @@ void populateHLOToLinalgOnBuffersConversionPatterns(
   patterns.insert<
       // clang-format off
       ConvOpConversion,
-      ConcatenateOpConversion,
       FillOpOnTensorConversion,
       InitTensorOpConversion,
       LinalgOpOnTensorConversion<linalg::GenericOp>,
@@ -1199,6 +1168,7 @@ void populateHLOToLinalgOnBuffersConversionPatterns(
       PadTensorOpConversion,
       ReduceWindowOpConversion,
       SubTensorOpConversion,
+      SubTensorInsertOpConversion,
       TensorReshapeOpConversion
       // clang-format on
       >(context, resultTensorToBufferMap);
@@ -1231,7 +1201,7 @@ void ConvertHLOToLinalgOnBuffersPass::runOnFunction() {
   // should be gone.
   target.addIllegalOp<IREE::HAL::InterfaceLoadTensorOp,
                       IREE::HAL::InterfaceStoreTensorOp, SubTensorOp,
-                      tensor::ExtractOp>();
+                      SubTensorInsertOp, tensor::ExtractOp>();
   target.addDynamicallyLegalOp<Shape::TieShapeOp>(
       [](Shape::TieShapeOp op) -> bool {
         return op.operand().getType().isa<MemRefType>();

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -504,7 +504,8 @@ struct SubTensorOpConversion
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Converts subtensor_insert operation to subview + linalg.copy
+/// Converts subtensor_insert operation to subview + linalg.copy.
+/// Note: this assumes dest and result are the same buffer.
 struct SubTensorInsertOpConversion
     : public ConvertToLinalgBufferOp<SubTensorInsertOpConversion,
                                      SubTensorInsertOp> {

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -379,15 +379,9 @@ struct ConcatenateOpConversion
     Value accBound = rewriter.create<ConstantIndexOp>(loc, 0);
     for (auto arg : args) {
       offsets[dim] = accBound;
-      if (auto cstOp = arg.getDefiningOp<ConstantOp>()) {
-        // TODO(hanchung): Support for concatenating with constant operands.
-        return rewriter.notifyMatchFailure(
-            op, "expected to concate non-constant value");
-      } else {
-        sizes[dim] = rewriter.create<DimOp>(loc, arg, dim);
-        result = rewriter.create<SubTensorInsertOp>(loc, arg, result, offsets,
-                                                    sizes, strides);
-      }
+      sizes[dim] = rewriter.create<DimOp>(loc, arg, dim);
+      result = rewriter.create<SubTensorInsertOp>(loc, arg, result, offsets,
+                                                  sizes, strides);
       accBound = rewriter.create<AddIOp>(loc, accBound, sizes[dim]);
     }
     rewriter.replaceOp(op, result);

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -335,6 +335,67 @@ LogicalResult DepthwiseConvOpConversion::matchAndRewrite(
 }
 }  // namespace
 
+//===----------------------------------------------------------------------===//
+// mhlo.concatenate conversion patterns.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Converts mhlo.concatenate operation to subtensor ops + subtensor_insert ops.
+struct ConcatenateOpConversion
+    : public OpConversionPattern<mhlo::ConcatenateOp> {
+  using OpConversionPattern<mhlo::ConcatenateOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mhlo::ConcatenateOp op, ArrayRef<Value> args,
+      ConversionPatternRewriter &rewriter) const override {
+    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    if (!resultType || !resultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "expected static shape for output");
+    }
+
+    Location loc = op.getLoc();
+    int dim = op.dimension();
+    int rank = resultType.getRank();
+    SmallVector<Value, 3> offsets, sizes, strides;
+    for (int i = 0; i < rank; ++i) {
+      offsets.push_back(rewriter.create<ConstantIndexOp>(loc, 0));
+      sizes.push_back(rewriter.create<DimOp>(loc, args[0], i));
+      strides.push_back(rewriter.create<ConstantIndexOp>(loc, 1));
+    }
+    Value resultDimSize = rewriter.create<ConstantIndexOp>(loc, 0);
+    for (auto arg : args) {
+      auto size = rewriter.create<DimOp>(loc, arg, dim);
+      resultDimSize = rewriter.create<AddIOp>(loc, resultDimSize, size);
+    }
+    sizes[dim] = resultDimSize;
+    auto initTensor = rewriter.create<linalg::InitTensorOp>(
+        loc, resultType.getShape(), resultType.getElementType());
+    auto zeroAttr = rewriter.getZeroAttr(resultType.getElementType());
+    Value zero = rewriter.create<ConstantOp>(loc, zeroAttr);
+    Value result =
+        rewriter.create<linalg::FillOp>(loc, initTensor, zero).getResult(0);
+
+    Value accBound = rewriter.create<ConstantIndexOp>(loc, 0);
+    for (auto arg : args) {
+      offsets[dim] = accBound;
+      if (auto cstOp = arg.getDefiningOp<ConstantOp>()) {
+        // TODO(hanchung): Support for concatenating with constant operands.
+        return rewriter.notifyMatchFailure(
+            op, "expected to concate non-constant value");
+      } else {
+        sizes[dim] = rewriter.create<DimOp>(loc, arg, dim);
+        result = rewriter.create<SubTensorInsertOp>(loc, arg, result, offsets,
+                                                    sizes, strides);
+      }
+      accBound = rewriter.create<AddIOp>(loc, accBound, sizes[dim]);
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+}  // namespace
+
 struct ConvertHLOToLinalgOnTensorsPass
     : public PassWrapper<ConvertHLOToLinalgOnTensorsPass, FunctionPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -380,7 +441,7 @@ void populateHLOToLinalgOnTensorsConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns) {
   mhlo::populateHLOToLinalgConversionPattern(context, &patterns);
   patterns.insert<TorchIndexSelectOpConversion, ConstOpConversion,
-                  DepthwiseConvOpConversion>(context);
+                  ConcatenateOpConversion, DepthwiseConvOpConversion>(context);
 }
 
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass() {

--- a/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
@@ -1,14 +1,18 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -canonicalize %s | IreeFileCheck %s
 
-// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1 + 2)>
-// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<2x5xi32>
-// CHECK-DAG: %[[IN0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
-// CHECK-DAG: %[[IN1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<2x3xi32>
-//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<2x5xi32> to memref<2x2xi32, #[[MAP0]]>
-//     CHECK: linalg.copy(%[[IN0]], %[[SUB0]])
-//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][0, 2] [2, 3] [1, 1]  : memref<2x5xi32> to memref<2x3xi32, #[[MAP1]]>
-//     CHECK: linalg.copy(%[[IN1]], %[[SUB1]])
+
+// CHECK-DAG:  %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:  %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:  %[[C2:.+]] = constant 2 : index
+// CHECK-DAG:  %[[C3:.+]] = constant 3 : index
+// CHECK-DAG:  %[[IN0:.+]] = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
+// CHECK-DAG:  %[[IN1:.+]] = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<2x3xi32>
+// CHECK:      %[[INIT:.+]] = linalg.init_tensor [2, 5] : tensor<2x5xi32>
+// CHECK:      %[[FILL:.+]] = linalg.fill(%[[INIT]], %{{.*}}) : tensor<2x5xi32>, i32 -> tensor<2x5xi32>
+// CHECK:      %[[OUT0:.+]] = subtensor_insert %[[IN0]] into
+// CHECK-SAME:   %[[FILL]][%[[C0]], %[[C0]]] [%[[C2]], %[[C2]]] [%[[C1]], %[[C1]]] : tensor<2x2xi32> into tensor<2x5xi32>
+// CHECK:      %[[OUT1:.+]] = subtensor_insert %[[IN1]] into
+// CHECK-SAME:   %[[OUT0]][%[[C0]], %[[C2]]] [%[[C2]], %[[C3]]] [%[[C1]], %[[C1]]] : tensor<2x3xi32> into tensor<2x5xi32>
 module {
   func @concatenate() {
     %c0 = constant 0 : index
@@ -29,16 +33,18 @@ module {
 
 // -----
 
-// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1 + 4)>
-// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<5x2xi32>
-// CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
-// CHECK-DAG: %[[CST:.+]] = constant 42 : i32
-//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<5x2xi32> to memref<2x2xi32, #[[MAP0]]>
-//     CHECK: linalg.copy(%[[IN]], %[[SUB0]])
-//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][2, 0] [3, 2] [1, 1]  : memref<5x2xi32> to memref<3x2xi32, #[[MAP1]]>
-//     CHECK: linalg.fill(%[[SUB1]], %[[CST]])
-
+// CHECK-DAG:  %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:  %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:  %[[C2:.+]] = constant 2 : index
+// CHECK-DAG:  %[[C3:.+]] = constant 3 : index
+// CHECK-DAG:  %[[CST:.+]] = constant dense<42> : tensor<3x2xi32>
+// CHECK-DAG:  %[[IN:.+]] = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
+// CHECK:      %[[INIT:.+]] = linalg.init_tensor [5, 2] : tensor<5x2xi32>
+// CHECK:      %[[FILL:.+]] = linalg.fill(%[[INIT]], %{{.*}}) : tensor<5x2xi32>, i32 -> tensor<5x2xi32>
+// CHECK:      %[[OUT0:.+]] = subtensor_insert %[[IN]] into
+// CHECK-SAME:   %[[FILL]][%[[C0]], %[[C0]]] [%[[C2]], %[[C2]]] [%[[C1]], %[[C1]]] : tensor<2x2xi32> into tensor<5x2xi32>
+// CHECK:      %[[OUT1:.+]] = subtensor_insert %[[CST]] into
+// CHECK-SAME:   %[[OUT0]][%[[C2]], %[[C0]]] [%[[C3]], %[[C2]]] [%[[C1]], %[[C1]]] : tensor<3x2xi32> into tensor<5x2xi32>
 module {
   func @concatenate() {
     %c0 = constant 0 : index

--- a/iree/compiler/Conversion/HLOToLinalg/test/subtensor_insert.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/subtensor_insert.mlir
@@ -1,0 +1,66 @@
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 5 + d1 + 2)>
+// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<2x5xi32>
+// CHECK-DAG: %[[IN0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
+// CHECK-DAG: %[[IN1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<2x3xi32>
+//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<2x5xi32> to memref<2x2xi32, #[[MAP0]]>
+//     CHECK: linalg.copy(%[[IN0]], %[[SUB0]])
+//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][0, 2] [2, 3] [1, 1]  : memref<2x5xi32> to memref<2x3xi32, #[[MAP1]]>
+//     CHECK: linalg.copy(%[[IN1]], %[[SUB1]])
+module  {
+  func @concatenate() {
+    %c1 = constant 1 : index
+    %c0_i32 = constant 0 : i32
+    %c0 = constant 0 : index
+    %c2 = constant 2 : index
+    %c3 = constant 3 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<2x3xi32>
+    %2 = linalg.init_tensor [2, 5] : tensor<2x5xi32>
+    %3 = linalg.fill(%2, %c0_i32) : tensor<2x5xi32>, i32 -> tensor<2x5xi32>
+    %4 = subtensor_insert %0 into %3[%c0, %c0] [%c2, %c2] [%c1, %c1] : tensor<2x2xi32> into tensor<2x5xi32>
+    %5 = subtensor_insert %1 into %4[%c0, %c2] [%c2, %c3] [%c1, %c1] : tensor<2x3xi32> into tensor<2x5xi32>
+    hal.interface.store.tensor %5, @legacy_io::@ret0, offset = %c0 : tensor<2x5xi32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
+  }
+}
+
+// -----
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0 * 2 + d1 + 4)>
+// CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<5x2xi32>
+// CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x2xi32>
+// CHECK-DAG: %[[CST:.+]] = constant 42 : i32
+//     CHECK: %[[SUB0:.+]] = subview %[[OUT]][0, 0] [2, 2] [1, 1]  : memref<5x2xi32> to memref<2x2xi32, #[[MAP0]]>
+//     CHECK: linalg.copy(%[[IN]], %[[SUB0]])
+//     CHECK: %[[SUB1:.+]] = subview %[[OUT]][2, 0] [3, 2] [1, 1]  : memref<5x2xi32> to memref<3x2xi32, #[[MAP1]]>
+//     CHECK: linalg.fill(%[[SUB1]], %[[CST]])
+module  {
+  func @concatenate() {
+    %cst = constant dense<42> : tensor<3x2xi32>
+    %c1 = constant 1 : index
+    %c0_i32 = constant 0 : i32
+    %c0 = constant 0 : index
+    %c2 = constant 2 : index
+    %c3 = constant 3 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x2xi32>
+    %1 = linalg.init_tensor [5, 2] : tensor<5x2xi32>
+    %2 = linalg.fill(%1, %c0_i32) : tensor<5x2xi32>, i32 -> tensor<5x2xi32>
+    %3 = subtensor_insert %0 into %2[%c0, %c0] [%c2, %c2] [%c1, %c1] : tensor<2x2xi32> into tensor<5x2xi32>
+    %4 = subtensor_insert %cst into %3[%c2, %c0] [%c3, %c2] [%c1, %c1] : tensor<3x2xi32> into tensor<5x2xi32>
+    hal.interface.store.tensor %4, @legacy_io::@ret0, offset = %c0 : tensor<5x2xi32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
+  }
+}

--- a/iree/test/e2e/xla_ops/concatenate.mlir
+++ b/iree/test/e2e/xla_ops/concatenate.mlir
@@ -16,3 +16,11 @@ func @xla_concatenate() attributes { iree.module.export } {
   check.expect_eq_const(%3, dense<[[1, 2], [3, 4], [11, 12], [13, 14]]> : tensor<4x2xi32>) : tensor<4x2xi32>
   return
 }
+
+func @concatenate_cst() attributes { iree.module.export } {
+  %c0 = iree.unfoldable_constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
+  %c1 = mhlo.constant dense<0> : tensor<2x3xi32>
+  %0 = "mhlo.concatenate"(%c0, %c1) {dimension = 1} : (tensor<2x2xi32>, tensor<2x3xi32>) -> tensor<2x5xi32>
+  check.expect_eq_const(%0, dense<[[1, 2, 0, 0, 0], [3, 4, 0, 0, 0]]> : tensor<2x5xi32>) : tensor<2x5xi32>
+  return
+}

--- a/iree/test/e2e/xla_ops/concatenate.mlir
+++ b/iree/test/e2e/xla_ops/concatenate.mlir
@@ -16,11 +16,3 @@ func @xla_concatenate() attributes { iree.module.export } {
   check.expect_eq_const(%3, dense<[[1, 2], [3, 4], [11, 12], [13, 14]]> : tensor<4x2xi32>) : tensor<4x2xi32>
   return
 }
-
-func @concatenate_cst() attributes { iree.module.export } {
-  %c0 = iree.unfoldable_constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
-  %c1 = mhlo.constant dense<0> : tensor<2x3xi32>
-  %0 = "mhlo.concatenate"(%c0, %c1) {dimension = 1} : (tensor<2x2xi32>, tensor<2x3xi32>) -> tensor<2x5xi32>
-  check.expect_eq_const(%0, dense<[[1, 2, 0, 0, 0], [3, 4, 0, 0, 0]]> : tensor<2x5xi32>) : tensor<2x5xi32>
-  return
-}


### PR DESCRIPTION
- Lowers the op to multiple subtensor_insert ops
- Add support for lowering subtensor_insert op to subview + fill/copy
- Propagate buffer uses for result tensor when the tensor is subtensor_insert

This only support static shapes for now because there are issues in builder and verifier. The canonicalize pass doesn't infer all the shapes for linalg.init_tensor and subtensor_insert. If the `linalg.init_tensor` can be created an inferred type with "OpFoldResult", we don't have to limit it to static shapes.