### PR TITLE
Fix bugs in ExtractReduceWindowOpPaddingAttributes.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -47,9 +47,13 @@ static llvm::cl::opt<bool> orderConvFeatures(
     llvm::cl::desc("Guarantees input/output features ordered for conv kernel"),
     llvm::cl::init(true));
 
+/// Returns true if the given `attr` is a splat of the given `value`.
+static bool isSplatValue(DenseIntElementsAttr attr, uint64_t value) {
+  return attr.isSplat() && attr.getSplatValue<uint64_t>() == value;
+}
+
 static bool isAllZero(DenseIntElementsAttr attr) {
-  if (!attr.isSplat()) return false;
-  return attr.getSplatValue<IntegerAttr>().getInt() == 0;
+  return isSplatValue(attr, 0);
 }
 
 static bool isIota(ArrayRef<int64_t> array) {
@@ -397,7 +401,11 @@ class ExtractReduceWindowOpPaddingAttributes
                                 PatternRewriter &rewriter) const override {
     if (!op.padding()) return failure();
 
-    if (op.base_dilations() || op.window_dilations()) return failure();
+
+    if ((op.base_dilations() && !isSplatValue(*op.base_dilations(), 1)) ||
+        (op.window_dilations() && !isSplatValue(*op.window_dilations(), 1))) {
+      return failure();
+    }
     if (isAllZero(op.paddingAttr())) return failure();
 
     // All inputs must be of the same static shape, since

--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -401,7 +401,6 @@ class ExtractReduceWindowOpPaddingAttributes
                                 PatternRewriter &rewriter) const override {
     if (!op.padding()) return failure();
 
-
     if ((op.base_dilations() && !isSplatValue(*op.base_dilations(), 1)) ||
         (op.window_dilations() && !isSplatValue(*op.window_dilations(), 1))) {
       return failure();

--- a/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/hlo_to_hlo_preprocessing.mlir
@@ -72,6 +72,8 @@ func @reduce_window(%input: tensor<1x16x16x64xf32>) -> tensor<1x8x8x64xf32> {
     "mhlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
       window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dilations = dense<1> : tensor<4xi64>,
+      base_dilations = dense<1> : tensor<4xi64>,
       padding = dense<[[0, 0], [1, 1], [1, 1], [0, 0]]> : tensor<4x2xi64>
   } : (tensor<1x16x16x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
   return %0 : tensor<1x8x8x64xf32>


### PR DESCRIPTION
The padding attribute can be extracted if all the dilation values are 1
or not set.