### PR TITLE
Adding simple transient buffer packing.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/Shape/IR",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertVariableOps.cpp"
   DEPS
     LLVMSupport
+    MLIRAnalysis
     MLIRIR
     MLIRMemRef
     MLIRPass

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -21,10 +21,13 @@
 #include "iree/compiler/Dialect/HAL/Utils/DeviceSwitchBuilder.h"
 #include "iree/compiler/Dialect/HAL/Utils/TypeUtils.h"
 #include "iree/compiler/Dialect/IREE/IR/IREETypes.h"
+#include "iree/compiler/Dialect/Shape/IR/Builders.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -37,54 +40,429 @@ namespace mlir {
 namespace iree_compiler {
 namespace {
 
-struct BufferRange {
-  BufferRange() = default;
-  explicit BufferRange(Value buffer) : buffer(buffer) {}
+//===----------------------------------------------------------------------===//
+// Alias analysis
+//===----------------------------------------------------------------------===//
 
-  Value buffer = nullptr;
-};
+using ValueAliasingMap = llvm::MapVector<Value, SmallPtrSet<Value, 16>>;
 
-// Allocated buffers used within the stream.
-struct BufferSet {
-  explicit BufferSet(Value allocator) : allocator(allocator) {}
+// Builds a map of value aliases from aliasee to a set of aliasers.
+// Only values that alias will be present in the map.
+static ValueAliasingMap computeValueAliases(
+    IREE::Flow::ExStreamFragmentOp streamOp) {
+  auto *streamBlock = &streamOp.body().front();
+  ValueAliasingMap valueAliases;
 
-  // Allocator instance the buffers come from.
-  Value allocator = nullptr;
+  std::function<void(Value streamValue, Value aliasedValue)> propagateAlias;
+  propagateAlias = [&](Value streamValue, Value aliasedValue) {
+    auto &baseSet = valueAliases[streamValue];
+    baseSet.insert(aliasedValue);
+    auto &aliasedSet = valueAliases[aliasedValue];
+    baseSet.insert(aliasedSet.begin(), aliasedSet.end());
+    aliasedSet.insert(streamValue);
+  };
 
-  // All output buffers in the same order as the original results.
-  SmallVector<Value, 4> outputBuffers;
+  // Start with outputs so that we handle tied values that may lead all the way
+  // back up the chain to the stream inputs.
+  auto tiedStreamOp = cast<IREE::TiedOpInterface>(streamOp.getOperation());
+  auto returnOp = cast<IREE::Flow::ReturnOp>(streamBlock->back());
+  for (auto result : llvm::enumerate(streamOp.getResults())) {
+    auto streamValue = returnOp.getOperand(result.index());
 
-  // Maps tensor values within the stream to a buffer range that stores them.
-  DenseMap<Value, BufferRange> rangeMap;
-};
-
-// HACK: until we are doing buffer allocation we need to pin tied buffers all
-// the way up the stream from the outputs.
-static void propagateTiedBuffer(BufferSet &bufferSet, Value streamValue,
-                                BufferRange bufferRange) {
-  Value baseValue = streamValue;
-  while (auto definingOp = dyn_cast_or_null<IREE::TiedOpInterface>(
-             baseValue.getDefiningOp())) {
-    auto tiedValue = definingOp.getTiedResultOperand(baseValue);
-    if (!tiedValue) break;
-    baseValue = tiedValue;
-    if (bufferSet.rangeMap[baseValue].buffer != bufferRange.buffer) {
-      LLVM_DEBUG(llvm::dbgs() << "    -- PROPAGATING TIED STREAM VALUE "
-                              << streamValue << " TO " << baseValue << "\n");
-      bufferSet.rangeMap[baseValue] = bufferRange;
+    // Tied stream results reuse their stream operand buffer.
+    auto tiedOperandIndex =
+        tiedStreamOp.getTiedResultOperandIndex(result.index());
+    if (tiedOperandIndex.hasValue()) {
+      auto operand = streamBlock->getArgument(tiedOperandIndex.getValue());
+      propagateAlias(streamValue, operand);
     }
   }
+
+  for (auto &op : *streamBlock) {
+    auto tiedOp = dyn_cast<IREE::TiedOpInterface>(op);
+    for (auto it : llvm::enumerate(op.getResults())) {
+      auto result = it.value();
+      if (!result.getType().isa<ShapedType>()) continue;
+
+      // Tied results reuse their operand buffer.
+      if (tiedOp) {
+        auto tiedOperandIndex = tiedOp.getTiedResultOperandIndex(it.index());
+        if (tiedOperandIndex.hasValue()) {
+          auto operand = op.getOperand(tiedOperandIndex.getValue());
+          propagateAlias(result, operand);
+        }
+      }
+    }
+  }
+
+  // Inverse the value aliaser->aliasee map so that we have for any particular
+  // value the list of all other values that alias it.
+  for (auto it : valueAliases) {
+    for (auto aliasee : it.second) {
+      for (auto aliaser : it.second) {
+        if (aliaser != aliasee) {
+          valueAliases[aliasee].insert(aliaser);
+        }
+      }
+    }
+  }
+
+  return valueAliases;
 }
+
+//===----------------------------------------------------------------------===//
+// Liveness interval analysis
+//===----------------------------------------------------------------------===//
+
+static constexpr int LIVE_IN = INT_MIN;
+static constexpr int LIVE_OUT = INT_MAX;
+struct LivenessInterval {
+  int start = 0;
+  int end = 0;
+  int ordinal = -1;  // unique per value
+  Value value;
+  bool operator<(const LivenessInterval &rhs) const {
+    return ordinal < rhs.ordinal;
+  }
+};
+using LivenessIntervalMap = DenseMap<Value, LivenessInterval>;
+using LivenessIntervalList = SmallVector<LivenessInterval>;
+
+// Computes the liveness intervals for each value in the stream.
+// Returns a closed range over an arbitrary operation ordering. The LIVE_IN and
+// LIVE_OUT sentinels will be used to indicate values that are live-in and
+// live-out to the stream (captured input arguments and escaping output
+// results).
+//
+// All values will have a range with aliased values sharing the union of their
+// constituent ranges - including block arguments. Note that not all values will
+// have buffers allocated to them - we are just tracking transitive SSA value
+// lifetime.
+static LivenessIntervalList computeLivenessIntervals(
+    IREE::Flow::ExStreamFragmentOp streamOp,
+    const ValueAliasingMap &valueAliases) {
+  // Perform a liveness analysis on the stream fragment.
+  // Fragments have a single block and as such the live-in/live-out block
+  // information derived here applies to the entire stream region.
+  assert(streamOp.body().getBlocks().size() == 1);
+  auto *streamBlock = &streamOp.body().front();
+  Liveness streamLiveness(streamOp);
+  auto *livenessInfo = streamLiveness.getLiveness(streamBlock);
+
+  // Operations don't allow us to get their already computed order so we make up
+  // our own. We have a single block and thus the ordering is complete.
+  DenseMap<Operation *, int> opOrdering;
+  for (auto &op : *streamBlock) {
+    opOrdering[&op] = opOrdering.size();
+  }
+
+  // Liveness doesn't track return values as live-outs so we do that here.
+  SmallPtrSet<Value, 16> liveOuts;
+  auto returnOp = cast<IREE::Flow::ReturnOp>(streamBlock->back());
+  for (auto returnValue : returnOp.operands()) {
+    if (!returnValue.getType().isa<ShapedType>()) continue;
+    liveOuts.insert(returnValue);
+  }
+
+  // Compute live-in intervals special as we won't catch them in the op walk
+  // below as they are block arguments.
+  LivenessIntervalMap valueIntervals;
+  int ordinal = 0;
+  for (Value value : streamBlock->getArguments()) {
+    if (!value.getType().isa<ShapedType>()) continue;
+    LivenessInterval interval;
+    interval.start = LIVE_IN;
+    if (liveOuts.contains(value)) {
+      interval.end = LIVE_OUT;
+    } else {
+      auto *endOp = livenessInfo->getEndOperation(value, &streamBlock->front());
+      interval.end = opOrdering[endOp];
+    }
+    interval.value = value;
+    interval.ordinal = ++ordinal;
+    valueIntervals[value] = interval;
+  }
+
+  // Compute ranges for all values independently (ignoring aliasing).
+  for (auto &op : *streamBlock) {
+    int start = opOrdering[&op];
+    for (auto value : op.getResults()) {
+      if (!value.getType().isa<ShapedType>()) continue;
+      LivenessInterval interval;
+      interval.start = start;
+      if (liveOuts.contains(value)) {
+        interval.end = LIVE_OUT;
+      } else {
+        interval.end = start;
+        for (auto &use : value.getUses()) {
+          interval.end = std::max(interval.end, opOrdering[use.getOwner()]);
+        }
+      }
+      interval.value = value;
+      interval.ordinal = ++ordinal;
+      valueIntervals[value] = interval;
+    }
+  }
+
+  // Walk the alias map and union intervals and propagate back.
+  for (auto it : valueAliases) {
+    auto &aliasee = it.first;
+    auto &aliasers = it.second;
+    auto &aliaseeInterval = valueIntervals[aliasee];
+    int start = aliaseeInterval.start;
+    int end = aliaseeInterval.end;
+    for (auto aliaser : aliasers) {
+      auto &aliaserInterval = valueIntervals[aliaser];
+      start = std::min(start, aliaserInterval.start);
+      end = std::max(end, aliaserInterval.end);
+    }
+    aliaseeInterval.start = start;
+    aliaseeInterval.end = end;
+    for (auto aliaser : aliasers) {
+      auto &aliaserInterval = valueIntervals[aliaser];
+      aliaserInterval.start = start;
+      aliaserInterval.end = end;
+    }
+  }
+
+  // Sort all intervals by lifetime start. This makes the intervals easier to
+  // read and deterministic across runs.
+  SmallVector<LivenessInterval> sortedIntervals;
+  for (auto it : valueIntervals) {
+    sortedIntervals.push_back(it.second);
+  }
+  std::sort(sortedIntervals.begin(), sortedIntervals.end());
+  return sortedIntervals;
+}
+
+//===----------------------------------------------------------------------===//
+// Stateful recording storage
+//===----------------------------------------------------------------------===//
+
+struct BufferRange {
+  BufferRange() = default;
+  explicit BufferRange(Value buffer, Value length)
+      : buffer(buffer), length(length) {}
+
+  Value buffer = nullptr;
+  Value length = nullptr;
+};
+
+// State cache used during stream scheduling.
+//
+// This contains caches used to memoize commonly occuring values such as
+// variable loads, shapes, and computed sizes. These caches are just to lighten
+// the load on cse/canonicalization and otherwise it would be fine to
+// materialize IR for everything.
+//
+// Any allocations made are also tracked here so that the tensor->!hal.buffer
+// mappings are available at any time a buffer may be required during the
+// scheduling.
+class StreamSchedulingState {
+ public:
+  explicit StreamSchedulingState(Location loc, Value device, Value allocator,
+                                 ValueAliasingMap &valueAliases)
+      : loc(loc),
+        device_(device),
+        allocator_(allocator),
+        valueAliases(valueAliases) {}
+
+  Value device() { return device_; }
+  Value allocator() { return allocator_; }
+
+  // Returns a ConstantIndexOp of |value|.
+  Value lookupOrCreateIndex(int64_t value, OpBuilder &builder) {
+    auto it = indexConstantMap.find(value);
+    if (it != indexConstantMap.end()) return it->second;
+    auto constantValue = builder.createOrFold<ConstantIndexOp>(loc, value);
+    indexConstantMap.insert(std::make_pair(value, constantValue));
+    return constantValue;
+  }
+
+  // Loads a variable with the given |symName|.
+  Value loadVariable(Type resultType, StringRef symName, OpBuilder &builder) {
+    auto it = loadedVariableMap.find(symName);
+    if (it != loadedVariableMap.end()) {
+      assert(it->second.getType() == resultType && "variable type mismatch");
+      return it->second;
+    }
+    auto value = builder.createOrFold<IREE::HAL::VariableLoadOp>(
+        loc, resultType, symName);
+    loadedVariableMap.insert(std::make_pair(symName, value));
+    return value;
+  }
+
+  // Returns an executable layout with the given attributes.
+  Value lookupExecutableLayout(Type resultType, IntegerAttr pushConstantsAttr,
+                               ArrayAttr layoutsAttr, OpBuilder &builder) {
+    auto keyAttr = builder.getArrayAttr({pushConstantsAttr, layoutsAttr});
+    auto it = executableLayoutMap.find(keyAttr);
+    if (it != executableLayoutMap.end()) {
+      assert(it->second.getType() == resultType && "variable type mismatch");
+      return it->second;
+    }
+    auto value = builder.createOrFold<IREE::HAL::ExecutableLayoutLookupOp>(
+        loc, IREE::HAL::ExecutableLayoutType::get(device().getContext()),
+        device(), pushConstantsAttr, layoutsAttr);
+    executableLayoutMap.insert(std::make_pair(keyAttr, value));
+    return value;
+  }
+
+  // Returns a computed shape value inserted at |builder| based on the shape of
+  // the given |streamValue|. Returns an existing size if one matching the
+  // parameters has already been inserted.
+  Value lookupOrComputeSize(Value streamValue, OpBuilder &builder) {
+    return lookupOrComputeSize(streamValue.getType().cast<ShapedType>(),
+                               Shape::buildOrFindDynamicDimsForValue(
+                                   streamValue.getLoc(), streamValue, builder),
+                               builder);
+  }
+
+  // Returns a computed shape value inserted at |builder| based on the given
+  // shaped type and its dynamic dimensions. Returns an existing size if one
+  // matching the parameters has already been inserted.
+  Value lookupOrComputeSize(ShapedType shapedType, ValueRange dynamicDims,
+                            OpBuilder &builder) {
+    if (shapedType.hasStaticShape()) {
+      auto it = staticShapeToSizeMap.find(shapedType);
+      if (it != staticShapeToSizeMap.end()) return it->second;
+    } else {
+      auto typeIt = dynamicShapeToSizeMap.find(shapedType);
+      if (typeIt != dynamicShapeToSizeMap.end()) {
+        for (auto dimsIt : typeIt->second) {
+          if (std::equal(dimsIt.first.begin(), dimsIt.first.end(),
+                         dynamicDims.begin())) {
+            return dimsIt.second;
+          }
+        }
+      }
+    }
+
+    auto elementType = getElementType(shapedType.getElementType(), builder);
+    assert(elementType && "unhandled element type for allocation");
+
+    SmallVector<Value> shapeDims(shapedType.getRank());
+    int64_t dynamicDimIndex = 0;
+    for (int64_t i = 0; i < shapedType.getRank(); ++i) {
+      if (shapedType.isDynamicDim(i)) {
+        shapeDims[i] = dynamicDims[dynamicDimIndex++];
+      } else {
+        shapeDims[i] = lookupOrCreateIndex(shapedType.getDimSize(i), builder);
+      }
+    }
+
+    auto size = builder.createOrFold<IREE::HAL::AllocatorComputeSizeOp>(
+        loc, allocator(), shapeDims, elementType);
+    if (shapedType.hasStaticShape()) {
+      staticShapeToSizeMap[shapedType] = size;
+    } else {
+      dynamicShapeToSizeMap[shapedType].push_back(
+          std::make_pair(dynamicDims, size));
+    }
+    return size;
+  }
+
+  // Maps |tensorValue| to the backing storage buffer defined by |bufferRange|.
+  void mapTensorToBufferRange(Value tensorValue, BufferRange bufferRange) {
+    assert(!bufferRangeMap.count(tensorValue));
+    bufferRangeMap.insert(std::make_pair(tensorValue, bufferRange));
+
+    // TODO(#5410): make alias propagation map through an indexing map for
+    // slices/updates. Right now we assume all aliases are 1:1 full maps.
+    for (auto alias : valueAliases[tensorValue]) {
+      bufferRangeMap.insert(std::make_pair(alias, bufferRange));
+    }
+  }
+
+  // Returns a buffer range backing the given stream |tensorValue|.
+  BufferRange lookupTensorBufferRange(Value tensorValue) {
+    auto it = bufferRangeMap.find(tensorValue);
+    assert(it != bufferRangeMap.end() && "buffer not pre-allocated for tensor");
+    return it->second;
+  }
+
+  // Returns true if the given |tensorValue| has a buffer range mapped to it.
+  bool hasTensorBufferRange(Value tensorValue) {
+    return bufferRangeMap.count(tensorValue) != 0;
+  }
+
+  // Calls |callback| for |tensorValue| and each value aliasing it.
+  void forEachEquivalentTensorValue(Value tensorValue,
+                                    std::function<void(Value)> callback) {
+    callback(tensorValue);
+    for (auto alias : valueAliases[tensorValue]) {
+      callback(alias);
+    }
+  }
+
+ private:
+  Value getElementType(Type elementType, OpBuilder &builder) {
+    auto it = memoizedElementTypesConstants.find(elementType);
+    if (it != memoizedElementTypesConstants.end()) return it->second;
+    auto i32Value = IREE::HAL::getElementTypeValue(elementType);
+    assert(i32Value.hasValue() && "unhandled element type for allocation");
+    auto constantValue =
+        builder.createOrFold<ConstantIntOp>(loc, i32Value.getValue(), 32);
+    memoizedElementTypesConstants[elementType] = constantValue;
+    return constantValue;
+  }
+
+  Location loc;
+
+  // !hal.device used throughout the stream.
+  Value device_;
+  // !hal.allocator used throughout the stream.
+  Value allocator_;
+
+  // All values that have aliases mapped to a set of all of the values they
+  // alias with. That two things alias does not imply the values can be treated
+  // as equivalent: some values may be subranges of others.
+  ValueAliasingMap valueAliases;
+
+  // Index value -> std.constant index value.
+  DenseMap<int64_t, Value> indexConstantMap;
+
+  // Variable sym name -> loaded value.
+  DenseMap<StringRef, Value> loadedVariableMap;
+
+  // Key of [push constants, set layouts] -> loaded value.
+  DenseMap<Attribute, Value> executableLayoutMap;
+
+  // Small cache of constants used for element types.
+  DenseMap<Type, Value> memoizedElementTypesConstants;
+
+  // Map of static shaped types to computed size values.
+  DenseMap<Type, Value> staticShapeToSizeMap;
+
+  // Map of dynamic shaped types to a set of dynamic dimension SSA values and
+  // the corresponding computed size. A single shaped type such as `?x4` may
+  // have multiple unique sizes if differing dimension values are used (such as
+  // `{%dimA}x4` and `{%dimB}x4`).
+  DenseMap<Type, SmallVector<std::pair<SmallVector<Value>, Value>>>
+      dynamicShapeToSizeMap;
+
+  // Maps tensor values inside the stream to a buffer range that stores them.
+  DenseMap<Value, BufferRange> bufferRangeMap;
+};
+
+//===----------------------------------------------------------------------===//
+// Buffer allocation
+//===----------------------------------------------------------------------===//
 
 // Allocates a buffer for the given stream output value.
 // |streamValue| is the Value used within the stream region and
 // |externalValue| is the returned value from the stream region in the parent
 // block.
-static Value allocateOutputBuffer(Value streamValue, Value externalValue,
-                                  Value allocator,
-                                  ConversionPatternRewriter &rewriter) {
+static BufferRange allocateOutputBuffer(Value streamValue, Value externalValue,
+                                        StreamSchedulingState &schedulingState,
+                                        ConversionPatternRewriter &rewriter) {
   Location loc = externalValue.getLoc();
+
   // TODO(benvanik): compute from SSA use-def chain uses.
+  // HACK: we have no idea right now whether the buffer escaping the stream will
+  // be used on the host or the device and have to allocate it as HOST_VISIBLE.
+  // Improvements to the flow dialect to track tensor lifetime and hal.stream
+  // for tracking usage will reduce this to just what is required.
   IREE::HAL::MemoryTypeBitfield memoryTypes =
       IREE::HAL::MemoryTypeBitfield::DeviceLocal |
       IREE::HAL::MemoryTypeBitfield::HostVisible;
@@ -92,36 +470,33 @@ static Value allocateOutputBuffer(Value streamValue, Value externalValue,
       IREE::HAL::BufferUsageBitfield::All;
 
   // Compute the allocation size for the value.
-  auto elementType = IREE::HAL::getElementTypeValue(
-      streamValue.getType().cast<ShapedType>().getElementType());
-  if (!elementType) {
-    return {};
-  }
-  auto shape = IREE::HAL::getShapeDims(loc, streamValue, rewriter);
-  if (!shape) {
-    return {};
-  }
-  auto allocationSize = rewriter
-                            .create<IREE::HAL::AllocatorComputeSizeOp>(
-                                loc, allocator, *shape, elementType.getValue())
-                            .getResult();
+  auto allocationSize = schedulingState.lookupOrComputeSize(
+      streamValue.getType().cast<ShapedType>(),
+      Shape::buildOrFindDynamicDimsForValue(streamValue.getLoc(), streamValue,
+                                            rewriter),
+      rewriter);
 
   auto buffer = rewriter
                     .create<IREE::HAL::AllocatorAllocateOp>(
                         loc, IREE::HAL::BufferType::get(rewriter.getContext()),
-                        allocator, memoryTypes, bufferUsage, allocationSize)
+                        schedulingState.allocator(), memoryTypes, bufferUsage,
+                        allocationSize)
                     .getResult();
 
-  return buffer;
+  return BufferRange{buffer, allocationSize};
 }
 
-// Allocates all output buffers for the stream and populates the |bufferSet|
-// with the new mappings.
-static void allocateOutputBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
-                                  BufferSet &bufferSet,
-                                  ConversionPatternRewriter &rewriter) {
+// Allocates all output buffers for the stream and populates the
+// |schedulingState| with the new mappings. Returns the set of output buffers
+// mapping 1:1 with the |streamOp| results.
+static SmallVector<Value> allocateOutputBuffers(
+    IREE::Flow::ExStreamFragmentOp streamOp,
+    StreamSchedulingState &schedulingState,
+    ConversionPatternRewriter &rewriter) {
   auto tiedStreamOp = cast<IREE::TiedOpInterface>(streamOp.getOperation());
   auto &entryBlock = streamOp.body().front();
+
+  SmallVector<Value> outputBuffers;
 
   // Allocate output buffers and replace the original uses with the buffers.
   auto returnOp = cast<IREE::Flow::ReturnOp>(streamOp.body().front().back());
@@ -129,7 +504,14 @@ static void allocateOutputBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
     auto streamValue = returnOp.getOperand(result.index());
     auto externalValue = result.value();
 
-    // Tied results reuse their operand buffer.
+    // Ignore already allocated buffers.
+    if (schedulingState.hasTensorBufferRange(streamValue)) {
+      outputBuffers.push_back(
+          schedulingState.lookupTensorBufferRange(streamValue).buffer);
+      continue;
+    }
+
+    // Tied stream results reuse their operand buffer.
     BufferRange bufferRange;
     auto tiedOperandIndex =
         tiedStreamOp.getTiedResultOperandIndex(result.index());
@@ -139,120 +521,129 @@ static void allocateOutputBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
                  << tiedOperandIndex.getValue() << ") BUFFER FOR STREAM RESULT("
                  << result.index() << "): " << streamOp << "\n");
       auto operand = entryBlock.getArgument(tiedOperandIndex.getValue());
-      bufferRange = bufferSet.rangeMap[operand];
+      bufferRange = schedulingState.lookupTensorBufferRange(operand);
     } else {
       LLVM_DEBUG(llvm::dbgs()
                  << "    -- ALLOCATE BUFFER FOR STREAM ESCAPE RESULT("
                  << result.index() << ")\n");
-      auto buffer = allocateOutputBuffer(streamValue, externalValue,
-                                         bufferSet.allocator, rewriter);
-      bufferRange = BufferRange{buffer};
+      bufferRange = allocateOutputBuffer(streamValue, externalValue,
+                                         schedulingState, rewriter);
     }
     assert(bufferRange.buffer);
-    bufferSet.outputBuffers.push_back(bufferRange.buffer);
-    bufferSet.rangeMap[externalValue] = bufferRange;
-    bufferSet.rangeMap[streamValue] = bufferRange;
-    propagateTiedBuffer(bufferSet, streamValue, bufferRange);
+    outputBuffers.push_back(bufferRange.buffer);
+    schedulingState.mapTensorToBufferRange(streamValue, bufferRange);
   }
+
+  return outputBuffers;
 }
 
-// Allocates a transient buffer for use entirely within the command buffer.
-static Value allocateTransientBuffer(Value streamValue, Value allocator,
+// Allocates transient buffers to store the intra-stream results and populates
+// the |schedulingState| with the new mappings.
+static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
+                                     LivenessIntervalList &livenessIntervals,
+                                     StreamSchedulingState &schedulingState,
                                      ConversionPatternRewriter &rewriter) {
-  Location loc = streamValue.getLoc();
+  // TODO(#5410): unify with slice/update handling below. We should have a
+  // more generic way of handling these special ops and need to be able to hook
+  // into ones that directly control aliasing behavior like slice/update.
+  SmallPtrSet<Value, 16> coveredValues;
+  streamOp.walk([&](IREE::HAL::ConstantSubspanOp subspanOp) {
+    auto tensorValue = subspanOp.result();
+    auto bufferValue = schedulingState.loadVariable(
+        IREE::HAL::BufferType::get(rewriter.getContext()),
+        subspanOp.runtime_buffer().getLeafReference(), rewriter);
+    auto offsetValue = schedulingState.lookupOrCreateIndex(
+        subspanOp.runtime_range().offset().getSExtValue(), rewriter);
+    auto lengthValue = schedulingState.lookupOrCreateIndex(
+        subspanOp.runtime_range().length().getSExtValue(), rewriter);
+    auto subspanValue = rewriter.createOrFold<IREE::HAL::BufferSubspanOp>(
+        subspanOp.getLoc(), bufferValue.getType(), bufferValue, offsetValue,
+        lengthValue);
+    auto bufferRange = BufferRange{subspanValue, lengthValue};
+    schedulingState.mapTensorToBufferRange(tensorValue, bufferRange);
+    schedulingState.forEachEquivalentTensorValue(
+        tensorValue, [&](Value alias) { coveredValues.insert(alias); });
+  });
+
+  // Gather all of the transient values we need to allocate buffers for.
+  SmallVector<Value> transientValues;
+  SmallVector<int64_t> lifetimeIntervals;
+  SmallVector<Value> dynamicSliceSizes;
+  AsmState state(streamOp);
+  for (auto valueInterval : livenessIntervals) {
+    auto value = valueInterval.value;
+    auto valueType = value.getType().dyn_cast<ShapedType>();
+    if (!valueType) continue;
+
+    // Only handle transient buffers (created/used/dropped within the stream).
+    if (valueInterval.start == LIVE_IN || valueInterval.end == LIVE_OUT) {
+      continue;
+    }
+
+    // Ignore covered values.
+    if (schedulingState.hasTensorBufferRange(value) ||
+        coveredValues.contains(value)) {
+      continue;
+    }
+
+    transientValues.push_back(value);
+    lifetimeIntervals.push_back(valueInterval.start);
+    lifetimeIntervals.push_back(valueInterval.end);
+
+    // Compute the allocation size for the value.
+    auto allocationSize = schedulingState.lookupOrComputeSize(
+        valueType,
+        Shape::buildOrFindDynamicDimsForValue(value.getLoc(), value, rewriter),
+        rewriter);
+    dynamicSliceSizes.push_back(allocationSize);
+
+    // Mark as covered so we don't allocate it again.
+    schedulingState.forEachEquivalentTensorValue(
+        value, [&](Value alias) { coveredValues.insert(alias); });
+  }
+  if (transientValues.empty()) {
+    // No transients required.
+    return;
+  }
+
+  // Insert the hal.allocator.pack op to compute the packed offsets and total
+  // buffer size required for all transients.
+  auto indexType = rewriter.getIndexType();
+  SmallVector<Type> packedOffsetTypes(dynamicSliceSizes.size(), indexType);
+  auto packOp = rewriter.create<IREE::HAL::AllocatorPackOp>(
+      streamOp.getLoc(), indexType, packedOffsetTypes,
+      schedulingState.allocator(),
+      /*offset=*/nullptr, rewriter.getIndexArrayAttr(lifetimeIntervals),
+      dynamicSliceSizes);
+
+  // Allocate the transient storage buffer.
   // TODO(benvanik): compute from SSA use-def chain uses.
   IREE::HAL::MemoryTypeBitfield memoryTypes =
       IREE::HAL::MemoryTypeBitfield::DeviceLocal;
   IREE::HAL::BufferUsageBitfield bufferUsage =
       IREE::HAL::BufferUsageBitfield::Dispatch |
       IREE::HAL::BufferUsageBitfield::Transfer;
+  auto allocateOp = rewriter.create<IREE::HAL::AllocatorAllocateOp>(
+      streamOp.getLoc(), IREE::HAL::BufferType::get(rewriter.getContext()),
+      schedulingState.allocator(), memoryTypes, bufferUsage,
+      packOp.total_length());
 
-  // Compute the allocation size for the value.
-  auto elementType = IREE::HAL::getElementTypeValue(
-      streamValue.getType().cast<ShapedType>().getElementType());
-  if (!elementType) {
-    return {};
-  }
-  auto shape = IREE::HAL::getShapeDims(loc, streamValue, rewriter);
-  if (!shape) {
-    return {};
-  }
-  auto allocationSize = rewriter
-                            .create<IREE::HAL::AllocatorComputeSizeOp>(
-                                loc, allocator, *shape, elementType.getValue())
-                            .getResult();
-
-  auto buffer = rewriter
-                    .create<IREE::HAL::AllocatorAllocateOp>(
-                        loc, IREE::HAL::BufferType::get(rewriter.getContext()),
-                        allocator, memoryTypes, bufferUsage, allocationSize)
-                    .getResult();
-
-  return buffer;
-}
-
-// Allocates transient buffers to store the intra-stream results and populates
-// the |bufferSet| with the new mappings.
-static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
-                                     BufferSet &bufferSet,
-                                     ConversionPatternRewriter &rewriter) {
-  LLVM_DEBUG(llvm::dbgs() << "HAL allocateTransientBuffers: "
-                          << *streamOp.getOperation() << "\n");
-
-  // Allocate any needed transient buffers.
-  for (auto &op : streamOp.body().front()) {
-    if (auto subspanOp = dyn_cast<IREE::HAL::ConstantSubspanOp>(op)) {
-      auto bufferValue = rewriter.createOrFold<IREE::HAL::VariableLoadOp>(
-          subspanOp.getLoc(), IREE::HAL::BufferType::get(rewriter.getContext()),
-          subspanOp.runtime_buffer().getLeafReference());
-      auto offsetValue = rewriter.createOrFold<mlir::ConstantOp>(
-          subspanOp.getLoc(), subspanOp.runtime_range().offsetAttr());
-      auto lengthValue = rewriter.createOrFold<mlir::ConstantOp>(
-          subspanOp.getLoc(), subspanOp.runtime_range().lengthAttr());
-      auto subspanValue = rewriter.createOrFold<IREE::HAL::BufferSubspanOp>(
-          subspanOp.getLoc(), bufferValue.getType(), bufferValue, offsetValue,
-          lengthValue);
-      bufferSet.rangeMap[subspanOp.result()] = BufferRange{subspanValue};
-      continue;
-    }
-
-    auto tiedOp = dyn_cast<IREE::TiedOpInterface>(op);
-    for (auto it : llvm::enumerate(op.getResults())) {
-      auto result = it.value();
-      if (!result.getType().isa<ShapedType>()) continue;
-
-      // If the result is an output buffer we can just use that directly.
-      if (bufferSet.rangeMap[result].buffer) {
-        LLVM_DEBUG(llvm::dbgs() << "    -- SKIP ALREADY SET BUFFER RESULT("
-                                << it.index() << "): " << op << "\n");
-        continue;
-      }
-
-      // Tied results reuse their operand buffer.
-      if (tiedOp) {
-        auto tiedOperandIndex = tiedOp.getTiedResultOperandIndex(it.index());
-        if (tiedOperandIndex.hasValue()) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "    -- REUSING TIED OPERAND("
-                     << tiedOperandIndex.getValue() << ") BUFFER FOR RESULT("
-                     << it.index() << "): " << op << "\n");
-          auto operand = op.getOperand(tiedOperandIndex.getValue());
-          auto operandBufferRange = bufferSet.rangeMap[operand];
-          assert(operandBufferRange.buffer);
-          bufferSet.rangeMap[result] = operandBufferRange;
-          continue;
-        }
-      }
-
-      LLVM_DEBUG(llvm::dbgs() << "    -- ALLOCATE BUFFER FOR RESULT("
-                              << it.index() << "): " << op << "\n");
-      auto buffer =
-          allocateTransientBuffer(result, bufferSet.allocator, rewriter);
-      auto bufferRange = BufferRange{buffer};
-      bufferSet.rangeMap[result] = bufferRange;
-    }
+  // Add a buffer set map entry for each transient buffer that references into
+  // a subspan of the transient storage buffer.
+  for (size_t i = 0; i < transientValues.size(); ++i) {
+    auto value = transientValues[i];
+    auto offset = packOp.packed_offsets()[i];
+    auto subspanValue = rewriter.createOrFold<IREE::HAL::BufferSubspanOp>(
+        value.getLoc(), allocateOp.result().getType(), allocateOp.result(),
+        offset, dynamicSliceSizes[i]);
+    auto bufferRange = BufferRange{subspanValue, dynamicSliceSizes[i]};
+    schedulingState.mapTensorToBufferRange(value, bufferRange);
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Conversion
+//===----------------------------------------------------------------------===//
 
 // Records a full execution barrier that forces visibility of all buffers.
 static void recordFullExecutionBarrier(Value commandBuffer, Location loc,
@@ -266,12 +657,14 @@ static void recordFullExecutionBarrier(Value commandBuffer, Location loc,
       IREE::HAL::ExecutionBarrierFlagBitfield::None);
 }
 
+// Records a dispatch using the given bindings attribute set populated by
+// the -iree-hal-materialize-interfaces2 pass.
 static void recordInterfaceBindings(Value device, Value commandBuffer,
                                     IREE::Flow::DispatchOp &dispatchOp,
                                     IREE::HAL::InterfaceOp &interfaceOp,
                                     Value executableLayout,
                                     ArrayAttr bindingsAttr,
-                                    BufferSet &bufferSet,
+                                    StreamSchedulingState &schedulingState,
                                     ConversionPatternRewriter &rewriter) {
   // Accumulate a potentially sparse set of push constants.
   // If we had canonicalizers for hal.command_buffer.push_constants then we
@@ -286,25 +679,20 @@ static void recordInterfaceBindings(Value device, Value commandBuffer,
   int setOrdinal = 0;  // always 0 today
   SmallVector<IREE::HAL::DescriptorSetBindingValue, 4> bindings;
 
-  auto zeroOffset =
-      rewriter.createOrFold<mlir::ConstantIndexOp>(dispatchOp.getLoc(), 0);
+  auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   auto push_buffer_binding = [&](StringRef bindingName, Value tensorValue) {
     auto bindingOp =
         interfaceOp.lookupSymbol<IREE::HAL::InterfaceBindingOp>(bindingName);
     assert(bindingOp);
     assert(bindingOp.set().getSExtValue() == 0);
 
-    auto &bufferRange = bufferSet.rangeMap[tensorValue];
+    auto bufferRange = schedulingState.lookupTensorBufferRange(tensorValue);
     assert(bufferRange.buffer && "buffer not preallocated");
-    auto value = IREE::HAL::TensorRewriteAdaptor::getChecked(
-        dispatchOp.getLoc(), tensorValue, bufferRange.buffer, rewriter);
-    assert(value.hasValue() && "cannot create adaptor for tensor");
-    auto byteLength = value->getByteLength();
-    assert(byteLength);
+    assert(bufferRange.length && "buffer has no precomputed size");
     bindings.push_back(
-        std::make_tuple(rewriter.createOrFold<mlir::ConstantOp>(
-                            dispatchOp.getLoc(), bindingOp.bindingAttr()),
-                        value->getBuffer(), zeroOffset, byteLength));
+        std::make_tuple(schedulingState.lookupOrCreateIndex(
+                            bindingOp.binding().getSExtValue(), rewriter),
+                        bufferRange.buffer, zeroOffset, bufferRange.length));
   };
 
   for (auto bindingAttr : bindingsAttr) {
@@ -314,18 +702,17 @@ static void recordInterfaceBindings(Value device, Value commandBuffer,
           constantStorageAttr.binding());
       assert(bindingOp);
       assert(bindingOp.set().getSExtValue() == setOrdinal);
-      auto storageBuffer = rewriter.createOrFold<IREE::HAL::VariableLoadOp>(
-          dispatchOp.getLoc(),
+      auto storageBuffer = schedulingState.loadVariable(
           IREE::HAL::BufferType::get(rewriter.getContext()),
-          constantStorageAttr.storage());
+          constantStorageAttr.storage(), rewriter);
       bindings.push_back(std::make_tuple(
-          rewriter.createOrFold<mlir::ConstantOp>(dispatchOp.getLoc(),
-                                                  bindingOp.bindingAttr()),
+          schedulingState.lookupOrCreateIndex(
+              bindingOp.binding().getSExtValue(), rewriter),
           storageBuffer,
-          rewriter.createOrFold<mlir::ConstantOp>(
-              dispatchOp.getLoc(), constantStorageAttr.offsetAttr()),
-          rewriter.createOrFold<mlir::ConstantOp>(
-              dispatchOp.getLoc(), constantStorageAttr.lengthAttr())));
+          schedulingState.lookupOrCreateIndex(
+              constantStorageAttr.offset().getSExtValue(), rewriter),
+          schedulingState.lookupOrCreateIndex(
+              constantStorageAttr.length().getSExtValue(), rewriter)));
     } else if (auto pushConstantAttr =
                    bindingAttr.dyn_cast<IREE::HAL::ExPushConstantAttr>()) {
       auto inputValue =
@@ -354,8 +741,8 @@ static void recordInterfaceBindings(Value device, Value commandBuffer,
   }
 
   rewriter.create<IREE::HAL::CommandBufferPushDescriptorSetOp>(
-      dispatchOp.getLoc(), commandBuffer, executableLayout, setOrdinal,
-      bindings);
+      dispatchOp.getLoc(), commandBuffer, executableLayout,
+      schedulingState.lookupOrCreateIndex(setOrdinal, rewriter), bindings);
 
   if (!pushConstantValues.empty()) {
     rewriter.create<IREE::HAL::CommandBufferPushConstantsOp>(
@@ -364,11 +751,12 @@ static void recordInterfaceBindings(Value device, Value commandBuffer,
   }
 }
 
-static void recordPushConstants(Value device, Value commandBuffer,
-                                IREE::Flow::DispatchOp &dispatchOp,
-                                IREE::HAL::InterfaceOp &interfaceOp,
-                                Value executableLayout,
-                                ConversionPatternRewriter &rewriter) {
+// DEPRECATED: this is going away with the legacy linalg-on-buffers path.
+static LogicalResult recordLegacyBindings(
+    Value device, Value commandBuffer, IREE::Flow::DispatchOp &dispatchOp,
+    IREE::HAL::InterfaceOp &interfaceOp, Value executableLayout,
+    StreamSchedulingState &schedulingState,
+    ConversionPatternRewriter &rewriter) {
   SmallVector<Value, 4> pushConstantValues;
   for (auto inputValue : dispatchOp.operands()) {
     if (inputValue.getType().isa<IndexType>() ||
@@ -384,52 +772,33 @@ static void recordPushConstants(Value device, Value commandBuffer,
       pushConstantValues.push_back(pushConstantValue);
     }
   }
-  if (pushConstantValues.empty()) {
-    return;
+  if (!pushConstantValues.empty()) {
+    uint64_t maxPushConstants =
+        interfaceOp.push_constants().hasValue()
+            ? interfaceOp.push_constants().getValue().getZExtValue()
+            : 0;
+    (void)maxPushConstants;
+    assert(pushConstantValues.size() <= maxPushConstants &&
+           "uniform buffer spilling not yet implemented");
+
+    rewriter.create<IREE::HAL::CommandBufferPushConstantsOp>(
+        dispatchOp.getLoc(), commandBuffer, executableLayout,
+        rewriter.getIndexAttr(0), pushConstantValues);
   }
 
-  uint64_t maxPushConstants =
-      interfaceOp.push_constants().hasValue()
-          ? interfaceOp.push_constants().getValue().getZExtValue()
-          : 0;
-  (void)maxPushConstants;
-  assert(pushConstantValues.size() <= maxPushConstants &&
-         "uniform buffer spilling not yet implemented");
-
-  rewriter.create<IREE::HAL::CommandBufferPushConstantsOp>(
-      dispatchOp.getLoc(), commandBuffer, executableLayout,
-      rewriter.getIndexAttr(0), pushConstantValues);
-}
-
-static LogicalResult recordPushBindings(Value device, Value commandBuffer,
-                                        IREE::Flow::DispatchOp &dispatchOp,
-                                        Value executableLayout,
-                                        BufferSet &bufferSet,
-                                        ConversionPatternRewriter &rewriter) {
   LLVM_DEBUG(llvm::dbgs() << "HAL recordPushBindings: "
                           << *dispatchOp.getOperation() << "\n");
   uint32_t setOrdinal = 0;
   uint32_t bindingOrdinal = 0;
   SmallVector<IREE::HAL::DescriptorSetBindingValue, 4> bindings;
-  auto zeroOffset =
-      rewriter.createOrFold<mlir::ConstantIndexOp>(dispatchOp.getLoc(), 0);
+  auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   auto pushBinding =
       [&](Value tensorValue,
           IREE::HAL::MemoryAccessBitfield accessType) -> LogicalResult {
-    auto &bufferRange = bufferSet.rangeMap[tensorValue];
-    assert(bufferRange.buffer && "buffer not preallocated");
-    auto value = IREE::HAL::TensorRewriteAdaptor::getChecked(
-        dispatchOp.getLoc(), tensorValue, bufferRange.buffer, rewriter);
-    if (!value.hasValue()) {
-      return dispatchOp.emitOpError() << "cannot create adaptor for tensor";
-    }
-    auto byteLength = value->getByteLength();
-    if (!byteLength) return failure();
-
-    bindings.push_back(
-        std::make_tuple(rewriter.createOrFold<mlir::ConstantIndexOp>(
-                            dispatchOp.getLoc(), bindingOrdinal++),
-                        value->getBuffer(), zeroOffset, byteLength));
+    auto bufferRange = schedulingState.lookupTensorBufferRange(tensorValue);
+    bindings.push_back(std::make_tuple(
+        schedulingState.lookupOrCreateIndex(bindingOrdinal++, rewriter),
+        bufferRange.buffer, zeroOffset, bufferRange.length));
     return success();
   };
   for (auto it : llvm::enumerate(dispatchOp.operands())) {
@@ -463,7 +832,7 @@ static LogicalResult recordPushBindings(Value device, Value commandBuffer,
 // Records a dispatch operation.
 static LogicalResult recordDispatch(Value device, Value commandBuffer,
                                     IREE::Flow::DispatchOp &dispatchOp,
-                                    BufferSet &bufferSet,
+                                    StreamSchedulingState &schedulingState,
                                     ConversionPatternRewriter &rewriter) {
   // Get the handle to the executable that is compatible with our device.
   auto executableOp =
@@ -498,25 +867,22 @@ static LogicalResult recordDispatch(Value device, Value commandBuffer,
       auto interfaceOp =
           dyn_cast<IREE::HAL::InterfaceOp>(SymbolTable::lookupSymbolIn(
               executableOp, entryPointOp.interfaceAttr()));
-      auto executableLayout =
-          rewriter.createOrFold<IREE::HAL::ExecutableLayoutLookupOp>(
-              dispatchOp.getLoc(),
-              IREE::HAL::ExecutableLayoutType::get(device.getContext()), device,
-              interfaceOp.push_constantsAttr(),
-              interfaceOp.getExecutableSetLayoutsAttr());
+      auto executableLayout = schedulingState.lookupExecutableLayout(
+          IREE::HAL::ExecutableLayoutType::get(interfaceOp.getContext()),
+          interfaceOp.push_constantsAttr(),
+          interfaceOp.getExecutableSetLayoutsAttr(), rewriter);
 
       // HACK: switch off for new-style bindings population if the metadata is
       // available.
       if (auto bindingsAttr =
               dispatchOp->getAttrOfType<ArrayAttr>("hal.bindings")) {
         recordInterfaceBindings(device, commandBuffer, dispatchOp, interfaceOp,
-                                executableLayout, bindingsAttr, bufferSet,
+                                executableLayout, bindingsAttr, schedulingState,
                                 rewriter);
       } else {
-        recordPushConstants(device, commandBuffer, dispatchOp, interfaceOp,
-                            executableLayout, rewriter);
-        if (failed(recordPushBindings(device, commandBuffer, dispatchOp,
-                                      executableLayout, bufferSet, rewriter))) {
+        if (failed(recordLegacyBindings(device, commandBuffer, dispatchOp,
+                                        interfaceOp, executableLayout,
+                                        schedulingState, rewriter))) {
           return failure();
         }
       }
@@ -534,57 +900,36 @@ static LogicalResult recordDispatch(Value device, Value commandBuffer,
   }
   switchRewriter.build();
 
-  // Full barriers for now as we aren't scheduling things.
-  // TODO(benvanik): don't add at the end of the command buffer (we could
-  // also do a canonicalization step that removed trailing barriers).
+  // Full barriers for now as we aren't scheduling things in waves.
   recordFullExecutionBarrier(commandBuffer, dispatchOp.getLoc(), rewriter);
   return success();
 }
 
 static LogicalResult recordTensorClone(Value device, Value commandBuffer,
                                        IREE::Flow::TensorCloneOp &cloneOp,
-                                       BufferSet &bufferSet,
+                                       StreamSchedulingState &schedulingState,
                                        ConversionPatternRewriter &rewriter) {
-  auto &operandBuffer = bufferSet.rangeMap[cloneOp.operand()];
-  auto &resultBuffer = bufferSet.rangeMap[cloneOp.result()];
+  auto operandBuffer =
+      schedulingState.lookupTensorBufferRange(cloneOp.operand());
+  auto resultBuffer = schedulingState.lookupTensorBufferRange(cloneOp.result());
 
-  auto operand = IREE::HAL::TensorRewriteAdaptor::getChecked(
-      cloneOp.getLoc(), cloneOp.operand(), operandBuffer.buffer, rewriter);
-  auto result = IREE::HAL::TensorRewriteAdaptor::getChecked(
-      cloneOp.getLoc(), cloneOp.result(), resultBuffer.buffer, rewriter);
-  if (!operand.hasValue() || !result.hasValue()) {
-    return cloneOp.emitOpError()
-           << "cannot create adaptors for tensor clone operands/results";
-  }
-
-  auto zeroOffset =
-      rewriter.createOrFold<mlir::ConstantIndexOp>(cloneOp.getLoc(), 0);
-  auto byteLength = operand->getByteLength();
-  if (!byteLength) return failure();
-
+  auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   rewriter.create<IREE::HAL::CommandBufferCopyBufferOp>(
-      cloneOp.getLoc(), commandBuffer, operand->getBuffer(), zeroOffset,
-      result->getBuffer(), zeroOffset, byteLength);
+      cloneOp.getLoc(), commandBuffer, operandBuffer.buffer, zeroOffset,
+      resultBuffer.buffer, zeroOffset, operandBuffer.length);
 
   // Full barriers for now as we aren't scheduling things.
-  // TODO(benvanik): don't add at the end of the command buffer (we could
-  // also do a canonicalization step that removed trailing barriers).
   recordFullExecutionBarrier(commandBuffer, cloneOp.getLoc(), rewriter);
   return success();
 }
 
-/// Convert a flow.tensor.slice to a copy.
-// TODO(benvanik, ravishankarm): The copy is not necessary. If there are no
-// other uses of this buffer you could just return the original buffer with an
-// offset. This should either be handled here, or the `flow.tensor.slice` (or
-// its equivalent `subtensor` op) must be pushed into dispatch regions (see
-// Github issue #5131)
+// TODO(#5410): make this an aliasing operation in allocateTransientBuffers.
 static LogicalResult recordTensorSlice(Value device, Value commandBuffer,
                                        IREE::Flow::TensorSliceOp &sliceOp,
-                                       BufferSet &bufferSet,
+                                       StreamSchedulingState &schedulingState,
                                        ConversionPatternRewriter &rewriter) {
-  auto &sourceBuffer = bufferSet.rangeMap[sliceOp.source()];
-  auto &resultBuffer = bufferSet.rangeMap[sliceOp.result()];
+  auto sourceBuffer = schedulingState.lookupTensorBufferRange(sliceOp.source());
+  auto resultBuffer = schedulingState.lookupTensorBufferRange(sliceOp.result());
 
   // TODO(benvanik): use something other than the BufferRange::buffer?
   // This may require us to subview the buffer first.
@@ -597,9 +942,6 @@ static LogicalResult recordTensorSlice(Value device, Value commandBuffer,
            << "cannot create adaptors for tensor slice operands/results";
   }
 
-  auto zeroOffset =
-      rewriter.createOrFold<mlir::ConstantIndexOp>(sliceOp.getLoc(), 0);
-
   // Compute the size of the update range.
   auto startIndices = llvm::to_vector<4>(llvm::map_range(
       sliceOp.start_indices(),
@@ -610,9 +952,10 @@ static LogicalResult recordTensorSlice(Value device, Value commandBuffer,
   if (!sourceRange) return failure();
 
   // TODO(benvanik): slice left/mid/right, but really just don't do this.
+  auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   rewriter.create<IREE::HAL::CommandBufferCopyBufferOp>(
-      sliceOp.getLoc(), commandBuffer, source->getBuffer(), sourceRange->offset,
-      result->getBuffer(), zeroOffset, sourceRange->length);
+      sliceOp.getLoc(), commandBuffer, sourceBuffer.buffer, sourceRange->offset,
+      resultBuffer.buffer, zeroOffset, sourceRange->length);
 
   // Full barriers for now as we aren't scheduling things.
   // TODO(benvanik): don't add at the end of the command buffer (we could
@@ -621,12 +964,15 @@ static LogicalResult recordTensorSlice(Value device, Value commandBuffer,
   return success();
 }
 
+// TODO(#5410): make this an aliasing operation in allocateTransientBuffers.
 static LogicalResult recordTensorUpdate(Value device, Value commandBuffer,
                                         IREE::Flow::TensorUpdateOp &updateOp,
-                                        BufferSet &bufferSet,
+                                        StreamSchedulingState &schedulingState,
                                         ConversionPatternRewriter &rewriter) {
-  auto &updateBuffer = bufferSet.rangeMap[updateOp.update()];
-  auto &targetBuffer = bufferSet.rangeMap[updateOp.target()];
+  auto updateBuffer =
+      schedulingState.lookupTensorBufferRange(updateOp.update());
+  auto targetBuffer =
+      schedulingState.lookupTensorBufferRange(updateOp.target());
 
   // TODO(benvanik): use something other than the BufferRange::buffer?
   // This may require us to subview the buffer first.
@@ -639,9 +985,6 @@ static LogicalResult recordTensorUpdate(Value device, Value commandBuffer,
            << "cannot create adaptors for tensor update operands/results";
   }
 
-  auto zeroOffset =
-      rewriter.createOrFold<mlir::ConstantIndexOp>(updateOp.getLoc(), 0);
-
   // Compute the size of the update range.
   auto startIndices = llvm::to_vector<4>(llvm::map_range(
       updateOp.start_indices(),
@@ -653,9 +996,10 @@ static LogicalResult recordTensorUpdate(Value device, Value commandBuffer,
   if (!targetRange) return failure();
 
   // TODO(benvanik): slice left/mid/right, but really just don't do this.
+  auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   rewriter.create<IREE::HAL::CommandBufferCopyBufferOp>(
-      updateOp.getLoc(), commandBuffer, update->getBuffer(), zeroOffset,
-      target->getBuffer(), targetRange->offset, targetRange->length);
+      updateOp.getLoc(), commandBuffer, updateBuffer.buffer, zeroOffset,
+      targetBuffer.buffer, targetRange->offset, targetRange->length);
 
   // Full barriers for now as we aren't scheduling things.
   // TODO(benvanik): don't add at the end of the command buffer (we could
@@ -664,29 +1008,29 @@ static LogicalResult recordTensorUpdate(Value device, Value commandBuffer,
   return success();
 }
 
-static LogicalResult recordStreamCommands(Value device, Value commandBuffer,
-                                          Block &streamBlock,
-                                          BufferSet &bufferSet,
-                                          ConversionPatternRewriter &rewriter) {
+static LogicalResult recordStreamCommands(
+    Value device, Value commandBuffer, Block &streamBlock,
+    StreamSchedulingState &schedulingState,
+    ConversionPatternRewriter &rewriter) {
   for (auto &op : streamBlock) {
     if (auto dispatchOp = dyn_cast<IREE::Flow::DispatchOp>(op)) {
-      if (failed(recordDispatch(device, commandBuffer, dispatchOp, bufferSet,
-                                rewriter))) {
+      if (failed(recordDispatch(device, commandBuffer, dispatchOp,
+                                schedulingState, rewriter))) {
         return failure();
       }
     } else if (auto cloneOp = dyn_cast<IREE::Flow::TensorCloneOp>(op)) {
-      if (failed(recordTensorClone(device, commandBuffer, cloneOp, bufferSet,
-                                   rewriter))) {
+      if (failed(recordTensorClone(device, commandBuffer, cloneOp,
+                                   schedulingState, rewriter))) {
         return failure();
       }
     } else if (auto sliceOp = dyn_cast<IREE::Flow::TensorSliceOp>(op)) {
-      if (failed(recordTensorSlice(device, commandBuffer, sliceOp, bufferSet,
-                                   rewriter))) {
+      if (failed(recordTensorSlice(device, commandBuffer, sliceOp,
+                                   schedulingState, rewriter))) {
         return failure();
       }
     } else if (auto updateOp = dyn_cast<IREE::Flow::TensorUpdateOp>(op)) {
-      if (failed(recordTensorUpdate(device, commandBuffer, updateOp, bufferSet,
-                                    rewriter))) {
+      if (failed(recordTensorUpdate(device, commandBuffer, updateOp,
+                                    schedulingState, rewriter))) {
         return failure();
       }
     } else if (auto returnOp = dyn_cast<IREE::Flow::ReturnOp>(op)) {
@@ -716,40 +1060,67 @@ class ExStreamFragmentOpConversion
     IREE::Flow::ExStreamFragmentOp::Adaptor adaptor(
         newOperands, streamOp->getAttrDictionary());
 
-    // TODO(benvanik): choose buffer mode/category based on stream commands.
-    auto mode = IREE::HAL::CommandBufferModeBitfield::OneShot;
-    auto category = IREE::HAL::CommandCategoryBitfield::Dispatch |
-                    IREE::HAL::CommandCategoryBitfield::Transfer;
+    auto valueAliases = computeValueAliases(streamOp);
+    auto livenessIntervals = computeLivenessIntervals(streamOp, valueAliases);
 
-    // We'll use this buffer set to track the original and converted tensors
-    // and buffers during conversion. Ideally we'd run some fancy allocation
-    // analysis first to produce it.
     auto device =
         rewriter.createOrFold<IREE::HAL::ExSharedDeviceOp>(streamOp.getLoc());
     auto allocator =
         rewriter.create<IREE::HAL::DeviceAllocatorOp>(streamOp.getLoc(), device)
             .getResult();
-    BufferSet bufferSet{allocator};
+    StreamSchedulingState schedulingState(streamOp.getLoc(), device, allocator,
+                                          valueAliases);
 
-    // Remap non-tensor operands (such as workloads).
+    // Map stream captures to their external buffers or SSA values.
+    // This covers all of the live-in stream values.
     auto &entryBlock = streamOp.body().front();
     for (int i = 0; i < adaptor.operands().size(); ++i) {
-      if (streamOp.getOperand(i).getType().isa<TensorType>()) {
-        bufferSet.rangeMap[entryBlock.getArgument(i)] =
-            BufferRange{adaptor.operands()[i]};
+      auto streamValue = entryBlock.getArgument(i);
+      auto bufferValue = adaptor.operands()[i];
+      if (auto shapedType = streamValue.getType().dyn_cast<TensorType>()) {
+        BufferRange bufferRange;
+        if (bufferValue.getType().isa<IREE::HAL::BufferViewType>()) {
+          bufferRange = BufferRange{
+              rewriter.createOrFold<IREE::HAL::BufferViewBufferOp>(
+                  streamOp.getLoc(),
+                  IREE::HAL::BufferType::get(rewriter.getContext()),
+                  bufferValue),
+              rewriter.createOrFold<IREE::HAL::BufferViewByteLengthOp>(
+                  streamOp.getLoc(), bufferValue)};
+        } else {
+          bufferRange = BufferRange{
+              bufferValue,
+              schedulingState.lookupOrComputeSize(streamValue, rewriter)};
+        }
+        schedulingState.mapTensorToBufferRange(streamValue, bufferRange);
+
       } else {
-        rewriter.replaceUsesOfBlockArgument(entryBlock.getArgument(i),
-                                            adaptor.operands()[i]);
+        rewriter.replaceUsesOfBlockArgument(streamValue, bufferValue);
       }
     }
 
-    // Allocate buffers for outputs and transient buffers.
-    allocateOutputBuffers(streamOp, bufferSet, rewriter);
-    allocateTransientBuffers(streamOp, bufferSet, rewriter);
+    // Allocate buffers for values that escape the stream via return.
+    // These may alias input buffers above such as when an input is returned or
+    // a return value is tied.
+    auto outputBuffers =
+        allocateOutputBuffers(streamOp, schedulingState, rewriter);
+
+    // Allocate all of the transient buffers used entirely within the stream.
+    // These all end up aliased from a single slab allocation and use the
+    // computed liveness information to know the lifetime intervals. Note that
+    // after we perform this allocation we can no longer safely rearrange the
+    // ops as buffers will start to alias. All reordering must have happened
+    // prior to this conversion.
+    allocateTransientBuffers(streamOp, livenessIntervals, schedulingState,
+                             rewriter);
 
     // Allocate and begin the command buffer.
     // In a real version we would want to pick the device based on the placement
     // information attached to the stream.
+    // TODO(benvanik): choose buffer mode/category based on stream commands.
+    auto mode = IREE::HAL::CommandBufferModeBitfield::OneShot;
+    auto category = IREE::HAL::CommandCategoryBitfield::Dispatch |
+                    IREE::HAL::CommandCategoryBitfield::Transfer;
     auto commandBuffer =
         rewriter.createOrFold<IREE::HAL::CommandBufferCreateOp>(
             streamOp.getLoc(),
@@ -760,7 +1131,7 @@ class ExStreamFragmentOpConversion
 
     // Record all of the commands into the command buffer.
     if (failed(recordStreamCommands(device, commandBuffer, entryBlock,
-                                    bufferSet, rewriter))) {
+                                    schedulingState, rewriter))) {
       return failure();
     }
 
@@ -772,7 +1143,7 @@ class ExStreamFragmentOpConversion
     rewriter.create<IREE::HAL::ExSubmitAndWaitOp>(streamOp.getLoc(), device,
                                                   commandBuffer);
 
-    // It's annoying, but we need to do this replacement at the very end as
+    // It's annoying but we need to do this replacement at the very end as
     // otherwise we lose access to the original values (which we need for
     // shape information).
     for (int i = 0; i < adaptor.operands().size(); ++i) {
@@ -782,7 +1153,7 @@ class ExStreamFragmentOpConversion
       }
     }
 
-    rewriter.replaceOp(streamOp, bufferSet.outputBuffers);
+    rewriter.replaceOp(streamOp, outputBuffers);
     return success();
   }
 };

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -484,6 +484,110 @@ def HAL_AllocatorMapOp : HAL_Op<"allocator.map", [
   }];
 }
 
+def HAL_AllocatorPackOp : HAL_PureOp<"allocator.pack", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{packs variable-sized slices into a single slab}];
+  let description = [{
+    Performs a greedy packing of one or more sized slices with specified
+    lifetimes and returns their relative offsets in an aliased linear space.
+
+    Slices are `[start, end] = %slice_byte_size`, where the start and end values
+    define an inclusive lifetime range and the size is the total number of bytes
+    required to be live for that range.
+
+    ```mlir
+    // Computes thte total length required for the packed values and the offsets
+    // of the 3 slices requested relative to the base of the packed memory:
+    %total_length, %offset_0, %offset_1, %offset_2 =
+        hal.allocator.pack<%allocator : !hal.allocator>
+            // Each slice gets one result offset:
+            slices([
+              // 3 slices where A and B overlap and will get unique offsets
+              // while B and C do not overlap and are allowed to alias.
+              [0, 10] = %size_0,  // A => %offset_0
+              [3,  8] = %size_1,  // B => %offset_1
+              [9, 10] = %size_2,  // C => %offset_2
+              ...
+            ]) : index
+    ```
+
+    The lifetime start and end points (inclusive) are only used for relative
+    comparisons and may originate with any meaning (op order in block, epoch,
+    phase of the moon, etc). The packing algorithm uses the intervals to
+    determine slice liveness and when aliasing is safe.
+
+    The size of each slice may either be a constant or runtime-computed dynamic
+    value. Constant slices can achieve more dense packing than the dynamic
+    values and CSE/canonicalization should be applied to ensure that as many of
+    the dynamic values are equivalent if possible.
+
+    The total length required to pack all slices is returned and can be used to
+    acquire storage. The individual slice offsets are 0-based and as such if are
+    directly used as buffer offsets may need additional offseting. This can
+    either be applied via the optional `offset` operand or slicing of the
+    underlying allocation buffer.
+  }];
+
+  let arguments = (ins
+    HAL_Allocator:$allocator,
+    Optional<HAL_DeviceSize>:$offset,
+    HAL_IndexArrayAttr:$lifetime_intervals,
+    Variadic<HAL_DeviceSize>:$dynamic_slice_sizes
+  );
+  let results = (outs
+    HAL_DeviceSize:$total_length,
+    Variadic<HAL_DeviceSize>:$packed_offsets
+  );
+
+  let assemblyFormat = [{
+    `<` $allocator `:` type($allocator) `>`
+    (`offset` `(` $offset^ `)`)?
+    `slices` `(` `{`
+    custom<PackSliceRanges>($lifetime_intervals,
+                            $dynamic_slice_sizes,
+                            type($packed_offsets))
+    `}` `)`
+    `:` type($total_length)
+    attr-dict-with-keyword
+  }];
+
+  let verifier = [{ return verifyAllocatorPackOp(*this); }];
+
+  let extraClassDeclaration = [{
+    struct Slice {
+      int64_t lifetimeStart;
+      int64_t lifetimeEnd;
+      Value dynamicSize;
+      Value packedOffset;
+
+      bool operator==(const Slice &rhs) const {
+        return lifetimeStart == rhs.lifetimeStart &&
+               lifetimeEnd == rhs.lifetimeEnd;
+      }
+      bool operator!=(const Slice &rhs) const {
+        return !(*this == rhs);
+      }
+      bool operator<(const Slice &rhs) const {
+        return std::make_pair(lifetimeStart, lifetimeEnd) <
+               std::make_pair(rhs.lifetimeStart, rhs.lifetimeEnd);
+      }
+      bool intersects(const Slice &rhs) const {
+        return lifetimeEnd >= rhs.lifetimeStart &&
+               rhs.lifetimeEnd >= lifetimeStart;
+      }
+    };
+
+    /// Returns all of the slices to be packed.
+    /// Order is ascending by lifetime interval (post-canonicalization).
+    SmallVector<Slice> getSlices();
+  }];
+
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // !hal.buffer / iree_hal_buffer_t
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "MaterializeInterfaces2.cpp",
         "MaterializeResourceCaches.cpp",
         "MemoizeDeviceQueries.cpp",
+        "PackAllocations.cpp",
         "PackConstantPoolStorage.cpp",
         "Passes.cpp",
         "PropagateConstantWorkgroupInfo.cpp",

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "MaterializeInterfaces2.cpp"
     "MaterializeResourceCaches.cpp"
     "MemoizeDeviceQueries.cpp"
+    "PackAllocations.cpp"
     "PackConstantPoolStorage.cpp"
     "Passes.cpp"
     "PropagateConstantWorkgroupInfo.cpp"

--- a/iree/compiler/Dialect/HAL/Transforms/PackAllocations.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PackAllocations.cpp
@@ -1,0 +1,367 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <list>
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "iree/compiler/Dialect/HAL/Utils/TypeUtils.h"
+#include "llvm/ADT/MapVector.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+class PackAllocationsPass
+    : public PassWrapper<PackAllocationsPass, OperationPass<FuncOp>> {
+ public:
+  using Slice = IREE::HAL::AllocatorPackOp::Slice;
+
+  explicit PackAllocationsPass(TargetOptions targetOptions)
+      : targetOptions_(targetOptions) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::StandardOpsDialect>();
+    registry.insert<IREE::HAL::HALDialect>();
+  }
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    // Derive buffer constraints based on target backends.
+    // TODO(benvanik): move to a module-level attribute so that we can query
+    // this without having to plumb through the target options and share code
+    // with IdentifyConstantPools.
+    auto bufferConstraints = computeConservativeBufferConstraints(
+        targetOptions_, funcOp.getContext());
+    if (!bufferConstraints) {
+      funcOp.emitWarning() << "no target backends provided buffer "
+                              "constraints; falling back to host default";
+      bufferConstraints =
+          TargetBackend::makeDefaultBufferConstraints(funcOp.getContext());
+    }
+
+    // NOTE: we could try several algorithms and compute which packs best. For
+    // now we just pack greedily as it's fast and what most existing ML
+    // frameworks do.
+    funcOp.walk([&](IREE::HAL::AllocatorPackOp packOp) {
+      // Bucket into static and dynamic sizes. Static packing is a much more
+      // constrained problem.
+      auto allSlices = packOp.getSlices();
+      SmallVector<Slice> staticSlices;
+      SmallVector<Slice> dynamicSlices;
+      staticSlices.reserve(allSlices.size());
+      dynamicSlices.reserve(allSlices.size());
+      for (auto &slice : allSlices) {
+        if (isa_and_nonnull<ConstantOp>(slice.dynamicSize.getDefiningOp())) {
+          staticSlices.push_back(slice);
+        } else {
+          dynamicSlices.push_back(slice);
+        }
+      }
+
+      OpBuilder builder(packOp);
+
+      // First pack all static slices as these are entirely knowable here at
+      // compile time.
+      auto offset = packOp.offset() ? packOp.offset()
+                                    : builder.createOrFold<ConstantIndexOp>(
+                                          packOp.getLoc(), 0);
+      if (!staticSlices.empty()) {
+        offset = packStaticSlicesGreedily(packOp, offset, staticSlices,
+                                          bufferConstraints, builder);
+
+        // TODO(benvanik): make this an option; it can be useful for debugging
+        // this code.
+        // offset = packSlicesWithNoAliasing(packOp, offset, staticSlices,
+        //                                   bufferConstraints, builder);
+      }
+
+      // Next pack all dynamic slices. Depending on the analysis information
+      // available we could reuse static slices with non-overlapping lifetimes
+      // in some cases.
+      if (!dynamicSlices.empty()) {
+        offset = packDynamicSlicesConservatively(packOp, offset, dynamicSlices,
+                                                 bufferConstraints, builder);
+      }
+
+      // Total packed length is the current offset after all slices are
+      // allocated. This should be aligned to the range constraints.
+      packOp.total_length().replaceAllUsesWith(offset);
+
+      packOp.erase();
+    });
+  }
+
+ private:
+  // Tries to find the min/max constraints on buffers across all target
+  // backends. This should really be done per pool based on the usage of the
+  // constants (if pool 0 is used by device A and pool 1 is used by device B
+  // then they should not need to have matching constraints).
+  BufferConstraintsAttr computeConservativeBufferConstraints(
+      const TargetOptions &targetOptions, MLIRContext *context) {
+    auto targetBackends = matchTargetBackends(targetOptions.targets);
+    BufferConstraintsAttr attr = {};
+    for (auto &targetBackend : targetBackends) {
+      if (attr) {
+        attr = intersectBufferConstraints(
+            attr, targetBackend->queryBufferConstraints(context));
+      } else {
+        attr = targetBackend->queryBufferConstraints(context);
+      }
+    }
+    return attr;
+  }
+
+  // Packs slices back-to-back with no aliasing. Useful when debugging to remove
+  // the aliasing that makes data breakpoints useless.
+  //
+  // Slice packed offset SSA values will be updated and start at the given
+  // |baseOffset|. Returns |baseOffset| + the total size of the allocation
+  // aligned to the requirements of |bufferConstraints|.
+  Value packSlicesWithNoAliasing(IREE::HAL::AllocatorPackOp packOp,
+                                 Value baseOffset, ArrayRef<Slice> slices,
+                                 BufferConstraintsAttr bufferConstraints,
+                                 OpBuilder &builder) {
+    auto loc = packOp.getLoc();
+    int64_t offsetAlignment =
+        bufferConstraints.min_buffer_offset_alignment().getSExtValue();
+    int64_t rangeAlignment =
+        bufferConstraints.min_buffer_range_alignment().getSExtValue();
+
+    Value offset = baseOffset;
+    for (auto &slice : slices) {
+      auto sliceSize = align(loc, slice.dynamicSize, rangeAlignment, builder);
+      slice.packedOffset.replaceAllUsesWith(offset);
+      offset = align(loc, builder.createOrFold<AddIOp>(loc, offset, sliceSize),
+                     offsetAlignment, builder);
+    }
+
+    return align(loc, offset, rangeAlignment, builder);
+  }
+
+  // Packs a set of statically-sized slices by greedy strip packing.
+  //
+  // This is the same algorithm used in tflite here:
+  // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/simple_memory_arena.cc
+  // It's not fantastic and can end up with a significant amount of wastage.
+  // They do the packing at runtime and as such care more about performance than
+  // we do while doing the packing here offline. For this initial version I
+  // wanted to ensure we matched apples/apples their implementation.
+  //
+  // We should use a set of heuristics and pick the smallest one. There are also
+  // some really great papers that have approximations (as all of these are -
+  // 2D strip packing is NP-hard) such as
+  // https://www.sciencedirect.com/science/article/pii/S0925772113001016 that
+  // someone with a brain able to parse mathy papers can try implementing.
+  //
+  // Slice packed offset SSA values will be updated and start at the given
+  // |baseOffset|. Returns |baseOffset| + the total size of the allocation
+  // aligned to the requirements of |bufferConstraints|.
+  Value packStaticSlicesGreedily(IREE::HAL::AllocatorPackOp packOp,
+                                 Value baseOffset, ArrayRef<Slice> slices,
+                                 BufferConstraintsAttr bufferConstraints,
+                                 OpBuilder &builder) {
+    int64_t offsetAlignment =
+        bufferConstraints.min_buffer_offset_alignment().getSExtValue();
+    int64_t rangeAlignment =
+        bufferConstraints.min_buffer_range_alignment().getSExtValue();
+
+    struct Reservation {
+      const Slice *slice = nullptr;
+      int64_t staticOffset = 0;
+      int64_t staticSize = 0;
+    };
+    static constexpr int64_t UNASSIGNED = INT64_MAX;
+
+    std::list<Reservation> reservations;
+    int64_t highwaterMark = 0;
+    for (auto &slice : slices) {
+      int64_t bestOffset = UNASSIGNED;
+      int64_t bestOffsetFit = UNASSIGNED;
+      int64_t staticSize =
+          dyn_cast<ConstantIndexOp>(slice.dynamicSize.getDefiningOp())
+              .getValue();
+      int64_t alignedSize = align(staticSize, rangeAlignment);
+
+      // Iterate through reservations (sorted by ascending offset) and identify
+      // gaps in which the slice will fit. To reduce wastage we want to find the
+      // smallest gap.
+      int64_t currentOffset = 0;
+      for (auto &reservation : reservations) {
+        if (!reservation.slice->intersects(slice)) {
+          // Non-overlapping - we can reuse the currentOffset (assuming we find
+          // no better place).
+          continue;
+        }
+
+        // If we found a gap >= the required size and smaller than
+        // previous best fit take it.
+        int64_t alignedOffset = align(currentOffset, offsetAlignment);
+        if (alignedOffset + alignedSize <= reservation.staticOffset &&
+            reservation.staticOffset - alignedOffset < bestOffsetFit) {
+          bestOffset = alignedOffset;
+          bestOffsetFit = reservation.staticOffset - currentOffset;
+        }
+        currentOffset = std::max(
+            currentOffset, reservation.staticOffset + reservation.staticSize);
+      }
+      if (bestOffset == UNASSIGNED) {
+        bestOffset = align(currentOffset, offsetAlignment);
+      }
+
+      // Reserve the memory.
+      Reservation reservation;
+      reservation.slice = &slice;
+      reservation.staticOffset = bestOffset;
+      reservation.staticSize = alignedSize;
+      auto insertionIt = reservations.begin();
+      while (insertionIt != reservations.end() &&
+             insertionIt->staticOffset < reservation.staticOffset) {
+        ++insertionIt;
+      }
+      reservations.insert(insertionIt, reservation);
+      slice.packedOffset.replaceAllUsesWith(builder.createOrFold<AddIOp>(
+          packOp.getLoc(), baseOffset,
+          builder.createOrFold<ConstantIndexOp>(packOp.getLoc(), bestOffset)));
+
+      // Update highwater mark indicating how much memory needs to be allocated
+      // for the entire slab.
+      highwaterMark = std::max(highwaterMark, bestOffset + alignedSize);
+    }
+
+    highwaterMark = align(highwaterMark, rangeAlignment);
+    return builder.createOrFold<AddIOp>(
+        packOp.getLoc(), baseOffset,
+        builder.createOrFold<ConstantIndexOp>(packOp.getLoc(), highwaterMark));
+  }
+
+  // Packs a set of dynamically-sized slices based on the structural information
+  // in the IR. Only slices that have the exact same size will be allowed to
+  // alias.
+  //
+  // We can improve this if we know which sizes are larger/smaller relative to
+  // others as then we can do things like reuse an allocation bucket with
+  // non-overlapping lifetimes if the thing we are trying to pack in it is
+  // definitely <=. If we end up knowing that certain sizes are less than some
+  // absolute value then we could also alias with static allocations like if %sz
+  // is known less than 1000b it could reuse any static allocation >= 1000b.
+  //
+  // We could also emit code for efficient runtime bucketing by providing the
+  // sorted, compacted, delta-coded lifetime intervals and runtime-computed
+  // sizes if we wanted to produce the smallest buffers.
+  //
+  // Slice packed offset SSA values will be updated and start at the given
+  // |baseOffset|. Returns |baseOffset| + the total size of the allocation
+  // aligned to the requirements of |bufferConstraints|.
+  Value packDynamicSlicesConservatively(IREE::HAL::AllocatorPackOp packOp,
+                                        Value baseOffset,
+                                        ArrayRef<Slice> slices,
+                                        BufferConstraintsAttr bufferConstraints,
+                                        OpBuilder &builder) {
+    auto loc = packOp.getLoc();
+    int64_t offsetAlignment =
+        bufferConstraints.min_buffer_offset_alignment().getSExtValue();
+    int64_t rangeAlignment =
+        bufferConstraints.min_buffer_range_alignment().getSExtValue();
+
+    // Bucket all slices by their size SSA value. We rely on shapes being
+    // lowered to computed byte sizes and CSE to then dedupe the values for us.
+    llvm::MapVector<Value, SmallVector<const Slice *>> slicesBySize;
+    for (auto &slice : slices) {
+      slicesBySize[slice.dynamicSize].push_back(&slice);
+    }
+
+    // Allocate each bucket while observing the lifetime of the slices within.
+    // Two or more slices may overlap in lifetime and need their own unique
+    // reservation.
+    Value offset = baseOffset;
+    for (auto &sizeBucket : slicesBySize) {
+      auto sliceSize = align(loc, sizeBucket.first, rangeAlignment, builder);
+      auto &slices = sizeBucket.second;
+      std::stable_sort(slices.begin(), slices.end());
+
+      // Bin the slices by those who do not overlap. All of the allocations in
+      // each bin can alias.
+      // NOTE: O(n^2) in the worst case but there's usually only a small number
+      // of bins (<10) as we have already bucketed by size class. We could do
+      // some sorting and make this O(nlogn) or O(logn) with some interval tree
+      // magic.
+      struct Bin {
+        Value offset;
+        SmallVector<const Slice *> slices;
+        bool intersects(const Slice &slice) const {
+          for (auto *binSlice : slices) {
+            if (binSlice->intersects(slice)) return true;
+          }
+          return false;
+        }
+      };
+      SmallVector<Bin> bins;
+      for (auto *slice : slices) {
+        // Try to find a bin we can reuse (non-intersecting lifetime).
+        Bin *targetBin = nullptr;
+        for (auto &bin : bins) {
+          if (!bin.intersects(*slice)) {
+            targetBin = &bin;
+            break;
+          }
+        }
+        if (!targetBin) {
+          // Allocate a new bin for this slice.
+          bins.push_back({offset, {}});
+          targetBin = &bins.back();
+          offset =
+              align(loc, builder.createOrFold<AddIOp>(loc, offset, sliceSize),
+                    offsetAlignment, builder);
+        }
+        targetBin->slices.push_back(slice);
+        slice->packedOffset.replaceAllUsesWith(targetBin->offset);
+      }
+    }
+
+    return align(loc, offset, rangeAlignment, builder);
+  }
+
+  TargetOptions targetOptions_;
+};
+
+std::unique_ptr<OperationPass<FuncOp>> createPackAllocationsPass(
+    TargetOptions targetOptions) {
+  return std::make_unique<PackAllocationsPass>(targetOptions);
+}
+
+static PassRegistration<PackAllocationsPass> pass(
+    "iree-hal-pack-allocations",
+    "Packs allocations and materializes runtime packing code as required.", [] {
+      auto options = getTargetOptionsFromFlags();
+      return std::make_unique<PackAllocationsPass>(options);
+    });
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -86,6 +86,13 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createCSEPass());
 
+  // Pack transient allocations in the program that were materialized during
+  // stream conversion.
+  //
+  // NOTE: this works best if canonicalization/CSE has run such that the packed
+  // sizes are as much as possible available as constants.
+  passManager.addNestedPass<FuncOp>(createPackAllocationsPass(targetOptions));
+
   // For each exported function, processes the reflection metadata and
   // generates public ABI wrappers for various calling conventions.
   // Phase ordering note: This operates on functions whose signatures have

--- a/iree/compiler/Dialect/HAL/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/test/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "materialize_interfaces2.mlir",
             "materialize_resource_caches.mlir",
             "memoize_device_queries.mlir",
+            "pack_allocations.mlir",
             "pack_constant_pool_storage.mlir",
             "propagate_constant_workgroup_info.mlir",
             "public_abi_generation.mlir",

--- a/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "materialize_interfaces2.mlir"
     "materialize_resource_caches.mlir"
     "memoize_device_queries.mlir"
+    "pack_allocations.mlir"
     "pack_constant_pool_storage.mlir"
     "propagate_constant_workgroup_info.mlir"
     "public_abi_generation.mlir"

--- a/iree/compiler/Dialect/HAL/Transforms/test/pack_allocations.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/pack_allocations.mlir
@@ -1,0 +1,100 @@
+// RUN: iree-opt -split-input-file -iree-hal-target-backends=dylib-llvm-aot -iree-hal-pack-allocations -cse -canonicalize %s | IreeFileCheck %s
+
+// CHECK-LABEL: @packStatic
+// CHECK-SAME: %[[ALLOCATOR:.+]]: !hal.allocator
+func @packStatic(%allocator: !hal.allocator) ->
+    (index, index, index, index, index, index, index) {
+  %c100 = constant 100 : index
+  %c200 = constant 200 : index
+  %t:7 = hal.allocator.pack<%allocator : !hal.allocator> slices({
+    [0, 1] = %c100,  // +0
+    [1, 2] = %c100,  // +112 (100 align 16)
+    [2, 3] = %c100,  // +0 (reuse [0, 1])
+    [0, 4] = %c200,  // +224 (after 112 + 112; end align 16)
+    [5, 6] = %c200,  // +0 (reuse [0, 1]/[2, 3])
+    [5, 8] = %c100,  // +208 (after 200 align 16)
+  }) : index
+  // 224 + 200 align 16 = 432 total bytes required
+  // CHECK: return %c432
+  // CHECK-SAME: %c0, %c112, %c0, %c224, %c0, %c208
+  return %t#0, %t#1, %t#2, %t#3, %t#4, %t#5, %t#6 : index, index, index, index, index, index, index
+}
+
+// -----
+
+// CHECK-LABEL: @packDynamic
+// CHECK-SAME: %[[ALLOCATOR:.+]]: !hal.allocator,
+// CHECK-SAME: %[[SIZE_A:.+]]: index, %[[SIZE_B:.+]]: index
+func @packDynamic(%allocator: !hal.allocator, %size_a: index, %size_b: index) ->
+    (index, index, index, index) {
+  %t:4 = hal.allocator.pack<%allocator : !hal.allocator> slices({
+    [0, 1] = %size_a,
+    [1, 2] = %size_b,
+    [2, 3] = %size_a,
+  }) : index
+
+  // TODO(#5405): make this math easier to read/track by adding an iree.align
+  // instead of expanding to the individual bit twiddling alignment ops.
+  // Right now this is too verbose to really test against with anything but
+  // a change detector like this.
+
+  // CHECK-DAG: %c0 = constant 0 : index
+  // CHECK-DAG: %c-16 = constant -16 : index
+  // CHECK-DAG: %c15 = constant 15 : index
+  // CHECK-DAG: %0 = addi %arg1, %c15 : index
+  // CHECK-DAG: %1 = and %0, %c-16 : index
+  // CHECK-DAG: %2 = addi %1, %c15 : index
+  // CHECK-DAG: %3 = and %2, %c-16 : index
+  // CHECK-DAG: %4 = addi %arg2, %c15 : index
+  // CHECK-DAG: %5 = and %4, %c-16 : index
+  // CHECK-DAG: %6 = addi %3, %5 : index
+  // CHECK-DAG: %7 = addi %6, %c15 : index
+  // CHECK-DAG: %8 = and %7, %c-16 : index
+  // CHECK-DAG: %9 = addi %8, %c15 : index
+  // CHECK-DAG: %10 = and %9, %c-16 : index
+
+  // CHECK-DAG: return %10, %c0, %3, %c0
+  return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
+}
+
+// -----
+
+// CHECK-LABEL: @packMixedStaticDynamic
+// CHECK-SAME: %[[ALLOCATOR:.+]]: !hal.allocator,
+// CHECK-SAME: %[[SIZE_A:.+]]: index, %[[SIZE_B:.+]]: index
+func @packMixedStaticDynamic(%allocator: !hal.allocator, %size_a: index, %size_b: index) ->
+    (index, index, index, index, index) {
+  %c100 = constant 100 : index
+  %c200 = constant 200 : index
+  %t:5 = hal.allocator.pack<%allocator : !hal.allocator> slices({
+    [0, 1] = %c100,
+    [1, 2] = %size_a,
+    [2, 3] = %size_b,
+    [5, 6] = %c200,
+  }) : index
+
+  // TODO(#5405): make this math easier to read/track by adding an iree.align
+  // instead of expanding to the individual bit twiddling alignment ops.
+  // Right now this is too verbose to really test against with anything but
+  // a change detector like this.
+
+  // CHECK-DAG: %c0 = constant 0 : index
+  // CHECK-DAG: %c208 = constant 208 : index
+  // CHECK-DAG: %c-16 = constant -16 : index
+  // CHECK-DAG: %c15 = constant 15 : index
+  // CHECK-DAG: %0 = addi %arg1, %c15 : index
+  // CHECK-DAG: %1 = and %0, %c-16 : index
+  // CHECK-DAG: %2 = addi %1, %c208 : index
+  // CHECK-DAG: %3 = addi %2, %c15 : index
+  // CHECK-DAG: %4 = and %3, %c-16 : index
+  // CHECK-DAG: %5 = addi %arg2, %c15 : index
+  // CHECK-DAG: %6 = and %5, %c-16 : index
+  // CHECK-DAG: %7 = addi %4, %6 : index
+  // CHECK-DAG: %8 = addi %7, %c15 : index
+  // CHECK-DAG: %9 = and %8, %c-16 : index
+  // CHECK-DAG: %10 = addi %9, %c15 : index
+  // CHECK-DAG: %11 = and %10, %c-16 : index
+
+  // CHECK-DAG: return %11, %c0, %c208, %4, %c0
+  return %t#0, %t#1, %t#2, %t#3, %t#4 : index, index, index, index, index
+}

--- a/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
+++ b/iree/compiler/Dialect/HAL/Utils/TypeUtils.cpp
@@ -33,6 +33,16 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
+Value align(Location loc, Value value, int64_t alignment, OpBuilder &builder) {
+  // (value + (alignment - 1)) & ~(alignment - 1)
+  return builder.createOrFold<AndOp>(
+      loc,
+      builder.createOrFold<AddIOp>(
+          loc, value,
+          builder.createOrFold<ConstantIndexOp>(loc, alignment - 1)),
+      builder.createOrFold<ConstantIndexOp>(loc, ~(alignment - 1)));
+}
+
 int32_t getRoundedElementByteWidth(Type type) {
   return (type.getIntOrFloatBitWidth() + 8 - 1) / 8;
 }

--- a/iree/compiler/Dialect/HAL/Utils/TypeUtils.h
+++ b/iree/compiler/Dialect/HAL/Utils/TypeUtils.h
@@ -34,6 +34,9 @@ static inline uint64_t align(uint64_t value, const APInt &alignment) {
   return align(value, alignment.getZExtValue());
 }
 
+// Aligns |value| to |alignment|, rounding up if needed.
+Value align(Location loc, Value value, int64_t alignment, OpBuilder &builder);
+
 // Returns the number of bytes an element of the given type occupies
 // post-conversion. For example, the size of i1 would be '1 byte'.
 int32_t getRoundedElementByteWidth(Type type);


### PR DESCRIPTION
Transient buffers used within a stream are now analyzed for liveness ranges and structured into a `hal.allocator.pack` op that computes offsets and a total length that minimizes the peak memory consumption of all of the buffers. This `hal.allocator.pack` op supports both static and dynamic sizes and is currently performing the same logic tflite is using as a baseline.

Though now all transients end up in the same storage buffer at runtime we are still binding each transient tensor uniquely to avoid non-zero binding offsets inside of executables. Future changes will combine bindings in the `-iree-hal-materialize-interfaces2` pass such that all transients share a single binding.

This was the lowest hanging fruit for allocation and dramatically drops the number of allocations we perform and our peak working set size. We are still allocating the transient storage per block entry (meaning per invocation in models without flow control or per loop in models that have flow control). It's still a 100-1000x faster process, though, and layering on the persistence of these is an incremental improvement.

BERT vulkan on pixel 4 went from ~930ms -> ~730ms and peak memory consumption went from 800MB to 25MB.
The gains on Windows (which does not do the same zero-page malloc trick that linux/android does) were more substantial:
![image](https://user-images.githubusercontent.com/75337/114596470-8bacd100-9c44-11eb-96d0-b19deafdc6ca.png)
