### PR TITLE
Implement vm to emitc.const conversions

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -90,6 +90,19 @@ class CallOpConversion : public OpConversionPattern<SrcOpTy> {
   StringRef funcName;
 };
 
+template <typename ConstOpTy>
+class ConstOpConversion : public OpRewritePattern<ConstOpTy> {
+public:
+  using OpRewritePattern<ConstOpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConstOpTy constOp,
+                                PatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<emitc::ConstOp>(constOp, constOp.getType(),
+                                                constOp.value());
+    return success();
+  }
+};
+
 template <typename LoadOpTy, typename GlobalOpTy>
 class GlobalLoadOpConversion : public OpConversionPattern<LoadOpTy> {
   using OpConversionPattern<LoadOpTy>::OpConversionPattern;
@@ -176,8 +189,7 @@ void populateVMToCPatterns(MLIRContext *context,
       context, "vm_global_store_i32");
 
   // Constants
-  patterns.insert<CallOpConversion<IREE::VM::ConstI32Op>>(context,
-                                                          "vm_const_i32");
+  patterns.insert<ConstOpConversion<IREE::VM::ConstI32Op>>(context);
 
   // Conditional assignment ops
   patterns.insert<CallOpConversion<IREE::VM::SelectI32Op>>(context,
@@ -240,8 +252,7 @@ void populateVMToCPatterns(MLIRContext *context,
                                                          "VM_CHECK_EQ");
 
   // ExtI64: Constants
-  patterns.insert<CallOpConversion<IREE::VM::ConstI64Op>>(context,
-                                                          "vm_const_i64");
+  patterns.insert<ConstOpConversion<IREE::VM::ConstI64Op>>(context);
 
   // ExtI64: Conditional assignment ops
   patterns.insert<CallOpConversion<IREE::VM::SelectI64Op>>(context,

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -92,7 +92,7 @@ class CallOpConversion : public OpConversionPattern<SrcOpTy> {
 
 template <typename ConstOpTy>
 class ConstOpConversion : public OpRewritePattern<ConstOpTy> {
-public:
+ public:
   using OpRewritePattern<ConstOpTy>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(ConstOpTy constOp,

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -4,11 +4,11 @@
 vm.module @module {
   // CHECK-LABEL: vm.func @const_i32
   vm.func @const_i32() {
-    // CHECK-NEXT: %0 = emitc.call "vm_const_i32"() {args = [0 : i32]} : () -> i32
+    // CHECK-NEXT: %0 = "emitc.const"() {value = 0 : i32} : () -> i32
     %0 = vm.const.i32 0 : i32
-    // CHECK-NEXT: %1 = emitc.call "vm_const_i32"() {args = [2 : i32]} : () -> i32
+    // CHECK-NEXT: %1 = "emitc.const"() {value = 2 : i32} : () -> i32
     %1 = vm.const.i32 2 : i32
-    // CHECK-NEXT: %2 = emitc.call "vm_const_i32"() {args = [-2 : i32]} : () -> i32
+    // CHECK-NEXT: %2 = "emitc.const"() {value = -2 : i32} : () -> i32
     %2 = vm.const.i32 -2 : i32
     // CHECK-NEXT: vm.return
     vm.return

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -4,11 +4,11 @@
 vm.module @module {
   // CHECK-LABEL: vm.func @const_i64
   vm.func @const_i64() {
-    // CHECK-NEXT: %0 = emitc.call "vm_const_i64"() {args = [0]} : () -> i64
+    // CHECK-NEXT: %0 = "emitc.const"() {value = 0 : i64} : () -> i64
     %0 = vm.const.i64 0 : i64
-    // CHECK-NEXT: %1 = emitc.call "vm_const_i64"() {args = [2]} : () -> i64
+    // CHECK-NEXT: %1 = "emitc.const"() {value = 2 : i64} : () -> i64
     %1 = vm.const.i64 2 : i64
-    // CHECK-NEXT: %2 = emitc.call "vm_const_i64"() {args = [-2]} : () -> i64
+    // CHECK-NEXT: %2 = "emitc.const"() {value = -2 : i64} : () -> i64
     %2 = vm.const.i64 -2 : i64
     // CHECK-NEXT: vm.return
     vm.return

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -33,12 +33,6 @@ static inline void vm_global_store_i32(uint8_t* base, uint32_t byte_offset,
 }
 
 //===------------------------------------------------------------------===//
-// Constants
-//===------------------------------------------------------------------===//
-
-static inline int32_t vm_const_i32(int32_t a) { return a; }
-
-//===------------------------------------------------------------------===//
 // Conditional assignment
 //===------------------------------------------------------------------===//
 
@@ -142,12 +136,6 @@ static inline int32_t vm_cmp_nz_i32(int32_t operand) {
     return iree_status_allocate(IREE_STATUS_FAILED_PRECONDITION, "<vm>", 0, \
                                 iree_make_cstring_view(#message));          \
   }
-
-//===------------------------------------------------------------------===//
-// ExtI64: Constants
-//===------------------------------------------------------------------===//
-
-static inline int64_t vm_const_i64(int64_t a) { return a; }
 
 //===------------------------------------------------------------------===//
 // ExtI64: Conditional assignment


### PR DESCRIPTION
Allows to remove the header only implementations from `iree/vm/ops.h`.
Depends on #5026.