### PR TITLE
Remove extra comma from context_wrapper.cc

### DIFF
--- a/experimental/bindings/java/com/google/iree/native/context_wrapper.cc
+++ b/experimental/bindings/java/com/google/iree/native/context_wrapper.cc
@@ -106,7 +106,7 @@ Status ContextWrapper::InvokeFunction(const FunctionWrapper& function_wrapper,
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
         input_buffer, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
         /*shape=*/&input_element_count,
-        /*shape_rank=*/1, , &input_buffer_view));
+        /*shape_rank=*/1, &input_buffer_view));
     iree_hal_buffer_release(input_buffer);
 
     // Marshal the input buffer views through the input VM variant list.


### PR DESCRIPTION
Remove an extra comma that jumped in due to bad autoformatting 😞  