### PR TITLE
Lower `linalg.tensor_reshape` to `flow.tensor.reshape`.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
@@ -40,3 +40,28 @@ func @subtensor_convert(%arg0 : tensor<?x24x48xf32>, %arg1 : index) ->
 //   CHECK-DAG:   %[[UNMODIFIED2:.+]] = subtensor %[[SLICE2]][0, 0, 0] [%[[D1]], 12, 24] [1, 2, 2]
 //   CHECK-DAG:   %[[UNMODIFIED3:.+]] = subtensor %[[ARG0]][0, %[[ARG1]], 0]
 //       CHECK:   return %[[UNMODIFIED1]], %[[UNMODIFIED2]], %[[UNMODIFIED3]]
+
+// -----
+
+func @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32>)
+    -> (tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>)
+{
+  %0 = linalg.tensor_reshape %arg0
+      [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+       affine_map<(d0, d1, d2, d3, d4, d5) -> (d3)>,
+       affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5)>]
+      : tensor<?x4x?x5x?x6xf32> into tensor<?x5x?xf32>
+  %1 = linalg.tensor_reshape %arg1
+      [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>,
+       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d2, d3)>,
+       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6)>]
+      : tensor<20x?x40xf32> into tensor<5x4x?x4x2x4x5xf32>
+  return %0, %1 : tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>
+}
+// CHECK-LABEL: func @tensor_reshape
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x4x?x5x?x6xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<20x?x40xf32>
+//   CHECK-DAG:   %[[R0:.+]] = flow.tensor.reshape %[[ARG0]]
+//   CHECK-DAG:   %[[R1:.+]] = flow.tensor.reshape %[[ARG1]]
+//       CHECK:   return %[[R0]], %[[R1]]
+

--- a/iree/test/e2e/models/unidirectional_lstm.mlir
+++ b/iree/test/e2e/models/unidirectional_lstm.mlir
@@ -3,6 +3,8 @@
 // RUN: iree-run-mlir %s -iree-hal-target-backends=vmla -function-input="1x5xf32=[0,1,0,3,4]" -function-input="1x5x2x2xf32=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]" | IreeFileCheck %s --implicit-check-not="[" --implicit-check-not="]"
 // RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir %s -iree-hal-target-backends=dylib-llvm-aot -function-input="1x5xf32=[0,1,0,3,4]" -function-input="1x5x2x2xf32=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]" | IreeFileCheck %s --implicit-check-not="[" --implicit-check-not="]")
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir %s -iree-hal-target-backends=vulkan-spirv -function-input="1x5xf32=[0,1,0,3,4]" -function-input="1x5x2x2xf32=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]" | IreeFileCheck %s --implicit-check-not="[" --implicit-check-not="]")
+// RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir %s -iree-hal-target-backends=dylib-llvm-aot -function-input="1x5xf32=[0,1,0,3,4]" -iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors -function-input="1x5x2x2xf32=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]" | IreeFileCheck %s --implicit-check-not="[" --implicit-check-not="]")
+// RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-run-mlir %s -iree-hal-target-backends=vulkan-spirv -function-input="1x5xf32=[0,1,0,3,4]" -iree-flow-dispatch-linalg-on-tensors -iree-codegen-spirv-experimental-linalg-on-tensors -function-input="1x5x2x2xf32=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]" | IreeFileCheck %s --implicit-check-not="[" --implicit-check-not="]")
 
 // Exported via the XLA HLO Importer
 // The resulting MLIR was modified by hand by changing all large constants to be


### PR DESCRIPTION
Inlining reshapes into dispatch regions cause subtle issue
1) The reshape can hamper using tied operands since the type of the
   operand/result might mismatch.
2) The `subtensor` -> `tensor_reshape` causes issues during
   bufferization.

To avoid this two approaches are possible
1) Fuse reshapes with other operations as much as possible during
   fusion on linalg ops.
2) Lower reshapes to `flow.tensor.reshape` before dispatch region
   creation.

These reshapes can become no-ops later on when lowering to HAL. For
now they are lowered as copies.