### PR TITLE
Switch simple_embeddding to test on DyLib + Vulkan

### DIFF
--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -23,8 +23,8 @@ package(
 
 iree_cmake_extra_content(
     content = """
-if(NOT ${IREE_TARGET_BACKEND_VMLA} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
-   OR NOT ${IREE_HAL_DRIVER_VMLA} OR NOT ${IREE_HAL_DRIVER_VULKAN})
+if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
+   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
   return()
 endif()
 """,
@@ -36,7 +36,7 @@ iree_bytecode_module(
     cc_namespace = "iree::samples",
     flags = [
         "-iree-mlir-to-vm-bytecode-module",
-        "-iree-hal-target-backends=vmla",
+        "-iree-hal-target-backends=dylib-llvm-aot",
         "-iree-hal-target-backends=vulkan-spirv",
     ],
 )
@@ -49,7 +49,7 @@ cc_test(
         "//iree/base:api",
         "//iree/base:logging",
         "//iree/hal:api",
-        "//iree/hal/vmla/registration",
+        "//iree/hal/dylib/registration",
         "//iree/hal/vulkan/registration",
         "//iree/modules/hal",
         "//iree/testing:gtest",

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -8,8 +8,8 @@
 # To disable autogeneration for this file entirely, delete this header.        #
 ################################################################################
 
-if(NOT ${IREE_TARGET_BACKEND_VMLA} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
-   OR NOT ${IREE_HAL_DRIVER_VMLA} OR NOT ${IREE_HAL_DRIVER_VULKAN})
+if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
+   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
   return()
 endif()
 
@@ -24,7 +24,7 @@ iree_bytecode_module(
     "iree::samples"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
-    "-iree-hal-target-backends=vmla"
+    "-iree-hal-target-backends=dylib-llvm-aot"
     "-iree-hal-target-backends=vulkan-spirv"
   PUBLIC
 )
@@ -41,7 +41,7 @@ iree_cc_test(
     iree::base::api
     iree::base::logging
     iree::hal::api
-    iree::hal::vmla::registration
+    iree::hal::dylib::registration
     iree::hal::vulkan::registration
     iree::modules::hal
     iree::testing::gtest

--- a/iree/samples/simple_embedding/simple_embedding_test.cc
+++ b/iree/samples/simple_embedding/simple_embedding_test.cc
@@ -17,7 +17,7 @@
 #include "iree/base/api.h"
 #include "iree/base/logging.h"
 #include "iree/hal/api.h"
-#include "iree/hal/vmla/registration/driver_module.h"
+#include "iree/hal/dylib/registration/driver_module.h"
 #include "iree/hal/vulkan/registration/driver_module.h"
 #include "iree/modules/hal/hal_module.h"
 #include "iree/testing/gtest.h"
@@ -43,14 +43,14 @@ std::ostream& operator<<(std::ostream& os, const TestParams& params) {
 }
 
 std::vector<TestParams> GetDriverTestParams() {
-  // The test file was compiled for VMLA+Vulkan, so test on each driver.
+  // The test file was compiled for DyLib+Vulkan, so test on each driver.
   std::vector<TestParams> test_params;
 
-  IREE_CHECK_OK(
-      iree_hal_vmla_driver_module_register(iree_hal_driver_registry_default()));
-  TestParams vmla_params;
-  vmla_params.driver_name = "vmla";
-  test_params.push_back(std::move(vmla_params));
+  IREE_CHECK_OK(iree_hal_dylib_driver_module_register(
+      iree_hal_driver_registry_default()));
+  TestParams dylib_params;
+  dylib_params.driver_name = "dylib";
+  test_params.push_back(std::move(dylib_params));
 
   IREE_CHECK_OK(iree_hal_vulkan_driver_module_register(
       iree_hal_driver_registry_default()));


### PR DESCRIPTION
1. VMLA is going to be deprecated.
2. The flow pipeline will be different between VMLA and Vulkan. One will
   go with legacy path, and another will go with `iree-flow-dispatch-linalg-on-tensors`

Fixes https://github.com/google/iree/issues/5373