### PR TITLE
Removes tied transient buffer assignment propagation.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -250,7 +250,6 @@ static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
           allocateTransientBuffer(result, bufferSet.allocator, rewriter);
       auto bufferRange = BufferRange{buffer};
       bufferSet.rangeMap[result] = bufferRange;
-      propagateTiedBuffer(bufferSet, result, bufferRange);
     }
   }
 }


### PR DESCRIPTION
It shouldn't be needed there as buffers are allocated top-down.