### PR TITLE
Add tracing to allocations made from VMA.

### DIFF
--- a/iree/base/tracing.h
+++ b/iree/base/tracing.h
@@ -448,14 +448,33 @@ enum {
 
 #else
 
+// TODO(benvanik): bump submodule when upstream patch lands:
+// https://github.com/wolfpld/tracy/pull/191
+#ifdef __cplusplus
+extern "C" {
+#endif
+TRACY_API void ___tracy_emit_memory_alloc_named(const void* ptr, size_t size,
+                                                int secure, const char* name);
+TRACY_API void ___tracy_emit_memory_free_named(const void* ptr, int secure,
+                                               const char* name);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
 #define IREE_TRACE_ALLOC(ptr, size) ___tracy_emit_memory_alloc(ptr, size, 0)
 #define IREE_TRACE_FREE(ptr) ___tracy_emit_memory_free(ptr, 0)
+#define IREE_TRACE_ALLOC_NAMED(name, ptr, size) \
+  ___tracy_emit_memory_alloc_named(ptr, size, 0, name)
+#define IREE_TRACE_FREE_NAMED(name, ptr) \
+  ___tracy_emit_memory_free_named(ptr, 0, name)
 
 #endif  // IREE_TRACING_FEATURE_ALLOCATION_CALLSTACKS
 
 #else
 #define IREE_TRACE_ALLOC(ptr, size)
 #define IREE_TRACE_FREE(ptr)
+#define IREE_TRACE_ALLOC_NAMED(name, ptr, size)
+#define IREE_TRACE_FREE_NAMED(name, ptr)
 #endif  // IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 
 #if defined(__cplusplus) && \

--- a/iree/hal/vulkan/vma_buffer.cc
+++ b/iree/hal/vulkan/vma_buffer.cc
@@ -72,6 +72,8 @@ iree_status_t iree_hal_vulkan_vma_buffer_wrap(
     //     VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT flag.
     vmaSetAllocationUserData(buffer->vma, buffer->allocation, buffer);
 
+    IREE_TRACE_ALLOC_NAMED("VMA", (void*)buffer->handle, byte_length);
+
     *out_buffer = &buffer->base;
   } else {
     vmaDestroyBuffer(vma, handle, allocation);
@@ -87,6 +89,8 @@ static void iree_hal_vulkan_vma_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   iree_allocator_t host_allocator =
       iree_hal_allocator_host_allocator(iree_hal_buffer_allocator(base_buffer));
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_TRACE_FREE_NAMED("VMA", (void*)buffer->handle);
 
   vmaDestroyBuffer(buffer->vma, buffer->handle, buffer->allocation);
   iree_allocator_free(host_allocator, buffer);


### PR DESCRIPTION
This does not match the amount of memory allocated from Vulkan itself as
VMA does magic. There may be ways of inserting ourselves between VMA and
Vulkan to more easily see what it's doing, but this at least gets us into
the ballpark of what we are requesting.

The allocations show under the "VMA" pool in the memory tool:
![image](https://user-images.githubusercontent.com/75337/113214455-5eb4f300-922e-11eb-882d-56b123676777.png)

The addresses are meaningless, unfortunately, but size/timing/callstacks are all valid.