### PR TITLE
Set wasm-export-name attributes on exported functions again.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -69,6 +69,8 @@ class WasmLinkerTool : public LinkerTool {
     }
 
     // https://lld.llvm.org/WebAssembly.html#exports
+    // Note: once we can set --shared this shouldn't be needed, since we set
+    // default visibility on exported functions.
     for (auto func : exportedFuncs) {
       func->addFnAttr("wasm-export-name", func->getName());
     }
@@ -102,6 +104,10 @@ class WasmLinkerTool : public LinkerTool {
 
         // Treat warnings as errors.
         "--fatal-warnings",
+
+        // Generated a shared object, not an executable.
+        // Note: disabled since creating shared libraries is not yet supported.
+        // "--shared",
 
         "-o " + artifacts.libraryFile.path,
     };

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -67,6 +67,12 @@ class WasmLinkerTool : public LinkerTool {
       // -ffreestanding-like behavior.
       func.addFnAttr("no-builtins");
     }
+
+    // https://lld.llvm.org/WebAssembly.html#exports
+    for (auto func : exportedFuncs) {
+      func->addFnAttr("wasm-export-name", func->getName());
+    }
+
     return success();
   }
 


### PR DESCRIPTION
Sanity checked that generated .wasm/.wat files have exported functions in them with names that look about right, but didn't test fully.