### PR TITLE
Re-commit Tile and distribute linalg.generic in DispatchLinalgOnTensors

### DIFF
--- a/iree/compiler/Conversion/LinalgToNVVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToNVVM/Passes.cpp
@@ -32,6 +32,7 @@ static void addLinalgToNVVMPasses(OpPassManager &pm) {
   //===--------------------------------------------------------------------===//
   // Initial clean up.
   //===--------------------------------------------------------------------===//
+  pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
@@ -312,6 +312,46 @@ static LogicalResult getConfigForCooperativeMatmul(
   return success();
 }
 
+/// Launch config for element-wise linalg.generic.
+template <>
+LogicalResult getOpLaunchConfig(linalg::GenericOp op,
+                                const spirv::TargetEnv &targetEnv,
+                                const SPIRVCodegenOptions &options,
+                                TileSizesListType &tileSizes,
+                                LaunchConfigInfo &config) {
+  int64_t subgroupSize =
+      targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
+  config.workgroupSize[0] = subgroupSize;
+  config.workgroupSize[1] = 1;
+  config.workgroupSize[2] = 1;
+  ShapedType outputShape = op.getOutputShapedType(0);
+
+  SmallVector<int64_t, 4> sizes;
+  // When Vectororization is not enabled the convertToGPU pass assumes that that
+  // tile size is equal to the workgroup size.
+  if (options.enableVectorization) {
+    sizes.append({4 * subgroupSize, 2 * subgroupSize});
+  }
+  sizes.push_back(subgroupSize);
+  int64_t lowerTs = config.workgroupSize[0];
+  for (int64_t size : sizes) {
+    if (outputShape.getShape().back() % size != 0) continue;
+    lowerTs = size;
+    break;
+  }
+  SmallVector<int64_t, 4> ts;
+  size_t numLoops = getNumOuterParallelLoops(op);
+  ts.resize(numLoops, 1);
+  ts.back() = lowerTs;
+  tileSizes.emplace_back(ts);
+  tileSizes.emplace_back();
+  ts.back() = lowerTs / subgroupSize;
+  tileSizes.emplace_back(ts);
+  // Vectorize only if we are processing more than one element per thread.
+  config.vectorize = options.enableVectorization && (ts.back() > 1);
+  return success();
+}
+
 /// Launch configuration for different known GPU configuration.
 static LogicalResult getTargetSpecificConfig(
     linalg::MatmulOp op, const spirv::TargetEnv &targetEnv,
@@ -706,6 +746,27 @@ Optional<LaunchConfig> initGPULaunchConfig(
     DISPATCH(linalg::PoolingNHWCSumOp)
 
 #undef DISPATCH
+  }
+
+  if (!rootOperation) {
+    for (linalg::LinalgOp linalgOp : linalgOps) {
+      if (auto op = dyn_cast<linalg::GenericOp>(linalgOp.getOperation())) {
+        if (getNumOuterParallelLoops(linalgOp) == 0 ||
+            llvm::any_of(linalgOp.getIndexingMaps(), [](AffineMap &map) {
+              return !map.isProjectedPermutation();
+            })) {
+          continue;
+        }
+        TileSizesListType tileSizesInfo;
+        if (failed(getOpLaunchConfig(op, targetEnv, options, tileSizesInfo,
+                                     config))) {
+          continue;
+        }
+        launchConfig.setTileSizes(op, tileSizesInfo);
+        launchConfig.setRootOperation(op);
+        break;
+      }
+    }
   }
 
   launchConfig.setWorkgroupSize(config.workgroupSize);

--- a/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/KernelDispatchUtils.cpp
@@ -349,10 +349,10 @@ LogicalResult getOpLaunchConfig(linalg::GenericOp op,
   size_t numLoops = getNumOuterParallelLoops(op);
   ts.resize(numLoops, 1);
   ts.back() = lowerTs;
-  tileSizes.emplace_back(ts); // Workgroup level.
-  tileSizes.emplace_back();   // Subgroup level.
+  tileSizes.emplace_back(ts);  // Workgroup level.
+  tileSizes.emplace_back();    // Subgroup level.
   ts.back() = lowerTs / subgroupSize;
-  tileSizes.emplace_back(ts); // Thread level.
+  tileSizes.emplace_back(ts);  // Thread level.
   // Vectorize only if we are processing more than one element per thread.
   config.vectorize = options.enableVectorization && (ts.back() > 1);
   return success();

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/BUILD
@@ -32,6 +32,7 @@ iree_lit_test_suite(
             "convert_to_gpu.mlir",
             "convert_to_spirv.mlir",
             "dead_alloc.mlir",
+            "elementwise_vectorization.mlir",
             "fold-gpu-procid-uses.mlir",
             "forop_canonicalization.mlir",
             "linalg_tile_and_fuse.mlir",

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "convert_to_gpu.mlir"
     "convert_to_spirv.mlir"
     "dead_alloc.mlir"
+    "elementwise_vectorization.mlir"
     "fold-gpu-procid-uses.mlir"
     "forop_canonicalization.mlir"
     "linalg_tile_and_fuse.mlir"

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/elementwise_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/elementwise_vectorization.mlir
@@ -1,0 +1,57 @@
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-spirv-linalg-tile-and-distribute,iree-spirv-tile-and-vectorize-in-one-workgroup,canonicalize,cse))" -iree-spirv-enable-vectorization %s | IreeFileCheck %s
+
+// CHECK-LABEL: func @elementwise_static_shape
+//       CHECK:   vector.transfer_read %10[%c0], {{.*}} memref<4xf32, #map1>, vector<4xf32>
+//       CHECK:   vector.transfer_read %11[%c0], {{.*}} memref<4xf32, #map1>, vector<4xf32>
+//       CHECK:   addf %{{.*}}, %{{.*}} : vector<4xf32>
+//       CHECK:   vector.transfer_write {{.*}} : vector<4xf32>, memref<4xf32
+hal.executable @elementwise_static_shape attributes {sym_visibility = "private"} {
+  hal.interface @legacy_io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @vulkan, filter="dylib*" {
+    hal.executable.entry_point @elementwise_static_shape attributes {
+      interface = @legacy_io, ordinal = 0 : i32,
+      signature = (!flow.dispatch.tensor<readonly:?xf32>,
+        !flow.dispatch.tensor<readonly:?xf32>,
+        !flow.dispatch.tensor<writeonly:?xf32>) -> ()}
+    module attributes {
+      spv.target_env =
+        #spv.target_env<#spv.vce<v1.5,
+          [Shader],
+          []>, NVIDIA:DiscreteGPU,
+          {subgroup_size = 32 : i32}>} {
+      func @elementwise_static_shape()
+        attributes {vkspv.num_workgroups_fn = @elementwise_static_shape__num_workgroups__} {
+        %arg0 = iree.placeholder for "interface buffer"
+          {binding = @legacy_io::@arg0, operand_result_num = 0 : i32} : memref<128xf32>
+        %arg1 = iree.placeholder for "interface buffer"
+          {binding = @legacy_io::@arg1, operand_result_num = 1 : i32} : memref<128xf32>
+        %ret0 = iree.placeholder for "interface buffer"
+          {binding = @legacy_io::@ret0, operand_result_num = 2 : i32} : memref<128xf32>
+        linalg.generic {
+          indexing_maps = [affine_map<(i) -> (i)>,
+                           affine_map<(i) -> (i)>,
+                           affine_map<(i) -> (i)>],
+           iterator_types = ["parallel"]
+          } ins(%arg0, %arg1 : memref<128xf32>, memref<128xf32>)
+            outs(%ret0 : memref<128xf32>) {
+              ^bb0(%a : f32, %b : f32, %c : f32):
+              %add = addf %a, %b : f32
+              linalg.yield %add : f32
+        }
+        return
+      }
+      func private @elementwise_static_shape__num_workgroups__
+        (!shapex.ranked_shape<[4096, 4096]>, !shapex.ranked_shape<[4096, 4096]>,
+         !shapex.ranked_shape<[4096, 4096]>) -> (index, index, index)
+      hal.interface @legacy_io attributes {sym_visibility = "private"} {
+        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -917,10 +917,8 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
           }));
     }
 
-    // NOTE: Special treatment for convolution, which have more than 3
-    // parallel dimensions. We want to ignore the batch dimension and tile
-    // along the next three. That means setting the first position to zero.
-    // TODO(#5048): figure out a better way to avoid this special case.
+    // For ops with more than 3 parallel dimensions, we want to ignore the
+    // higher dimension and tile along last three dimensions.
     for (size_t dim = 0; dim < numTiledLoops; ++dim) {
       useTileSizes[numParallelDims - dim - 1] =
           buildFlowWorkgroupInfoOp<Flow::DispatchWorkgroupSizeOp>(builder, dim);

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -612,13 +612,11 @@ struct TileAndDistributeOnTensorsPattern
     SmallVector<Value, 4> count = llvm::to_vector<4>(
         llvm::map_range(linalgOp.createLoopRanges(rewriter, loc),
                         [](Range r) { return r.size; }));
-    // NOTE: Special treatment for convolution, which have more than 3 parallel
-    // dimensions. We want to ignore the batch dimension and tile along the
-    // next three.
-    // TODO(#5048): figure out a better way to avoid this special case.
-    if (isa<linalg::ConvInputNHWCFilterHWCFOp,
-            linalg::DepthwiseConvInputNHWCFilterHWCOp>(op)) {
-      count.erase(count.begin());
+    size_t numParrallelLoops = getNumOuterParallelLoops(op);
+    if (numParrallelLoops > kNumMaxParallelDims) {
+      count.erase(
+          count.begin(),
+          std::next(count.begin(), numParrallelLoops - kNumMaxParallelDims));
     }
     count.resize(getNumTilableLoops(op));
     auto workload = convertToWorkload(rewriter, loc, count);
@@ -849,6 +847,23 @@ static void decideFusableLinalgOps(FuncOp funcOp) {
                             builder.getI64ArrayAttr(fusionGroups));
       }
     }
+
+    // As a second step mark all the element-wise linalg ops not fused as roots
+    // so that they get tiled and distributed.
+    for (linalg::LinalgOp linalgOp : linalgOps) {
+      Operation *op = linalgOp.getOperation();
+      if (!isa<linalg::GenericOp>(op) ||
+          getNumOuterParallelLoops(linalgOp) == 0 ||
+          llvm::any_of(linalgOp.getIndexingMaps(), [](AffineMap &map) {
+            return !map.isProjectedPermutation();
+          })) {
+        continue;
+      }
+
+      if (op->hasAttr(kRootOpAttr) || op->hasAttr(kFusionGroupsAttr)) continue;
+      unsigned currGroupNum = numRootOps++;
+      op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(currGroupNum));
+    }
   }
 }
 
@@ -906,11 +921,8 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     // parallel dimensions. We want to ignore the batch dimension and tile
     // along the next three. That means setting the first position to zero.
     // TODO(#5048): figure out a better way to avoid this special case.
-    bool isConvOp = isa<linalg::ConvInputNHWCFilterHWCFOp,
-                        linalg::DepthwiseConvInputNHWCFilterHWCOp>(op);
-
     for (size_t dim = 0; dim < numTiledLoops; ++dim) {
-      useTileSizes[(isConvOp ? numParallelDims : numTiledLoops) - dim - 1] =
+      useTileSizes[numParallelDims - dim - 1] =
           buildFlowWorkgroupInfoOp<Flow::DispatchWorkgroupSizeOp>(builder, dim);
     }
     return useTileSizes;

--- a/iree/compiler/Dialect/HAL/Target/CUDA/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/BUILD
@@ -49,6 +49,7 @@ cc_library(
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:LLVMToLLVMIRTranslation",
         "@llvm-project//mlir:NVVMDialect",
+        "@llvm-project//mlir:NVVMToLLVMIRTranslation",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:ToLLVMIRTranslation",

--- a/iree/compiler/Dialect/HAL/Target/CUDA/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     MLIRLLVMIR
     MLIRLLVMToLLVMIRTranslation
     MLIRNVVMIR
+    MLIRNVVMToLLVMIRTranslation
     MLIRPass
     MLIRSupport
     MLIRTargetLLVMIRExport

--- a/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 
 namespace mlir {
@@ -64,6 +65,7 @@ class CUDATargetBackend final : public TargetBackend {
 
   void getDependentDialects(DialectRegistry &registry) const override {
     mlir::registerLLVMDialectTranslation(registry);
+    mlir::registerNVVMDialectTranslation(registry);
   }
 
   void buildTranslationPassPipeline(OpPassManager &passManager) override {

--- a/iree/test/e2e/xla_ops/add.mlir
+++ b/iree/test/e2e/xla_ops/add.mlir
@@ -5,3 +5,24 @@ func @tensor() attributes { iree.module.export } {
   check.expect_almost_eq_const(%result, dense<[6.0, 8.0, 10.0, 12.0]> : tensor<4xf32>) : tensor<4xf32>
   return
 }
+
+func @tensor_4d() attributes { iree.module.export } {
+  %0 = iree.unfoldable_constant dense<[[[[1.0, 2.0], [3.0, 4.0]],
+                                         [[5.0, 6.0], [7.0, 8.0]]],
+                                        [[[9.0, 10.0], [11.0, 12.0]],
+                                         [[13.0, 14.0], [15.0, 16.0]]]]> :
+    tensor<2x2x2x2xf32>
+  %1 = iree.unfoldable_constant dense<[[[[1.0, 2.0], [3.0, 4.0]],
+                                         [[5.0, 6.0], [7.0, 8.0]]],
+                                        [[[9.0, 10.0], [11.0, 12.0]],
+                                         [[13.0, 14.0], [15.0, 16.0]]]]> :
+    tensor<2x2x2x2xf32>
+  %result = "mhlo.add"(%0, %1) : (tensor<2x2x2x2xf32>, tensor<2x2x2x2xf32>)
+    -> tensor<2x2x2x2xf32>
+  check.expect_almost_eq_const(%result, dense<[[[[2.0, 4.0], [6.0, 8.0]],
+                                               [[10.0, 12.0], [14.0, 16.0]]],
+                                              [[[18.0, 20.0], [22.0, 24.0]],
+                                               [[26.0, 28.0], [30.0, 32.0]]]]> :
+    tensor<2x2x2x2xf32>) : tensor<2x2x2x2xf32>
+  return
+}


### PR DESCRIPTION
Recommit 156f0bbe972992fa48ea223d0b035cef23a03c35 after fixing the
problem with vectorization. Skip vectorization for single element tiles
to avoid problem with vector<1> not supported in SPIR-V conversion. 

Also add a test to exercise vectorization path.