### PR TITLE
Adds C++ wrappers for the TFLite C API for upcoming Java bindings. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ if(${IREE_BUILD_TENSORFLOW_COMPILER} OR
 endif()
 
 option(IREE_BUILD_BINDINGS_TFLITE "Builds the IREE TFLite C API compatibility shim" ON)
+option(IREE_BUILD_BINDINGS_TFLITE_JAVA "Builds the IREE TFLite Java bindings with the C API compatability shim" ON)
 
 # Default python bindings to enabled for some features.
 if(${IREE_ENABLE_TENSORFLOW})

--- a/bindings/tflite/CMakeLists.txt
+++ b/bindings/tflite/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 iree_add_all_subdirs()
 
+if(${IREE_BUILD_BINDINGS_TFLITE_JAVA})
+  add_subdirectory(java/com/google/iree)
+endif()
+
 iree_cc_library(
   NAME
     shim

--- a/bindings/tflite/java/com/google/iree/CMakeLists.txt
+++ b/bindings/tflite/java/com/google/iree/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()

--- a/bindings/tflite/java/com/google/iree/native/CMakeLists.txt
+++ b/bindings/tflite/java/com/google/iree/native/CMakeLists.txt
@@ -1,0 +1,97 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_cc_library(
+  NAME
+    interpreter_wrapper
+  HDRS
+    "interpreter_wrapper.h"
+  SRCS
+    "interpreter_wrapper.cc"
+  DEPS
+    ::model_wrapper
+    ::options_wrapper
+    ::tensor_wrapper
+    absl::memory
+    bindings::tflite::shim
+    iree::base::api
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    model_wrapper
+  HDRS
+    "model_wrapper.h"
+  SRCS
+    "model_wrapper.cc"
+  DEPS
+    bindings::tflite::shim
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    options_wrapper
+  HDRS
+    "options_wrapper.h"
+  SRCS
+    "options_wrapper.cc"
+  DEPS
+    bindings::tflite::shim
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    tensor_wrapper
+  HDRS
+    "tensor_wrapper.h"
+  SRCS
+    "tensor_wrapper.cc"
+  DEPS
+    ::tflite_macros
+    bindings::tflite::shim
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    tflite_macros
+  HDRS
+    "tflite_macros.h"
+  DEPS
+    bindings::tflite::shim
+    iree::base::api
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    interpreter_wrapper_test
+  SRCS
+    "interpreter_wrapper_test.cc"
+  DEPS
+    ::interpreter_wrapper
+    ::model_wrapper
+    ::options_wrapper
+    ::tensor_wrapper
+    bindings::tflite::shim
+    bindings::tflite::testdata::add_static_cc
+    iree::base::api
+    iree::testing::gtest
+    iree::testing::gtest_main
+)

--- a/bindings/tflite/java/com/google/iree/native/interpreter_wrapper.cc
+++ b/bindings/tflite/java/com/google/iree/native/interpreter_wrapper.cc
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/java/com/google/iree/native/interpreter_wrapper.h"
+
+#include "absl/memory/memory.h"
+#include "bindings/tflite/java/com/google/iree/native/tflite_macros.h"
+
+namespace iree {
+namespace tflite {
+
+iree_status_t InterpreterWrapper::Create(const ModelWrapper& model,
+                                         const OptionsWrapper& options) {
+  interpreter_ = TfLiteInterpreterCreate(model.model(), options.options());
+  if (interpreter_ == nullptr) {
+    return iree_make_status(IREE_STATUS_UNKNOWN,
+                            "Failed to create interpreter wrapper.");
+  }
+  return iree_ok_status();
+}
+
+InterpreterWrapper::~InterpreterWrapper() {
+  TfLiteInterpreterDelete(interpreter_);
+  interpreter_ = nullptr;
+}
+
+iree_status_t InterpreterWrapper::AllocateTensors() {
+  TFLITE_RETURN_IF_ERROR(TfLiteInterpreterAllocateTensors(interpreter_));
+  return iree_ok_status();
+}
+
+iree_status_t InterpreterWrapper::ResizeInputTensor(int32_t input_index,
+                                                    const int* input_dims,
+                                                    int32_t input_dims_size) {
+  return TFLITE_TO_IREE_STATUS(TfLiteInterpreterResizeInputTensor(
+      interpreter_, input_index, input_dims, input_dims_size));
+}
+
+std::unique_ptr<TensorWrapper> InterpreterWrapper::GetInputTensor(
+    int input_index) {
+  return absl::make_unique<TensorWrapper>(
+      TfLiteInterpreterGetInputTensor(interpreter_, input_index));
+}
+
+std::unique_ptr<TensorWrapper> InterpreterWrapper::GetOutputTensor(
+    int output_index) {
+  return absl::make_unique<TensorWrapper>(
+      TfLiteInterpreterGetOutputTensor(interpreter_, output_index));
+}
+
+iree_status_t InterpreterWrapper::Invoke() {
+  return TFLITE_TO_IREE_STATUS(TfLiteInterpreterInvoke(interpreter_));
+}
+
+}  // namespace tflite
+}  // namespace iree

--- a/bindings/tflite/java/com/google/iree/native/interpreter_wrapper.h
+++ b/bindings/tflite/java/com/google/iree/native/interpreter_wrapper.h
@@ -1,0 +1,60 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_INTERPRETER_WRAPPER_H_
+#define BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_INTERPRETER_WRAPPER_H_
+
+#include <memory>
+
+#include "bindings/tflite/java/com/google/iree/native/model_wrapper.h"
+#include "bindings/tflite/java/com/google/iree/native/options_wrapper.h"
+#include "bindings/tflite/java/com/google/iree/native/tensor_wrapper.h"
+#include "iree/base/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+namespace iree {
+namespace tflite {
+
+class InterpreterWrapper {
+ public:
+  iree_status_t Create(const ModelWrapper& model,
+                       const OptionsWrapper& options);
+  ~InterpreterWrapper();
+
+  TfLiteInterpreter* interpreter() const { return interpreter_; }
+  int get_input_tensor_count() const {
+    return TfLiteInterpreterGetInputTensorCount(interpreter_);
+  }
+  int get_output_tensor_count() const {
+    return TfLiteInterpreterGetOutputTensorCount(interpreter_);
+  }
+
+  iree_status_t AllocateTensors();
+  iree_status_t ResizeInputTensor(int32_t input_index, const int* input_dims,
+                                  int32_t input_dims_size);
+  std::unique_ptr<TensorWrapper> GetInputTensor(int input_index);
+  std::unique_ptr<TensorWrapper> GetOutputTensor(int output_index);
+  iree_status_t Invoke();
+
+ private:
+  TfLiteInterpreter* interpreter_ = nullptr;
+};
+
+}  // namespace tflite
+}  // namespace iree
+
+#endif  // BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_INTERPRETER_WRAPPER_H_

--- a/bindings/tflite/java/com/google/iree/native/interpreter_wrapper_test.cc
+++ b/bindings/tflite/java/com/google/iree/native/interpreter_wrapper_test.cc
@@ -1,0 +1,123 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/java/com/google/iree/native/interpreter_wrapper.h"
+
+#include <memory>
+
+#include "bindings/tflite/java/com/google/iree/native/model_wrapper.h"
+#include "bindings/tflite/java/com/google/iree/native/options_wrapper.h"
+#include "bindings/tflite/java/com/google/iree/native/tensor_wrapper.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+
+// Test model is available both on the filesystem and here for embedding testing
+// embedding the module directly in a binary.
+#include "bindings/tflite/testdata/add_static.h"
+#define IREE_BINDINGS_TFLITE_TESTDATA_ADD_STATIC_EMBEDDED_DATA \
+  iree::bindings::tflite::testdata::add_static_create()->data
+#define IREE_BINDINGS_TFLITE_TESTDATA_ADD_STATIC_EMBEDDED_SIZE \
+  iree::bindings::tflite::testdata::add_static_create()->size
+
+#define ASSERT_OK(status) ASSERT_EQ(status, iree_ok_status())
+
+namespace iree {
+namespace tflite {
+namespace {
+
+class InterpreterWrapperTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Code here will be called before *each* test.
+  }
+
+  void TearDown() override {
+    // Code here will be called after *each* test.
+  }
+};
+
+TEST_F(InterpreterWrapperTest, AddStaticTest) {
+  // std::unique_ptr<ModelWrapper> model_wrapper = absl::MakeUnique();
+  ModelWrapper model_wrapper;
+  ASSERT_OK(model_wrapper.Create(
+      IREE_BINDINGS_TFLITE_TESTDATA_ADD_STATIC_EMBEDDED_DATA,
+      IREE_BINDINGS_TFLITE_TESTDATA_ADD_STATIC_EMBEDDED_SIZE));
+  ASSERT_NE(model_wrapper.model(), nullptr);
+
+  OptionsWrapper options_wrapper;
+  options_wrapper.SetNumThreads(2);
+  ASSERT_NE(options_wrapper.options(), nullptr);
+
+  InterpreterWrapper interpreter_wrapper;
+  ASSERT_OK(interpreter_wrapper.Create(model_wrapper, options_wrapper));
+  ASSERT_NE(interpreter_wrapper.interpreter(), nullptr);
+
+  ASSERT_OK(interpreter_wrapper.AllocateTensors());
+  ASSERT_EQ(interpreter_wrapper.get_input_tensor_count(), 1);
+  ASSERT_EQ(interpreter_wrapper.get_output_tensor_count(), 1);
+
+  TensorWrapper input_tensor_wrapper = *(interpreter_wrapper.GetInputTensor(0));
+  ASSERT_NE(input_tensor_wrapper.tensor(), nullptr);
+  EXPECT_EQ(input_tensor_wrapper.tensor_type(), kTfLiteFloat32);
+  EXPECT_EQ(input_tensor_wrapper.num_dims(), 4);
+  EXPECT_EQ(input_tensor_wrapper.dim(0), 1);
+  EXPECT_EQ(input_tensor_wrapper.dim(1), 8);
+  EXPECT_EQ(input_tensor_wrapper.dim(2), 8);
+  EXPECT_EQ(input_tensor_wrapper.dim(3), 3);
+  EXPECT_EQ(input_tensor_wrapper.byte_size(), sizeof(float) * 1 * 8 * 8 * 3);
+  EXPECT_NE(input_tensor_wrapper.tensor_data(), nullptr);
+  EXPECT_STREQ(input_tensor_wrapper.tensor_name(), "input");
+
+  TfLiteQuantizationParams input_params =
+      input_tensor_wrapper.quantization_params();
+  EXPECT_EQ(input_params.scale, 0.f);
+  EXPECT_EQ(input_params.zero_point, 0);
+
+  std::array<float, 1 * 8 * 8 * 3> input = {
+      1.f,
+      3.f,
+  };
+  ASSERT_OK(input_tensor_wrapper.CopyFromBuffer(input.data(),
+                                                input.size() * sizeof(float)));
+
+  ASSERT_OK(interpreter_wrapper.Invoke());
+
+  TensorWrapper output_tensor_wrapper =
+      *(interpreter_wrapper.GetOutputTensor(0));
+  ASSERT_NE(output_tensor_wrapper.tensor(), nullptr);
+  EXPECT_EQ(output_tensor_wrapper.tensor_type(), kTfLiteFloat32);
+  EXPECT_EQ(output_tensor_wrapper.num_dims(), 4);
+  EXPECT_EQ(output_tensor_wrapper.dim(0), 1);
+  EXPECT_EQ(output_tensor_wrapper.dim(1), 8);
+  EXPECT_EQ(output_tensor_wrapper.dim(2), 8);
+  EXPECT_EQ(output_tensor_wrapper.dim(3), 3);
+  EXPECT_EQ(output_tensor_wrapper.byte_size(), sizeof(float) * 1 * 8 * 8 * 3);
+  EXPECT_NE(output_tensor_wrapper.tensor_data(), nullptr);
+  EXPECT_STREQ(output_tensor_wrapper.tensor_name(), "output");
+
+  TfLiteQuantizationParams output_params =
+      output_tensor_wrapper.quantization_params();
+  EXPECT_EQ(output_params.scale, 0.f);
+  EXPECT_EQ(output_params.zero_point, 0);
+
+  std::array<float, 1 * 8 * 8 * 3> output;
+  ASSERT_OK(output_tensor_wrapper.CopyToBuffer(output.data(),
+                                               output.size() * sizeof(float)));
+  EXPECT_EQ(output[0], 2.f);
+  EXPECT_EQ(output[1], 6.f);
+}
+
+}  // namespace
+}  // namespace tflite
+}  // namespace iree

--- a/bindings/tflite/java/com/google/iree/native/model_wrapper.cc
+++ b/bindings/tflite/java/com/google/iree/native/model_wrapper.cc
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/java/com/google/iree/native/model_wrapper.h"
+
+namespace iree {
+namespace tflite {
+
+iree_status_t ModelWrapper::Create(const void* model_data, size_t model_size) {
+  model_ = TfLiteModelCreate(model_data, model_size);
+  if (model_ == nullptr) {
+    return iree_make_status(IREE_STATUS_UNKNOWN,
+                            "Failed to create model wrapper.");
+  }
+  return iree_ok_status();
+}
+
+ModelWrapper::~ModelWrapper() {
+  TfLiteModelDelete(model_);
+  model_ = nullptr;
+}
+
+}  // namespace tflite
+}  // namespace iree

--- a/bindings/tflite/java/com/google/iree/native/model_wrapper.h
+++ b/bindings/tflite/java/com/google/iree/native/model_wrapper.h
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_MODEL_WRAPPER_H_
+#define BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_MODEL_WRAPPER_H_
+
+#include "iree/base/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+namespace iree {
+namespace tflite {
+
+class ModelWrapper {
+ public:
+  iree_status_t Create(const void* model_data, size_t model_size);
+  ~ModelWrapper();
+
+  TfLiteModel* model() const { return model_; }
+
+ private:
+  TfLiteModel* model_ = nullptr;
+};
+
+}  // namespace tflite
+}  // namespace iree
+
+#endif  // BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_MODEL_WRAPPER_H_

--- a/bindings/tflite/java/com/google/iree/native/options_wrapper.cc
+++ b/bindings/tflite/java/com/google/iree/native/options_wrapper.cc
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/java/com/google/iree/native/options_wrapper.h"
+
+namespace iree {
+namespace tflite {
+
+OptionsWrapper::OptionsWrapper() {
+  options_ = TfLiteInterpreterOptionsCreate();
+}
+
+OptionsWrapper::~OptionsWrapper() {
+  TfLiteInterpreterOptionsDelete(options_);
+  options_ = nullptr;
+}
+
+void OptionsWrapper::SetNumThreads(int num_threads) {
+  TfLiteInterpreterOptionsSetNumThreads(options_, num_threads);
+}
+
+}  // namespace tflite
+}  // namespace iree

--- a/bindings/tflite/java/com/google/iree/native/options_wrapper.h
+++ b/bindings/tflite/java/com/google/iree/native/options_wrapper.h
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_OPTIONS_WRAPPER_H_
+#define BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_OPTIONS_WRAPPER_H_
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+namespace iree {
+namespace tflite {
+
+class OptionsWrapper {
+ public:
+  OptionsWrapper();
+  ~OptionsWrapper();
+
+  TfLiteInterpreterOptions* options() const { return options_; }
+
+  void SetNumThreads(int num_threads);
+
+ private:
+  TfLiteInterpreterOptions* options_ = nullptr;
+};
+
+}  // namespace tflite
+}  // namespace iree
+
+#endif  // BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_OPTIONS_WRAPPER_H_

--- a/bindings/tflite/java/com/google/iree/native/tensor_wrapper.cc
+++ b/bindings/tflite/java/com/google/iree/native/tensor_wrapper.cc
@@ -1,0 +1,57 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/java/com/google/iree/native/tensor_wrapper.h"
+
+#include "bindings/tflite/java/com/google/iree/native/tflite_macros.h"
+#include "iree/base/logging.h"
+
+namespace iree {
+namespace tflite {
+
+TensorWrapper::TensorWrapper(const TfLiteTensor* tensor) : tensor_(tensor) {}
+
+TensorWrapper::TensorWrapper(TfLiteTensor* mutable_tensor)
+    : mutable_tensor_(mutable_tensor) {}
+
+TensorWrapper::~TensorWrapper() { tensor_ = nullptr; }
+
+iree_status_t TensorWrapper::CopyFromBuffer(const void* input_data,
+                                            size_t input_data_size) {
+  IREE_CHECK(is_mutable_tensor()) << "Can only copy into non-const tensors.";
+  TFLITE_RETURN_IF_ERROR(
+      TfLiteTensorCopyFromBuffer(mutable_tensor_, input_data, input_data_size));
+  return iree_ok_status();
+}
+
+iree_status_t TensorWrapper::CopyToBuffer(void* output_data,
+                                          size_t output_data_size) {
+  TFLITE_RETURN_IF_ERROR(
+      TfLiteTensorCopyToBuffer(tensor(), output_data, output_data_size));
+  return iree_ok_status();
+}
+
+void TensorWrapper::Assign(const TfLiteTensor* tensor) {
+  IREE_CHECK_EQ(mutable_tensor_, nullptr) << "This tensor is already mutable.";
+  tensor_ = tensor;
+}
+
+void TensorWrapper::AssignMutable(TfLiteTensor* tensor) {
+  IREE_CHECK_EQ(tensor_, nullptr) << "This tensor is already const.";
+
+  mutable_tensor_ = tensor;
+}
+
+}  // namespace tflite
+}  // namespace iree

--- a/bindings/tflite/java/com/google/iree/native/tensor_wrapper.h
+++ b/bindings/tflite/java/com/google/iree/native/tensor_wrapper.h
@@ -1,0 +1,62 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TENSOR_WRAPPER_H_
+#define BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TENSOR_WRAPPER_H_
+
+#include "iree/base/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+namespace iree {
+namespace tflite {
+
+class TensorWrapper {
+ public:
+  TensorWrapper(const TfLiteTensor* tensor);
+  TensorWrapper(TfLiteTensor* mutable_tensor_);
+  ~TensorWrapper();
+
+  const TfLiteTensor* tensor() const {
+    return is_mutable_tensor() ? mutable_tensor_ : tensor_;
+  }
+  bool is_mutable_tensor() const { return mutable_tensor_ != nullptr; }
+  TfLiteType tensor_type() const { return TfLiteTensorType(tensor()); }
+  int num_dims() const { return TfLiteTensorNumDims(tensor()); }
+  int dim(int dim_index) const { return TfLiteTensorDim(tensor(), dim_index); }
+  size_t byte_size() const { return TfLiteTensorByteSize(tensor()); }
+  void* tensor_data() const { return TfLiteTensorData(tensor()); }
+  const char* tensor_name() const { return TfLiteTensorName(tensor()); }
+
+  TfLiteQuantizationParams quantization_params() const {
+    return TfLiteTensorQuantizationParams(tensor());
+  }
+
+  iree_status_t CopyFromBuffer(const void* input_data, size_t input_data_size);
+  iree_status_t CopyToBuffer(void* output_data, size_t output_data_size);
+
+  void Assign(const TfLiteTensor* tensor);
+  void AssignMutable(TfLiteTensor* tensor);
+
+ private:
+  const TfLiteTensor* tensor_ = nullptr;
+  TfLiteTensor* mutable_tensor_ = nullptr;
+};
+
+}  // namespace tflite
+}  // namespace iree
+
+#endif  // BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TENSOR_WRAPPER_H_

--- a/bindings/tflite/java/com/google/iree/native/tflite_macros.h
+++ b/bindings/tflite/java/com/google/iree/native/tflite_macros.h
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TFLITE_MACROS_H_
+#define BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TFLITE_MACROS_H_
+
+#include "iree/base/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+#define TFLITE_TO_IREE_STATUS(tf_status) \
+  ((tf_status) == kTfLiteOk)             \
+      ? iree_ok_status()                 \
+      : iree_make_status(IREE_STATUS_ABORTED, "TFLite Error")
+
+#define TFLITE_RETURN_IF_ERROR(tf_status) \
+  IREE_RETURN_IF_ERROR(TFLITE_TO_IREE_STATUS(tf_status))
+
+#endif  // BINDINGS_TFLITE_JAVA_COM_GOOGLE_IREE_NATIVE_TFLITE_MACROS_H_


### PR DESCRIPTION
Currently built with CMake. Requires enablidng new `IREE_BUILD_BINDINGS_TFLITE_JAVA` flag. 

There is an `interpreter_wrapper_test.cc` that runs through the bindings/wrappers. This is based on `smoke_test.cc`. I'm currently only using the static mlir file since thats completely supported. 
