### PR TITLE
[ci] Allow parallel testing on NVIDIA GPUs

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -69,9 +69,7 @@ echo "Building with Ninja"
 cd "${CMAKE_BUILD_DIR?}"
 ninja
 
-# Limit parallelism dramatically to avoid exhausting GPU memory
-# TODO(#5162): Handle this more robustly
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
 # Only test drivers that use the GPU, since we run all tests on non-GPU machines
 # as well.


### PR DESCRIPTION
This reverts https://github.com/google/iree/pull/5163 and
https://github.com/google/iree/pull/5166 as now buffer usage
is improved on Vulkan.

Related to https://github.com/google/iree/issues/5162