### PR TITLE
Create InitTensorOp based on input operand shapes.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -95,13 +95,16 @@ struct TorchIndexSelectOpConversion
     for (int i = 0; i < rank; ++i) {
       if (!resultType.isDynamicDim(i)) continue;
       if (i < axis) {
-        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.input(), i));
+        dynSizes.push_back(
+            rewriter.createOrFold<DimOp>(loc, adaptor.input(), i));
       } else if (i < (axis + nIndices - batch)) {
         int idx = i - axis + batch;
-        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.index(), idx));
+        dynSizes.push_back(
+            rewriter.createOrFold<DimOp>(loc, adaptor.index(), idx));
       } else {
         int idx = i - (axis + nIndices - batch) + axis + 1;
-        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.input(), idx));
+        dynSizes.push_back(
+            rewriter.createOrFold<DimOp>(loc, adaptor.input(), idx));
       }
     }
     Value initOp = rewriter.create<linalg::InitTensorOp>(

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -95,16 +95,13 @@ struct TorchIndexSelectOpConversion
     for (int i = 0; i < rank; ++i) {
       if (!resultType.isDynamicDim(i)) continue;
       if (i < axis) {
-        dynSizes.push_back(
-            rewriter.createOrFold<DimOp>(loc, adaptor.input(), i));
+        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.input(), i));
       } else if (i < (axis + nIndices - batch)) {
         int idx = i - axis + batch;
-        dynSizes.push_back(
-            rewriter.createOrFold<DimOp>(loc, adaptor.index(), idx));
+        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.index(), idx));
       } else {
         int idx = i - (axis + nIndices - batch) + axis + 1;
-        dynSizes.push_back(
-            rewriter.createOrFold<DimOp>(loc, adaptor.input(), idx));
+        dynSizes.push_back(rewriter.create<DimOp>(loc, adaptor.input(), idx));
       }
     }
     Value initOp = rewriter.create<linalg::InitTensorOp>(


### PR DESCRIPTION
According to the documentation, the output shape is:
`params.shape[:axis] + indices.shape[batch_dims:] + params.shape[axis + 1:]`

E.g., if the varibles are:
params.shape = [16, 2, 3]
indices.shape = [16, 5]
axis = 2
batch_dims = 1

Then the output shape is `[16, 2] + [5] + [] = [16, 2, 5]`.

See https://www.tensorflow.org/api_docs/python/tf/gather for more details.
