### PR TITLE
Changing iree_vm_list_resize to grow by 2x.

### DIFF
--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -253,7 +253,8 @@ iree_vm_list_resize(iree_vm_list_t* list, iree_host_size_t new_size) {
     list->count = new_size;
   } else if (new_size > list->capacity) {
     // Extending beyond capacity.
-    IREE_RETURN_IF_ERROR(iree_vm_list_reserve(list, new_size));
+    IREE_RETURN_IF_ERROR(iree_vm_list_reserve(
+        list, iree_max(list->capacity * 2, iree_align(new_size, 64))));
   }
   list->count = new_size;
   return iree_ok_status();


### PR DESCRIPTION
This prevents bad push behavior leading to many reallocs.

Before:
![image](https://user-images.githubusercontent.com/75337/113212111-34ae0180-922b-11eb-86b3-38701df5ad0b.png)

After:
![image](https://user-images.githubusercontent.com/75337/113212031-17793300-922b-11eb-9bb1-fb52032a2edb.png)
