### PR TITLE
Add mobile-bert f16 version to Mako benchmark.

### DIFF
--- a/build_tools/mako/config/mobile-bert-f16-s20.config
+++ b/build_tools/mako/config/mobile-bert-f16-s20.config
@@ -1,0 +1,37 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+benchmark_key: "4636549841944576"
+benchmark_name: "MobileBert f16 version (S20) (Time Unit: ms)"
+project_name: "iree"
+
+# Only owners can write to the benchmark
+owner_list: "hanchung@google.com"
+owner_list: "buildkite-agent@iree-oss.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: NUMERIC
+}
+
+# Three metrics, define the names for y-axis values of both run and aggregate
+# charts.
+metric_info_list: {
+  value_key: "vlk"
+  label: "Vulkan-SPIRV"
+}
+
+description: "Mobile BERT Q&A model f16 version"

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -236,6 +236,18 @@ MODEL_BENCHMARKS = [
                     'cpu2': 10,
                     'vlk2': 64
                 })),
+        ]),
+    ModelBenchmarkInfo(
+        name="mobilebert-f16",
+        model_artifacts_name="mobilebert-f16.tar.gz",
+        model_path="mobilebert-f16/mobilebert-f16.mlir",
+        flagfile_path="mobilebert-f16/flagfile",
+        phones=[
+            PhoneBenchmarkInfo(
+                name="S20",
+                benchmark_key="4636549841944576",
+                targets=get_s20_default_target_list(
+                    skipped_target=['cpu', 'vmla', 'cpu2', 'vlk2'])),
         ])
 ]
 


### PR DESCRIPTION
This only runs on S20 GPU. The batch_size=1 because the current benchmarking mechanism does not reflect real performance. See https://github.com/google/iree/issues/5248