### PR TITLE
[NFC] Make HLOToHLOPreprocessing pass follow naming convention.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -805,8 +805,8 @@ class ReorderBroadcastInDimOpAndElementwiseOp
   }
 };
 
-struct HLOToHLOPreprocessing
-    : public PassWrapper<HLOToHLOPreprocessing, FunctionPass> {
+struct HLOToHLOPreprocessingPass
+    : public PassWrapper<HLOToHLOPreprocessingPass, FunctionPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<shape::ShapeDialect, mhlo::MhloDialect,
                     tensor::TensorDialect>();
@@ -899,11 +899,11 @@ struct HLOToHLOPreprocessing
 
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createHLOPreprocessingPass() {
-  return std::make_unique<HLOToHLOPreprocessing>();
+std::unique_ptr<OperationPass<FuncOp>> createHLOToHLOPreprocessingPass() {
+  return std::make_unique<HLOToHLOPreprocessingPass>();
 }
 
-static PassRegistration<HLOToHLOPreprocessing> legalize_pass(
+static PassRegistration<HLOToHLOPreprocessingPass> legalize_pass(
     "iree-flow-hlo-to-hlo-preprocessing",
     "Apply hlo to hlo transformations for some hlo ops");
 

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -65,9 +65,9 @@ namespace Flow {
 // here, but soon we'll be shifting away from that and only accepting upstream
 // dialects like linalg.
 static void buildHLOInputTransformPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(IREE::Flow::createHLOPreprocessingPass());
+  passManager.addNestedPass<FuncOp>(IREE::Flow::createHLOToHLOPreprocessingPass());
   if (clEnableLinalgOnTensorsDispatch) {
-    // TODO(ataei): This should run as part of createHLOPreprocessingPass which
+    // TODO(ataei): This should run as part of createHLOToHLOPreprocessingPass which
     // will break VMLA backend.
     passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
   }

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -65,10 +65,11 @@ namespace Flow {
 // here, but soon we'll be shifting away from that and only accepting upstream
 // dialects like linalg.
 static void buildHLOInputTransformPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(IREE::Flow::createHLOToHLOPreprocessingPass());
+  passManager.addNestedPass<FuncOp>(
+      IREE::Flow::createHLOToHLOPreprocessingPass());
   if (clEnableLinalgOnTensorsDispatch) {
-    // TODO(ataei): This should run as part of createHLOToHLOPreprocessingPass which
-    // will break VMLA backend.
+    // TODO(ataei): This should run as part of createHLOToHLOPreprocessingPass
+    // which will break VMLA backend.
     passManager.addNestedPass<FuncOp>(createDecomposeHLOClampPass());
   }
 

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -74,7 +74,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createLegalizeInputTypesPass();
 /// Creates XLA-HLO preprocessing transformation pass. In this pass we should
 /// have all mhlo -> mhlo transformations that are shared between all
 /// backends.
-std::unique_ptr<OperationPass<FuncOp>> createHLOPreprocessingPass();
+std::unique_ptr<OperationPass<FuncOp>> createHLOToHLOPreprocessingPass();
 
 // Runs pre-partitioning conversion passes to convert to the flow dialect.
 // This converts some input ops directly to flow ops when doing so has a
@@ -167,7 +167,7 @@ inline void registerFlowPasses() {
   registerFlowTransformPassPipeline();
   createConvertToFlowTensorOpsPass();
   createLegalizeInputTypesPass();
-  createHLOPreprocessingPass();
+  createHLOToHLOPreprocessingPass();
   createPrePartitioningConversionPass();
   createExpandVariableDynamicDimsPass();
   createDispatchabilityAnalysisPass();


### PR DESCRIPTION
The class name of the pass should end with `Pass`, and `createXXXPass`
should match the filename.