### PR TITLE
Moving non-HLO linalg-on-tensors passes out of the HLO helpers.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensorPasses.h
@@ -39,11 +39,6 @@ std::unique_ptr<OperationPass<FuncOp>> createHLOToLinalgOnTensorsPass(
 void populateHLOToLinalgOnTensorsConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns);
 
-/// Populated passes to convert from MHLO to Linalg on tensors as well as fusion
-/// of the converted operations.
-void addHLOToLinalgOnTensorsPasses(OpPassManager &pm,
-                                   bool useLinalgOnTensorsPath = false);
-
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/Passes.cpp
@@ -24,18 +24,14 @@ namespace mlir {
 namespace iree_compiler {
 
 void addHLOToLinalgOnBuffersPasses(OpPassManager &pm) {
-  addHLOToLinalgOnTensorsPasses(pm);
-  pm.addNestedPass<FuncOp>(createHLOToLinalgOnBuffersPass());
-}
-
-void addHLOToLinalgOnTensorsPasses(OpPassManager &pm,
-                                   bool useLinalgOnTensorsPath) {
-  pm.addNestedPass<FuncOp>(
-      createHLOToLinalgOnTensorsPass(useLinalgOnTensorsPath));
+  // HACK: this is only for the old linalg-on-buffers path. It should be
+  // deleted.
+  pm.addNestedPass<FuncOp>(createHLOToLinalgOnTensorsPass(false));
   pm.addNestedPass<FuncOp>(createLinalgFoldUnitExtentDimsPass());
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());
   pm.addNestedPass<FuncOp>(createCSEPass());
+  pm.addNestedPass<FuncOp>(createHLOToLinalgOnBuffersPass());
 }
 
 static PassPipelineRegistration<> hloToLinalgOnBuffersPipeline(


### PR DESCRIPTION
This allows us to separate the common work (fusion, etc) from the HLO
specific work and eventually hoist HLO up and out of this pipeline.