### PR TITLE
Avoid allocating temporary buffer for tensors derived from read-only tensors

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -248,7 +248,7 @@ static LogicalResult convertInitTensorOp(
   return success();
 }
 
-/// Walks the use-def chain and see if this value ceoms from a read-only tensor.
+/// Walks the use-def chain and see if this value comes from a read-only tensor.
 static bool isFromReadOnlyTensor(Value v) {
   auto definingOp = v.getDefiningOp();
   if (!definingOp) return false;

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -248,6 +248,28 @@ static LogicalResult convertInitTensorOp(
   return success();
 }
 
+/// Walks the use-def chain and see if this value ceoms from a read-only tensor.
+static bool isFromReadOnlyTensor(Value v) {
+  auto definingOp = v.getDefiningOp();
+  if (!definingOp) return false;
+  return TypeSwitch<Operation *, bool>(definingOp)
+      .Case<ConstantOp>([&](ConstantOp constantOp) { return true; })
+      .Case<linalg::TensorReshapeOp>([&](linalg::TensorReshapeOp reshapeOp) {
+        return isFromReadOnlyTensor(reshapeOp.src());
+      })
+      .Case<SubTensorOp>([&](SubTensorOp subTensorOp) {
+        return isFromReadOnlyTensor(subTensorOp.source());
+      })
+      .Case<IREE::Flow::DispatchTensorLoadOp>(
+          [&](IREE::Flow::DispatchTensorLoadOp loadOp) {
+            return loadOp.source()
+                       .getType()
+                       .cast<IREE::Flow::DispatchTensorType>()
+                       .getAccess() == IREE::Flow::TensorAccess::ReadOnly;
+          })
+      .Default([&](Operation *op) { return false; });
+}
+
 /// Avoids creating an allocation if the result tensor can just be aliased to
 /// use the same buffer (`inputBuffer`) that `srcTensor` is mapped to. This can
 /// be done if `srcTensor` has a single use, which is the operation which is
@@ -266,9 +288,9 @@ static LogicalResult createAliasingBufferOrAllocationForResult(
     }
     return success();
   }
-  // Case 2: If the input tensor has only one use (this operation, then no need
-  // to create a copy either.
-  if (srcTensor.hasOneUse()) {
+  // Case 2: If the input tensor has only one use (this operation) or is from a
+  // read-only tensor, then no need to create a copy either.
+  if (srcTensor.hasOneUse() || isFromReadOnlyTensor(srcTensor)) {
     bvm.map(resultTensor, inputBuffer);
     return success();
   }
@@ -341,13 +363,6 @@ static LogicalResult convertSubTensorOp(
       loc, subViewResultType, inputBuffer, op.offsets(), op.sizes(),
       op.strides(), op.static_offsets(), op.static_sizes(),
       op.static_strides());
-  // For now special case the constant source case (where sub-tensor can
-  // directly be replaced by a subview). All this needs to be cleaned up soon.
-  // TODO(GH-5013): This should fall out naturally when doing buffer planning.
-  if (srcTensor.getDefiningOp<ConstantOp>()) {
-    bvm.map(resultTensor, subViewOp);
-    return success();
-  }
   auto allocationDynamicSizes = llvm::to_vector<4>(
       llvm::map_range(subViewOp.getOrCreateRanges(b, loc), [](Range range) {
         assert(matchPattern(range.stride, m_One()) &&

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -760,3 +760,72 @@ hal.interface @legacy_io attributes {sym_visibility = "private"} {
 //  CHECK-SAME:     strides = dense<[2, 3]> : vector<2xi64>
 //  CHECK-SAME:     ins(%[[INPUT]], %[[WINDOW]] : memref<1x4x6x1xf32>, memref<2x3xf32>)
 //  CHECK-SAME:    outs(%[[RET0]] : memref<1x2x2x1xf32>)
+
+// -----
+
+func @read_only_subtensor() {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = hal.interface.binding.subspan @legacy_io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>
+  %1 = hal.interface.binding.subspan @legacy_io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>
+  %2 = flow.dispatch.tensor.load %1 : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
+  %3 = hal.interface.binding.subspan @legacy_io::@ro1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>
+  %4 = flow.dispatch.tensor.load %3 : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
+  %workgroup_size_x = hal.interface.workgroup.size[0] : index
+  %workgroup_size_y = hal.interface.workgroup.size[1] : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+  %6 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+  %dim0 = memref.dim %2, %c0 : tensor<?x?xf32>
+  %dim1 = memref.dim %2, %c1 : tensor<?x?xf32>
+  scf.for %arg0 = %5 to %dim0 step %6 {
+    %7 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+    %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+    scf.for %arg1 = %7 to %dim1 step %8 {
+      %9 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %dim0]
+      %10 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %dim1]
+      %11 = subtensor %2[%arg0, %arg1] [%9, %10] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+      %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %dim0]
+      %13 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %dim1]
+      %14 = subtensor %2[%arg0, %arg1] [%12, %13] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+      %15 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %dim0]
+      %16 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %dim1]
+      %17 = subtensor %4[%arg0, %arg1] [%15, %16] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+      %18 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %dim0]
+      %19 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %dim1]
+      %20 = subtensor %4[%arg0, %arg1] [%18, %19] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+      %21 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %dim0]
+      %22 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %dim1]
+      %23 = linalg.init_tensor [%21, %22] : tensor<?x?xf32>
+      %24 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11, %14, %17, %20 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) outs(%23 : tensor<?x?xf32>) attrs =  {__internal_linalg_transform__ = "workgroup"} {
+      ^bb0(%arg2: f32, %arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
+        %25 = mulf %arg4, %arg5 : f32
+        %26 = mulf %arg2, %arg3 : f32
+        %27 = addf %26, %25 : f32
+        %28 = math.sqrt %27 : f32
+        linalg.yield %28 : f32
+      } -> tensor<?x?xf32>
+      flow.dispatch.tensor.store %24, %0, offsets = [%arg0, %arg1], sizes = [%21, %22], strides = [%c1, %c1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?xf32>
+    }
+  }
+  return
+}hal.interface @legacy_io attributes {sym_visibility = "private"} {
+  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer", access="Read"
+  hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @read_only_subtensor
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @legacy_io::@ro0[%c0] : memref<?x?xf32>
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @legacy_io::@ro1[%c0] : memref<?x?xf32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @legacy_io::@wo2[%c0] : memref<?x?xf32>
+//       CHECK:   scf.for
+//       CHECK:     scf.for
+//   CHECK-DAG:       %[[SV1:.+]] = memref.subview %[[ARG0]]
+//   CHECK-DAG:       %[[SV2:.+]] = memref.subview %[[ARG1]]
+//   CHECK-DAG:       %[[SV3:.+]] = memref.subview %[[RET0]]
+//       CHECK:       linalg.generic
+//  CHECK-SAME:         ins(%[[SV1]], %[[SV1]], %[[SV2]], %[[SV2]] :
+//  CHECK-SAME:         outs(%[[SV3]] :


### PR DESCRIPTION
If a tensor value for an operand is coming from a read-only tensor,
then the buffer used for the result can be an alias of that used for
the operand since all values derived from a "read-only" tensor is
never written to within the dispatch region.

Fixes #5206 