### PR TITLE
Add new metrics to MobileNetV2 benchmarks.

### DIFF
--- a/build_tools/mako/config/mobilenet-v2-pixel4.config
+++ b/build_tools/mako/config/mobilenet-v2-pixel4.config
@@ -41,5 +41,9 @@ metric_info_list: {
   value_key: "vlk"
   label: "Vulkan-SPIRV"
 }
+metric_info_list: {
+  value_key: "cpu2"
+  label: "DYLib_AOT_Linalg-On-Tensors"
+}
 
 description: "Keras Applications: MobileNet V2"

--- a/build_tools/mako/config/mobilenet-v2-s20.config
+++ b/build_tools/mako/config/mobilenet-v2-s20.config
@@ -41,5 +41,13 @@ metric_info_list: {
   value_key: "vlk"
   label: "Vulkan-SPIRV"
 }
+metric_info_list: {
+  value_key: "cpu2"
+  label: "DYLib_AOT_Linalg-On-Tensors"
+}
+metric_info_list: {
+  value_key: "vlk2"
+  label: "Vulkan-SPIRV_Linalg-On-Tensors"
+}
 
 description: "Keras Applications: MobileNet V2"

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -94,7 +94,9 @@ class ModelBenchmarkInfo:
     self.phones = phones
 
 
-def get_pixel4_default_target_list(batch_config=None):
+def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
+  if skipped_target is None:
+    skipped_target = []
   if batch_config is None:
     batch_config = []
   targets = [
@@ -111,15 +113,36 @@ def get_pixel4_default_target_list(batch_config=None):
           compilation_flags=[
               "--iree-spirv-enable-vectorization",
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10"
+          ]),
+      TargetInfo(name="dylib-llvm-aot",
+                 mako_tag="cpu2",
+                 compilation_flags=[
+                     "--iree-llvm-target-triple=aarch64-none-linux-android29",
+                     "--iree-flow-dispatch-linalg-on-tensors",
+                     "--iree-codegen-llvm-experimental-linalg-on-tensors",
+                     "-iree-flow-inline-constants-max-byte-length=2048"
+                 ],
+                 runtime_flags=["--dylib_worker_count=1"]),
+      TargetInfo(
+          name="vulkan-spirv",
+          mako_tag="vlk2",
+          compilation_flags=[
+              "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10",
+              "--iree-flow-dispatch-linalg-on-tensors",
+              "--iree-codegen-spirv-experimental-linalg-on-tensors",
+              "-iree-flow-inline-constants-max-byte-length=2048"
           ])
   ]
+  targets = [elem for elem in targets if elem.mako_tag not in skipped_target]
   for target in targets:
     if target.mako_tag in batch_config:
       target.add_batch_flag(batch_config[target.mako_tag])
   return targets
 
 
-def get_s20_default_target_list(batch_config=None):
+def get_s20_default_target_list(skipped_target=None, batch_config=None):
+  if skipped_target is None:
+    skipped_target = []
   if batch_config is None:
     batch_config = []
   targets = [
@@ -130,13 +153,33 @@ def get_s20_default_target_list(batch_config=None):
                      "--iree-llvm-target-triple=aarch64-none-linux-android29"
                  ],
                  runtime_flags=["--dylib_worker_count=1"]),
-      TargetInfo(name="vulkan-spirv",
-                 mako_tag="vlk",
+      TargetInfo(
+          name="vulkan-spirv",
+          mako_tag="vlk",
+          compilation_flags=[
+              "--iree-spirv-enable-vectorization",
+              "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
+          ]),
+      TargetInfo(name="dylib-llvm-aot",
+                 mako_tag="cpu2",
                  compilation_flags=[
-                     "--iree-spirv-enable-vectorization",
-                     "--iree-vulkan-target-triple=valhall-g77-unknown-android10"
-                 ])
+                     "--iree-llvm-target-triple=aarch64-none-linux-android29",
+                     "--iree-flow-dispatch-linalg-on-tensors",
+                     "--iree-codegen-llvm-experimental-linalg-on-tensors",
+                     "-iree-flow-inline-constants-max-byte-length=2048"
+                 ],
+                 runtime_flags=["--dylib_worker_count=1"]),
+      TargetInfo(
+          name="vulkan-spirv",
+          mako_tag="vlk2",
+          compilation_flags=[
+              "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
+              "--iree-flow-dispatch-linalg-on-tensors",
+              "--iree-codegen-spirv-experimental-linalg-on-tensors",
+              "-iree-flow-inline-constants-max-byte-length=2048"
+          ])
   ]
+  targets = [elem for elem in targets if elem.mako_tag not in skipped_target]
   for target in targets:
     if target.mako_tag in batch_config:
       target.add_batch_flag(batch_config[target.mako_tag])
@@ -159,13 +202,16 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="5538704950034432",
                                targets=get_pixel4_default_target_list(
-                                   {'cpu': 8})),
+                                   skipped_target=['cpu2', 'vlk2'],
+                                   batch_config={'cpu': 8})),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="4699630718681088",
-                               targets=get_s20_default_target_list({
-                                   'cpu': 8,
-                                   'vlk': 16
-                               })),
+                               targets=get_s20_default_target_list(
+                                   skipped_target=['cpu2', 'vlk2'],
+                                   batch_config={
+                                       'cpu': 8,
+                                       'vlk': 16
+                                   })),
         ]),
     ModelBenchmarkInfo(
         name="mobilenet-v2",
@@ -176,13 +222,17 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
                                targets=get_pixel4_default_target_list(
-                                   {'cpu': 16})),
-            PhoneBenchmarkInfo(name="S20",
-                               benchmark_key="5618403088793600",
-                               targets=get_s20_default_target_list({
-                                   'cpu': 16,
-                                   'vlk': 64
-                               })),
+                                   skipped_target=['cpu2', 'vlk2'],
+                                   batch_config={'cpu': 16})),
+            PhoneBenchmarkInfo(
+                name="S20",
+                benchmark_key="5618403088793600",
+                targets=get_s20_default_target_list(batch_config={
+                    'cpu': 16,
+                    'vlk': 64,
+                    'cpu2': 8,
+                    'vlk2': 64
+                })),
         ])
 ]
 

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -222,7 +222,7 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
                                targets=get_pixel4_default_target_list(
-                                   skipped_target=['cpu2'],
+                                   skipped_target=['vlk2'],
                                    batch_config={
                                        'cpu': 16,
                                        'cpu2': 10

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -222,15 +222,18 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
                                targets=get_pixel4_default_target_list(
-                                   skipped_target=['cpu2', 'vlk2'],
-                                   batch_config={'cpu': 16})),
+                                   skipped_target=['cpu2'],
+                                   batch_config={
+                                       'cpu': 16,
+                                       'cpu2': 10
+                                   })),
             PhoneBenchmarkInfo(
                 name="S20",
                 benchmark_key="5618403088793600",
                 targets=get_s20_default_target_list(batch_config={
                     'cpu': 16,
                     'vlk': 64,
-                    'cpu2': 8,
+                    'cpu2': 10,
                     'vlk2': 64
                 })),
         ])


### PR DESCRIPTION
Add Linalg on tensors path to Mako benchmarks.

GPU target is only added to S20, and CPU target is added to both S20 and Pixel 4.