### PR TITLE
Fix operation ordering issue during inlining of operations into dispatch region

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -377,9 +377,12 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
   // Assuming operands is O(1), i.e. constant order, the complexity is O(sum of
   // number of uses of each operation). Given that the size of `ops` is at max
   // O(10), and not O(100), this is assumed to be reasonable.
-  SmallVector<Operation *> readyOps = orderedOps;
+  // SmallVector<Operation *> readyOps = orderedOps;
+  ArrayRef<Operation *> readyOps(orderedOps);
+  size_t startPos = 0;
   while (!readyOps.empty()) {
-    auto op = readyOps.pop_back_val();
+    auto op = readyOps.front();
+    startPos++;
     // Check all uses of `op` within `ops`. If all of the operations that define
     // the operands of the user have been added to `orderedOps`, then the user
     // is ready to be scheduled.
@@ -389,11 +392,12 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
             Operation *operandDefiningOp = operand.getDefiningOp();
             return !operandDefiningOp || processed.count(operandDefiningOp);
           })) {
-        readyOps.push_back(insertAfterOp);
+        // readyOps.push_back(insertAfterOp);
         orderedOps.push_back(insertAfterOp);
         processed.insert(insertAfterOp);
       }
     }
+    readyOps = ArrayRef<Operation *>(orderedOps).drop_front(startPos);
   }
 
   DEBUG_WITH_TYPE(DEBUG_TYPE, {

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Block.h"
@@ -94,8 +95,9 @@ struct PatternRewriterWithScopedReplaceOp : public PatternRewriter {
 struct DispatchLinalgOnTensorsPass
     : public PassWrapper<DispatchLinalgOnTensorsPass, OperationPass<FuncOp>> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, IREE::Flow::FlowDialect,
-                    AffineDialect, scf::SCFDialect, ShapeDialect>();
+    registry
+        .insert<AffineDialect, IREE::Flow::FlowDialect, linalg::LinalgDialect,
+                memref::MemRefDialect, scf::SCFDialect, ShapeDialect>();
   }
   DispatchLinalgOnTensorsPass() = default;
   DispatchLinalgOnTensorsPass(const DispatchLinalgOnTensorsPass &pass) {}
@@ -330,14 +332,106 @@ static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
   return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
 }
 
+/// Order the operations such that they could be inlined into the dispatch
+/// region in that order to satisfy dependencies.
+static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Ops to be inlined : \n";
+    for (auto op : ops) {
+      llvm::dbgs() << "\t";
+      op->print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
+  });
+
+  llvm::SmallMapVector<Operation *, SmallVector<Operation *>, 16>
+      insertAfterMap;
+  llvm::SetVector<Operation *> allOps(ops.begin(), ops.end());
+  llvm::SetVector<Operation *> leafOps = allOps;
+  // For each operation compute the list of operations in `ops` that use its
+  // results. Also compute the operations that form the leafs of the DAG of
+  // operations in `ops`.
+  for (auto op : ops) {
+    // insertAfterList.emplace_back(ElementTy{op, {}});
+    // ElementTy &element = insertAfterList.back();
+    for (auto operand : op->getOperands()) {
+      auto definingOp = operand.getDefiningOp();
+      if (!definingOp) continue;
+      insertAfterMap[definingOp].push_back(op);
+      if (allOps.count(definingOp)) leafOps.remove(op);
+    }
+  }
+
+  // The leaves are at the head of the ordered list.
+  SmallVector<Operation *, 16> orderedOps = llvm::to_vector<4>(leafOps);
+  orderedOps.reserve(ops.size());
+  llvm::SmallPtrSet<Operation *, 16> processed;
+  processed.insert(leafOps.begin(), leafOps.end());
+
+  // `readyOps` contains the list of operations that have been just added to the
+  // `orderedOps` list. With these marked ready, they might make further
+  // operations in `ops` ready as well.
+  // The complexity of the algorithm is driven by these
+  // - Each operations is added to `readyOps` list at most once, and is removed
+  //   after being processed
+  // - For every operation in `readyOps` every use of its results (within `ops`)
+  //   is looked at once.
+  // - For every use, the operands of the user are processed.
+  // Assuming operands is O(1), i.e. constant order, the complexity is O(sum of
+  // number of uses of each operation). Given that the size of `ops` is at max
+  // O(10), and not O(100), this is assumed to be reasonable.
+  SmallVector<Operation *, 16> readyOps = orderedOps;
+  readyOps.assign(leafOps.begin(), leafOps.end());
+  while (!readyOps.empty()) {
+    SmallVector<Operation *> nextReadyOps;
+    LLVM_DEBUG({
+      llvm::dbgs() << "ReadyOps :\n";
+      for (auto readyOp : readyOps) {
+        llvm::dbgs() << "\t";
+        readyOp->print(llvm::dbgs());
+        llvm::dbgs() << "\n";
+      }
+    });
+    for (auto readyOp : readyOps) {
+      // Check all uses of `readyOp` within `ops`. If all of the operations that
+      // define the operands of the user have been added to `orderedOps`, then
+      // the user is ready to be scheduled.
+      for (auto insertAfterOp : insertAfterMap[readyOp]) {
+        if (processed.count(insertAfterOp)) continue;
+        if (llvm::all_of(insertAfterOp->getOperands(), [&](Value operand) {
+              Operation *operandDefiningOp = operand.getDefiningOp();
+              return !operandDefiningOp || processed.count(operandDefiningOp);
+            })) {
+          nextReadyOps.push_back(insertAfterOp);
+          orderedOps.push_back(insertAfterOp);
+          processed.insert(insertAfterOp);
+        }
+      }
+    }
+    std::swap(nextReadyOps, readyOps);
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Ops to be inlined (sorted) : \n";
+    for (auto op : orderedOps) {
+      llvm::dbgs() << "\t";
+      op->print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
+  });
+  assert(orderedOps.size() == ops.size());
+  return std::move(orderedOps);
+}
+
 /// Computes the values that will be eventually be used within the dispatch
 /// workgroup op but defined outside the op after all clonable operations are
 /// cloned into the region. Returns (by reference) the clonable operations too,
 /// in order in which they can be cloned within the region to satisfy use-def
 /// relationships between them.
 static void getUsedValuesDefinedAboveAfterCloningOps(
-    Region &region, llvm::SetVector<Value> &valuesDefinedAbove,
-    llvm::SmallVector<Operation *, 4> &clonedOps) {
+    IREE::Flow::DispatchWorkgroupsOp dispatchOp,
+    llvm::SetVector<Value> &valuesDefinedAbove,
+    llvm::SmallVector<Operation *> &clonedOps) {
   llvm::SetVector<Value> visited;
   SmallVector<Value, 4> worklist;
   worklist.assign(valuesDefinedAbove.begin(), valuesDefinedAbove.end());
@@ -352,35 +446,20 @@ static void getUsedValuesDefinedAboveAfterCloningOps(
       valuesDefinedAbove.insert(outsideValue);
       continue;
     }
+    // Only clone if operation either has no operands, or the operation is in
+    // same basic block as the dispatch op. This could really be relaxed, but
+    // this is conservative for now.
+    if (definingOp->getNumOperands() != 0 &&
+        definingOp->getBlock() != dispatchOp->getBlock()) {
+      valuesDefinedAbove.insert(outsideValue);
+      continue;
+    }
     clonedOps.push_back(definingOp);
     worklist.append(definingOp->operand_begin(), definingOp->operand_end());
   }
-  // The cloned operations form a DAG. Return the cloned operations in reverse
-  // so the leaves come first, and can be cloned in-order into the dispatch
-  // region. Do the same for `valuesDefinedAbove` to keep return values
-  // consistent with order gotten from `mlir::getUsedValuesDefinedAbove` (more
-  // for a convention that correctness)
-  clonedOps = llvm::to_vector<4>(llvm::reverse(clonedOps));
-  llvm::SetVector<Value> reverseValuesDefinedAbove;
-  for (auto value : llvm::reverse(valuesDefinedAbove)) {
-    reverseValuesDefinedAbove.insert(value);
-  }
-  std::swap(reverseValuesDefinedAbove, valuesDefinedAbove);
-}
-
-/// Returns a valid insertion point for an operation based on the values used.
-static Operation *getInsertionPoint(Block &block, ArrayRef<Value> usedValues) {
-  if (usedValues.empty()) return &block.front();
-  Operation *insertAfter = &block.front();
-  for (auto value : usedValues) {
-    Operation *definingOp = value.getDefiningOp();
-    if (!definingOp) continue;
-    if (definingOp->getBlock() != &block) return nullptr;
-    if (insertAfter->isBeforeInBlock(definingOp)) {
-      insertAfter = definingOp;
-    }
-  }
-  return insertAfter->getNextNode();
+  // The cloned operations form a DAG. Return the cloned operations so the
+  // leaves come first, and can be cloned in-order into the dispatch region.
+  clonedOps = orderOperations(clonedOps);
 }
 
 /// Modifies `dispatchOp` to attach operand-result tie information when
@@ -453,6 +532,18 @@ static void tryToTieOperandsAndResults(
   }
 }
 
+void replaceAllUsesWithinDispatchOp(IREE::Flow::DispatchWorkgroupsOp dispatchOp,
+                                    Value value, Value replacement) {
+  SmallPtrSet<Operation *, 4> usesOutsideDispatch;
+  for (Operation *user : value.getUsers()) {
+    if (isa<IREE::Flow::DispatchWorkgroupsOp>(user) ||
+        !dispatchOp->isAncestor(user)) {
+      usesOutsideDispatch.insert(user);
+    }
+  }
+  value.replaceAllUsesExcept(replacement, usesOutsideDispatch);
+}
+
 // After outlining in dispatch region we can rewrite the dispatch ops with
 // proper captures.
 // A later RematerializeDispatchConstants should be called to avoid passing
@@ -466,14 +557,15 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
   OpBuilder b = OpBuilder::atBlockBegin(&block);
 
   llvm::SetVector<Value> valuesDefinedAbove;
-  llvm::SmallVector<Operation *, 4> clonedOps;
+  llvm::SmallVector<Operation *> clonedOps;
   mlir::getUsedValuesDefinedAbove(region, valuesDefinedAbove);
   if (valuesDefinedAbove.empty()) return success();
 
-  getUsedValuesDefinedAboveAfterCloningOps(region, valuesDefinedAbove,
+  getUsedValuesDefinedAboveAfterCloningOps(dispatchOp, valuesDefinedAbove,
                                            clonedOps);
 
   BlockAndValueMapping map;
+  SmallVector<Value> toReplaceWithinRegion;
   // Replace valuesDefinedAbove by new BB args (including the op's operands).
   for (Value operand : valuesDefinedAbove) {
     if (auto rt = operand.getType().dyn_cast<RankedTensorType>()) {
@@ -493,55 +585,29 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
       continue;
     }
     map.map(operand, repl);
+    toReplaceWithinRegion.push_back(operand);
   }
 
   // The only existing arguments are for the outputs. Just need to add a new
   // argument for the outputs and remap the value to use the new argument.
   for (auto ba : block.getArguments().take_front(numOldBBArgs)) {
     assert(ba.getType().isa<IREE::Flow::DispatchTensorType>());
-    map.map(ba, block.addArgument(ba.getType()));
+    ba.replaceAllUsesWith(block.addArgument(ba.getType()));
   }
-
-  auto getUsesOfValueOutsideOfDispatchOp = [&](Value v) {
-    SmallPtrSet<Operation *, 4> res;
-    for (Operation *user : v.getUsers())
-      if (isa<IREE::Flow::DispatchWorkgroupsOp>(user) ||
-          !dispatchOp->isAncestor(user))
-        res.insert(user);
-    return res;
-  };
-  // Replace all uses of mapped values within the dispatch op to the new value.
-  for (Value value : valuesDefinedAbove) {
-    auto uses = getUsesOfValueOutsideOfDispatchOp(value);
-    value.replaceAllUsesExcept(map.lookup(value), uses);
-  }
-
-  // Clone the marked operations.
-  for (Operation *op : clonedOps) {
-    SmallVector<Value, 2> clonedOpOperands = llvm::to_vector<2>(llvm::map_range(
-        op->getOperands(), [&map](Value v) { return map.lookup(v); }));
-    Operation *insertionPoint = getInsertionPoint(block, clonedOpOperands);
-    if (!insertionPoint) {
-      return op->emitOpError(
-          "failed to find insetion point within dispatch workgroup op for "
-          "cloned operation");
-    }
-    OpBuilder::InsertionGuard g(b);
-    b.setInsertionPoint(insertionPoint);
-    b.clone(*op, map);
-    for (Value result : op->getResults()) {
-      auto uses = getUsesOfValueOutsideOfDispatchOp(result);
-      result.replaceAllUsesExcept(map.lookup(result), uses);
-    }
-  }
-
-  for (Value ba : block.getArguments().take_front(numOldBBArgs)) {
-    ba.replaceAllUsesWith(map.lookup(ba));
-  }
-
   // Drop old BB args.
   block.eraseArguments(
       llvm::to_vector<4>(llvm::seq<unsigned>(0, numOldBBArgs)));
+
+  // Clone the marked operations.
+  for (Operation *op : clonedOps) {
+    b.clone(*op, map);
+    toReplaceWithinRegion.append(op->result_begin(), op->result_end());
+  }
+
+  // Make the region isolated from above.
+  for (auto value : toReplaceWithinRegion) {
+    replaceAllUsesWithinDispatchOp(dispatchOp, value, map.lookup(value));
+  }
 
   // Gather the dynamic dimensions for all operands.
   SmallVector<Value, 4> operandDynamicDims;

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -335,7 +335,7 @@ static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
 /// Order the operations such that they could be inlined into the dispatch
 /// region in that order to satisfy dependencies.
 static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
-  LLVM_DEBUG({
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
     llvm::dbgs() << "Ops to be inlined : \n";
     for (auto op : ops) {
       llvm::dbgs() << "\t";
@@ -384,7 +384,7 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
   readyOps.assign(leafOps.begin(), leafOps.end());
   while (!readyOps.empty()) {
     SmallVector<Operation *> nextReadyOps;
-    LLVM_DEBUG({
+    DEBUG_WITH_TYPE(DEBUG_TYPE, {
       llvm::dbgs() << "ReadyOps :\n";
       for (auto readyOp : readyOps) {
         llvm::dbgs() << "\t";
@@ -411,7 +411,7 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
     std::swap(nextReadyOps, readyOps);
   }
 
-  LLVM_DEBUG({
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
     llvm::dbgs() << "Ops to be inlined (sorted) : \n";
     for (auto op : orderedOps) {
       llvm::dbgs() << "\t";

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -360,7 +360,7 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
   }
 
   // The leaves are at the head of the ordered list.
-  SmallVector<Operation *> orderedOps(leafOps.begin, leafOps.end());
+  SmallVector<Operation *> orderedOps(leafOps.begin(), leafOps.end());
   orderedOps.reserve(ops.size());
   llvm::SmallPtrSet<Operation *, 16> processed;
   processed.insert(leafOps.begin(), leafOps.end());

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -460,6 +460,11 @@ static void getUsedValuesDefinedAboveAfterCloningOps(
   // The cloned operations form a DAG. Return the cloned operations so the
   // leaves come first, and can be cloned in-order into the dispatch region.
   clonedOps = orderOperations(clonedOps);
+  // Reverse the values. This is not for correctness, but more for readability
+  // of the IR.
+  llvm::SetVector<Value> reversedValues;
+  reversedValues.insert(valuesDefinedAbove.rbegin(), valuesDefinedAbove.rend());
+  std::swap(reversedValues, valuesDefinedAbove);
 }
 
 /// Modifies `dispatchOp` to attach operand-result tie information when

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -599,3 +599,112 @@ func @fuse_non_tiled_reduction_fill(%input1: tensor<1000xf32>, %input2: tensor<1
 // CHECK-SAME:     ins(%[[INPUT1_LOAD]], %[[INPUT2_LOAD]], %[[OFFSET_LOAD]] : tensor<1000xf32>, tensor<1000xf32>, tensor<f32>)
 // CHECK-SAME:     outs(%[[FILL]] : tensor<f32>)
 //      CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUTPUT]]
+
+// -----
+
+#map0 = affine_map<(d0) -> ()>
+#map1 = affine_map<(d0) -> (d0)>
+func @inline_dag_1(
+    %arg0: tensor<?xf32>, %arg1 : tensor<1x?xf32>, %arg2 : tensor<i32>,
+    %arg3 : index) -> tensor<?xf32> {
+  %0 = linalg.tensor_reshape %arg0 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<?xf32> into tensor<1x?xf32>
+  %1 = subtensor %0[0, 20] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %2 = linalg.tensor_reshape %1 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %3 = linalg.tensor_reshape %arg1 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %4 = subtensor %0[0, 10] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %5 = linalg.tensor_reshape %4 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %6 = subtensor %0[0, 0] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %7 = linalg.tensor_reshape %6 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %8 = linalg.init_tensor [%arg3] : tensor<?xf32>
+  %9 = linalg.generic {
+      indexing_maps = [#map0, #map1, #map1, #map1, #map1, #map1],
+      iterator_types = ["parallel"]}
+      ins(%arg2, %2, %3, %5, %7 : tensor<i32>, tensor<?xf32>,
+          tensor<?xf32>, tensor<?xf32>, tensor<?xf32>)
+      outs(%8 : tensor<?xf32>) {
+      ^bb0(%arg4: i32, %arg5: f32, %arg6: f32, %arg7: f32, %arg8: f32, %arg9: f32):
+        %10 = addf %arg5, %arg6 : f32
+        %11 = addf %arg7, %arg8 : f32
+        %12 = addf %10, %11 : f32
+        %13 = sitofp %arg4 : i32 to f32
+        %14 = addf %12, %13 : f32
+        linalg.yield %14 : f32
+      } -> tensor<?xf32>
+  return %9 : tensor<?xf32>
+}
+// CHECK-LABEL: func @inline_dag_1
+//   CHECK-NOT:   linalg.
+//   CHECK-NOT:   subtensor
+//       CHECK:   flow.dispatch.workgroups
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
+//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
+//   CHECK-DAG:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+//   CHECK-DAG:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]]
+//   CHECK-DAG:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG7]]
+//   CHECK-DAG:     %[[OP1:.+]] = linalg.tensor_reshape %[[LEAF2]]
+//   CHECK-DAG:     %[[OP2:.+]] = linalg.tensor_reshape %[[LEAF3]]
+//   CHECK-DAG:     %[[OP3:.+]] = subtensor %[[OP1]][0, 0]
+//   CHECK-DAG:     %[[OP4:.+]] = subtensor %[[OP1]][0, 10]
+//   CHECK-DAG:     %[[OP5:.+]] = subtensor %[[OP1]][0, 20]
+//   CHECK-DAG:     %[[OP6:.+]] = linalg.tensor_reshape %[[OP3]]
+//   CHECK-DAG:     %[[OP7:.+]] = linalg.tensor_reshape %[[OP4]]
+//   CHECK-DAG:     %[[OP8:.+]] = linalg.tensor_reshape %[[OP5]]
+
+// -----
+
+#map0 = affine_map<(d0) -> ()>
+#map1 = affine_map<(d0) -> (d0)>
+func @inline_dag_2(
+    %arg0: tensor<?xf32>, %arg1 : tensor<1x?xf32>, %arg2 : tensor<i32>,
+    %arg3 : index) -> tensor<?xf32> {
+  %0 = linalg.tensor_reshape %arg0 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<?xf32> into tensor<1x?xf32>
+  %1 = subtensor %0[0, 20] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %2 = linalg.tensor_reshape %arg1 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  br ^bb1
+^bb1:
+  %3 = linalg.tensor_reshape %1 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %4 = subtensor %0[0, 10] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %5 = linalg.tensor_reshape %4 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %6 = subtensor %0[0, 0] [1, %arg3] [1, 1] : tensor<1x?xf32> to tensor<1x?xf32>
+  %7 = linalg.tensor_reshape %6 [affine_map<(d0, d1) -> (d0, d1)>] : tensor<1x?xf32> into tensor<?xf32>
+  %8 = linalg.init_tensor [%arg3] : tensor<?xf32>
+  %9 = linalg.generic {
+      indexing_maps = [#map0, #map1, #map1, #map1, #map1, #map1],
+      iterator_types = ["parallel"]}
+      ins(%arg2, %3, %2, %5, %7 : tensor<i32>, tensor<?xf32>,
+          tensor<?xf32>, tensor<?xf32>, tensor<?xf32>)
+      outs(%8 : tensor<?xf32>) {
+      ^bb0(%arg4: i32, %arg5: f32, %arg6: f32, %arg7: f32, %arg8: f32, %arg9: f32):
+        %10 = addf %arg5, %arg6 : f32
+        %11 = addf %arg7, %arg8 : f32
+        %12 = addf %10, %11 : f32
+        %13 = sitofp %arg4 : i32 to f32
+        %14 = addf %12, %13 : f32
+        linalg.yield %14 : f32
+      } -> tensor<?xf32>
+  return %9 : tensor<?xf32>
+}
+// CHECK-LABEL: func @inline_dag_2
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<1x?xf32>
+//       CHECK:   %[[OP1:.+]] = linalg.tensor_reshape %[[ARG0]]
+//       CHECK:   subtensor %[[OP1]]
+//       CHECK:   linalg.tensor_reshape %[[ARG1]]
+//       CHECK:   flow.dispatch.workgroups
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
+//  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG9:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
+//   CHECK-DAG:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+//   CHECK-DAG:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]]
+//   CHECK-DAG:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG8]]
+//   CHECK-DAG:     %[[OP1:.+]] = subtensor %[[LEAF2]][0, 0]
+//   CHECK-DAG:     %[[OP2:.+]] = subtensor %[[LEAF2]][0, 10]
+//   CHECK-DAG:     %[[OP3:.+]] = linalg.tensor_reshape %[[LEAF3]]
+//   CHECK-DAG:     %[[OP4:.+]] = linalg.tensor_reshape %[[OP1]]
+//   CHECK-DAG:     %[[OP5:.+]] = linalg.tensor_reshape %[[OP2]]

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -591,11 +591,11 @@ func @fuse_non_tiled_reduction_fill(%input1: tensor<1000xf32>, %input2: tensor<1
 // CHECK-SAME:      %[[INPUT2:[a-z0-9]+]]: !flow.dispatch.tensor<readonly:1000xf32>,
 // CHECK-SAME:      %[[OFFSET:[a-z0-9]+]]: !flow.dispatch.tensor<readonly:f32>,
 // CHECK-SAME:      %[[OUTPUT:[a-z0-9]+]]: !flow.dispatch.tensor<writeonly:f32>) {
-//      CHECK:   %[[INPUT1_LOAD:.+]] = flow.dispatch.tensor.load %[[INPUT1]]
-// CHECK-NEXT:   %[[INPUT2_LOAD:.+]] = flow.dispatch.tensor.load %[[INPUT2]]
-// CHECK-NEXT:   %[[OFFSET_LOAD:.+]] = flow.dispatch.tensor.load %[[OFFSET]]
-// CHECK-NEXT:   %[[FILL:.+]] = linalg.fill
-// CHECK-NEXT:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-DAG:   %[[INPUT1_LOAD:.+]] = flow.dispatch.tensor.load %[[INPUT1]]
+//  CHECK-DAG:   %[[INPUT2_LOAD:.+]] = flow.dispatch.tensor.load %[[INPUT2]]
+//  CHECK-DAG:   %[[OFFSET_LOAD:.+]] = flow.dispatch.tensor.load %[[OFFSET]]
+//      CHECK:   %[[FILL:.+]] = linalg.fill
+//      CHECK:   %[[GENERIC:.+]] = linalg.generic
 // CHECK-SAME:     ins(%[[INPUT1_LOAD]], %[[INPUT2_LOAD]], %[[OFFSET_LOAD]] : tensor<1000xf32>, tensor<1000xf32>, tensor<f32>)
 // CHECK-SAME:     outs(%[[FILL]] : tensor<f32>)
 //      CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUTPUT]]
@@ -636,22 +636,22 @@ func @inline_dag_1(
 //   CHECK-NOT:   linalg.
 //   CHECK-NOT:   subtensor
 //       CHECK:   flow.dispatch.workgroups
-//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: index
-//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
-//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
-//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
-//   CHECK-DAG:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG5]]
-//   CHECK-DAG:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]]
-//   CHECK-DAG:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG7]]
-//   CHECK-DAG:     %[[OP1:.+]] = linalg.tensor_reshape %[[LEAF2]]
-//   CHECK-DAG:     %[[OP2:.+]] = linalg.tensor_reshape %[[LEAF3]]
-//   CHECK-DAG:     %[[OP3:.+]] = subtensor %[[OP1]][0, 0]
-//   CHECK-DAG:     %[[OP4:.+]] = subtensor %[[OP1]][0, 10]
-//   CHECK-DAG:     %[[OP5:.+]] = subtensor %[[OP1]][0, 20]
-//   CHECK-DAG:     %[[OP6:.+]] = linalg.tensor_reshape %[[OP3]]
-//   CHECK-DAG:     %[[OP7:.+]] = linalg.tensor_reshape %[[OP4]]
-//   CHECK-DAG:     %[[OP8:.+]] = linalg.tensor_reshape %[[OP5]]
+//       CHECK:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+//       CHECK:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+//       CHECK:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG6]]
+//       CHECK:     %[[OP1:.+]] = linalg.tensor_reshape %[[LEAF2]]
+//       CHECK:     %[[OP2:.+]] = linalg.tensor_reshape %[[LEAF1]]
+//       CHECK:     %[[OP3:.+]] = subtensor %[[OP1]][0, 0]
+//       CHECK:     %[[OP4:.+]] = subtensor %[[OP1]][0, 10]
+//       CHECK:     %[[OP5:.+]] = subtensor %[[OP1]][0, 20]
+//       CHECK:     %[[OP6:.+]] = linalg.tensor_reshape %[[OP3]]
+//       CHECK:     %[[OP7:.+]] = linalg.tensor_reshape %[[OP4]]
+//       CHECK:     %[[OP8:.+]] = linalg.tensor_reshape %[[OP5]]
 
 // -----
 
@@ -694,17 +694,17 @@ func @inline_dag_2(
 //       CHECK:   subtensor %[[OP1]]
 //       CHECK:   linalg.tensor_reshape %[[ARG1]]
 //       CHECK:   flow.dispatch.workgroups
-//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: index
-//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
 //  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
-//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
-//  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:     %[[ARG9:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
-//   CHECK-DAG:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG5]]
-//   CHECK-DAG:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]]
-//   CHECK-DAG:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG8]]
-//   CHECK-DAG:     %[[OP1:.+]] = subtensor %[[LEAF2]][0, 0]
-//   CHECK-DAG:     %[[OP2:.+]] = subtensor %[[LEAF2]][0, 10]
-//   CHECK-DAG:     %[[OP3:.+]] = linalg.tensor_reshape %[[LEAF3]]
-//   CHECK-DAG:     %[[OP4:.+]] = linalg.tensor_reshape %[[OP1]]
-//   CHECK-DAG:     %[[OP5:.+]] = linalg.tensor_reshape %[[OP2]]
+//       CHECK:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+//       CHECK:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]]
+//       CHECK:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG7]]
+//       CHECK:     %[[OP1:.+]] = subtensor %[[LEAF2]][0, 0]
+//       CHECK:     %[[OP2:.+]] = subtensor %[[LEAF2]][0, 10]
+//       CHECK:     %[[OP3:.+]] = linalg.tensor_reshape %[[LEAF1]]
+//       CHECK:     %[[OP4:.+]] = linalg.tensor_reshape %[[OP1]]
+//       CHECK:     %[[OP5:.+]] = linalg.tensor_reshape %[[OP2]]


### PR DESCRIPTION
In general the operations cloned into a dispatch region could form a
DAG. These operations have to be cloned while keeping the order
amongst them consistent to not violate use-def chains. This changes
adds a method to clone the operations in the right order. Also cleans
up the dispatch region creation code.

Fixes #5151.