### PR TITLE
Fix some issues in installed_test

### DIFF
--- a/build_tools/cmake/iree_installed_test.cmake
+++ b/build_tools/cmake/iree_installed_test.cmake
@@ -54,8 +54,8 @@ function(iree_add_installed_test)
   set_property(
     TEST
       ${_RULE_TEST_NAME}
-      PROPERTY LABELS
-        "${_RULE_LABELS}"
+    PROPERTY LABELS
+      "${_RULE_LABELS}"
   )
   set_property(
     TEST

--- a/build_tools/cmake/iree_installed_test.cmake
+++ b/build_tools/cmake/iree_installed_test.cmake
@@ -36,20 +36,39 @@ function(iree_add_installed_test)
     ${ARGN}
   )
 
+
   add_test(
-    NAME ${_RULE_TEST_NAME}
-    WORKING_DIRECTORY ${_RULE_WORKING_DIRECTORY}
+    NAME
+      ${_RULE_TEST_NAME}
     COMMAND
-        ${_RULE_COMMAND}
-    WORKING_DIRECTORY
-        "${CMAKE_BINARY_DIR}"
+      ${_RULE_COMMAND}
   )
-  set_property(TEST ${_RULE_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
-  set_property(TEST ${_RULE_TEST_NAME} PROPERTY ENVIRONMENT "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_NAME}_test_tmpdir" ${_RULE_ENVIRONMENT})
+  if (DEFINED _RULE_WORKING_DIRECTORY)
+    set_property(
+      TEST
+        ${_RULE_TEST_NAME}
+      PROPERTY WORKING_DIRECTORY
+        "${_RULE_WORKING_DIRECTORY}"
+    )
+  endif()
+  set_property(
+    TEST
+      ${_RULE_TEST_NAME}
+      PROPERTY LABELS
+        "${_RULE_LABELS}"
+  )
+  set_property(
+    TEST
+      ${_RULE_TEST_NAME}
+    PROPERTY ENVIRONMENT
+      "TEST_TMPDIR=${CMAKE_BINARY_DIR}/${_RULE_TEST_NAME}_test_tmpdir"
+      ${_RULE_ENVIRONMENT}
+  )
   iree_add_test_environment_properties(${_RULE_TEST_NAME})
 
   # Write the to the installed ctest file template.
-  set(_installed_ctest_input_file "${CMAKE_BINARY_DIR}/iree_installed_tests.cmake.in")
+  set(_installed_ctest_input_file
+        "${CMAKE_BINARY_DIR}/iree_installed_tests.cmake.in")
   get_property(_has_tests GLOBAL PROPERTY IREE_HAS_INSTALLED_TESTS)
   if(NOT _has_tests)
     # First time.


### PR DESCRIPTION
`TEST_TMPDIR` was being set based on an undefined variable `_NAME`,
which I guess we maybe happened to set in every invocation of this
function or something.

`WORKING_DIRECTORY` was being set twice in the invocation of `add_test`
and I think ignoring the argument being passed. It also was being set
to `CMAKE_BINARY_DIR` by default, which is different than the default
specified for `add_test`, which seemed weird, since that behavior
wasn't mentioned anywhere.

I hate CMake.