### PR TITLE
Moving HLO tuple/control flow handling up to the TF importer.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/BUILD
@@ -22,6 +22,7 @@ cc_library(
     name = "TF",
     srcs = [
         "ConvertToMHLO.cpp",
+        "FlattenTuplesInCFG.cpp",
         "LowerExportedFunctions.cpp",
         "LowerGlobalTensors.cpp",
         "Passes.cpp",
@@ -57,7 +58,9 @@ cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:all_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/hlo:chlo_legalize_to_hlo",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:mhlo_to_mhlo_lowering_patterns",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:lower_tf_lib",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",

--- a/integrations/tensorflow/iree_tf_compiler/TF/FlattenTuplesInCFG.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/FlattenTuplesInCFG.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree_tf_compiler/TF/Passes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
@@ -26,9 +26,8 @@
 #include "mlir/Transforms/Utils.h"
 
 namespace mlir {
-namespace iree_compiler {
-namespace IREE {
-namespace Flow {
+namespace iree_integrations {
+namespace TF {
 
 namespace {
 
@@ -330,10 +329,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createFlattenTuplesInCFGPass() {
 }
 
 static PassRegistration<FlattenTuplesInCFGPass> pass(
-    "iree-flow-flatten-tuples-in-cfg",
+    "iree-tf-flatten-tuples-in-cfg",
     "Convert functions to remove tuples from method signatures and blocks");
 
-}  // namespace Flow
-}  // namespace IREE
-}  // namespace iree_compiler
+}  // namespace TF
+}  // namespace iree_integrations
 }  // namespace mlir

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
@@ -42,6 +42,9 @@ void registerTFImportPassPipeline();
 // Converts the TF dialect to the XLA MHLO dialect.
 std::unique_ptr<FunctionPass> createConvertToMHLOPass();
 
+// Flattens tuple values in function signatures and blocks.
+std::unique_ptr<OperationPass<ModuleOp>> createFlattenTuplesInCFGPass();
+
 // In a module tagged with `tf_saved_model.semantics`, lowers
 // `tf_saved_model.global_variable`'s to `flow.variable`'s.
 //
@@ -74,6 +77,7 @@ inline void registerAllPasses() {
   registerTFImportPassPipeline();
 
   createConvertToMHLOPass();
+  createFlattenTuplesInCFGPass();
   createLowerGlobalTensorsPass();
   createLowerExportedFunctionsPass();
   createPropagateResourceCastsPass();

--- a/iree/compiler/Bindings/SIP/Transforms/Passes.cpp
+++ b/iree/compiler/Bindings/SIP/Transforms/Passes.cpp
@@ -27,14 +27,6 @@ namespace IREE {
 namespace SIP {
 
 void buildTransformPassPipeline(OpPassManager &passManager) {
-  // Run inlining to avoid issues with flatten tuples in cfg and tf.while & co.
-  // This should not be required if we are going to linalg in the importer.
-  passManager.addPass(createInlinerPass());
-
-  // Currently SIP can't handle tuples; we probably want to make it handle them
-  // if we expect them to be in the inputs.
-  passManager.addPass(IREE::Flow::createFlattenTuplesInCFGPass());
-
   // Materialize default arg/result reflection metadata.
   // This pass must come before any 1:N type expansion that will not be retained
   // in the public ABI (i.e. loose shape dims, etc).

--- a/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/ConvertStandardToFlow.cpp
+++ b/iree/compiler/Dialect/Flow/Conversion/StandardToFlow/ConvertStandardToFlow.cpp
@@ -37,7 +37,7 @@ struct ExtractElementOpLowering : public OpRewritePattern<tensor::ExtractOp> {
     }
     // tensor<i1> is not valid to load, it needs to be converted to i8 or
     // something else instead.
-    if (tensorType.getElementTypeBitWidth() == 1) {
+    if (tensorType.getElementType().isInteger(1)) {
       return rewriter.notifyMatchFailure(op, "expected non-i1 type");
     }
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorLoadOp>(

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -98,7 +98,11 @@ namespace {
 static bool hasUsersInStreamAfterUpdate(Value value, Operation *updateOp) {
   for (auto user : value.getUsers()) {
     if (user == updateOp) continue;
-    if (user->isBeforeInBlock(updateOp)) continue;
+    if (user->getBlock() != updateOp->getBlock() ||
+        user->isBeforeInBlock(updateOp)) {
+      // From a dominating block or earlier in the block, cannot be a consumer.
+      continue;
+    }
     return true;
   }
   return false;

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -31,7 +31,6 @@ cc_library(
         "DispatchabilityAnalysis.cpp",
         "ExpandVariableDynamicDims.cpp",
         "ExportBenchmarkFuncs.cpp",
-        "FlattenTuplesInCFG.cpp",
         "FoldCompatibleDispatchRegions.cpp",
         "FormStreams.cpp",
         "HLOToHLOPreprocessing.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -26,7 +26,6 @@ iree_cc_library(
     "DispatchabilityAnalysis.cpp"
     "ExpandVariableDynamicDims.cpp"
     "ExportBenchmarkFuncs.cpp"
-    "FlattenTuplesInCFG.cpp"
     "FoldCompatibleDispatchRegions.cpp"
     "FormStreams.cpp"
     "HLOToHLOPreprocessing.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -65,9 +65,6 @@ void registerFlowTransformPassPipeline();
 // dispatch regions and could be represented as flow.tensor.* ops.
 std::unique_ptr<OperationPass<FuncOp>> createConvertToFlowTensorOpsPass();
 
-// Flattens tuple values in function signatures and blocks.
-std::unique_ptr<OperationPass<ModuleOp>> createFlattenTuplesInCFGPass();
-
 // Legalizes the input types to those supported by the flow dialect.
 // This will fail if types that cannot be supported at all are present, however
 // conditionally supported types (based on availability, etc) may still be
@@ -174,7 +171,6 @@ inline void registerFlowPasses() {
   registerInputTransformPassPipeline();
   registerFlowTransformPassPipeline();
   createConvertToFlowTensorOpsPass();
-  createFlattenTuplesInCFGPass();
   createLegalizeInputTypesPass();
   createHLOPreprocessingPass();
   createPrePartitioningConversionPass();

--- a/iree/compiler/Dialect/Flow/Transforms/PrePostPartitioningConversion.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/PrePostPartitioningConversion.cpp
@@ -48,7 +48,7 @@ struct ExtractElementOpPromotion
     if (!tensorType) {
       return rewriter.notifyMatchFailure(op, "expected tensor types");
     }
-    if (tensorType.getElementTypeBitWidth() != 1) {
+    if (!tensorType.getElementType().isInteger(1)) {
       return rewriter.notifyMatchFailure(op, "expected i1 type");
     }
     Location loc = op.getLoc();

--- a/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
@@ -38,17 +38,17 @@ module {
 
 // -----
 
-func @while(%start: tensor<i32>, %bound: tensor<i32>) -> tensor<i32> attributes { iree.module.export }  {
-  %res = "mhlo.while"(%start) ( {
-  ^bb0(%count: tensor<i32>):
-    %1 = "mhlo.compare"(%count, %bound) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
-    "mhlo.return"(%1) : (tensor<i1>) -> ()
-  },  {
-  ^bb0(%count: tensor<i32>):
-    %1 = mhlo.add %count, %count : tensor<i32>
-    "mhlo.return"(%1) : (tensor<i32>) -> ()
-  }) : (tensor<i32>) -> tensor<i32>
-  return %res : tensor<i32>
+func @while(%start: tensor<i32>, %bound: tensor<i32>) -> tensor<i32> attributes {iree.module.export} {
+  br ^bb1(%start : tensor<i32>)
+^bb1(%0: tensor<i32>):
+  %1 = "mhlo.compare"(%0, %bound) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %2 = tensor.extract %1[] : tensor<i1>
+  cond_br %2, ^bb2(%0 : tensor<i32>), ^bb3(%0 : tensor<i32>)
+^bb2(%3: tensor<i32>):
+  %4 = mhlo.add %3, %3 : tensor<i32>
+  br ^bb1(%4 : tensor<i32>)
+^bb3(%5: tensor<i32>):
+  return %5 : tensor<i32>
 }
 
 //     CHECK: flow.variable @_benchmark_input_0 dense<0> : tensor<i32> attributes {noinline, sym_visibility = "private"}

--- a/iree/test/e2e/models/fullyconnected.mlir
+++ b/iree/test/e2e/models/fullyconnected.mlir
@@ -5,7 +5,7 @@
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir -export-all %s -iree-hal-target-backends=vulkan-spirv  -iree-flow-dispatch-linalg-on-tensors -iree-codegen-spirv-experimental-linalg-on-tensors -function-input="1x5xf32=1,-2,-3,4,-5" -function-input="1x5x3x1xf32=15,14,13,12,11,10,9,8,7,6,5,4,3,2,1" | IreeFileCheck %s)
 
 // CHECK-LABEL: EXEC @main
-func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x3x1xf32>) -> tuple<tensor<5x1x5xf32>>
+func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x3x1xf32>) -> tensor<5x1x5xf32>
   attributes {iree.module.export} {
   %0 = "mhlo.reshape"(%arg0) {name = "reshape.3"} : (tensor<1x5xf32>) -> tensor<1x5xf32>
   %1 = "mhlo.transpose"(%0) {name = "transpose.41", permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<1x5xf32>) -> tensor<5x1xf32>
@@ -80,8 +80,7 @@ func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x3x1xf32>) -> tuple<tensor<5
   %52 = "mhlo.reshape"(%51) {name = "reshape.94"} : (tensor<5x5xf32>) -> tensor<5x1x5xf32>
   %53 = "mhlo.select"(%8, %9, %52) {name = "select.95"} : (tensor<5x1x5xi1>, tensor<5x1x5xf32>, tensor<5x1x5xf32>) -> tensor<5x1x5xf32>
   %54 = "mhlo.reshape"(%53) {name = "reshape.96"} : (tensor<5x1x5xf32>) -> tensor<5x1x5xf32>
-  %55 = "mhlo.tuple"(%54) {name = "tuple.97"} : (tensor<5x1x5xf32>) -> tuple<tensor<5x1x5xf32>>
-  return %55 : tuple<tensor<5x1x5xf32>>
+  return %54 : tensor<5x1x5xf32>
 }
 
 // On separate lines to avoid "[[" which IreeFileCheck interprets as substitutions

--- a/iree/test/e2e/models/unidirectional_lstm.mlir
+++ b/iree/test/e2e/models/unidirectional_lstm.mlir
@@ -11,242 +11,130 @@
 // extra whitespace. On top of that, the result was further trimmed by removing
 // some calls from @main and the call graphs of the removed callees.
 
-func private @Min_reduction.47(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  %0 = mhlo.minimum %arg0, %arg1 : tensor<f32>
-  return %0 : tensor<f32>
+func private @ForwardLoopCond_gFAnjWGSoLs__.167(%arg0: tensor<i64>, %arg1: tensor<i64>, %arg2: tensor<40xf32>, %arg3: tensor<i64>, %arg4: tensor<74x40xf32>, %arg5: tensor<i64>, %arg6: tensor<1x10xf32>, %arg7: tensor<1x10xf32>, %arg8: tensor<5x1x64xf32>, %arg9: tensor<5x1x1xf32>, %arg10: tensor<5x1x1xf32>, %arg11: tensor<5xi64>, %arg12: tensor<5x1x10xf32>, %arg13: tensor<5x1x10xf32>) -> tensor<i1> {
+  %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<i64>, tensor<i64>) -> tensor<i1>
+  return %0 : tensor<i1>
 }
-func private @Max_reduction.51(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  %0 = mhlo.maximum %arg0, %arg1 : tensor<i32>
-  return %0 : tensor<i32>
-}
-func private @Max_1_reduction.55(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
-  %0 = mhlo.maximum %arg0, %arg1 : tensor<i32>
-  return %0 : tensor<i32>
-}
-func private @ForwardLoopCond_gFAnjWGSoLs__.167(%arg0: tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tuple<tensor<i1>> {
-  %0 = "mhlo.get_tuple_element"(%arg0) {index = 0 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-  %1 = "mhlo.get_tuple_element"(%arg0) {index = 1 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-  %2 = "mhlo.compare"(%0, %1) {comparison_direction = "LT"} : (tensor<i64>, tensor<i64>) -> tensor<i1>
-  %3 = "mhlo.tuple"(%2) : (tensor<i1>) -> tuple<tensor<i1>>
-  return %3 : tuple<tensor<i1>>
-}
-func private @Forward_o16DF3vQKaI__disable_call_shape_inference_true_.189(%arg0: tensor<1x10xf32>, %arg1: tensor<1x10xf32>, %arg2: tensor<5x1x64xf32>, %arg3: tensor<5x1x1xf32>, %arg4: tensor<5x1x1xf32>) -> tuple<tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>> {
-  %cst = constant  dense<5> : tensor<i32>
-  %0 = "mhlo.convert"(%arg3) : (tensor<5x1x1xf32>) -> tensor<5x1x1xf32>
-  %cst_0 = constant dense<0x7F800000> : tensor<f32>
-  %1 = "mhlo.convert"(%cst_0) : (tensor<f32>) -> tensor<f32>
-  %2 = "mhlo.reduce"(%0, %1) ( {
-  ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):
-    %42 = mhlo.minimum %arg5, %arg6 : tensor<f32>
-    "mhlo.return"(%42) : (tensor<f32>) -> ()
+func private @Forward_o16DF3vQKaI__disable_call_shape_inference_true_.189(%arg0: tensor<1x10xf32>, %arg1: tensor<1x10xf32>, %arg2: tensor<5x1x64xf32>, %arg3: tensor<5x1x1xf32>, %arg4: tensor<5x1x1xf32>) -> (tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>) {
+  %cst = constant dense<0x7F800000> : tensor<f32>
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<5xf32>
+  %cst_0 = constant dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
+  %cst_1 = constant dense<-2147483648> : tensor<i32>
+  %cst_2 = constant dense<5> : tensor<i32>
+  %1 = mhlo.constant dense<0.000000e+00> : tensor<40xf32>
+  %cst_3 = constant dense<4.200000e-01> : tensor<74x40xf32>
+  %cst_4 = constant dense<0> : tensor<i64>
+  %2 = mhlo.constant dense<0> : tensor<5xi64>
+  %3 = mhlo.constant dense<0.000000e+00> : tensor<5x1x10xf32>
+  %cst_5 = constant dense<1> : tensor<i64>
+  %4 = mhlo.constant dense<1.000000e+01> : tensor<1x10xf32>
+  %5 = mhlo.constant dense<-1.000000e+01> : tensor<1x10xf32>
+  %6 = mhlo.constant dense<1.000000e+00> : tensor<1x10xf32>
+  %7 = mhlo.constant dense<0.000000e+00> : tensor<1x10xf32>
+  %8 = mhlo.constant dense<5.000000e-01> : tensor<1x10xf32>
+  %cst_6 = constant dense<0> : tensor<i32>
+  %9 = "mhlo.reduce"(%arg3, %cst) ( {
+  ^bb0(%arg5: tensor<f32>, %arg6: tensor<f32>):  // no predecessors
+    %115 = mhlo.minimum %arg5, %arg6 : tensor<f32>
+    "mhlo.return"(%115) : (tensor<f32>) -> ()
   }) {dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<5x1x1xf32>, tensor<f32>) -> tensor<5xf32>
-  %3 = "mhlo.convert"(%2) : (tensor<5xf32>) -> tensor<5xf32>
-  %cst_1 = constant  dense<0.000000e+00> : tensor<f32>
-  %4 = "mhlo.broadcast_in_dim"(%cst_1) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<5xf32>
-  %5 = "mhlo.compare"(%3, %4) {comparison_direction = "EQ"} : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xi1>
-  %6 = "mhlo.convert"(%5) : (tensor<5xi1>) -> tensor<5xi32>
-  %cst_2 = constant  dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
-  %7 = mhlo.multiply %6, %cst_2 : tensor<5xi32>
-  %8 = "mhlo.convert"(%7) : (tensor<5xi32>) -> tensor<5xi32>
-  %cst_3 = constant dense<-2147483648> : tensor<i32>
-  %9 = "mhlo.convert"(%cst_3) : (tensor<i32>) -> tensor<i32>
-  %10 = "mhlo.reduce"(%8, %9) ( {
-  ^bb0(%arg5: tensor<i32>, %arg6: tensor<i32>):
-    %42 = mhlo.maximum %arg5, %arg6 : tensor<i32>
-    "mhlo.return"(%42) : (tensor<i32>) -> ()
+  %10 = "mhlo.compare"(%9, %0) {comparison_direction = "EQ"} : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xi1>
+  %11 = "mhlo.convert"(%10) : (tensor<5xi1>) -> tensor<5xi32>
+  %12 = mhlo.multiply %11, %cst_0 : tensor<5xi32>
+  %13 = "mhlo.reduce"(%12, %cst_1) ( {
+  ^bb0(%arg5: tensor<i32>, %arg6: tensor<i32>):  // no predecessors
+    %115 = mhlo.maximum %arg5, %arg6 : tensor<i32>
+    "mhlo.return"(%115) : (tensor<i32>) -> ()
   }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5xi32>, tensor<i32>) -> tensor<i32>
-  %11 = "mhlo.convert"(%10) : (tensor<i32>) -> tensor<i32>
-  %12 = mhlo.subtract %cst, %11 : tensor<i32>
-  %cst_4 = constant dense<5> : tensor<i32>
-  %13 = "mhlo.compare"(%12, %cst_4) {comparison_direction = "EQ"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
-  %cst_5 = constant dense<0> : tensor<i32>
-  %cst_6 = constant dense<5> : tensor<i32>
-  %14 = "mhlo.reverse"(%3) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5xf32>) -> tensor<5xf32>
-  %cst_7 = constant dense<0.000000e+00> : tensor<f32>
-  %15 = "mhlo.broadcast_in_dim"(%cst_7) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<5xf32>
-  %16 = "mhlo.compare"(%14, %15) {comparison_direction = "EQ"} : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xi1>
-  %17 = "mhlo.convert"(%16) : (tensor<5xi1>) -> tensor<5xi32>
-  %cst_8 = constant  dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
-  %18 = mhlo.multiply %17, %cst_8 : tensor<5xi32>
-  %19 = "mhlo.convert"(%18) : (tensor<5xi32>) -> tensor<5xi32>
-  %cst_9 = constant dense<-2147483648> : tensor<i32>
-  %20 = "mhlo.convert"(%cst_9) : (tensor<i32>) -> tensor<i32>
-  %21 = "mhlo.reduce"(%19, %20) ( {
-  ^bb0(%arg5: tensor<i32>, %arg6: tensor<i32>):
-    %42 = mhlo.maximum %arg5, %arg6 : tensor<i32>
-    "mhlo.return"(%42) : (tensor<i32>) -> ()
+  %14 = mhlo.subtract %cst_2, %13 : tensor<i32>
+  %15 = "mhlo.compare"(%14, %cst_2) {comparison_direction = "EQ"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %16 = "mhlo.reverse"(%9) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5xf32>) -> tensor<5xf32>
+  %17 = "mhlo.compare"(%16, %0) {comparison_direction = "EQ"} : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xi1>
+  %18 = "mhlo.convert"(%17) : (tensor<5xi1>) -> tensor<5xi32>
+  %19 = mhlo.multiply %18, %cst_0 : tensor<5xi32>
+  %20 = "mhlo.reduce"(%19, %cst_1) ( {
+  ^bb0(%arg5: tensor<i32>, %arg6: tensor<i32>):  // no predecessors
+    %115 = mhlo.maximum %arg5, %arg6 : tensor<i32>
+    "mhlo.return"(%115) : (tensor<i32>) -> ()
   }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5xi32>, tensor<i32>) -> tensor<i32>
-  %22 = "mhlo.convert"(%21) : (tensor<i32>) -> tensor<i32>
-  %23 = mhlo.subtract %cst_6, %22 : tensor<i32>
-  %24 = "mhlo.select"(%13, %cst_5, %23) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
+  %21 = mhlo.subtract %cst_2, %20 : tensor<i32>
+  %22 = "mhlo.select"(%15, %cst_6, %21) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
+  %23 = "mhlo.convert"(%22) : (tensor<i32>) -> tensor<i64>
+  %24 = mhlo.subtract %cst_2, %14 : tensor<i32>
   %25 = "mhlo.convert"(%24) : (tensor<i32>) -> tensor<i64>
-  %cst_10 = constant dense<5> : tensor<i32>
-  %26 = mhlo.subtract %cst_10, %12 : tensor<i32>
-  %27 = "mhlo.convert"(%26) : (tensor<i32>) -> tensor<i64>
-  %cst_11 = constant dense<0.000000e+00> : tensor<f32>
-  %28 = "mhlo.broadcast_in_dim"(%cst_11) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<40xf32>
-  %cst_12 = constant  dense<0> : tensor<i64>
-  %cst_13 = constant  dense<0.42> : tensor<74x40xf32>
-  %cst_14 = constant  dense<0> : tensor<i64>
-  %cst_15 = constant  dense<0> : tensor<i64>
-  %29 = "mhlo.broadcast_in_dim"(%cst_15) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<i64>) -> tensor<5xi64>
-  %cst_16 = constant dense<0.000000e+00> : tensor<f32>
-  %30 = "mhlo.broadcast_in_dim"(%cst_16) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<5x1x10xf32>
-  %cst_17 = constant dense<0.000000e+00> : tensor<f32>
-  %31 = "mhlo.broadcast_in_dim"(%cst_17) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<5x1x10xf32>
-  %32 = "mhlo.tuple"(%25, %27, %28, %cst_12, %cst_13, %cst_14, %arg0, %arg1, %arg2, %arg3, %arg4, %29, %30, %31) : (tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>) -> tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>
-  %33 = "mhlo.while"(%32) ( {
-  ^bb0(%arg5: tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>):
-    %42 = call @ForwardLoopCond_gFAnjWGSoLs__.167(%arg5) : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tuple<tensor<i1>>
-    %43 = "mhlo.get_tuple_element"(%42) {index = 0 : i32} : (tuple<tensor<i1>>) -> tensor<i1>
-    "mhlo.return"(%43) : (tensor<i1>) -> ()
-  },  {
-  ^bb0(%arg5: tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>):
-    %42 = "mhlo.get_tuple_element"(%arg5) {index = 0 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-    %cst_18 = constant dense<1> : tensor<i64>
-    %43 = mhlo.add %42, %cst_18 : tensor<i64>
-    %44 = "mhlo.get_tuple_element"(%arg5) {index = 1 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-    %45 = "mhlo.get_tuple_element"(%arg5) {index = 2 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<40xf32>
-    %46 = "mhlo.get_tuple_element"(%arg5) {index = 3 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-    %47 = "mhlo.get_tuple_element"(%arg5) {index = 4 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<74x40xf32>
-    %48 = "mhlo.get_tuple_element"(%arg5) {index = 5 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-    %49 = "mhlo.get_tuple_element"(%arg5) {index = 9 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x1xf32>
-    %50 = "mhlo.gather"(%49, %42) {dimension_numbers = {collapsed_slice_dims = dense<0> : tensor<1xi64>, index_vector_dim = 0 : i64, offset_dims = dense<[0, 1]> : tensor<2xi64>, start_index_map = dense<0> : tensor<1xi64>}, slice_sizes = dense<1> : tensor<3xi64>, start_index_map = dense<0> : tensor<1xi64>} : (tensor<5x1x1xf32>, tensor<i64>) -> tensor<1x1xf32>
-    %51 = "mhlo.reshape"(%50) : (tensor<1x1xf32>) -> tensor<1xf32>
-    %52 = "mhlo.broadcast_in_dim"(%51) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xf32>) -> tensor<1x10xf32>
-    %cst_19 = constant dense<1.000000e+00> : tensor<f32>
-    %53 = "mhlo.broadcast_in_dim"(%cst_19) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %54 = mhlo.multiply %52, %53 : tensor<1x10xf32>
-    %cst_20 = constant dense<0.000000e+00> : tensor<f32>
-    %55 = "mhlo.broadcast_in_dim"(%cst_20) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %56 = "mhlo.compare"(%54, %55) {comparison_direction = "GT"} : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xi1>
-    %57 = "mhlo.get_tuple_element"(%arg5) {index = 6 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<1x10xf32>
-    %cst_21 = constant dense<5.000000e-01> : tensor<f32>
-    %58 = "mhlo.broadcast_in_dim"(%cst_21) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %59 = "mhlo.broadcast_in_dim"(%cst_21) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %60 = "mhlo.broadcast_in_dim"(%cst_21) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %61 = "mhlo.get_tuple_element"(%arg5) {index = 8 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x64xf32>
-    %62 = "mhlo.gather"(%61, %42) {dimension_numbers = {collapsed_slice_dims = dense<0> : tensor<1xi64>, index_vector_dim = 0 : i64, offset_dims = dense<[0, 1]> : tensor<2xi64>, start_index_map = dense<0> : tensor<1xi64>}, slice_sizes = dense<[1, 1, 64]> : tensor<3xi64>} : (tensor<5x1x64xf32>, tensor<i64>) -> tensor<1x64xf32>
-    %63 = "mhlo.get_tuple_element"(%arg5) {index = 7 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<1x10xf32>
-    %64 = "mhlo.concatenate"(%62, %63) {dimension = 1 : i64} : (tensor<1x64xf32>, tensor<1x10xf32>) -> tensor<1x74xf32>
-    %65 = "mhlo.dot"(%64, %47) {precision_config = ["DEFAULT", "DEFAULT"]} : (tensor<1x74xf32>, tensor<74x40xf32>) -> tensor<1x40xf32>
-    %66 = "mhlo.transpose"(%65) {permutation = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x40xf32>
-    %67 = "mhlo.reshape"(%45) : (tensor<40xf32>) -> tensor<1x40xf32>
-    %68 = mhlo.add %66, %67 : tensor<1x40xf32>
-    %69 = "mhlo.slice"(%68) {limit_indices = dense<[1, 30]> : tensor<2xi64>, start_indices = dense<[0, 20]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
-    %70 = mhlo.multiply %60, %69 : tensor<1x10xf32>
-    %71 = "mhlo.tanh"(%70) : (tensor<1x10xf32>) -> tensor<1x10xf32>
-    %72 = mhlo.multiply %59, %71 : tensor<1x10xf32>
-    %73 = mhlo.add %58, %72 : tensor<1x10xf32>
-    %74 = mhlo.multiply %73, %57 : tensor<1x10xf32>
-    %cst_22 = constant dense<5.000000e-01> : tensor<f32>
-    %75 = "mhlo.broadcast_in_dim"(%cst_22) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %76 = "mhlo.broadcast_in_dim"(%cst_22) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %77 = "mhlo.broadcast_in_dim"(%cst_22) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %78 = "mhlo.slice"(%68) {limit_indices = dense<[1, 20]> : tensor<2xi64>, start_indices = dense<[0, 10]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
-    %79 = mhlo.multiply %77, %78 : tensor<1x10xf32>
-    %80 = "mhlo.tanh"(%79) : (tensor<1x10xf32>) -> tensor<1x10xf32>
-    %81 = mhlo.multiply %76, %80 : tensor<1x10xf32>
-    %82 = mhlo.add %75, %81 : tensor<1x10xf32>
-    %83 = "mhlo.slice"(%68) {limit_indices = dense<[1, 10]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
-    %84 = "mhlo.tanh"(%83) : (tensor<1x10xf32>) -> tensor<1x10xf32>
-    %85 = mhlo.multiply %82, %84 : tensor<1x10xf32>
-    %86 = mhlo.add %74, %85 : tensor<1x10xf32>
-    %cst_23 = constant dense<1.000000e+01> : tensor<f32>
-    %87 = "mhlo.broadcast_in_dim"(%cst_23) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %88 = mhlo.minimum %86, %87 : tensor<1x10xf32>
-    %cst_24 = constant dense<-1.000000e+01> : tensor<f32>
-    %89 = "mhlo.broadcast_in_dim"(%cst_24) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %90 = mhlo.maximum %88, %89 : tensor<1x10xf32>
-    %91 = "mhlo.select"(%56, %57, %90) : (tensor<1x10xi1>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
-    %92 = "mhlo.reshape"(%50) : (tensor<1x1xf32>) -> tensor<1xf32>
-    %93 = "mhlo.broadcast_in_dim"(%92) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xf32>) -> tensor<1x10xf32>
-    %cst_25 = constant dense<1.000000e+00> : tensor<f32>
-    %94 = "mhlo.broadcast_in_dim"(%cst_25) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %95 = mhlo.multiply %93, %94 : tensor<1x10xf32>
-    %cst_26 = constant dense<0.000000e+00> : tensor<f32>
-    %96 = "mhlo.broadcast_in_dim"(%cst_26) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %97 = "mhlo.compare"(%95, %96) {comparison_direction = "GT"} : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xi1>
-    %cst_27 = constant dense<5.000000e-01> : tensor<f32>
-    %98 = "mhlo.broadcast_in_dim"(%cst_27) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %99 = "mhlo.broadcast_in_dim"(%cst_27) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %100 = "mhlo.broadcast_in_dim"(%cst_27) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-    %101 = "mhlo.slice"(%68) {limit_indices = dense<[1, 40]> : tensor<2xi64>, start_indices = dense<[0, 30]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
-    %102 = mhlo.multiply %100, %101 : tensor<1x10xf32>
-    %103 = "mhlo.tanh"(%102) : (tensor<1x10xf32>) -> tensor<1x10xf32>
-    %104 = mhlo.multiply %99, %103 : tensor<1x10xf32>
-    %105 = mhlo.add %98, %104 : tensor<1x10xf32>
-    %106 = "mhlo.tanh"(%90) : (tensor<1x10xf32>) -> tensor<1x10xf32>
-    %107 = mhlo.multiply %105, %106 : tensor<1x10xf32>
-    %108 = "mhlo.select"(%97, %63, %107) : (tensor<1x10xi1>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
-    %109 = "mhlo.get_tuple_element"(%arg5) {index = 10 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x1xf32>
-    %110 = "mhlo.get_tuple_element"(%arg5) {index = 11 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5xi64>
-    %111 = "mhlo.reshape"(%48) : (tensor<i64>) -> tensor<1xi64>
-    %112 = "mhlo.slice"(%111) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<1xi64>
-    %113 = "mhlo.reshape"(%42) : (tensor<i64>) -> tensor<1xi64>
-    %114 = "mhlo.concatenate"(%113) {dimension = 0 : i64} : (tensor<1xi64>) -> tensor<1xi64>
-    %115 = "mhlo.convert"(%114) : (tensor<1xi64>) -> tensor<1xi32>
-    %116 = "mhlo.slice"(%115) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
-    %117 = "mhlo.reshape"(%116) : (tensor<1xi32>) -> tensor<i32>
-    %118 = "mhlo.dynamic-update-slice"(%110, %112, %117) : (tensor<5xi64>, tensor<1xi64>, tensor<i32>) -> tensor<5xi64>
-    %119 = "mhlo.get_tuple_element"(%arg5) {index = 12 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x10xf32>
-    %120 = "mhlo.reshape"(%91) : (tensor<1x10xf32>) -> tensor<1x1x10xf32>
-    %121 = "mhlo.slice"(%120) {limit_indices = dense<[1, 1, 10]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<1x1x10xf32>) -> tensor<1x1x10xf32>
-    %122 = "mhlo.slice"(%115) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
-    %123 = "mhlo.reshape"(%122) : (tensor<1xi32>) -> tensor<i32>
-    %cst_28 = constant dense<0> : tensor<i32>
-    %124 = "mhlo.dynamic-update-slice"(%119, %121, %123, %cst_28, %cst_28) : (tensor<5x1x10xf32>, tensor<1x1x10xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x1x10xf32>
-    %125 = "mhlo.get_tuple_element"(%arg5) {index = 13 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x10xf32>
-    %126 = "mhlo.reshape"(%108) : (tensor<1x10xf32>) -> tensor<1x1x10xf32>
-    %127 = "mhlo.slice"(%126) {limit_indices = dense<[1, 1, 10]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<1x1x10xf32>) -> tensor<1x1x10xf32>
-    %128 = "mhlo.slice"(%115) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
-    %129 = "mhlo.reshape"(%128) : (tensor<1xi32>) -> tensor<i32>
-    %cst_29 = constant dense<0> : tensor<i32>
-    %130 = "mhlo.dynamic-update-slice"(%125, %127, %129, %cst_29, %cst_29) : (tensor<5x1x10xf32>, tensor<1x1x10xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x1x10xf32>
-    %131 = "mhlo.tuple"(%43, %44, %45, %46, %47, %48, %91, %108, %61, %49, %109, %118, %124, %130) : (tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>) -> tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>
-    "mhlo.return"(%131) : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> ()
-  }) : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>
-  %34 = "mhlo.get_tuple_element"(%33) {index = 0 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-  %35 = "mhlo.get_tuple_element"(%33) {index = 11 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5xi64>
-  %36 = "mhlo.get_tuple_element"(%33) {index = 12 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x10xf32>
-  %37 = "mhlo.get_tuple_element"(%33) {index = 13 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<5x1x10xf32>
-  %38 = "mhlo.get_tuple_element"(%33) {index = 5 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<i64>
-  %39 = "mhlo.get_tuple_element"(%33) {index = 6 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<1x10xf32>
-  %40 = "mhlo.get_tuple_element"(%33) {index = 7 : i32} : (tuple<tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>>) -> tensor<1x10xf32>
-  %41 = "mhlo.tuple"(%34, %35, %36, %37, %38, %39, %40) : (tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>) -> tuple<tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>>
-  return %41 : tuple<tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>>
+  br ^bb1(%23, %25, %1, %cst_4, %cst_3, %cst_4, %arg0, %arg1, %arg2, %arg3, %arg4, %2, %3, %3 : tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>)
+^bb1(%26: tensor<i64>, %27: tensor<i64>, %28: tensor<40xf32>, %29: tensor<i64>, %30: tensor<74x40xf32>, %31: tensor<i64>, %32: tensor<1x10xf32>, %33: tensor<1x10xf32>, %34: tensor<5x1x64xf32>, %35: tensor<5x1x1xf32>, %36: tensor<5x1x1xf32>, %37: tensor<5xi64>, %38: tensor<5x1x10xf32>, %39: tensor<5x1x10xf32>):  // 2 preds: ^bb0, ^bb2
+  %40 = call @ForwardLoopCond_gFAnjWGSoLs__.167(%26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, %38, %39) : (tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>) -> tensor<i1>
+  %41 = tensor.extract %40[] : tensor<i1>
+  cond_br %41, ^bb2(%26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, %38, %39 : tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>), ^bb3(%26, %31, %32, %33, %37, %38, %39 : tensor<i64>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>)
+^bb2(%42: tensor<i64>, %43: tensor<i64>, %44: tensor<40xf32>, %45: tensor<i64>, %46: tensor<74x40xf32>, %47: tensor<i64>, %48: tensor<1x10xf32>, %49: tensor<1x10xf32>, %50: tensor<5x1x64xf32>, %51: tensor<5x1x1xf32>, %52: tensor<5x1x1xf32>, %53: tensor<5xi64>, %54: tensor<5x1x10xf32>, %55: tensor<5x1x10xf32>):  // pred: ^bb1
+  %56 = mhlo.add %42, %cst_5 : tensor<i64>
+  %57 = "mhlo.gather"(%51, %42) {dimension_numbers = {collapsed_slice_dims = dense<0> : tensor<1xi64>, index_vector_dim = 0 : i64, offset_dims = dense<[0, 1]> : tensor<2xi64>, start_index_map = dense<0> : tensor<1xi64>}, slice_sizes = dense<1> : tensor<3xi64>, start_index_map = dense<0> : tensor<1xi64>} : (tensor<5x1x1xf32>, tensor<i64>) -> tensor<1x1xf32>
+  %58 = "mhlo.reshape"(%57) : (tensor<1x1xf32>) -> tensor<1xf32>
+  %59 = "mhlo.broadcast_in_dim"(%58) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xf32>) -> tensor<1x10xf32>
+  %60 = mhlo.multiply %59, %6 : tensor<1x10xf32>
+  %61 = "mhlo.compare"(%60, %7) {comparison_direction = "GT"} : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xi1>
+  %62 = "mhlo.gather"(%50, %42) {dimension_numbers = {collapsed_slice_dims = dense<0> : tensor<1xi64>, index_vector_dim = 0 : i64, offset_dims = dense<[0, 1]> : tensor<2xi64>, start_index_map = dense<0> : tensor<1xi64>}, slice_sizes = dense<[1, 1, 64]> : tensor<3xi64>} : (tensor<5x1x64xf32>, tensor<i64>) -> tensor<1x64xf32>
+  %63 = "mhlo.concatenate"(%62, %49) {dimension = 1 : i64} : (tensor<1x64xf32>, tensor<1x10xf32>) -> tensor<1x74xf32>
+  %64 = "mhlo.dot"(%63, %46) {precision_config = ["DEFAULT", "DEFAULT"]} : (tensor<1x74xf32>, tensor<74x40xf32>) -> tensor<1x40xf32>
+  %65 = "mhlo.reshape"(%44) : (tensor<40xf32>) -> tensor<1x40xf32>
+  %66 = mhlo.add %64, %65 : tensor<1x40xf32>
+  %67 = "mhlo.slice"(%66) {limit_indices = dense<[1, 30]> : tensor<2xi64>, start_indices = dense<[0, 20]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
+  %68 = mhlo.multiply %67, %8 : tensor<1x10xf32>
+  %69 = "mhlo.tanh"(%68) : (tensor<1x10xf32>) -> tensor<1x10xf32>
+  %70 = mhlo.multiply %69, %8 : tensor<1x10xf32>
+  %71 = mhlo.add %70, %8 : tensor<1x10xf32>
+  %72 = mhlo.multiply %71, %48 : tensor<1x10xf32>
+  %73 = "mhlo.slice"(%66) {limit_indices = dense<[1, 20]> : tensor<2xi64>, start_indices = dense<[0, 10]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
+  %74 = mhlo.multiply %73, %8 : tensor<1x10xf32>
+  %75 = "mhlo.tanh"(%74) : (tensor<1x10xf32>) -> tensor<1x10xf32>
+  %76 = mhlo.multiply %75, %8 : tensor<1x10xf32>
+  %77 = mhlo.add %76, %8 : tensor<1x10xf32>
+  %78 = "mhlo.slice"(%66) {limit_indices = dense<[1, 10]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
+  %79 = "mhlo.tanh"(%78) : (tensor<1x10xf32>) -> tensor<1x10xf32>
+  %80 = mhlo.multiply %77, %79 : tensor<1x10xf32>
+  %81 = mhlo.add %72, %80 : tensor<1x10xf32>
+  %82 = mhlo.minimum %81, %4 : tensor<1x10xf32>
+  %83 = mhlo.maximum %82, %5 : tensor<1x10xf32>
+  %84 = "mhlo.select"(%61, %48, %83) : (tensor<1x10xi1>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
+  %85 = "mhlo.reshape"(%57) : (tensor<1x1xf32>) -> tensor<1xf32>
+  %86 = "mhlo.broadcast_in_dim"(%85) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xf32>) -> tensor<1x10xf32>
+  %87 = mhlo.multiply %86, %6 : tensor<1x10xf32>
+  %88 = "mhlo.compare"(%87, %7) {comparison_direction = "GT"} : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xi1>
+  %89 = "mhlo.slice"(%66) {limit_indices = dense<[1, 40]> : tensor<2xi64>, start_indices = dense<[0, 30]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x40xf32>) -> tensor<1x10xf32>
+  %90 = mhlo.multiply %89, %8 : tensor<1x10xf32>
+  %91 = "mhlo.tanh"(%90) : (tensor<1x10xf32>) -> tensor<1x10xf32>
+  %92 = mhlo.multiply %91, %8 : tensor<1x10xf32>
+  %93 = mhlo.add %92, %8 : tensor<1x10xf32>
+  %94 = "mhlo.tanh"(%83) : (tensor<1x10xf32>) -> tensor<1x10xf32>
+  %95 = mhlo.multiply %93, %94 : tensor<1x10xf32>
+  %96 = "mhlo.select"(%88, %49, %95) : (tensor<1x10xi1>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
+  %97 = "mhlo.reshape"(%47) : (tensor<i64>) -> tensor<1xi64>
+  %98 = "mhlo.reshape"(%42) : (tensor<i64>) -> tensor<1xi64>
+  %99 = "mhlo.convert"(%98) : (tensor<1xi64>) -> tensor<1xi32>
+  %100 = "mhlo.reshape"(%99) : (tensor<1xi32>) -> tensor<i32>
+  %101 = "mhlo.dynamic-update-slice"(%53, %97, %100) : (tensor<5xi64>, tensor<1xi64>, tensor<i32>) -> tensor<5xi64>
+  %102 = "mhlo.reshape"(%84) : (tensor<1x10xf32>) -> tensor<1x1x10xf32>
+  %103 = "mhlo.reshape"(%99) : (tensor<1xi32>) -> tensor<i32>
+  %104 = "mhlo.dynamic-update-slice"(%54, %102, %103, %cst_6, %cst_6) : (tensor<5x1x10xf32>, tensor<1x1x10xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x1x10xf32>
+  %105 = "mhlo.reshape"(%96) : (tensor<1x10xf32>) -> tensor<1x1x10xf32>
+  %106 = "mhlo.reshape"(%99) : (tensor<1xi32>) -> tensor<i32>
+  %107 = "mhlo.dynamic-update-slice"(%55, %105, %106, %cst_6, %cst_6) : (tensor<5x1x10xf32>, tensor<1x1x10xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x1x10xf32>
+  br ^bb1(%56, %43, %44, %45, %46, %47, %84, %96, %50, %51, %52, %101, %104, %107 : tensor<i64>, tensor<i64>, tensor<40xf32>, tensor<i64>, tensor<74x40xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>)
+^bb3(%108: tensor<i64>, %109: tensor<i64>, %110: tensor<1x10xf32>, %111: tensor<1x10xf32>, %112: tensor<5xi64>, %113: tensor<5x1x10xf32>, %114: tensor<5x1x10xf32>):  // pred: ^bb1
+  return %108, %112, %113, %114, %109, %110, %111 : tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>
 }
-
-// CHECK-LABEL: EXEC @main
-func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x2x2xf32>) -> tuple<tensor<5x1x10xf32>> attributes { iree.module.export } {
+func @main(%arg0: tensor<1x5xf32>, %arg1: tensor<1x5x2x2xf32>) -> tensor<5x1x10xf32> attributes {iree.module.export} {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<1x10xf32>
   %cst = constant dense<0.000000e+00> : tensor<f32>
-  %0 = "mhlo.broadcast_in_dim"(%cst) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %cst_0 = constant dense<0.000000e+00> : tensor<f32>
-  %1 = "mhlo.broadcast_in_dim"(%cst_0) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %cst_1 = constant dense<0.000000e+00> : tensor<f32>
-  %2 = "mhlo.broadcast_in_dim"(%cst_1) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %cst_2 = constant dense<0.000000e+00> : tensor<f32>
-  %3 = "mhlo.broadcast_in_dim"(%cst_2) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %cst_3 = constant dense<0.000000e+00> : tensor<f32>
-  %4 = "mhlo.broadcast_in_dim"(%cst_3) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %cst_4 = constant dense<0.000000e+00> : tensor<f32>
-  %5 = "mhlo.broadcast_in_dim"(%cst_4) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<1x10xf32>
-  %6 = "mhlo.reshape"(%arg1) : (tensor<1x5x2x2xf32>) -> tensor<1x5x2x2xf32>
-  %7 = "mhlo.reshape"(%6) : (tensor<1x5x2x2xf32>) -> tensor<1x5x4xf32>
-  %cst_5 = constant dense<0.000000e+00> : tensor<f32>
-  %8 = "mhlo.pad"(%7, %cst_5) {edge_padding_high = dense<[0, 0, 60]> : tensor<3xi64>, edge_padding_low = dense<0> : tensor<3xi64>, interior_padding = dense<0> : tensor<3xi64>} : (tensor<1x5x4xf32>, tensor<f32>) -> tensor<1x5x64xf32>
-  %9 = "mhlo.transpose"(%8) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<1x5x64xf32>) -> tensor<5x1x64xf32>
-  %10 = "mhlo.reshape"(%arg0) : (tensor<1x5xf32>) -> tensor<1x5xf32>
-  %11 = "mhlo.transpose"(%10) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<1x5xf32>) -> tensor<5x1xf32>
-  %12 = "mhlo.reshape"(%11) : (tensor<5x1xf32>) -> tensor<5x1x1xf32>
-  %cst_6 = constant dense<0.000000e+00> : tensor<f32>
-  %13 = "mhlo.broadcast_in_dim"(%cst_6) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (tensor<f32>) -> tensor<5x1x1xf32>
-  %14 = call @Forward_o16DF3vQKaI__disable_call_shape_inference_true_.189(%4, %5, %9, %12, %13) : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>) -> tuple<tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>>
-  %21 = "mhlo.get_tuple_element"(%14) {index = 3 : i32} : (tuple<tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>>) -> tensor<5x1x10xf32>
-  %22 = "mhlo.copy"(%21) : (tensor<5x1x10xf32>) -> tensor<5x1x10xf32>
-  %23 = "mhlo.reshape"(%22) : (tensor<5x1x10xf32>) -> tensor<5x1x10xf32>
-  %24 = "mhlo.tuple"(%23) : (tensor<5x1x10xf32>) -> tuple<tensor<5x1x10xf32>>
-  return %24 : tuple<tensor<5x1x10xf32>>
+  %1 = mhlo.constant dense<0.000000e+00> : tensor<5x1x1xf32>
+  %2 = "mhlo.reshape"(%arg1) : (tensor<1x5x2x2xf32>) -> tensor<1x5x4xf32>
+  %3 = "mhlo.pad"(%2, %cst) {edge_padding_high = dense<[0, 0, 60]> : tensor<3xi64>, edge_padding_low = dense<0> : tensor<3xi64>, interior_padding = dense<0> : tensor<3xi64>} : (tensor<1x5x4xf32>, tensor<f32>) -> tensor<1x5x64xf32>
+  %4 = "mhlo.transpose"(%3) {permutation = dense<[1, 0, 2]> : tensor<3xi64>} : (tensor<1x5x64xf32>) -> tensor<5x1x64xf32>
+  %5 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<1x5xf32>) -> tensor<5x1xf32>
+  %6 = "mhlo.reshape"(%5) : (tensor<5x1xf32>) -> tensor<5x1x1xf32>
+  %7:7 = call @Forward_o16DF3vQKaI__disable_call_shape_inference_true_.189(%0, %0, %4, %6, %1) : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<5x1x64xf32>, tensor<5x1x1xf32>, tensor<5x1x1xf32>) -> (tensor<i64>, tensor<5xi64>, tensor<5x1x10xf32>, tensor<5x1x10xf32>, tensor<i64>, tensor<1x10xf32>, tensor<1x10xf32>)
+  return %7#3 : tensor<5x1x10xf32>
 }
 
 // CHECK: 5x1x10xf32=

--- a/iree/test/e2e/xla_ops/while.mlir
+++ b/iree/test/e2e/xla_ops/while.mlir
@@ -1,15 +1,17 @@
-func @while() attributes { iree.module.export }  {
+// NOTE: this has already been legalized to CFG form in the TF import tools.
+func @while() attributes {iree.module.export} {
   %start = iree.unfoldable_constant dense<1> : tensor<i32>
   %bound = iree.unfoldable_constant dense<3> : tensor<i32>
-  %res = "mhlo.while"(%start) ( {
-  ^bb0(%count: tensor<i32>):
-    %1 = "mhlo.compare"(%count, %bound) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
-    "mhlo.return"(%1) : (tensor<i1>) -> ()
-  },  {
-  ^bb0(%count: tensor<i32>):
-    %1 = mhlo.add %count, %count : tensor<i32>
-    "mhlo.return"(%1) : (tensor<i32>) -> ()
-  }) : (tensor<i32>) -> tensor<i32>
-  check.expect_eq_const(%res, dense<4> : tensor<i32>) : tensor<i32>
+  %cst_1 = constant dense<4> : tensor<i32>
+  br ^bb1(%start : tensor<i32>)
+^bb1(%2: tensor<i32>):
+  %3 = "mhlo.compare"(%2, %bound) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %4 = tensor.extract %3[] : tensor<i1>
+  cond_br %4, ^bb2(%2 : tensor<i32>), ^bb3(%2 : tensor<i32>)
+^bb2(%5: tensor<i32>):
+  %6 = mhlo.add %5, %5 : tensor<i32>
+  br ^bb1(%6 : tensor<i32>)
+^bb3(%7: tensor<i32>):
+  check.expect_eq_const(%7, dense<4> : tensor<i32>) : tensor<i32>
   return
 }


### PR DESCRIPTION
This also allows us to receive HLO in SCF form as input, similar to how
TOSA is being imported.

The current HLO->SCF pass is only partially working, though, so we'll
still be going to CFG in all but the simple case it handles. I'd still
rather be working towards SCF as input, though, and this is a fine
placeholder.