### PR TITLE
Adding an error message to iree.unreachable.

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
@@ -200,7 +200,9 @@ static void buildConditionDispatchTable(IREE::HAL::DeviceSwitchOp switchOp,
       // condition will add its IR to the block.
     } else {
       // Fallthrough of all expressions; die if we expected return values.
-      funcBuilder.create<IREE::UnreachableOp>(switchOp.getLoc());
+      funcBuilder.create<IREE::UnreachableOp>(
+          switchOp.getLoc(),
+          "device not supported in the compiled configuration");
     }
   }
 

--- a/iree/compiler/Dialect/IREE/IR/IREEOps.td
+++ b/iree/compiler/Dialect/IREE/IR/IREEOps.td
@@ -167,14 +167,16 @@ def IREE_UnreachableOp : IREE_Op<"unreachable", [NoSideEffect, Terminator]> {
       cond_br %true, ^bb2, ^bb1
     ^bb1:
       // Indicates that this branch should never be taken.
-      iree.unreachable
+      iree.unreachable "shouldn't be here"
     ^bb2:
       ...
 
     ```
   }];
 
-  let assemblyFormat = "attr-dict";
+  let arguments = (ins StrAttr:$message);
+
+  let assemblyFormat = "$message attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/ConvertIREEToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/ConvertIREEToVM.cpp
@@ -78,7 +78,7 @@ class UnreachableOpConversion
         rewriter.createOrFold<mlir::ConstantIntOp>(
             srcOp.getLoc(), static_cast<int32_t>(IREE::StatusCode::Unknown),
             32),
-        "unreachable location reached");
+        srcOp.message());
     return success();
   }
 };

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/hint_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/hint_ops.mlir
@@ -6,8 +6,8 @@ module {
   // CHECK: vm.func @my_fn
   func @my_fn() {
     // CHECK-NEXT: %[[CODE:.+]] = vm.const.i32 2
-    // CHECK-NEXT: vm.fail %[[CODE]], "unreachable location reached"
-    iree.unreachable
+    // CHECK-NEXT: vm.fail %[[CODE]], "nope!"
+    iree.unreachable "nope!"
   }
 }
 }


### PR DESCRIPTION
Much more useful message at runtime when running with a mismatched
compilation target and runtime support.