### PR TITLE
Enable batch mode benchmarking on iree-android-benchmark

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -137,7 +137,7 @@ def get_s20_default_target_list(batch_config=None):
   return targets
 
 
-# The batch numbers are roughly computed to let it benchmark more then 3
+# The batch numbers are roughly computed to let it benchmark more than 3
 # seconds.
 # Do not set batch size on Pixel 4 for GPU targets, because it will get killed
 # after 2 seconds. See https://github.com/google/iree/issues/5052

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -47,6 +47,11 @@ class TargetInfo:
     """ Returns a string indicates the driver of the target."""
     return self.name.split("-")[0]
 
+  def add_batch_flag(self, size):
+    self.compilation_flags.append(
+        f"--iree-hal-benchmark-dispatch-repeat-count={size}")
+    self.runtime_flags.append(f"--batch_size={size}")
+
 
 class PhoneBenchmarkInfo:
   """Information of a phone.
@@ -83,8 +88,8 @@ class ModelBenchmarkInfo:
     self.phones = phones
 
 
-def get_pixel4_default_target_list():
-  return [
+def get_pixel4_default_target_list(batch_config={}):
+  targets = [
       TargetInfo(name="vmla", mako_tag="vmla"),
       TargetInfo(name="dylib-llvm-aot",
                  mako_tag="cpu",
@@ -100,10 +105,14 @@ def get_pixel4_default_target_list():
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10"
           ])
   ]
+  for target in targets:
+    if target.mako_tag in batch_config:
+      target.add_batch_flag(batch_config[target.mako_tag])
+  return targets
 
 
-def get_s20_default_target_list():
-  return [
+def get_s20_default_target_list(batch_config={}):
+  targets = [
       TargetInfo(name="vmla", mako_tag="vmla"),
       TargetInfo(name="dylib-llvm-aot",
                  mako_tag="cpu",
@@ -118,6 +127,10 @@ def get_s20_default_target_list():
                      "--iree-vulkan-target-triple=valhall-g77-unknown-android10"
                  ])
   ]
+  for target in targets:
+    if target.mako_tag in batch_config:
+      target.add_batch_flag(batch_config[target.mako_tag])
+  return targets
 
 
 MODEL_BENCHMARKS = [
@@ -127,10 +140,14 @@ MODEL_BENCHMARKS = [
         phones=[
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="5538704950034432",
-                               targets=get_pixel4_default_target_list()),
+                               targets=get_pixel4_default_target_list(
+                                   {'cpu': 16})),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="4699630718681088",
-                               targets=get_s20_default_target_list()),
+                               targets=get_s20_default_target_list({
+                                   'cpu': 16,
+                                   'vlk': 16
+                               })),
         ]),
     ModelBenchmarkInfo(
         name="mobilenet-v2",
@@ -138,10 +155,14 @@ MODEL_BENCHMARKS = [
         phones=[
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
-                               targets=get_pixel4_default_target_list()),
+                               targets=get_pixel4_default_target_list(
+                                   {'cpu': 8})),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="5618403088793600",
-                               targets=get_s20_default_target_list()),
+                               targets=get_s20_default_target_list({
+                                   'cpu': 16,
+                                   'vlk': 32
+                               })),
         ])
 ]
 

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -88,7 +88,9 @@ class ModelBenchmarkInfo:
     self.phones = phones
 
 
-def get_pixel4_default_target_list(batch_config={}):
+def get_pixel4_default_target_list(batch_config=None):
+  if batch_config is None:
+    batch_config = []
   targets = [
       TargetInfo(name="vmla", mako_tag="vmla"),
       TargetInfo(name="dylib-llvm-aot",
@@ -111,7 +113,9 @@ def get_pixel4_default_target_list(batch_config={}):
   return targets
 
 
-def get_s20_default_target_list(batch_config={}):
+def get_s20_default_target_list(batch_config=None):
+  if batch_config is None:
+    batch_config = []
   targets = [
       TargetInfo(name="vmla", mako_tag="vmla"),
       TargetInfo(name="dylib-llvm-aot",

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -133,6 +133,10 @@ def get_s20_default_target_list(batch_config={}):
   return targets
 
 
+# The batch numbers are roughly computed to let it benchmark more then 3
+# seconds.
+# Do not set batch size on Pixel 4 for GPU targets, because it will get killed
+# after 2 seconds. See https://github.com/google/iree/issues/5052
 MODEL_BENCHMARKS = [
     ModelBenchmarkInfo(
         name="mobile-bert",
@@ -141,11 +145,11 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="5538704950034432",
                                targets=get_pixel4_default_target_list(
-                                   {'cpu': 16})),
+                                   {'cpu': 8})),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="4699630718681088",
                                targets=get_s20_default_target_list({
-                                   'cpu': 16,
+                                   'cpu': 8,
                                    'vlk': 16
                                })),
         ]),
@@ -156,12 +160,12 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
                                targets=get_pixel4_default_target_list(
-                                   {'cpu': 8})),
+                                   {'cpu': 16})),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="5618403088793600",
                                targets=get_s20_default_target_list({
                                    'cpu': 16,
-                                   'vlk': 32
+                                   'vlk': 64
                                })),
         ])
 ]


### PR DESCRIPTION
This produces more stable numbers because it can amortize overhead in batch mode.

Due to issues on Pixel 4 GPU, we can't let it run more than two seconds. Otherwise it will get killed. Thus, the batch mode is not enabled for Pixel 4 GPU.

## Pixel 4

MobileBert - CPU: ~660 ms
MobileBert - GPU: ~952 ms (unchanged)
MobileNetV2 - CPU: ~380 ms
MobileNetV2 - GPU: ~1024 ms (unchanged)

## S20

MobileBert - CPU: ~750 ms
MobileBert - GPU: ~270 ms 
MobileNetV2 - CPU: ~266 ms
MobileNetV2 - GPU:  ~55 ms