### PR TITLE
Fix and re-enable jax testing

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -70,4 +70,6 @@ ninja
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
 echo "Testing with CTest"
-ctest --output-on-failure -L 'integrations/tensorflow' --label-exclude "^nokokoro$"
+ctest --output-on-failure \
+   --tests-regex "^integrations/tensorflow/|^bindings/python/" \
+   --label-exclude "^nokokoro$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -78,6 +78,6 @@ export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
 # as well.
 echo "Testing with CTest"
 ctest --output-on-failure \
-   --tests-regex "^integrations/tensorflow/" \
+   --tests-regex "^integrations/tensorflow/|^bindings/python/" \
    --label-regex "^driver=vulkan$|^driver=cuda$" \
    --label-exclude "^nokokoro$"

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -93,6 +93,7 @@ cc_binary(
         "//iree_tf_compiler/TF",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:hlo_to_mlir_hlo",
         "@org_tensorflow//tensorflow/compiler/xla/service:hlo_parser",

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
@@ -127,6 +127,10 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   pm.nest<ModuleOp>().addPass(createStripFunctionMetadataPass());
   pm.addPass(createVerifyFullyConvertedPass());
 
+  buildMHLOImportPassPipeline(pm);
+}
+
+void buildMHLOImportPassPipeline(OpPassManager &pm) {
   //----------------------------------------------------------------------------
   // Convert control flow and flatten tuples (like tuple<tensor<...>, ...>)
   //----------------------------------------------------------------------------
@@ -146,6 +150,16 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   // shapes until these can be done properly upstream.
   ////////////////////////////////////////////////////////////////////////////
   pm.addPass(iree_compiler::Shape::createConvertHLOToShapePass());
+}
+
+
+void registerMHLOImportPassPipeline() {
+  mlir::PassPipelineRegistration<> pipeline(
+      "iree-mhlo-import-pipeline",
+      "Run IREE-specific passes for importing MHLO code into IREE",
+      [](OpPassManager &passManager) {
+        buildMHLOImportPassPipeline(passManager);
+      });
 }
 
 void registerTFImportPassPipeline() {

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
@@ -152,7 +152,6 @@ void buildMHLOImportPassPipeline(OpPassManager &pm) {
   pm.addPass(iree_compiler::Shape::createConvertHLOToShapePass());
 }
 
-
 void registerMHLOImportPassPipeline() {
   mlir::PassPipelineRegistration<> pipeline(
       "iree-mhlo-import-pipeline",

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
@@ -33,7 +33,11 @@ namespace TF {
 // passes in the right order.
 void buildTFImportPassPipeline(OpPassManager &pm);
 
+void buildMHLOImportPassPipeline(OpPassManager &pm);
+
 void registerTFImportPassPipeline();
+
+void registerMHLOImportPassPipeline();
 
 //===----------------------------------------------------------------------===//
 // IREE-specific Passes For TensorFlow Import
@@ -75,6 +79,7 @@ void registerAllDialects(mlir::DialectRegistry &registry);
 
 inline void registerAllPasses() {
   registerTFImportPassPipeline();
+  registerMHLOImportPassPipeline();
 
   createConvertToMHLOPass();
   createFlattenTuplesInCFGPass();


### PR DESCRIPTION
In https://github.com/google/iree/pull/5101 I accidentally removed
bindings/python tests from the CI because I assumed that they would be
covered not in the integrations build. It turns out that we have
tests depending on the TF integrations living under bindings/python
(gross. https://github.com/google/iree/issues/5181). So when
https://github.com/google/iree/pull/5104 moved MHLO tuple and control
flow legalization out of core, we didn't catch the test failure for
JAX.

This adds passes to convert from MHLO as produced by XLA->MHLO
translation to the form accepted by IREE. As we move more towards
making linalg on tensors our input and push more MHLO out of IREE core
the pipeline here will likely grow.