### PR TITLE
Add missing CMake dep

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -314,6 +314,7 @@ if(${IREE_BUILD_COMPILER})
       ::init_xla_dialects
       LLVMSupport
       MLIRIR
+      MLIRLLVMToLLVMIRTranslation
       MLIRSCFTransforms
       MLIRPass
       MLIRSupport


### PR DESCRIPTION
Required to call `mlir::registerLLVMDialectTranslation()`.
Unbreaks upgrading the IREE submodule in iree-template-cpp.