### PR TITLE
Use correct tied operand index when creating DispatchWorkgroupsOp

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1179,7 +1179,7 @@ void DispatchOp::build(OpBuilder &builder, OperationState &state,
                        DispatchEntryOp entryPoint, ValueRange workgroupCount,
                        TypeRange resultTypes, ValueRange resultDims,
                        ValueRange operands, ValueRange operandDims,
-                       ArrayRef<int64_t> tiedOperands,
+                       ArrayAttr tiedOperands,
                        ArrayRef<NamedAttribute> attributes) {
   StringRef executableOpSymName =
       entryPoint->getParentOp()
@@ -1197,8 +1197,7 @@ void DispatchOp::build(OpBuilder &builder, OperationState &state,
   state.addOperands(resultDims);
   state.addAttributes(attributes);
   state.attributes.erase(TiedOpInterface::getStorageAttrName());
-  state.addAttribute(TiedOpInterface::getStorageAttrName(),
-                     builder.getIndexArrayAttr(tiedOperands));
+  state.addAttribute(TiedOpInterface::getStorageAttrName(), tiedOperands);
   state.attributes.erase("operand_segment_sizes");
   state.addAttribute("operand_segment_sizes",
                      builder.getI32VectorAttr({

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -693,8 +693,20 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
       "DispatchEntryOp":$entryPoint, "ValueRange":$workgroupCount,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$operands, "ValueRange":$operandDims,
-      "ArrayRef<int64_t>":$tiedOperands,
+      "ArrayAttr":$tiedOperands,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+    OpBuilder<(ins
+      "DispatchEntryOp":$entryPoint, "ValueRange":$workgroupCount,
+      "TypeRange":$resultTypes, "ValueRange":$resultDims,
+      "ValueRange":$operands, "ValueRange":$operandDims,
+      "ArrayRef<int64_t>":$tiedOperands,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes),
+      [{
+        build($_builder, $_state, entryPoint, workgroupCount,
+              resultTypes, resultDims, operands, operandDims,
+              $_builder.getIndexArrayAttr(tiedOperands),
+              attributes);
+      }]>
   ];
 
   let extraClassDeclaration = [{

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
@@ -77,7 +77,7 @@ static LogicalResult convertToDispatchOp(DispatchWorkgroupsOp regionOp,
   auto dispatchOp = builder.create<DispatchOp>(
       regionOp.getLoc(), entryPointOp, regionOp.workgroup_count(),
       regionOp.getResultTypes(), resultDynamicDims, newOperands,
-      operandDynamicDims, regionOp.getTiedResultOperandIndices());
+      operandDynamicDims, regionOp.tied_operandsAttr());
 
   // Replace uses of the existing results with the new results.
   for (int i = 0; i < regionOp.getNumResults(); ++i) {

--- a/iree/compiler/Dialect/IREE/IR/IREEInterfaces.td
+++ b/iree/compiler/Dialect/IREE/IR/IREEInterfaces.td
@@ -49,6 +49,10 @@ def IREE_TiedOpInterface : OpInterface<"TiedOpInterface"> {
     The default implementations use an attribute on the op to store the
     relationship:
       `OptionalAttr<IREE_TiedOpStorageAttr>:$tied_operands`
+
+    Note that `$tied_operands` are indices inside the operand range returned
+    by `getTiedOperandsIndexAndLength`, which may *not* be the full operand
+    range of the op.
   }];
 
   let methods = [
@@ -109,6 +113,9 @@ def IREE_TiedOpInterface : OpInterface<"TiedOpInterface"> {
     InterfaceMethod<
       /*desc=*/[{
         Returns the operand index tied to the given result index, if any.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
       }],
       /*retTy=*/"::llvm::Optional<unsigned>",
       /*methodName=*/"getTiedResultOperandIndex",
@@ -121,6 +128,9 @@ def IREE_TiedOpInterface : OpInterface<"TiedOpInterface"> {
     InterfaceMethod<
       /*desc=*/[{
         Sets the operand index tied to the given result index, if any.
+
+        Note that the index should be into the operand range returned by
+        `getTiedOperandsIndexAndLength`.
       }],
       /*retTy=*/"void",
       /*methodName=*/"setTiedResultOperandIndex",
@@ -135,6 +145,9 @@ def IREE_TiedOpInterface : OpInterface<"TiedOpInterface"> {
       /*desc=*/[{
         Returns an array containing the tied result operand indices with -1
         indicating that a result is not tied.
+
+        Note that the index returned is into the full range of all operands of
+        the current op.
       }],
       /*retTy=*/"SmallVector<int64_t, 4>",
       /*methodName=*/"getTiedResultOperandIndices",


### PR DESCRIPTION
getTiedResultOperandIndices() returns indices into the full operand
range, while the underlying storage attribute expects indcies
into the operand range returned by getTiedOperandsIndexAndLength().

Also makes the doc clear.