### PR TITLE
Insert clones prior to mutation and not where it originates.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -153,7 +153,7 @@ struct InsertImmutabilityPreservingStreamClones
       if (!tiedOperandIndex.hasValue()) continue;
       auto tiedOperand = tiedOp->getOperand(tiedOperandIndex.getValue());
       if (hasUsersInStreamAfterUpdate(tiedOperand, tiedOp)) {
-        rewriter.setInsertionPointAfterValue(tiedOperand);
+        rewriter.setInsertionPoint(tiedOp);
         auto clonedOperand = rewriter.createOrFold<TensorCloneOp>(
             tiedOperand.getLoc(), tiedOperand);
         SmallPtrSet<Operation *, 1> excludedOps;


### PR DESCRIPTION
This dramatically reduces the lifetime of the clones.
Fixes #5291.