### PR TITLE
Add support for bufferization of ConstantOp.

### DIFF
--- a/experimental/runners/LinalgTensorCodegenStrategy.cpp
+++ b/experimental/runners/LinalgTensorCodegenStrategy.cpp
@@ -24,7 +24,9 @@
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -45,8 +47,10 @@ struct LinalgTensorCodegenStrategyPass
     registry.insert<AffineDialect,
                     gpu::GPUDialect,
                     linalg::LinalgDialect,
+                    memref::MemRefDialect,
                     scf::SCFDialect,
                     StandardOpsDialect,
+                    tensor::TensorDialect,
                     vector::VectorDialect>();
     // clang-format on
   }

--- a/experimental/runners/test/test_constant.mlir
+++ b/experimental/runners/test/test_constant.mlir
@@ -1,0 +1,49 @@
+// RUN: mlir-proto-opt %s -linalg-comprehensive-bufferize-inplace | FileCheck %s
+
+// RUN: mlir-proto-opt %s -linalg-comprehensive-bufferize-inplace |\
+// RUN: mlir-opt -convert-vector-to-scf -lower-affine -convert-linalg-to-loops |\
+// RUN: mlir-opt -canonicalize -convert-scf-to-std -convert-vector-to-llvm -convert-std-to-llvm | \
+
+// RUN: mlir-cpu-runner -O3 -e main -entry-point-result=void \
+// RUN:   -shared-libs=%iree_runners_test_dir/libruntime-support%shlibext | \
+// RUN: tee | FileCheck %s --check-prefix=EXEC
+
+// CHECK: memref.global "private" constant @__constant_1x1xf32_1 : memref<1x1xf32> = dense<1.000000e+00>
+// CHECK: memref.global "private" constant @__constant_1x1xf32_0 : memref<1x1xf32> = dense<3.000000e+00>
+// CHECK: memref.global "private" constant @__constant_1x1xf32 : memref<1x1xf32> = dense<2.000000e+00>
+
+// CHECK-LABEL: func @main() {
+func @main() {
+  %c0 = constant 0: index
+  %v0 = constant 0.0 : f32
+
+  // Top of the function globals, memref.alloc, copy.
+  // CHECK-DAG:   %[[A:.*]] = memref.get_global @__constant_1x1xf32 : memref<1x1xf32>
+  // CHECK-DAG:   %[[B:.*]] = memref.get_global @__constant_1x1xf32_0 : memref<1x1xf32>
+  // CHECK-DAG:   %[[C:.*]] = memref.get_global @__constant_1x1xf32_1 : memref<1x1xf32>
+  //     CHECK:   %[[MUTABLE_C:.*]] = memref.alloc() : memref<1x1xf32>
+  //     CHECK:   linalg.copy(%[[C]], %[[MUTABLE_C]]) : memref<1x1xf32>, memref<1x1xf32>
+  %lhs = constant dense<[[2.]]> : tensor<1x1xf32>
+  %rhs = constant dense<[[3.]]> : tensor<1x1xf32>
+  %accum = constant dense<[[1.]]> : tensor<1x1xf32>
+
+  //     CHECK:   vector.transfer_read %[[A]]{{.*}} {masked = [false, false]} : memref<1x1xf32>, vector<1x1xf32>
+  %result_vector_0 = vector.transfer_read %lhs[%c0, %c0], %v0 : tensor<1x1xf32>, vector<1x1xf32>
+
+  // EXEC: ( ( 2 ) )
+  vector.print %result_vector_0: vector<1x1xf32>
+
+
+  //     CHECK:   linalg.matmul ins(%[[A]], %[[B]] : memref<1x1xf32>, memref<1x1xf32>) outs(%[[MUTABLE_C]] : memref<1x1xf32>)
+  %result = linalg.matmul ins(%lhs, %rhs : tensor<1x1xf32>, tensor<1x1xf32>)
+    outs(%accum: tensor<1x1xf32>) -> tensor<1x1xf32>
+
+  //     CHECK:   vector.transfer_read %[[MUTABLE_C]]{{.*}} {masked = [false, false]} : memref<1x1xf32>, vector<1x1xf32>
+  %result_vector_1 = vector.transfer_read %result[%c0, %c0], %v0 : tensor<1x1xf32>, vector<1x1xf32>
+
+  // EXEC: ( ( 7 ) )
+  vector.print %result_vector_1: vector<1x1xf32>
+
+  //     CHECK:   memref.dealloc %[[MUTABLE_C]] : memref<1x1xf32>
+  return
+}

--- a/experimental/runners/test/test_dot.mlir
+++ b/experimental/runners/test/test_dot.mlir
@@ -26,30 +26,30 @@ attributes { __inplace_args_attr__ = ["none", "none", "true"] }
 //       CHECK:   constant 0.0
   %v0 = constant 0.0 : f32
 
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //       CHECK:   linalg.fill(%[[C]], %{{.*}}) : memref<f32>, f32
   %d = linalg.fill(%c, %v0) : tensor<f32>, f32 -> tensor<f32>
 
 //       CHECK:   scf.for %[[I:.*]]
 //       CHECK:     scf.for %[[II:.*]]
-//       CHECK:       %[[PACK_B:.*]] = alloc(%{{.*}}) : memref<?x2xf32>
-//       CHECK:       %[[PACK_A:.*]] = alloc(%{{.*}}) : memref<?x2xf32>
+//       CHECK:       %[[PACK_B:.*]] = memref.alloc(%{{.*}}) : memref<?x2xf32>
+//       CHECK:       %[[PACK_A:.*]] = memref.alloc(%{{.*}}) : memref<?x2xf32>
 //       CHECK:       scf.for %[[III_PACK_B:.*]]
-//       CHECK:         %[[sB:.*]] = subview %[[PACK_B]]
+//       CHECK:         %[[sB:.*]] = memref.subview %[[PACK_B]]
 //       CHECK:         linalg.copy(%{{.*}}, %[[sB]]) : memref<2xf32, #[[$MAP5]]>, memref<2xf32, #[[$MAP1]]>
 //       CHECK:       scf.for %[[III_PACK_A:.*]]
-//       CHECK:         %[[sA:.*]] = subview %[[PACK_A]]
+//       CHECK:         %[[sA:.*]] = memref.subview %[[PACK_A]]
 //       CHECK:         linalg.copy(%{{.*}}, %[[sA]]) : memref<2xf32, #[[$MAP5]]>, memref<2xf32, #[[$MAP1]]>
 //       CHECK:       scf.for %[[III:.*]]
-//       CHECK:         %[[sA:.*]] = subview %[[PACK_A]][%{{.*}}, 0] [1, 2] [1, 1] : memref<?x2xf32> to memref<2xf32, #[[$MAP1]]>
-//       CHECK:         %[[sB:.*]] = subview %[[PACK_B]][%{{.*}}, 0] [1, 2] [1, 1] : memref<?x2xf32> to memref<2xf32, #[[$MAP1]]>
+//       CHECK:         %[[sA:.*]] = memref.subview %[[PACK_A]][%{{.*}}, 0] [1, 2] [1, 1] : memref<?x2xf32> to memref<2xf32, #[[$MAP1]]>
+//       CHECK:         %[[sB:.*]] = memref.subview %[[PACK_B]][%{{.*}}, 0] [1, 2] [1, 1] : memref<?x2xf32> to memref<2xf32, #[[$MAP1]]>
 //       CHECK:         linalg.dot ins(%[[sA]], %[[sB]] : memref<2xf32, #[[$MAP1]]>, memref<2xf32, #[[$MAP1]]>) outs(%[[C]] : memref<f32>)
-//       CHECK:       dealloc %[[PACK_A]] : memref<?x2xf32>
-//       CHECK:       dealloc %[[PACK_B]] : memref<?x2xf32>
+//       CHECK:       memref.dealloc %[[PACK_A]] : memref<?x2xf32>
+//       CHECK:       memref.dealloc %[[PACK_B]] : memref<?x2xf32>
   %e = linalg.dot ins(%a, %b : tensor<?xf32>,tensor<?xf32>)
     outs(%d: tensor<f32>) -> tensor<f32>
 
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //   CHECK-NOT:   copy
 //       CHECK:   return
   return %e : tensor<f32>

--- a/experimental/runners/test/test_matmul_f32_000.mlir
+++ b/experimental/runners/test/test_matmul_f32_000.mlir
@@ -10,7 +10,7 @@
 //  CHECK-SAME:       %[[C:[0-9a-zA-Z]+]]: memref<
 //       CHECK:   constant 0.0
 
-// Analysis kicks in, we can write in %[[C]] and no spurious alloc/copies are inserted.
+// Analysis kicks in, we can write in %[[C]] and no spurious memref.alloc/copies are inserted.
 //  CHECK-NEXT:   linalg.fill(%[[C]], %{{.*}}) : memref<32x64xf32>, f32
 //  CHECK-NEXT:   linalg.matmul ins(%[[A]], %[[B]] : memref<32x128xf32>, memref<128x64xf32>) outs(%[[C]] : memref<32x64xf32>)
 //  CHECK-NEXT:   return
@@ -19,17 +19,17 @@
 //   CHECK-DAG:   %[[f0:.*]] = constant 0.0
 //   CHECK-DAG:   %[[f1:.*]] = constant 1.0
 //   CHECK-DAG:   %[[f2:.*]] = constant 2.0
-//   CHECK-DAG:   alloc() : memref<32x128xf32>
-//   CHECK-DAG:   alloc() : memref<128x64xf32>
-//   CHECK-DAG:   alloc() : memref<32x64xf32>
+//   CHECK-DAG:   memref.alloc() : memref<32x128xf32>
+//   CHECK-DAG:   memref.alloc() : memref<128x64xf32>
+//   CHECK-DAG:   memref.alloc() : memref<32x64xf32>
 //   CHECK-DAG:   linalg.fill(%[[A:.*]], %[[f1]]) : memref<32x128xf32>, f32
 //   CHECK-DAG:   linalg.fill(%[[B:.*]], %[[f2]]) : memref<128x64xf32>, f32
 //   CHECK-DAG:   linalg.fill(%[[C:.*]], %[[f0]]) : memref<32x64xf32>, f32
 
 // On the caller side, we do not (yet) determine that the scf.for operand used in
 // iterative calls to init_and_matmul can all be made in place.
-// So an extra alloc + copy is performed form which the final result is read.
-//       CHECK:   %[[RES:.*]] = alloc() : memref<32x64xf32>
+// So an extra memref.alloc + copy is performed form which the final result is read.
+//       CHECK:   %[[RES:.*]] = memref.alloc() : memref<32x64xf32>
 //       CHECK:   call @rtclock() : () -> f64
 //       CHECK:   scf.for %{{.*}} {
 //  CHECK-NEXT:     call @init_and_matmul(%[[A]], %[[B]], %[[C]]) : (memref<32x128xf32>, memref<128x64xf32>, memref<32x64xf32>) -> ()

--- a/experimental/runners/test/test_matmul_f32_001.mlir
+++ b/experimental/runners/test/test_matmul_f32_001.mlir
@@ -10,16 +10,16 @@
 //  CHECK-SAME:       %[[B:[0-9a-zA-Z]+]]: memref<
 //  CHECK-SAME:       %[[C:[0-9a-zA-Z]+]]: memref<
 //       CHECK:   constant 0.0
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //       CHECK:   linalg.fill(%[[C]], %{{.*}}) : memref<32x64xf32>, f32
 //   CHECK-NOT:   copy
 //       CHECK:   scf.for %[[I:.*]] =
 //       CHECK:     scf.for %[[J:.*]] =
-//       CHECK:       %[[SVC:.*]] = subview %[[C]]{{.*}} : memref<32x64xf32> to memref<4x8xf32
+//       CHECK:       %[[SVC:.*]] = memref.subview %[[C]]{{.*}} : memref<32x64xf32> to memref<4x8xf32
 //       CHECK:       %[[VC:.*]] = vector.transfer_read %[[SVC]]{{.*}}{masked = [false, false]} : memref<4x8xf32{{.*}}>, vector<4x8xf32>
 //       CHECK:       scf.for %[[K:.*]] = {{.*}} iter_args(%{{.*}} = %[[VC]]) -> (vector<4x8xf32>)
-//       CHECK:         %[[SVA:.*]] = subview %[[A]][%[[I]], %[[K]]] [4, 16] [1, 1] : memref<32x128xf32> to memref<4x16xf32
-//       CHECK:         %[[SVB:.*]] = subview %[[B]][%[[K]], %[[J]]] [16, 8] [1, 1] : memref<128x64xf32> to memref<16x8xf32
+//       CHECK:         %[[SVA:.*]] = memref.subview %[[A]][%[[I]], %[[K]]] [4, 16] [1, 1] : memref<32x128xf32> to memref<4x16xf32
+//       CHECK:         %[[SVB:.*]] = memref.subview %[[B]][%[[K]], %[[J]]] [16, 8] [1, 1] : memref<128x64xf32> to memref<16x8xf32
 //       CHECK:         vector.transfer_read %[[SVA]]{{.*}} {masked = [false, false]} : memref<4x16xf32{{.*}}>, vector<4x16xf32>
 //       CHECK:         vector.transfer_read %[[SVB]]{{.*}}, %cst {masked = [false, false]} : memref<16x8xf32{{.*}}>, vector<16x8xf32>
 //       CHECK:         vector.contract

--- a/experimental/runners/test/test_matmul_f32_002.mlir
+++ b/experimental/runners/test/test_matmul_f32_002.mlir
@@ -11,29 +11,29 @@
 //  CHECK-SAME:       %[[B:[0-9a-zA-Z]+]]: memref<
 //  CHECK-SAME:       %[[C:[0-9a-zA-Z]+]]: memref<
 //       CHECK:   constant 0.0
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //       CHECK:   linalg.fill(%[[C]], %{{.*}}) : memref<32x64xf32>, f32
-//   CHECK-DAG:   %[[PACKED_A:.*]] = alloc() : memref<8x4x16xf32>
-//   CHECK-DAG:   %[[PACKED_B:.*]] = alloc() : memref<8x16x8xf32>
+//   CHECK-DAG:   %[[PACKED_A:.*]] = memref.alloc() : memref<8x4x16xf32>
+//   CHECK-DAG:   %[[PACKED_B:.*]] = memref.alloc() : memref<8x16x8xf32>
 //   CHECK-NOT:   copy
 //       CHECK:   scf.for %[[I:.*]] =
 //       CHECK:     scf.for %[[J:.*]] =
 //       CHECK:       scf.for %[[K1:.*]] =
 //       CHECK:         %[[PACKED_IDX_B:.*]] = affine.apply
-//       CHECK:         subview %[[B]][%[[K1]], %[[J]]] [16, 8] [1, 1] : memref<128x64xf32> to memref<16x8xf32
-//       CHECK:         subview %[[PACKED_B]][%[[PACKED_IDX_B]], 0, 0] [1, 16, 8] [1, 1, 1] : memref<8x16x8xf32> to memref<16x8xf32
+//       CHECK:         memref.subview %[[B]][%[[K1]], %[[J]]] [16, 8] [1, 1] : memref<128x64xf32> to memref<16x8xf32
+//       CHECK:         memref.subview %[[PACKED_B]][%[[PACKED_IDX_B]], 0, 0] [1, 16, 8] [1, 1, 1] : memref<8x16x8xf32> to memref<16x8xf32
 //       CHECK:         linalg.copy
 //       CHECK:       scf.for %[[K2:.*]] =
 //       CHECK:         %[[PACKED_IDX_A:.*]] = affine.apply
-//       CHECK:         subview %[[A]][%[[I]], %[[K2]]] [4, 16] [1, 1] : memref<32x128xf32> to memref<4x16xf32
-//       CHECK:         subview %[[PACKED_A]][%[[PACKED_IDX_A]], 0, 0] [1, 4, 16] [1, 1, 1] : memref<8x4x16xf32> to memref<4x16xf32
+//       CHECK:         memref.subview %[[A]][%[[I]], %[[K2]]] [4, 16] [1, 1] : memref<32x128xf32> to memref<4x16xf32
+//       CHECK:         memref.subview %[[PACKED_A]][%[[PACKED_IDX_A]], 0, 0] [1, 4, 16] [1, 1, 1] : memref<8x4x16xf32> to memref<4x16xf32
 //       CHECK:         linalg.copy
-//       CHECK:       %[[SVC:.*]] = subview %[[C]]{{.*}} : memref<32x64xf32> to memref<4x8xf32
+//       CHECK:       %[[SVC:.*]] = memref.subview %[[C]]{{.*}} : memref<32x64xf32> to memref<4x8xf32
 //       CHECK:       %[[VC:.*]] = vector.transfer_read %[[SVC]]{{.*}}{masked = [false, false]} : memref<4x8xf32{{.*}}>, vector<4x8xf32>
 //       CHECK:       scf.for %[[K:.*]] = {{.*}} iter_args(%{{.*}} = %[[VC]]) -> (vector<4x8xf32>)
 //       CHECK:         %[[PACKED_IDX:.*]] = affine.apply
-//       CHECK:         %[[SVA:.*]] = subview %[[PACKED_A]][%[[PACKED_IDX]], 0, 0] [1, 4, 16] [1, 1, 1] : memref<8x4x16xf32> to memref<4x16xf32
-//       CHECK:         %[[SVB:.*]] = subview %[[PACKED_B]][%[[PACKED_IDX]], 0, 0] [1, 16, 8] [1, 1, 1] : memref<8x16x8xf32> to memref<16x8xf32
+//       CHECK:         %[[SVA:.*]] = memref.subview %[[PACKED_A]][%[[PACKED_IDX]], 0, 0] [1, 4, 16] [1, 1, 1] : memref<8x4x16xf32> to memref<4x16xf32
+//       CHECK:         %[[SVB:.*]] = memref.subview %[[PACKED_B]][%[[PACKED_IDX]], 0, 0] [1, 16, 8] [1, 1, 1] : memref<8x16x8xf32> to memref<16x8xf32
 //       CHECK:         vector.transfer_read %[[SVA]]{{.*}} {masked = [false, false]} : memref<4x16xf32{{.*}}>, vector<4x16xf32>
 //       CHECK:         vector.transfer_read %[[SVB]]{{.*}}, %cst {masked = [false, false]} : memref<16x8xf32{{.*}}>, vector<16x8xf32>
 //       CHECK:         vector.contract
@@ -45,7 +45,7 @@
 //       CHECK:     }
 //       CHECK:   }
 //   CHECK-NOT:   copy
-//   CHECK-DAG:   dealloc %[[PACKED_A]]
-//   CHECK-DAG:   dealloc %[[PACKED_B]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_A]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_B]]
 
 // CHECK-LABEL: func @main(

--- a/experimental/runners/test/test_matmul_f32_003.mlir
+++ b/experimental/runners/test/test_matmul_f32_003.mlir
@@ -11,34 +11,34 @@
 //  CHECK-SAME:       %[[B:[0-9a-zA-Z]+]]: memref<
 //  CHECK-SAME:       %[[C:[0-9a-zA-Z]+]]: memref<
 //       CHECK:   constant 0.0
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //       CHECK:   linalg.fill(%[[C]], %{{.*}}) : memref<32x64xf32>, f32
-//   CHECK-DAG:   %[[PACKED_A:.*]] = alloc() : memref<8x2x16xf32>
-//   CHECK-DAG:   %[[PACKED_B:.*]] = alloc() : memref<16x8x16x4xf32>
+//   CHECK-DAG:   %[[PACKED_A:.*]] = memref.alloc() : memref<8x2x16xf32>
+//   CHECK-DAG:   %[[PACKED_B:.*]] = memref.alloc() : memref<16x8x16x4xf32>
 //   CHECK-NOT:   copy
 //       CHECK:   scf.for %[[I:.*]] =
 //       CHECK:     scf.for %[[J1:.*]] =
 //       CHECK:       %[[PACKED_IDX_B_J1:.*]] = affine.apply
 //       CHECK:       scf.for %[[K1:.*]] =
 //       CHECK:         %[[PACKED_IDX_B_K1:.*]] = affine.apply
-//       CHECK:         subview %[[B]][%[[K1]], %[[J1]]] [16, 4] [1, 1] : memref<128x64xf32> to memref<16x4xf32
+//       CHECK:         memref.subview %[[B]][%[[K1]], %[[J1]]] [16, 4] [1, 1] : memref<128x64xf32> to memref<16x4xf32
 // Loop order is I, J, K -> packed_B is J x K x tK x tJ
-//       CHECK:         subview %[[PACKED_B]][%[[PACKED_IDX_B_J1]], %[[PACKED_IDX_B_K1]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
+//       CHECK:         memref.subview %[[PACKED_B]][%[[PACKED_IDX_B_J1]], %[[PACKED_IDX_B_K1]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
 //       CHECK:         linalg.copy
 //       CHECK:     scf.for %[[K2:.*]] =
 //       CHECK:       %[[PACKED_IDX_A:.*]] = affine.apply
-//       CHECK:       subview %[[A]][%[[I]], %[[K2]]] [2, 16] [1, 1] : memref<32x128xf32> to memref<2x16xf32
-//       CHECK:       subview %[[PACKED_A]][%[[PACKED_IDX_A]], 0, 0] [1, 2, 16] [1, 1, 1] : memref<8x2x16xf32> to memref<2x16xf32
+//       CHECK:       memref.subview %[[A]][%[[I]], %[[K2]]] [2, 16] [1, 1] : memref<32x128xf32> to memref<2x16xf32
+//       CHECK:       memref.subview %[[PACKED_A]][%[[PACKED_IDX_A]], 0, 0] [1, 2, 16] [1, 1, 1] : memref<8x2x16xf32> to memref<2x16xf32
 //       CHECK:       linalg.copy
 //       CHECK:     scf.for %[[J:.*]] =
 //       CHECK:       %[[PACKED_IDX_J:.*]] = affine.apply
-//       CHECK:       %[[SVC:.*]] = subview %[[C]]{{.*}} : memref<32x64xf32> to memref<2x4xf32
+//       CHECK:       %[[SVC:.*]] = memref.subview %[[C]]{{.*}} : memref<32x64xf32> to memref<2x4xf32
 //       CHECK:       %[[VC:.*]] = vector.transfer_read %[[SVC]]{{.*}}{masked = [false, false]} : memref<2x4xf32{{.*}}>, vector<2x4xf32>
 //       CHECK:       scf.for %[[K:.*]] = {{.*}} iter_args(%{{.*}} = %[[VC]]) -> (vector<2x4xf32>)
 //       CHECK:         %[[PACKED_IDX_K:.*]] = affine.apply
-//       CHECK:         %[[SVA:.*]] = subview %[[PACKED_A]][%[[PACKED_IDX_K]], 0, 0] [1, 2, 16] [1, 1, 1] : memref<8x2x16xf32> to memref<2x16xf32
+//       CHECK:         %[[SVA:.*]] = memref.subview %[[PACKED_A]][%[[PACKED_IDX_K]], 0, 0] [1, 2, 16] [1, 1, 1] : memref<8x2x16xf32> to memref<2x16xf32
 // Loop order is I, J, K -> packed_B is J x K x tK x tJ
-//       CHECK:         %[[SVB:.*]] = subview %[[PACKED_B]][%[[PACKED_IDX_J]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
+//       CHECK:         %[[SVB:.*]] = memref.subview %[[PACKED_B]][%[[PACKED_IDX_J]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
 //       CHECK:         vector.transfer_read %[[SVA]]{{.*}} {masked = [false, false]} : memref<2x16xf32{{.*}}>, vector<2x16xf32>
 //       CHECK:         vector.transfer_read %[[SVB]]{{.*}}, %cst {masked = [false, false]} : memref<16x4xf32{{.*}}>, vector<16x4xf32>
 //       CHECK:         %[[RES:.*]] = vector.contract
@@ -50,5 +50,5 @@
 //       CHECK:     }
 //       CHECK:   }
 //   CHECK-NOT:   copy
-//   CHECK-DAG:   dealloc %[[PACKED_A]]
-//   CHECK-DAG:   dealloc %[[PACKED_B]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_A]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_B]]

--- a/experimental/runners/test/test_matmul_f32_004.mlir
+++ b/experimental/runners/test/test_matmul_f32_004.mlir
@@ -11,41 +11,41 @@
 //  CHECK-SAME:       %[[B:[0-9a-zA-Z]+]]: memref<
 //  CHECK-SAME:       %[[C:[0-9a-zA-Z]+]]: memref<
 //       CHECK:   constant 0.0
-//   CHECK-NOT:   alloc
+//   CHECK-NOT:   memref.alloc
 //       CHECK:   linalg.fill(%[[C]], %{{.*}}) : memref<32x64xf32>, f32
-//   CHECK-DAG:   %[[PACKED_B:.*]] = alloc() : memref<16x8x16x4xf32>
+//   CHECK-DAG:   %[[PACKED_B:.*]] = memref.alloc() : memref<16x8x16x4xf32>
 //   CHECK-NOT:   copy
 //       CHECK:   scf.for %[[J1:.*]] =
 //       CHECK:     %[[PACKED_IDX_B_J1:.*]] = affine.apply
 //       CHECK:     scf.for %[[K1:.*]] =
 //       CHECK:       %[[PACKED_IDX_B_K1:.*]] = affine.apply
-//       CHECK:       subview %[[B]][%[[K1]], %[[J1]]] [16, 4] [1, 1] : memref<128x64xf32> to memref<16x4xf32
+//       CHECK:       memref.subview %[[B]][%[[K1]], %[[J1]]] [16, 4] [1, 1] : memref<128x64xf32> to memref<16x4xf32
 // Loop order is I, J, K -> packed_B is J x K x tK x tJ
-//       CHECK:       subview %[[PACKED_B]][%[[PACKED_IDX_B_J1]], %[[PACKED_IDX_B_K1]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
+//       CHECK:       memref.subview %[[PACKED_B]][%[[PACKED_IDX_B_J1]], %[[PACKED_IDX_B_K1]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
 //       CHECK:       linalg.copy
 //
-//   CHECK-DAG:   %[[PACKED_A:.*]] = alloc() : memref<16x8x2x16xf32>
+//   CHECK-DAG:   %[[PACKED_A:.*]] = memref.alloc() : memref<16x8x2x16xf32>
 //       CHECK:   scf.for %[[I2:.*]] =
 //       CHECK:     %[[PACKED_IDX_A_I:.*]] = affine.apply
 //       CHECK:     scf.for %[[K2:.*]] =
 //       CHECK:       %[[PACKED_IDX_A_K:.*]] = affine.apply
-//       CHECK:       subview %[[A]][%[[I2]], %[[K2]]] [2, 16] [1, 1] : memref<32x128xf32> to memref<2x16xf32
+//       CHECK:       memref.subview %[[A]][%[[I2]], %[[K2]]] [2, 16] [1, 1] : memref<32x128xf32> to memref<2x16xf32
 // Loop order is I, J, K -> packed_A is I x K x tI x tK
-//       CHECK:       subview %[[PACKED_A]][%[[PACKED_IDX_A_I]], %[[PACKED_IDX_A_K]], 0, 0] [1, 1, 2, 16] [1, 1, 1, 1] : memref<16x8x2x16xf32> to memref<2x16xf32
+//       CHECK:       memref.subview %[[PACKED_A]][%[[PACKED_IDX_A_I]], %[[PACKED_IDX_A_K]], 0, 0] [1, 1, 2, 16] [1, 1, 1, 1] : memref<16x8x2x16xf32> to memref<2x16xf32
 //       CHECK:       linalg.copy
 //
 //       CHECK:   scf.for %[[I:.*]] =
 //       CHECK:     %[[PACKED_IDX_I:.*]] = affine.apply
 //       CHECK:     scf.for %[[J:.*]] =
 //       CHECK:       %[[PACKED_IDX_J:.*]] = affine.apply
-//       CHECK:       %[[SVC:.*]] = subview %[[C]]{{.*}} : memref<32x64xf32> to memref<2x4xf32
+//       CHECK:       %[[SVC:.*]] = memref.subview %[[C]]{{.*}} : memref<32x64xf32> to memref<2x4xf32
 //       CHECK:       %[[VC:.*]] = vector.transfer_read %[[SVC]]{{.*}}{masked = [false, false]} : memref<2x4xf32{{.*}}>, vector<2x4xf32>
 //       CHECK:       scf.for %[[K:.*]] = {{.*}} iter_args(%{{.*}} = %[[VC]]) -> (vector<2x4xf32>)
 //       CHECK:         %[[PACKED_IDX_K:.*]] = affine.apply
 // Loop order is I, J, K -> packed_A is I x K x tI x tK
-//       CHECK:         %[[SVA:.*]] = subview %[[PACKED_A]][%[[PACKED_IDX_I]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 2, 16] [1, 1, 1, 1] : memref<16x8x2x16xf32> to memref<2x16xf32
+//       CHECK:         %[[SVA:.*]] = memref.subview %[[PACKED_A]][%[[PACKED_IDX_I]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 2, 16] [1, 1, 1, 1] : memref<16x8x2x16xf32> to memref<2x16xf32
 // Loop order is I, J, K -> packed_B is J x K x tK x tJ
-//       CHECK:         %[[SVB:.*]] = subview %[[PACKED_B]][%[[PACKED_IDX_J]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
+//       CHECK:         %[[SVB:.*]] = memref.subview %[[PACKED_B]][%[[PACKED_IDX_J]], %[[PACKED_IDX_K]], 0, 0] [1, 1, 16, 4] [1, 1, 1, 1] : memref<16x8x16x4xf32> to memref<16x4xf32
 //       CHECK:         vector.transfer_read %[[SVA]]{{.*}} {masked = [false, false]} : memref<2x16xf32{{.*}}>, vector<2x16xf32>
 //       CHECK:         vector.transfer_read %[[SVB]]{{.*}}, %cst {masked = [false, false]} : memref<16x4xf32{{.*}}>, vector<16x4xf32>
 //       CHECK:         %[[RES:.*]] = vector.contract
@@ -57,5 +57,5 @@
 //       CHECK:     }
 //       CHECK:   }
 //   CHECK-NOT:   copy
-//   CHECK-DAG:   dealloc %[[PACKED_A]]
-//   CHECK-DAG:   dealloc %[[PACKED_B]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_A]]
+//   CHECK-DAG:   memref.dealloc %[[PACKED_B]]


### PR DESCRIPTION
This needs a rebase on top of LLVM b661788b77e570dc82fe2f89a355713c144407f1.
Also fix the MemRef dialect introduced mismatches.