### PR TITLE
Limit CTEST_PARALLEL_LEVEL to 8 for GPU tests

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -70,7 +70,13 @@ echo "Building with Ninja"
 cd "${CMAKE_BUILD_DIR?}"
 ninja
 
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
+# Limit parallelism to 8 to avoid exhausting GPU memory
+# TODO(#5162): Handle this more robustly
+DEFAULT_PARALLELISM="$(nproc)"
+if [[ "${DEFAULT_PARALLELISM?}" -gt "8" ]]; then
+   DEFAULT_PARALLELISM=8
+fi
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-${DEFAULT_PARALLELISM?}}
 
 echo "Testing with CTest"
 ctest --output-on-failure -L 'integrations/tensorflow' --label-exclude "^nokokoro$"


### PR DESCRIPTION
This should hopefully avoid exhausting GPU memory while testing.
Unfortunately, it will also slow down testing. 
https://github.com/google/iree/issues/5162 for more robust handling.