### PR TITLE
Fix vulkan_device struct manipulation issue with std::vector.

### DIFF
--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -731,6 +731,9 @@ iree_status_t iree_hal_vulkan_device_create(
   // all queues created from the same family are done in the same
   // VkDeviceQueueCreateInfo struct.
   std::vector<VkDeviceQueueCreateInfo> queue_create_info;
+  // Reserve space for create infos. Note: must be the maximum used, or else
+  // references used below will be invalidated as the vector grows.
+  queue_create_info.reserve(2);
   std::vector<float> dispatch_queue_priorities;
   std::vector<float> transfer_queue_priorities;
   queue_create_info.push_back({});


### PR DESCRIPTION
More fallout from https://github.com/google/iree/pull/5302 :/

Actually caught by validation layer warnings about `pQueuePriorities` being null when it must not be.

In debug builds, this incorrect use of references sometimes allocated crazy amounts of memory by using uninitialized memory as the size to resize to... ouch.