### PR TITLE
Fix benchmarking MobileNetV2 on S20 GPU in Linalg on tensor path.

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -176,7 +176,10 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
               "--iree-flow-dispatch-linalg-on-tensors",
               "--iree-codegen-spirv-experimental-linalg-on-tensors",
-              "-iree-flow-inline-constants-max-byte-length=2048"
+              "-iree-flow-inline-constants-max-byte-length=2048",
+              "-iree-spirv-enable-vectorization",
+              # TODO(GH-5330): Remove the flag.
+              "-iree-flow-inline-constants-max-byte-length=16"
           ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -176,10 +176,9 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
               "--iree-flow-dispatch-linalg-on-tensors",
               "--iree-codegen-spirv-experimental-linalg-on-tensors",
-              "-iree-flow-inline-constants-max-byte-length=2048",
-              "-iree-spirv-enable-vectorization",
-              # TODO(GH-5330): Remove the flag.
-              "-iree-flow-inline-constants-max-byte-length=16"
+              # TODO(GH-5330): Replace 16 with 2048 or delete the flag.
+              "-iree-flow-inline-constants-max-byte-length=16",
+              "-iree-spirv-enable-vectorization"
           ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -176,7 +176,7 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
               "--iree-flow-dispatch-linalg-on-tensors",
               "--iree-codegen-spirv-experimental-linalg-on-tensors",
-              # TODO(GH-5330): Replace 16 with 2048 or delete the flag.
+              # TODO(GH-5330): Revisit the number or delete the flag.
               "-iree-flow-inline-constants-max-byte-length=16",
               "-iree-spirv-enable-vectorization"
           ])


### PR DESCRIPTION
See https://github.com/google/iree/pull/5282 for more details.

The Linalg on tensors path should work with `-iree-spirv-enable-vectorization`, also added the forgotten flag.