### PR TITLE
Legalize ui64 to i32 in Flow type converter

### DIFF
--- a/iree/compiler/Dialect/Flow/Conversion/TypeConverter.cpp
+++ b/iree/compiler/Dialect/Flow/Conversion/TypeConverter.cpp
@@ -43,8 +43,10 @@ FlowTypeConverter::FlowTypeConverter() {
   // 64-bit types natively.
   // TODO(benvanik): make whether to narrow integers an option.
   addConversion([](IntegerType integerType) -> Optional<Type> {
-    if (integerType.isSignlessInteger() && integerType.getWidth() > 32) {
+    if (integerType.getWidth() > 32) {
       // Don't support 64-bit types in general. Rewrite to i32 (if desired).
+      // note: std.constant op requires integer result types to be signless, so
+      // we narrow ui64 to i32 as well.
       return IntegerType::get(integerType.getContext(), 32);
     }
     return llvm::None;

--- a/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
@@ -8,12 +8,26 @@ func @constantI64() -> i64 {
   return %c123 : i64
 }
 
+// CHECK-LABEL: func @argUI64
+// CHECK-SAME: (%{{.*}}: i32) -> i32
+func @argUI64(%arg: ui64) -> ui64 {
+  return %arg : ui64
+}
+
 // CHECK-LABEL: func @hloConstantI64
 // CHECK-SAME: () -> tensor<1xi32>
 func @hloConstantI64() -> tensor<1xi64> {
   // CHECK-NEXT: mhlo.constant dense<123> : tensor<1xi32>
   %c123 = mhlo.constant dense<123> : tensor<1xi64>
   return %c123 : tensor<1xi64>
+}
+
+// CHECK-LABEL: func @hloConstantUI64
+// CHECK-SAME: () -> tensor<1xi32>
+func @hloConstantUI64() -> tensor<1xui64> {
+  // CHECK-NEXT: mhlo.constant dense<123> : tensor<1xi32>
+  %c123 = mhlo.constant dense<123> : tensor<1xui64>
+  return %c123 : tensor<1xui64>
 }
 
 // -----


### PR DESCRIPTION
Although mhlo.constant can take unsigned integers, std.constant requires integer result types to be signless.

Legalize all to i32 for consistency, and it will make things easier. E.g., we do not have to handle lowering mhlo.constant on ui64 to
std.constant.

Part of https://github.com/google/iree/issues/5383