### PR TITLE
Limit tests and disable parallelism in integrations GPU build

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -70,13 +70,14 @@ echo "Building with Ninja"
 cd "${CMAKE_BUILD_DIR?}"
 ninja
 
-# Limit parallelism to 8 to avoid exhausting GPU memory
+# Limit parallelism dramatically to avoid exhausting GPU memory
 # TODO(#5162): Handle this more robustly
-DEFAULT_PARALLELISM="$(nproc)"
-if [[ "${DEFAULT_PARALLELISM?}" -gt "8" ]]; then
-   DEFAULT_PARALLELISM=8
-fi
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-${DEFAULT_PARALLELISM?}}
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
 
+# Run only the vulkan tests, since these are the only ones for which running on
+# a machine with a GPU should be different.
 echo "Testing with CTest"
-ctest --output-on-failure -L 'integrations/tensorflow' --label-exclude "^nokokoro$"
+ctest --output-on-failure \
+   --tests-regex "^integrations/tensorflow" \
+   --label-regex "^driver=vulkan$" \
+   --label-exclude "^nokokoro$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -78,6 +78,6 @@ export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
 # a machine with a GPU should be different.
 echo "Testing with CTest"
 ctest --output-on-failure \
-   --tests-regex "^integrations/tensorflow" \
+   --tests-regex "^integrations/tensorflow/" \
    --label-regex "^driver=vulkan$" \
    --label-exclude "^nokokoro$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -74,10 +74,10 @@ ninja
 # TODO(#5162): Handle this more robustly
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
 
-# Run only the vulkan tests, since these are the only ones for which running on
-# a machine with a GPU should be different.
+# Only test drivers that use the GPU, since we run all tests on non-GPU machines
+# as well.
 echo "Testing with CTest"
 ctest --output-on-failure \
    --tests-regex "^integrations/tensorflow/" \
-   --label-regex "^driver=vulkan$" \
+   --label-regex "^driver=vulkan$|^driver=cuda$" \
    --label-exclude "^nokokoro$"


### PR DESCRIPTION
Part of https://github.com/google/iree/issues/5162. Let's just try
*no* parallelism. But we can also limit to only vulkan tests, which is
about one tenth the number of tests, so this shouldn't actually slow
things down *too* much. Thanks to @phoenix-meadowlark for pointing out
that we didn't need to be running a bunch of these tests :grin: