### PR TITLE
Replace remaining uses of absl::make_unique with std::make_unique.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -43,7 +43,6 @@ iree_pyext_module(
     iree::vm
     iree::vm::bytecode_module
     absl::inlined_vector
-    absl::memory
     absl::strings
     absl::optional
     absl::span

--- a/bindings/python/iree/runtime/function_abi.cc
+++ b/bindings/python/iree/runtime/function_abi.cc
@@ -14,7 +14,8 @@
 
 #include "bindings/python/iree/runtime/function_abi.h"
 
-#include "absl/memory/memory.h"
+#include <memory>
+
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
 #include "bindings/python/iree/runtime/hal.h"
@@ -431,7 +432,7 @@ std::unique_ptr<FunctionAbi> FunctionAbi::Create(
     HalDevice& device, std::shared_ptr<HostTypeFactory> host_type_factory,
     AttributeLookup lookup) {
   auto abi =
-      absl::make_unique<FunctionAbi>(device, std::move(host_type_factory));
+      std::make_unique<FunctionAbi>(device, std::move(host_type_factory));
 
   // Fetch key attributes for the raw ABI.
   auto raw_version = lookup("fv");

--- a/bindings/python/iree/runtime/host_types.cc
+++ b/bindings/python/iree/runtime/host_types.cc
@@ -14,8 +14,9 @@
 
 #include "bindings/python/iree/runtime/host_types.h"
 
+#include <memory>
+
 #include "absl/container/inlined_vector.h"
-#include "absl/memory/memory.h"
 #include "bindings/python/iree/runtime/hal.h"
 #include "bindings/python/iree/runtime/status_utils.h"
 #include "iree/base/signature_parser.h"
@@ -145,9 +146,9 @@ class PyMappedMemory {
                        buffer.raw_ptr(), IREE_HAL_MEMORY_ACCESS_READ,
                        0 /* element_offset */, byte_length, &mapped_memory),
                    "Could not map memory");
-    return absl::make_unique<PyMappedMemory>(std::move(desc), mapped_memory,
-                                             std::move(buffer),
-                                             std::move(parent_keep_alive));
+    return std::make_unique<PyMappedMemory>(std::move(desc), mapped_memory,
+                                            std::move(buffer),
+                                            std::move(parent_keep_alive));
   }
 
   py::buffer_info ToBufferInfo() {

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -77,7 +77,6 @@ EXPLICIT_TARGET_MAPPING = {
 def _convert_absl_target(target):
   # Default to a pattern substitution approach.
   # Take "absl::" and append the name part of the full target identifier, e.g.
-  #   "@com_google_absl//absl/memory"         -> "absl::memory"
   #   "@com_google_absl//absl/types:optional" -> "absl::optional"
   #   "@com_google_absl//absl/types:span"     -> "absl::span"
   if ":" in target:

--- a/iree/hal/vulkan/BUILD
+++ b/iree/hal/vulkan/BUILD
@@ -105,7 +105,6 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",

--- a/iree/hal/vulkan/CMakeLists.txt
+++ b/iree/hal/vulkan/CMakeLists.txt
@@ -74,7 +74,6 @@ iree_cc_library(
     absl::core_headers
     absl::flat_hash_map
     absl::inlined_vector
-    absl::memory
     absl::span
     absl::strings
     absl::synchronization

--- a/iree/hal/vulkan/util/BUILD
+++ b/iree/hal/vulkan/util/BUILD
@@ -61,7 +61,6 @@ cc_test(
         ":intrusive_list",
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
-        "@com_google_absl//absl/memory",
     ],
 )
 

--- a/iree/hal/vulkan/util/CMakeLists.txt
+++ b/iree/hal/vulkan/util/CMakeLists.txt
@@ -55,7 +55,6 @@ iree_cc_test(
     "intrusive_list_unique_ptr_test.cc"
   DEPS
     ::intrusive_list
-    absl::memory
     iree::testing::gtest
     iree::testing::gtest_main
 )

--- a/iree/hal/vulkan/util/intrusive_list.h
+++ b/iree/hal/vulkan/util/intrusive_list.h
@@ -43,7 +43,7 @@
 //
 // Usage (unique_ptr):
 //   IntrusiveList<std::unique_ptr<MyElement>> list;
-//   list.push_back(absl::make_unique<MyElement>());
+//   list.push_back(std::make_unique<MyElement>());
 //   std::unique_ptr<MyElement> elm = list.take(list.front());
 //
 // This type is thread-unsafe.

--- a/iree/hal/vulkan/util/intrusive_list_unique_ptr_test.cc
+++ b/iree/hal/vulkan/util/intrusive_list_unique_ptr_test.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "absl/memory/memory.h"
+#include <memory>
+
 #include "iree/hal/vulkan/util/intrusive_list.h"
 #include "iree/testing/gtest.h"
 
@@ -32,14 +33,14 @@ TEST(IntrusiveListUniquePtrTest, UniquePtr) {
   // Push/clear.
   IntrusiveList<std::unique_ptr<AllocatedType>> list;
   EXPECT_EQ(0, AllocatedType::alloc_count);
-  list.push_back(absl::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
   EXPECT_EQ(1, AllocatedType::alloc_count);
   EXPECT_NE(nullptr, list.front());
   list.clear();
   EXPECT_EQ(0, AllocatedType::alloc_count);
 
   // Push/pop.
-  list.push_back(absl::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
   EXPECT_EQ(1, AllocatedType::alloc_count);
   EXPECT_NE(nullptr, list.front());
   for (auto item : list) {
@@ -49,7 +50,7 @@ TEST(IntrusiveListUniquePtrTest, UniquePtr) {
   EXPECT_EQ(0, AllocatedType::alloc_count);
 
   // Push/take.
-  list.push_back(absl::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
   EXPECT_EQ(1, AllocatedType::alloc_count);
   EXPECT_NE(nullptr, list.front());
   auto item = list.take(list.front());
@@ -60,17 +61,17 @@ TEST(IntrusiveListUniquePtrTest, UniquePtr) {
   EXPECT_EQ(0, AllocatedType::alloc_count);
 
   // Push/replace.
-  list.push_back(absl::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
   EXPECT_EQ(1, AllocatedType::alloc_count);
-  list.replace(list.front(), absl::make_unique<AllocatedType>());
+  list.replace(list.front(), std::make_unique<AllocatedType>());
   EXPECT_EQ(1, AllocatedType::alloc_count);
   list.clear();
   EXPECT_EQ(0, AllocatedType::alloc_count);
 
   // Iteration.
-  list.push_back(absl::make_unique<AllocatedType>());
-  list.push_back(absl::make_unique<AllocatedType>());
-  list.push_back(absl::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
+  list.push_back(std::make_unique<AllocatedType>());
   EXPECT_EQ(3, AllocatedType::alloc_count);
   for (auto item : list) {
     AllocatedType* item_ptr = item;

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -18,7 +18,6 @@
 #include <utility>
 
 #include "absl/container/inlined_vector.h"
-#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "iree/base/internal/math.h"
 #include "iree/base/status.h"

--- a/iree/modules/vmla/BUILD
+++ b/iree/modules/vmla/BUILD
@@ -44,7 +44,6 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/types:span",
         "@com_google_ruy//ruy",
         "@com_google_ruy//ruy:context",

--- a/iree/modules/vmla/CMakeLists.txt
+++ b/iree/modules/vmla/CMakeLists.txt
@@ -28,7 +28,6 @@ iree_cc_library(
     absl::core_headers
     absl::flat_hash_set
     absl::inlined_vector
-    absl::memory
     absl::span
     iree::base::status
     iree::base::tracing

--- a/iree/modules/vmla/op_kernels_ruy.h
+++ b/iree/modules/vmla/op_kernels_ruy.h
@@ -15,10 +15,10 @@
 #ifndef IREE_MODULES_VMLA_OP_KERNELS_RUY_H_
 #define IREE_MODULES_VMLA_OP_KERNELS_RUY_H_
 
+#include <memory>
 #include <type_traits>
 
 #include "absl/base/thread_annotations.h"
-#include "absl/memory/memory.h"
 #include "iree/base/status.h"
 #include "ruy/context.h"
 #include "ruy/mul_params.h"
@@ -37,7 +37,7 @@ struct MatMul::RuntimeState {
 };
 
 inline std::unique_ptr<MatMul::RuntimeState> MatMul::CreateRuntimeState() {
-  return absl::make_unique<RuntimeState>();
+  return std::make_unique<RuntimeState>();
 }
 
 // Floating-point case.


### PR DESCRIPTION
We use `std::make_unique` throughout the project. If we needed compatibility with older compilers, we could switch to `absl::make_unique` ([source](https://github.com/abseil/abseil-cpp/blob/9fde5a6eb081ea080f5aa895102a9154c3a2d09f/absl/memory/memory.h#L96-L103)) or add our own implementation without a dep on abseil (see https://github.com/google/iree/issues/3848).