### PR TITLE
Support PadOp on Linalg on tensors.

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -121,7 +121,8 @@ static LogicalResult allocateBuffersForResults(
         Value dimTensor = bvm.lookupOrNull(outTensor);
         if (!dimTensor) dimTensor = outTensor;
         if (dim.value() == TensorType::kDynamicSize) {
-          dynOperands.push_back(b.create<DimOp>(loc, dimTensor, dim.index()));
+          dynOperands.push_back(
+              b.createOrFold<DimOp>(loc, dimTensor, dim.index()));
         }
       }
       alloc = allocationFn(b, loc, tensorShape, tensorType.getElementType(),
@@ -152,10 +153,12 @@ static void finalizeBufferAllocation(OpBuilder &b, linalg::LinalgOp op,
                                      BlockAndValueMapping &bvm) {
   SmallVector<Value, 8> newOperands = inputs;
   newOperands.append(outputs.begin(), outputs.end());
-  auto otherOperands = op.getAssumedNonShapedOperands();
+  auto otherOperands =
+      llvm::map_range(op.getAssumedNonShapedOperands(),
+                      [&bvm](Value v) { return bvm.lookupOrDefault(v); });
   newOperands.append(otherOperands.begin(), otherOperands.end());
   Location loc = op.getLoc();
-  op.clone(b, loc, /*resultTypes=*/TypeRange{}, newOperands);
+  op.cloneWithMapper(b, loc, /*resultTypes=*/TypeRange{}, newOperands, bvm);
 
   // Replace the results of the old op with the new output buffers.
   for (auto result : llvm::enumerate(op.getOperation()->getResults())) {
@@ -254,7 +257,8 @@ static LogicalResult convertTensorReshapeOp(
   // Create the reshape op.
   auto reshapeSrcType = getMemrefTypeForTensor(
       srcTensorType, {}, inputBufferType.getMemorySpaceAsInt());
-  Value reshapeSrc = b.create<MemRefCastOp>(loc, inputBuffer, reshapeSrcType);
+  Value reshapeSrc =
+      b.createOrFold<MemRefCastOp>(loc, inputBuffer, reshapeSrcType);
   auto reshapeResultType = getMemrefTypeForTensor(
       resultTensorType, {}, inputBufferType.getMemorySpaceAsInt());
   Value bufferReshape = b.create<linalg::ReshapeOp>(
@@ -265,6 +269,12 @@ static LogicalResult convertTensorReshapeOp(
   return createAliasingBufferOrAllocationForResult(
       b, loc, allocationFn, srcTensor, bufferReshape, resultTensor,
       allocationDynamicSizes, bvm);
+}
+
+static SmallVector<int64_t, 4> extractFromI64ArrayAttr(ArrayAttr attr) {
+  return llvm::to_vector<4>(llvm::map_range(attr, [](Attribute a) -> int64_t {
+    return a.cast<IntegerAttr>().getInt();
+  }));
 }
 
 /// Converts a `subtensor` operation to a `subview` operation.
@@ -279,11 +289,6 @@ static LogicalResult convertSubTensorOp(
   Value inputBuffer = bvm.lookup(srcTensor);
   MemRefType inputBufferType = inputBuffer.getType().cast<MemRefType>();
 
-  auto extractFromI64ArrayAttr = [](ArrayAttr attr) {
-    return llvm::to_vector<4>(llvm::map_range(attr, [](Attribute a) -> int64_t {
-      return a.cast<IntegerAttr>().getInt();
-    }));
-  };
   auto subViewResultType = SubViewOp::inferResultType(
       inputBufferType, extractFromI64ArrayAttr(op.static_offsets()),
       extractFromI64ArrayAttr(op.static_sizes()),
@@ -301,6 +306,58 @@ static LogicalResult convertSubTensorOp(
   return createAliasingBufferOrAllocationForResult(
       b, loc, allocationFn, srcTensor, subViewOp, resultTensor,
       allocationDynamicSizes, bvm);
+}
+
+/// Converts a `subtensor_insert` operation to buffers by
+/// - Allocating a buffer for the result (if needed), and copying the
+///   destination value into this tensor.
+/// - Copying the source values into a subview of the result.
+static LogicalResult convertSubTensorInsertOp(
+    OpBuilder &b, WorkgroupMemoryAllocationFn allocationFn,
+    SubTensorInsertOp op, BlockAndValueMapping &bvm) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(op);
+  Location loc = op.getLoc();
+  Value dest = op.dest();
+  Value inputBuffer = bvm.lookup(dest);
+  auto allocationDynamicSizes = llvm::to_vector<4>(llvm::map_range(
+      llvm::seq<unsigned>(0,
+                          inputBuffer.getType().cast<ShapedType>().getRank()),
+      [&](int64_t dim) {
+        return b.createOrFold<DimOp>(loc, inputBuffer, dim);
+      }));
+  if (failed(createAliasingBufferOrAllocationForResult(
+          b, loc, allocationFn, dest, inputBuffer, op.getResult(),
+          allocationDynamicSizes, bvm))) {
+    return success();
+  }
+
+  Value source = op.source();
+  Value outputBuffer = bvm.lookup(op.result());
+  Value sourceBuffer = bvm.lookup(source);
+  auto subViewResultType =
+      SubViewOp::inferResultType(outputBuffer.getType().cast<MemRefType>(),
+                                 extractFromI64ArrayAttr(op.static_offsets()),
+                                 extractFromI64ArrayAttr(op.static_sizes()),
+                                 extractFromI64ArrayAttr(op.static_strides()));
+  auto subViewOp =
+      b.create<SubViewOp>(loc, subViewResultType, outputBuffer, op.offsets(),
+                          op.sizes(), op.strides(), op.static_offsets(),
+                          op.static_sizes(), op.static_strides());
+  b.create<linalg::CopyOp>(loc, sourceBuffer, subViewOp);
+  return success();
+}
+
+/// Converts a `tensor.extract` operation into a `load`.
+static LogicalResult convertTensorExtractOp(
+    OpBuilder &b, WorkgroupMemoryAllocationFn allocationFn,
+    tensor::ExtractOp op, BlockAndValueMapping &bvm) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(op);
+  Value inputBuffer = bvm.lookup(op.tensor());
+  Value load = b.createOrFold<LoadOp>(op.getLoc(), inputBuffer, op.indices());
+  bvm.map(op.result(), load);
+  return success();
 }
 
 static LogicalResult convertTransferOp(OpBuilder &b,
@@ -323,7 +380,7 @@ static LogicalResult convertTransferOp(OpBuilder &b,
       if (tensorType.isDynamicDim(idx)) {
         Value tensor = bvm.lookupOrNull(outputTensor);
         if (!tensor) tensor = outputTensor;
-        dynOperands.push_back(b.create<DimOp>(loc, tensor, idx));
+        dynOperands.push_back(b.createOrFold<DimOp>(loc, tensor, idx));
       }
     }
     auto alloc = allocationFn(b, loc, tensorShape, tensorType.getElementType(),
@@ -397,7 +454,7 @@ static Operation *getInsertionPointForReplacementStoreOp(
 /// For cases where the value operand of the `storeOp` is produced by a
 /// LinalgOp, create the subview operation that can be used by the op itself to
 /// store the result into directly. This avoids an extra allocation + copies.
-LogicalResult preProcessConvertInterfaceStoreTensorOp(
+LogicalResult preProcessInterfaceStoreTensorOp(
     OpBuilder &b, IREE::Flow::DispatchOutputStoreOp storeOp,
     BlockAndValueMapping &bvm) {
   // Find the insertion point for the subview.
@@ -520,7 +577,7 @@ void LinalgBufferizePass::runOnFunction() {
   });
   if (funcOp
           .walk([&](IREE::Flow::DispatchOutputStoreOp op) -> WalkResult {
-            return preProcessConvertInterfaceStoreTensorOp(b, op, bvm);
+            return preProcessInterfaceStoreTensorOp(b, op, bvm);
           })
           .wasInterrupted()) {
     return signalPassFailure();
@@ -556,11 +613,18 @@ void LinalgBufferizePass::runOnFunction() {
         .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
           return convertAnyLinalgOp(b, allocationFn, linalgOp, bvm);
         })
+        .Case<SubTensorInsertOp>([&](SubTensorInsertOp subTensorInsertOp) {
+          return convertSubTensorInsertOp(b, allocationFn, subTensorInsertOp,
+                                          bvm);
+        })
         .Case<SubTensorOp>([&](SubTensorOp subTensorOp) {
           return convertSubTensorOp(b, allocationFn, subTensorOp, bvm);
         })
         .Case<linalg::TensorReshapeOp>([&](linalg::TensorReshapeOp reshapeOp) {
           return convertTensorReshapeOp(b, allocationFn, reshapeOp, bvm);
+        })
+        .Case<tensor::ExtractOp>([&](tensor::ExtractOp extractOp) {
+          return convertTensorExtractOp(b, allocationFn, extractOp, bvm);
         })
         .Case<VectorTransferOpInterface>(
             [&](VectorTransferOpInterface vectorTransferOp) {

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -310,8 +310,8 @@ static LogicalResult convertSubTensorOp(
 
 /// Converts a `subtensor_insert` operation to buffers by
 /// - Allocating a buffer for the result (if needed), and copying the
-///   destination value into this tensor.
-/// - Copying the source values into a subview of the result.
+///   destination value into this buffer.
+/// - Copying the source values into a subview of the result buffer.
 static LogicalResult convertSubTensorInsertOp(
     OpBuilder &b, WorkgroupMemoryAllocationFn allocationFn,
     SubTensorInsertOp op, BlockAndValueMapping &bvm) {

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -536,3 +536,59 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
 //       CHECK:   %[[SUBVIEW:.+]] = subview %[[INPUT]]
 //       CHECK:   linalg.copy(%[[SUBVIEW]], %[[OUTPUT]])
+
+// -----
+
+func @subtensor_insert() {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.input<?x?xi32>
+  %1 = hal.interface.binding.subspan @legacy_io::@arg1[%c0] : !flow.dispatch.input<?x?xi32>
+  %2 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<?x?xi32>
+  %3 = flow.dispatch.input.load %0 : !flow.dispatch.input<?x?xi32> -> tensor<?x?xi32>
+  %4 = flow.dispatch.input.load %1 : !flow.dispatch.input<?x?xi32> -> tensor<?x?xi32>
+  %5 = dim %3, %c0 : tensor<?x?xi32>
+  %6 = dim %3, %c1 : tensor<?x?xi32>
+  %7 = subtensor_insert %3 into %4[3, 4] [%5, %6] [1, 1] : tensor<?x?xi32> into tensor<?x?xi32>
+  flow.dispatch.output.store %7, %2 : tensor<?x?xi32> -> !flow.dispatch.output<?x?xi32>
+  return
+}
+hal.interface @legacy_io attributes {sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @subtensor_insert()
+//   CHECK-DAG:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[C1:.+]] = constant 1
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @legacy_io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @legacy_io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
+//   CHECK-DAG:   %[[D0:.+]] = dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = dim %[[ARG0]], %[[C1]]
+//       CHECK:   linalg.copy(%[[ARG1]], %[[RET0]])
+//       CHECK:   %[[SUBVIEW:.+]] = subview %[[RET0]][3, 4] [%[[D0]], %[[D1]]] [1, 1]
+//       CHECK:   linalg.copy(%[[ARG0]], %[[SUBVIEW]])
+
+// -----
+
+func @tensor_extract() {
+  %c0 = constant 0 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.input<i32>
+  %1 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<3x9xi32>
+  %2 = linalg.init_tensor [3, 9] : tensor<3x9xi32>
+  %3 = flow.dispatch.input.load %0 : !flow.dispatch.input<i32> -> tensor<i32>
+  %4 = tensor.extract %3[] : tensor<i32>
+  %5 = linalg.fill(%2, %4) : tensor<3x9xi32>, i32 -> tensor<3x9xi32> 
+  flow.dispatch.output.store %5, %1 : tensor<3x9xi32> -> !flow.dispatch.output<3x9xi32>
+  return
+}
+hal.interface @legacy_io attributes {sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @tensor_extract()
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @legacy_io::@arg0
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
+//       CHECK:   %[[LOAD:.+]] = load %[[ARG0]]
+//       CHECK:   linalg.fill(%[[RET0]], %[[LOAD]])

--- a/iree/compiler/Conversion/HLOToLinalg/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "HLOToLinalgOnTensorPasses.h",
     ],
     deps = [
+        "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
         "//iree/compiler/Dialect/Shape/IR",

--- a/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensor
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::Shape::IR

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
@@ -31,7 +31,8 @@ namespace iree_compiler {
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();
 
 /// Creates XLA-HLO to Linalg on tensors transformation pass.
-std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass();
+std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
+    bool useLinalgOnTensorsPath = false);
 
 /// Populates the patterns that convert from MHLO to Linalg on tensors. Imports
 /// patterns from XLA, as well as some IREE specific modifications.
@@ -40,7 +41,8 @@ void populateHLOToLinalgOnTensorsConversionPatterns(
 
 /// Populated passes to convert from MHLO to Linalg on tensors as well as fusion
 /// of the converted operations.
-void addHLOToLinalgOnTensorsPasses(OpPassManager &pm);
+void addHLOToLinalgOnTensorsPasses(OpPassManager &pm,
+                                   bool useLinalgOnTensorsPath = false);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
@@ -34,10 +34,6 @@ std::unique_ptr<Pass> createFusionOfTensorOpsPass();
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
     bool useLinalgOnTensorsPath = false);
 
-/// Creates XLA-HLO to Linalg on tensors transformation pass.
-std::unique_ptr<OperationPass<FuncOp>>
-createHLOToLinalgOnTensorsPassExperimental();
-
 /// Populates the patterns that convert from MHLO to Linalg on tensors. Imports
 /// patterns from XLA, as well as some IREE specific modifications.
 void populateHLOToLinalgOnTensorsConversionPatterns(

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
@@ -34,6 +34,10 @@ std::unique_ptr<Pass> createFusionOfTensorOpsPass();
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
     bool useLinalgOnTensorsPath = false);
 
+/// Creates XLA-HLO to Linalg on tensors transformation pass.
+std::unique_ptr<OperationPass<FuncOp>>
+createHLOToLinalgOnTensorsPassExperimental();
+
 /// Populates the patterns that convert from MHLO to Linalg on tensors. Imports
 /// patterns from XLA, as well as some IREE specific modifications.
 void populateHLOToLinalgOnTensorsConversionPatterns(

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -557,29 +557,24 @@ void populateHLOToLinalgOnTensorsConversionPatterns(
                   ConcatenateOpConversion, DepthwiseConvOpConversion>(context);
 }
 
+static llvm::cl::opt<bool> clUseLinalgOnTensorsPath(
+    "iree-linalg-on-tensors-path",
+    llvm::cl::desc("Convert from MHLO to Linalg on tensors for linalg on "
+                   "tensor codegen path"),
+    llvm::cl::init(false));
+
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
     bool useLinalgOnTensorsPath) {
   return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(
       useLinalgOnTensorsPath);
 }
 
-std::unique_ptr<OperationPass<FuncOp>>
-createHLOToLinalgOnTensorsPassExperimental() {
-  return std::make_unique<ConvertHLOToLinalgOnTensorsPassExperimental>();
-}
-
 static PassRegistration<ConvertHLOToLinalgOnTensorsPass> legalize_pass(
     "iree-codegen-hlo-to-linalg-on-tensors",
-    "Convert from XLA-HLO ops to Linalg ops on tensors",
-    []() { return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(); });
-
-static PassRegistration<ConvertHLOToLinalgOnTensorsPassExperimental>
-    legalize_pass_linalg_on_tensors(
-        "iree-codegen-hlo-to-linalg-on-tensors-experimental",
-        "Convert from XLA-HLO ops to Linalg ops on tensors", []() {
-          return std::make_unique<
-              ConvertHLOToLinalgOnTensorsPassExperimental>();
-        });
+    "Convert from XLA-HLO ops to Linalg ops on tensors", []() {
+      return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(
+          clUseLinalgOnTensorsPath);
+    });
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -530,6 +530,14 @@ struct ConvertHLOToLinalgOnTensorsPass
   bool useLinalgOnTensorsPath;
 };
 
+/// This pass is just added for lit-testing when using the linalg on tensors
+/// path. Remove when the linalg on tensors path becomes default.
+struct ConvertHLOToLinalgOnTensorsPassExperimental
+    : public ConvertHLOToLinalgOnTensorsPass {
+  ConvertHLOToLinalgOnTensorsPassExperimental()
+      : ConvertHLOToLinalgOnTensorsPass(true){};
+};
+
 /// Convert mhlo.constant op into std.const.
 struct ConstOpConversion : public OpRewritePattern<mhlo::ConstOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -549,24 +557,29 @@ void populateHLOToLinalgOnTensorsConversionPatterns(
                   ConcatenateOpConversion, DepthwiseConvOpConversion>(context);
 }
 
-static llvm::cl::opt<bool> clUseLinalgOnTensorsPath(
-    "iree-linalg-on-tensors-path",
-    llvm::cl::desc("Convert from MHLO to Linalg on tensors for linalg on "
-                   "tensor codegen path"),
-    llvm::cl::init(false));
-
 std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
     bool useLinalgOnTensorsPath) {
   return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(
       useLinalgOnTensorsPath);
 }
 
+std::unique_ptr<OperationPass<FuncOp>>
+createHLOToLinalgOnTensorsPassExperimental() {
+  return std::make_unique<ConvertHLOToLinalgOnTensorsPassExperimental>();
+}
+
 static PassRegistration<ConvertHLOToLinalgOnTensorsPass> legalize_pass(
     "iree-codegen-hlo-to-linalg-on-tensors",
-    "Convert from XLA-HLO ops to Linalg ops on tensors", []() {
-      return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(
-          clUseLinalgOnTensorsPath);
-    });
+    "Convert from XLA-HLO ops to Linalg ops on tensors",
+    []() { return std::make_unique<ConvertHLOToLinalgOnTensorsPass>(); });
+
+static PassRegistration<ConvertHLOToLinalgOnTensorsPassExperimental>
+    legalize_pass_linalg_on_tensors(
+        "iree-codegen-hlo-to-linalg-on-tensors-experimental",
+        "Convert from XLA-HLO ops to Linalg ops on tensors", []() {
+          return std::make_unique<
+              ConvertHLOToLinalgOnTensorsPassExperimental>();
+        });
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
@@ -30,7 +30,8 @@ void addHLOToLinalgOnBuffersPasses(OpPassManager &pm) {
 
 void addHLOToLinalgOnTensorsPasses(OpPassManager &pm,
                                    bool useLinalgOnTensorsPath) {
-  pm.addNestedPass<FuncOp>(createHLOToLinalgOnTensorsPass(useLinalgOnTensorsPath));
+  pm.addNestedPass<FuncOp>(
+      createHLOToLinalgOnTensorsPass(useLinalgOnTensorsPath));
   pm.addNestedPass<FuncOp>(createLinalgFoldUnitExtentDimsPass());
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());

--- a/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
@@ -28,8 +28,9 @@ void addHLOToLinalgOnBuffersPasses(OpPassManager &pm) {
   pm.addNestedPass<FuncOp>(createHLOToLinalgOnBuffersPass());
 }
 
-void addHLOToLinalgOnTensorsPasses(OpPassManager &pm) {
-  pm.addNestedPass<FuncOp>(createHLOToLinalgOnTensorsPass());
+void addHLOToLinalgOnTensorsPasses(OpPassManager &pm,
+                                   bool useLinalgOnTensorsPath) {
+  pm.addNestedPass<FuncOp>(createHLOToLinalgOnTensorsPass(useLinalgOnTensorsPath));
   pm.addNestedPass<FuncOp>(createLinalgFoldUnitExtentDimsPass());
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors-experimental -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path -canonicalize %s | IreeFileCheck %s
 
 module  {
   func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -30,7 +30,7 @@ module  {
 //   CHECK-DAG:   %[[RD1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]], %[[D1]]]
 //       CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[RD0]], %[[RD1]]]
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
-//       CHECK:   %[[RESULT:.+]] = flow.tensor.update %[[ARG0]], %[[FILL]][%[[C4]], %[[ARG2]]]
+//       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, %[[ARG2]]] [%[[D0]], %[[D1]]] [1, 1]
 //       CHECK:   return %[[RESULT]]
 
 
@@ -58,5 +58,5 @@ module  {
 //   CHECK-DAG:   %[[VAL:.+]] = tensor.extract %[[ARG1]]
 //       CHECK:   %[[INIT:.+]] = linalg.init_tensor [18, 12]
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
-//       CHECK:   %[[RESULT:.+]] = flow.tensor.update %[[ARG0]], %[[FILL]][%[[C4]], %[[C5]]]
+//       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [18, 12] [1, 1]
 //       CHECK:   return %[[RESULT]]

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors-experimental -canonicalize %s | IreeFileCheck %s
 
 module  {
   func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -22,7 +22,6 @@ module  {
 //  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: index
 //   CHECK-DAG:   %[[C0:.+]] = constant 0
 //   CHECK-DAG:   %[[C1:.+]] = constant 1
-//   CHECK-DAG:   %[[C4:.+]] = constant 4
 //   CHECK-DAG:   %[[VAL:.+]] = tensor.extract %[[ARG1]]
 //   CHECK-DAG:   %[[D0:.+]] = dim %[[ARG0]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = dim %[[ARG0]], %[[C1]]
@@ -32,7 +31,6 @@ module  {
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, %[[ARG2]]] [%[[D0]], %[[D1]]] [1, 1]
 //       CHECK:   return %[[RESULT]]
-
 
 // -----
 
@@ -53,10 +51,8 @@ module  {
 // CHECK-LABEL: func @pad_tensor_static
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<12x4xf32>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<f32>
-//   CHECK-DAG:   %[[C4:.+]] = constant 4
-//   CHECK-DAG:   %[[C5:.+]] = constant 5
 //   CHECK-DAG:   %[[VAL:.+]] = tensor.extract %[[ARG1]]
 //       CHECK:   %[[INIT:.+]] = linalg.init_tensor [18, 12]
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
-//       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [18, 12] [1, 1]
+//       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [12, 4] [1, 1]
 //       CHECK:   return %[[RESULT]]

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,0 +1,62 @@
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path -canonicalize %s | IreeFileCheck %s
+
+module  {
+  func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
+    %c0 = constant 0 : index
+    %c4 = constant 4 : index
+    %c3 = constant 3 : index
+    %0 = tensor.extract %arg1[] : tensor<f32>
+    %1 = linalg.pad_tensor %arg0 low[%c4, %arg2] high[%arg3, %c3]  {
+    ^bb0(%arg4: index, %arg5: index):  // no predecessors
+      linalg.yield %0 : f32
+    } : tensor<?x?xf32> to tensor<?x?xf32>
+    return %1 : tensor<?x?xf32>
+  }
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 + s1 + 4)>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s0 + s1 + 3)>
+//       CHECK: func @pad_tensor
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<f32>
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[C1:.+]] = constant 1
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[VAL:.+]] = tensor.extract %[[ARG1]]
+//   CHECK-DAG:   %[[D0:.+]] = dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = dim %[[ARG0]], %[[C1]]
+//   CHECK-DAG:   %[[RD0:.+]] = affine.apply #[[MAP0]]()[%[[ARG3]], %[[D0]]]
+//   CHECK-DAG:   %[[RD1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]], %[[D1]]]
+//       CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[RD0]], %[[RD1]]]
+//       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
+//       CHECK:   %[[RESULT:.+]] = flow.tensor.update %[[ARG0]], %[[FILL]][%[[C4]], %[[ARG2]]]
+//       CHECK:   return %[[RESULT]]
+
+
+// -----
+
+module  {
+  func @pad_tensor_static(%arg0: tensor<12x4xf32>, %arg1: tensor<f32>) -> tensor<18x12xf32> {
+    %c4 = constant 4 : index
+    %c2 = constant 2 : index
+    %c5 = constant 5 : index
+    %c3 = constant 3 : index
+    %0 = tensor.extract %arg1[] : tensor<f32>
+    %1 = linalg.pad_tensor %arg0 low[%c4, %c5] high[%c2, %c3]  {
+    ^bb0(%arg2: index, %arg3: index):  // no predecessors
+      linalg.yield %0 : f32
+    } : tensor<12x4xf32> to tensor<18x12xf32>
+    return %1 : tensor<18x12xf32>
+  }
+}
+// CHECK-LABEL: func @pad_tensor_static
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<12x4xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<f32>
+//   CHECK-DAG:   %[[C4:.+]] = constant 4
+//   CHECK-DAG:   %[[C5:.+]] = constant 5
+//   CHECK-DAG:   %[[VAL:.+]] = tensor.extract %[[ARG1]]
+//       CHECK:   %[[INIT:.+]] = linalg.init_tensor [18, 12]
+//       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
+//       CHECK:   %[[RESULT:.+]] = flow.tensor.update %[[ARG0]], %[[FILL]][%[[C4]], %[[C5]]]
+//       CHECK:   return %[[RESULT]]

--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorToGPUPass.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -42,11 +42,14 @@ inline void registerCommonConversionPasses() {
 }
 
 inline void registerHLOToLinalgPasses() {
-  createDecomposeHLOClampPass();
-  createHLOToLinalgOnBuffersPass();
-  createHLOToLinalgOnTensorsPass();
-  createHLOToLinalgOnTensorsPassExperimental();
-  createDemoteF32ToF16Pass();
+  static bool init_once = []() {
+    createDecomposeHLOClampPass();
+    createHLOToLinalgOnBuffersPass();
+    createHLOToLinalgOnTensorsPass();
+    createDemoteF32ToF16Pass();
+    return true;
+  }();
+  (void)init_once;
 }
 
 inline void registerLinalgToVectorPasses() {

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -45,6 +45,7 @@ inline void registerHLOToLinalgPasses() {
   createDecomposeHLOClampPass();
   createHLOToLinalgOnBuffersPass();
   createHLOToLinalgOnTensorsPass();
+  createHLOToLinalgOnTensorsPassExperimental();
   createDemoteF32ToF16Pass();
 }
 

--- a/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/BUILD
@@ -60,7 +60,7 @@ cc_library(
         "@llvm-project//mlir:SideEffects",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:Tensor",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/BUILD
@@ -60,6 +60,7 @@ cc_library(
         "@llvm-project//mlir:SideEffects",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Tensor",
         "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     MLIRSideEffectInterfaces
     MLIRStandard
     MLIRSupport
+    MLIRTensor
     MLIRTransformUtils
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::Shape::IR

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -921,6 +921,7 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
   }];
 
   // TODO(benvanik): canonicalize contiguous updates/across slices.
+  let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -322,8 +322,7 @@ func @propogateStaticShapeOfUpdate(%arg0 : tensor<?x?xf32>, %arg1 : f32) -> tens
   ^bb0(%arg2: index, %arg3: index):
     tensor.yield %arg1 : f32
   } :  tensor<?x?xf32>
-  // CHECK: %[[UPDATED:.+]] = flow.tensor.update  %[[UPDATE]] %{{.+}}
-  // CHECK: %[[RESULT:.+]] = tensor.cast %[[UPDATED]] : tensor<21x42xf32> to tensor<?x?xf32>
+  // CHECK: %[[RESULT:.+]] = flow.tensor.update  %[[UPDATE]]
   %1 = flow.tensor.update %0, %arg0[%c2, %c4] : tensor<?x?xf32> -> tensor<?x?xf32>
   // CHECK: return %[[RESULT]]
   return %1 : tensor<?x?xf32>

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -290,3 +290,41 @@ func @updateReplace(%arg0 : tensor<4xi32>, %arg1 : tensor<4xi32>) -> tensor<4xi3
   // CHECK-NEXT: return %arg0
   return %0 : tensor<4xi32>
 }
+
+// CHECK-LABEL: @propogateStaticShapeOfTarget
+func @propogateStaticShapeOfTarget(%arg0 : tensor<?x?xf32>, %arg1 : f32) -> tensor<?x?xf32> {
+  %c21 = constant 21 : index
+  %c42 = constant 42 : index
+  %c2 = constant 2 : index
+  %c4 = constant 4 : index
+  // CHECK: %[[TARGET:.+]] = tensor.generate {
+  // CHECK: } : tensor<21x42xf32>
+  %0 = tensor.generate %c21, %c42 {
+  ^bb0(%arg2: index, %arg3: index):
+    tensor.yield %arg1 : f32
+  } :  tensor<?x?xf32>
+  // CHECK: %[[UPDATED:.+]] = flow.tensor.update %{{.+}}, %[[TARGET]]
+  // CHECK: %[[RESULT:.+]] = tensor.cast %[[UPDATED]] : tensor<21x42xf32> to tensor<?x?xf32>
+  %1 = flow.tensor.update %arg0, %0[%c2, %c4] : tensor<?x?xf32> -> tensor<?x?xf32>
+  // CHECK: return %[[RESULT]]
+  return %1 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @propogateStaticShapeOfUpdate
+func @propogateStaticShapeOfUpdate(%arg0 : tensor<?x?xf32>, %arg1 : f32) -> tensor<?x?xf32> {
+  %c21 = constant 21 : index
+  %c42 = constant 42 : index
+  %c2 = constant 2 : index
+  %c4 = constant 4 : index
+  // CHECK: %[[UPDATE:.+]] = tensor.generate {
+  // CHECK: } : tensor<21x42xf32>
+  %0 = tensor.generate %c21, %c42 {
+  ^bb0(%arg2: index, %arg3: index):
+    tensor.yield %arg1 : f32
+  } :  tensor<?x?xf32>
+  // CHECK: %[[UPDATED:.+]] = flow.tensor.update  %[[UPDATE]] %{{.+}}
+  // CHECK: %[[RESULT:.+]] = tensor.cast %[[UPDATED]] : tensor<21x42xf32> to tensor<?x?xf32>
+  %1 = flow.tensor.update %0, %arg0[%c2, %c4] : tensor<?x?xf32> -> tensor<?x?xf32>
+  // CHECK: return %[[RESULT]]
+  return %1 : tensor<?x?xf32>
+}

--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -409,8 +409,11 @@ static LogicalResult rewriteDestructiveUpdateInPlace(OpBuilder &b, Value v,
 
   // Try to rewrite inplace.
   if (failed(rewriteSubTensorInsertInPlace(
-          b, cast<SubTensorInsertOp>(capture.rootDestructiveUpdate), target)))
-    return failure();
+          b, cast<SubTensorInsertOp>(capture.rootDestructiveUpdate), target))) {
+    // Nothing has changed yet, so return success. SubTensorInserts will be
+    // handled later.
+    return success();
+  }
 
   // Reload the value produced inplace right after the inplace update.
   OpBuilder::InsertionGuard g(b);

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -193,7 +193,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
     // will break VMLA backend.
     passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
     passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
-    addHLOToLinalgOnTensorsPasses(passManager);
+    addHLOToLinalgOnTensorsPasses(passManager, clEnableLinalgOnTensorsDispatch);
     passManager.addNestedPass<FuncOp>(createDispatchLinalgOnTensorsPass());
     passManager.addPass(createCanonicalizerPass());
     passManager.addPass(createCSEPass());

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -350,3 +350,44 @@ func @always_fuse_reshape
 //      CHECK:   %[[RESULT2:.+]] = flow.dispatch.workgroups[%[[N2]], %[[M]], %[[C1]]]
 // CHECK-SAME:     (%[[M]], %[[N2]], %[[ARG0]], %[[RHS2]])
 //      CHECK:   return %[[RESULT1]], %[[RESULT2]]
+
+// -----
+
+func @pad_test(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index,
+    %arg3 : index, %arg4 : index, %arg5 : index ) -> tensor<?x?xf32> {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = tensor.extract %arg1[] : tensor<f32>
+  %1 = dim %arg0, %c0 : tensor<?x?xf32>
+  %2 = dim %arg0, %c1 : tensor<?x?xf32>
+  %3 = affine.apply affine_map<(d0)[s0, s1] -> (d0 + s0 + s1)>(%1)[%arg2, %arg4]
+  %4 = affine.apply affine_map<(d0)[s0, s1] -> (d0 + s0 + s1)>(%2)[%arg3, %arg5]
+  %5 = linalg.init_tensor [%3, %4] : tensor<?x?xf32>
+  %6 = linalg.fill(%5, %0) : tensor<?x?xf32>, f32 -> tensor<?x?xf32>
+  %7 = flow.tensor.update %arg0, %6[%arg2, %arg3] : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %7 : tensor<?x?xf32>
+}
+
+//       CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 + s1 + s2)>
+//       CHECK: func @pad_test
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<f32>
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:   %[[ARG4:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:   %[[ARG5:[a-zA-Z0-9]+]]: index
+//   CHECK-DAG:   %[[C0:.+]] = constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:   %[[D0:.+]] = dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = dim %[[ARG0]], %[[C1]]
+//   CHECK-DAG:   %[[RD0:.+]] = affine.apply #[[MAP]]()[%[[ARG2]], %[[ARG4]], %[[D0]]]
+//   CHECK-DAG:   %[[RD1:.+]] = affine.apply #[[MAP]]()[%[[ARG3]], %[[ARG5]], %[[D1]]]
+//       CHECK:   %[[RESULT:.+]] = flow.dispatch.workgroups
+//  CHECK-SAME:    [%[[RD1]], %[[RD0]], %[[C1]]]
+//  CHECK-SAME:    (%[[ARG1]], %[[RD0]], %[[RD1]])
+//   CHECK-DAG:      %[[VAL:.+]] = tensor.extract
+//   CHECK-DAG:      %[[INIT:.+]] = linalg.init_tensor
+//       CHECK:      %[[RETURN:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
+//       CHECK:      flow.dispatch.output.store %[[RETURN]]
+//  CHECK-NEXT:      flow.return
+//       CHECK:   flow.tensor.update %[[ARG0]], %[[RESULT]]

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -168,7 +168,7 @@ iree_check_single_backend_test_suite(
         "multiply.mlir",
         "negate.mlir",
         # https://github.com/google/iree/issues/4079
-        # "pad.mlir",
+        "pad.mlir",
         # "reduce.mlir",
         # "reduce_window.mlir",
         "remainder.mlir",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -154,6 +154,7 @@ iree_check_single_backend_test_suite(
     "minimum.mlir"
     "multiply.mlir"
     "negate.mlir"
+    "pad.mlir"
     "remainder.mlir"
     "reshape.mlir"
     "reverse.mlir"


### PR DESCRIPTION
linalg.pad_tensor cannot be represented as a structured
operation. Instead it is lowered to

%b = linalg.fill(%dest, %pad_val)
%c = subtensor_insert %source into %b[%low_pad_0, %low_pad_1, ...]

This requires handling subtensor_insert when converting from tensors
to buffers. This can be done effectively only when it is possible to
do in-place updates within dispatch regions. So currently only support
this on CPU side.