### PR TITLE
Speicify -iree-hal-target-backends in some iree_bytecode_module targets

### DIFF
--- a/iree/modules/strings/BUILD
+++ b/iree/modules/strings/BUILD
@@ -67,5 +67,8 @@ iree_bytecode_module(
     testonly = True,
     src = "strings_module_test.mlir",
     cc_namespace = "iree::strings_module_test",
-    flags = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = [
+        "-iree-mlir-to-vm-bytecode-module",
+        "-iree-hal-target-backends=dylib-llvm-aot",
+    ],
 )

--- a/iree/modules/strings/CMakeLists.txt
+++ b/iree/modules/strings/CMakeLists.txt
@@ -69,6 +69,7 @@ iree_bytecode_module(
     "iree::strings_module_test"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
+    "-iree-hal-target-backends=dylib-llvm-aot"
   TESTONLY
   PUBLIC
 )

--- a/iree/modules/tensorlist/BUILD
+++ b/iree/modules/tensorlist/BUILD
@@ -50,7 +50,10 @@ iree_bytecode_module(
     testonly = True,
     src = "tensorlist_test.mlir",
     cc_namespace = "iree::modules::tensorlist",
-    flags = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = [
+        "-iree-mlir-to-vm-bytecode-module",
+        "-iree-hal-target-backends=dylib-llvm-aot",
+    ],
 )
 
 cc_test(

--- a/iree/modules/tensorlist/CMakeLists.txt
+++ b/iree/modules/tensorlist/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_bytecode_module(
     "iree::modules::tensorlist"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
+    "-iree-hal-target-backends=dylib-llvm-aot"
   TESTONLY
   PUBLIC
 )

--- a/iree/samples/custom_modules/BUILD
+++ b/iree/samples/custom_modules/BUILD
@@ -34,7 +34,10 @@ iree_bytecode_module(
     name = "custom_modules_test_module",
     src = "custom_modules_test.mlir",
     cc_namespace = "iree::samples::custom_modules",
-    flags = ["-iree-mlir-to-vm-bytecode-module"],
+    flags = [
+        "-iree-mlir-to-vm-bytecode-module",
+        "-iree-hal-target-backends=dylib-llvm-aot",
+    ],
     translate_tool = "//iree/samples/custom_modules/dialect:custom-translate",
 )
 

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_bytecode_module(
     iree_samples_custom_modules_dialect_custom-translate
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
+    "-iree-hal-target-backends=dylib-llvm-aot"
   PUBLIC
 )
 


### PR DESCRIPTION
VMLA is going to be deprecated, so the PR uses dylib-llvm-aot instead.

Fixes https://github.com/google/iree/issues/5449