### PR TITLE
Merge main -> google

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -45,6 +45,7 @@ EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:SideEffects": ["MLIRSideEffectInterfaces"],
     "@llvm-project//mlir:SPIRVDialect": ["MLIRSPIRV"],
     "@llvm-project//mlir:TosaDialect": ["MLIRTosa"],
+    "@llvm-project//mlir:ToLLVMIRTranslation": ["MLIRTargetLLVMIRExport"],
     "@llvm-project//mlir:mlir_c_runner_utils": ["MLIRExecutionEngine"],
     "@llvm-project//mlir:mlir-translate": ["mlir-translate"],
     "@llvm-project//mlir:MlirTableGenMain": ["MLIRTableGen"],

--- a/experimental/ModelBuilder/CMakeLists.txt
+++ b/experimental/ModelBuilder/CMakeLists.txt
@@ -79,7 +79,7 @@ iree_cc_library(
     MLIRSPIRV
     MLIRStandardToLLVM
     MLIRStandardToSPIRV
-    MLIRTargetLLVMIR
+    MLIRTargetLLVMIRExport
     MLIRTransformUtils
     MLIRVector
     MLIRVectorToLLVM

--- a/experimental/ModelBuilder/test/CMakeLists.txt
+++ b/experimental/ModelBuilder/test/CMakeLists.txt
@@ -139,7 +139,7 @@ iree_cc_binary(
     MLIRStandardToLLVM
     MLIRStandardToSPIRV
     MLIRSupport
-    MLIRTargetLLVMIR
+    MLIRTargetLLVMIRExport
     MLIRTransformUtils
     MLIRVectorToLLVM
     experimental::ModelBuilder

--- a/iree/compiler/Dialect/HAL/Target/CUDA/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/CMakeLists.txt
@@ -31,7 +31,7 @@ iree_cc_library(
     MLIRNVVMIR
     MLIRPass
     MLIRSupport
-    MLIRToLLVMIRTranslation
+    MLIRTargetLLVMIRExport
     iree::base::flatcc
     iree::compiler::Conversion::LinalgToNVVM
     iree::compiler::Dialect::HAL::Target

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -39,7 +39,7 @@ iree_cc_library(
     LLVMX86CodeGen
     MLIRLLVMIR
     MLIRLLVMToLLVMIRTranslation
-    MLIRToLLVMIRTranslation
+    MLIRTargetLLVMIRExport
     iree::base::flatcc
     iree::compiler::Conversion::CodegenUtils
     iree::compiler::Conversion::Common

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -317,7 +317,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRSCFTransforms
       MLIRPass
       MLIRSupport
-      MLIRTargetLLVMIR
+      MLIRTargetLLVMIRExport
       MLIRTranslation
       iree::compiler::Conversion::init_conversions
       iree::compiler::Dialect::VM::Target::Bytecode
@@ -364,7 +364,7 @@ if(${IREE_BUILD_COMPILER})
       MLIRParser
       MLIRPass
       MLIRSupport
-      MLIRTargetLLVMIR
+      MLIRTargetLLVMIRExport
       absl::flags
       absl::span
       absl::strings


### PR DESCRIPTION
* beeaaf95c Migrate linalg.conv to linalg.conv_2d_input_nhwc_filter_hwcf in Img2Col. (#4973)
* aad57c23d Update vulkan profiling doc. (#4989)
* c31cb9d8c Support HLO Text format for the XLA importer. (#4984)
* 36d8c903c Fix CUDA C struct initialization for older MSVC. (#4988)
* de7cf2175 Integrate MLIR-EmitC at iml130/mlir-emitc@b57346c (#4987)
* 8045a2c2a Fix concatenate test due to upstream change. (#4986)
* 4f5dd78dc Adapt mhlo.concatenate lowering to Linalg on tensors (#4954)
* 205c0b20a HAL CUDA step 3, enable executable. (#4982)
* 370e672e8 Fixing bazel-to-cmake regression that broke it on Windows. (#4981)
* 5b0375017 Merge google -> main (#4976)
* 608299995 Further updates to getting_started_tensorflow.md.
* d0af3da7a Correct target name for `iree-tf-import`.
* c96d07cc3 Move TF documentation out of Python documentation (#4977)

COPYBARA_INTEGRATE_REVIEW=https://github.com/google/iree/pull/4993 from NatashaKnk:main-to-google 38016af097166a43915eeed55ca99ad45daf0311
PiperOrigin-RevId: 360824857