### PR TITLE
Add CMakeLists.txt to build linalg-opt

### DIFF
--- a/experimental/runners/CMakeLists.txt
+++ b/experimental/runners/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.18)
+project(linalg-opt CXX)
+
+find_package(MLIR REQUIRED CONFIG)
+list(APPEND CMAKE_MODULE_PATH ${MLIR_DIR})
+list(APPEND CMAKE_MODULE_PATH ${MLIR_DIR}/../llvm)
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+set(LIBS
+  ${dialect_libs}
+  ${conversion_libs}
+  MLIROptLib
+)
+
+add_llvm_executable(linalg-opt
+  mlir-opt.cpp
+  LinalgTileToGeneric.cpp
+  LinalgComprehensiveBufferizePass.cpp
+  LinalgTensorCodegenStrategy.cpp
+)
+target_link_libraries(linalg-opt PRIVATE ${LIBS})
+mlir_check_all_link_libraries(linalg-opt)

--- a/experimental/runners/LinalgComprehensiveBufferizePass.cpp
+++ b/experimental/runners/LinalgComprehensiveBufferizePass.cpp
@@ -966,7 +966,7 @@ static LogicalResult convertPadTensorOp(OpBuilder &b, PadTensorOp padTensorOp,
   auto sourceMemRefType = sourceMemRef.getType().cast<MemRefType>();
   auto memRefType =
       getContiguousMemRefType(tensorType, sourceMemRefType.getAffineMaps(),
-                              sourceMemRefType.getMemorySpace());
+                              sourceMemRefType.getMemorySpaceAsInt());
   Value res =
       b.create<MemRefCastOp>(padTensorOp.getLoc(), memRefType, sourceMemRef);
   map(bvm, padTensorOp.result(), res);
@@ -1040,12 +1040,12 @@ static LogicalResult convertTensorCastOp(OpBuilder &b, tensor::CastOp castOp,
   Type memRefType;
   TensorType tensorType = castOp.getResult().getType().cast<TensorType>();
   if (tensorType.isa<UnrankedTensorType>()) {
-    memRefType = UnrankedMemRefType::get(tensorType.getElementType(),
-                                         sourceMemRefType.getMemorySpace());
+    memRefType = UnrankedMemRefType::get(
+        tensorType.getElementType(), sourceMemRefType.getMemorySpaceAsInt());
   } else {
     memRefType =
         getContiguousMemRefType(tensorType, sourceMemRefType.getAffineMaps(),
-                                sourceMemRefType.getMemorySpace());
+                                sourceMemRefType.getMemorySpaceAsInt());
   }
   Value res = b.create<MemRefCastOp>(castOp.getLoc(), memRefType,
                                      lookup(bvm, castOp.source()));

--- a/experimental/runners/LinalgTensorCodegenStrategy.cpp
+++ b/experimental/runners/LinalgTensorCodegenStrategy.cpp
@@ -14,7 +14,7 @@
 // Will get better once upstreamed to core and it replaces the existing codegen
 // strategy.
 
-#include "iree/experimental/runners/Transforms.h"
+#include "Transforms.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/experimental/runners/LinalgTileToGeneric.cpp
+++ b/experimental/runners/LinalgTileToGeneric.cpp
@@ -14,7 +14,7 @@
 #include <iterator>
 #include <memory>
 
-#include "iree/experimental/runners/Transforms.h"
+#include "Transforms.h"
 #include "llvm/ADT/None.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"

--- a/experimental/runners/mlir-opt.cpp
+++ b/experimental/runners/mlir-opt.cpp
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "iree/tools/init_dialects.h"
-#include "iree/tools/init_passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"


### PR DESCRIPTION
This patch adds a self-contained CMakeLists.txt to build
this mlir-opt (renamed to linalg-opt) that includes the
passes to test linalg on tensors.

TEST: Compiles
In this runners directory run,
cmake -GNinja -B build -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12
-DMLIR_DIR=<Path to MLIRConfig.cmake>