### PR TITLE
Removing hal.buffer.fill and hal.buffer.copy.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertBufferOps.cpp
@@ -88,8 +88,6 @@ void populateHALBufferToVMPatterns(MLIRContext *context,
       context, importSymbols, typeConverter, "hal.buffer.allocator");
   patterns.insert<VMImportOpConversion<IREE::HAL::BufferSubspanOp>>(
       context, importSymbols, typeConverter, "hal.buffer.subspan");
-  patterns.insert<VMImportOpConversion<IREE::HAL::BufferFillOp>>(
-      context, importSymbols, typeConverter, "hal.buffer.fill");
   patterns.insert<BufferLoadOpConversion>(context, importSymbols, typeConverter,
                                           "hal.buffer.load");
   patterns.insert<BufferStoreOpConversion>(context, importSymbols,

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_ops.mlir
@@ -11,18 +11,6 @@ func @buffer_subspan(%arg0 : !hal.buffer) -> !hal.buffer {
 
 // -----
 
-// CHECK-LABEL: @buffer_fill
-func @buffer_fill(%arg0 : !hal.buffer) {
-  %c42 = constant 42 : index
-  %c43 = constant 43 : index
-  %c123 = constant 123 : i32
-  // CHECK: vm.call @hal.buffer.fill(%arg0, %c42, %c43, %c123) : (!vm.ref<!hal.buffer>, i32, i32, i32) -> ()
-  hal.buffer.fill<%arg0 : !hal.buffer>[%c42, %c43] pattern(%c123 : i32)
-  return
-}
-
-// -----
-
 // CHECK-LABEL: @buffer_load
 func @buffer_load(%arg0 : !hal.buffer) -> (i8, i16, i32) {
   %c42 = constant 42 : index

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
@@ -49,9 +49,5 @@ func private @pool_splats_initializer() -> !hal.buffer {
   %buffer = hal.allocator.allocate<%allocator : !hal.allocator>
       type("HostVisible|DeviceVisible|DeviceLocal")
       usage("Constant|Transfer|Mapping|Dispatch") : !hal.buffer{%c64}
-  // CHECK: vm.call @hal.buffer.fill([[BUFFER]], %zero, %c4, %c1065353216)
-  hal.buffer.fill<%buffer : !hal.buffer>[%c0, %c4] pattern(%c1065353216_i32 : i32)
-  // CHECK: vm.call @hal.buffer.fill([[BUFFER]], %c32, %c32, %c1234567890)
-  hal.buffer.fill<%buffer : !hal.buffer>[%c32, %c32] pattern(%c1234567890_i32 : i32)
   return %buffer : !hal.buffer
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -562,51 +562,6 @@ def HAL_BufferLengthOp : HAL_PureOp<"buffer.length", [
   }];
 }
 
-def HAL_BufferFillOp : HAL_Op<"buffer.fill"> {
-  let summary = [{buffer fill operation}];
-  let description = [{
-    Fills the target buffer with the given repeating value.
-  }];
-
-  let arguments = (ins
-    HAL_BufferType:$target_buffer,
-    HAL_DeviceSize:$target_offset,
-    HAL_DeviceSize:$length,
-    I32:$pattern
-  );
-
-  let assemblyFormat = [{
-    `<` $target_buffer `:` type($target_buffer) `>`
-    `` `[` $target_offset `,` $length `]`
-    `pattern` `(` $pattern `:` type($pattern) `)`
-    attr-dict-with-keyword
-  }];
-}
-
-def HAL_BufferCopyOp : HAL_Op<"buffer.copy"> {
-  let summary = [{buffer-to-buffer copy operation}];
-  let description = [{
-    Copies data from the provided source_buffer into the buffer.
-  }];
-
-  let arguments = (ins
-    HAL_BufferType:$source_buffer,
-    HAL_DeviceSize:$source_offset,
-    HAL_BufferType:$target_buffer,
-    HAL_DeviceSize:$target_offset,
-    HAL_DeviceSize:$length
-  );
-
-  let assemblyFormat = [{
-    `source` `(` $source_buffer `:` type($source_buffer) `)`
-    `` `[` $source_offset `]`
-    `target` `(` $target_buffer `:` type($target_buffer) `)`
-    `` `[` $target_offset `]`
-    `length` `(` $length `)`
-    attr-dict-with-keyword
-  }];
-}
-
 def HAL_BufferLoadOp : HAL_PureOp<"buffer.load"> {
   let summary = [{buffer element load operation}];
   let description = [{

--- a/iree/compiler/Dialect/HAL/IR/test/buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/buffer_ops.mlir
@@ -33,40 +33,6 @@ func @buffer_length(%arg0: !hal.buffer) -> index {
 
 // -----
 
-// CHECK-LABEL: @buffer_fill
-func @buffer_fill(%arg0: !hal.buffer) {
-  // CHECK-DAG: %[[OFFSET:.+]] = constant 100
-  %offset = constant 100 : index
-  // CHECK-DAG: %[[LENGTH:.+]] = constant 200
-  %length = constant 200 : index
-  // CHECK-DAG: %[[PATTERN:.+]] = constant 42
-  %pattern = constant 42 : i32
-  // CHECK: hal.buffer.fill<%arg0 : !hal.buffer>[%[[OFFSET]], %[[LENGTH]]] pattern(%[[PATTERN]] : i32)
-  hal.buffer.fill<%arg0 : !hal.buffer>[%offset, %length] pattern(%pattern : i32)
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @buffer_copy
-func @buffer_copy(%arg0: !hal.buffer, %arg1: !hal.buffer) {
-  // CHECK-DAG: %[[SRC_OFFSET:.+]] = constant 100
-  %src_offset = constant 100 : index
-  // CHECK-DAG: %[[DST_OFFSET:.+]] = constant 200
-  %dst_offset = constant 200 : index
-  // CHECK-DAG: %[[LENGTH:.+]] = constant 300
-  %length = constant 300 : index
-  // CHECK: hal.buffer.copy source(%arg0 : !hal.buffer)[%[[SRC_OFFSET]]]
-  // CHECK-SAME:            target(%arg1 : !hal.buffer)[%[[DST_OFFSET]]]
-  // CHECK-SAME:            length(%[[LENGTH]])
-  hal.buffer.copy source(%arg0 : !hal.buffer)[%src_offset]
-                  target(%arg1 : !hal.buffer)[%dst_offset]
-                  length(%length)
-  return
-}
-
-// -----
-
 // CHECK-LABEL: @buffer_load
 func @buffer_load(%arg0: !hal.buffer) -> i32 {
   // CHECK-DAG: %[[SRC_OFFSET:.+]] = constant 100

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -55,17 +55,6 @@ vm.import @buffer.subspan(
   %length : i32
 ) -> !vm.ref<!hal.buffer>
 
-// DEPRECATED: this will be removed in future versions and replaced with
-// transfer queue operations by the compiler.
-//
-// Fills the target buffer with the given repeating value.
-vm.import @buffer.fill(
-  %target_buffer : !vm.ref<!hal.buffer>,
-  %target_offset : i32,
-  %length : i32,
-  %pattern : i32
-)
-
 // Loads a value from a buffer by mapping it.
 vm.import @buffer.load(
   %source_buffer : !vm.ref<!hal.buffer>,

--- a/iree/modules/hal/exports.inl
+++ b/iree/modules/hal/exports.inl
@@ -36,7 +36,6 @@ EXPORT_FN("allocator.allocate", iree_hal_module_allocator_allocate, riii, r)
 EXPORT_FN("allocator.wrap.byte_buffer", iree_hal_module_allocator_wrap_byte_buffer, riirii, r)
 
 EXPORT_FN("buffer.allocator", iree_hal_module_buffer_allocator, r, r)
-EXPORT_FN("buffer.fill", iree_hal_module_buffer_fill, riii, v)
 EXPORT_FN("buffer.load", iree_hal_module_buffer_load, rii, i)
 EXPORT_FN("buffer.store", iree_hal_module_buffer_store, irii, v)
 EXPORT_FN("buffer.subspan", iree_hal_module_buffer_subspan, rii, r)

--- a/iree/modules/hal/hal_module.c
+++ b/iree/modules/hal/hal_module.c
@@ -324,21 +324,6 @@ IREE_VM_ABI_EXPORT(iree_hal_module_buffer_subspan, rii, r) {
   return iree_ok_status();
 }
 
-IREE_VM_ABI_EXPORT(iree_hal_module_buffer_fill, riii, v) {
-  // DEPRECATED: will be removed in future versions. Use command buffers.
-  iree_hal_buffer_t* target_buffer = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_buffer_check_deref(args->r0, &target_buffer));
-  iree_vm_size_t target_offset = (iree_vm_size_t)args->i1;
-  iree_vm_size_t length = (iree_vm_size_t)args->i2;
-  uint32_t pattern = (uint32_t)args->i3;
-
-  IREE_RETURN_IF_ERROR(iree_hal_buffer_fill(target_buffer, target_offset,
-                                            length, &pattern, sizeof(pattern)),
-                       "fill range failed (target_offset=%d, length=%d)",
-                       target_offset, length);
-  return iree_ok_status();
-}
-
 IREE_VM_ABI_EXPORT(iree_hal_module_buffer_load, rii, i) {
   iree_hal_buffer_t* source_buffer = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_buffer_check_deref(args->r0, &source_buffer));


### PR DESCRIPTION
Neither are used anymore (and should never be). The implementation of these relies on host-visible memory that may not be available on all backends - and even if it was may incur significant performance penalties (metal needs to dispatch command buffers, vulkan requires HOST_VISIBLE mappings from limited memory pools, etc). It'd be nice to remove these from the HAL API too but there are legit uses and it's easier to diagnose user C code calling into C APIs than it is compiler output.