### PR TITLE
Do more exotic compiler selection and pinning in configure_bazel.py.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -35,67 +35,52 @@ jobs:
           - os: ubuntu-18.04
             build_package: main-dist
             experimental: false
-            needs_bazel: false
           - os: ubuntu-18.04
             build_package: py-runtime-pkg
             experimental: false
-            needs_bazel: false
           - os: ubuntu-18.04
             build_package: py-xla-compiler-tools-pkg
             experimental: false
-            needs_bazel: true
           - os: ubuntu-18.04
             build_package: py-tflite-compiler-tools-pkg
             experimental: false
-            needs_bazel: true
           - os: ubuntu-18.04
             build_package: py-tf-compiler-tools-pkg
             experimental: false
-            needs_bazel: true
 
           # Windows packages.
           - os: windows-2019
             build_package: main-dist
             experimental: true
-            needs_bazel: false
           - os: windows-2019
             build_package: py-runtime-pkg
             experimental: true
-            needs_bazel: false
           - os: windows-2019
             build_package: py-xla-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
           - os: windows-2019
             build_package: py-tflite-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
           - os: windows-2019
             build_package: py-tf-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
 
           # Macos packages.
           - os: macos-latest
             build_package: main-dist
             experimental: true
-            needs_bazel: false
           - os: macos-latest
             build_package: py-runtime-pkg
             experimental: true
-            needs_bazel: false
           - os: macos-latest
             build_package: py-xla-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
           - os: macos-latest
             build_package: py-tflite-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
           - os: macos-latest
             build_package: py-tf-compiler-tools-pkg
             experimental: true
-            needs_bazel: true
     env:
       CIBW_BUILD_VERBOSITY: 1
       # Note that on Linux, we run under docker with an altered path.
@@ -155,13 +140,6 @@ jobs:
           }
           EOF
           cat ./main_checkout/version_info.json
-
-      - name: Configure Bazel
-        if: matrix.needs_bazel
-        shell: bash
-        run: |
-          cd main_checkout
-          python ./configure_bazel.py
 
       # The main distribution builds the main binary package, tests and compiler
       # wheels (which are OS but not python version specific). The latter is

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -77,6 +77,7 @@ THIS_DIR = os.path.realpath(os.path.dirname(__file__))
 CMAKE_CI_SCRIPT = os.path.join(THIS_DIR, "cmake_ci.py")
 BUILD_REQUIREMENTS_TXT = os.path.join(IREESRC_DIR, "bindings", "python",
                                       "build_requirements.txt")
+CONFIGURE_BAZEL_PY = os.path.join(IREESRC_DIR, "configure_bazel.py")
 INSTALL_TARGET = ("install"
                   if platform.system() == "Windows" else "install/strip")
 
@@ -110,6 +111,11 @@ def install_python_requirements():
   print("Installing python requirements...")
   subprocess.check_call(
       [sys.executable, "-m", "pip", "install", "-r", BUILD_REQUIREMENTS_TXT])
+
+
+def configure_bazel():
+  print("Generating configured.bazelrc...")
+  subprocess.check_call([sys.executable, CONFIGURE_BAZEL_PY])
 
 
 def build_main_dist():
@@ -208,6 +214,7 @@ def build_py_runtime_pkg():
 def bazel_build_tf_binary(target):
   """Builds a binary in the IREE-TF Workspace and returns the filepath."""
   install_python_requirements()
+  configure_bazel()
 
   # Builds a runnable target and returns the path to the executable. Yes this is
   # really the best Bazel gives us.
@@ -238,6 +245,7 @@ def bazel_build_tf_binary(target):
 def build_py_xla_compiler_tools_pkg():
   """Builds the iree-install/python_packages/iree_tools_xla package."""
   install_python_requirements()
+  configure_bazel()
 
   # Clean up install and build trees.
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)
@@ -277,6 +285,7 @@ def build_py_xla_compiler_tools_pkg():
 def build_py_tflite_compiler_tools_pkg():
   """Builds the iree-install/python_packages/iree_tools_tflite package."""
   install_python_requirements()
+  configure_bazel()
 
   # Clean up install and build trees.
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)
@@ -316,6 +325,7 @@ def build_py_tflite_compiler_tools_pkg():
 def build_py_tf_compiler_tools_pkg():
   """Builds the iree-install/python_packages/iree_tools_tf package."""
   install_python_requirements()
+  configure_bazel()
 
   # Clean up install and build trees.
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -18,12 +18,51 @@ import subprocess
 import sys
 
 
+def detect_unix_platform_config(bazelrc):
+  # This is hoaky. Ideally, bazel had any kind of rational way of selecting
+  # options from within its environment (key word: "rational"), but sadly, it
+  # is unintelligible to mere mortals. Why should a build system have a way for
+  # people to condition their build options on what compiler they are using
+  # (without descending down the hole of deciphering what a Bazel toolchain is)?
+  # All I want to do is set a couple of project specific warning options!
+
+  if platform.system() == "Darwin":
+    print(f"build --config=generic_clang", file=bazelrc)
+    print(f"build:release --config=generic_clang_release", file=bazelrc)
+
+  # If the user specified a CXX environment var, bazel will later respect that,
+  # so we just see if it says "clang".
+  cxx = os.environ.get("CXX")
+  cc = os.environ.get("CC")
+  if (cxx is not None and cc is None) or (cxx is None and cc is not None):
+    print("WARNING: Only one of CXX or CC is set, which can confuse bazel. "
+          "Recommend: set both appropriately (or none)")
+  if cc is not None and cxx is not None:
+    # Persist the variables.
+    print(f"build --action_env CC=\"{cc}\"", file=bazelrc)
+    print(f"build --action_env CXX=\"{cxx}\"", file=bazelrc)
+  else:
+    print(
+        "WARNING: CC and CXX are not set, which can cause mismatches between "
+        "flag configurations and compiler. Recommend setting them explicitly.")
+
+  if cxx is not None and "clang" in cxx:
+    print(f"Choosing generic_clang config because CXX is set to clang ({cxx})")
+    print(f"build --config=generic_clang", file=bazelrc)
+    print(f"build:release --config=generic_clang_release", file=bazelrc)
+  else:
+    print(f"Choosing generic_gcc config by default because no CXX set or "
+          f"not recognized as clang ({cxx})")
+    print(f"build --config=generic_gcc", file=bazelrc)
+    print(f"build:release --config=generic_gcc_release", file=bazelrc)
+
+
 def write_platform(bazelrc):
-  platform_config = "generic_clang"
   if platform.system() == "Windows":
-    platform_config = "msvc"
-  print(f"build --config={platform_config}", file=bazelrc)
-  print(f"build:release --config={platform_config}_release", file=bazelrc)
+    print(f"build --config=msvc", file=bazelrc)
+    print(f"build:release --config=msvc_release", file=bazelrc)
+  else:
+    detect_unix_platform_config(bazelrc)
   if not (platform.system() == "Darwin"):
     print("common --config=non_darwin", file=bazelrc)
 


### PR DESCRIPTION
* Previously when invokved via cmake, cmake ensured that everything lined up without ambiguity, and we have lost that coupling.
* Practically, this was failing on the release CI, which only has gcc but was selecting a clang config during configure.
* Also took the chance to pin the CC/CXX vars in the action env so that it is obvious when this mismatches by looking at the configured.bazelrc file.
* Should fix #4961
* If it passes presubmit, I'll just submit to unbreak the releases and can rework later.