### PR TITLE
Remove attribute that is pass internal.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -925,6 +925,7 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
       pullInProducersInSameGroup(
           rewriter, dispatchOp, clonedLinalgOp, shapedOperands,
           /*tiledLoops=*/ArrayRef<Operation *>(), rootOpAttr.getInt());
+      clonedLinalgOp->removeAttr(kRootOpAttr);
     }
 
     rewriter.replaceOpWithIf(op, dispatchOp.getOperation()->getResults(),


### PR DESCRIPTION
Removing this attribute allows deduping executables to kick in.