### PR TITLE
Make it easier for external folks to file issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: GMNGeoffrey
 
 ---
 
-If you are an IREE team member, consider removing the "help wanted" tag and redirecting the assignee to a more appropriate person.
+If you are an IREE team member, please consider doing further triage: remove the "help wanted" label, add other relevant labels, and redirect to a more appropriate assignee.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,10 +2,12 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
-assignees: ''
+labels: "bug \U0001F41E, help wanted"
+assignees: GMNGeoffrey
 
 ---
+
+If you are an IREE team member, consider removing the "help wanted" tag and redirecting the assignee to a more appropriate person.
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
Hardcode the default assignee to me and add the "help wanted" label. I
also added a note asking team members to do more specific triage
themselves. At our current volume of issues, I think I can handle this,
and I'll complain if that changes :-D