### PR TITLE
LLVMCodegenOptions with target specific overrides

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -44,15 +44,18 @@ cc_library(
         "ConvertToLLVM.cpp",
         "FoldTensorExtractOpPass.cpp",
         "KernelDispatch.cpp",
+        "LLVMCodeGenOptions.cpp",
         "LinalgTileAndDistributePass.cpp",
         "LinalgTileAndVectorizePass.cpp",
         "LinalgVectorizePass.cpp",
         "MaterializeCPULaunchConfigurationPass.cpp",
         "Passes.cpp",
         "PlanConvLoopOrder.cpp",
+        "UnfuseFMAOps.cpp",
     ],
     hdrs = [
         "KernelDispatch.h",
+        "LLVMCodeGenOptions.h",
         "Passes.h",
     ],
     deps = [

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -24,18 +24,21 @@ iree_cc_library(
     LinalgToLLVM
   HDRS
     "KernelDispatch.h"
+    "LLVMCodeGenOptions.h"
     "Passes.h"
   SRCS
     "ConvImg2ColMatmulConversion.cpp"
     "ConvertToLLVM.cpp"
     "FoldTensorExtractOpPass.cpp"
     "KernelDispatch.cpp"
+    "LLVMCodeGenOptions.cpp"
     "LinalgTileAndDistributePass.cpp"
     "LinalgTileAndVectorizePass.cpp"
     "LinalgVectorizePass.cpp"
     "MaterializeCPULaunchConfigurationPass.cpp"
     "Passes.cpp"
     "PlanConvLoopOrder.cpp"
+    "UnfuseFMAOps.cpp"
   DEPS
     LLVMSupport
     MLIRAffineToStandard

--- a/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.cpp
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h"
+
+#include "llvm/Support/CommandLine.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+static llvm::cl::opt<bool> clEnableLLVMLinalgOnTensors(
+    "iree-codegen-llvm-experimental-linalg-on-tensors",
+    llvm::cl::desc("Enable the linalg on tensors experimental LLVM path"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> convImg2ColConversion(
+    "iree-codegen-linalg-to-llvm-conv-img2col-conversion",
+    llvm::cl::desc("Enable rewriting linalg.conv_2d_input_nhwc_filter_hwcf "
+                   "linalg.generic that does img2col buffer packing + "
+                   "linag.matmul"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> unfusedFMA(
+    "iree-codegen-linalg-to-llvm-use-unfused-fma",
+    llvm::cl::desc("Enable rewriting llvm.fma to its unfused version."),
+    llvm::cl::init(false));
+
+LLVMCodegenOptions getLLVMCodegenOptionsFromClOptions() {
+  LLVMCodegenOptions options;
+  options.usingLinalgOnTensors = clEnableLLVMLinalgOnTensors;
+  options.useConvImg2Col = convImg2ColConversion;
+  options.unfuseFMAOps = unfusedFMA;
+  return options;
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_COMPILER_CONVERSION_LINALGTOLLVM_LLVMCODEGENOPTIONS_H_
+#define IREE_COMPILER_CONVERSION_LINALGTOLLVM_LLVMCODEGENOPTIONS_H_
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+// Options used to configure LLVM passes.
+struct LLVMCodegenOptions {
+  bool usingLinalgOnTensors = false;
+  bool useConvImg2Col = false;
+  // Target specific options.
+  bool unfuseFMAOps = false;
+  bool useVectorToAarch64 = false;
+};
+
+// Returns LLVM CodeGen options from command-line options.
+LLVMCodegenOptions getLLVMCodegenOptionsFromClOptions();
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CONVERSION_LINALGTOLLVM_LLVMCODEGENOPTIONS_H_

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -15,6 +15,7 @@
 #ifndef IREE_COMPILER_CONVERSION_LINALGTOLLVM_PASSES_H_
 #define IREE_COMPILER_CONVERSION_LINALGTOLLVM_PASSES_H_
 
+#include "iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -36,16 +37,20 @@ createLinalgTileAndDistributePass();
 /// Vectorizes linalg ops executed in the same hal.interface.workgroup.
 std::unique_ptr<FunctionPass> createLinalgTileAndVectorizeWorkgroupsPass();
 
-std::unique_ptr<OperationPass<ModuleOp>>
-createFastExpApproximationConversionPass();
+/// Replaces llvm.intr.fma with its unfused mul and add ops.
+std::unique_ptr<FunctionPass> createUnfusedFMAOpsPass();
 
 /// Populates patterns to rewrite linalg::ConvInputNHWCFilterHWCFOp into packed
 /// img2col operation followed by linalg::MatmulOp.
 void populateConvImg2ColMatmulConversionPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns);
 
+void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
+                                       OwningRewritePatternList &patterns);
+
 /// Performs the final conversion to LLVM dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass(
+    LLVMCodegenOptions options);
 
 /// Pass to convert Linalg ops into vector operations.
 std::unique_ptr<FunctionPass> createLinalgVectorizePass();
@@ -63,7 +68,8 @@ std::unique_ptr<OperationPass<>> createFoldTensorExtractOpPass();
 /// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the
 /// module within the IREE::HAL::ExecutableOp.
-void buildLLVMTransformPassPipeline(OpPassManager &passManager);
+void buildLLVMTransformPassPipeline(OpPassManager &passManager,
+                                    LLVMCodegenOptions options);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/UnfuseFMAOps.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/UnfuseFMAOps.cpp
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+// Rewrites llvm.intr.fma as its un-fuse version.
+// TODO(ataei): Upstream this pattern if needed ?
+class UnfusedFMAOpsPassConversion : public OpRewritePattern<LLVM::FMAOp> {
+ public:
+  using OpRewritePattern<LLVM::FMAOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::FMAOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto mulPart = rewriter.create<LLVM::FMulOp>(loc, op.getResult().getType(),
+                                                 op.a(), op.b());
+    auto fmaResult = rewriter.create<LLVM::FAddOp>(
+        loc, mulPart.getResult().getType(), mulPart.getResult(), op.c());
+    rewriter.replaceOp(op, fmaResult.getResult());
+    return success();
+  }
+};
+}  // namespace
+
+namespace {
+struct UnfusedFMAOpsPass : PassWrapper<UnfusedFMAOpsPass, FunctionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect>();
+  }
+  void runOnFunction() override;
+};
+}  // namespace
+
+void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
+                                       OwningRewritePatternList &patterns) {
+  patterns.insert<UnfusedFMAOpsPassConversion>(context);
+}
+
+void UnfusedFMAOpsPass::runOnFunction() {
+  auto funcOp = getOperation();
+  auto context = funcOp.getContext();
+  OwningRewritePatternList patterns;
+  populateUnfusedFMAOpsPassPatterns(context, patterns);
+  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+}
+
+std::unique_ptr<FunctionPass> createUnfusedFMAOpsPass() {
+  return std::make_unique<UnfusedFMAOpsPass>();
+}
+
+static PassRegistration<UnfusedFMAOpsPass> pass(
+    "iree-codegen-linalg-to-llvm-unfuse-fma-pass",
+    "Convert llvm.fma into unfused mulf and addf ops",
+    [] { return std::make_unique<UnfusedFMAOpsPass>(); });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "matmul_vectorization.mlir",
             "plan_conv_loop_order.mlir",
             "tile_and_distribute.mlir",
+            "unfused_fma.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "matmul_vectorization.mlir"
     "plan_conv_loop_order.mlir"
     "tile_and_distribute.mlir"
+    "unfused_fma.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Conversion/LinalgToLLVM/test/unfused_fma.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/unfused_fma.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-opt -iree-codegen-linalg-to-llvm-unfuse-fma-pass %s | IreeFileCheck %s
+
+func @fma_unfused(%a : f32, %b: f32, %c: f32) -> f32 {
+    %0 = "llvm.intr.fma"(%a, %b, %c) : (f32, f32, f32) -> f32
+    return %0 : f32
+}
+
+// CHECK: func @fma_unfused(%[[A:.+]]: f32, %[[B:.+]]: f32, %[[C:.+]]: f32)
+// CHECK: %[[MUL:.+]] = llvm.fmul %[[A]], %[[B]]
+// CHECK: %[[RES:.+]] = llvm.fadd %[[MUL]], %[[C]]
+// CHECK: return %[[RES]]

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -84,6 +84,7 @@ inline void registerLinalgToLLVMPasses() {
     createLinalgTileAndDistributePass();
     createLinalgTileAndVectorizeWorkgroupsPass();
     createMaterializeCPULaunchConfigurationPass();
+    createUnfusedFMAOpsPass();
     return true;
   }();
   (void)init_once;


### PR DESCRIPTION
- Creates LLVMCodeGenOptions  to configure LLVM compilation passes. its initited from llvm:opt flags.
- Overrides target specific options before translation  (e.g wasm target triggers unfuse-fma-ops pass).