### PR TITLE
Initial WasmLinkerTool implementation and supporting cleanup.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -55,6 +55,8 @@ cc_library(
         "@llvm-project//llvm:RISCVAsmParser",
         "@llvm-project//llvm:RISCVCodeGen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:WebAssemblyAsmParser",
+        "@llvm-project//llvm:WebAssemblyCodeGen",
         "@llvm-project//llvm:X86AsmParser",
         "@llvm-project//llvm:X86CodeGen",
         "@llvm-project//mlir:LLVMDialect",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -103,7 +103,9 @@ cc_library(
     name = "LinkerTool",
     srcs = ["LinkerTool.cpp"],
     hdrs = ["LinkerTool.h"],
-    deps = platform_trampoline_deps("LinkerTools", "compiler/Dialect/HAL/Target/LLVM"),
+    deps = platform_trampoline_deps("LinkerTools", "compiler/Dialect/HAL/Target/LLVM") + [
+        "@llvm-project//llvm:Support",
+    ],
 )
 
 cc_library(

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -33,6 +33,8 @@ iree_cc_library(
     LLVMRISCVAsmParser
     LLVMRISCVCodeGen
     LLVMSupport
+    LLVMWebAssemblyAsmParser
+    LLVMWebAssemblyCodeGen
     LLVMX86AsmParser
     LLVMX86CodeGen
     MLIRLLVMIR

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -90,6 +90,7 @@ iree_cc_library(
   SRCS
     "LinkerTool.cpp"
   DEPS
+    LLVMSupport
     iree::compiler::Dialect::HAL::Target::LLVM::internal::LinkerTools_internal
   PUBLIC
 )

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -295,6 +295,7 @@ void registerLLVMAOTTargetBackends(
     INIT_LLVM_TARGET(ARM)
     INIT_LLVM_TARGET(AArch64)
     INIT_LLVM_TARGET(RISCV)
+    INIT_LLVM_TARGET(WebAssembly)
     return std::make_unique<LLVMAOTTargetBackend>(queryOptions());
   });
 }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -110,6 +110,10 @@ class LinkerTool {
   // Runs the given command line on the shell, logging failures.
   LogicalResult runLinkCommand(const std::string& commandLine);
 
+  // Returns the path to the first tool in |toolNames| found in the environment.
+  std::string findToolInEnvironment(
+      SmallVector<std::string, 4> toolNames) const;
+
   llvm::Triple targetTriple;
   LLVMTargetOptions targetOptions;
 };

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
@@ -82,7 +82,10 @@ class AndroidLinkerTool : public LinkerTool {
 
     // ANDROID_NDK must be set for us to infer the tool path.
     char *androidNDKPath = std::getenv("ANDROID_NDK");
-    if (!androidNDKPath) return toolPath;
+    if (!androidNDKPath) {
+      llvm::errs() << "ANDROID_NDK environment variable must be set\n";
+      return "";
+    }
 
     // Extract the Android version from the `android30` like triple piece.
     unsigned androidEnv[3];

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "AndroidLinkerTool.cpp",
         "LinkerTools.cpp",
         "UnixLinkerTool.cpp",
+        "WasmLinkerTool.cpp",
         "WindowsLinkerTool.cpp",
     ],
     deps = [

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "AndroidLinkerTool.cpp"
     "LinkerTools.cpp"
     "UnixLinkerTool.cpp"
+    "WasmLinkerTool.cpp"
     "WindowsLinkerTool.cpp"
   DEPS
     LLVMCore

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
@@ -21,11 +21,12 @@ namespace HAL {
 
 // TODO(benvanik): add other platforms:
 // createMacLinkerTool using ld64.lld
-// createWasmLinkerTool wasm-ld
 
 std::unique_ptr<LinkerTool> createAndroidLinkerTool(
     llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createUnixLinkerTool(
+    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+std::unique_ptr<LinkerTool> createWasmLinkerTool(
     llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createWindowsLinkerTool(
     llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
@@ -38,6 +39,8 @@ std::unique_ptr<LinkerTool> LinkerTool::getForTarget(
   } else if (targetTriple.isOSWindows() ||
              targetTriple.isWindowsMSVCEnvironment()) {
     return createWindowsLinkerTool(targetTriple, targetOptions);
+  } else if (targetTriple.isWasm()) {
+    return createWasmLinkerTool(targetTriple, targetOptions);
   }
   return createUnixLinkerTool(targetTriple, targetOptions);
 }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -1,0 +1,134 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#define DEBUG_TYPE "llvmaot-linker"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+// Wasm linker using wasm-ld for producing WebAssembly binaries.
+// wasm-ld behaves like traditional ELF linkers and uses similar flags.
+//
+// For details on the linking process and file formats, see:
+// * https://lld.llvm.org/WebAssembly.html
+// * https://github.com/WebAssembly/tool-conventions/blob/master/Linking.md
+//
+// For more background on WebAssembly, see:
+// * https://webassembly.org/
+// * https://developer.mozilla.org/en-US/docs/WebAssembly
+//
+// When working with WebAssembly files, these projects are useful:
+// * https://github.com/WebAssembly/wabt
+// * https://github.com/bytecodealliance/wasmtime
+//
+// Use -iree-llvm-target-triple=wasm32-unknown-unknown.
+class WasmLinkerTool : public LinkerTool {
+ public:
+  using LinkerTool::LinkerTool;
+
+  std::string getToolPath() const override {
+    // First check for setting the linker explicitly.
+    auto toolPath = LinkerTool::getToolPath();
+    if (!toolPath.empty()) return toolPath;
+
+    // No explicit linker specified, search the environment for common tools.
+    toolPath = findToolInEnvironment({"wasm-ld"});
+    if (!toolPath.empty()) return toolPath;
+
+    llvm::errs() << "No Wasm linker tool specified or discovered\n";
+    return "";
+  }
+
+  LogicalResult configureModule(llvm::Module *llvmModule,
+                                ArrayRef<StringRef> entryPointNames) override {
+    for (auto &func : *llvmModule) {
+      // Enable frame pointers to ensure that stack unwinding works.
+      func.addFnAttr("frame-pointer", "all");
+
+      // -ffreestanding-like behavior.
+      func.addFnAttr("no-builtins");
+    }
+
+    // https://lld.llvm.org/WebAssembly.html#exports
+    for (auto entryPointName : entryPointNames) {
+      auto *entryPointFn = llvmModule->getFunction(entryPointName);
+      entryPointFn->addFnAttr("wasm-export-name", entryPointName);
+    }
+
+    return success();
+  }
+
+  Optional<Artifacts> linkDynamicLibrary(
+      StringRef libraryName, ArrayRef<Artifact> objectFiles) override {
+    Artifacts artifacts;
+
+    // Create the wasm binary file name; if we only have a single input object
+    // we can just reuse that.
+    if (objectFiles.size() == 1) {
+      artifacts.libraryFile =
+          Artifact::createVariant(objectFiles.front().path, "wasm");
+    } else {
+      artifacts.libraryFile = Artifact::createTemporary(libraryName, "wasm");
+    }
+    artifacts.libraryFile.close();
+
+    SmallVector<std::string, 8> flags = {
+        getToolPath(),
+
+        // entry symbol not defined (pass --no-entry to suppress): _start
+        "--no-entry",
+
+        // Allow undefined symbols, provided by the runtime environment (?)
+        // TODO(scotttodd): figure out how to avoid this.
+        "--allow-undefined",
+
+        // Treat warnings as errors.
+        "--fatal-warnings",
+
+        "-o " + artifacts.libraryFile.path,
+    };
+
+    // Strip debug information when not requested.
+    if (!targetOptions.debugSymbols) {
+      flags.push_back("--strip-debug");
+    }
+
+    // Link all input objects. Note that we are not linking whole-archive as
+    // we want to allow dropping of unused codegen outputs.
+    for (auto &objectFile : objectFiles) {
+      flags.push_back(objectFile.path);
+    }
+
+    auto commandLine = llvm::join(flags, " ");
+    if (failed(runLinkCommand(commandLine))) return llvm::None;
+    return artifacts;
+  }
+};
+
+std::unique_ptr<LinkerTool> createWasmLinkerTool(
+    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+  return std::make_unique<WasmLinkerTool>(targetTriple, targetOptions);
+}
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
@@ -30,8 +30,16 @@ class WindowsLinkerTool : public LinkerTool {
   using LinkerTool::LinkerTool;
 
   std::string getToolPath() const override {
+    // First check for setting the linker explicitly.
     auto toolPath = LinkerTool::getToolPath();
-    return toolPath.empty() ? "lld-link" : toolPath;
+    if (!toolPath.empty()) return toolPath;
+
+    // No explicit linker specified, search the environment for common tools.
+    toolPath = findToolInEnvironment({"lld-link"});
+    if (!toolPath.empty()) return toolPath;
+
+    llvm::errs() << "No Windows linker tool specified or discovered\n";
+    return "";
   }
 
   LogicalResult configureModule(llvm::Module *llvmModule,


### PR DESCRIPTION
Progress on https://github.com/google/iree/issues/4019. I can generate .wasm files using `iree-translate -iree-hal-target-backends=dylib-llvm-aot -iree-llvm-target-triple=wasm32-unknown-unknown -iree-llvm-keep-linker-artifacts` and can inspect the .wasm artifacts using `wasm-decompile` and the other tools from https://github.com/WebAssembly/wabt. I haven't yet been able to actually call a function from a generated .wasm file and inspect its output though, so we could be missing some configuration.

This PR also includes some supporting changes in the other linker tools, mostly playing cross-platform development whack-a-mole until the code is robust enough. As one side effect, I can now use `UnixLinkerTool` from Windows, by passing `-iree-llvm-target-triple=x86_64-linux-gnu`, which discovers `C:\Program Files\LLVM\bin\ld.lld` on my system, from having that `bin\` directory on my `PATH`.