### PR TITLE
Tidying up a few pages of documentation.

### DIFF
--- a/docs/developing_iree/benchmarking.md
+++ b/docs/developing_iree/benchmarking.md
@@ -22,7 +22,7 @@ To use `iree-benchmark-module`, generate an IREE module for the target backend:
 $ bazel run //iree/tools:iree-translate -- \
   -iree-mlir-to-vm-bytecode-module \
   --iree-hal-target-backends=vmla \
-  $PWD/iree/tools/test/simple.mlir \
+  $PWD/iree/tools/test/iree-benchmark-module.mlir \
   -o /tmp/module.fb
 ```
 

--- a/docs/developing_iree/developer_overview.md
+++ b/docs/developing_iree/developer_overview.md
@@ -232,31 +232,4 @@ function.
 ### Useful Vulkan driver flags
 
 For IREE's Vulkan runtime driver, there are a few useful flags defined in
-[vulkan_driver_module.cc](https://github.com/google/iree/blob/main/iree/hal/vulkan/vulkan_driver_module.cc):
-
-#### `--vulkan_renderdoc`
-
-This flag tells IREE to load RenderDoc, connect to it's in-application API, and
-trigger capturing on its own. For example, this command runs `iree-run-mlir` on
-a simple MLIR file with some sample input values and saves a RenderDoc capture
-to the default location on your system (e.g. `/tmp/RenderDoc/`):
-
-```shell
-$ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/renderdoc/lib/path \
-  ../iree-build/iree/tools/iree-run-mlir \
-    $PWD/iree/samples/vulkan/simple_mul.mlir \
-    -iree-hal-target-backends=vulkan-spirv \
-    -function-input="4xf32=1,2,3,4" \
-    -function-input="4xf32=2,4,6,8" \
-    -run-arg="--vulkan_renderdoc"
-```
-
-This flag also works for other IREE execution tools like `iree-run-module`,
-`iree-check-module`.
-
-You can also launch IREE's headless programs through RenderDoc itself, just be
-sure to set the command line arguments appropriately. Saving capture settings in
-RenderDoc can help if you find yourself doing this frequently.
-
-Note: RenderDoc version 1.7 or higher is needed to record captures from IREE's
-headless compute programs.
+[driver_module.cc](https://github.com/google/iree/blob/main/iree/hal/vulkan/registration/driver_module.cc):

--- a/docs/developing_iree/developer_overview.md
+++ b/docs/developing_iree/developer_overview.md
@@ -118,7 +118,7 @@ For example, to translate `simple.mlir` to an IREE module:
 $ ../iree-build/iree/tools/iree-translate \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=vmla \
-  $PWD/iree/tools/test/simple.mlir \
+  $PWD/iree/tools/test/iree-run-module.mlir \
   -o /tmp/simple.vmfb
 ```
 
@@ -176,11 +176,11 @@ does some additional work that usually must be explicit, like marking every
 function as exported by default and running all of them.
 
 For example, to execute the contents of
-[iree/tools/test/simple.mlir](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir):
+[iree/tools/test/iree-run-mlir.mlir](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir):
 
 ```shell
 $ ../iree-build/iree/tools/iree-run-mlir \
-  $PWD/iree/tools/test/simple.mlir \
+  $PWD/iree/tools/test/iree-run-mlir.mlir \
   -function-input="i32=-2" \
   -iree-hal-target-backends=vmla
 ```

--- a/docs/get_started/getting_started_android_cmake.md
+++ b/docs/get_started/getting_started_android_cmake.md
@@ -71,7 +71,7 @@ $ cmake -G Ninja -B ../iree-build-host/ -DCMAKE_INSTALL_PREFIX=../iree-build-hos
 $ cmake --build ../iree-build-host/ --target install
 ```
 
-Debugging note: 
+Debugging note:
   * If `IREE_LLVMAOT_LINKER_PATH` is set for targeting Android then
 the build above will fail, and you should run `unset IREE_LLVMAOT_LINKER_PATH`.
   * If you experience the build error similar to issue [#4915](https://github.com/google/iree/issues/4915), update the cmake configuration CLI to
@@ -146,7 +146,7 @@ Translate a source MLIR into IREE module:
 $ ../iree-build-host/install/bin/iree-translate \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=vmla \
-  $PWD/iree/tools/test/simple.mlir \
+  $PWD/iree/tools/test/iree-run-module.mlir \
   -o /tmp/simple-vmla.vmfb
 ```
 
@@ -184,7 +184,7 @@ Translate a source MLIR into IREE module:
 $ ../iree-build-host/install/bin/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
     -iree-hal-target-backends=vulkan-spirv \
-    $PWD/iree/tools/test/simple.mlir \
+    $PWD/iree/tools/test/iree-run-module.mlir \
     -o /tmp/simple-vulkan.vmfb
 ```
 
@@ -261,7 +261,7 @@ $ ../iree-build-host/install/bin/iree-translate \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=dylib-llvm-aot \
   -iree-llvm-target-triple=aarch64-linux-android \
-  $PWD/iree/tools/test/simple.mlir \
+  $PWD/iree/tools/test/iree-run-module.mlir \
   -o /tmp/simple-llvm_aot.vmfb
 ```
 

--- a/docs/get_started/getting_started_linux_bazel.md
+++ b/docs/get_started/getting_started_linux_bazel.md
@@ -113,11 +113,11 @@ $ ./bazel-bin/iree/tools/iree-translate --help
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir)
 and execute a function in the compiled module:
 
 ```shell
-$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir \
+$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/iree-run-mlir.mlir \
   -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -120,7 +120,7 @@ Translate a source MLIR into an IREE module:
 
 ```shell
 # Assuming in IREE source root
-$ ./build/iree/tools/iree-translate \
+$ ../iree-build/iree/tools/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
     -iree-llvm-target-triple=x86_64-linux-gnu \
     -iree-hal-target-backends=dylib-llvm-aot \
@@ -131,10 +131,10 @@ $ ./build/iree/tools/iree-translate \
 Then run the compiled module using the `dylib` HAL driver:
 
 ```shell
-$ ./build/iree/tools/iree-run-module -driver=dylib \
-          -module_file=/tmp/simple-llvm_aot.vmfb \
-          -entry_function=abs \
-          -function_inputs="i32=-5"
+$ ../iree-build/iree/tools/iree-run-module -driver=dylib \
+    -module_file=/tmp/simple-llvm_aot.vmfb \
+    -entry_function=abs \
+    -function_inputs="i32=-5"
 
 EXEC @abs
 i32=5

--- a/docs/get_started/getting_started_linux_cmake.md
+++ b/docs/get_started/getting_started_linux_cmake.md
@@ -99,11 +99,11 @@ $ ../iree-build/iree/tools/iree-translate --help
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-module.mlir)
 and execute a function in the compiled module:
 
 ```shell
-$ ../iree-build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
+$ ../iree-build/iree/tools/iree-run-mlir $PWD/iree/tools/test/iree-run-module.mlir \
   -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
@@ -124,7 +124,7 @@ $ ./build/iree/tools/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
     -iree-llvm-target-triple=x86_64-linux-gnu \
     -iree-hal-target-backends=dylib-llvm-aot \
-    iree/tools/test/simple.mlir \
+    iree/tools/test/iree-run-module.mlir \
     -o /tmp/simple-llvm_aot.vmfb
 ```
 

--- a/docs/get_started/getting_started_linux_vulkan.md
+++ b/docs/get_started/getting_started_linux_vulkan.md
@@ -117,10 +117,10 @@ Pass the flag `-iree-hal-target-backends=vulkan-spirv` to `iree-translate`:
 ```shell
 # -- CMake --
 $ cmake --build ../iree-build/ --target iree_tools_iree-translate
-$ ../iree-build/iree/tools/iree-translate -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv ./iree/tools/test/simple.mlir -o /tmp/module.vmfb
+$ ../iree-build/iree/tools/iree-translate -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv ./iree/tools/test/iree-run-module.mlir -o /tmp/module.vmfb
 
 # -- Bazel --
-$ bazel run iree/tools:iree-translate -- -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv $PWD/iree/tools/test/simple.mlir -o /tmp/module.vmfb
+$ bazel run iree/tools:iree-translate -- -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv $PWD/iree/tools/test/iree-run-module.mlir -o /tmp/module.vmfb
 ```
 
 > Tip:<br>

--- a/docs/get_started/getting_started_macos_bazel.md
+++ b/docs/get_started/getting_started_macos_bazel.md
@@ -116,11 +116,11 @@ $ ./bazel-bin/iree/tools/iree-translate --help
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir)
 and execute a function in the compiled module:
 
 ```shell
-$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/simple.mlir \
+$ ./bazel-bin/iree/tools/iree-run-mlir ./iree/tools/test/iree-run-mlir.mlir \
   -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 

--- a/docs/get_started/getting_started_macos_cmake.md
+++ b/docs/get_started/getting_started_macos_cmake.md
@@ -99,11 +99,11 @@ $ ../iree-build/iree/tools/iree-translate --help
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir)
 and execute a function in the compiled module:
 
 ```shell
-$ ../iree-build/iree/tools/iree-run-mlir $PWD/iree/tools/test/simple.mlir \
+$ ../iree-build/iree/tools/iree-run-mlir $PWD/iree/tools/test/iree-run-mlir.mlir \
   -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 

--- a/docs/get_started/getting_started_windows_bazel.md
+++ b/docs/get_started/getting_started_windows_bazel.md
@@ -118,11 +118,11 @@ Check out what was built:
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir)
 and execute a function in the compiled module:
 
 ```powershell
-> .\bazel-bin\iree\tools\iree-run-mlir.exe .\iree\tools\test\simple.mlir -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+> .\bazel-bin\iree\tools\iree-run-mlir.exe .\iree\tools\test\iree-run-mlir.mlir -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/get_started/getting_started_windows_cmake.md
+++ b/docs/get_started/getting_started_windows_cmake.md
@@ -115,7 +115,7 @@ Translate a source MLIR file into an IREE module:
 > ..\iree-build\iree\tools\iree-translate.exe \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=dylib-llvm-aot \
-  iree/tools/test/simple.mlir \
+  iree/tools/test/iree-run-module.mlir \
   -o %TMP%/simple-llvm_aot.vmfb
 ```
 
@@ -130,7 +130,7 @@ cross-compiling:
   -iree-llvm-target-triple=x86_64-pc-windows-msvc \
   -iree-llvm-target-cpu=host \
   -iree-llvm-target-cpu-features=host \
-  iree/tools/test/simple.mlir \
+  iree/tools/test/iree-run-module.mlir \
   -o %TMP%/simple-llvm_aot.vmfb
 ```
 
@@ -146,11 +146,11 @@ Check out the contents of the 'tools' build directory:
 ```
 
 Translate a
-[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/simple.mlir)
+[MLIR file](https://github.com/google/iree/blob/main/iree/tools/test/iree-run-mlir.mlir)
 and execute a function in the compiled module:
 
 ```powershell
-> ..\iree-build\iree\tools\iree-run-mlir.exe .\iree\tools\test\simple.mlir -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
+> ..\iree-build\iree\tools\iree-run-mlir.exe .\iree\tools\test\iree-run-mlir.mlir -function-input="i32=-2" -iree-hal-target-backends=vmla -print-mlir
 ```
 
 ### Further Reading

--- a/docs/get_started/getting_started_windows_vulkan.md
+++ b/docs/get_started/getting_started_windows_vulkan.md
@@ -115,10 +115,10 @@ Pass the flag `-iree-hal-target-backends=vulkan-spirv` to `iree-translate.exe`:
 ```powershell
 # -- CMake --
 > cmake --build ..\iree-build\ --target iree_tools_iree-translate
-> ..\iree-build\iree\tools\iree-translate.exe -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv .\iree\tools\test\simple.mlir -o .\build\module.vmfb
+> ..\iree-build\iree\tools\iree-translate.exe -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv .\iree\tools\test\iree-run-module.mlir -o .\build\module.vmfb
 
 # -- Bazel --
-> bazel run iree/tools:iree-translate -- -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv .\iree\tools\test\simple.mlir -o .\build\module.vmfb
+> bazel run iree/tools:iree-translate -- -iree-mlir-to-vm-bytecode-module -iree-hal-target-backends=vulkan-spirv .\iree\tools\test\iree-run-module.mlir -o .\build\module.vmfb
 ```
 
 > Tip:<br>


### PR DESCRIPTION
* Redirect `test/simple.mlir` to `test/iree-run-[module,mlir].mlir` in docs (split in https://github.com/google/iree/commit/32b3101ba74d0283b49304d1e8062ba9a2db2585, https://github.com/google/iree/issues/4667 has other ideas for how to address this)
* Use `../iree-build/` consistently in getting started linux cmake doc.
* Fix link to moved file and delete old RenderDoc instructions. (integration was dropped as part of https://github.com/google/iree/issues/4369)

Fixes https://github.com/google/iree/issues/4667
Fixes https://github.com/google/iree/issues/4704 (as filed - there are likely more outdated docs)