### PR TITLE
Fix task.c failure on 32-bit systems.

### DIFF
--- a/iree/task/task.c
+++ b/iree/task/task.c
@@ -287,15 +287,15 @@ static uint32_t iree_math_ptr_to_xrgb(const uintptr_t ptr) {
   // This is just a simple hack to give us a unique(ish) per-pointer color.
   // It's only to make it easier to distinguish which tiles are from the same
   // dispatch.
-  #if UINTPTR_MAX == 0xFFFF
-    return (uint32_t) ptr;
-  #elif UINTPTR_MAX == 0xFFFFFFFF
-    return (uint32_t) ptr;
-  #elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
-    return (uint32_t)ptr ^ (uint32_t)(ptr >> 32);
-  #else
-    #error TBD pointer size
-  #endif
+#if UINTPTR_MAX == 0xFFFF
+  return (uint32_t)ptr;
+#elif UINTPTR_MAX == 0xFFFFFFFF
+  return (uint32_t)ptr;
+#elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+  return (uint32_t)ptr ^ (uint32_t)(ptr >> 32);
+#else
+#error TBD pointer size
+#endif
 }
 
 // Returns an XXBBGGRR color (red in the lowest bits).

--- a/iree/task/task.c
+++ b/iree/task/task.c
@@ -287,7 +287,15 @@ static uint32_t iree_math_ptr_to_xrgb(const uintptr_t ptr) {
   // This is just a simple hack to give us a unique(ish) per-pointer color.
   // It's only to make it easier to distinguish which tiles are from the same
   // dispatch.
-  return (uint32_t)ptr ^ (uint32_t)(ptr >> 32);
+  #if UINTPTR_MAX == 0xFFFF
+    return (uint32_t) ptr;
+  #elif UINTPTR_MAX == 0xFFFFFFFF
+    return (uint32_t) ptr;
+  #elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+    return (uint32_t)ptr ^ (uint32_t)(ptr >> 32);
+  #else
+    #error TBD pointer size
+  #endif
 }
 
 // Returns an XXBBGGRR color (red in the lowest bits).

--- a/iree/task/task.c
+++ b/iree/task/task.c
@@ -287,14 +287,12 @@ static uint32_t iree_math_ptr_to_xrgb(const uintptr_t ptr) {
   // This is just a simple hack to give us a unique(ish) per-pointer color.
   // It's only to make it easier to distinguish which tiles are from the same
   // dispatch.
-#if UINTPTR_MAX == 0xFFFF
+#if defined(IREE_PTR_SIZE_32)
   return (uint32_t)ptr;
-#elif UINTPTR_MAX == 0xFFFFFFFF
-  return (uint32_t)ptr;
-#elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+#elif defined(IREE_PTR_SIZE_64)
   return (uint32_t)ptr ^ (uint32_t)(ptr >> 32);
 #else
-#error TBD pointer size
+#error Unknown pointer size
 #endif
 }
 


### PR DESCRIPTION
Right shift by >=32 bits requires the input is 64-bit.