### PR TITLE
Removing hack that forced all Vulkan buffers to be host-visible.

### DIFF
--- a/integrations/tensorflow/e2e/keras/applications/BUILD
+++ b/integrations/tensorflow/e2e/keras/applications/BUILD
@@ -107,13 +107,6 @@ KERAS_APPLICATIONS_MODELS = [
 iree_e2e_cartesian_product_test_suite(
     name = "large_cifar10_tests",
     size = "large",
-    failing_configurations = [
-        {
-            # TODO(#5268): Failing on Vulkan due to OOM.
-            "model": "ResNet50",
-            "target_backends": "iree_vulkan",
-        },
-    ],
     matrix = {
         "src": "applications_test.py",
         "reference_backend": "tf",

--- a/integrations/tensorflow/e2e/keras/applications/CMakeLists.txt
+++ b/integrations/tensorflow/e2e/keras/applications/CMakeLists.txt
@@ -26,8 +26,6 @@ iree_e2e_cartesian_product_test_suite(
     "cifar10"
     "MobileNet;MobileNetV2;ResNet50;VGG16;VGG19"
     "tf;tflite;iree_vmla;iree_llvmaot;iree_vulkan"
-  FAILING_CONFIGURATIONS
-    ",,,ResNet50,iree_vulkan"
   LABELS
     "manual"
 )

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -159,12 +159,6 @@ static iree_status_t iree_hal_vulkan_vma_allocator_make_compatible(
     iree_hal_memory_type_t* memory_type,
     iree_hal_memory_access_t* allowed_access,
     iree_hal_buffer_usage_t* allowed_usage) {
-  // TODO(benvanik): remove this entirely!
-  // Host currently uses mapping to copy buffers, which is done a lot.
-  // We could probably remove this mutation by preventing copies in those cases
-  // or issuing small copy command buffers.
-  *allowed_usage |=
-      IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_BUFFER_USAGE_MAPPING;
   return iree_ok_status();
 }
 

--- a/iree/test/e2e/models/BUILD
+++ b/iree/test/e2e/models/BUILD
@@ -65,9 +65,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_linalg_on_tensors_vulkan-spirv_vulkan",
-    # TODO(#5268) Add bert_encoder to this list once the issue is
-    # fixed.
-    srcs = ["mobilenetv2_fake_weights.mlir"],
+    srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = [
         "-iree-flow-dispatch-linalg-on-tensors",
         "-iree-flow-inline-constants-max-byte-length=2048",

--- a/iree/test/e2e/models/CMakeLists.txt
+++ b/iree/test/e2e/models/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_linalg_on_tensors_vulkan-spirv_vulkan
   SRCS
+    "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv2_fake_weights.mlir"
   TARGET_BACKEND
     "vulkan-spirv"


### PR DESCRIPTION
After removing copy/fill from the compiler the only users are now C code
that can be easily changed to do the right thing.

Fixes #5268.