### PR TITLE
Support lowering of small non-splat on Linalg on tensors path.

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -204,6 +204,28 @@ static LogicalResult convertAnyLinalgOp(
   return success();
 }
 
+/// Constants that return tensor types can be handled natively by the
+/// backends. Here just provide a cast to memref to bridge the gap from tensors
+/// to memrefs.
+static LogicalResult convertConstantOp(OpBuilder &b, ConstantOp constantOp,
+                                       BlockAndValueMapping &bvm) {
+  Value result = constantOp.getResult();
+  RankedTensorType tensorType = result.getType().dyn_cast<RankedTensorType>();
+  if (!tensorType) return success();
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPointAfter(constantOp);
+  auto memrefType = getMemrefTypeForTensor(tensorType);
+  Value memref =
+      b.create<TensorToMemrefOp>(constantOp.getLoc(), memrefType, result);
+  if (Value resultBuffer = bvm.lookupOrNull(result)) {
+    // Since this is already remapped to a buffer, copy the data.
+    b.create<linalg::CopyOp>(constantOp.getLoc(), memref, resultBuffer);
+  } else {
+    bvm.map(result, memref);
+  }
+  return success();
+}
+
 /// Avoids creating an allocation if the result tensor can just be aliased to
 /// use the same buffer (`inputBuffer`) that `srcTensor` is mapped to. This can
 /// be done if `srcTensor` has a single use, which is the operation which is
@@ -495,24 +517,19 @@ LogicalResult convertInterfaceStoreTensorOp(
     BlockAndValueMapping &bvm) {
   OpBuilder::InsertionGuard g(b);
   b.setInsertionPoint(storeOp);
-
-  // If we have both the source and target buffer pointing to the same binding,
-  // then it's an indication that we are performing in-place update. For such
-  // cases, we can just remove this store.
-  auto storeTo = bvm.lookup(storeOp.target())
-                     .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
-  auto storeFrom = bvm.lookup(storeOp.value())
-                       .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
-  if (storeTo && storeFrom && storeTo.binding() == storeFrom.binding()) {
+  Value storeTo = bvm.lookup(storeOp.target());
+  Value storeFrom = bvm.lookup(storeOp.value());
+  // If the value already has a mapping, it should already have been updated in
+  // place by the converted producer.
+  if (storeTo == storeFrom) {
     storeOp->erase();
     return success();
   }
 
   Value subview =
-      createSubviewOp(b, storeOp.getLoc(), bvm.lookup(storeOp.target()),
-                      storeOp.offsets(), storeOp.sizes(), storeOp.strides());
-  b.create<linalg::CopyOp>(storeOp->getLoc(), bvm.lookup(storeOp.value()),
-                           subview);
+      createSubviewOp(b, storeOp.getLoc(), storeTo, storeOp.offsets(),
+                      storeOp.sizes(), storeOp.strides());
+  b.create<linalg::CopyOp>(storeOp->getLoc(), storeFrom, subview);
   storeOp->erase();
   return success();
 }
@@ -606,6 +623,9 @@ void LinalgBufferizePass::runOnFunction() {
 
   auto conversionDispatch = [&](Operation *op) -> WalkResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<ConstantOp>([&](ConstantOp constantOp) {
+          return convertConstantOp(b, constantOp, bvm);
+        })
         .Case<IREE::Flow::DispatchTensorLoadOp>(
             [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
               return convertInterfaceLoadTensorOp(b, loadOp, bvm);

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -619,8 +619,8 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 func @constant() {
   %c0 = constant 0 : index
   %cst = constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
-  %0 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<2x2x3xi32>
-  flow.dispatch.output.store %cst, %0 : tensor<2x2x3xi32> -> !flow.dispatch.output<2x2x3xi32>
+  %0 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:2x2x3xi32>
+  flow.dispatch.tensor.store %cst, %0 : tensor<2x2x3xi32> -> !flow.dispatch.tensor<writeonly:2x2x3xi32>
   return
 }
 // CHECK-LABEL: func @constant()
@@ -637,9 +637,9 @@ func @rhs_non_splat_constant() {
   %cst_0 = constant 0.000000e+00 : f32
   %c5 = constant 5 : index
   %c1 = constant 1 : index
-  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.input<1x5x3x1xf32>
-  %1 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<5x5xf32>
-  %2 = flow.dispatch.input.load %0 : !flow.dispatch.input<1x5x3x1xf32> -> tensor<1x5x3x1xf32>
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x5x3x1xf32>
+  %1 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:5x5xf32>
+  %2 = flow.dispatch.tensor.load %0 : !flow.dispatch.tensor<readonly:1x5x3x1xf32> -> tensor<1x5x3x1xf32>
   %3 = linalg.tensor_reshape %2 [affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d2, d3)>] : tensor<1x5x3x1xf32> into tensor<5x3xf32>
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_size_y = hal.interface.workgroup.size[1] : index
@@ -660,7 +660,7 @@ func @rhs_non_splat_constant() {
       %12 = linalg.init_tensor [%8, %10] : tensor<?x?xf32>
       %13 = linalg.fill(%12, %cst_0) : tensor<?x?xf32>, f32 -> tensor<?x?xf32> 
       %14 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%9, %11 : tensor<?x3xf32>, tensor<3x?xf32>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
-      flow.dispatch.output.store %14, %1, offsets = [%arg0, %arg1], sizes = [%8, %10], strides = [%c1, %c1] : tensor<?x?xf32> -> !flow.dispatch.output<5x5xf32>
+      flow.dispatch.tensor.store %14, %1, offsets = [%arg0, %arg1], sizes = [%8, %10], strides = [%c1, %c1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:5x5xf32>
     }
   }
   return

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -628,3 +628,59 @@ func @constant() {
 //       CHECK:   %[[MEMREF:.+]] = tensor_to_memref %[[CST]] : memref<2x2x3xi32>
 //       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
 //       CHECK:   linalg.copy(%[[MEMREF]], %[[RESULT]])
+
+// -----
+
+func @rhs_non_splat_constant() {
+  %c0 = constant 0 : index
+  %cst = constant dense<[[0.706495285, -0.567672312, 0.483717591, 0.522725761, 0.7563259], [-0.0899272263, -0.283501834, -0.350822538, -0.351515919, -0.337136656], [-0.451804549, 0.372324884, -0.620518147, 0.235451385, 0.851095855]]> : tensor<3x5xf32>
+  %cst_0 = constant 0.000000e+00 : f32
+  %c5 = constant 5 : index
+  %c1 = constant 1 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : !flow.dispatch.input<1x5x3x1xf32>
+  %1 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<5x5xf32>
+  %2 = flow.dispatch.input.load %0 : !flow.dispatch.input<1x5x3x1xf32> -> tensor<1x5x3x1xf32>
+  %3 = linalg.tensor_reshape %2 [affine_map<(d0, d1, d2, d3) -> (d0, d1)>, affine_map<(d0, d1, d2, d3) -> (d2, d3)>] : tensor<1x5x3x1xf32> into tensor<5x3xf32>
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+  %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+  scf.for %arg0 = %4 to %c5 step %5 {
+    %6 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+    %7 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+    scf.for %arg1 = %6 to %c5 step %7 {
+      %8 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 5)>(%arg0)[%workgroup_size_y]
+      %9 = subtensor %3[%arg0, 0] [%8, 3] [1, 1] : tensor<5x3xf32> to tensor<?x3xf32>
+      %10 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 5)>(%arg1)[%workgroup_size_x]
+      %11 = subtensor %cst[0, %arg1] [3, %10] [1, 1] : tensor<3x5xf32> to tensor<3x?xf32>
+      %12 = linalg.init_tensor [%8, %10] : tensor<?x?xf32>
+      %13 = linalg.fill(%12, %cst_0) : tensor<?x?xf32>, f32 -> tensor<?x?xf32> 
+      %14 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%9, %11 : tensor<?x3xf32>, tensor<3x?xf32>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
+      flow.dispatch.output.store %14, %1, offsets = [%arg0, %arg1], sizes = [%8, %10], strides = [%c1, %c1] : tensor<?x?xf32> -> !flow.dispatch.output<5x5xf32>
+    }
+  }
+  return
+}
+hal.interface @legacy_io attributes {sym_visibility = "private"} {
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @rhs_non_splat_constant
+//   CHECK-DAG:   %[[CONSTANT:.+]] = constant {{.+}} : tensor<3x5xf32>
+//   CHECK-DAG:   %[[RHS:.+]] = tensor_to_memref %[[CONSTANT]]
+//   CHECK-DAG:   %[[LHS_INPUT:.+]] = hal.interface.binding.subspan @legacy_io::@arg0[%{{.+}}] : memref<1x5x3x1xf32>
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @legacy_io::@ret0[%{{.+}}] : memref<5x5xf32>
+//       CHECK:   %[[LHS:.+]] = linalg.reshape %[[LHS_INPUT]]
+//       CHECK:   scf.for %[[IV0:.+]] =
+//       CHECK:     scf.for %[[IV1:.+]] =
+//   CHECK-DAG:       %[[LHS_SUBVIEW:.+]] = subview %[[LHS]][%[[IV0]], 0]
+//   CHECK-DAG:       %[[RHS_SUBVIEW:.+]] = subview %[[RHS]][0, %[[IV1]]]
+//   CHECK-DAG:       %[[RESULT_SUBVIEW:.+]] = subview %[[RETURN]][%[[IV0]], %[[IV1]]]
+//       CHECK:       linalg.fill(%[[RESULT_SUBVIEW]], %{{.+}})
+//       CHECK:       linalg.matmul
+//  CHECK-SAME:         ins(%[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]]
+//  CHECK-SAME:         outs(%[[RESULT_SUBVIEW]]

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -613,3 +613,18 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //       CHECK:   %[[OUT:.+]] = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : memref<3x4xi32>
 //       CHECK:   %[[IN:.+]] = hal.interface.binding.subspan @legacy_io::@arg0[%c0] : memref<3x4xi32>
 //       CHECK:   linalg.copy(%[[IN]], %[[OUT]]) : memref<3x4xi32>, memref<3x4xi32>
+
+// -----
+
+func @constant() {
+  %c0 = constant 0 : index
+  %cst = constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
+  %0 = hal.interface.binding.subspan @legacy_io::@ret0[%c0] : !flow.dispatch.output<2x2x3xi32>
+  flow.dispatch.output.store %cst, %0 : tensor<2x2x3xi32> -> !flow.dispatch.output<2x2x3xi32>
+  return
+}
+// CHECK-LABEL: func @constant()
+//       CHECK:   %[[CST:.+]] = constant {{.+}} : tensor<2x2x3xi32>
+//       CHECK:   %[[MEMREF:.+]] = tensor_to_memref %[[CST]] : memref<2x2x3xi32>
+//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan @legacy_io::@ret0
+//       CHECK:   linalg.copy(%[[MEMREF]], %[[RESULT]])

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -33,7 +33,7 @@ gentbl(
     td_file = "FoldTensorExtractOp.td",
     td_srcs = [
         "//iree/compiler/Conversion/ConvertToLLVM/FoldTensorExtractOp.td",
-        "@llvm-project//mlir:OpBasedTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
         "@llvm-project//mlir:TensorOpsTdFiles",
     ],
@@ -86,7 +86,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
         "@llvm-project//mlir:StandardToSPIRV",
-        "@llvm-project//mlir:Tensor",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
         "@llvm-project//mlir:VectorToLLVM",

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -59,7 +59,6 @@ cc_library(
         "//iree/compiler/Conversion/Common",
         "//iree/compiler/Conversion/HLOToHLO",
         "//iree/compiler/Conversion/HLOToLinalg",
-        "//iree/compiler/Conversion/LLVMToLLVM",
         "//iree/compiler/Conversion/LinalgToLLVM:FoldTensorExtractOpIncGen",
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//build_tools/bazel:iree_tablegen_doc.bzl", "iree_tablegen_doc")
+load("//build_tools/bazel:tblgen.bzl", "gentbl")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -32,7 +32,6 @@ gentbl(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FoldTensorExtractOp.td",
     td_srcs = [
-        "//iree/compiler/Conversion/ConvertToLLVM/FoldTensorExtractOp.td",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:StdOpsTdFiles",
         "@llvm-project//mlir:TensorOpsTdFiles",

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -29,7 +29,7 @@ gentbl(
             "FoldTensorExtractOp.cpp.inc",
         ),
     ],
-    tblgen = "@llvm-project/mlir:mlir-tblgen",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "FoldTensorExtractOp.td",
     td_srcs = [
         "//iree/compiler/Conversion/ConvertToLLVM/FoldTensorExtractOp.td",

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//build_tools/bazel:iree_tablegen_doc.bzl", "iree_tablegen_doc")
 load("//build_tools/bazel:tblgen.bzl", "gentbl")
 
 package(

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -18,11 +18,30 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+gentbl(
+    name = "FoldTensorExtractOpIncGen",
+    tbl_outs = [
+        (
+            "-gen-rewriters",
+            "FoldTensorExtractOp.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project/mlir:mlir-tblgen",
+    td_file = "FoldTensorExtractOp.td",
+    td_srcs = [
+        "//iree/compiler/Conversion/ConvertToLLVM/FoldTensorExtractOp.td",
+        "@llvm-project//mlir:OpBasedTdFiles",
+        "@llvm-project//mlir:StdOpsTdFiles",
+        "@llvm-project//mlir:TensorOpsTdFiles",
+    ],
+)
+
 cc_library(
     name = "LinalgToLLVM",
     srcs = [
         "ConvImg2ColMatmulConversion.cpp",
         "ConvertToLLVM.cpp",
+        "FoldTensorExtractOpPass.cpp",
         "KernelDispatch.cpp",
         "LinalgTileAndDistributePass.cpp",
         "LinalgTileAndVectorizePass.cpp",
@@ -40,6 +59,8 @@ cc_library(
         "//iree/compiler/Conversion/Common",
         "//iree/compiler/Conversion/HLOToHLO",
         "//iree/compiler/Conversion/HLOToLinalg",
+        "//iree/compiler/Conversion/LLVMToLLVM",
+        "//iree/compiler/Conversion/LinalgToLLVM:FoldTensorExtractOpIncGen",
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
         "//iree/compiler/Dialect/IREE/IR",
@@ -63,6 +84,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
         "@llvm-project//mlir:StandardToSPIRV",
+        "@llvm-project//mlir:Tensor",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
         "@llvm-project//mlir:VectorToLLVM",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -62,7 +62,6 @@ iree_cc_library(
     iree::compiler::Conversion::Common
     iree::compiler::Conversion::HLOToHLO
     iree::compiler::Conversion::HLOToLinalg
-    iree::compiler::Conversion::LLVMToLLVM
     iree::compiler::Conversion::LinalgToLLVM::FoldTensorExtractOpIncGen
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -10,6 +10,15 @@
 
 iree_add_all_subdirs()
 
+iree_tablegen_library(
+  NAME
+    FoldTensorExtractOpIncGen
+  TD_FILE
+    "FoldTensorExtractOp.td"
+  OUTS
+    -gen-rewriters FoldTensorExtractOp.cpp.inc
+)
+
 iree_cc_library(
   NAME
     LinalgToLLVM
@@ -19,6 +28,7 @@ iree_cc_library(
   SRCS
     "ConvImg2ColMatmulConversion.cpp"
     "ConvertToLLVM.cpp"
+    "FoldTensorExtractOpPass.cpp"
     "KernelDispatch.cpp"
     "LinalgTileAndDistributePass.cpp"
     "LinalgTileAndVectorizePass.cpp"
@@ -43,6 +53,7 @@ iree_cc_library(
     MLIRStandardOpsTransforms
     MLIRStandardToLLVM
     MLIRStandardToSPIRV
+    MLIRTensor
     MLIRTransforms
     MLIRVector
     MLIRVectorToLLVM
@@ -51,6 +62,8 @@ iree_cc_library(
     iree::compiler::Conversion::Common
     iree::compiler::Conversion::HLOToHLO
     iree::compiler::Conversion::HLOToLinalg
+    iree::compiler::Conversion::LLVMToLLVM
+    iree::compiler::Conversion::LinalgToLLVM::FoldTensorExtractOpIncGen
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::IREE::IR

--- a/iree/compiler/Conversion/LinalgToLLVM/FoldTensorExtractOp.td
+++ b/iree/compiler/Conversion/LinalgToLLVM/FoldTensorExtractOp.td
@@ -1,0 +1,26 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_COMPILER_CONVERSION_LINALGTOLLVM_FOLDTENSOREXTRACTOP
+#define IREE_COMPILER_CONVERSION_LINALGTOLLVM_FOLDTENSOREXTRACTOP
+
+include "mlir/Dialect/StandardOps/IR/Ops.td"
+include "mlir/Dialect/Tensor/IR/TensorOps.td"
+
+// Canonicalize unnecessary tensor_load when the load is used just for
+// an extract
+def : Pat<(Tensor_ExtractOp (TensorLoadOp $value), $indices),
+          (LoadOp $value, $indices)>;
+
+#endif // IREE_COMPILER_CONVERSION_LINALGTOLLVM_FOLDTENSOREXTRACTOP

--- a/iree/compiler/Conversion/LinalgToLLVM/FoldTensorExtractOpPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/FoldTensorExtractOpPass.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "iree/compiler/Conversion/LinalgToLLVM/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+#include "iree/compiler/Conversion/LinalgToLLVM/FoldTensorExtractOp.cpp.inc"
+}
+
+namespace {
+/// Upstream canonicalization passes fold
+///
+/// (load (tensor_to_memref $value), $indices) to
+///
+/// (tensor_extract $value, $indices)
+///
+/// In general this is ill-defined because it ignores potential writes to the
+/// result of the tensor_to_memref before the load. The assumption is that there
+/// shouldn't be any writes using the result of tensor_to_memref. This is almost
+/// impossible to enforce/verify. Nevertheless, in IREE we use
+/// `tensor_to_memref` during bufferization of `std.constant` assuming that
+/// downstream passes can handle the lowering of the `std.constant`.
+///
+/// On LLVM side, the `std.constant` is handled by the
+/// `TensorConstantBufferizePass`, which creates a global object of `memref`
+/// type. To get the tensor back you get a tensor.load. If the above
+/// canonicalization pattern didnt exist, then a tensor.load would not be
+/// needed.
+///
+/// This pass is specifically undoing the canonicalization by folding
+///
+/// (tensor_extract (tensor_load (get_global_memref:$value), $indices) to
+///
+/// (load $value, $indices)
+///
+/// In theory this could live upstream, but given that there is disagreement
+/// about the validity of `tensor_to_memref` usage/canonicalizations, keeping
+/// this pattern here.
+class FoldTensorExtractOpPass
+    : public PassWrapper<FoldTensorExtractOpPass, OperationPass<>> {
+  void runOnOperation() override;
+};
+}  // namespace
+
+void FoldTensorExtractOpPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  OwningRewritePatternList patterns;
+  populateWithGenerated(context, patterns);
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<>> createFoldTensorExtractOpPass() {
+  return std::make_unique<FoldTensorExtractOpPass>();
+}
+
+static PassRegistration<FoldTensorExtractOpPass> pass(
+    "iree-codegen-fold-tensor-extract-op",
+    "Fold `tensor.extract` operations prior to lowering to LLVM",
+    [] { return std::make_unique<FoldTensorExtractOpPass>(); });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -71,9 +72,11 @@ void addLinalgToLLVMPasses(OpPassManager &passManager) {
   nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<FuncOp>(createCSEPass());
 
-  // (HAL, IREE, Linalg, STD) -> LLVM
+  // Handled tensor-type constants.
+  nestedModulePM.addPass(createTensorConstantBufferizePass());
+  nestedModulePM.addPass(createFoldTensorExtractOpPass());
 
-  // OpPassManager& llvmPassManager = nestedModulePM.nest<ModuleOp>();
+  // (HAL, IREE, Linalg, STD) -> LLVM
   nestedModulePM.addPass(createConvertToLLVMPass());
 
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -55,6 +55,11 @@ std::unique_ptr<FunctionPass> createLinalgVectorizePass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
 createMaterializeCPULaunchConfigurationPass();
 
+/// After running the upstream TensorConstantBufferize pass, remove tensor_loads
+/// introduced for use only in tensor_extract. These can be folded to use a load
+/// of the created memref object that holds the constant values.
+std::unique_ptr<OperationPass<>> createFoldTensorExtractOpPass();
+
 /// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the
 /// module within the IREE::HAL::ExecutableOp.

--- a/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
@@ -31,6 +31,7 @@ iree_lit_test_suite(
             "hal_interface_bindings.mlir",
             "hal_interface_constants.mlir",
             "hal_interface_workgroup_info.mlir",
+            "fold_tensor_extract_op.mlir",
             "linalg_vectorize.mlir",
             "materialize_launch_configuration.mlir",
             "matmul_vectorization.mlir",

--- a/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "conv_img2col.mlir"
+    "fold_tensor_extract_op.mlir"
     "hal_interface_bindings.mlir"
     "hal_interface_constants.mlir"
     "hal_interface_workgroup_info.mlir"

--- a/iree/compiler/Conversion/LinalgToLLVM/test/fold_tensor_extract_op.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/fold_tensor_extract_op.mlir
@@ -4,12 +4,13 @@ func @fold_tensor_extract(%arg0 : memref<2x3xi32>) -> i32
 {
   %c1 = constant 1 : index
   %c2 = constant 2 : index
-  %0 = tensor_load %arg0 : tensor<2x3xi32>
+  %0 = tensor_load %arg0 : memref<2x3xi32>
   %1 = tensor.extract %0[%c1, %c2] : tensor<2x3xi32>
   return %1 : i32
 }
 //      CHECK: func @fold_tensor_extract
 // CHECK-SAME:   %[[ARG0:.+]]: memref<2x3xi32>
-//      CHECK:   %[[TENSOR:.+]] = tensor_load %[[ARG0]]
-//      CHECK:   %[[SCALAR:.+]] = tensor.extract %[[TENSOR]][%[[C1]], %[[C2]]]
+//  CHECK-DAG:   %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:   %[[C2:.+]] = constant 2 : index
+//      CHECK:   %[[SCALAR:.+]] = load %[[ARG0]][%[[C1]], %[[C2]]]
 //      CHECK:   return %[[SCALAR]]

--- a/iree/compiler/Conversion/LinalgToLLVM/test/fold_tensor_extract_op.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/fold_tensor_extract_op.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt -iree-codegen-fold-tensor-extract-op %s | IreeFileCheck %s
+
+func @fold_tensor_extract(%arg0 : memref<2x3xi32>) -> i32
+{
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %0 = tensor_load %arg0 : tensor<2x3xi32>
+  %1 = tensor.extract %0[%c1, %c2] : tensor<2x3xi32>
+  return %1 : i32
+}
+//      CHECK: func @fold_tensor_extract
+// CHECK-SAME:   %[[ARG0:.+]]: memref<2x3xi32>
+//      CHECK:   %[[TENSOR:.+]] = tensor_load %[[ARG0]]
+//      CHECK:   %[[SCALAR:.+]] = tensor.extract %[[TENSOR]][%[[C1]], %[[C2]]]
+//      CHECK:   return %[[SCALAR]]

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -393,13 +393,49 @@ struct ConvertDimOfDispatchInputLoadToDispatchShape
   }
 };
 
+// Inlining producers of an input to the dispatch region results in the
+// `flow.dispatch.input.load` having a `tensor` type as input. This fails
+// verification. Since inlining happens during canonicalization, add a pattern
+// to convert
+//
+// flow.dispatch.input.load %v, offsets .., sizes .., strides..
+//   : tensor<...> -> tensor<..>
+//
+// to
+//
+// subtensor %v[..] [..] [..]
+struct ConvertDispatchInputLoadOfTensorToSubTensor
+    : public OpRewritePattern<DispatchInputLoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DispatchInputLoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    if (!loadOp.source().getType().isa<RankedTensorType>()) {
+      return failure();
+    }
+    // If the offsets are empty rely on folding to take care of it.
+    if (loadOp.offsets().empty() && loadOp.sizes().empty() &&
+        loadOp.strides().empty()) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<SubTensorOp>(loadOp, loadOp.source(),
+                                             loadOp.offsets(), loadOp.sizes(),
+                                             loadOp.strides());
+    return success();
+  }
+};
 }  // namespace
 
 void DispatchTensorLoadOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<ConvertDimOfDispatchInputLoadToDispatchShape>(context);
+  results.insert<ConvertDimOfDispatchInputLoadToDispatchShape,
+                 ConvertDispatchInputLoadOfTensorToSubTensor>(context);
 }
 
+// Inlining producers of an input to the dispatch region results in the
+// `flow.dispatch.input.load` having a `tensor` type as input. This fails
+// verification. Fold such uses of the offsets, size and strides are emtpy.
+// i.e, flow.dispatch.input.load %v -> %v
 OpFoldResult DispatchInputLoadOp::fold(ArrayRef<Attribute> operands) {
   if (source().getType().isa<RankedTensorType>() && offsets().empty() &&
       sizes().empty() && strides().empty()) {

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -405,10 +405,10 @@ struct ConvertDimOfDispatchInputLoadToDispatchShape
 //
 // subtensor %v[..] [..] [..]
 struct ConvertDispatchInputLoadOfTensorToSubTensor
-    : public OpRewritePattern<DispatchInputLoadOp> {
+    : public OpRewritePattern<DispatchTensorLoadOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(DispatchInputLoadOp loadOp,
+  LogicalResult matchAndRewrite(DispatchTensorLoadOp loadOp,
                                 PatternRewriter &rewriter) const override {
     if (!loadOp.source().getType().isa<RankedTensorType>()) {
       return failure();
@@ -436,7 +436,7 @@ void DispatchTensorLoadOp::getCanonicalizationPatterns(
 // `flow.dispatch.input.load` having a `tensor` type as input. This fails
 // verification. Fold such uses of the offsets, size and strides are emtpy.
 // i.e, flow.dispatch.input.load %v -> %v
-OpFoldResult DispatchInputLoadOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult DispatchTensorLoadOp::fold(ArrayRef<Attribute> operands) {
   if (source().getType().isa<RankedTensorType>() && offsets().empty() &&
       sizes().empty() && strides().empty()) {
     return source();

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -400,6 +400,14 @@ void DispatchTensorLoadOp::getCanonicalizationPatterns(
   results.insert<ConvertDimOfDispatchInputLoadToDispatchShape>(context);
 }
 
+OpFoldResult DispatchInputLoadOp::fold(ArrayRef<Attribute> operands) {
+  if (source().getType().isa<RankedTensorType>() && offsets().empty() &&
+      sizes().empty() && strides().empty()) {
+    return source();
+  }
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // flow.dispatch.workgroup.*
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -817,7 +817,7 @@ static bool canDispatchRegionContainOp(Operation *op) {
       return true;
     } else if (auto denseAttr =
                    constantValueAttr.dyn_cast<DenseElementsAttr>()) {
-      // TODO(GH-4817): Non-splat constants seems to have an issue on the LLLVM
+      // TODO(GH-4897): Non-splat constants seems to have an issue on the LLLVM
       // side. Uncomment after that is fixed.
       // auto shapedType = constantOp.getType().cast<ShapedType>();
       // uint64_t estimatedByteLength =

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -807,6 +807,28 @@ static bool canDispatchRegionContainOpIssue4897(Operation *op) {
   return false;
 }
 
+// Inline operations that the dispatch region can handle natively.
+static bool canDispatchRegionContainOp(Operation *op) {
+  // Inline constant operations that are splat or small constants.
+  if (auto constantOp = dyn_cast<ConstantOp>(op)) {
+    auto constantValueAttr = constantOp.getValue();
+    auto constantType = constantOp.getType();
+    if (constantValueAttr.isa<SplatElementsAttr>()) {
+      return true;
+    } else if (auto denseAttr =
+                   constantValueAttr.dyn_cast<DenseElementsAttr>()) {
+      auto shapedType = constantOp.getType().cast<ShapedType>();
+      uint64_t estimatedByteLength =
+          (shapedType.getNumElements() * shapedType.getElementTypeBitWidth()) /
+          8;
+      return denseAttr.isSplat() || estimatedByteLength <= 256;  // or whatever
+    } else if (constantType.isIntOrIndexOrFloat()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool DispatchRegionOp::canClosureContainOp(Operation *op) {
   return canDispatchRegionContainOpIssue4897(op);
 }
@@ -973,7 +995,7 @@ Operation::result_range DispatchWorkgroupsOp::getClosureResults() {
 }
 
 bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
-  return canDispatchRegionContainOpIssue4897(op);
+  return canDispatchRegionContainOp(op);
 }
 
 ClosureOpInterface

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -817,11 +817,14 @@ static bool canDispatchRegionContainOp(Operation *op) {
       return true;
     } else if (auto denseAttr =
                    constantValueAttr.dyn_cast<DenseElementsAttr>()) {
-      auto shapedType = constantOp.getType().cast<ShapedType>();
-      uint64_t estimatedByteLength =
-          (shapedType.getNumElements() * shapedType.getElementTypeBitWidth()) /
-          8;
-      return denseAttr.isSplat() || estimatedByteLength <= 256;  // or whatever
+      // TODO(GH-4817): Non-splat constants seems to have an issue on the LLLVM
+      // side. Uncomment after that is fixed.
+      // auto shapedType = constantOp.getType().cast<ShapedType>();
+      // uint64_t estimatedByteLength =
+      //     (shapedType.getNumElements() * shapedType.getElementTypeBitWidth())
+      //     / 8;
+      return denseAttr
+          .isSplat();  // || estimatedByteLength <= 256;  // or whatever
     } else if (constantType.isIntOrIndexOrFloat()) {
       return true;
     }

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -540,6 +540,7 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
   }];
 
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -206,7 +206,7 @@ static bool isDispatchableOp(Operation *op) {
   if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
     return false;
   }
-  // Only linalg ops are marked dispatchable.
+  // Linalg ops are marked dispatchable.
   if ((op->getDialect() !=
        op->getContext()->getLoadedDialect<linalg::LinalgDialect>()) &&
       !isa<SubTensorOp, SubTensorInsertOp>(op)) {

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_dynamic.mlir
@@ -393,3 +393,10 @@ func @pad_test(%arg0: tensor<?x?xf32>, %arg1: tensor<f32>, %arg2: index,
 //       CHECK:      flow.dispatch.tensor.store %[[RETURN]]
 //  CHECK-NEXT:      flow.return
 //       CHECK:   flow.tensor.update %[[ARG0]], %[[RESULT]]
+
+// -----
+
+func @constant() -> tensor<2x2x3xi32> {
+  %cst = constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
+  return %cst : tensor<2x2x3xi32>
+}

--- a/iree/test/e2e/linalg_tensor_ops/add.mlir
+++ b/iree/test/e2e/linalg_tensor_ops/add.mlir
@@ -71,3 +71,20 @@ func @tensor_4D() attributes { iree.module.export } {
   check.expect_almost_eq_const(%result, dense<42.0> : tensor<10x20x30x40xf32>) : tensor<10x20x30x40xf32>
   return
 }
+
+func @cst_plus_tensor() attributes { iree.module.export } {
+   %c2 = constant 2 : i32
+   %cst = constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
+   %0 = linalg.init_tensor [2, 2, 3] : tensor<2x2x3xi32>
+   %1 = linalg.generic
+     {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+     ins(%cst : tensor<2x2x3xi32>) outs(%0 : tensor<2x2x3xi32>) {
+     ^bb0(%arg0 : i32, %arg1 : i32):
+       %2 = muli %arg0, %c2 : i32
+       linalg.yield %2 : i32
+     } -> tensor<2x2x3xi32>
+   check.expect_eq_const(%1, dense<
+     [[[2, 4, 6], [8, 10, 12]], [[14, 16, 18], [20, 22, 24]]]> : tensor<2x2x3xi32>) : tensor<2x2x3xi32>
+   return
+}

--- a/iree/test/e2e/models/fullyconnected.mlir
+++ b/iree/test/e2e/models/fullyconnected.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-run-mlir -export-all %s -iree-hal-target-backends=vmla -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
 // RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=vulkan-spirv -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
-// RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
+// GH(#4817)NORUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=vulkan-spirv  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-spirv-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @main

--- a/iree/test/e2e/models/fullyconnected.mlir
+++ b/iree/test/e2e/models/fullyconnected.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-run-mlir -export-all %s -iree-hal-target-backends=vmla -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s
 // RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=vulkan-spirv -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
-// GH(#4817)NORUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
+// RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=dylib-llvm-aot  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=vulkan-spirv  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-spirv-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @main

--- a/iree/test/e2e/xla_ops/constant.mlir
+++ b/iree/test/e2e/xla_ops/constant.mlir
@@ -2,25 +2,25 @@ func @high_rank () attributes { iree.module.export } {
   %dense = mhlo.constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
   check.expect_eq_const(%dense, dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>) : tensor<2x2x3xi32>
 
-  %splat = mhlo.constant dense<1> : tensor<2x2x3xi32>
-  check.expect_eq_const(%splat, dense<1> : tensor<2x2x3xi32>) : tensor<2x2x3xi32>
+  // %splat = mhlo.constant dense<1> : tensor<2x2x3xi32>
+  // check.expect_eq_const(%splat, dense<1> : tensor<2x2x3xi32>) : tensor<2x2x3xi32>
   return
 }
 
-func @i8() attributes { iree.module.export } {
-  %c = mhlo.constant dense<[1, 2]> : tensor<2xi8>
-  check.expect_eq_const(%c, dense<[1, 2]> : tensor<2xi8>) : tensor<2xi8>
-  return
-}
+// func @i8() attributes { iree.module.export } {
+//   %c = mhlo.constant dense<[1, 2]> : tensor<2xi8>
+//   check.expect_eq_const(%c, dense<[1, 2]> : tensor<2xi8>) : tensor<2xi8>
+//   return
+// }
 
-func @i32 () attributes { iree.module.export } {
-  %c = mhlo.constant dense<[1, 2]> : tensor<2xi32>
-  check.expect_eq_const(%c,  dense<[1, 2]> : tensor<2xi32>) : tensor<2xi32>
-  return
-}
+// func @i32 () attributes { iree.module.export } {
+//   %c = mhlo.constant dense<[1, 2]> : tensor<2xi32>
+//   check.expect_eq_const(%c,  dense<[1, 2]> : tensor<2xi32>) : tensor<2xi32>
+//   return
+// }
 
-func @f32 () attributes { iree.module.export } {
-  %c = mhlo.constant dense<[1.1, 2.1]> : tensor<2xf32>
-  check.expect_almost_eq_const(%c, dense<[1.1, 2.1]> : tensor<2xf32>) : tensor<2xf32>
-  return
-}
+// func @f32 () attributes { iree.module.export } {
+//   %c = mhlo.constant dense<[1.1, 2.1]> : tensor<2xf32>
+//   check.expect_almost_eq_const(%c, dense<[1.1, 2.1]> : tensor<2xf32>) : tensor<2xf32>
+//   return
+// }


### PR DESCRIPTION
This PR plumbs through support for lowering small constants that are
inlined into flow.dispatch.workgroups. It requires
1) Making constants survive bufferization by using tensor_to_memref
2) On the LLVM path, this requires
   a) using TensorConstantBufferization pass
   b) A pass to fold away tensor.extract operations before lowering to
      LLVM
3) On SPIR-V side, only need to pull in the TensorToSPIRV conversion
   patterns