### PR TITLE
Migrate linalg.conv to linalg.conv_nd ops in GPU pipeline

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -830,7 +830,6 @@ void ConvertToGPUPass::runOnOperation() {
       MapLinalgOpToGlobalInvocationId<linalg::FillOp>,
       MapLinalgOpToGlobalInvocationId<linalg::GenericOp>,
       MapLinalgOpToGlobalInvocationId<linalg::IndexedGenericOp>,
-      MapLinalgOpToLocalInvocationId<linalg::ConvOp>,
       MapLinalgOpToLocalInvocationId<linalg::ConvInputNWCFilterWCFOp>,
       MapLinalgOpToLocalInvocationId<linalg::ConvInputNHWCFilterHWCFOp>,
       MapLinalgOpToLocalInvocationId<linalg::ConvInputNDHWCFilterDHWCFOp>,

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
@@ -448,7 +448,6 @@ LogicalResult getConvOpLaunchConfig(T op, const spirv::TargetEnv &targetEnv,
     return getConvOpLaunchConfig(op, targetEnv, options, tileSizes, config); \
   }
 
-GET_CONV_LAUNCH_CONFIG(linalg::ConvOp)
 GET_CONV_LAUNCH_CONFIG(linalg::ConvInputNWCFilterWCFOp)
 GET_CONV_LAUNCH_CONFIG(linalg::ConvInputNHWCFilterHWCFOp)
 GET_CONV_LAUNCH_CONFIG(linalg::ConvInputNDHWCFilterDHWCFOp)
@@ -614,7 +613,6 @@ Optional<LaunchConfig> initGPULaunchConfig(
   }
 
     DISPATCH(linalg::BatchMatmulOp)
-    DISPATCH(linalg::ConvOp)
     DISPATCH(linalg::DepthwiseConvInputNHWCFilterHWCOp)
     DISPATCH(linalg::ConvInputNWCFilterWCFOp)
     DISPATCH(linalg::ConvInputNHWCFilterHWCFOp)

--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -177,9 +177,7 @@ static void populatePromotionPatterns(MLIRContext *context,
                                       OwningRewritePatternList &patterns) {
   patterns
       .insert<PromoteMatmulSubviewsPattern,
-              PromoteConvSubviewsPattern<linalg::ConvInputNWCFilterWCFOp>,
-              PromoteConvSubviewsPattern<linalg::ConvInputNHWCFilterHWCFOp>,
-              PromoteConvSubviewsPattern<linalg::ConvInputNDHWCFilterDHWCFOp>>(
+              PromoteConvSubviewsPattern<linalg::ConvInputNHWCFilterHWCFOp>>(
           context,
           linalg::LinalgPromotionOptions()
               .setAllocationDeallocationFns(allocateWorkgroupMemory,
@@ -316,9 +314,7 @@ static void populateTilingToInvocationPatterns(
           getVectorizeMarker(), context));
 
   patterns.insert<
-      linalg::LinalgTilingPattern<linalg::ConvInputNWCFilterWCFOp>,
       linalg::LinalgTilingPattern<linalg::ConvInputNHWCFilterHWCFOp>,
-      linalg::LinalgTilingPattern<linalg::ConvInputNDHWCFilterDHWCFOp>,
       linalg::LinalgTilingPattern<linalg::DepthwiseConvInputNHWCFilterHWCOp>>(
       context, tilingOptions,
       getLinalgMatchAndReplaceMarker(
@@ -419,9 +415,7 @@ static void populateTilingConvFilterPatterns(
                            .setTileSizeComputationFunction(getTileSizeFn);
 
   patterns.insert<
-      linalg::LinalgTilingPattern<linalg::ConvInputNWCFilterWCFOp>,
       linalg::LinalgTilingPattern<linalg::ConvInputNHWCFilterHWCFOp>,
-      linalg::LinalgTilingPattern<linalg::ConvInputNDHWCFilterDHWCFOp>,
       linalg::LinalgTilingPattern<linalg::DepthwiseConvInputNHWCFilterHWCOp>>(
       context, tilingOptions, marker);
 }

--- a/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/LinalgTileAndFusePass.cpp
@@ -167,7 +167,7 @@ struct PromoteConvSubviewsPattern
                              PatternBenefit benefit = 1)
       : linalg::LinalgPromotionPattern<ConvOpTy>(
             context,
-            options.setOperandsToPromote({1}).setUseFullTileBuffers(
+            options.setOperandsToPromote({0}).setUseFullTileBuffers(
                 {false, false}),
             marker, benefit) {}
 };
@@ -175,18 +175,18 @@ struct PromoteConvSubviewsPattern
 
 static void populatePromotionPatterns(MLIRContext *context,
                                       OwningRewritePatternList &patterns) {
-  patterns.insert<
-      PromoteMatmulSubviewsPattern, PromoteConvSubviewsPattern<linalg::ConvOp>,
-      PromoteConvSubviewsPattern<linalg::ConvInputNWCFilterWCFOp>,
-      PromoteConvSubviewsPattern<linalg::ConvInputNHWCFilterHWCFOp>,
-      PromoteConvSubviewsPattern<linalg::ConvInputNDHWCFilterDHWCFOp>>(
-      context,
-      linalg::LinalgPromotionOptions()
-          .setAllocationDeallocationFns(allocateWorkgroupMemory,
-                                        deallocateWorkgroupMemory)
-          .setCopyInOutFns(copyToWorkgroupMemory, copyToWorkgroupMemory),
-      getLinalgMatchAndReplaceMarker(getWorkgroupMarker(),
-                                     getWorkgroupMemoryMarker(), context));
+  patterns
+      .insert<PromoteMatmulSubviewsPattern,
+              PromoteConvSubviewsPattern<linalg::ConvInputNWCFilterWCFOp>,
+              PromoteConvSubviewsPattern<linalg::ConvInputNHWCFilterHWCFOp>,
+              PromoteConvSubviewsPattern<linalg::ConvInputNDHWCFilterDHWCFOp>>(
+          context,
+          linalg::LinalgPromotionOptions()
+              .setAllocationDeallocationFns(allocateWorkgroupMemory,
+                                            deallocateWorkgroupMemory)
+              .setCopyInOutFns(copyToWorkgroupMemory, copyToWorkgroupMemory),
+          getLinalgMatchAndReplaceMarker(getWorkgroupMarker(),
+                                         getWorkgroupMemoryMarker(), context));
 }
 
 //===----------------------------------------------------------------------===//
@@ -316,7 +316,6 @@ static void populateTilingToInvocationPatterns(
           getVectorizeMarker(), context));
 
   patterns.insert<
-      linalg::LinalgTilingPattern<linalg::ConvOp>,
       linalg::LinalgTilingPattern<linalg::ConvInputNWCFilterWCFOp>,
       linalg::LinalgTilingPattern<linalg::ConvInputNHWCFilterHWCFOp>,
       linalg::LinalgTilingPattern<linalg::ConvInputNDHWCFilterDHWCFOp>,

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/linalg_tile_and_fuse.mlir
@@ -25,8 +25,9 @@ hal.executable @conv_no_padding attributes {sym_visibility = "private"} {
           {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<2x16x16x6xf32>
         %2 = iree.placeholder for "interace buffer"
           {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<2x13x11x14xf32>
-        linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [1, 1]} :
-          memref<3x4x6x14xf32>, memref<2x16x16x6xf32>, memref<2x13x11x14xf32>
+        linalg.conv_2d_input_nhwc_filter_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+           ins (%1, %0: memref<2x16x16x6xf32>, memref<3x4x6x14xf32>)
+          outs (%2: memref<2x13x11x14xf32>)
         return
       }
       hal.interface @legacy_io attributes {sym_visibility = "private"} {
@@ -58,9 +59,10 @@ hal.executable @conv_no_padding attributes {sym_visibility = "private"} {
 //  CHECK-SAME:     [%[[BIDZ]], %[[LBY]], %[[LBX]], 0]
 //       CHECK:   %[[SV_RET0:.+]] = subview %[[RET0]]
 //  CHECK-SAME:     [%[[BIDZ]], %[[LBY]], %[[LBX]], 0]
-//       CHECK:   linalg.conv
-//  CHECK-SAME:     %[[ARG0]], %[[SV_ARG1]], %[[SV_RET0]]
+//       CHECK:   linalg.conv_2d_input_nhwc_filter_hwcf
 //  CHECK-SAME:     "workgroup"
+//  CHECK-SAME:     ins(%[[SV_ARG1]], %[[ARG0]]
+//  CHECK-SAME:    outs(%[[SV_RET0]]
 
 
 // -----
@@ -348,8 +350,9 @@ hal.executable @conv_no_padding_fusion attributes {sym_visibility = "private"} {
           {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<2x13x11x14xf32>
         %cst = constant 0.000000e+00 : f32
         linalg.fill(%2, %cst) : memref<2x13x11x14xf32>, f32
-        linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [1, 1]} :
-          memref<3x4x6x14xf32>, memref<2x16x16x6xf32>, memref<2x13x11x14xf32>
+        linalg.conv_2d_input_nhwc_filter_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+           ins (%1, %0: memref<2x16x16x6xf32>, memref<3x4x6x14xf32>)
+          outs (%2: memref<2x13x11x14xf32>)
         return
       }
       hal.interface @legacy_io attributes {sym_visibility = "private"} {
@@ -383,9 +386,10 @@ hal.executable @conv_no_padding_fusion attributes {sym_visibility = "private"} {
 //  CHECK-SAME:     [%[[BIDZ]], %[[LBY]], %[[LBX]], 0]
 //       CHECK:   linalg.fill(%[[SV_RET0]], %{{.*}})
 //  CHECK-SAME:     "workgroup"
-//       CHECK:   linalg.conv
-//  CHECK-SAME:     %[[ARG0]], %[[SV_ARG1]], %[[SV_RET0]]
+//       CHECK:   linalg.conv_2d_input_nhwc_filter_hwcf
 //  CHECK-SAME:     "workgroup"
+//  CHECK-SAME:     ins(%[[SV_ARG1]], %[[ARG0]]
+//  CHECK-SAME:    outs(%[[SV_RET0]]
 
 // -----
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/workgroup_memory_promotion.mlir
@@ -82,8 +82,9 @@ hal.executable @conv_no_padding_tile attributes {sym_visibility = "private"} {
           {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<2x16x16x6xf32>
         %2 = iree.placeholder for "interace buffer"
           {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<2x13x11x14xf32>
-        linalg.conv(%0, %1, %2) {dilations = [1, 1], strides = [1, 1]}
-          : memref<3x4x6x14xf32>, memref<2x16x16x6xf32>, memref<2x13x11x14xf32>
+        linalg.conv_2d_input_nhwc_filter_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+           ins (%1, %0: memref<2x16x16x6xf32>, memref<3x4x6x14xf32>)
+          outs (%2: memref<2x13x11x14xf32>)
         return
       }
       hal.interface @legacy_io attributes {sym_visibility = "private"} {
@@ -104,5 +105,7 @@ hal.executable @conv_no_padding_tile attributes {sym_visibility = "private"} {
 //       CHECK:   %[[SUBVIEW1:.+]] = subview %[[ALLOC1]]
 //       CHECK:   linalg.copy(%[[ARG1SV]], %[[SUBVIEW1]])
 //  CHECK-SAME:      "copy_to_workgroup_memory"
-//       CHECK:   linalg.conv(%[[ARG0]], %[[SUBVIEW1]], %[[RET0SV]])
-//  CHECK-SAME:      "workgroup_memory"
+//       CHECK:   linalg.conv_2d_input_nhwc_filter_hwcf
+//  CHECK-SAME:     "workgroup_memory"
+//  CHECK-SAME:     ins(%[[SUBVIEW1]], %[[ARG0]]
+//  CHECK-SAME:    outs(%[[RET0SV]]


### PR DESCRIPTION
- Delete all linalg::ConvOp from the patterns in LinalgToSPIRV/
- Adapt linalg.conv tests to linalg. conv_2d_input_nhwc_filter_hwcf.
- Drop promotion support for conv_1d and conv_3d.
- Add conv_1d and conv_3d tests to convert_to_gpu.mlir

Part of https://github.com/google/iree/issues/4908