### PR TITLE
make bazel build on macOS work again

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -152,7 +152,13 @@ build:generic_clang --copt=-Wvla
 
 build:macos_clang --config=generic_clang
 build:macos_clang --per_file_copt=tensorflow,iree_tf_compiler@-Wno-unused-variable
-build:macos_clang --per_file_copt=tensorflow,iree_tf_compiler@-Wno-range-loop-analysis
+build:macos_clang --per_file_copt=tensorflow,iree_tf_compiler,utils@-Wno-range-loop-analysis
+
+build:macos_clang_release --config=macos_clang
+build:macos_clang_release --per_file_copt=tensorflow,iree_tf_compiler@-Wno-unused-variable
+build:macos_clang_release --per_file_copt=tensorflow,iree_tf_compiler,utils@-Wno-range-loop-analysis
+build:macos_clang_release --compilation_mode=opt
+build:macos_clang_release --copt=-DNDEBUG
 
 ###############################################################################
 # Additional options for release builds. These do *not* automatically pull in

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -45,10 +45,12 @@ def detect_unix_platform_config(bazelrc):
     else:
       print(
           "WARNING: CC and CXX are not set, which can cause mismatches between "
-          "flag configurations and compiler. Recommend setting them explicitly.")
+          "flag configurations and compiler. Recommend setting them explicitly."
+      )
 
     if cxx is not None and "clang" in cxx:
-      print(f"Choosing generic_clang config because CXX is set to clang ({cxx})")
+      print(
+          f"Choosing generic_clang config because CXX is set to clang ({cxx})")
       print(f"build --config=generic_clang", file=bazelrc)
       print(f"build:release --config=generic_clang_release", file=bazelrc)
     else:
@@ -56,6 +58,7 @@ def detect_unix_platform_config(bazelrc):
             f"not recognized as clang ({cxx})")
       print(f"build --config=generic_gcc", file=bazelrc)
       print(f"build:release --config=generic_gcc_release", file=bazelrc)
+
 
 def write_platform(bazelrc):
   if platform.system() == "Windows":

--- a/configure_bazel.py
+++ b/configure_bazel.py
@@ -27,35 +27,35 @@ def detect_unix_platform_config(bazelrc):
   # All I want to do is set a couple of project specific warning options!
 
   if platform.system() == "Darwin":
-    print(f"build --config=generic_clang", file=bazelrc)
-    print(f"build:release --config=generic_clang_release", file=bazelrc)
-
-  # If the user specified a CXX environment var, bazel will later respect that,
-  # so we just see if it says "clang".
-  cxx = os.environ.get("CXX")
-  cc = os.environ.get("CC")
-  if (cxx is not None and cc is None) or (cxx is None and cc is not None):
-    print("WARNING: Only one of CXX or CC is set, which can confuse bazel. "
-          "Recommend: set both appropriately (or none)")
-  if cc is not None and cxx is not None:
-    # Persist the variables.
-    print(f"build --action_env CC=\"{cc}\"", file=bazelrc)
-    print(f"build --action_env CXX=\"{cxx}\"", file=bazelrc)
+    print(f"build --config=macos_clang", file=bazelrc)
+    print(f"build:release --config=macos_clang_release", file=bazelrc)
   else:
-    print(
-        "WARNING: CC and CXX are not set, which can cause mismatches between "
-        "flag configurations and compiler. Recommend setting them explicitly.")
 
-  if cxx is not None and "clang" in cxx:
-    print(f"Choosing generic_clang config because CXX is set to clang ({cxx})")
-    print(f"build --config=generic_clang", file=bazelrc)
-    print(f"build:release --config=generic_clang_release", file=bazelrc)
-  else:
-    print(f"Choosing generic_gcc config by default because no CXX set or "
-          f"not recognized as clang ({cxx})")
-    print(f"build --config=generic_gcc", file=bazelrc)
-    print(f"build:release --config=generic_gcc_release", file=bazelrc)
+    # If the user specified a CXX environment var, bazel will later respect that,
+    # so we just see if it says "clang".
+    cxx = os.environ.get("CXX")
+    cc = os.environ.get("CC")
+    if (cxx is not None and cc is None) or (cxx is None and cc is not None):
+      print("WARNING: Only one of CXX or CC is set, which can confuse bazel. "
+            "Recommend: set both appropriately (or none)")
+    if cc is not None and cxx is not None:
+      # Persist the variables.
+      print(f"build --action_env CC=\"{cc}\"", file=bazelrc)
+      print(f"build --action_env CXX=\"{cxx}\"", file=bazelrc)
+    else:
+      print(
+          "WARNING: CC and CXX are not set, which can cause mismatches between "
+          "flag configurations and compiler. Recommend setting them explicitly.")
 
+    if cxx is not None and "clang" in cxx:
+      print(f"Choosing generic_clang config because CXX is set to clang ({cxx})")
+      print(f"build --config=generic_clang", file=bazelrc)
+      print(f"build:release --config=generic_clang_release", file=bazelrc)
+    else:
+      print(f"Choosing generic_gcc config by default because no CXX set or "
+            f"not recognized as clang ({cxx})")
+      print(f"build --config=generic_gcc", file=bazelrc)
+      print(f"build:release --config=generic_gcc_release", file=bazelrc)
 
 def write_platform(bazelrc):
   if platform.system() == "Windows":


### PR DESCRIPTION
make
```
bazel build //iree/...
```
work on both macOS x86_64 and arm64 machine

1. use `macos_clang` in configure_bazel.py, so that there will be `build --config=macos_clang` in `configured.bazelrc` after running `python configure_bazel.py`
2. make iree/tools/utils/ build by per_file_opt `-Wno-range-loop-analysis`