### PR TITLE
Note supported CMake version in various places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.13.4)
-# Allow target_link_libraries() from other directories (since 3.13):
-#   https://cmake.org/cmake/help/v3.13/policy/CMP0079.html
-if(POLICY CMP0079)
-  cmake_policy(SET CMP0079 NEW)
-endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(iree CXX C)

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -19,16 +19,16 @@ documented separately, as they require further setup.
 
 ### Install CMake
 
-IREE uses CMake version `>= 3.13`. First try installing via your distribution's
-package manager and verify the version:
+IREE uses CMake version `>= 3.13.4`. First try installing via your
+distribution's package manager and verify the version:
 
 ```shell
 $ sudo apt install cmake
-$ cmake --version # >= 3.13
+$ cmake --version # >= 3.13.4
 ```
 
 Some package managers (like `apt`) distribute old versions of cmake. If your
-package manager installs a version `< 3.13`, then follow the installation
+package manager installs a version `< 3.13.4`, then follow the installation
 instructions [here](https://cmake.org/install/) to install a newer version (e.g.
 the latest).
 

--- a/docs/get_started/getting_started_macos_cmake.md
+++ b/docs/get_started/getting_started_macos_cmake.md
@@ -31,12 +31,12 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 
 ### Install CMake
 
-IREE uses [CMake](https://cmake.org/) version `>= 3.13`. Brew ships the latest
+IREE uses [CMake](https://cmake.org/) version `>= 3.13.4`. Brew ships the latest
 release.
 
 ```shell
 $ brew install cmake
-$ cmake --version  # >= 3.13
+$ cmake --version  # >= 3.13.4
 ```
 
 ### Install Ninja

--- a/docs/get_started/getting_started_windows_cmake.md
+++ b/docs/get_started/getting_started_windows_cmake.md
@@ -19,7 +19,7 @@ documented separately, as they require further setup.
 
 ### Install CMake
 
-Install CMake version >= 3.13 from the
+Install CMake version >= 3.13.4 from the
 [downloads page](https://cmake.org/download/).
 
 > Tip:<br>

--- a/experimental/bindings/java/build.gradle
+++ b/experimental/bindings/java/build.gradle
@@ -54,7 +54,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version "3.13.0+"
+            version "3.13.4.0+"
             path "../../../CMakeLists.txt"
         }
     }


### PR DESCRIPTION
Also don't redundantly set CMP0079. This is already done by
`cmake_minimum_required`
(https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)