### PR TITLE
[spirv] Move vector.transfer_read scalarization earlier

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/ConvertToSPIRVPass.cpp
@@ -211,22 +211,6 @@ struct FoldAsNoOp final : public OpConversionPattern<OpTy> {
   }
 };
 
-/// Translates vector.transfer_read with less than 4 scalars into reading each
-/// scalar and then compose the vector.
-///
-/// This is a very specific pattern for handling corner cases and boundary
-/// cases. For example, in vision models we can have the initial image with
-/// three channels. We cannot perform the native load4 there; by performing
-/// scalar read we lose some benefits of load4 but we can still make sure the
-/// overall vectorization does not fail.
-struct ScalarizeVectorTransferRead final
-    : public OpConversionPattern<vector::TransferReadOp> {
-  using OpConversionPattern::OpConversionPattern;
-  LogicalResult matchAndRewrite(
-      vector::TransferReadOp readOp, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override;
-};
-
 /// Base class for lowering to SPIR-V cooperative matrix ops.
 template <typename SourceOp>
 class CoopMatOpLowering : public OpConversionPattern<SourceOp> {
@@ -427,32 +411,6 @@ LogicalResult HALInterfaceLoadConstantConverter::matchAndRewrite(
   return success();
 }
 
-LogicalResult ScalarizeVectorTransferRead::matchAndRewrite(
-    vector::TransferReadOp readOp, ArrayRef<Value> operands,
-    ConversionPatternRewriter &rewriter) const {
-  VectorType vectorType = readOp.getType();
-  Type scalarType = vectorType.getElementType();
-  if (vectorType.getRank() != 1 || vectorType.getDimSize(0) >= 4)
-    return failure();
-
-  Location loc = readOp.getLoc();
-  vector::TransferReadOp::Adaptor adaptor(operands,
-                                          readOp->getAttrDictionary());
-
-  SmallVector<Value, 4> scalars;
-  SmallVector<Value, 4> indices(adaptor.indices().begin(),
-                                adaptor.indices().end());
-  for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-    indices.back() = rewriter.createOrFold<ConstantIndexOp>(loc, i);
-    scalars.push_back(rewriter.create<memref::LoadOp>(
-        loc, scalarType, readOp.source(), indices));
-  }
-
-  rewriter.replaceOpWithNewOp<spirv::CompositeConstructOp>(readOp, vectorType,
-                                                           scalars);
-  return success();
-}
-
 static void populateVectorToSPIRVPatterns(
     MLIRContext *context, SPIRVTypeConverter &converter,
     OwningRewritePatternList &patterns,
@@ -508,8 +466,8 @@ void ConvertToSPIRVPass::runOnOperation() {
       HALInterfaceWorkgroupIdAndCountConverter<
           IREE::HAL::InterfaceWorkgroupIDOp, spirv::BuiltIn::WorkgroupId>,
       HALInterfaceWorkgroupIdAndCountConverter<
-          IREE::HAL::InterfaceWorkgroupCountOp, spirv::BuiltIn::NumWorkgroups>,
-      ScalarizeVectorTransferRead>(typeConverter, context);
+          IREE::HAL::InterfaceWorkgroupCountOp, spirv::BuiltIn::NumWorkgroups>>(
+      typeConverter, context);
   auto aliasedResources = getAliasedResources(moduleOp);
   patterns.insert<InterfaceOpConverter<IREE::PlaceholderOp>,
                   InterfaceOpConverter<IREE::HAL::InterfaceBindingSubspanOp>>(

--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemref.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemref.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 constexpr int kMaxVectorizationSizeInBits = 128;
 constexpr int kMaxVectorNumElements = 4;
@@ -397,6 +398,50 @@ class ProcessInterfaceBinding final
   }
 };
 
+/// Translates vector.transfer_read with less than 4 scalars into reading each
+/// scalar and then compose the vector.
+///
+/// This is a very specific pattern for handling corner cases and boundary
+/// cases. For example, in vision models we can have the initial image with
+/// three channels. We cannot perform the native load4 there; by performing
+/// scalar read we lose some benefits of load4 but we can still make sure the
+/// overall vectorization does not fail.
+struct ScalarizeVectorTransferRead final
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    VectorType vectorType = readOp.getType();
+    Type scalarType = vectorType.getElementType();
+    if (vectorType.getRank() != 1 || vectorType.getDimSize(0) >= 4)
+      return failure();
+
+    Location loc = readOp.getLoc();
+
+    SmallVector<Value, 4> scalars;
+    SmallVector<Value, 4> indices(readOp.indices().begin(),
+                                  readOp.indices().end());
+    for (int i = 0; i < vectorType.getDimSize(0); ++i) {
+      indices.back() = rewriter.createOrFold<ConstantIndexOp>(loc, i);
+      scalars.push_back(rewriter.create<memref::LoadOp>(
+          loc, scalarType, readOp.source(), indices));
+    }
+
+    Value newVector = rewriter.create<ConstantOp>(
+        loc, vectorType, rewriter.getZeroAttr(vectorType));
+    for (int i = 0; i < vectorType.getDimSize(0); ++i) {
+      Value index = rewriter.createOrFold<ConstantOp>(
+          loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(i));
+      newVector = rewriter.create<vector::InsertElementOp>(loc, scalars[i],
+                                                           newVector, index);
+    }
+
+    rewriter.replaceOp(readOp, newVector);
+
+    return success();
+  }
+};
+
 class VectorizeMemRefPass final
     : public PassWrapper<VectorizeMemRefPass, OperationPass<ModuleOp>> {
   void runOnOperation() override;
@@ -442,10 +487,11 @@ void VectorizeMemRefPass::runOnOperation() {
 
   memrefUsageAnalysis = &getAnalysis<MemRefUsageAnalysis>();
 
-  OwningRewritePatternList patterns(&getContext());
-  patterns.insert<ProcessFuncArg, ProcessTransferRead, ProcessTransferWrite,
-                  ProcessAlloc, ProcessPlaceHolder, ProcessInterfaceBinding>(
-      context, *memrefUsageAnalysis);
+  RewritePatternSet conversionPatterns(context);
+  conversionPatterns
+      .add<ProcessFuncArg, ProcessTransferRead, ProcessTransferWrite,
+           ProcessAlloc, ProcessPlaceHolder, ProcessInterfaceBinding>(
+          context, *memrefUsageAnalysis);
 
   ConversionTarget target(*context);
   target.addDynamicallyLegalOp<FuncOp>([&](FuncOp op) {
@@ -469,8 +515,16 @@ void VectorizeMemRefPass::runOnOperation() {
       return !memrefUsageAnalysis->transferConvert(op);
     return true;
   });
-  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+  if (failed(applyPartialConversion(module, target,
+                                    std::move(conversionPatterns))))
     return signalPassFailure();
+
+  for (FuncOp func : module.getOps<FuncOp>()) {
+    RewritePatternSet rewritingPatterns(context);
+    rewritingPatterns.add<ScalarizeVectorTransferRead>(context);
+
+    (void)applyPatternsAndFoldGreedily(func, std::move(rewritingPatterns));
+  }
 }
 
 std::unique_ptr<OperationPass<ModuleOp>> createVectorizeMemref() {


### PR DESCRIPTION
This pattern was originally placed in ConvertToSPIRVPass, where
we generate mixed MemRef and SPIR-V ops. Moving it earlier to
after MemRef vectorization and let it generate pure vector ops.
This is a better layering.

This addresses the failure [here](https://buildkite.com/iree/iree-android-benchmark/builds/2281#86930fce-a0f0-4fc7-8e74-e85e028345c8).