### PR TITLE
Disable tile+distribute for elementwise operations due to regressions on CPU

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -115,7 +115,8 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
           compilation_flags=[
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10",
               "-iree-flow-inline-constants-max-byte-length=2048",
-              "-iree-flow-dispatch-formation-enable-operand-fusion"
+              "-iree-flow-dispatch-formation-enable-operand-fusion",
+              "-iree-flow-tile-and-distribute-elementwise-ops"
           ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]
@@ -147,7 +148,8 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
               # TODO(GH-5330): Revisit the number or delete the flag.
               "-iree-flow-inline-constants-max-byte-length=16",
-              "-iree-flow-dispatch-formation-enable-operand-fusion"
+              "-iree-flow-dispatch-formation-enable-operand-fusion",
+              "-iree-flow-tile-and-distribute-elementwise-ops",
           ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -950,7 +950,7 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
 /// heuristic is used below, but the mechanism should be general enough to
 /// capture any heuristic.
 
-/// Method to set elementwise operations as root operations.
+/// Sets elementwise operations as root operations.
 // TODO(#5045): After the regression issue on CPU side is addressed, this can be
 // folded into the main logic of fusion.
 template <typename GenericOpTy>

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -43,15 +43,27 @@
 
 #define DEBUG_TYPE "iree-flow-dispatch-linalg-on-tensors"
 
+// TODO(ravishankarm): Prune this list. These flags should go away ASAP!!
+
 static llvm::cl::list<int64_t> clLinalgOnTensorsTileSizes(
     "iree-flow-dispatch-linalg-on-tensors-tile-sizes",
     llvm::cl::desc("Comma-separated list of tile sizes for tiling on tensors"),
     llvm::cl::CommaSeparated);
 
+// TODO(#5040): This works for the most part but the downstream bufferization
+// needs to be sorted out before this can be made the default. Remove after
+// making this default.
 static llvm::cl::opt<bool> clEnableOperandFusion(
     "iree-flow-dispatch-formation-enable-operand-fusion",
     llvm::cl::desc(
         "Enable fusing operand producers during dispatch region formation"),
+    llvm::cl::init(false));
+
+// TODO(#5045): Tile and distribute on CPU causes performance regressions. This
+// needs to be addressed before this can be turned on by default.
+static llvm::cl::opt<bool> clTileAndDistributeElementwiseOps(
+    "iree-flow-tile-and-distribute-elementwise-ops",
+    llvm::cl::desc("Enable tile and distribute on elementwise operations"),
     llvm::cl::init(false));
 
 static const char kRootOpAttr[] = "__root_op__";
@@ -167,7 +179,7 @@ static SmallVector<int64_t, 1> getFusionGroups(Operation *op) {
 }
 
 /// Appends the given `op` to the `newGroups` fusion groups.
-static void appendFusionGroups(Operation *op, ArrayRef<int64_t> newGroups) {
+static void appendToFusionGroup(Operation *op, ArrayRef<int64_t> newGroups) {
   SmallVector<int64_t, 1> fusionGroups = getFusionGroups(op);
   fusionGroups.append(newGroups.begin(), newGroups.end());
   op->setAttr(kFusionGroupsAttr, Builder(op).getI64ArrayAttr(fusionGroups));
@@ -221,12 +233,6 @@ static bool isRootOp(Operation *op) {
         contractionOp.isRowMajorBatchMatmul()) {
       return true;
     }
-  }
-
-  if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
-    return llvm::all_of(genericOp.getIndexingMaps(), [](AffineMap map) {
-      return map.isProjectedPermutation();
-    });
   }
 
   return isa<linalg::ConvInputNHWCFilterHWCFOp,
@@ -808,17 +814,28 @@ struct TileAndDistributeOnTensorsPattern
 
 /// The workload is computed based on the problem size. For a given operation,
 /// return the problem size.
-static Optional<SmallVector<Value, 4>> getResultShape(PatternRewriter &rewriter,
-                                                      Operation *op) {
+static Optional<SmallVector<Value>> getResultShape(PatternRewriter &rewriter,
+                                                   Operation *op) {
   Location loc = op->getLoc();
-  auto getShapeOfShapedTypeVal = [&](Value v) -> SmallVector<Value, 4> {
-    return llvm::to_vector<4>(llvm::map_range(
-        llvm::seq<int64_t>(0, v.getType().cast<ShapedType>().getRank()),
-        [&](int64_t dim) -> Value {
-          return rewriter.create<memref::DimOp>(loc, v, dim);
-        }));
+  auto getShapeOfShapedTypeVal = [&](Value v) -> SmallVector<Value> {
+    SmallVector<Value> shape;
+    for (auto dim :
+         llvm::seq<int64_t>(0, v.getType().cast<ShapedType>().getRank())) {
+      shape.push_back(rewriter.createOrFold<memref::DimOp>(loc, v, dim));
+    }
+    return shape;
   };
   if (op->getNumResults() != 1) return llvm::None;
+
+  // Check if the op implements the shape interface.
+  if (auto shapedOp = dyn_cast<InferShapedTypeOpInterface>(op)) {
+    SmallVector<SmallVector<Value>> resultShape;
+    if (succeeded(shapedOp.reifyReturnTypeShapesPerResultDim(rewriter,
+                                                             resultShape)) &&
+        resultShape.size() == 1) {
+      return resultShape[0];
+    }
+  }
 
   // TODO(ravishankarm): Since the workload depends on the output shape, set the
   // insertion point to after the operation. After dim canonicalization, the
@@ -858,10 +875,9 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
 
     // The workgroup count is based on the result shape.
     if (op->getNumResults() != 1) return failure();
-    Optional<SmallVector<Value, 4>> resultShapeOpt =
-        getResultShape(rewriter, op);
+    Optional<SmallVector<Value>> resultShapeOpt = getResultShape(rewriter, op);
     if (!resultShapeOpt) return failure();
-    SmallVector<Value, 4> resultShape = *resultShapeOpt;
+    SmallVector<Value> resultShape = *resultShapeOpt;
 
     // TODO(ravishankarm): For now the Flow -> HAL conversion only handles
     // workload count of 3, though it should be generalized. For now making sure
@@ -869,7 +885,7 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
     // workloads for all higher dimensions greater than or equal to
     // kNumMaxParallelDims.
     Location loc = op->getLoc();
-    SmallVector<Value, 4> count = resultShape;
+    SmallVector<Value, 4> count(resultShape.begin(), resultShape.end());
     if (count.size() > kNumMaxParallelDims) {
       unsigned numSymbols = 0;
       AffineExpr expr = rewriter.getAffineSymbolExpr(numSymbols++);
@@ -934,45 +950,45 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
 /// heuristic is used below, but the mechanism should be general enough to
 /// capture any heuristic.
 
-/// Checks if the `producer` can be fused into the dispatch region of the
-/// `consumer`.
-static bool isProducerFusable(linalg::LinalgOp producer,
-                              linalg::LinalgOp consumer,
-                              OpOperand &consumerOperand) {
-  if (consumer.isInputTensor(&consumerOperand)) {
-    if (!clEnableOperandFusion) return false;
+/// Method to set elementwise operations as root operations.
+// TODO(#5045): After the regression issue on CPU side is addressed, this can be
+// folded into the main logic of fusion.
+template <typename GenericOpTy>
+static unsigned makeElementwiseOpsRootOps(FuncOp funcOp, unsigned numRoots) {
+  MLIRContext *context = funcOp.getContext();
+  OpBuilder builder(context);
+  for (Block &block : funcOp) {
+    auto linalgOps = block.getOps<linalg::LinalgOp>();
+    for (linalg::LinalgOp linalgOp : llvm::reverse(linalgOps)) {
+      Operation *op = linalgOp.getOperation();
+      if (op->getAttrOfType<IntegerAttr>(kRootOpAttr) ||
+          op->getAttrOfType<ArrayAttr>(kFusionGroupsAttr))
+        continue;
+      if (!isa<GenericOpTy>(op) ||
+          !llvm::all_of(
+              cast<linalg::LinalgOp>(op).getIndexingMaps(),
+              [](AffineMap map) { return map.isProjectedPermutation(); })) {
+        continue;
+      }
+      unsigned newGroup = numRoots++;
+      op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(newGroup));
 
-    // Make sure that we have an identity indexing map for the operand for now.
-    //
-    // Theoretically with tensor abstraction, we can pull in whatever operand
-    // subrange for fusion. But if the consumer's access patterns for the input
-    // and output are not the same, we must materialize buffers for holding the
-    // temporary result, because we can have multiple levels of distribution.
-    // Identity map makes sure that we can actually avoid a new intermediate
-    // buffer and directly use the one for the consumer.
-    auto map = consumer.getIndexingMap(consumerOperand.getOperandNumber());
-    if (!map.isIdentity()) return false;
-
-    // If the producer's result is used by the consumer as an input, fuse if
-    // this producer has no other users.
-    return consumerOperand.get().hasOneUse();
-  } else {
-    // If the producer's result is used by the consumer as an output
-    // initializer, fuse if the producer is an elementwise parallel operation.
-    auto isElementWiseParallelOp = [](linalg::LinalgOp op) {
-      return llvm::all_of(op.iterator_types(), [](Attribute attr) {
-        return linalg::isParallelIteratorType(attr);
-      });
-    };
-    return isElementWiseParallelOp(producer);
+      for (OpOperand *operand : linalgOp.getOutputTensorsOpOperands()) {
+        auto producer = operand->get().getDefiningOp<linalg::LinalgOp>();
+        if (!producer) continue;
+        if (producer.getNumLoops() != producer.getNumParallelLoops()) continue;
+        appendToFusionGroup(producer, newGroup);
+      }
+    }
   }
+  return numRoots;
 }
 
 /// For a given block partition the LinalgOps in the block into fusable
 /// groups. All analysis of what to fuse happens here. For now this is just
 /// hard-wiring from basic heuristic but this could be adapted to have 1) better
 /// heuristics and 2) use a search approach to decide what all should be fused.
-static void decideFusableLinalgOps(FuncOp funcOp) {
+static unsigned decideFusableLinalgOps(FuncOp funcOp) {
   unsigned numRootOps = 0;
   MLIRContext *context = funcOp.getContext();
   OpBuilder builder(context);
@@ -986,42 +1002,53 @@ static void decideFusableLinalgOps(FuncOp funcOp) {
       // Start with a root operation and fuse its producers.
       Operation *op = linalgOp.getOperation();
       if (!isRootOp(op)) continue;
-
-      // This might be a root op that is already fused into another root op.
-      // In that case, it has fusion groups attached on it.
-      SmallVector<int64_t, 1> fusionGroups = getFusionGroups(op);
-      if (fusionGroups.empty()) {
-        // Otherwise, create a new group.
-        unsigned newGroup = numRootOps++;
-        fusionGroups.push_back(newGroup);
-        op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(newGroup));
-      }
-
-      for (OpOperand *operand : linalgOp.getInputTensorsOpOperands()) {
-        auto producer = operand->get().getDefiningOp<linalg::LinalgOp>();
-        if (!producer) continue;
-        Operation *producerOp = producer.getOperation();
-        if (!isProducerFusable(producer, op, *operand)) continue;
-
-        appendFusionGroups(producerOp, fusionGroups);
-
-        // For input operands, only allow fusing the first one for now. This
-        // avoids pulling in two many operations in the same region. Multiple
-        // inputs also means it's less likely to elide all the intermediate
-        // buffers.
-        break;
-      }
+      unsigned newGroup = numRootOps++;
+      op->setAttr(kRootOpAttr, builder.getI64IntegerAttr(newGroup));
 
       for (OpOperand *operand : linalgOp.getOutputTensorsOpOperands()) {
         auto producer = operand->get().getDefiningOp<linalg::LinalgOp>();
         if (!producer) continue;
-        Operation *producerOp = producer.getOperation();
-        if (!isProducerFusable(producer, op, *operand)) continue;
+        if (producer.getNumLoops() != producer.getNumParallelLoops()) continue;
+        appendToFusionGroup(producer, newGroup);
+      }
+    }
 
-        appendFusionGroups(producerOp, fusionGroups);
+    if (clEnableOperandFusion) {
+      // To fuse root operations with their consumers, for all root ops chosen.
+      // If, 1) The root op has a single use 2) The consumer is an elementwise
+      // operation 3) The indexing map in the producer and consumer are identity
+      // maps The root operation can be fused with its consumer. To do this,
+      // mark the consumer as the root and add the operation to the fusion
+      // group.
+      for (linalg::LinalgOp linalgOp : linalgOps) {
+        Operation *op = linalgOp.getOperation();
+        IntegerAttr rootOpAttr = op->getAttrOfType<IntegerAttr>(kRootOpAttr);
+        if (!rootOpAttr) continue;
+        if (op->getNumResults() != 1 || !op->hasOneUse()) continue;
+        OpOperand &use = *op->use_begin();
+        Operation *user = use.getOwner();
+        if (user->getAttrOfType<IntegerAttr>(kRootOpAttr) ||
+            user->getAttrOfType<IntegerAttr>(kFusionGroupsAttr))
+          continue;
+        linalg::LinalgOp consumer = dyn_cast<linalg::LinalgOp>(use.getOwner());
+        if (!consumer ||
+            consumer.getNumLoops() != consumer.getNumParallelLoops())
+          continue;
+        AffineMap consumerIndexingMap =
+            consumer.getInputIndexingMap(use.getOperandNumber());
+        AffineMap producerIndexingMap = linalgOp.getOutputIndexingMap(0);
+        if (!consumerIndexingMap.isIdentity() ||
+            producerIndexingMap.getResults() !=
+                consumerIndexingMap.getResults()) {
+          continue;
+        }
+        user->setAttr(kRootOpAttr, rootOpAttr);
+        op->removeAttr(kRootOpAttr);
+        appendToFusionGroup(op, rootOpAttr.getInt());
       }
     }
   }
+  return numRootOps;
 }
 
 void DispatchLinalgOnTensorsPass::runOnOperation() {
@@ -1032,7 +1059,10 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   MLIRContext *context = funcOp->getContext();
   context->allowUnregisteredDialects(true);
 
-  decideFusableLinalgOps(funcOp);
+  unsigned numRoots = decideFusableLinalgOps(funcOp);
+  if (clTileAndDistributeElementwiseOps) {
+    makeElementwiseOpsRootOps<linalg::GenericOp>(funcOp, numRoots);
+  }
 
   DEBUG_WITH_TYPE(DEBUG_TYPE, {
     llvm::dbgs() << "\n--- After annotating linalg op fusion scheme ---\n";
@@ -1112,6 +1142,18 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     patterns.insert<linalg::AffineMinSCFCanonicalizationPattern>(context);
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
+
+  // If elementwise operations are not tiled and distributed, the wont be marked
+  // as root ops previously. Mark them so here to allow fusion of `fill` etc.
+  numRoots = makeElementwiseOpsRootOps<linalg::GenericOp>(funcOp, numRoots);
+  makeElementwiseOpsRootOps<linalg::IndexedGenericOp>(funcOp, numRoots);
+
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
+    llvm::dbgs()
+        << "\n--- After annotating linalg op fusion scheme for fallback ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
 
   // After outlining in dispatch region we can rewrite the dispatch ops with
   // proper captures.

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "convert_to_flow_tensor_ops.mlir",
             "deduplicate_executables.mlir",
             "dispatch_linalg_on_tensors.mlir",
+            "dispatch_linalg_on_tensors_elementwise.mlir",
             "dispatch_linalg_on_tensors_fusion.mlir",
             "expand_variable_dynamic_dims.mlir",
             "export_benchmark_funcs.mlir",

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "convert_to_flow_tensor_ops.mlir"
     "deduplicate_executables.mlir"
     "dispatch_linalg_on_tensors.mlir"
+    "dispatch_linalg_on_tensors_elementwise.mlir"
     "dispatch_linalg_on_tensors_fusion.mlir"
     "expand_variable_dynamic_dims.mlir"
     "export_benchmark_funcs.mlir"

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -64,7 +64,6 @@ func @tile_generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x
     } -> tensor<?x?xf32>
   return %1 : tensor<?x?xf32>
 }
-// CHECK: #[[MULMAP:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //      CHECK: func @tile_generic_op_alone
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?xf32>
@@ -79,27 +78,13 @@ func @tile_generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x
 // CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>
-//  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
-//  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
-//  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
-//  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
-//  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
-//  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
-//      CHECK:     %[[OFFSET_Y:.+]] = affine.apply #[[MULMAP]]()[%[[WGID_Y]], %[[WGSIZE_Y]]]
-//      CHECK:     %[[STEP_Y:.+]] = affine.apply #[[MULMAP]]()[%[[WGCOUNT_Y]], %[[WGSIZE_Y]]]
-//      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
-// CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
-//      CHECK:       %[[OFFSET_X:.+]] = affine.apply #[[MULMAP]]()[%[[WGID_X]], %[[WGSIZE_X]]]
-//      CHECK:       %[[STEP_X:.+]] = affine.apply #[[MULMAP]]()[%[[WGCOUNT_X]], %[[WGSIZE_X]]]
-//      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
-// CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
-//  CHECK-DAG:         %[[LOAD2:.+]] = flow.dispatch.tensor.load %[[ARG2]], {{.*}}
-//  CHECK-DAG:         %[[INIT:.+]] = linalg.init_tensor
-//  CHECK-DAG:         %[[LOAD3:.+]] = flow.dispatch.tensor.load %[[ARG3]], {{.*}}
-//      CHECK:         %[[RESULT:.+]] = linalg.generic
-// CHECK-SAME:           ins(%[[LOAD2]], %[[LOAD3]] : tensor<?x?xf32>, tensor<?xf32>)
-// CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
-//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %[[ARG6]], {{.*}}
+//  CHECK-DAG:     %[[LOAD2:.+]] = flow.dispatch.tensor.load %[[ARG2]], {{.*}}
+//  CHECK-DAG:     %[[LOAD3:.+]] = flow.dispatch.tensor.load %[[ARG3]], {{.*}}
+//  CHECK-DAG:     %[[INIT:.+]] = linalg.init_tensor
+//      CHECK:     %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:         ins(%[[LOAD2]], %[[LOAD3]] : tensor<?x?xf32>, tensor<?xf32>)
+// CHECK-SAME:         outs(%[[INIT]] : tensor<?x?xf32>)
+//      CHECK:     flow.dispatch.tensor.store %[[RESULT]], %[[ARG6]], {{.*}}
 
 // -----
 
@@ -184,12 +169,12 @@ func @keep_separate_dispatches_for_producer(%A : tensor<?x?xf32>, %B : tensor<?x
 //  CHECK-SAME:        %[[ARG4:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:        %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>) {
 //       CHECK:          %[[ONE:.+]] = constant 1.0
-//   CHECK-DAG:          %[[INPUT:.+]] = flow.dispatch.tensor.load %[[ARG2]], {{.*}}
+//   CHECK-DAG:          %[[INPUT:.+]] = flow.dispatch.tensor.load %[[ARG2]]
 //   CHECK-DAG:          %[[INIT:.+]] = linalg.init_tensor
 //       CHECK:          %[[RESULT:.+]] = linalg.generic
 //  CHECK-SAME:            ins(%[[INPUT]] : tensor<?x?xf32>)
 //  CHECK-SAME:            outs(%[[INIT]] : tensor<?x?xf32>)
-//       CHECK:          flow.dispatch.tensor.store %[[RESULT]], %[[ARG5]], {{,*}}
+//       CHECK:          flow.dispatch.tensor.store %[[RESULT]], %[[ARG5]]
 //       CHECK:          flow.return
 //       CHECK:     }
 //       CHECK:     flow.dispatch.workgroups[%[[N]], %[[M]], %[[C1]]]
@@ -286,7 +271,8 @@ func @tile_4d_generic_op_alone
 //  CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = memref.dim %[[ARG0]], %[[C2]]
 //  CHECK-DAG:   %[[D3:.+]] = memref.dim %[[ARG0]], %[[C3]]
-//      CHECK:   flow.dispatch.workgroups[%[[D3]], %[[D2]], %[[D1]]]
+//      CHECK:   %[[D4:.+]] = affine.apply #[[MAP0]]()[%[[D0]], %[[D1]]]
+//      CHECK:   flow.dispatch.workgroups[%[[D3]], %[[D2]], %[[D4]]]
 
 // -----
 
@@ -524,44 +510,6 @@ func @subtensor_insert(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x225x225x3xf32
 
 // -----
 
-func @tile_parallel_reduction(%arg0: tensor<7x7x1280xf32>) -> tensor<1280xf32> {
-  %cst = constant 0.000000e+00 : f32
-  %0 = linalg.init_tensor [1280] : tensor<1280xf32>
-  %1 = linalg.fill(%0, %cst) : tensor<1280xf32>, f32 -> tensor<1280xf32>
-  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%arg0 : tensor<7x7x1280xf32>) outs(%1 : tensor<1280xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32):
-    %3 = addf %arg1, %arg2 : f32
-    linalg.yield %3 : f32
-  } -> tensor<1280xf32>
-  return %2 : tensor<1280xf32>
-}
-
-//  CHECK-DAG: #[[SIZE_MAP0:.+]] = affine_map<(d0, d1) -> (d1, -d0 + 1280)>
-//  CHECK-DAG: #[[SIZE_MAP1:.+]] = affine_map<(d0, d1) -> (-d0 + 1280, d1)>
-
-//      CHECK: func @tile_parallel_reduction
-// CHECK-SAME: (%[[INPUT:.+]]: tensor<7x7x1280xf32>)
-
-//  CHECK-DAG: %[[C1:.+]] = constant 1 : index
-//  CHECK-DAG: %[[C1280:.+]] = constant 1280 : index
-//      CHECK: %[[REDUCE:.+]] = flow.dispatch.workgroups[%[[C1280]], %[[C1]], %[[C1]]](%[[INPUT]]) : (tensor<7x7x1280xf32>) -> tensor<1280xf32> =
-// CHECK-NEXT:     (%[[ARG1:.+]]: !flow.dispatch.tensor<readonly:7x7x1280xf32>, %[[ARG2:.+]]: !flow.dispatch.tensor<writeonly:1280xf32>) {
-//      CHECK:   %[[WG_SIZE0:.+]] = flow.dispatch.workgroup.size[0] : index
-//      CHECK:   scf.for %[[IV:.+]] = %{{.+}} to %{{.+}} step %{{.+}}
-//      CHECK:     %[[SIZE0:.+]] = affine.min #[[SIZE_MAP0]](%[[IV]], %[[WG_SIZE0]])
-//      CHECK:     %[[IN:.+]] = flow.dispatch.tensor.load %[[ARG1]],
-// CHECK-SAME:       sizes = [7, 7, %[[SIZE0]]]
-//      CHECK:     %[[SIZE1:.+]] = affine.min #[[SIZE_MAP1]](%[[IV]], %[[WG_SIZE0]])
-//      CHECK:     %[[INIT:.+]] = linalg.init_tensor [%[[SIZE1]]] : tensor<?xf32>
-// CHECK-NEXT:     %[[OUT:.+]] = linalg.fill(%[[INIT]]
-//      CHECK:     %[[GENERIC:.+]] = linalg.generic
-// CHECK-SAME:       ins(%[[IN]] : tensor<7x7x?xf32>) outs(%[[OUT]] : tensor<?xf32>)
-//      CHECK:     flow.dispatch.tensor.store %[[GENERIC]], %[[ARG2]], {{.*}}
-
-//      CHECK: return %[[REDUCE]]
-
-// -----
-
 func @fuse_non_tiled_reduction_fill(%input1: tensor<1000xf32>, %input2: tensor<1000xf32>, %offset: tensor<f32>) -> tensor<f32> {
   %zero = constant 0.0 : f32
   %init = linalg.init_tensor [] : tensor<f32>
@@ -634,16 +582,16 @@ func @inline_dag_1(
 //   CHECK-NOT:   linalg.
 //   CHECK-NOT:   subtensor
 //       CHECK:   flow.dispatch.workgroups
-//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
-//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
-//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
 //  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
 //       CHECK:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG4]], {{.*}}
 //       CHECK:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG5]], {{.*}}
 //       CHECK:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG6]], {{.*}}
-//       CHECK:     %[[OP1:.+]] = linalg.tensor_reshape %[[LEAF2]]
-//       CHECK:     %[[OP2:.+]] = linalg.tensor_reshape %[[LEAF1]]
+//       CHECK:     %[[OP1:.+]] = linalg.tensor_reshape %[[LEAF3]]
+//       CHECK:     %[[OP2:.+]] = linalg.tensor_reshape %[[LEAF2]]
 //       CHECK:     %[[OP3:.+]] = subtensor %[[OP1]][0, 0]
 //       CHECK:     %[[OP4:.+]] = subtensor %[[OP1]][0, 10]
 //       CHECK:     %[[OP5:.+]] = subtensor %[[OP1]][0, 20]
@@ -692,17 +640,17 @@ func @inline_dag_2(
 //       CHECK:   subtensor %[[OP1]]
 //       CHECK:   linalg.tensor_reshape %[[ARG1]]
 //       CHECK:   flow.dispatch.workgroups
-//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
-//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
-//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
-//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-NEXT:     %[[ARG4:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:i32>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
+//  CHECK-SAME:     %[[ARG7:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:1x?xf32>
 //  CHECK-SAME:     %[[ARG8:[a-zA-Z0-9_]+]]: index
 //  CHECK-SAME:     %[[ARG9:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xf32>
-//       CHECK:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG4]], {{.*}}
+//       CHECK:     %[[LEAF1:.+]] = flow.dispatch.tensor.load %[[ARG5]], {{.*}}
 //       CHECK:     %[[LEAF2:.+]] = flow.dispatch.tensor.load %[[ARG6]], {{.*}}
 //       CHECK:     %[[LEAF3:.+]] = flow.dispatch.tensor.load %[[ARG7]], {{.*}}
-//       CHECK:     %[[OP1:.+]] = subtensor %[[LEAF2]][0, 0]
-//       CHECK:     %[[OP2:.+]] = subtensor %[[LEAF2]][0, 10]
+//       CHECK:     %[[OP1:.+]] = subtensor %[[LEAF3]][0, 0]
+//       CHECK:     %[[OP2:.+]] = subtensor %[[LEAF3]][0, 10]
 //       CHECK:     %[[OP3:.+]] = linalg.tensor_reshape %[[LEAF1]]
 //       CHECK:     %[[OP4:.+]] = linalg.tensor_reshape %[[OP1]]
 //       CHECK:     %[[OP5:.+]] = linalg.tensor_reshape %[[OP2]]

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_elementwise.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_elementwise.mlir
@@ -1,0 +1,142 @@
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -iree-flow-tile-and-distribute-elementwise-ops -canonicalize -cse %s | IreeFileCheck %s
+
+func @tile_generic_op_alone(%A: tensor<?x?xf32>, %B: tensor<?xf32>) -> tensor<?x?xf32> {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %d0 = memref.dim %A, %c0 : tensor<?x?xf32>
+  %d1 = memref.dim %A, %c1 : tensor<?x?xf32>
+  %0 = linalg.init_tensor [%d0, %d1] : tensor<?x?xf32>
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins (%A, %B: tensor<?x?xf32>, tensor<?xf32>)
+    outs (%0 : tensor<?x?xf32>) {
+      ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
+        %2 = addf %arg0, %arg1 : f32
+        linalg.yield %2 : f32
+    } -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK: #[[MULMAP:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+//      CHECK: func @tile_generic_op_alone
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG0]], %[[C1]]
+//      CHECK:   flow.dispatch.workgroups
+// CHECK-SAME:     [%[[D1]], %[[D0]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[D0]], %[[D1]])
+// CHECK-NEXT:     %[[ARG2:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?x?xf32>
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<readonly:?xf32>
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>
+//  CHECK-DAG:     %[[WGSIZE_X:.+]] = flow.dispatch.workgroup.size[0]
+//  CHECK-DAG:     %[[WGSIZE_Y:.+]] = flow.dispatch.workgroup.size[1]
+//  CHECK-DAG:     %[[WGID_X:.+]] = flow.dispatch.workgroup.id[0]
+//  CHECK-DAG:     %[[WGID_Y:.+]] = flow.dispatch.workgroup.id[1]
+//  CHECK-DAG:     %[[WGCOUNT_X:.+]] = flow.dispatch.workgroup.count[0]
+//  CHECK-DAG:     %[[WGCOUNT_Y:.+]] = flow.dispatch.workgroup.count[1]
+//      CHECK:     %[[OFFSET_Y:.+]] = affine.apply #[[MULMAP]]()[%[[WGID_Y]], %[[WGSIZE_Y]]]
+//      CHECK:     %[[STEP_Y:.+]] = affine.apply #[[MULMAP]]()[%[[WGCOUNT_Y]], %[[WGSIZE_Y]]]
+//      CHECK:     scf.for %[[ARG7:.+]] = %[[OFFSET_Y]]
+// CHECK-SAME:       to %{{.+}} step %[[STEP_Y]]
+//      CHECK:       %[[OFFSET_X:.+]] = affine.apply #[[MULMAP]]()[%[[WGID_X]], %[[WGSIZE_X]]]
+//      CHECK:       %[[STEP_X:.+]] = affine.apply #[[MULMAP]]()[%[[WGCOUNT_X]], %[[WGSIZE_X]]]
+//      CHECK:       scf.for %[[ARG8:.+]] = %[[OFFSET_X]]
+// CHECK-SAME:         to %{{.+}} step %[[STEP_X]]
+//  CHECK-DAG:         %[[LOAD2:.+]] = flow.dispatch.tensor.load %[[ARG2]], {{.*}}
+//  CHECK-DAG:         %[[INIT:.+]] = linalg.init_tensor
+//  CHECK-DAG:         %[[LOAD3:.+]] = flow.dispatch.tensor.load %[[ARG3]], {{.*}}
+//      CHECK:         %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:           ins(%[[LOAD2]], %[[LOAD3]] : tensor<?x?xf32>, tensor<?xf32>)
+// CHECK-SAME:           outs(%[[INIT]] : tensor<?x?xf32>)
+//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %[[ARG6]], {{.*}}
+
+// -----
+
+
+// -----
+
+func @tile_4d_generic_op_alone
+  (%A: tensor<?x?x?x?xf32>, %B: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c3 = constant 3 : index
+  %d0 = memref.dim %A, %c0 : tensor<?x?x?x?xf32>
+  %d1 = memref.dim %A, %c1 : tensor<?x?x?x?xf32>
+  %d2 = memref.dim %A, %c2 : tensor<?x?x?x?xf32>
+  %d3 = memref.dim %A, %c3 : tensor<?x?x?x?xf32>
+  %0 = linalg.init_tensor [%d0, %d1, %d2, %d3] : tensor<?x?x?x?xf32>
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins (%A, %B: tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+    outs (%0 : tensor<?x?x?x?xf32>) {
+      ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : f32):
+        %2 = addf %arg0, %arg1 : f32
+        linalg.yield %2 : f32
+    } -> tensor<?x?x?x?xf32>
+  return %1 : tensor<?x?x?x?xf32>
+}
+// For ops of rank greater than 3 we serialized the higher dimension. When flow
+// supports larger ranks this can be changed.
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+//      CHECK: func @tile_4d_generic_op_alone
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?x?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:   %[[C2:.+]] = constant 2 : index
+//  CHECK-DAG:   %[[C3:.+]] = constant 3 : index
+//  CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[D2:.+]] = memref.dim %[[ARG0]], %[[C2]]
+//  CHECK-DAG:   %[[D3:.+]] = memref.dim %[[ARG0]], %[[C3]]
+//      CHECK:   flow.dispatch.workgroups[%[[D3]], %[[D2]], %[[D1]]]
+
+// -----
+
+
+// -----
+
+func @tile_parallel_reduction(%arg0: tensor<7x7x1280xf32>) -> tensor<1280xf32> {
+  %cst = constant 0.000000e+00 : f32
+  %0 = linalg.init_tensor [1280] : tensor<1280xf32>
+  %1 = linalg.fill(%0, %cst) : tensor<1280xf32>, f32 -> tensor<1280xf32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d0)>], iterator_types = ["parallel", "reduction", "reduction"]} ins(%arg0 : tensor<7x7x1280xf32>) outs(%1 : tensor<1280xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32):
+    %3 = addf %arg1, %arg2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<1280xf32>
+  return %2 : tensor<1280xf32>
+}
+
+//  CHECK-DAG: #[[SIZE_MAP0:.+]] = affine_map<(d0, d1) -> (d1, -d0 + 1280)>
+//  CHECK-DAG: #[[SIZE_MAP1:.+]] = affine_map<(d0, d1) -> (-d0 + 1280, d1)>
+
+//      CHECK: func @tile_parallel_reduction
+// CHECK-SAME: (%[[INPUT:.+]]: tensor<7x7x1280xf32>)
+
+//  CHECK-DAG: %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG: %[[C1280:.+]] = constant 1280 : index
+//      CHECK: %[[REDUCE:.+]] = flow.dispatch.workgroups[%[[C1280]], %[[C1]], %[[C1]]](%[[INPUT]]) : (tensor<7x7x1280xf32>) -> tensor<1280xf32> =
+// CHECK-NEXT:     (%[[ARG1:.+]]: !flow.dispatch.tensor<readonly:7x7x1280xf32>, %[[ARG2:.+]]: !flow.dispatch.tensor<writeonly:1280xf32>) {
+//      CHECK:   %[[WG_SIZE0:.+]] = flow.dispatch.workgroup.size[0] : index
+//      CHECK:   scf.for %[[IV:.+]] = %{{.+}} to %{{.+}} step %{{.+}}
+//      CHECK:     %[[SIZE0:.+]] = affine.min #[[SIZE_MAP0]](%[[IV]], %[[WG_SIZE0]])
+//      CHECK:     %[[IN:.+]] = flow.dispatch.tensor.load %[[ARG1]],
+// CHECK-SAME:       sizes = [7, 7, %[[SIZE0]]]
+//      CHECK:     %[[SIZE1:.+]] = affine.min #[[SIZE_MAP1]](%[[IV]], %[[WG_SIZE0]])
+//      CHECK:     %[[INIT:.+]] = linalg.init_tensor [%[[SIZE1]]] : tensor<?xf32>
+// CHECK-NEXT:     %[[OUT:.+]] = linalg.fill(%[[INIT]]
+//      CHECK:     %[[GENERIC:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[IN]] : tensor<7x7x?xf32>) outs(%[[OUT]] : tensor<?xf32>)
+//      CHECK:     flow.dispatch.tensor.store %[[GENERIC]], %[[ARG2]], {{.*}}
+
+//      CHECK: return %[[REDUCE]]

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion.mlir
@@ -78,8 +78,6 @@ func @dont_fuse_conv2d_with_multiple_uses(%input: tensor<1x225x225x16xf32>, %fil
 // CHECK:       linalg.conv_2d_input_nhwc_filter_hwcf
 
 // CHECK: flow.dispatch.workgroups
-// CHECK:   scf.for
-// CHECK:     scf.for
 // CHECK:       linalg.generic
 
 // -----
@@ -116,6 +114,4 @@ func @dont_fuse_conv2d_with_non_identity_map(%input: tensor<1x225x225x16xf32>, %
 // CHECK:       linalg.conv_2d_input_nhwc_filter_hwcf
 
 // CHECK: flow.dispatch.workgroups
-// CHECK:   scf.for
-// CHECK:     scf.for
 // CHECK:       linalg.generic


### PR DESCRIPTION
To use tile+distribute the tile size configuration needs to be selected so as to not have significant perf regressions.