### PR TITLE
Tie operands and results when creating DispatchWorkgroupsOp

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -370,7 +370,8 @@ static Operation *getInsertionPoint(Block &block, ArrayRef<Value> usedValues) {
   return insertAfter->getNextNode();
 }
 
-/// Modifies `dispatchOp` to attach operand-result tie information when possible.
+/// Modifies `dispatchOp` to attach operand-result tie information when
+/// possible.
 static void tryToTieOperandsAndResults(
     IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   Block *block = dispatchOp.getBody(0);

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -370,6 +370,69 @@ static Operation *getInsertionPoint(Block &block, ArrayRef<Value> usedValues) {
   return insertAfter->getNextNode();
 }
 
+/// Modifies `dispatchOp` to attach operand-result tie information when possible.
+static void tryToTieOperandsAndResults(
+    IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
+  Block *block = dispatchOp.getBody(0);
+  unsigned numResults = dispatchOp.getNumResults();
+  auto inputs = block->getArguments().drop_back(numResults);
+  auto outputs = block->getArguments().take_back(numResults);
+
+  // Returns the tied operand for the given `resultArg`. Returns nullptr
+  // if error or not found.
+  auto getTiledOperandBlockArgument =
+      [](BlockArgument resultArg) -> BlockArgument {
+    // Each output block argument should just have one use.
+    if (!llvm::hasSingleElement(resultArg.getUses())) return nullptr;
+
+    // And that's a flow.dispatch.output.store op.
+    auto storeOp = dyn_cast<IREE::Flow::DispatchTensorStoreOp>(
+        (*resultArg.getUses().begin()).getOwner());
+    if (!storeOp) return nullptr;
+
+    Operation *tieOp = storeOp.value().getDefiningOp();
+
+    // TODO(antiagainst): use TileOpInterface here instead of hardcoding ops
+    // when it's available in MLIR core in some form.
+    if (auto insertOp = dyn_cast_or_null<SubTensorInsertOp>(tieOp)) {
+      auto loadOp =
+          insertOp.dest().getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+      if (!loadOp) return nullptr;
+      return loadOp.source().cast<BlockArgument>();
+    }
+
+    return nullptr;
+  };
+
+  SmallVector<BlockArgument, 4> tiedOperands;
+  tiedOperands.reserve(numResults);
+
+  // Collect all result argument's tied operand arguments.
+  for (BlockArgument &arg : outputs) {
+    tiedOperands.push_back(getTiledOperandBlockArgument(arg));
+  }
+
+  // Go over each result to tie operand when possible, by:
+  // 1. Update the tied operand argument to take readwrite tensors.
+  // 2. Erase the result argument.
+  // 3. Attach the tie information to the DispatchWorkgroupsOp.
+  for (int i = outputs.size() - 1; i >= 0; --i) {
+    BlockArgument inputArg = tiedOperands[i];
+    if (!inputArg) continue;
+
+    auto oldType = inputArg.getType().cast<IREE::Flow::DispatchTensorType>();
+    inputArg.setType(IREE::Flow::DispatchTensorType::get(
+        IREE::Flow::TensorAccess::ReadWrite, oldType.getShape(),
+        oldType.getElementType()));
+
+    BlockArgument outputArg = block->getArgument(inputs.size() + i);
+    outputArg.replaceAllUsesWith(inputArg);
+    block->eraseArgument(inputs.size() + i);
+
+    dispatchOp.setTiedResultOperandIndex(i, inputArg.getArgNumber());
+  }
+}
+
 // After outlining in dispatch region we can rewrite the dispatch ops with
 // proper captures.
 // A later RematerializeDispatchConstants should be called to avoid passing
@@ -476,6 +539,12 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
   // Set the values captured from above as the new operands.
   dispatchOp.operandsMutable().assign(llvm::to_vector<4>(valuesDefinedAbove));
   dispatchOp.operand_dimsMutable().assign(operandDynamicDims);
+
+  // Now try to see if we can tie certain results to operands in order to
+  // indicate sharing storage. This need to happen here because it needs to
+  // access region block arguments for input/output tensors, which aren't
+  // available until now.
+  tryToTieOperandsAndResults(dispatchOp);
 
   return success();
 }

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -381,7 +381,7 @@ static void tryToTieOperandsAndResults(
 
   // Returns the tied operand for the given `resultArg`. Returns nullptr
   // if error or not found.
-  auto getTiledOperandBlockArgument =
+  auto getTiedOperandBlockArgument =
       [](BlockArgument resultArg) -> BlockArgument {
     // Each output block argument should just have one use.
     if (!llvm::hasSingleElement(resultArg.getUses())) return nullptr;
@@ -393,7 +393,7 @@ static void tryToTieOperandsAndResults(
 
     Operation *tieOp = storeOp.value().getDefiningOp();
 
-    // TODO(antiagainst): use TileOpInterface here instead of hardcoding ops
+    // TODO(antiagainst): use TiedOpInterface here instead of hardcoding ops
     // when it's available in MLIR core in some form.
     if (auto insertOp = dyn_cast_or_null<SubTensorInsertOp>(tieOp)) {
       auto loadOp =
@@ -410,7 +410,7 @@ static void tryToTieOperandsAndResults(
 
   // Collect all result argument's tied operand arguments.
   for (BlockArgument &arg : outputs) {
-    tiedOperands.push_back(getTiledOperandBlockArgument(arg));
+    tiedOperands.push_back(getTiedOperandBlockArgument(arg));
   }
 
   // Go over each result to tie operand when possible, by:

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -225,6 +225,8 @@ func @depthwise_conv2d(%input: tensor<1x113x113x96xf32>, %filter: tensor<3x3x96x
 // CHECK: scf.for
 // CHECK: linalg.depthwise_conv_2d_input_nhwc_filter_hwc
 
+// -----
+
 func @subtensor_insert(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x225x225x3xf32> {
   %cst = constant 0.000000e+00 : f32
   %0 = linalg.init_tensor [1, 225, 225, 3] : tensor<1x225x225x3xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -224,3 +224,31 @@ func @depthwise_conv2d(%input: tensor<1x113x113x96xf32>, %filter: tensor<3x3x96x
 // CHECK: scf.for
 // CHECK: scf.for
 // CHECK: linalg.depthwise_conv_2d_input_nhwc_filter_hwc
+
+func @subtensor_insert(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x225x225x3xf32> {
+  %cst = constant 0.000000e+00 : f32
+  %0 = linalg.init_tensor [1, 225, 225, 3] : tensor<1x225x225x3xf32>
+  %1 = linalg.fill(%0, %cst) : tensor<1x225x225x3xf32>, f32 -> tensor<1x225x225x3xf32>
+  %2 = subtensor_insert %arg0 into %1[0, 0, 0, 0] [1, 224, 224, 3] [1, 1, 1, 1] : tensor<1x224x224x3xf32> into tensor<1x225x225x3xf32>
+  return %2 : tensor<1x225x225x3xf32>
+}
+
+//      CHECK: func @subtensor_insert
+// CHECK-SAME: (%[[INPUT:.+]]: tensor<1x224x224x3xf32>)
+//
+//      CHECK:   %[[FILL:.+]] = flow.dispatch.workgroups[{{.+}}]() : () -> tensor<1x225x225x3xf32> =
+// CHECK-NEXT:       (%[[OUTPUT:.+]]: !flow.dispatch.tensor<writeonly:1x225x225x3xf32>) {
+//      CHECK:     linalg.init_tensor
+// CHECK-NEXT:     %[[TENSOR:.+]] = linalg.fill
+// CHECK-NEXT:     flow.dispatch.tensor.store %[[TENSOR]], %[[OUTPUT]]
+// CHECK-NEXT:     flow.return
+//
+//      CHECK:   %[[PAD:.+]] = flow.dispatch.workgroups[{{.+}}](%[[INPUT]], %[[FILL]]) : (tensor<1x224x224x3xf32>, tensor<1x225x225x3xf32>) -> %[[FILL]] =
+// CHECK-NEXT:       (%[[SRC:.+]]: !flow.dispatch.tensor<readonly:1x224x224x3xf32>, %[[DST:.+]]: !flow.dispatch.tensor<readwrite:1x225x225x3xf32>) {
+// CHECK-NEXT:     %[[SRC_TENSOR:.+]] = flow.dispatch.tensor.load %[[SRC]] : !flow.dispatch.tensor<readonly:1x224x224x3xf32> -> tensor<1x224x224x3xf32>
+// CHECK-NEXT:     %[[DST_TENSOR:.+]] = flow.dispatch.tensor.load %[[DST]] : !flow.dispatch.tensor<readwrite:1x225x225x3xf32> -> tensor<1x225x225x3xf32>
+// CHECK-NEXT:     %[[INSERT:.+]] = subtensor_insert %[[SRC_TENSOR]] into %[[DST_TENSOR]][0, 0, 0, 0] [1, 224, 224, 3] [1, 1, 1, 1]
+// CHECK-NEXT:     flow.dispatch.tensor.store %[[INSERT]], %[[DST]] : tensor<1x225x225x3xf32> -> !flow.dispatch.tensor<readwrite:1x225x225x3xf32>
+// CHECK-NEXT:     flow.return
+//
+//      CHECK:   return %[[PAD]] : tensor<1x225x225x3xf32>

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -279,8 +279,7 @@ iree_check_single_backend_test_suite(
         "minimum.mlir",
         "multiply.mlir",
         "negate.mlir",
-        # https://github.com/google/iree/issues/4079
-        # "pad.mlir",
+        "pad.mlir",
         # "reduce.mlir",
         # "reduce_window.mlir",
         "remainder.mlir",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -247,6 +247,7 @@ iree_check_single_backend_test_suite(
     "minimum.mlir"
     "multiply.mlir"
     "negate.mlir"
+    "pad.mlir"
     "remainder.mlir"
     "reshape.mlir"
     "reverse.mlir"


### PR DESCRIPTION
For each resultant tensor, DispatchWorkgroupsOp now can indicate
to which operand it ties to, in order to share the underlying
buffer storage. This can be used for subtensor_insert ops, where
we insert into the target tensor and also return the target
tensor as the result, which can happen as in-place update on
the buffer down the layers.

Addresses https://github.com/google/iree/issues/5042