### PR TITLE
Make iree-flow-dispatch-linalg-on-tensors work

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -36,7 +36,7 @@ static llvm::cl::opt<bool> clEnableLinalgOnTensorsDispatch(
     "iree-flow-dispatch-linalg-on-tensors",
     llvm::cl::desc(
         "Enable use of Linalg on tensors for dispatch region creation."),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 // TODO(benvanik): change to a pipeline option.
 static llvm::cl::opt<bool> clExportBenchmarkFuncs(
@@ -109,6 +109,10 @@ void registerInputTransformPassPipeline() {
 
 void buildFlowTransformPassPipeline(OpPassManager &passManager,
                                     bool dispatchLinalgOnTensors) {
+  // TODO(hanchung): Delete the hack. The flag is still useful when Linalg on
+  // buffers path is not deprecated.
+  if (!clEnableLinalgOnTensorsDispatch) dispatchLinalgOnTensors = false;
+
   //----------------------------------------------------------------------------
   // Entry dialect cleanup
   //----------------------------------------------------------------------------


### PR DESCRIPTION
We should turn it true by default when migrating to Linalg on tensors.
It was not used in any place. Fallback to Linalg on buffers logic when
it is false.