### PR TITLE
Fix benchmark configuration to Linalg on tensors setting.

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -104,33 +104,16 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
       TargetInfo(name="dylib-llvm-aot",
                  mako_tag="cpu",
                  compilation_flags=[
-                     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-                 ],
-                 runtime_flags=["--dylib_worker_count=1"]),
-      TargetInfo(
-          name="vulkan-spirv",
-          mako_tag="vlk",
-          compilation_flags=[
-              "--iree-spirv-enable-vectorization",
-              "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10"
-          ]),
-      TargetInfo(name="dylib-llvm-aot",
-                 mako_tag="cpu2",
-                 compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
-                     "--iree-flow-dispatch-linalg-on-tensors",
-                     "--iree-codegen-llvm-experimental-linalg-on-tensors",
                      "-iree-flow-inline-constants-max-byte-length=2048",
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
                  ],
                  runtime_flags=["--dylib_worker_count=1"]),
       TargetInfo(
           name="vulkan-spirv",
-          mako_tag="vlk2",
+          mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10",
-              "--iree-flow-dispatch-linalg-on-tensors",
-              "--iree-codegen-spirv-experimental-linalg-on-tensors",
               "-iree-flow-inline-constants-max-byte-length=2048",
               "-iree-flow-dispatch-formation-enable-operand-fusion"
           ])
@@ -152,36 +135,18 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
       TargetInfo(name="dylib-llvm-aot",
                  mako_tag="cpu",
                  compilation_flags=[
-                     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-                 ],
-                 runtime_flags=["--dylib_worker_count=1"]),
-      TargetInfo(
-          name="vulkan-spirv",
-          mako_tag="vlk",
-          compilation_flags=[
-              "--iree-spirv-enable-vectorization",
-              "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
-          ]),
-      TargetInfo(name="dylib-llvm-aot",
-                 mako_tag="cpu2",
-                 compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
-                     "--iree-flow-dispatch-linalg-on-tensors",
-                     "--iree-codegen-llvm-experimental-linalg-on-tensors",
                      "-iree-flow-inline-constants-max-byte-length=2048",
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
                  ],
                  runtime_flags=["--dylib_worker_count=1"]),
       TargetInfo(
           name="vulkan-spirv",
-          mako_tag="vlk2",
+          mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",
-              "--iree-flow-dispatch-linalg-on-tensors",
-              "--iree-codegen-spirv-experimental-linalg-on-tensors",
               # TODO(GH-5330): Revisit the number or delete the flag.
               "-iree-flow-inline-constants-max-byte-length=16",
-              "-iree-spirv-enable-vectorization",
               "-iree-flow-dispatch-formation-enable-operand-fusion"
           ])
   ]
@@ -231,7 +196,6 @@ MODEL_BENCHMARKS = [
                                    skipped_target=["vlk2"],
                                    batch_config={
                                        "cpu": 16,
-                                       "cpu2": 10
                                    })),
             PhoneBenchmarkInfo(
                 name="S20",
@@ -239,8 +203,6 @@ MODEL_BENCHMARKS = [
                 targets=get_s20_default_target_list(batch_config={
                     "cpu": 16,
                     "vlk": 64,
-                    "cpu2": 10,
-                    "vlk2": 64
                 })),
         ]),
     ModelBenchmarkInfo(


### PR DESCRIPTION
We set Linalg on tensors path pipeline by default, so the configurations
should map to Linalg on tensors.

Part of https://github.com/google/iree/issues/5443