### PR TITLE
[ci] Avoid batching for Vulkan benchmarks

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -183,7 +183,6 @@ MODEL_BENCHMARKS = [
                                    skipped_target=["cpu2", "vlk2"],
                                    batch_config={
                                        "cpu": 8,
-                                       "vlk": 16
                                    })),
         ]),
     ModelBenchmarkInfo(
@@ -204,7 +203,6 @@ MODEL_BENCHMARKS = [
                 benchmark_key="5618403088793600",
                 targets=get_s20_default_target_list(batch_config={
                     "cpu": 16,
-                    "vlk": 64,
                 })),
         ]),
     ModelBenchmarkInfo(


### PR DESCRIPTION
Duplicating dispatches without barriers causes the reported perf
number better than it really is, as tracked in #5248. Avoid
batching for now.