### PR TITLE
Control TF MLIR print options via flags

### DIFF
--- a/bindings/python/iree/compiler/core.py
+++ b/bindings/python/iree/compiler/core.py
@@ -77,6 +77,10 @@ class CompilerOptions:
       Example: ["--print-ir-after-all"]
     optimize: Whether to apply some default high level optimizations (default
       True).
+    output_mlir_debuginfo: Include debuginfo (including paths) in any saved or
+      returned MLIR.
+    output_generic_mlir: Use the generic (and more portable) MLIR formatting for
+      any saved or returned MLIR instead of the per-dialect custom assembly.
     strip_debug_ops: Whether to strip high level operations used to aid
       debugging.
     strip_source_map: Whether to strip source map information (used to generate
@@ -98,6 +102,8 @@ class CompilerOptions:
                                     str] = OutputFormat.FLATBUFFER_BINARY,
                extra_args: Sequence[str] = (),
                optimize: bool = True,
+               output_mlir_debuginfo: bool = True,
+               output_generic_mlir: bool = False,
                strip_debug_ops: bool = False,
                strip_source_map: bool = False,
                strip_symbols: bool = False,
@@ -109,6 +115,8 @@ class CompilerOptions:
     self.output_format = OutputFormat.parse(output_format)
     self.extra_args = extra_args
     self.optimize = optimize
+    self.output_mlir_debuginfo = output_mlir_debuginfo
+    self.output_generic_mlir = output_generic_mlir
     self.strip_debug_ops = strip_debug_ops
     self.strip_source_map = strip_source_map
     self.strip_symbols = strip_symbols
@@ -145,6 +153,12 @@ def build_compile_command_line(input_file: str,
 
   # Translation to perform.
   cl.append("--iree-mlir-to-vm-bytecode-module")
+
+  # MLIR flags.
+  if options.output_mlir_debuginfo:
+    cl.append("--mlir-print-debuginfo")
+  if options.output_generic_mlir:
+    cl.append("--mlir-print-op-generic")
 
   # Other options to set if specified.
   if options.strip_debug_ops:

--- a/bindings/python/iree/compiler/tf.py
+++ b/bindings/python/iree/compiler/tf.py
@@ -90,7 +90,6 @@ class ImportOptions(CompilerOptions):
                import_extra_args: Sequence[str] = (),
                save_temp_tf_input: Optional[str] = None,
                save_temp_iree_input: Optional[str] = None,
-               output_generic_mlir: bool = False,
                **kwargs):
     """Initialize options from keywords.
 

--- a/bindings/python/iree/compiler/tf.py
+++ b/bindings/python/iree/compiler/tf.py
@@ -90,6 +90,7 @@ class ImportOptions(CompilerOptions):
                import_extra_args: Sequence[str] = (),
                save_temp_tf_input: Optional[str] = None,
                save_temp_iree_input: Optional[str] = None,
+               output_generic_mlir: bool = False,
                **kwargs):
     """Initialize options from keywords.
 
@@ -139,20 +140,29 @@ def build_import_command_line(input_path: str,
       f"--tf-savedmodel-exported-names={','.join(options.exported_names)}",
       f"--tf-savedmodel-tags={','.join(options.saved_model_tags)}",
   ]
+
   if options.import_only and options.output_file:
     # Import stage directly outputs.
-    if options.output_file:
-      cl.append(f"-o={options.output_file}")
+    cl.append(f"-o={options.output_file}")
+
+  # MLIR flags.
+  if options.output_mlir_debuginfo:
+    cl.append("--mlir-print-debuginfo")
+  if options.output_generic_mlir:
+    cl.append("--mlir-print-op-generic")
+
   # Save temps flags.
   if options.save_temp_tf_input:
     cl.append(f"--save-temp-tf-input={options.save_temp_tf_input}")
   if options.save_temp_iree_input:
     cl.append(f"--save-temp-iree-input={options.save_temp_iree_input}")
+
   # Crash reproducer (locally qualified).
   if options.crash_reproducer_path:
     cl.append(
         f"--pass-pipeline-crash-reproducer={options.crash_reproducer_path}"
         f".import-tf")
+
   # Extra args.
   cl.extend(options.import_extra_args)
   return cl

--- a/bindings/python/iree/compiler/tflite.py
+++ b/bindings/python/iree/compiler/tflite.py
@@ -100,24 +100,31 @@ def build_import_command_line(input_path: str,
   cl = [
       import_tool,
       input_path,
-      "--mlir-print-op-generic",
-      "--mlir-print-debuginfo",
   ]
+
   if options.import_only and options.output_file:
     # Import stage directly outputs.
-    if options.output_file:
-      cl.append(f"-o={options.output_file}")
+    cl.append(f"-o={options.output_file}")
+
   # Input arrays.
   if options.input_arrays:
     for input_array in options.input_arrays:
       cl.append(f"--input-array={input_array}")
     for output_array in options.output_arrays:
       cl.append(f"--output-array={output_array}")
+
+  # MLIR flags.
+  if options.output_mlir_debuginfo:
+    cl.append("--mlir-print-debuginfo")
+  if options.output_generic_mlir:
+    cl.append("--mlir-print-op-generic")
+
   # Save temps flags.
   if options.save_temp_tfl_input:
     cl.append(f"--save-temp-tfl-input={options.save_temp_tfl_input}")
   if options.save_temp_iree_input:
     cl.append(f"--save-temp-iree-input={options.save_temp_iree_input}")
+
   # Extra args.
   cl.extend(options.import_extra_args)
   return cl

--- a/bindings/python/iree/compiler/xla.py
+++ b/bindings/python/iree/compiler/xla.py
@@ -113,13 +113,21 @@ def build_import_command_line(input_path: str,
       input_path,
       f"--xla-format={options.import_format.value}",
   ]
+
   if options.import_only and options.output_file:
     # Import stage directly outputs.
-    if options.output_file:
-      cl.append(f"-o={options.output_file}")
+    cl.append(f"-o={options.output_file}")
+
+  # MLIR flags.
+  if options.output_mlir_debuginfo:
+    cl.append("--mlir-print-debuginfo")
+  if options.output_generic_mlir:
+    cl.append("--mlir-print-op-generic")
+
   # Save temps flags.
   if options.save_temp_iree_input:
     cl.append(f"--save-temp-iree-input={options.save_temp_iree_input}")
+
   # Extra args.
   cl.extend(options.import_extra_args)
   return cl

--- a/bindings/python/tests/compiler_tf_test.py
+++ b/bindings/python/tests/compiler_tf_test.py
@@ -53,7 +53,7 @@ class TfCompilerTest(tf.test.TestCase):
 
   def testImportSavedModel(self):
     import_mlir = iree.compiler.tf.compile_saved_model(
-        self.smdir, import_only=True).decode("utf-8")
+        self.smdir, import_only=True, output_generic_mlir=True).decode("utf-8")
     self.assertIn("sym_name = \"simple_matmul\"", import_mlir)
 
   def testCompileSavedModel(self):

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -207,8 +207,6 @@ int main(int argc, char **argv) {
       return failure();
     }
     OpPrintingFlags printFlags;
-    printFlags.enableDebugInfo();
-    printFlags.printGenericOpForm();
     module->print(outputFile->os(), printFlags);
     outputFile->os() << "\n";
     outputFile->keep();

--- a/integrations/tensorflow/iree_tf_compiler/iree-tf-import-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-tf-import-main.cpp
@@ -181,8 +181,6 @@ int main(int argc, char **argv) {
       return failure();
     }
     OpPrintingFlags printFlags;
-    printFlags.enableDebugInfo();
-    printFlags.printGenericOpForm();
     module->print(outputFile->os(), printFlags);
     outputFile->os() << "\n";
     outputFile->keep();


### PR DESCRIPTION
- Update `iree-import-*` to use `--mlir-print-op-generic` and `--mlir-print-debuginfo` to control formatting and debuginfo.
- Update the python bindings to control these via `CompilerOptions.output_generic_mlir=False` and `CompilerOptions.output_mlir_debuginfo=True`.
- Small changes for formatting consistency between `core.py`, `tf.py` `xla.py` and `tflite.py`.