### PR TITLE
Lower `linalg.tensor_reshape` to `flow.tensor.reshape`.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -553,7 +553,8 @@ static uint64_t getFlattenedIndex(ShapedType type, ArrayRef<uint64_t> index) {
 
 static bool compareShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
                                ShapedType rhsType, ValueRange rhsDynamicDims) {
-  if (lhsType.hasStaticShape() && lhsType == rhsType) {
+  if (lhsType.hasStaticShape() &&
+      lhsType.getNumElements() == rhsType.getNumElements()) {
     // Static shape equivalence means we can fast-path the check.
     return true;
   }

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/PatternMatch.h"
@@ -31,6 +32,34 @@ namespace IREE {
 namespace Flow {
 
 namespace {
+
+/// Converts linalg.tensor_reshape operations into flow.tensor.reshape
+/// operations.
+struct LinalgTensorReshapeToFlowTensorReshape
+    : OpRewritePattern<linalg::TensorReshapeOp> {
+  using OpRewritePattern<linalg::TensorReshapeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::TensorReshapeOp reshapeOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = reshapeOp.getLoc();
+    SmallVector<SmallVector<Value>> outputShape;
+    if (failed(reshapeOp.reifyReturnTypeShapesPerResultDim(rewriter,
+                                                           outputShape))) {
+      return failure();
+    }
+    SmallVector<Value> outputDynamicShapes;
+    for (auto shape :
+         llvm::zip(reshapeOp.getResultType().getShape(), outputShape[0])) {
+      if (std::get<0>(shape) != ShapedType::kDynamicSize) continue;
+      outputDynamicShapes.push_back(std::get<1>(shape));
+    }
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
+        reshapeOp, reshapeOp.getResultType(), reshapeOp.src(),
+        outputDynamicShapes);
+    return success();
+  }
+};
+
 /// Convert subtensor operation to flow.tensor.slice if
 /// - all offsets apart from the first one are 0
 /// - all the sizes apart from the first match the sizes of the source
@@ -88,7 +117,8 @@ struct SubTensorToTensorSlice : OpRewritePattern<SubTensorOp> {
 struct ConvertToFlowTensorOpsPass
     : public PassWrapper<ConvertToFlowTensorOpsPass, OperationPass<FuncOp>> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<mlir::StandardOpsDialect, IREE::Flow::FlowDialect>();
+    registry.insert<IREE::Flow::FlowDialect, memref::MemRefDialect,
+                    mlir::StandardOpsDialect>();
   }
   ConvertToFlowTensorOpsPass() = default;
   ConvertToFlowTensorOpsPass(const ConvertToFlowTensorOpsPass &pass) {}
@@ -97,7 +127,9 @@ struct ConvertToFlowTensorOpsPass
     MLIRContext *context = funcOp->getContext();
     context->allowUnregisteredDialects(true);
     OwningRewritePatternList patterns(&getContext());
-    patterns.insert<SubTensorToTensorSlice>(context);
+    patterns
+        .insert<LinalgTensorReshapeToFlowTensorReshape, SubTensorToTensorSlice>(
+            context);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
@@ -40,3 +40,28 @@ func @subtensor_convert(%arg0 : tensor<?x24x48xf32>, %arg1 : index) ->
 //   CHECK-DAG:   %[[UNMODIFIED2:.+]] = subtensor %[[SLICE2]][0, 0, 0] [%[[D1]], 12, 24] [1, 2, 2]
 //   CHECK-DAG:   %[[UNMODIFIED3:.+]] = subtensor %[[ARG0]][0, %[[ARG1]], 0]
 //       CHECK:   return %[[UNMODIFIED1]], %[[UNMODIFIED2]], %[[UNMODIFIED3]]
+
+// -----
+
+func @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32>)
+    -> (tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>)
+{
+  %0 = linalg.tensor_reshape %arg0
+      [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>,
+       affine_map<(d0, d1, d2, d3, d4, d5) -> (d3)>,
+       affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5)>]
+      : tensor<?x4x?x5x?x6xf32> into tensor<?x5x?xf32>
+  %1 = linalg.tensor_reshape %arg1
+      [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1)>,
+       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d2, d3)>,
+       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6)>]
+      : tensor<20x?x40xf32> into tensor<5x4x?x4x2x4x5xf32>
+  return %0, %1 : tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>
+}
+// CHECK-LABEL: func @tensor_reshape
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x4x?x5x?x6xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<20x?x40xf32>
+//   CHECK-DAG:   %[[R0:.+]] = flow.tensor.reshape %[[ARG0]]
+//   CHECK-DAG:   %[[R1:.+]] = flow.tensor.reshape %[[ARG1]]
+//       CHECK:   return %[[R0]], %[[R1]]
+


### PR DESCRIPTION
Inlining reshapes into dispatch regions cause subtle issue. Lowering `subtensor` -> `tensor_reshape` causes issues during bufferization.

To avoid this two approaches are possible
1) Fuse reshapes with other operations as much as possible during
   fusion on linalg ops.
2) Lower reshapes to `flow.tensor.reshape` before dispatch region
   creation.