### PR TITLE
Add StripAsserts pass and handle tf.Identity ops on tensor lists.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/BUILD
@@ -27,6 +27,7 @@ cc_library(
         "LowerGlobalTensors.cpp",
         "Passes.cpp",
         "PropagateResourceCasts.cpp",
+        "StripAsserts.cpp",
         "StripMetadata.cpp",
         "VerifyFullyConverted.cpp",
     ],

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
@@ -51,6 +51,7 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   //----------------------------------------------------------------------------
   // Try to get the IR in good condition.
   //----------------------------------------------------------------------------
+  pm.addPass(createStripAssertsPass());
   pm.addPass(createInlinerPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(TFDevice::CreateDecomposeResourceOpsPass());

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
@@ -64,6 +64,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createLowerExportedFunctionsPass();
 // Push resource casts forward to better propagate resource related shapes.
 std::unique_ptr<OperationPass<ModuleOp>> createPropagateResourceCastsPass();
 
+// Strips tf.Assert ops.
+std::unique_ptr<OperationPass<FuncOp>> createStripAssertsPass();
+
 // Strips all TF-related attributes; none are needed by IREE.
 std::unique_ptr<OperationPass<ModuleOp>> createStripModuleMetadataPass();
 std::unique_ptr<OperationPass<FuncOp>> createStripFunctionMetadataPass();
@@ -86,6 +89,7 @@ inline void registerAllPasses() {
   createLowerGlobalTensorsPass();
   createLowerExportedFunctionsPass();
   createPropagateResourceCastsPass();
+  createStripAssertsPass();
   createStripModuleMetadataPass();
   createStripFunctionMetadataPass();
   createVerifyFullyConvertedPass();

--- a/integrations/tensorflow/iree_tf_compiler/TF/StripAsserts.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/StripAsserts.cpp
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree_tf_compiler/TF/Passes.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
+
+namespace mlir {
+namespace iree_integrations {
+namespace TF {
+
+class StripAssertsPass
+    : public PassWrapper<StripAssertsPass, OperationPass<FuncOp>> {
+ public:
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    DenseSet<Operation *> assertOps;
+    funcOp.walk([&](Operation *op) {
+      if (isa<mlir::TF::AssertOp>(op)) {
+        assertOps.insert(op);
+      }
+    });
+
+    for (Operation *assertOp : assertOps) {
+      assertOp->erase();
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<FuncOp>> createStripAssertsPass() {
+  return std::make_unique<StripAssertsPass>();
+}
+
+static PassRegistration<StripAssertsPass> funcPass("iree-tf-strip-asserts",
+                                                   "Remove tf.Assert ops");
+
+}  // namespace TF
+}  // namespace iree_integrations
+}  // namespace mlir

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/BUILD
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "lower_global_tensors_complex.mlir",
             "lower_global_tensors_invalid.mlir",
             "propagate_resource_casts.mlir",
+            "strip_asserts.mlir",
             "strip_metadata.mlir",
             "verify_fully_converted.mlir",
         ],

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/strip_asserts.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/strip_asserts.mlir
@@ -1,0 +1,12 @@
+// RUN: iree-tf-opt -split-input-file -verify-diagnostics -pass-pipeline='func(iree-tf-strip-asserts)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @asserts
+// CHECK-NOT: tf.Assert
+func @asserts(%arg0 : tensor<*xi1>, %arg1 : tensor<!tf.string>,
+      %arg2 : tensor<!tf.string>, %arg3 : tensor<!tf.string>,
+      %arg4 : tensor<i32>, %arg5 : tensor<!tf.string>, %arg6 : tensor<i32>) {
+  "tf.Assert"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6)
+    : (tensor<*xi1>, tensor<!tf.string>, tensor<!tf.string>, tensor<!tf.string>,
+       tensor<i32>, tensor<!tf.string>, tensor<i32>) -> ()
+  return
+}

--- a/integrations/tensorflow/iree_tf_compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/dialect/tf_tensorlist/conversion/test/convert_tf_to_tf_tensorlist.mlir
@@ -38,6 +38,16 @@ func @concat(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>, %lead: tensor<
   return %t#0, %t#1 : tensor<?xf32>, tensor<0xi64>
 }
 
+// CHECK-LABEL: func @identity
+func @identity(%arg0: tensor<?xf32>, %element_shape: tensor<0xi32>, %lead: tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>) {
+  // CHECK-NOT: tf.Identity
+  // CHECK: return
+
+  %list0 = "tf.TensorListFromTensor"(%arg0, %element_shape) : (tensor<?xf32>, tensor<0xi32>) -> tensor<!tf.variant<tensor<f32>>>
+  %ident = "tf.Identity"(%list0) : (tensor<!tf.variant<tensor<f32>>>) -> tensor<!tf.variant<tensor<f32>>>
+  %t:2 = "tf.TensorListConcatV2"(%ident, %element_shape, %lead) : (tensor<!tf.variant<tensor<f32>>>, tensor<0xi32>, tensor<i64>) -> (tensor<?xf32>, tensor<0xi64>)
+  return %t#0, %t#1 : tensor<?xf32>, tensor<0xi64>
+}
 
 // CHECK-LABEL: func @control_flow_simple
 func @control_flow_simple(%arg0: tensor<f32>, %num_elements: tensor<i32>, %element_shape: tensor<0xi32>, %index: tensor<i32>, %item: tensor<f32>) {


### PR DESCRIPTION
* Both issues found when porting a non-trivial model.
* We may eventually want to do something with the asserts, but between IREE missing functionality to implement them properly and my observation that they are often incidental in TF programs (i.e. TF has no global control for them so it is down to the whims of library and model authors), stripping is likely a good default, even if we had good support for them.
* Should fix #5290 and #4865