### PR TITLE
Check for merge commit after checking Copybara tag

### DIFF
--- a/scripts/git/fix_copybara_export.sh
+++ b/scripts/git/fix_copybara_export.sh
@@ -66,11 +66,6 @@ if git merge-base --is-ancestor HEAD main; then
   exit 1
 fi
 
-if [[ -n "$(git rev-list --merges HEAD^..HEAD)" ]]; then
-  echo -e "\n\nHEAD commit is already a merge commit. Aborting."
-  exit 1
-fi
-
 ################################################################################
 
 echo -e "\n\nTo revert the changes made by this script, run:"
@@ -88,6 +83,11 @@ if ! echo "${MESSAGE?}" | grep -q "${COPYBARA_TAG}"; then
   echo -e "\n\nHEAD commit does not contain Copybara tag '${COPYBARA_TAG?}'."
   git log -n 1 HEAD
   exit 0
+fi
+
+if [[ -n "$(git rev-list --merges HEAD^..HEAD)" ]]; then
+  echo -e "\n\nHEAD commit is already a merge commit. Aborting."
+  exit 1
 fi
 
 COPYBARA_LINE="$(echo "${MESSAGE?}" | grep "${COPYBARA_TAG?}")"


### PR DESCRIPTION
We don't want to try to create merge commits from things that don't
have the Copybara tag or are already merge commits, but we do still
want to fix submodules. Probably if it's a merge commit it shouldn't
have messed up submodules anyway, but we want to exit successfully if
it doesn't have the Copybara tag. Otherwise we will fail on every
google export (like https://github.com/google/iree/runs/2071416701).

TESTED=yolo