### PR TITLE
Support HLO Text format for the XLA importer.

### DIFF
--- a/bindings/python/pyiree/compiler2/xla.py
+++ b/bindings/python/pyiree/compiler2/xla.py
@@ -51,6 +51,7 @@ class ImportFormat(Enum):
   """Import type of the model."""
   BINARY_PROTO = "binary_proto"
   TEXT_PROTO = "text_proto"
+  HLO_TEXT = "hlo_text"
 
   @staticmethod
   def parse(spec: Union[str, "ImportFormat"]) -> "ImportFormat":
@@ -164,7 +165,9 @@ def compile_str(xla_content: Union[bytes, str], **kwargs):
   """
   options = ImportOptions(**kwargs)
   if isinstance(xla_content, str):
-    if options.import_format != ImportFormat.TEXT_PROTO:
+    if options.import_format not in [
+        ImportFormat.TEXT_PROTO, ImportFormat.HLO_TEXT
+    ]:
       raise ValueError("If passing a string, ImportFormat must be TEXT_PROTO")
     xla_content = xla_content.encode("utf-8")
 

--- a/bindings/python/tests/compiler_xla_test.py
+++ b/bindings/python/tests/compiler_xla_test.py
@@ -90,6 +90,34 @@ class CompilerTest(unittest.TestCase):
     logging.info("Binary length = %d", len(binary))
     self.assertIn(b"main", binary)
 
+  def testImportHloTextFile(self):
+    path = os.path.join(os.path.dirname(__file__), "testdata", "xla_sample.hlo")
+    text = compile_file(path, import_only=True,
+                        import_format="hlo_text").decode("utf-8")
+    logging.info("%s", text)
+    self.assertIn("mhlo.constant", text)
+    self.assertIn("iree.module.export", text)
+
+  def testImportHloTextStr(self):
+    path = os.path.join(os.path.dirname(__file__), "testdata", "xla_sample.hlo")
+    with open(path, "rt") as f:
+      content = f.read()
+    text = compile_str(content, import_only=True,
+                       import_format="hlo_text").decode("utf-8")
+    logging.info("%s", text)
+    self.assertIn("mhlo.constant", text)
+    self.assertIn("iree.module.export", text)
+
+  def testImportHloTextBytes(self):
+    path = os.path.join(os.path.dirname(__file__), "testdata", "xla_sample.hlo")
+    with open(path, "rb") as f:
+      content = f.read()
+    text = compile_str(content, import_only=True,
+                       import_format="hlo_text").decode("utf-8")
+    logging.info("%s", text)
+    self.assertIn("mhlo.constant", text)
+    self.assertIn("iree.module.export", text)
+
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.DEBUG)

--- a/bindings/python/tests/testdata/generate_xla.py
+++ b/bindings/python/tests/testdata/generate_xla.py
@@ -32,3 +32,5 @@ xla_computation = builder.Build(result)
 this_dir = os.path.dirname(__file__)
 with open(os.path.join(this_dir, "xla_sample.pb"), "wb") as f:
   f.write(xla_computation.as_serialized_hlo_module_proto())
+with open(os.path.join(this_dir, "xla_sample.hlo"), "wt") as f:
+  f.write(xla_computation.as_hlo_text())

--- a/bindings/python/tests/testdata/xla_sample.hlo
+++ b/bindings/python/tests/testdata/xla_sample.hlo
@@ -1,0 +1,9 @@
+HloModule testbuilder.5
+
+ENTRY testbuilder.5 {
+  parameter.1 = f32[1] parameter(0)
+  constant.2 = f32[] constant(1)
+  broadcast.3 = f32[1]{0} broadcast(constant.2), dimensions={}
+  ROOT add.4 = f32[1]{0} add(parameter.1, broadcast.3)
+}
+

--- a/integrations/tensorflow/build_tools/bazel/iree-tf.bazelrc
+++ b/integrations/tensorflow/build_tools/bazel/iree-tf.bazelrc
@@ -14,3 +14,7 @@
 
 # For now, just import the main IREE bazelrc
 try-import %workspace%/../../build_tools/bazel/iree.bazelrc
+
+# Ignore visibility issues in TensorFlow. They are inconsistently applied
+# to the OSS codebase.
+build --nocheck_visibility

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -95,6 +95,7 @@ cc_binary(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo_to_mlir_hlo",
+        "@org_tensorflow//tensorflow/compiler/xla/service:hlo_parser",
         "@org_tensorflow//tensorflow/compiler/xla/service:hlo_proto_cc",
         "@org_tensorflow//tensorflow/core:lib",
     ],


### PR DESCRIPTION
* New binary argument `--xla-format=hlo_text`
* Argument to `pyiree.compiler2.xla.compile(import_format="hlo_text")`
* It might be nice to add some hinting to eliminate the need to specify import_format. Also can probably drop text proto parsing at this point.