### PR TITLE
Generate and use the iree_hal_executable_library_t metadata.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_bindings.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_bindings.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
 
-// CHECK-LABEL: llvm.func @binding_ptrs
+// CHECK-LABEL: llvm.func internal @binding_ptrs
 func @binding_ptrs() {
   // CHECK-DAG: %[[C72:.+]] = llvm.mlir.constant(72 : index) : i64
   %c72 = constant 72 : index
@@ -28,7 +28,7 @@ hal.interface @io attributes {push_constants = 2 : i32, sym_visibility = "privat
 
 // -----
 
-// CHECK-LABEL: llvm.func @tie_shape
+// CHECK-LABEL: llvm.func internal @tie_shape
 func @tie_shape() {
   %c72 = constant 72 : index
   // ...

--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_constants.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_constants.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
 
-// CHECK-LABEL: llvm.func @constant_values
+// CHECK-LABEL: llvm.func internal @constant_values
 func @constant_values() {
   // CHECK: %[[STATE:.+]] = llvm.load %arg0 : !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t"
   // CHECK: %[[PTR_BASE:.+]] = llvm.extractvalue %[[STATE]][3]

--- a/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_workgroup_info.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/hal_interface_workgroup_info.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -allow-unregistered-dialect -iree-codegen-convert-to-llvm -split-input-file %s | IreeFileCheck %s
 
-// CHECK-LABEL: llvm.func @workgroup_id
+// CHECK-LABEL: llvm.func internal @workgroup_id
 func @workgroup_id() {
   // CHECK: %[[PTR:.+]] = llvm.load %arg1 : !llvm.ptr<array<3 x i32>>
   // CHECK: %[[Z32:.+]] = llvm.extractvalue %[[PTR]][2] : !llvm.array<3 x i32>
@@ -13,7 +13,7 @@ func @workgroup_id() {
 
 // -----
 
-// CHECK-LABEL: llvm.func @workgroup_size
+// CHECK-LABEL: llvm.func internal @workgroup_size
 func @workgroup_size() {
   // CHECK: %[[STATE:.+]] = llvm.load %arg0 : !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t"
   // CHECK: %[[SIZE_PTR:.+]] = llvm.extractvalue %[[STATE]][1] : !llvm.struct<"iree_hal_executable_dispatch_state_v0_t"
@@ -27,7 +27,7 @@ func @workgroup_size() {
 
 // -----
 
-// CHECK-LABEL: llvm.func @workgroup_count
+// CHECK-LABEL: llvm.func internal @workgroup_count
 func @workgroup_count() {
   // CHECK: %[[STATE:.+]] = llvm.load %arg0 : !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t"
   // CHECK: %[[COUNT_PTR:.+]] = llvm.extractvalue %[[STATE]][0] : !llvm.struct<"iree_hal_executable_dispatch_state_v0_t"

--- a/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -32,9 +32,11 @@ cc_library(
     name = "LLVM",
     srcs = [
         "LLVMAOTTarget.cpp",
+        "LibraryBuilder.cpp",
     ],
     hdrs = [
         "LLVMAOTTarget.h",
+        "LibraryBuilder.h",
     ],
     deps = [
         ":LLVMIRPasses",

--- a/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -19,8 +19,10 @@ iree_cc_library(
     LLVM
   HDRS
     "LLVMAOTTarget.h"
+    "LibraryBuilder.h"
   SRCS
     "LLVMAOTTarget.cpp"
+    "LibraryBuilder.cpp"
   DEPS
     ::LLVMIRPasses
     ::LLVMTargetOptions

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.cpp
@@ -1,0 +1,347 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h"
+
+#include "llvm/IR/IRBuilder.h"
+
+// =============================================================================
+//
+// NOTE: these structures model 1:1 those in iree/hal/local/executable_library.h
+//
+// This file must always track the latest version. Backwards compatibility with
+// existing runtimes using older versions of the header is maintained by
+// emitting variants of the structs matching those in the older headers and
+// selecting between them in the query function based on the requested version.
+//
+// =============================================================================
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+//===----------------------------------------------------------------------===//
+// iree/hal/local/executable_library.h structure types
+//===----------------------------------------------------------------------===//
+// The IR snippets below were pulled from clang running with `-S -emit-llvm`
+// on the executable_library.h header: https://godbolt.org/z/6bMv5jfvf
+
+// %struct.iree_hal_executable_import_table_v0_t = type {
+//   i64,
+//   i8*
+// }
+static llvm::StructType *makeImportTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_import_table_v0_t")) {
+    return existingType;
+  }
+  auto *i8PtrType = llvm::IntegerType::getInt8PtrTy(context);
+  auto *i64Type = llvm::IntegerType::getInt64Ty(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i64Type,
+                                            i8PtrType,
+                                        },
+                                        "iree_hal_executable_import_table_v0_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.anon = type { i32, i32, i32 }
+// %union.iree_hal_vec3_t = type { %struct.anon }
+static llvm::StructType *makeVec3Type(llvm::LLVMContext &context) {
+  if (auto *existingType =
+          llvm::StructType::getTypeByName(context, "iree_hal_vec3_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i32Type,
+                                            i32Type,
+                                            i32Type,
+                                        },
+                                        "iree_hal_vec3_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_dispatch_state_v0_t = type {
+//   %union.iree_hal_vec3_t,
+//   %union.iree_hal_vec3_t,
+//   i64,
+//   i32*,
+//   i64,
+//   i8**,
+//   i64*,
+//   %struct.iree_hal_executable_import_table_v0_t*
+// }
+static llvm::StructType *makeDispatchStateType(llvm::LLVMContext &context) {
+  auto *type = llvm::StructType::getTypeByName(
+      context, "iree_hal_executable_dispatch_state_v0_t");
+  assert(type && "state type must be defined by ConvertToLLVM");
+  return type;
+}
+
+// i32 (%struct.iree_hal_executable_dispatch_state_v0_t*,
+//      %union.iree_hal_vec3_t*)
+static llvm::FunctionType *makeDispatchFunctionType(
+    llvm::LLVMContext &context) {
+  auto *dispatchStateType = makeDispatchStateType(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *vec3Type = llvm::ArrayType::get(i32Type, 3);
+  return llvm::FunctionType::get(i32Type,
+                                 {
+                                     dispatchStateType->getPointerTo(),
+                                     vec3Type->getPointerTo(),
+                                 },
+                                 /*isVarArg=*/false);
+}
+
+// %struct.iree_hal_executable_library_header_t = type {
+//   i32,
+//   i8*,
+//   i32,
+//   i32
+// }
+static llvm::StructType *makeLibraryHeaderType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_library_header_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::IntegerType::getInt8PtrTy(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i32Type,
+                                            i8PtrType,
+                                            i32Type,
+                                            i32Type,
+                                        },
+                                        "iree_hal_executable_library_header_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_library_v0_t = type {
+//   %struct.iree_hal_executable_library_header_t*,
+//   i32,
+//   i32 (%struct.iree_hal_executable_dispatch_state_v0_t*,
+//        %union.iree_hal_vec3_t*)**,
+//   i8**,
+//   i8**
+// }
+static llvm::StructType *makeLibraryType(llvm::StructType *libraryHeaderType) {
+  auto &context = libraryHeaderType->getContext();
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_library_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *dispatchFunctionType = makeDispatchFunctionType(context);
+  auto *i8PtrType = llvm::IntegerType::getInt8PtrTy(context);
+  auto *type = llvm::StructType::create(
+      context,
+      {
+          libraryHeaderType->getPointerTo(),
+          i32Type,
+          dispatchFunctionType->getPointerTo()->getPointerTo(),
+          i8PtrType->getPointerTo(),
+          i8PtrType->getPointerTo(),
+      },
+      "iree_hal_executable_library_v0_t",
+      /*isPacked=*/false);
+  return type;
+}
+
+//===----------------------------------------------------------------------===//
+// IR construction utilities
+//===----------------------------------------------------------------------===//
+
+// Creates a global NUL-terminated string constant.
+//
+// Example:
+//   @.str.2 = private unnamed_addr constant [6 x i8] c"lib_a\00", align 1
+static llvm::Constant *getStringConstant(StringRef value,
+                                         llvm::Module *module) {
+  auto i8Type = llvm::IntegerType::getInt8Ty(module->getContext());
+  auto i32Type = llvm::IntegerType::getInt32Ty(module->getContext());
+  auto *stringType = llvm::ArrayType::get(i8Type, value.size() + /*NUL*/ 1);
+  auto *literal =
+      llvm::ConstantDataArray::getString(module->getContext(), value);
+  auto *global = new llvm::GlobalVariable(*module, stringType,
+                                          /*isConstant=*/true,
+                                          llvm::GlobalVariable::PrivateLinkage,
+                                          literal, /*Name=*/"");
+  global->setAlignment(llvm::MaybeAlign(1));
+  llvm::Constant *zero = llvm::ConstantInt::get(i32Type, 0);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      stringType, global, ArrayRef<llvm::Constant *>{zero, zero});
+}
+
+//===----------------------------------------------------------------------===//
+// Builder interface
+//===----------------------------------------------------------------------===//
+
+llvm::Function *LibraryBuilder::build(StringRef queryFuncName) {
+  auto &context = module->getContext();
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *libraryHeaderType = makeLibraryHeaderType(context);
+
+  // %struct.iree_hal_executable_library_header_t** @iree_hal_library_query(i32)
+  auto *queryFuncType =
+      llvm::FunctionType::get(libraryHeaderType->getPointerTo(),
+                              {
+                                  i32Type,
+                              },
+                              /*isVarArg=*/false);
+  auto *func =
+      llvm::Function::Create(queryFuncType, llvm::GlobalValue::InternalLinkage,
+                             queryFuncName, *module);
+
+  auto *entryBlock = llvm::BasicBlock::Create(context, "entry", func);
+  llvm::IRBuilder<> builder(entryBlock);
+
+  // Build out the header for each version and select it at runtime.
+  // NOTE: today there is just one version so this is rather simple:
+  //   return max_version == 0 ? &library : NULL;
+  auto *v0 = buildLibraryV0((queryFuncName + "_v0").str());
+  builder.CreateRet(builder.CreateSelect(
+      builder.CreateICmpEQ(func->getArg(0), llvm::ConstantInt::get(i32Type, 0)),
+      builder.CreatePointerCast(v0, libraryHeaderType->getPointerTo()),
+      llvm::ConstantPointerNull::get(libraryHeaderType->getPointerTo())));
+
+  return func;
+}
+
+llvm::Constant *LibraryBuilder::buildLibraryV0(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *libraryHeaderType = makeLibraryHeaderType(context);
+  auto *libraryType = makeLibraryType(libraryHeaderType);
+  auto *dispatchFunctionType = makeDispatchFunctionType(context);
+  auto *i8Type = llvm::IntegerType::getInt8Ty(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  llvm::Constant *zero = llvm::ConstantInt::get(i32Type, 0);
+
+  // ----- Header -----
+
+  auto *libraryHeader = new llvm::GlobalVariable(
+      *module, libraryHeaderType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantStruct::get(
+          libraryHeaderType,
+          {
+              // version=
+              llvm::ConstantInt::get(i32Type,
+                                     static_cast<int64_t>(Version::V_0)),
+              // name=
+              getStringConstant(module->getName(), module),
+              // features=
+              llvm::ConstantInt::get(i32Type, static_cast<int64_t>(features)),
+              // sanitizer=
+              llvm::ConstantInt::get(i32Type,
+                                     static_cast<int64_t>(sanitizerKind)),
+          }),
+      /*Name=*/libraryName + "_header");
+  // TODO(benvanik): force alignment (8? natural pointer width?)
+
+  // ----- Entry points -----
+
+  SmallVector<llvm::Constant *, 4> entryPointFuncValues;
+  for (auto entryPoint : entryPoints) {
+    entryPointFuncValues.push_back(entryPoint.func);
+  }
+  auto *entryPointFuncsType = llvm::ArrayType::get(
+      dispatchFunctionType->getPointerTo(), entryPointFuncValues.size());
+  llvm::Constant *entryPointFuncs = new llvm::GlobalVariable(
+      *module, entryPointFuncsType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantArray::get(entryPointFuncsType, entryPointFuncValues),
+      /*Name=*/libraryName + "_funcs");
+  // TODO(benvanik): force alignment (16? natural pointer width *2?)
+  entryPointFuncs = llvm::ConstantExpr::getInBoundsGetElementPtr(
+      entryPointFuncsType, entryPointFuncs,
+      ArrayRef<llvm::Constant *>{zero, zero});
+
+  llvm::Constant *entryPointNames =
+      llvm::Constant::getNullValue(i8Type->getPointerTo());
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
+    SmallVector<llvm::Constant *, 4> entryPointNameValues;
+    for (auto entryPoint : entryPoints) {
+      entryPointNameValues.push_back(
+          getStringConstant(entryPoint.name, module));
+    }
+    auto *entryPointNamesType = llvm::ArrayType::get(
+        i8Type->getPointerTo(), entryPointNameValues.size());
+    auto *global = new llvm::GlobalVariable(
+        *module, entryPointNamesType, /*isConstant=*/true,
+        llvm::GlobalVariable::PrivateLinkage,
+        llvm::ConstantArray::get(entryPointNamesType, entryPointNameValues),
+        /*Name=*/libraryName + "_names");
+    // TODO(benvanik): force alignment (16? natural pointer width *2?)
+
+    entryPointNames = llvm::ConstantExpr::getInBoundsGetElementPtr(
+        entryPointNamesType, global, ArrayRef<llvm::Constant *>{zero, zero});
+  }
+
+  llvm::Constant *entryPointTags =
+      llvm::Constant::getNullValue(i8Type->getPointerTo());
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
+    SmallVector<llvm::Constant *, 4> entryPointTagValues;
+    for (auto entryPoint : entryPoints) {
+      entryPointTagValues.push_back(getStringConstant(entryPoint.tag, module));
+    }
+    auto *entryPointTagsType = llvm::ArrayType::get(i8Type->getPointerTo(),
+                                                    entryPointTagValues.size());
+    auto *global = new llvm::GlobalVariable(
+        *module, entryPointTagsType, /*isConstant=*/true,
+        llvm::GlobalVariable::PrivateLinkage,
+        llvm::ConstantArray::get(entryPointTagsType, entryPointTagValues),
+        /*Name=*/libraryName + "_tags");
+    // TODO(benvanik): force alignment (16? natural pointer width *2?)
+
+    entryPointTags = llvm::ConstantExpr::getInBoundsGetElementPtr(
+        entryPointTagsType, global, ArrayRef<llvm::Constant *>{zero, zero});
+  }
+
+  // ----- Library -----
+
+  auto *library = new llvm::GlobalVariable(
+      *module, libraryType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantStruct::get(
+          libraryType,
+          {
+              // header=
+              libraryHeader,
+              // entry_point_count=
+              llvm::ConstantInt::get(i32Type, entryPoints.size()),
+              // entry_points=
+              entryPointFuncs,
+              // entry_point_names=
+              entryPointNames,
+              // entry_point_tags=
+              entryPointTags,
+          }),
+      /*Name=*/libraryName);
+  // TODO(benvanik): force alignment (8? natural pointer width?)
+
+  return library;
+}
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
@@ -1,0 +1,135 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef IREE_COMPILER_DIALECT_HAL_TARGET_LLVM_LIBRARYBUILDER_H_
+#define IREE_COMPILER_DIALECT_HAL_TARGET_LLVM_LIBRARYBUILDER_H_
+
+#include <string>
+
+#include "iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/Module.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+// Defines an `iree_hal_executable_library_v0_t` and builds the runtime metadata
+// structures and query functions.
+//
+// See iree/hal/local/executable_library.h for more information.
+//
+// Usage:
+//  LibraryBuilder builder(&module);
+//  builder.addEntryPoint("hello", "", &helloFunc);
+//  ...
+//  auto *queryFunc = builder.build("_query_library_foo");
+//  // call queryFunc, export it, etc
+class LibraryBuilder {
+ public:
+  // Builder mode setting.
+  enum class Mode : uint32_t {
+    // Include entry point names and tags.
+    // If not specified then the reflection strings will be excluded to reduce
+    // binary size.
+    INCLUDE_REFLECTION_ATTRS = 1 << 0u,
+  };
+
+  // iree_hal_executable_library_version_t
+  enum class Version : uint32_t {
+    // IREE_HAL_EXECUTABLE_LIBRARY_VERSION_0
+    V_0 = 0u,
+  };
+
+  // iree_hal_executable_library_features_t
+  enum class Features : uint32_t {
+    // IREE_HAL_EXECUTABLE_LIBRARY_FEATURE_NONE
+    NONE = 0u,
+  };
+
+  // iree_hal_executable_library_sanitizer_kind_t
+  enum class SanitizerKind : uint32_t {
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_NONE
+    NONE = 0u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_ADDRESS
+    ADDRESS = 1u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_MEMORY
+    MEMORY = 2u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD
+    THREAD = 3u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_UNDEFINED
+    UNDEFINED = 4u,
+  };
+
+  LibraryBuilder(llvm::Module *module, Mode mode,
+                 Version version = Version::V_0)
+      : module(module), mode(mode), version(version) {}
+
+  // Adds a new required feature flag bit. The runtime must support the feature
+  // for the library to be usable.
+  void addRequiredFeature(Features feature) {
+    features = static_cast<Features>(static_cast<uint32_t>(features) |
+                                     static_cast<uint32_t>(feature));
+  }
+
+  // Sets the LLVM sanitizer the executable is built to be used with. The
+  // runtime must also be compiled with the same sanitizer enabled.
+  void setSanitizerKind(SanitizerKind sanitizerKind) {
+    this->sanitizerKind = sanitizerKind;
+  }
+
+  // Defines a new entry point on the library implemented by |func|.
+  // |name| will be used as the library export and an optional |tag| will be
+  // attached.
+  void addEntryPoint(StringRef name, StringRef tag, llvm::Function *func) {
+    entryPoints.push_back({name.str(), tag.str(), func});
+  }
+
+  // Builds a `iree_hal_executable_library_query_fn_t` with the given
+  // |queryFuncName| that will return the current library metadata.
+  //
+  // The returned function will be inserted into the module with internal
+  // linkage. Callers may change the linkage based on their needs (such as
+  // exporting if producing a dynamic library or making dso_local for static
+  // libraries that reference the function via extern in another compilation
+  // unit, etc).
+  llvm::Function *build(StringRef queryFuncName);
+
+ private:
+  // Builds and returns an iree_hal_executable_library_v0_t global constant.
+  llvm::Constant *buildLibraryV0(std::string libraryName);
+
+  llvm::Module *module = nullptr;
+  Mode mode = Mode::INCLUDE_REFLECTION_ATTRS;
+  Version version = Version::V_0;
+  Features features = Features::NONE;
+  SanitizerKind sanitizerKind = SanitizerKind::NONE;
+
+  struct EntryPoint {
+    std::string name;
+    std::string tag;
+    llvm::Function *func;
+  };
+  std::vector<EntryPoint> entryPoints;
+};
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_HAL_TARGET_LLVM_LIBRARYBUILDER_H_

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -98,7 +98,7 @@ class LinkerTool {
   // Configures a module prior to compilation with any additional
   // functions/exports it may need, such as shared object initializer functions.
   virtual LogicalResult configureModule(
-      llvm::Module* llvmModule, ArrayRef<StringRef> entryPointNames) = 0;
+      llvm::Module* llvmModule, ArrayRef<llvm::Function*> exportedFuncs) = 0;
 
   // Links the given object files into a dynamically loadable library.
   // The resulting library (and other associated artifacts) will be returned on

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
@@ -107,8 +107,9 @@ class AndroidLinkerTool : public LinkerTool {
         .str();
   }
 
-  LogicalResult configureModule(llvm::Module *llvmModule,
-                                ArrayRef<StringRef> entryPointNames) override {
+  LogicalResult configureModule(
+      llvm::Module *llvmModule,
+      ArrayRef<llvm::Function *> exportedFuncs) override {
     for (auto &func : *llvmModule) {
       // Enable frame pointers to ensure that stack unwinding works, e.g. in
       // Tracy. In principle this could also be achieved by enabling unwind
@@ -120,16 +121,6 @@ class AndroidLinkerTool : public LinkerTool {
       // -ffreestanding-like behavior.
       func.addFnAttr("no-builtins");
     }
-
-    // TODO(benvanik): switch to executable libraries w/ internal functions.
-    for (auto entryPointName : entryPointNames) {
-      auto *entryPointFn = llvmModule->getFunction(entryPointName);
-      entryPointFn->setLinkage(
-          llvm::GlobalValue::LinkageTypes::ExternalLinkage);
-      entryPointFn->setVisibility(
-          llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-    }
-
     return success();
   }
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -43,8 +43,9 @@ class UnixLinkerTool : public LinkerTool {
     return "";
   }
 
-  LogicalResult configureModule(llvm::Module *llvmModule,
-                                ArrayRef<StringRef> entryPointNames) override {
+  LogicalResult configureModule(
+      llvm::Module *llvmModule,
+      ArrayRef<llvm::Function *> exportedFuncs) override {
     for (auto &func : *llvmModule) {
       // Enable frame pointers to ensure that stack unwinding works.
       func.addFnAttr("frame-pointer", "all");
@@ -52,16 +53,6 @@ class UnixLinkerTool : public LinkerTool {
       // -ffreestanding-like behavior.
       func.addFnAttr("no-builtins");
     }
-
-    // TODO(benvanik): switch to executable libraries w/ internal functions.
-    for (auto entryPointName : entryPointNames) {
-      auto *entryPointFn = llvmModule->getFunction(entryPointName);
-      entryPointFn->setLinkage(
-          llvm::GlobalValue::LinkageTypes::ExternalLinkage);
-      entryPointFn->setVisibility(
-          llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-    }
-
     return success();
   }
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -57,8 +57,9 @@ class WasmLinkerTool : public LinkerTool {
     return "";
   }
 
-  LogicalResult configureModule(llvm::Module *llvmModule,
-                                ArrayRef<StringRef> entryPointNames) override {
+  LogicalResult configureModule(
+      llvm::Module *llvmModule,
+      ArrayRef<llvm::Function *> exportedFuncs) override {
     for (auto &func : *llvmModule) {
       // Enable frame pointers to ensure that stack unwinding works.
       func.addFnAttr("frame-pointer", "all");
@@ -66,13 +67,6 @@ class WasmLinkerTool : public LinkerTool {
       // -ffreestanding-like behavior.
       func.addFnAttr("no-builtins");
     }
-
-    // https://lld.llvm.org/WebAssembly.html#exports
-    for (auto entryPointName : entryPointNames) {
-      auto *entryPointFn = llvmModule->getFunction(entryPointName);
-      entryPointFn->addFnAttr("wasm-export-name", entryPointName);
-    }
-
     return success();
   }
 

--- a/iree/hal/local/executable_library.h
+++ b/iree/hal/local/executable_library.h
@@ -112,7 +112,7 @@ typedef struct {
 // The provided |max_version| is the maximum version the caller supports;
 // callees must return NULL if their lowest available version is greater
 // than the max version supported by the caller.
-typedef const iree_hal_executable_library_header_t* (
+typedef const iree_hal_executable_library_header_t** (
     *iree_hal_executable_library_query_fn_t)(
     iree_hal_executable_library_version_t max_version);
 
@@ -204,12 +204,12 @@ typedef struct {
   // Optional table of export function entry point names 1:1 with entry_points.
   // These names are only used for tracing/debugging and can be omitted to save
   // binary size.
-  const char** entry_point_names;
+  const char* const* entry_point_names;
   // Optional table of entry point tags that describe the entry point in a
   // human-readable format useful for verbose logging. The string values, when
   // present, may be attached to tracing/debugging events related to the entry
   // point.
-  const char** entry_point_tags;
+  const char* const* entry_point_tags;
 
   // TODO(benvanik): optional import declarations.
 } iree_hal_executable_library_v0_t;

--- a/iree/schemas/dylib_executable_def.fbs
+++ b/iree/schemas/dylib_executable_def.fbs
@@ -14,13 +14,6 @@
 
 namespace iree;
 
-// Define kinds of sanitizers (the order in enum should be same as enum in LLVM
-// TargetOptions)
-enum SanitizerKind : ubyte {
-  None = 0,
-  Address
-}
-
 // 'Dynamic Library (dylib) Executable'.
 
 file_identifier "DLIB";
@@ -28,9 +21,6 @@ file_extension "dlib";
 
 // Dynamic library (.so/.dll/.dylib) executable module.
 table DyLibExecutableDef {
-  // A map of entry points to string names with the same order as in the
-  // executable op.
-  entry_points:[string];
   // An embedded (as opposed to external) dynamic library file.
   // TODO(scotttodd): List of embedded files?
   // TODO(scotttodd): Format of files, platform information (x86/arm/etc.)
@@ -38,7 +28,6 @@ table DyLibExecutableDef {
 
   debug_database_filename:string;
   debug_database_embedded:[ubyte];
-  sanitized_kind:SanitizerKind = None;
 
   // TODO(scotttodd): Relative file path from this flatbuffer file
 }


### PR DESCRIPTION
The flatbuffers are still present (and we may always need some kind of
descriptor to help the runtime load) but all reflection is now performed
through the interface.

Fixes #3580.