### PR TITLE
Migrate pooling ops to TC ops.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -395,8 +395,7 @@ LogicalResult ReduceWindowOpConversion::apply(
     ArrayRef<Value> resultBuffers, ConversionPatternRewriter &rewriter) const {
   auto loc = op.getLoc();
   auto resultType = op.getResult().getType().cast<ShapedType>();
-  int rank = resultType.getRank();
-  if (rank != 4) {
+  if (resultType.getRank() != 4) {
     return rewriter.notifyMatchFailure(op, "expected NHWC pooling-based op");
   }
 
@@ -424,7 +423,6 @@ LogicalResult ReduceWindowOpConversion::apply(
     return rewriter.notifyMatchFailure(op, "expected element type to be f32");
   }
 
-  // TODO(hanchung): Use template lambda after migrating to C++20.
   Attribute strides;
   if (op.window_stridesAttr()) {
     strides = rewriter.getI64VectorAttr(

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -394,33 +394,60 @@ LogicalResult ReduceWindowOpConversion::apply(
     mhlo::ReduceWindowOp op, ArrayRef<Value> inputBuffers,
     ArrayRef<Value> resultBuffers, ConversionPatternRewriter &rewriter) const {
   auto loc = op.getLoc();
+  auto resultType = op.getResult().getType().cast<ShapedType>();
+  int rank = resultType.getRank();
+  if (rank != 4) {
+    return rewriter.notifyMatchFailure(op, "expected NHWC pooling-based op");
+  }
 
   // Create a fake window dimension.
   SmallVector<int64_t, 4> shapes;
-  for (auto dim : op.window_dimensions().getValues<int64_t>()) {
-    shapes.push_back(dim);
-  }
-  Type type = rewriter.getIntegerType(32);
-  auto memrefType = MemRefType::get(shapes, type);
+  shapes.push_back(op.window_dimensions().getValue<int64_t>(1));
+  shapes.push_back(op.window_dimensions().getValue<int64_t>(2));
+  auto memrefType = MemRefType::get(shapes, rewriter.getF32Type());
   auto fakeWindowDims = rewriter.create<AllocOp>(loc, memrefType);
 
-  llvm::SmallVector<Attribute, 4> strides;
-  if (op.window_strides().hasValue()) {
-    strides.insert(strides.begin(),
-                   op.window_strides().getValue().getAttributeValues().begin(),
-                   op.window_strides().getValue().getAttributeValues().end());
+  if (op.window_strides() &&
+      (op.window_strides().getValue().getValue<int64_t>(0) != 1 ||
+       op.window_strides().getValue().getValue<int64_t>(3) != 1)) {
+    return rewriter.notifyMatchFailure(
+        op, "expected window_strides to be [1,x,y,1]");
   }
-  auto stridesArg = ArrayAttr::get(op.getContext(), strides);
+  if (op.window_dimensions() &&
+      (op.window_dimensions().getValue<int64_t>(0) != 1 ||
+       op.window_dimensions().getValue<int64_t>(3) != 1)) {
+    return rewriter.notifyMatchFailure(
+        op, "expected window_dimensions to be [1,x,y,1]");
+  }
+
+  if (!inputBuffers[0].getType().cast<ShapedType>().getElementType().isF32()) {
+    return rewriter.notifyMatchFailure(op, "expected element type to be f32");
+  }
 
   // TODO(hanchung): Use template lambda after migrating to C++20.
+  Attribute strides;
+  if (op.window_stridesAttr()) {
+    strides = rewriter.getI64VectorAttr(
+        {op.window_strides().getValue().getValue<int64_t>(1),
+         op.window_strides().getValue().getValue<int64_t>(2)});
+  } else {
+    strides = rewriter.getI64VectorAttr({1, 1});
+  }
+  Attribute dilations;
+  if (op.window_dilations()) {
+    dilations = rewriter.getI64VectorAttr(
+        {op.window_dilations().getValue().getValue<int64_t>(1),
+         op.window_dilations().getValue().getValue<int64_t>(2)});
+  } else {
+    dilations = rewriter.getI64VectorAttr({1, 1});
+  }
   auto createOp = [&](auto *type_ptr) -> linalg::LinalgOp {
     return cast<linalg::LinalgOp>(
         rewriter
             .create<std::remove_pointer_t<decltype(type_ptr)>>(
-                loc, ArrayRef<Type>{}, inputBuffers[0],
-                fakeWindowDims.getResult(), resultBuffers[0], stridesArg,
-                /*dilations=*/nullptr,
-                /*padding=*/nullptr)
+                loc, ArrayRef<Type>{},
+                ValueRange{inputBuffers[0], fakeWindowDims.getResult()},
+                resultBuffers[0], dilations, strides)
             .getOperation());
   };
   linalg::LinalgOp poolingOp;
@@ -438,21 +465,19 @@ LogicalResult ReduceWindowOpConversion::apply(
 
   switch (poolingType) {
     case PoolingType::kMin: {
-      poolingOp = createOp(static_cast<linalg::PoolingMinOp *>(nullptr));
+      poolingOp = createOp(static_cast<linalg::PoolingNHWCMinOp *>(nullptr));
       break;
     }
     case PoolingType::kMax: {
-      poolingOp = createOp(static_cast<linalg::PoolingMaxOp *>(nullptr));
+      poolingOp = createOp(static_cast<linalg::PoolingNHWCMaxOp *>(nullptr));
       break;
     }
     case PoolingType::kAdd: {
-      poolingOp = createOp(static_cast<linalg::PoolingSumOp *>(nullptr));
+      poolingOp = createOp(static_cast<linalg::PoolingNHWCSumOp *>(nullptr));
       break;
     }
   }
-
   rewriter.create<DeallocOp>(loc, fakeWindowDims);
-
   return success();
 }
 

--- a/iree/compiler/Conversion/HLOToLinalg/test/reduce_window.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/reduce_window.mlir
@@ -24,11 +24,14 @@ module {
 // CHECK-DAG:     %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<1x18x18x64xf32>
 // CHECK-DAG:     %[[ARG1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
 // CHECK-DAG:     %[[RES:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<1x8x8x64xf32>
-// CHECK:         %[[WINDOW:.+]] = alloc() : memref<1x3x3x1xi32>
+// CHECK:         %[[WINDOW:.+]] = alloc() : memref<3x3xf32>
 // CHECK:         %[[INIT:.+]] = load %[[ARG1]][] : memref<f32>
 // CHECK:         linalg.fill(%[[RES]], %[[INIT]]) : memref<1x8x8x64xf32>, f32
-// CHECK:         linalg.pooling_min(%[[ARG0]], %[[WINDOW]], %[[RES]])
-// CHECK-SAME:      strides = [1, 2, 2, 1]
+// CHECK:         linalg.pooling_nhwc_min
+// CHECK-SAME:      {dilations = dense<1> : vector<2xi64>
+// CHECK-SAME:       strides = dense<2> : vector<2xi64>}
+// CHECK-SAME:      ins(%[[ARG0]], %[[WINDOW]] : memref<1x18x18x64xf32>, memref<3x3xf32>)
+// CHECK-SAME:      outs(%[[RES]] : memref<1x8x8x64xf32>)
 
 // -----
 
@@ -56,11 +59,14 @@ module {
 // CHECK-DAG:     %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<1x18x18x64xf32>
 // CHECK-DAG:     %[[ARG1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
 // CHECK-DAG:     %[[RES:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<1x8x8x64xf32>
-// CHECK:         %[[WINDOW:.+]] = alloc() : memref<1x3x3x1xi32>
+// CHECK:         %[[WINDOW:.+]] = alloc() : memref<3x3xf32>
 // CHECK:         %[[INIT:.+]] = load %[[ARG1]][] : memref<f32>
 // CHECK:         linalg.fill(%[[RES]], %[[INIT]]) : memref<1x8x8x64xf32>, f32
-// CHECK:         linalg.pooling_max(%[[ARG0]], %[[WINDOW]], %[[RES]])
-// CHECK-SAME:      strides = [1, 2, 2, 1]
+// CHECK:         linalg.pooling_nhwc_max
+// CHECK-SAME:      {dilations = dense<1> : vector<2xi64>
+// CHECK-SAME:       strides = dense<2> : vector<2xi64>}
+// CHECK-SAME:      ins(%[[ARG0]], %[[WINDOW]] : memref<1x18x18x64xf32>, memref<3x3xf32>)
+// CHECK-SAME:      outs(%[[RES]] : memref<1x8x8x64xf32>)
 
 // -----
 
@@ -88,11 +94,14 @@ module {
 // CHECK-DAG:     %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<1x18x18x64xf32>
 // CHECK-DAG:     %[[ARG1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
 // CHECK-DAG:     %[[RES:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<1x8x8x64xf32>
-// CHECK:         %[[WINDOW:.+]] = alloc() : memref<1x3x3x1xi32>
+// CHECK:         %[[WINDOW:.+]] = alloc() : memref<3x3xf32>
 // CHECK:         %[[INIT:.+]] = load %[[ARG1]][] : memref<f32>
 // CHECK:         linalg.fill(%[[RES]], %[[INIT]]) : memref<1x8x8x64xf32>, f32
-// CHECK:         linalg.pooling_sum(%[[ARG0]], %[[WINDOW]], %[[RES]])
-// CHECK-SAME:      strides = [1, 2, 2, 1]
+// CHECK:         linalg.pooling_nhwc_sum
+// CHECK-SAME:      {dilations = dense<1> : vector<2xi64>
+// CHECK-SAME:       strides = dense<2> : vector<2xi64>}
+// CHECK-SAME:      ins(%[[ARG0]], %[[WINDOW]] : memref<1x18x18x64xf32>, memref<3x3xf32>)
+// CHECK-SAME:      outs(%[[RES]] : memref<1x8x8x64xf32>)
 
 // -----
 
@@ -119,7 +128,10 @@ module {
 // CHECK-DAG:     %[[INIT:.+]] = constant 0xFF800000 : f32
 // CHECK-DAG:     %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<1x18x18x64xf32>
 // CHECK-DAG:     %[[RES:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<1x8x8x64xf32>
-// CHECK:         %[[WINDOW:.+]] = alloc() : memref<1x3x3x1xi32>
+// CHECK:         %[[WINDOW:.+]] = alloc() : memref<3x3xf32>
 // CHECK:         linalg.fill(%[[RES]], %[[INIT]]) : memref<1x8x8x64xf32>, f32
-// CHECK:         linalg.pooling_max(%[[ARG0]], %[[WINDOW]], %[[RES]])
-// CHECK-SAME:      strides = [1, 2, 2, 1]
+// CHECK:         linalg.pooling_nhwc_max
+// CHECK-SAME:      {dilations = dense<1> : vector<2xi64>
+// CHECK-SAME:       strides = dense<2> : vector<2xi64>}
+// CHECK-SAME:      ins(%[[ARG0]], %[[WINDOW]] : memref<1x18x18x64xf32>, memref<3x3xf32>)
+// CHECK-SAME:      outs(%[[RES]] : memref<1x8x8x64xf32>)

--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToGPUPass.cpp
@@ -839,10 +839,11 @@ void ConvertToGPUPass::runOnOperation() {
       MapLinalgOpToLocalInvocationId<linalg::IndexedGenericOp>,
       MapLinalgOpToLocalInvocationId<linalg::MatmulOp>,
       MapLinalgOpToLocalInvocationId<linalg::BatchMatmulOp>,
-      MapLinalgOpToLocalInvocationId<linalg::PoolingMaxOp>,
-      MapLinalgOpToLocalInvocationId<linalg::PoolingMinOp>,
-      MapLinalgOpToLocalInvocationId<linalg::PoolingSumOp>, RemoveLinalgRange,
-      SerializeParallelLoopPattern>(context, options.usingLinalgOnTensors);
+      MapLinalgOpToLocalInvocationId<linalg::PoolingNHWCMaxOp>,
+      MapLinalgOpToLocalInvocationId<linalg::PoolingNHWCMinOp>,
+      MapLinalgOpToLocalInvocationId<linalg::PoolingNHWCSumOp>,
+      RemoveLinalgRange, SerializeParallelLoopPattern>(
+      context, options.usingLinalgOnTensors);
   FrozenRewritePatternList frozenPatterns(std::move(patterns));
 
   for (FuncOp funcOp : getOperation().getInnerModule().getOps<FuncOp>()) {

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
@@ -563,7 +563,7 @@ static LogicalResult getPoolingOpLaunchConfig(
   // pooled dimension and which are not. Need to fix that, but for now just use
   // a working heuristic.
   SmallVector<int64_t, 4> ts(std::min<int64_t>(
-      op.output().getType().template cast<ShapedType>().getRank(), 3));
+      op.getOutput(0).getType().template cast<ShapedType>().getRank(), 3));
   const int64_t tileSizeX = 32;
   int64_t tileSizeY = maxWorkgroupSize / tileSizeX;
   ts[ts.size() - 2] = tileSizeY;
@@ -583,9 +583,9 @@ static LogicalResult getPoolingOpLaunchConfig(
                                     config);                            \
   }
 
-DEFINE_POOLING_OP_CONFIG(linalg::PoolingMaxOp)
-DEFINE_POOLING_OP_CONFIG(linalg::PoolingMinOp)
-DEFINE_POOLING_OP_CONFIG(linalg::PoolingSumOp)
+DEFINE_POOLING_OP_CONFIG(linalg::PoolingNHWCMaxOp)
+DEFINE_POOLING_OP_CONFIG(linalg::PoolingNHWCMinOp)
+DEFINE_POOLING_OP_CONFIG(linalg::PoolingNHWCSumOp)
 
 #undef DEFINE_POOLINGOP_CONFIG
 
@@ -636,9 +636,9 @@ Optional<LaunchConfig> initGPULaunchConfig(
     DISPATCH(linalg::ConvInputNHWCFilterHWCFOp)
     DISPATCH(linalg::ConvInputNDHWCFilterDHWCFOp)
     DISPATCH(linalg::MatmulOp)
-    DISPATCH(linalg::PoolingMaxOp)
-    DISPATCH(linalg::PoolingMinOp)
-    DISPATCH(linalg::PoolingSumOp)
+    DISPATCH(linalg::PoolingNHWCMaxOp)
+    DISPATCH(linalg::PoolingNHWCMinOp)
+    DISPATCH(linalg::PoolingNHWCSumOp)
 
 #undef DISPATCH
   }

--- a/iree/compiler/Conversion/LinalgToSPIRV/SplitDispatchFunctionPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/SplitDispatchFunctionPass.cpp
@@ -98,11 +98,11 @@ static bool isFusableWithCurrentOpsList(
                      linalg::LinalgDependenceGraph::DependenceType::WAW)
     ADD_FUSABLE_PAIR(linalg::FillOp, linalg::BatchMatmulOp,
                      linalg::LinalgDependenceGraph::DependenceType::WAW)
-    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingMaxOp,
+    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingNHWCMaxOp,
                      linalg::LinalgDependenceGraph::DependenceType::WAW)
-    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingMinOp,
+    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingNHWCMinOp,
                      linalg::LinalgDependenceGraph::DependenceType::WAW)
-    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingSumOp,
+    ADD_FUSABLE_PAIR(linalg::FillOp, linalg::PoolingNHWCSumOp,
                      linalg::LinalgDependenceGraph::DependenceType::WAW)
     ADD_FUSABLE_PAIR(linalg::MatmulOp, linalg::GenericOp,
                      linalg::LinalgDependenceGraph::DependenceType::RAW)

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/convert_to_gpu.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/convert_to_gpu.mlir
@@ -588,101 +588,77 @@ hal.executable @conv_3d attributes {sym_visibility = "private"} {
 // -----
 
 #map0 = affine_map<()[s0] -> (s0 * 4)>
-#map1 = affine_map<()[s0] -> (s0 * 32)>
-#map2 = affine_map<(d0)[s0, s1] -> (s0 + 4, -d0 + s1)>
-#map3 = affine_map<(d0)[s0, s1] -> (s0 + 32, -d0 + s1)>
-#map4 = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
-#map5 = affine_map<(d0)[s0] -> (4, -d0 + s0)>
-#map6 = affine_map<(d0)[s0] -> (32, -d0 + s0)>
-
-
-hal.executable @pooling_no_padding attributes {sym_visibility = "private"} {
-  hal.interface @legacy_io {
-    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
-    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
-    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
-  }
-  hal.executable.target @vulkan, filter="vulkan*" {
-    hal.executable.entry_point @pooling_no_padding attributes {
-      interface = @legacy_io, ordinal = 0 : i32,
-      signature = (!flow.dispatch.input<?x?xf32>, !flow.dispatch.input<?x?xf32>,
-        !flow.dispatch.output<?x?xf32>) -> ()}
-    module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-      func @pooling_no_padding() {
-        %arg0 = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0} : memref<?x?xf32>
-        %arg1 = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1} : memref<?x?xf32>
-        %arg2 = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0} : memref<?x?xf32>
-        %c0 = constant 0 : index
+#map1 = affine_map<()[s0] -> (6, s0 * -4 + 16)>
+#map2 = affine_map<()[s0] -> (s0 * 32)>
+#map3 = affine_map<()[s0] -> (35, s0 * -32 + 16)>
+#map4 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 1536 + s0 + d1 * 96 + d2 * 6 + d3)>
+#map5 = affine_map<()[s0] -> (4, s0 * -4 + 14)>
+#map6 = affine_map<()[s0] -> (32, s0 * -32 + 13)>
+#map7 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 1092 + s0 + d1 * 78 + d2 * 6 + d3)>
+module  {
+  hal.executable @pooling_nhwc_max attributes {sym_visibility = "private"} {
+    hal.interface @legacy_io {
+      hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+      hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+      hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+    }
+    hal.executable.target @vulkan, filter="vulkan*" {
+      hal.executable.entry_point @pooling_nhwc_max attributes {interface = @legacy_io, ordinal = 0 : i32, signature = (!flow.dispatch.input<2x16x16x6xf32>, !flow.dispatch.input<1x3x4x2xf32>, !flow.dispatch.output<2x14x13x5xf32>) -> ()} {
+      ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+        %c4 = constant 4 : index
         %c1 = constant 1 : index
-        %0 = dim %arg1, %c0 : memref<?x?xf32>
-        %1 = dim %arg1, %c1 : memref<?x?xf32>
-        %2 = dim %arg2, %c0 : memref<?x?xf32>
-        %3 = dim %arg2, %c1 : memref<?x?xf32>
-        %4 = "gpu.block_id"() {dimension = "x"} : () -> index
-        %5 = "gpu.grid_dim"() {dimension = "x"} : () -> index
-        %6 = "gpu.block_id"() {dimension = "y"} : () -> index
-        %7 = "gpu.grid_dim"() {dimension = "y"} : () -> index
-        %8 = affine.apply #map0()[%6]
-        %9 = affine.apply #map0()[%7]
-        %10 = affine.apply #map1()[%4]
-        %11 = affine.apply #map1()[%5]
-        scf.parallel (%arg3, %arg4) = (%8, %10) to (%2, %3) step (%9, %11) {
-          %12 = dim %arg0, %c0 : memref<?x?xf32>
-          %13 = affine.min #map2(%arg3)[%0, %12]
-          %14 = dim %arg0, %c1 : memref<?x?xf32>
-          %15 = affine.min #map3(%arg4)[%1, %14]
-          %16 = subview %arg0[%arg3, %arg4] [%13, %15] [1, 1]  : memref<?x?xf32> to memref<?x?xf32, #map4>
-          %17 = affine.min #map5(%arg3)[%2]
-          %18 = affine.min #map6(%arg4)[%3]
-          %19 = subview %arg2[%arg3, %arg4] [%17, %18] [1, 1]  : memref<?x?xf32> to memref<?x?xf32, #map4>
-          linalg.pooling_max(%16, %arg1, %19)
-            {__internal_linalg_transform__ = "workgroup", dilations = [1, 1], strides = [1, 1]}
-            : memref<?x?xf32, #map4>, memref<?x?xf32>, memref<?x?xf32, #map4>
-          scf.yield
-        }
-        return
+        hal.return %c1, %c4, %c1 : index, index, index
       }
-      hal.interface @legacy_io attributes {sym_visibility = "private"} {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+      module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}  {
+        func @pooling_nhwc_max() attributes {spv.entry_point_abi = {local_size = dense<[32, 4, 1]> : vector<3xi32>}} {
+          %0 = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32} : memref<2x16x16x6xf32>
+          %1 = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1, operand_result_index = 1 : i32} : memref<3x4xf32>
+          %2 = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0, operand_result_index = 2 : i32} : memref<2x14x13x6xf32>
+          %3 = "gpu.block_id"() {dimension = "x"} : () -> index
+          %4 = "gpu.block_id"() {dimension = "y"} : () -> index
+          %5 = affine.apply #map0()[%4]
+          %6 = affine.min #map1()[%4]
+          %7 = affine.apply #map2()[%3]
+          %8 = affine.min #map3()[%3]
+          %9 = subview %0[0, %5, %7, 0] [2, %6, %8, 6] [1, 1, 1, 1] : memref<2x16x16x6xf32> to memref<2x?x?x6xf32, #map4>
+          %10 = affine.min #map5()[%4]
+          %11 = affine.min #map6()[%3]
+          %12 = subview %2[0, %5, %7, 0] [2, %10, %11, 6] [1, 1, 1, 1] : memref<2x14x13x6xf32> to memref<2x?x?x6xf32, #map7>
+          linalg.pooling_nhwc_max {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%9, %1 : memref<2x?x?x6xf32, #map4>, memref<3x4xf32>) outs(%12 : memref<2x?x?x6xf32, #map7>)
+          return
+        }
+        hal.interface @legacy_io attributes {sym_visibility = "private"} {
+          hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+          hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+          hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+        }
       }
     }
   }
 }
 
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 4)>
-//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
-//       CHECK: func @pooling_no_padding
-//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0}
-//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1}
-//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0}
-//   CHECK-DAG:   %[[C0:.+]] = constant 0 : index
-//   CHECK-DAG:   %[[C1:.+]] = constant 1 : index
-//   CHECK-DAG:   %[[P:.+]] = dim %[[RET0]], %[[C0]]
-//   CHECK-DAG:   %[[Q:.+]] = dim %[[RET0]], %[[C1]]
+//   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 32)>
+//       CHECK: func @pooling_nhwc_max
+//   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
+//   CHECK-DAG:   %[[ARG1:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@arg1, operand_result_index = 1 : i32}
+//   CHECK-DAG:   %[[RET0:.+]] = iree.placeholder for "interace buffer" {binding = @legacy_io::@ret0, operand_result_index = 2 : i32}
 //   CHECK-DAG:   %[[BIDX:.+]] = "gpu.block_id"() {dimension = "x"}
-//   CHECK-DAG:   %[[NBLOCKSX:.+]] = "gpu.grid_dim"() {dimension = "x"}
 //   CHECK-DAG:   %[[BIDY:.+]] = "gpu.block_id"() {dimension = "y"}
-//   CHECK-DAG:   %[[NBLOCKSY:.+]] = "gpu.grid_dim"() {dimension = "y"}
-//       CHECK:   %[[BOFFSETY:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
-//       CHECK:   %[[BSTEPY:.+]] = affine.apply #[[MAP0]]()[%[[NBLOCKSY]]]
-//       CHECK:   %[[BOFFSETX:.+]] = affine.apply #[[MAP1]]()[%[[BIDX]]]
-//       CHECK:   %[[BSTEPX:.+]] = affine.apply #[[MAP1]]()[%[[NBLOCKSX]]]
-//       CHECK:   scf.for %[[IV3:.+]] = %[[BOFFSETY]] to %[[P]] step %[[BSTEPY]]
-//       CHECK:     scf.for %[[IV4:.+]] = %[[BOFFSETX]] to %[[Q]] step %[[BSTEPX]]
-//       CHECK:       %[[SV1:.+]] = subview %[[ARG0]][%[[IV3]], %[[IV4]]]
-//       CHECK:       %[[SV2:.+]] = subview %[[RET0]][%[[IV3]], %[[IV4]]]
-//   CHECK-DAG:       %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"}
-//   CHECK-DAG:       %[[TIDY:.+]] = "gpu.thread_id"() {dimension = "y"}
-//       CHECK:       %[[C1:.+]] = cmpi slt, %[[TIDY]], %{{.*}}
-//       CHECK:       %[[C2:.+]] = cmpi slt, %[[TIDX]], %{{.*}}
-//       CHECK:       %[[COND:.+]] = and %[[C1]], %[[C2]]
-//       CHECK:       scf.if %[[COND]]
+//       CHECK:   %[[IV1:.+]] = affine.apply #[[MAP0]]()[%[[BIDY]]]
+//       CHECK:   %[[IV2:.+]] = affine.apply #[[MAP2]]()[%[[BIDX]]]
+//       CHECK:   %[[SV1:.+]] = subview %[[ARG0]][0, %[[IV1]], %[[IV2]], 0]
+//       CHECK:   %[[SV2:.+]] = subview %[[RET0]][0, %[[IV1]], %[[IV2]], 0]
+//   CHECK-DAG:   %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"}
+//   CHECK-DAG:   %[[TIDY:.+]] = "gpu.thread_id"() {dimension = "y"}
+//   CHECK-DAG:   %[[TIDZ:.+]] = "gpu.thread_id"() {dimension = "z"}
+//       CHECK:   %[[C1:.+]] = cmpi slt, %[[TIDZ]], %{{.*}}
+//       CHECK:   %[[C2:.+]] = cmpi slt, %[[TIDY]], %{{.*}}
+//       CHECK:   %[[C3:.+]] = and %[[C1]], %[[C2]] : i1
+//       CHECK:   %[[C4:.+]] = cmpi slt, %[[TIDX]], %{{.*}}
+//       CHECK:   %[[COND:.+]] = and %[[C3]], %[[C4]]
+//       CHECK:   scf.if %[[COND]]
+//       CHECK:     scf.for
+//       CHECK:       scf.for
 //       CHECK:         scf.for
-//       CHECK:           scf.for
-//   CHECK-NOT:             linalg.pooling_max
+//   CHECK-NOT:           linalg.pooling_nhwc_max

--- a/iree/test/e2e/xla_ops/reduce_window.mlir
+++ b/iree/test/e2e/xla_ops/reduce_window.mlir
@@ -1,66 +1,66 @@
-func @reduce_window_nonoverlapping_4x6xi32() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[[ 1,  2,  3,  4,  5,  6],
-                                       [ 7,  8,  9, 10, 11, 12],
-                                       [13, 14, 15, 16, 17, 18],
-                                       [19, 20, 21, 22, 23, 24]]> : tensor<4x6xi32>
-  %1 = iree.unfoldable_constant dense<0> : tensor<i32>
+func @reduce_window_nonoverlapping_1x4x6x1xf32() attributes { iree.module.export } {
+  %0 = iree.unfoldable_constant dense<[[[[ 1.0], [ 2.0], [ 3.0], [ 4.0], [ 5.0], [ 6.0]],
+                                        [[ 7.0], [ 8.0], [ 9.0], [10.0], [11.0], [12.0]],
+                                        [[13.0], [14.0], [15.0], [16.0], [17.0], [18.0]],
+                                        [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
+  %1 = iree.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "mhlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
-    %3 = "mhlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-    "mhlo.return"(%3) : (tensor<i32>) -> ()
-  }) {window_dimensions = dense<[2, 3]> : tensor<2xi64>,
-      window_strides = dense<[2, 3]> : tensor<2xi64>} : (tensor<4x6xi32>, tensor<i32>) -> tensor<2x2xi32>
-  check.expect_eq_const(%res, dense<[[30, 48],[102, 120]]> : tensor<2x2xi32>) : tensor<2x2xi32>
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+    %3 = "mhlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    "mhlo.return"(%3) : (tensor<f32>) -> ()
+  }) {window_dimensions = dense<[1, 2, 3, 1]> : tensor<4xi64>,
+      window_strides = dense<[1, 2, 3, 1]> : tensor<4xi64>} : (tensor<1x4x6x1xf32>, tensor<f32>) -> tensor<1x2x2x1xf32>
+  check.expect_eq_const(%res, dense<[[[[30.0], [48.0]],[[102.0], [120.0]]]]> : tensor<1x2x2x1xf32>) : tensor<1x2x2x1xf32>
   return
 }
 
-func @reduce_window_overlapping_4x6xi32() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[[ 1,  2,  3,  4,  5,  6],
-                                       [ 7,  8,  9, 10, 11, 12],
-                                       [13, 14, 15, 16, 17, 18],
-                                       [19, 20, 21, 22, 23, 24]]> : tensor<4x6xi32>
-  %1 = iree.unfoldable_constant dense<0> : tensor<i32>
+func @reduce_window_overlapping_4x6xf32() attributes { iree.module.export } {
+  %0 = iree.unfoldable_constant dense<[[[[ 1.0], [ 2.0], [ 3.0], [ 4.0], [ 5.0], [ 6.0]],
+                                        [[ 7.0], [ 8.0], [ 9.0], [10.0], [11.0], [12.0]],
+                                        [[13.0], [14.0], [15.0], [16.0], [17.0], [18.0]],
+                                        [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
+  %1 = iree.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "mhlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
-    %3 = "mhlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-    "mhlo.return"(%3) : (tensor<i32>) -> ()
-  }) {window_dimensions = dense<[2, 3]> : tensor<2xi64>,
-      window_strides = dense<[1, 1]> : tensor<2xi64>} : (tensor<4x6xi32>, tensor<i32>) -> tensor<3x4xi32>
-  check.expect_eq_const(%res, dense<[
-      [30, 36, 42, 48],
-      [66, 72, 78, 84],
-      [102, 108, 114, 120]]> : tensor<3x4xi32>) : tensor<3x4xi32>
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+    %3 = "mhlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    "mhlo.return"(%3) : (tensor<f32>) -> ()
+  }) {window_dimensions = dense<[1, 2, 3, 1]> : tensor<4xi64>,
+      window_strides = dense<[1, 1, 1, 1]> : tensor<4xi64>} : (tensor<1x4x6x1xf32>, tensor<f32>) -> tensor<1x3x4x1xf32>
+  check.expect_eq_const(%res, dense<[[
+      [[ 30.0], [ 36.0], [ 42.0], [ 48.0]],
+      [[ 66.0], [ 72.0], [ 78.0], [ 84.0]],
+      [[102.0], [108.0], [114.0], [120.0]]]]> : tensor<1x3x4x1xf32>) : tensor<1x3x4x1xf32>
   return
 }
 
 func @reduce_window_max_4x6xf32() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[[ 1.0,  2.0,  3.0,  4.0,  5.0,  6.0],
-                                       [ 7.0,  8.0,  9.0, 10.0, 11.0, 12.0],
-                                       [13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
-                                       [19.0, 20.0, 21.0, 22.0, 23.0, 24.0]]> : tensor<4x6xf32>
+  %0 = iree.unfoldable_constant dense<[[[[ 1.0], [ 2.0], [ 3.0], [ 4.0], [ 5.0], [ 6.0]],
+                                        [[ 7.0], [ 8.0], [ 9.0], [10.0], [11.0], [12.0]],
+                                        [[13.0], [14.0], [15.0], [16.0], [17.0], [18.0]],
+                                        [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = iree.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "mhlo.reduce_window"(%0, %1) ( {
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
     %3 = "mhlo.maximum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "mhlo.return"(%3) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[2, 3]> : tensor<2xi64>,
-      window_strides = dense<[2, 3]> : tensor<2xi64>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<2x2xf32>
-  check.expect_almost_eq_const(%res, dense<[[9.0, 12.0], [21.0, 24.0]]> : tensor<2x2xf32>) : tensor<2x2xf32>
+  }) {window_dimensions = dense<[1, 2, 3, 1]> : tensor<4xi64>,
+      window_strides = dense<[1, 2, 3, 1]> : tensor<4xi64>} : (tensor<1x4x6x1xf32>, tensor<f32>) -> tensor<1x2x2x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[[[9.0], [12.0]], [[21.0], [24.0]]]]> : tensor<1x2x2x1xf32>) : tensor<1x2x2x1xf32>
   return
 }
 
 func @reduce_window_min_4x6xf32() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[[ 1.0,  2.0,  3.0,  4.0,  5.0,  6.0],
-                                       [ 7.0,  8.0,  9.0, 10.0, 11.0, 12.0],
-                                       [13.0, 14.0, 15.0, 16.0, 17.0, 18.0],
-                                       [19.0, 20.0, 21.0, 22.0, 23.0, 24.0]]> : tensor<4x6xf32>
+  %0 = iree.unfoldable_constant dense<[[[[ 1.0], [ 2.0], [ 3.0], [ 4.0], [ 5.0], [ 6.0]],
+                                        [[ 7.0], [ 8.0], [ 9.0], [10.0], [11.0], [12.0]],
+                                        [[13.0], [14.0], [15.0], [16.0], [17.0], [18.0]],
+                                        [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = iree.unfoldable_constant dense<14.0> : tensor<f32>
   %res = "mhlo.reduce_window"(%0, %1) ( {
   ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
     %3 = "mhlo.minimum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "mhlo.return"(%3) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[2, 3]> : tensor<2xi64>,
-      window_strides = dense<[2, 3]> : tensor<2xi64>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<2x2xf32>
-  check.expect_almost_eq_const(%res, dense<[[1.0, 4.0], [13.0, 14.0]]> : tensor<2x2xf32>) : tensor<2x2xf32>
+  }) {window_dimensions = dense<[1, 2, 3, 1]> : tensor<4xi64>,
+      window_strides = dense<[1, 2, 3, 1]> : tensor<4xi64>} : (tensor<1x4x6x1xf32>, tensor<f32>) -> tensor<1x2x2x1xf32>
+  check.expect_almost_eq_const(%res, dense<[[[[1.0], [4.0]], [[13.0], [14.0]]]]> : tensor<1x2x2x1xf32>) : tensor<1x2x2x1xf32>
   return
 }


### PR DESCRIPTION
- Only supports 2D NHWC pooling ops.
- Adapt tests in reduce_window.mlir to be 2D NHWC cases
- Replaces all tests in GPU pipeline with linalg_nhwc_*

This depends on https://github.com/llvm/llvm-project/commit/b47c6c686c860483e6f48f80741836ab242e4baa