### PR TITLE
[vulkan] Disable ResNet50 test failing on NVIDIA GPUs

### DIFF
--- a/integrations/tensorflow/e2e/keras/applications/BUILD
+++ b/integrations/tensorflow/e2e/keras/applications/BUILD
@@ -107,6 +107,13 @@ KERAS_APPLICATIONS_MODELS = [
 iree_e2e_cartesian_product_test_suite(
     name = "large_cifar10_tests",
     size = "large",
+    failing_configurations = [
+        {
+            # TODO(#5268): Failing on Vulkan due to OOM.
+            "model": "ResNet50",
+            "target_backends": "iree_vulkan",
+        },
+    ],
     matrix = {
         "src": "applications_test.py",
         "reference_backend": "tf",

--- a/integrations/tensorflow/e2e/keras/applications/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/applications/CMakeLists.txt
@@ -26,6 +26,8 @@ iree_e2e_cartesian_product_test_suite(
     "cifar10"
     "MobileNet;MobileNetV2;ResNet50;VGG16;VGG19"
     "tf;tflite;iree_vmla;iree_llvmaot;iree_vulkan"
+  FAILING_CONFIGURATIONS
+    ",,,ResNet50,iree_vulkan"
   LABELS
     "manual"
 )


### PR DESCRIPTION
More discussions in https://github.com/google/iree/issues/5268.

Disable it for now to avoid hiding other failures.