### PR TITLE
Limit fusion of linalg.generic/indexed_generic ops to avoid redundant computation

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -92,7 +92,8 @@ struct FusionOfTensorOpsPass
         [](const OpResult &producer, const OpOperand & /*consumer*/) {
           llvm::SmallDenseSet<Operation *, 4> numUsers;
           for (Operation *user : producer.getUsers()) {
-            if (isa<linalg::GenericOp, linalg::IndexedGenericOp>(user)) continue;
+            if (isa<linalg::GenericOp, linalg::IndexedGenericOp>(user))
+              continue;
             numUsers.insert(user);
           }
           return numUsers.empty();

--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -85,10 +85,24 @@ struct FusionOfTensorOpsPass
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        frozenInterfacePatterns);
 
-    linalg::populateElementwiseOpsFusionPatterns(fusionPatterns,
-                                                 linalg::LinalgElementwiseFusionOptions()
-                                                 .setAllowFoldingUnitDimReshapes(true));
-    
+    // Only fuse operations where all uses of the producer are generic or
+    // indexed generic operations. If an operation is used in a named op, it
+    // will be computed anyway, so the consumers can just use that value.
+    linalg::ControlElementwiseOpsFusionFn controlFn =
+        [](const OpResult &producer, const OpOperand & /*consumer*/) {
+          llvm::SmallDenseSet<Operation *, 4> numUsers;
+          for (Operation *user : producer.getUsers()) {
+            if (isa<linalg::GenericOp, linalg::IndexedGenericOp>(user)) continue;
+            numUsers.insert(user);
+          }
+          return numUsers.empty();
+        };
+
+    linalg::populateElementwiseOpsFusionPatterns(
+        fusionPatterns, linalg::LinalgElementwiseFusionOptions()
+                            .setAllowFoldingUnitDimReshapes(true)
+                            .setControlElementwiseOpsFusionFn(controlFn));
+
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        std::move(fusionPatterns));
 


### PR DESCRIPTION
The upstream fusion pass is greedy. It will fuse two operations based
only on whether they can be fused or not. This means there are cases
where operations are fused even if the original producer has other
uses that make the original producer non-dead. The side-effect is that
you end up with cases where the same computation is done many times
using multiple generic/indexed_generic operation.
It also has the side-effect of
1) Increasing the number of arguments to the dispatch region.
2) Increasing life-times of tensors.
3) Make dispatch regions non-dedupable.

Also add pass-statistics to `DispatchLinalgOnTensors` to get the number of dispatch regions created.