### PR TITLE
MaterializeCPULaunch configurations before bufferization

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndVectorizePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndVectorizePass.cpp
@@ -134,14 +134,6 @@ LogicalResult deallocateWorkgroupMemory(OpBuilder &b, Value buffer) {
 void TileAndVectorizeWorkgroups::runOnFunction() {
   auto funcOp = getOperation();
   MLIRContext *context = &getContext();
-
-  // Apply prior vectorization canonicalization passes.
-  {
-    OwningRewritePatternList canonicalization(&getContext());
-    populateAffineMinSCFCanonicalizationPattern(canonicalization);
-    (void)applyPatternsAndFoldGreedily(funcOp, std::move(canonicalization));
-  }
-
   // Promotes workgroups subviews to a full-tile allocated on the stack.
   if (clEnablePromoteWorkgroupToFullTiles) {
     OwningRewritePatternList promotionPatterns(&getContext());

--- a/iree/compiler/Conversion/LinalgToLLVM/MaterializeCPULaunchConfigurationPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/MaterializeCPULaunchConfigurationPass.cpp
@@ -126,6 +126,14 @@ void MaterializeCPULaunchConfigurationPass::runOnOperation() {
     }
 
     launchConfig.finalize(funcOp);
+
+    // Apply post distribution canonicalization passes.
+    {
+      OwningRewritePatternList canonicalization(&getContext());
+      AffineMinOp::getCanonicalizationPatterns(canonicalization, context);
+      populateAffineMinSCFCanonicalizationPattern(canonicalization);
+      (void)applyPatternsAndFoldGreedily(funcOp, std::move(canonicalization));
+    }
   }
 }
 

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -30,15 +30,6 @@ namespace iree_compiler {
 
 void addLinalgToLLVMPasses(OpPassManager &passManager,
                            LLVMCodegenOptions options) {
-  // Distribute linalg op among a 3d grid of parallel threads. Tile each
-  // workgroup thread memory then vectorize the linalg op.
-
-  if (options.usingLinalgOnTensors) {
-    passManager.addPass(createMaterializeCPULaunchConfigurationPass());
-  } else {
-    passManager.addPass(createLinalgTileAndDistributePass());
-  }
-
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
 
@@ -49,9 +40,9 @@ void addLinalgToLLVMPasses(OpPassManager &passManager,
     nestedModulePM.addNestedPass<FuncOp>(
         createConvImg2ColMatmulConversionPass());
   }
-
   nestedModulePM.addNestedPass<FuncOp>(
       createLinalgTileAndVectorizeWorkgroupsPass());
+
   nestedModulePM.addNestedPass<FuncOp>(createPlanConvLoopOrderPass());
 
   // Linalg -> SCF
@@ -77,13 +68,12 @@ void addLinalgToLLVMPasses(OpPassManager &passManager,
 
 void buildLLVMTransformPassPipeline(OpPassManager &passManager,
                                     LLVMCodegenOptions options) {
-  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
-
-  nestedModulePM.addPass(createInlinerPass());
-
-  // HLO -> Linalg on buffers.
   if (options.usingLinalgOnTensors) {
-    nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
+    passManager.addPass(createMaterializeCPULaunchConfigurationPass());
+    OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+    nestedModulePM.addPass(createInlinerPass());
+    // TODO(ataei): Currently tensor -> vector is failing (GH-5370).
+    // nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
     // Use stack allocation on CPU side.
     WorkgroupMemoryAllocationFn allocationFn =
         [](OpBuilder &builder, Location loc, ArrayRef<int64_t> staticShape,
@@ -94,6 +84,11 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager,
     addLinalgBufferizePasses(nestedModulePM, allocationFn);
     nestedModulePM.addPass(createPromoteBuffersToStackPass(1 << 10, 64, 10));
   } else {
+    // Distribute linalg op among a 3d grid of parallel threads. Tile each
+    // workgroup thread memory then vectorize the linalg op.
+    OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+    nestedModulePM.addPass(createInlinerPass());
+    passManager.addPass(createLinalgTileAndDistributePass());
     // Propagates dynamic shapes computation on tensors.
     nestedModulePM.addNestedPass<FuncOp>(Shape::createTieDynamicShapesPass());
     nestedModulePM.addNestedPass<FuncOp>(

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -72,8 +72,7 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager,
     passManager.addPass(createMaterializeCPULaunchConfigurationPass());
     OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
     nestedModulePM.addPass(createInlinerPass());
-    // TODO(ataei): Currently tensor -> vector is failing (GH-5370).
-    // nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
+    nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
     // Use stack allocation on CPU side.
     WorkgroupMemoryAllocationFn allocationFn =
         [](OpBuilder &builder, Location loc, ArrayRef<int64_t> staticShape,


### PR DESCRIPTION
- Move materlialize configs to be the first thing to run.
- Move distributed affine.min and other canoncalization passes to run as
post materialization step.

Depends on #5369 