### PR TITLE
Fixing tracing on Windows and improving the dylib tracing statistics.

### DIFF
--- a/iree/base/internal/file_io.cc
+++ b/iree/base/internal/file_io.cc
@@ -39,7 +39,7 @@ iree_status_t FileExists(const char* path) {
 iree_status_t GetFileContents(const char* path, std::string* out_contents) {
   IREE_TRACE_ZONE_BEGIN(z0);
   *out_contents = std::string();
-  FILE* file = fopen(path, "r");
+  FILE* file = fopen(path, "rb");
   if (file == NULL) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(iree_status_code_from_errno(errno),

--- a/iree/hal/local/loaders/legacy_library_loader.c
+++ b/iree/hal/local/loaders/legacy_library_loader.c
@@ -75,6 +75,9 @@ typedef struct {
   // Loaded platform dynamic library.
   iree_dynamic_library_t* handle;
 
+  // Name used for the file field in tracy and debuggers.
+  iree_string_view_t identifier;
+
   // Queried metadata from the library.
   union {
     const iree_hal_executable_library_header_t** header;
@@ -155,6 +158,8 @@ static iree_status_t iree_hal_legacy_executable_query_library(
           "compiled to enable/understand: %u",
           (uint32_t)header->sanitizer);
   }
+
+  executable->identifier = iree_make_cstring_view(header->name);
 
   return iree_ok_status();
 }
@@ -257,8 +262,9 @@ static iree_status_t iree_hal_legacy_executable_issue_call(
   if (iree_string_view_is_empty(entry_point_name)) {
     entry_point_name = iree_make_cstring_view("unknown_dylib_call");
   }
-  IREE_TRACE_ZONE_BEGIN_NAMED_DYNAMIC(z0, entry_point_name.data,
-                                      entry_point_name.size);
+  IREE_TRACE_ZONE_BEGIN_EXTERNAL(
+      z0, executable->identifier.data, executable->identifier.size, ordinal,
+      entry_point_name.data, entry_point_name.size, NULL, 0);
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
   library->entry_points[ordinal](dispatch_state, workgroup_id);

--- a/iree/tools/utils/vm_util.cc
+++ b/iree/tools/utils/vm_util.cc
@@ -42,6 +42,10 @@ Status ValidateFunctionAbi(const iree_vm_function_t& function) {
 
   iree_string_view_t sig_fv =
       iree_vm_function_reflection_attr(&function, iree_make_cstring_view("fv"));
+  if (sig_fv.size == 0) {
+    // Ignore functions without reflection information.
+    return OkStatus();
+  }
   if (absl::string_view{sig_fv.data, sig_fv.size} != "1") {
     auto function_name = iree_vm_function_name(&function);
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -49,6 +53,7 @@ Status ValidateFunctionAbi(const iree_vm_function_t& function) {
                             (int)function_name.size, function_name.data,
                             (int)sig_fv.size, sig_fv.data);
   }
+
   return OkStatus();
 }
 


### PR DESCRIPTION
This gets us per-tile statistics for llvm aot functions in instrumentation mode:
![image](https://user-images.githubusercontent.com/75337/113034569-15d63f00-9147-11eb-8b36-44cd4e3de505.png)
