### PR TITLE
Add conversion for const.ref.zero to EmitC

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -24,3 +24,14 @@ vm.module @my_module {
     vm.return
   }
 }
+
+// -----
+
+vm.module @my_module {
+  // CHECK-LABEL: vm.func @const_ref_zero
+  vm.func @const_ref_zero() -> !vm.ref<?> {
+    // CHECK: %[[NULL:.+]] = "emitc.const"() {value = "{0}"} : () -> !emitc.opaque<"iree_vm_ref_t">
+    %null = vm.const.ref.zero : !vm.ref<?>
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -4,7 +4,7 @@
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i32_zero
   vm.func @const_i32_zero() -> i32 {
-    // CHECK: %zero = "emitc.const"() {value = 0 : i32} : () -> i32
+    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0 : i32} : () -> i32
     %zero = vm.const.i32.zero : i32
     vm.return %zero : i32
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -4,7 +4,7 @@
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i64_zero
   vm.func @const_i64_zero() -> i64 {
-    // CHECK: %zero = "emitc.const"() {value = 0 : i64} : () -> i64
+    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0 : i64} : () -> i64
     %zero = vm.const.i64.zero : i64
     vm.return %zero : i64
   }


### PR DESCRIPTION
The IR `%v1 = "emitc.const"() {value = "{0}"} : () -> !emitc.opaque<"iree_vm_ref_t">` is translated into the C snippet `iree_vm_ref_t v1 = {0};`. Further fixes VM to EmitC conversion tests.