### PR TITLE
No deprecation warnings and no release asserts

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -97,7 +97,7 @@ build:generic_clang --copt=-Wall
 # ratio.
 build:generic_clang --copt=-Wno-ambiguous-member-template
 build:generic_clang --copt=-Wno-char-subscripts
-build:generic_clang --copt=-Wno-error=deprecated-declarations
+build:generic_clang --copt=-Wno-deprecated-declarations
 build:generic_clang --copt=-Wno-extern-c-compat # Matches upstream. Cannot impact due to extern C inclusion method.
 build:generic_clang --copt=-Wno-gnu-alignof-expression
 build:generic_clang --copt=-Wno-gnu-variable-sized-type-not-at-end
@@ -161,8 +161,10 @@ build:macos_clang --per_file_copt=tensorflow,iree_tf_compiler@-Wno-range-loop-an
 # causes flags to be passed twice.
 ###############################################################################
 build:generic_clang_release --compilation_mode=opt
+build:generic_clang_release --copt=-DNDEBUG
 build:generic_clang_release --linkopt=-Wl,--strip-all
 build:generic_gcc_release --compilation_mode=opt
+build:generic_gcc_release --copt=-DNDEBUG
 build:generic_gcc_release --linkopt=-Wl,--strip-all
 # MSVC doesn't store symbols in the binary (they're in separate .pdb files), so
 # nothing needs to be stripped.

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -106,7 +106,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # signal/noise ratio.
     "-Wno-ambiguous-member-template"
     "-Wno-char-subscripts"
-    "-Wno-error=deprecated-declarations"
+    "-Wno-deprecated-declarations"
     "-Wno-extern-c-compat" # Matches upstream. Cannot impact due to extern C inclusion method.
     "-Wno-gnu-alignof-expression"
     "-Wno-gnu-variable-sized-type-not-at-end"


### PR DESCRIPTION
Fix release builds to build without asserts and turn off annoying
deprecation warnings.

The former is fallout from https://github.com/google/iree/pull/4836 and
the latter is something we've noticed being really annoying recently.

The setting of deprecation to no-error (explicitly inviting warning
spam) is something we seem to have inherited from Google's internal
build. My best guess is that people mostly only see these in the code
they're changing because everything is cached or something. If we want
to surface these warnings, we should set up clang-tidy. Spamming the
logs for anyone building anything in the project is not the way.