### PR TITLE
Patch VMLA performance by reserving vector size before pushing to it.

### DIFF
--- a/iree/modules/vmla/op_kernels_generic.h
+++ b/iree/modules/vmla/op_kernels_generic.h
@@ -961,6 +961,7 @@ inline void ReduceDimension(absl::Span<const T> src_buffer,
     // TODO(scotttodd): Clean this up somehow, share across recursion levels?
     size_t dst_size = src_shape.size() - reduce_dims.size();
     std::vector<int> dst_indices;
+    dst_indices.reserve(src_indices.size());
     for (size_t i = 0; i < src_indices.size(); ++i) {
       if (std::find(std::begin(reduce_dims), std::end(reduce_dims), i) ==
           std::end(reduce_dims)) {


### PR DESCRIPTION
Addressing a performance regression introduced by https://github.com/google/iree/pull/5302

![image](https://user-images.githubusercontent.com/4010439/113621630-b5487580-9610-11eb-930b-961ada1755b8.png)
