### PR TITLE
Canonicalizations for dispatch.tensor.load

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.cpp
@@ -24,23 +24,29 @@ static llvm::cl::opt<bool> clEnableLLVMLinalgOnTensors(
     llvm::cl::desc("Enable the linalg on tensors experimental LLVM path"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> convImg2ColConversion(
+static llvm::cl::opt<bool> clConvImg2ColConversion(
     "iree-codegen-linalg-to-llvm-conv-img2col-conversion",
     llvm::cl::desc("Enable rewriting linalg.conv_2d_input_nhwc_filter_hwcf "
                    "linalg.generic that does img2col buffer packing + "
                    "linag.matmul"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> unfusedFMA(
+static llvm::cl::opt<bool> clUnfusedFMA(
     "iree-codegen-linalg-to-llvm-use-unfused-fma",
+    llvm::cl::desc("Enable rewriting llvm.fma to its unfused version."),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> clEnableLinalgOnTensorsToVectors(
+    "iree-codegen-linalg-to-llvm-linalg-on-tensors-to-vectors",
     llvm::cl::desc("Enable rewriting llvm.fma to its unfused version."),
     llvm::cl::init(false));
 
 LLVMCodegenOptions getLLVMCodegenOptionsFromClOptions() {
   LLVMCodegenOptions options;
   options.usingLinalgOnTensors = clEnableLLVMLinalgOnTensors;
-  options.useConvImg2Col = convImg2ColConversion;
-  options.unfuseFMAOps = unfusedFMA;
+  options.useConvImg2Col = clConvImg2ColConversion;
+  options.unfuseFMAOps = clUnfusedFMA;
+  options.useLinalgOnTensorsToVectors = clEnableLinalgOnTensorsToVectors;
   return options;
 }
 

--- a/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/LLVMCodeGenOptions.h
@@ -27,6 +27,7 @@ struct LLVMCodegenOptions {
   // Target specific options.
   bool unfuseFMAOps = false;
   bool useVectorToAarch64 = false;
+  bool useLinalgOnTensorsToVectors = false;
 };
 
 // Returns LLVM CodeGen options from command-line options.

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -72,7 +72,11 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager,
     passManager.addPass(createMaterializeCPULaunchConfigurationPass());
     OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
     nestedModulePM.addPass(createInlinerPass());
-    nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
+    // TODO(ataei): We want to enable when tensor -> vector pass is fully
+    // supported which requires first moving vector-tiling before this step.
+    if (options.useLinalgOnTensorsToVectors) {
+      nestedModulePM.addNestedPass<FuncOp>(createLinalgVectorizePass());
+    }
     // Use stack allocation on CPU side.
     WorkgroupMemoryAllocationFn allocationFn =
         [](OpBuilder &builder, Location loc, ArrayRef<int64_t> staticShape,

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -554,7 +554,11 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
     // Builder for tensor.load with empty offset, sizes and strides operands.
     // This is used to load an entire tensor.
     OpBuilder<(ins "RankedTensorType":$resultType, "Value":$source,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+    // Builder for tensor.load with mixed static/dynamic opperands.
+    OpBuilder<(ins "Value":$source, "ArrayRef<OpFoldResult>":$offsets,
+      "ArrayRef<OpFoldResult>":$sizes, "ArrayRef<OpFoldResult>":$strides,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
   ];
 
   let extraClassDeclaration = [{

--- a/iree/compiler/Dialect/Flow/IR/test/BUILD
+++ b/iree/compiler/Dialect/Flow/IR/test/BUILD
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "dispatch_ops.mlir",
             "dispatch_region_folding.mlir",
             "dispatch_regions.mlir",
+            "dispatch_tensor_folding.mlir",
             "dispatch_workgroups.mlir",
             "dispatch_workgroups_folding.mlir",
             "executable_ops.mlir",

--- a/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "dispatch_ops.mlir"
     "dispatch_region_folding.mlir"
     "dispatch_regions.mlir"
+    "dispatch_tensor_folding.mlir"
     "dispatch_workgroups.mlir"
     "dispatch_workgroups_folding.mlir"
     "executable_ops.mlir"

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_tensor_folding.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -canonicalize %s | IreeFileCheck %s
+
+func @canonicalizeStaticOperands(%arg0: !flow.dispatch.tensor<readonly:4x4xf32>) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c2 = constant 2 : index
+    %0 = flow.dispatch.tensor.load %arg0, offsets=[%c0, %c0], sizes=[%c2, %c2], strides=[%c1, %c1] : !flow.dispatch.tensor<readonly:4x4xf32> -> tensor<?x?xf32>
+    "test.sink"(%0) : (tensor<?x?xf32>) -> ()
+    return
+}
+
+// CHECK: @canonicalizeStaticOperand
+// CHECK: %[[ARG0:.+]]: !flow.dispatch.tensor<readonly:4x4xf32>
+// CHECK: flow.dispatch.tensor.load %[[ARG0]]
+//      CHECK-SAME: offsets = [0, 0]
+//      CHECK-SAME: sizes = [2, 2]
+//      CHECK-SAME: strides = [1, 1]
+//      CHECK-SAME: !flow.dispatch.tensor<readonly:4x4xf32> -> tensor<2x2xf32>
+
+// -----
+
+func @canonicalizePartiallyStaticOperands(%arg0: !flow.dispatch.tensor<readonly:4x4xf32>, %offset: index, %size: index, %stride: index) {
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c2 = constant 2 : index
+    %0 = flow.dispatch.tensor.load %arg0, offsets=[%offset, %c0], sizes=[%size, %c2], strides=[%stride, %c1] : !flow.dispatch.tensor<readonly:4x4xf32> -> tensor<?x?xf32>
+    "test.sink"(%0) : (tensor<?x?xf32>) -> ()
+    return
+}
+
+// CHECK: @canonicalizePartiallyStaticOperands
+// CHECK: %[[ARG0:.+]]: !flow.dispatch.tensor<readonly:4x4xf32>
+// CHECK: %[[OFFSET:.+]]: index, %[[SIZE:.+]]: index, %[[STRIDE:.+]]: index
+// CHECK: flow.dispatch.tensor.load %[[ARG0]]
+//      CHECK-SAME: offsets = [%[[OFFSET]], 0]
+//      CHECK-SAME: sizes = [%[[SIZE]], 2]
+//      CHECK-SAME: strides = [%[[STRIDE]], 1]
+//      CHECK-SAME: !flow.dispatch.tensor<readonly:4x4xf32> -> tensor<?x2xf32>


### PR DESCRIPTION
- Adds a builder to `dispatch.tensor.load` to accept mixedOperands.
- Canonicalizes `dispatch.tensor.load` operands with upstream pattern.