### PR TITLE
Skip results with tied operands when creating push descriptor updates

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -382,8 +382,12 @@ static LogicalResult recordPushBindings(Value device, Value commandBuffer,
   for (auto it : llvm::enumerate(dispatchOp.results())) {
     LLVM_DEBUG(llvm::dbgs()
                << "  + RESULT(" << it.index() << "): " << it.value() << "\n");
-    if (failed(pushBinding(it.value()))) {
-      return failure();
+    if (dispatchOp.getTiedResultOperandIndex(it.index())) {
+      LLVM_DEBUG(llvm::dbgs() << "    TIED TO OPERAND; SKIP\n");
+    } else {
+      if (failed(pushBinding(it.value()))) {
+        return failure();
+      }
     }
   }
   rewriter.create<IREE::HAL::CommandBufferPushDescriptorSetOp>(


### PR DESCRIPTION
Results with tied operands won't have bindings in the descriptor
set layout. So we need to be consistent when creating push
descriptor updates.