### PR TITLE
Add command line options for c module target

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/C/CMakeLists.txt
@@ -21,8 +21,10 @@ if(${IREE_ENABLE_EMITC})
       C
     HDRS
       "CModuleTarget.h"
+      "TranslationFlags.h"
     SRCS
       "CModuleTarget.cpp"
+      "TranslationFlags.cpp"
       "TranslationRegistration.cpp"
     DEPS
       LLVMSupport

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -423,10 +423,8 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
 }
 
 // Adapted from BytecodeModuleTarget and extended by C specific passes
-static LogicalResult canonicalizeModule(IREE::VM::ModuleOp moduleOp) {
-  bool optimize = true;
-  bool stripDebugOps = false;
-
+static LogicalResult canonicalizeModule(
+    IREE::VM::ModuleOp moduleOp, IREE::VM::CCodeTargetOptions targetOptions) {
   OwningRewritePatternList patterns;
   ConversionTarget target(*moduleOp.getContext());
   target.addLegalDialect<IREE::VM::VMDialect>();
@@ -446,7 +444,8 @@ static LogicalResult canonicalizeModule(IREE::VM::ModuleOp moduleOp) {
 
     // Debug ops must not be present when stripping.
     // TODO(benvanik): add RemoveDisabledDebugOp pattern.
-    if (op->hasTrait<OpTrait::IREE::VM::DebugOnly>() && stripDebugOps) {
+    if (op->hasTrait<OpTrait::IREE::VM::DebugOnly>() &&
+        targetOptions.stripDebugOps) {
       target.setOpAction(OperationName(op->name, context),
                          ConversionTarget::LegalizationAction::Illegal);
     }
@@ -460,7 +459,7 @@ static LogicalResult canonicalizeModule(IREE::VM::ModuleOp moduleOp) {
   mlir::applyPassManagerCLOptions(passManager);
   auto &modulePasses = passManager.nest<IREE::VM::ModuleOp>();
 
-  if (optimize) {
+  if (targetOptions.optimize) {
     // TODO(benvanik): does this run until it quiesces?
     // TODO(simon-camp): reenable pass once support for control flow ops has
     // landed
@@ -496,10 +495,18 @@ static LogicalResult canonicalizeModule(IREE::VM::ModuleOp moduleOp) {
 }
 
 LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
+                                 CCodeTargetOptions targetOptions,
                                  llvm::raw_ostream &output) {
-  if (failed(canonicalizeModule(moduleOp))) {
+  if (failed(canonicalizeModule(moduleOp, targetOptions))) {
     return moduleOp.emitError()
            << "failed to canonicalize vm.module to a serializable form";
+  }
+
+  if (targetOptions.outputFormat == CCodeOutputFormat::kMlirText) {
+    // Use the standard MLIR text printer.
+    moduleOp.getOperation()->print(output);
+    output << "\n";
+    return success();
   }
 
   auto printInclude = [&output](std::string include) {
@@ -545,13 +552,14 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
 }
 
 LogicalResult translateModuleToC(mlir::ModuleOp outerModuleOp,
+                                 CCodeTargetOptions targetOptions,
                                  llvm::raw_ostream &output) {
   auto moduleOps = outerModuleOp.getOps<IREE::VM::ModuleOp>();
   if (moduleOps.empty()) {
     return outerModuleOp.emitError()
            << "outer module does not contain a vm.module op";
   }
-  return translateModuleToC(*moduleOps.begin(), output);
+  return translateModuleToC(*moduleOps.begin(), targetOptions, output);
 }
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -424,7 +424,7 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
 
 // Adapted from BytecodeModuleTarget and extended by C specific passes
 static LogicalResult canonicalizeModule(
-    IREE::VM::ModuleOp moduleOp, IREE::VM::CCodeTargetOptions targetOptions) {
+    IREE::VM::ModuleOp moduleOp, IREE::VM::CTargetOptions targetOptions) {
   OwningRewritePatternList patterns;
   ConversionTarget target(*moduleOp.getContext());
   target.addLegalDialect<IREE::VM::VMDialect>();
@@ -495,14 +495,14 @@ static LogicalResult canonicalizeModule(
 }
 
 LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
-                                 CCodeTargetOptions targetOptions,
+                                 CTargetOptions targetOptions,
                                  llvm::raw_ostream &output) {
   if (failed(canonicalizeModule(moduleOp, targetOptions))) {
     return moduleOp.emitError()
            << "failed to canonicalize vm.module to a serializable form";
   }
 
-  if (targetOptions.outputFormat == CCodeOutputFormat::kMlirText) {
+  if (targetOptions.outputFormat == COutputFormat::kMlirText) {
     // Use the standard MLIR text printer.
     moduleOp.getOperation()->print(output);
     output << "\n";
@@ -552,7 +552,7 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
 }
 
 LogicalResult translateModuleToC(mlir::ModuleOp outerModuleOp,
-                                 CCodeTargetOptions targetOptions,
+                                 CTargetOptions targetOptions,
                                  llvm::raw_ostream &output) {
   auto moduleOps = outerModuleOp.getOps<IREE::VM::ModuleOp>();
   if (moduleOps.empty()) {

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
@@ -26,7 +26,7 @@ namespace IREE {
 namespace VM {
 
 // Defines the output format of the c module.
-enum class CCodeOutputFormat {
+enum class COutputFormat {
   // C code.
   kCode,
   // MLIR text of the VM module mixed with emitc operations.
@@ -34,9 +34,9 @@ enum class CCodeOutputFormat {
 };
 
 // Options that can be provided to c code translation.
-struct CCodeTargetOptions {
+struct CTargetOptions {
   // Format of the module written to the output stream.
-  CCodeOutputFormat outputFormat = CCodeOutputFormat::kCode;
+  COutputFormat outputFormat = COutputFormat::kCode;
 
   // Run basic CSE/inlining/etc passes prior to serialization.
   bool optimize = true;
@@ -49,10 +49,10 @@ struct CCodeTargetOptions {
 //
 // Exposed via the --iree-vm-ir-to-c-module translation.
 LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
-                                 CCodeTargetOptions targetOptions,
+                                 CTargetOptions targetOptions,
                                  llvm::raw_ostream &output);
 LogicalResult translateModuleToC(mlir::ModuleOp outerModuleOp,
-                                 CCodeTargetOptions targetOptions,
+                                 CTargetOptions targetOptions,
                                  llvm::raw_ostream &output);
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
@@ -25,12 +25,34 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
+// Defines the output format of the bytecode module.
+enum class CCodeOutputFormat {
+  // C code.
+  kCode,
+  // MLIR text of the VM module mixed with emitc operations.
+  kMlirText,
+};
+
+// Options that can be provided to c code translation.
+struct CCodeTargetOptions {
+  // Format of the module written to the output stream.
+  CCodeOutputFormat outputFormat = CCodeOutputFormat::kCode;
+
+  // Run basic CSE/inlining/etc passes prior to serialization.
+  bool optimize = true;
+
+  // Strips vm ops with the VM_DebugOnly trait.
+  bool stripDebugOps = false;
+};
+
 // Translates a vm.module to a c module.
 //
 // Exposed via the --iree-vm-ir-to-c-module translation.
 LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
+                                 CCodeTargetOptions targetOptions,
                                  llvm::raw_ostream &output);
 LogicalResult translateModuleToC(mlir::ModuleOp outerModuleOp,
+                                 CCodeTargetOptions targetOptions,
                                  llvm::raw_ostream &output);
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.h
@@ -25,7 +25,7 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
-// Defines the output format of the bytecode module.
+// Defines the output format of the c module.
 enum class CCodeOutputFormat {
   // C code.
   kCode,

--- a/iree/compiler/Dialect/VM/Target/C/TranslationFlags.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslationFlags.cpp
@@ -21,13 +21,13 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
-static llvm::cl::opt<CCodeOutputFormat> outputFormatFlag{
+static llvm::cl::opt<COutputFormat> outputFormatFlag{
     "iree-vm-c-module-output-format",
-    llvm::cl::desc("Output format the c module is written in"),
-    llvm::cl::init(CCodeOutputFormat::kCode),
+    llvm::cl::desc("Output format used to write the C module"),
+    llvm::cl::init(COutputFormat::kCode),
     llvm::cl::values(
-        clEnumValN(CCodeOutputFormat::kCode, "code", "C Code file"),
-        clEnumValN(CCodeOutputFormat::kMlirText, "mlir-text",
+        clEnumValN(COutputFormat::kCode, "code", "C Code file"),
+        clEnumValN(COutputFormat::kMlirText, "mlir-text",
                    "MLIR module file in the VM and EmitC dialects")),
 };
 
@@ -44,8 +44,8 @@ static llvm::cl::opt<bool> stripDebugOpsFlag{
     llvm::cl::init(false),
 };
 
-CCodeTargetOptions getCCodeTargetOptionsFromFlags() {
-  CCodeTargetOptions targetOptions;
+CTargetOptions getCTargetOptionsFromFlags() {
+  CTargetOptions targetOptions;
   targetOptions.outputFormat = outputFormatFlag;
   targetOptions.optimize = optimizeFlag;
   targetOptions.stripDebugOps = stripDebugOpsFlag;

--- a/iree/compiler/Dialect/VM/Target/C/TranslationFlags.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslationFlags.cpp
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/VM/Target/C/TranslationFlags.h"
+
+#include "llvm/Support/CommandLine.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VM {
+
+static llvm::cl::opt<CCodeOutputFormat> outputFormatFlag{
+    "iree-vm-c-module-output-format",
+    llvm::cl::desc("Output format the c module is written in"),
+    llvm::cl::init(CCodeOutputFormat::kCode),
+    llvm::cl::values(
+        clEnumValN(CCodeOutputFormat::kCode, "code", "C Code file"),
+        clEnumValN(CCodeOutputFormat::kMlirText, "mlir-text",
+                   "MLIR module file in the VM and EmitC dialects")),
+};
+
+static llvm::cl::opt<bool> optimizeFlag{
+    "iree-vm-c-module-optimize",
+    llvm::cl::desc(
+        "Optimizes the VM module with CSE/inlining/etc prior to serialization"),
+    llvm::cl::init(true),
+};
+
+static llvm::cl::opt<bool> stripDebugOpsFlag{
+    "iree-vm-c-module-strip-debug-ops",
+    llvm::cl::desc("Strips debug-only ops from the module"),
+    llvm::cl::init(false),
+};
+
+CCodeTargetOptions getCCodeTargetOptionsFromFlags() {
+  CCodeTargetOptions targetOptions;
+  targetOptions.outputFormat = outputFormatFlag;
+  targetOptions.optimize = optimizeFlag;
+  targetOptions.stripDebugOps = stripDebugOpsFlag;
+  return targetOptions;
+}
+
+}  // namespace VM
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/VM/Target/C/TranslationFlags.h
+++ b/iree/compiler/Dialect/VM/Target/C/TranslationFlags.h
@@ -22,9 +22,9 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
-// Returns a CCodeTargetOptions struct initialized with the
+// Returns a CTargetOptions struct initialized with the
 // --iree-vm-c-* flags.
-CCodeTargetOptions getCCodeTargetOptionsFromFlags();
+CTargetOptions getCTargetOptionsFromFlags();
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Target/C/TranslationFlags.h
+++ b/iree/compiler/Dialect/VM/Target/C/TranslationFlags.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef IREE_COMPILER_DIALECT_VM_TARGET_C_TRANSLATIONFLAGS_H_
+#define IREE_COMPILER_DIALECT_VM_TARGET_C_TRANSLATIONFLAGS_H_
+
 #include "iree/compiler/Dialect/VM/Target/C/CModuleTarget.h"
-#include "iree/compiler/Dialect/VM/Target/C/TranslationFlags.h"
-#include "mlir/Translation.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
-void registerToCTranslation() {
-  TranslateFromMLIRRegistration toCModule(
-      "iree-vm-ir-to-c-module",
-      [](mlir::ModuleOp moduleOp, llvm::raw_ostream &output) {
-        return translateModuleToC(moduleOp, getCCodeTargetOptionsFromFlags(),
-                                  output);
-      });
-}
+// Returns a CCodeTargetOptions struct initialized with the
+// --iree-vm-c-* flags.
+CCodeTargetOptions getCCodeTargetOptionsFromFlags();
 
 }  // namespace VM
 }  // namespace IREE
 }  // namespace iree_compiler
 }  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_VM_TARGET_C_TRANSLATIONFLAGS_H_

--- a/iree/compiler/Dialect/VM/Target/C/TranslationRegistration.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslationRegistration.cpp
@@ -25,7 +25,7 @@ void registerToCTranslation() {
   TranslateFromMLIRRegistration toCModule(
       "iree-vm-ir-to-c-module",
       [](mlir::ModuleOp moduleOp, llvm::raw_ostream &output) {
-        return translateModuleToC(moduleOp, getCCodeTargetOptionsFromFlags(),
+        return translateModuleToC(moduleOp, getCTargetOptionsFromFlags(),
                                   output);
       });
 }

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -26,6 +26,7 @@
 
 #ifdef IREE_HAVE_EMITC_DIALECT
 #include "iree/compiler/Dialect/VM/Target/C/CModuleTarget.h"
+#include "iree/compiler/Dialect/VM/Target/C/TranslationFlags.h"
 #endif  // IREE_HAVE_EMITC_DIALECT
 
 namespace mlir {
@@ -194,7 +195,9 @@ static LogicalResult translateFromMLIRToBenchmarkVMBytecodeModuleWithFlags(
 static LogicalResult translateFromMLIRToVMCModule(
     ModuleOp moduleOp, BindingOptions bindingOptions,
     IREE::HAL::TargetOptions executableOptions,
-    IREE::VM::TargetOptions targetOptions, llvm::raw_ostream &output) {
+    IREE::VM::TargetOptions targetOptions,
+    IREE::VM::CCodeTargetOptions cCodeTargetOptions,
+    llvm::raw_ostream &output) {
   auto result = translateFromMLIRToVM(moduleOp, bindingOptions,
                                       executableOptions, targetOptions,
                                       /*addExportDispatchesPipeline=*/false);
@@ -203,7 +206,8 @@ static LogicalResult translateFromMLIRToVMCModule(
   }
 
   // Serialize to c code.
-  return mlir::iree_compiler::IREE::VM::translateModuleToC(moduleOp, output);
+  return mlir::iree_compiler::IREE::VM::translateModuleToC(
+      moduleOp, cCodeTargetOptions, output);
 }
 
 static LogicalResult translateFromMLIRToVMCModuleWithFlags(
@@ -212,8 +216,10 @@ static LogicalResult translateFromMLIRToVMCModuleWithFlags(
   auto bindingOptions = getBindingOptionsFromFlags();
   auto halTargetOptions = IREE::HAL::getTargetOptionsFromFlags();
   auto vmTargetOptions = IREE::VM::getTargetOptionsFromFlags();
-  return translateFromMLIRToVMCModule(
-      moduleOp, bindingOptions, halTargetOptions, vmTargetOptions, output);
+  auto cCodeTargetOptions = IREE::VM::getCCodeTargetOptionsFromFlags();
+  return translateFromMLIRToVMCModule(moduleOp, bindingOptions,
+                                      halTargetOptions, vmTargetOptions,
+                                      cCodeTargetOptions, output);
 }
 #endif  // IREE_HAVE_EMITC_DIALECT
 

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -196,8 +196,7 @@ static LogicalResult translateFromMLIRToVMCModule(
     ModuleOp moduleOp, BindingOptions bindingOptions,
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions,
-    IREE::VM::CCodeTargetOptions cCodeTargetOptions,
-    llvm::raw_ostream &output) {
+    IREE::VM::CTargetOptions cTargetOptions, llvm::raw_ostream &output) {
   auto result = translateFromMLIRToVM(moduleOp, bindingOptions,
                                       executableOptions, targetOptions,
                                       /*addExportDispatchesPipeline=*/false);
@@ -207,7 +206,7 @@ static LogicalResult translateFromMLIRToVMCModule(
 
   // Serialize to c code.
   return mlir::iree_compiler::IREE::VM::translateModuleToC(
-      moduleOp, cCodeTargetOptions, output);
+      moduleOp, cTargetOptions, output);
 }
 
 static LogicalResult translateFromMLIRToVMCModuleWithFlags(
@@ -216,10 +215,10 @@ static LogicalResult translateFromMLIRToVMCModuleWithFlags(
   auto bindingOptions = getBindingOptionsFromFlags();
   auto halTargetOptions = IREE::HAL::getTargetOptionsFromFlags();
   auto vmTargetOptions = IREE::VM::getTargetOptionsFromFlags();
-  auto cCodeTargetOptions = IREE::VM::getCCodeTargetOptionsFromFlags();
+  auto cTargetOptions = IREE::VM::getCTargetOptionsFromFlags();
   return translateFromMLIRToVMCModule(moduleOp, bindingOptions,
                                       halTargetOptions, vmTargetOptions,
-                                      cCodeTargetOptions, output);
+                                      cTargetOptions, output);
 }
 #endif  // IREE_HAVE_EMITC_DIALECT
 


### PR DESCRIPTION
This adds a command line switch to print the mixed VM / EmitC IR in the c module target. That should become handy once more logic is moved into the VM to EmitC conversion.
Depends on #5026.