### PR TITLE
Cleaning up HAL timeouts and tunneling iree_hal_device_submit_and_wait through the stack.

### DIFF
--- a/iree/hal/cts/cts_test_base.h
+++ b/iree/hal/cts/cts_test_base.h
@@ -117,8 +117,8 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
                                      /*queue_affinity=*/0,
                                      /*batch_count=*/1, &submission_batch);
     if (iree_status_is_ok(status)) {
-      status = iree_hal_semaphore_wait_with_deadline(signal_semaphore, 1ull,
-                                                     IREE_TIME_INFINITE_FUTURE);
+      status = iree_hal_semaphore_wait(signal_semaphore, 1ull,
+                                       iree_infinite_timeout());
     }
 
     iree_hal_semaphore_release(signal_semaphore);

--- a/iree/hal/cts/event_test.cc
+++ b/iree/hal/cts/event_test.cc
@@ -109,8 +109,8 @@ TEST_P(EventTest, SubmitWithChainedCommandBuffers) {
       iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
                                    /*queue_affinity=*/0,
                                    /*batch_count=*/1, &submission_batch));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      signal_semaphore, 1ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer_1);
   iree_hal_command_buffer_release(command_buffer_2);

--- a/iree/hal/cts/semaphore_submission_test.cc
+++ b/iree/hal/cts/semaphore_submission_test.cc
@@ -47,8 +47,8 @@ TEST_P(SemaphoreSubmissionTest, SubmitWithNoCommandBuffers) {
       iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
                                    /*queue_affinity=*/0,
                                    /*batch_count=*/1, &submission_batch));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      signal_semaphore, 1ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
 
   iree_hal_semaphore_release(signal_semaphore);
 }
@@ -83,8 +83,8 @@ TEST_P(SemaphoreSubmissionTest, SubmitAndSignal) {
       iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
                                    /*queue_affinity=*/0,
                                    /*batch_count=*/1, &submission_batch));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      signal_semaphore, 1ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer);
   iree_hal_semaphore_release(signal_semaphore);
@@ -132,8 +132,8 @@ TEST_P(SemaphoreSubmissionTest, SubmitWithWait) {
 
   // Signal the wait semaphore, work should begin and complete.
   IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore, 1ull));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      signal_semaphore, 101ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(signal_semaphore, 101ull,
+                                         iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer);
   iree_hal_semaphore_release(wait_semaphore);
@@ -196,9 +196,9 @@ TEST_P(SemaphoreSubmissionTest, SubmitWithMultipleSemaphores) {
   signal_semaphore_list.semaphores = signal_semaphore_ptrs;
   uint64_t payload_values[] = {1ull, 1ull};
   signal_semaphore_list.payload_values = payload_values;
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_deadline(
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ALL, &signal_semaphore_list,
-      IREE_TIME_INFINITE_FUTURE));
+      iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer);
   iree_hal_semaphore_release(wait_semaphore_1);

--- a/iree/hal/cts/semaphore_test.cc
+++ b/iree/hal/cts/semaphore_test.cc
@@ -85,15 +85,19 @@ TEST_P(SemaphoreTest, Failure) {
 
 // Tests waiting on no semaphores.
 TEST_P(SemaphoreTest, EmptyWait) {
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_deadline(
-      device_, IREE_HAL_WAIT_MODE_ANY, NULL, IREE_TIME_INFINITE_FUTURE));
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_deadline(
-      device_, IREE_HAL_WAIT_MODE_ALL, NULL, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ANY, NULL,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ALL, NULL,
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_timeout(
-      device_, IREE_HAL_WAIT_MODE_ANY, NULL, IREE_DURATION_INFINITE));
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_timeout(
-      device_, IREE_HAL_WAIT_MODE_ALL, NULL, IREE_DURATION_INFINITE));
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ANY, NULL,
+      iree_make_timeout(IREE_DURATION_INFINITE)));
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
+      device_, IREE_HAL_WAIT_MODE_ALL, NULL,
+      iree_make_timeout(IREE_DURATION_INFINITE)));
 }
 
 // Tests waiting on a semaphore that has already been signaled.
@@ -103,15 +107,15 @@ TEST_P(SemaphoreTest, DISABLED_WaitAlreadySignaled) {
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
 
   // Test both previous and current values.
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      semaphore, 1ull, IREE_TIME_INFINITE_FUTURE));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      semaphore, 2ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 1ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 2ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_timeout(semaphore, 1ull,
-                                                      IREE_DURATION_INFINITE));
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_timeout(semaphore, 2ull,
-                                                      IREE_DURATION_INFINITE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 1ull, iree_make_timeout(IREE_DURATION_INFINITE)));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      semaphore, 2ull, iree_make_timeout(IREE_DURATION_INFINITE)));
 
   iree_hal_semaphore_release(semaphore);
 }
@@ -124,8 +128,8 @@ TEST_P(SemaphoreTest, WaitUnsignaled) {
   // NOTE: we don't actually block here because otherwise we'd lock up.
   // Result status is undefined - some backends may return DeadlineExceededError
   // while others may return success.
-  IREE_IGNORE_ERROR(iree_hal_semaphore_wait_with_deadline(
-      semaphore, 3ull, IREE_TIME_INFINITE_PAST));
+  IREE_IGNORE_ERROR(iree_hal_semaphore_wait(
+      semaphore, 3ull, iree_make_deadline(IREE_TIME_INFINITE_PAST)));
 
   iree_hal_semaphore_release(semaphore);
 }
@@ -150,9 +154,9 @@ TEST_P(SemaphoreTest, WaitAllButNotAllSignaled) {
   // NOTE: we don't actually block here because otherwise we'd lock up.
   // Result status is undefined - some backends may return DeadlineExceededError
   // while others may return success.
-  IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores_with_deadline(
+  IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ALL, &semaphore_list,
-      IREE_TIME_INFINITE_PAST));
+      iree_make_deadline(IREE_TIME_INFINITE_PAST)));
 
   iree_hal_semaphore_release(semaphore_a);
   iree_hal_semaphore_release(semaphore_b);
@@ -175,9 +179,9 @@ TEST_P(SemaphoreTest, WaitAllAndAllSignaled) {
   // NOTE: we don't actually block here because otherwise we'd lock up.
   // Result status is undefined - some backends may return DeadlineExceededError
   // while others may return success.
-  IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores_with_deadline(
+  IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ALL, &semaphore_list,
-      IREE_TIME_INFINITE_FUTURE));
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   iree_hal_semaphore_release(semaphore_a);
   iree_hal_semaphore_release(semaphore_b);
@@ -198,9 +202,9 @@ TEST_P(SemaphoreTest, DISABLED_WaitAny) {
   uint64_t payload_values[] = {1ull, 1ull};
   semaphore_list.payload_values = payload_values;
 
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores_with_deadline(
+  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ANY, &semaphore_list,
-      IREE_TIME_INFINITE_FUTURE));
+      iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   iree_hal_semaphore_release(semaphore_a);
   iree_hal_semaphore_release(semaphore_b);
@@ -215,16 +219,16 @@ TEST_P(SemaphoreTest, PingPong) {
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &b2a));
   std::thread thread([&]() {
     // Should advance right past this because the value is already set.
-    IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-        a2b, 0ull, IREE_TIME_INFINITE_FUTURE));
+    IREE_ASSERT_OK(iree_hal_semaphore_wait(
+        a2b, 0ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
     IREE_ASSERT_OK(iree_hal_semaphore_signal(b2a, 1ull));
     // Jump ahead (blocking at first).
-    IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-        a2b, 4ull, IREE_TIME_INFINITE_FUTURE));
+    IREE_ASSERT_OK(iree_hal_semaphore_wait(
+        a2b, 4ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
   });
   // Block until thread signals.
-  IREE_ASSERT_OK(iree_hal_semaphore_wait_with_deadline(
-      b2a, 1ull, IREE_TIME_INFINITE_FUTURE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(
+      b2a, 1ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
   IREE_ASSERT_OK(iree_hal_semaphore_signal(a2b, 4ull));
   thread.join();
 

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -251,52 +251,30 @@ static iree_status_t iree_hal_cuda_device_queue_submit(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_cuda_device_submit_and_wait_with_deadline(
+static iree_status_t iree_hal_cuda_device_submit_and_wait(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches,
     iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_time_t deadline_ns) {
+    iree_timeout_t timeout) {
   // Submit...
   IREE_RETURN_IF_ERROR(iree_hal_cuda_device_queue_submit(
       base_device, command_categories, queue_affinity, batch_count, batches));
 
   // ...and wait.
-  return iree_hal_semaphore_wait_with_deadline(wait_semaphore, wait_value,
-                                               deadline_ns);
+  return iree_hal_semaphore_wait(wait_semaphore, wait_value, timeout);
 }
 
-static iree_status_t iree_hal_cuda_device_submit_and_wait_with_timeout(
-    iree_hal_device_t* base_device,
-    iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches,
-    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_duration_t timeout_ns) {
-  return iree_hal_cuda_device_submit_and_wait_with_deadline(
-      base_device, command_categories, queue_affinity, batch_count, batches,
-      wait_semaphore, wait_value,
-      iree_relative_timeout_to_deadline_ns(timeout_ns));
-}
-
-static iree_status_t iree_hal_cuda_device_wait_semaphores_with_timeout(
+static iree_status_t iree_hal_cuda_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list,
-    iree_duration_t timeout_ns) {
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "semaphore not implemented");
 }
 
-static iree_status_t iree_hal_cuda_device_wait_semaphores_with_deadline(
-    iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "semaphore not implemented");
-}
-
-static iree_status_t iree_hal_cuda_device_wait_idle_with_deadline(
-    iree_hal_device_t* base_device, iree_time_t deadline_ns) {
+static iree_status_t iree_hal_cuda_device_wait_idle(
+    iree_hal_device_t* base_device, iree_timeout_t timeout) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   // Wait until the stream is done.
   // TODO(thomasraoux): CUDA doesn't support a deadline for wait, figure out how
@@ -305,12 +283,6 @@ static iree_status_t iree_hal_cuda_device_wait_idle_with_deadline(
                        cuStreamSynchronize(device->stream),
                        "cuStreamSynchronize");
   return iree_ok_status();
-}
-
-static iree_status_t iree_hal_cuda_device_wait_idle_with_timeout(
-    iree_hal_device_t* base_device, iree_duration_t timeout_ns) {
-  return iree_hal_cuda_device_wait_idle_with_deadline(
-      base_device, iree_relative_timeout_to_deadline_ns(timeout_ns));
 }
 
 const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
@@ -328,14 +300,7 @@ const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .create_executable_layout = iree_hal_cuda_device_create_executable_layout,
     .create_semaphore = iree_hal_cuda_device_create_semaphore,
     .queue_submit = iree_hal_cuda_device_queue_submit,
-    .submit_and_wait_with_deadline =
-        iree_hal_cuda_device_submit_and_wait_with_deadline,
-    .submit_and_wait_with_timeout =
-        iree_hal_cuda_device_submit_and_wait_with_timeout,
-    .wait_semaphores_with_deadline =
-        iree_hal_cuda_device_wait_semaphores_with_deadline,
-    .wait_semaphores_with_timeout =
-        iree_hal_cuda_device_wait_semaphores_with_timeout,
-    .wait_idle_with_deadline = iree_hal_cuda_device_wait_idle_with_deadline,
-    .wait_idle_with_timeout = iree_hal_cuda_device_wait_idle_with_timeout,
+    .submit_and_wait = iree_hal_cuda_device_submit_and_wait,
+    .wait_semaphores = iree_hal_cuda_device_wait_semaphores,
+    .wait_idle = iree_hal_cuda_device_wait_idle,
 };

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -251,6 +251,35 @@ static iree_status_t iree_hal_cuda_device_queue_submit(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_cuda_device_submit_and_wait_with_deadline(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_time_t deadline_ns) {
+  // Submit...
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_device_queue_submit(
+      base_device, command_categories, queue_affinity, batch_count, batches));
+
+  // ...and wait.
+  return iree_hal_semaphore_wait_with_deadline(wait_semaphore, wait_value,
+                                               deadline_ns);
+}
+
+static iree_status_t iree_hal_cuda_device_submit_and_wait_with_timeout(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_duration_t timeout_ns) {
+  return iree_hal_cuda_device_submit_and_wait_with_deadline(
+      base_device, command_categories, queue_affinity, batch_count, batches,
+      wait_semaphore, wait_value,
+      iree_relative_timeout_to_deadline_ns(timeout_ns));
+}
+
 static iree_status_t iree_hal_cuda_device_wait_semaphores_with_timeout(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t* semaphore_list,
@@ -299,6 +328,10 @@ const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .create_executable_layout = iree_hal_cuda_device_create_executable_layout,
     .create_semaphore = iree_hal_cuda_device_create_semaphore,
     .queue_submit = iree_hal_cuda_device_queue_submit,
+    .submit_and_wait_with_deadline =
+        iree_hal_cuda_device_submit_and_wait_with_deadline,
+    .submit_and_wait_with_timeout =
+        iree_hal_cuda_device_submit_and_wait_with_timeout,
     .wait_semaphores_with_deadline =
         iree_hal_cuda_device_wait_semaphores_with_deadline,
     .wait_semaphores_with_timeout =

--- a/iree/hal/cuda/event_semaphore.c
+++ b/iree/hal/cuda/event_semaphore.c
@@ -82,19 +82,12 @@ static iree_status_t iree_hal_cuda_semaphore_signal(
 static void iree_hal_cuda_semaphore_fail(iree_hal_semaphore_t* base_semaphore,
                                          iree_status_t status) {}
 
-static iree_status_t iree_hal_cuda_semaphore_wait_with_deadline(
+static iree_status_t iree_hal_cuda_semaphore_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t value,
-    iree_time_t deadline_ns) {
+    iree_timeout_t timeout) {
   // TODO: Support semaphores completely. Return OK currently as everything is
   // synchronized for each submit to allow things to run.
   return iree_ok_status();
-}
-
-static iree_status_t iree_hal_cuda_semaphore_wait_with_timeout(
-    iree_hal_semaphore_t* base_semaphore, uint64_t value,
-    iree_duration_t timeout_ns) {
-  return iree_hal_cuda_semaphore_wait_with_deadline(
-      base_semaphore, value, iree_relative_timeout_to_deadline_ns(timeout_ns));
 }
 
 const iree_hal_semaphore_vtable_t iree_hal_cuda_semaphore_vtable = {
@@ -102,6 +95,5 @@ const iree_hal_semaphore_vtable_t iree_hal_cuda_semaphore_vtable = {
     .query = iree_hal_cuda_semaphore_query,
     .signal = iree_hal_cuda_semaphore_signal,
     .fail = iree_hal_cuda_semaphore_fail,
-    .wait_with_deadline = iree_hal_cuda_semaphore_wait_with_deadline,
-    .wait_with_timeout = iree_hal_cuda_semaphore_wait_with_timeout,
+    .wait = iree_hal_cuda_semaphore_wait,
 };

--- a/iree/hal/device.c
+++ b/iree/hal/device.c
@@ -59,85 +59,39 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_queue_submit(
   return status;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_submit_and_wait_with_deadline(
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_submit_and_wait(
     iree_hal_device_t* device, iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches,
     iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_time_t deadline_ns) {
+    iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(!batch_count || batches);
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status =
-      _VTABLE_DISPATCH(device, submit_and_wait_with_deadline)(
-          device, command_categories, queue_affinity, batch_count, batches,
-          wait_semaphore, wait_value, deadline_ns);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_submit_and_wait_with_timeout(
-    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches,
-    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_duration_t timeout_ns) {
-  IREE_ASSERT_ARGUMENT(device);
-  IREE_ASSERT_ARGUMENT(!batch_count || batches);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(device, submit_and_wait_with_timeout)(
+  iree_status_t status = _VTABLE_DISPATCH(device, submit_and_wait)(
       device, command_categories, queue_affinity, batch_count, batches,
-      wait_semaphore, wait_value, timeout_ns);
+      wait_semaphore, wait_value, timeout);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_wait_semaphores_with_deadline(
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_wait_semaphores(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(device);
   if (!semaphore_list || semaphore_list->count == 0) return iree_ok_status();
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status =
-      _VTABLE_DISPATCH(device, wait_semaphores_with_deadline)(
-          device, wait_mode, semaphore_list, deadline_ns);
+  iree_status_t status = _VTABLE_DISPATCH(device, wait_semaphores)(
+      device, wait_mode, semaphore_list, timeout);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_wait_semaphores_with_timeout(
-    iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list,
-    iree_duration_t timeout_ns) {
-  IREE_ASSERT_ARGUMENT(device);
-  if (!semaphore_list || semaphore_list->count == 0) return iree_ok_status();
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(device, wait_semaphores_with_timeout)(
-      device, wait_mode, semaphore_list, timeout_ns);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t iree_hal_device_wait_idle_with_deadline(
-    iree_hal_device_t* device, iree_time_t deadline_ns) {
+IREE_API_EXPORT iree_status_t
+iree_hal_device_wait_idle(iree_hal_device_t* device, iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status =
-      _VTABLE_DISPATCH(device, wait_idle_with_deadline)(device, deadline_ns);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t iree_hal_device_wait_idle_with_timeout(
-    iree_hal_device_t* device, iree_duration_t timeout_ns) {
-  IREE_ASSERT_ARGUMENT(device);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status =
-      _VTABLE_DISPATCH(device, wait_idle_with_timeout)(device, timeout_ns);
+  iree_status_t status = _VTABLE_DISPATCH(device, wait_idle)(device, timeout);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/device.c
+++ b/iree/hal/device.c
@@ -60,6 +60,41 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_queue_submit(
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_submit_and_wait_with_deadline(
+    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_time_t deadline_ns) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(!batch_count || batches);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status =
+      _VTABLE_DISPATCH(device, submit_and_wait_with_deadline)(
+          device, command_categories, queue_affinity, batch_count, batches,
+          wait_semaphore, wait_value, deadline_ns);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_submit_and_wait_with_timeout(
+    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_duration_t timeout_ns) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(!batch_count || batches);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(device, submit_and_wait_with_timeout)(
+      device, command_categories, queue_affinity, batch_count, batches,
+      wait_semaphore, wait_value, timeout_ns);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_hal_device_wait_semaphores_with_deadline(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -189,6 +189,36 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_queue_submit(
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches);
 
+// Submits batches of work and waits until |wait_semaphore| reaches or exceeds
+// |wait_value|.
+//
+// This is equivalent to following iree_hal_device_queue_submit with a
+// iree_hal_semaphore_wait_with_deadline on |wait_semaphore|/|wait_value| but
+// may help to reduce overhead by preventing thread wakeups, kernel calls, and
+// internal tracking.
+//
+// See iree_hal_device_queue_submit for more information about the queuing
+// behavior and iree_hal_semaphore_wait_with_deadline for the waiting
+// behavior.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_submit_and_wait_with_deadline(
+    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_time_t deadline_ns);
+
+// Submits batches of work and waits |wait_semaphore| reaches |wait_value|.
+// A relative-time version of iree_hal_device_submit_and_wait_with_deadline
+// using the relative nanoseconds from the time the call is made.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_device_submit_and_wait_with_timeout(
+    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_duration_t timeout_ns);
+
 // Blocks the caller until the semaphores reach or exceed the specified payload
 // values or the |deadline_ns| elapses. All semaphores in |semaphore_list| must
 // be created from this device (or be imported into it).
@@ -298,6 +328,19 @@ typedef struct {
       iree_hal_device_t* device, iree_hal_command_category_t command_categories,
       iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
       const iree_hal_submission_batch_t* batches);
+
+  iree_status_t(IREE_API_PTR* submit_and_wait_with_deadline)(
+      iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+      iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+      const iree_hal_submission_batch_t* batches,
+      iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+      iree_time_t deadline_ns);
+  iree_status_t(IREE_API_PTR* submit_and_wait_with_timeout)(
+      iree_hal_device_t* device, iree_hal_command_category_t command_categories,
+      iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+      const iree_hal_submission_batch_t* batches,
+      iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+      iree_duration_t timeout_ns);
 
   iree_status_t(IREE_API_PTR* wait_semaphores_with_deadline)(
       iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -193,35 +193,22 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_queue_submit(
 // |wait_value|.
 //
 // This is equivalent to following iree_hal_device_queue_submit with a
-// iree_hal_semaphore_wait_with_deadline on |wait_semaphore|/|wait_value| but
+// iree_hal_semaphore_wait on |wait_timeout|/|wait_value| but
 // may help to reduce overhead by preventing thread wakeups, kernel calls, and
 // internal tracking.
 //
 // See iree_hal_device_queue_submit for more information about the queuing
-// behavior and iree_hal_semaphore_wait_with_deadline for the waiting
-// behavior.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_submit_and_wait_with_deadline(
+// behavior and iree_hal_semaphore_wait for the waiting  behavior.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_submit_and_wait(
     iree_hal_device_t* device, iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches,
     iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_time_t deadline_ns);
-
-// Submits batches of work and waits |wait_semaphore| reaches |wait_value|.
-// A relative-time version of iree_hal_device_submit_and_wait_with_deadline
-// using the relative nanoseconds from the time the call is made.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_submit_and_wait_with_timeout(
-    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches,
-    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_duration_t timeout_ns);
+    iree_timeout_t timeout);
 
 // Blocks the caller until the semaphores reach or exceed the specified payload
-// values or the |deadline_ns| elapses. All semaphores in |semaphore_list| must
-// be created from this device (or be imported into it).
+// values or the |timeout| elapses. All semaphores in |semaphore_list| must be
+// created from this device (or be imported into it).
 //
 // |wait_mode| can be used to decide when the wait will proceed; whether *all*
 // semaphores in |semaphore_list| must be signaled or whether *any* (one or
@@ -230,43 +217,25 @@ iree_hal_device_submit_and_wait_with_timeout(
 // Returns success if the wait is successful and semaphores have been signaled
 // satisfying the |wait_mode|.
 //
-// Returns DEADLINE_EXCEEDED if the |deadline_ns| elapses without the
-// |wait_mode| being satisfied. Note that even on success only a subset of the
-// semaphores may have been signaled and each can be queried to see which ones.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_wait_semaphores_with_deadline(
+// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the |wait_mode|
+// being satisfied. Note that even on success only a subset of the semaphores
+// may have been signaled and each can be queried to see which ones.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_wait_semaphores(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns);
-
-// Blocks the caller until the semaphores reach or exceed the specified payload
-// values or the |timeout_ns| elapses.
-// A relative-time version of iree_hal_device_wait_semaphores_with_deadline
-// using the relative nanoseconds from the time the call is made.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_device_wait_semaphores_with_timeout(
-    iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list,
-    iree_duration_t timeout_ns);
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
 
 // Blocks the caller until all outstanding requests on all queues have been
-// completed or the |deadline_ns| elapses. This is equivalent to having waited
+// completed or the |timeout| elapses. This is equivalent to having waited
 // on all semaphores outstanding at the time of the call, meaning that if new
 // work is submitted by another thread it may not be waited on prior to this
 // call returning.
 //
 // Returns success if the device reaches an idle point during the call.
 //
-// Returns DEADLINE_EXCEEDED if the |deadline_ns| elapses without the device
-// having become idle.
-IREE_API_EXPORT iree_status_t iree_hal_device_wait_idle_with_deadline(
-    iree_hal_device_t* device, iree_time_t deadline_ns);
-
-// Blocks the caller until all outstanding requests on all quests have been
-// completed or the |timeout_ns| elapses.
-// A relative-time version of iree_hal_device_wait_idle_with_deadline
-// using the relative nanoseconds from the time the call is made.
-IREE_API_EXPORT iree_status_t iree_hal_device_wait_idle_with_timeout(
-    iree_hal_device_t* device, iree_duration_t timeout_ns);
+// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the device having
+// become idle.
+IREE_API_EXPORT iree_status_t
+iree_hal_device_wait_idle(iree_hal_device_t* device, iree_timeout_t timeout);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_device_t implementation details
@@ -329,31 +298,19 @@ typedef struct {
       iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
       const iree_hal_submission_batch_t* batches);
 
-  iree_status_t(IREE_API_PTR* submit_and_wait_with_deadline)(
+  iree_status_t(IREE_API_PTR* submit_and_wait)(
       iree_hal_device_t* device, iree_hal_command_category_t command_categories,
       iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
       const iree_hal_submission_batch_t* batches,
       iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-      iree_time_t deadline_ns);
-  iree_status_t(IREE_API_PTR* submit_and_wait_with_timeout)(
-      iree_hal_device_t* device, iree_hal_command_category_t command_categories,
-      iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-      const iree_hal_submission_batch_t* batches,
-      iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-      iree_duration_t timeout_ns);
+      iree_timeout_t timeout);
 
-  iree_status_t(IREE_API_PTR* wait_semaphores_with_deadline)(
+  iree_status_t(IREE_API_PTR* wait_semaphores)(
       iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-      const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns);
-  iree_status_t(IREE_API_PTR* wait_semaphores_with_timeout)(
-      iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-      const iree_hal_semaphore_list_t* semaphore_list,
-      iree_duration_t timeout_ns);
+      const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
 
-  iree_status_t(IREE_API_PTR* wait_idle_with_deadline)(
-      iree_hal_device_t* device, iree_time_t deadline_ns);
-  iree_status_t(IREE_API_PTR* wait_idle_with_timeout)(
-      iree_hal_device_t* device, iree_duration_t timeout_ns);
+  iree_status_t(IREE_API_PTR* wait_idle)(iree_hal_device_t* device,
+                                         iree_timeout_t timeout);
 } iree_hal_device_vtable_t;
 
 IREE_API_EXPORT void IREE_API_CALL

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -88,8 +88,8 @@ static void iree_hal_system_executable_destroy(
 
 static iree_status_t iree_hal_system_executable_issue_call(
     iree_hal_local_executable_t* base_executable, iree_host_size_t ordinal,
-    const iree_hal_executable_dispatch_state_v0_t* IREE_RESTRICT dispatch_state,
-    const iree_hal_vec3_t* IREE_RESTRICT workgroup_id) {
+    const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
+    const iree_hal_vec3_t* workgroup_id) {
   iree_hal_system_executable_t* executable =
       (iree_hal_system_executable_t*)base_executable;
 

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -300,71 +300,41 @@ static iree_status_t iree_hal_task_device_queue_submit(
                                     batches);
 }
 
-static iree_status_t iree_hal_task_device_submit_and_wait_with_deadline(
+static iree_status_t iree_hal_task_device_submit_and_wait(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches,
     iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_time_t deadline_ns) {
+    iree_timeout_t timeout) {
   // Submit...
   IREE_RETURN_IF_ERROR(iree_hal_task_device_queue_submit(
       base_device, command_categories, queue_affinity, batch_count, batches));
 
   // ...and wait.
-  return iree_hal_semaphore_wait_with_deadline(wait_semaphore, wait_value,
-                                               deadline_ns);
+  return iree_hal_semaphore_wait(wait_semaphore, wait_value, timeout);
 }
 
-static iree_status_t iree_hal_task_device_submit_and_wait_with_timeout(
-    iree_hal_device_t* base_device,
-    iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches,
-    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_duration_t timeout_ns) {
-  return iree_hal_task_device_submit_and_wait_with_deadline(
-      base_device, command_categories, queue_affinity, batch_count, batches,
-      wait_semaphore, wait_value,
-      iree_relative_timeout_to_deadline_ns(timeout_ns));
-}
-
-static iree_status_t iree_hal_task_device_wait_semaphores_with_deadline(
+static iree_status_t iree_hal_task_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
-  return iree_hal_task_semaphore_multi_wait(wait_mode, semaphore_list,
-                                            deadline_ns, device->event_pool,
+  return iree_hal_task_semaphore_multi_wait(wait_mode, semaphore_list, timeout,
+                                            device->event_pool,
                                             &device->large_block_pool);
 }
 
-static iree_status_t iree_hal_task_device_wait_semaphores_with_timeout(
-    iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list,
-    iree_duration_t timeout_ns) {
-  return iree_hal_task_device_wait_semaphores_with_deadline(
-      base_device, wait_mode, semaphore_list,
-      iree_relative_timeout_to_deadline_ns(timeout_ns));
-}
-
-static iree_status_t iree_hal_task_device_wait_idle_with_deadline(
-    iree_hal_device_t* base_device, iree_time_t deadline_ns) {
+static iree_status_t iree_hal_task_device_wait_idle(
+    iree_hal_device_t* base_device, iree_timeout_t timeout) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
-    status = iree_hal_task_queue_wait_idle_with_deadline(&device->queues[i],
-                                                         deadline_ns);
+    status = iree_hal_task_queue_wait_idle(&device->queues[i], timeout);
     if (!iree_status_is_ok(status)) break;
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
-}
-
-static iree_status_t iree_hal_task_device_wait_idle_with_timeout(
-    iree_hal_device_t* base_device, iree_duration_t timeout_ns) {
-  return iree_hal_task_device_wait_idle_with_deadline(
-      base_device, iree_relative_timeout_to_deadline_ns(timeout_ns));
 }
 
 static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
@@ -382,14 +352,7 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .create_executable_layout = iree_hal_task_device_create_executable_layout,
     .create_semaphore = iree_hal_task_device_create_semaphore,
     .queue_submit = iree_hal_task_device_queue_submit,
-    .submit_and_wait_with_deadline =
-        iree_hal_task_device_submit_and_wait_with_deadline,
-    .submit_and_wait_with_timeout =
-        iree_hal_task_device_submit_and_wait_with_timeout,
-    .wait_semaphores_with_deadline =
-        iree_hal_task_device_wait_semaphores_with_deadline,
-    .wait_semaphores_with_timeout =
-        iree_hal_task_device_wait_semaphores_with_timeout,
-    .wait_idle_with_deadline = iree_hal_task_device_wait_idle_with_deadline,
-    .wait_idle_with_timeout = iree_hal_task_device_wait_idle_with_timeout,
+    .submit_and_wait = iree_hal_task_device_submit_and_wait,
+    .wait_semaphores = iree_hal_task_device_wait_semaphores,
+    .wait_idle = iree_hal_task_device_wait_idle,
 };

--- a/iree/hal/local/task_queue.c
+++ b/iree/hal/local/task_queue.c
@@ -514,9 +514,10 @@ iree_status_t iree_hal_task_queue_submit(
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_task_queue_wait_idle_with_deadline(
-    iree_hal_task_queue_t* queue, iree_time_t deadline_ns) {
+iree_status_t iree_hal_task_queue_wait_idle(iree_hal_task_queue_t* queue,
+                                            iree_timeout_t timeout) {
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
   iree_status_t status = iree_task_scope_wait_idle(&queue->scope, deadline_ns);
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/iree/hal/local/task_queue.h
+++ b/iree/hal/local/task_queue.h
@@ -68,6 +68,12 @@ iree_status_t iree_hal_task_queue_submit(
     iree_hal_task_queue_t* queue, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches);
 
+iree_status_t iree_hal_task_queue_submit_and_wait(
+    iree_hal_task_queue_t* queue, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_timeout_t timeout);
+
 iree_status_t iree_hal_task_queue_wait_idle(iree_hal_task_queue_t* queue,
                                             iree_timeout_t timeout);
 

--- a/iree/hal/local/task_queue.h
+++ b/iree/hal/local/task_queue.h
@@ -68,8 +68,8 @@ iree_status_t iree_hal_task_queue_submit(
     iree_hal_task_queue_t* queue, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches);
 
-iree_status_t iree_hal_task_queue_wait_idle_with_deadline(
-    iree_hal_task_queue_t* queue, iree_time_t deadline_ns);
+iree_status_t iree_hal_task_queue_wait_idle(iree_hal_task_queue_t* queue,
+                                            iree_timeout_t timeout);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/hal/local/task_semaphore.h
+++ b/iree/hal/local/task_semaphore.h
@@ -47,7 +47,7 @@ iree_status_t iree_hal_task_semaphore_enqueue_timepoint(
 // |deadline_ns| elapses.
 iree_status_t iree_hal_task_semaphore_multi_wait(
     iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
     iree_hal_local_event_pool_t* event_pool,
     iree_arena_block_pool_t* block_pool);
 

--- a/iree/hal/semaphore.c
+++ b/iree/hal/semaphore.c
@@ -67,25 +67,12 @@ iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore, iree_status_t status) {
   IREE_TRACE_ZONE_END(z0);
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_semaphore_wait_with_deadline(iree_hal_semaphore_t* semaphore,
-                                      uint64_t value, iree_time_t deadline_ns) {
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_semaphore_wait(
+    iree_hal_semaphore_t* semaphore, uint64_t value, iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(semaphore, wait_with_deadline)(
-      semaphore, value, deadline_ns);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_semaphore_wait_with_timeout(iree_hal_semaphore_t* semaphore,
-                                     uint64_t value,
-                                     iree_duration_t timeout_ns) {
-  IREE_ASSERT_ARGUMENT(semaphore);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(semaphore, wait_with_timeout)(
-      semaphore, value, timeout_ns);
+  iree_status_t status =
+      _VTABLE_DISPATCH(semaphore, wait)(semaphore, value, timeout);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/semaphore.h
+++ b/iree/hal/semaphore.h
@@ -103,26 +103,16 @@ IREE_API_EXPORT void IREE_API_CALL
 iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore, iree_status_t status);
 
 // Blocks the caller until the semaphore reaches or exceedes the specified
-// payload value or the |deadline_ns| elapses.
+// payload value or the |timeout| elapses.
 //
 // Returns success if the wait is successful and the semaphore has met or
 // exceeded the required payload value.
 //
-// Returns DEADLINE_EXCEEDED if the |deadline_ns| elapses without the semaphore
+// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the semaphore
 // reaching the required value. If an asynchronous failure occured this will
 // return the failure status that was set immediately.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_semaphore_wait_with_deadline(iree_hal_semaphore_t* semaphore,
-                                      uint64_t value, iree_time_t deadline_ns);
-
-// Blocks the caller until the semaphore reaches or exceedes the specified
-// payload value or the |timeout_ns| elapses.
-// A relative-time version of iree_hal_semaphore_wait_with_deadline using the
-// relative nanoseconds from the time the call is made.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_semaphore_wait_with_timeout(iree_hal_semaphore_t* semaphore,
-                                     uint64_t value,
-                                     iree_duration_t timeout_ns);
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_semaphore_wait(
+    iree_hal_semaphore_t* semaphore, uint64_t value, iree_timeout_t timeout);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_semaphore_t implementation details
@@ -141,11 +131,8 @@ typedef struct {
   void(IREE_API_PTR* fail)(iree_hal_semaphore_t* semaphore,
                            iree_status_t status);
 
-  iree_status_t(IREE_API_PTR* wait_with_deadline)(
-      iree_hal_semaphore_t* semaphore, uint64_t value, iree_time_t deadline_ns);
-  iree_status_t(IREE_API_PTR* wait_with_timeout)(
-      iree_hal_semaphore_t* semaphore, uint64_t value,
-      iree_duration_t timeout_ns);
+  iree_status_t(IREE_API_PTR* wait)(iree_hal_semaphore_t* semaphore,
+                                    uint64_t value, iree_timeout_t timeout);
 } iree_hal_semaphore_vtable_t;
 
 IREE_API_EXPORT void IREE_API_CALL

--- a/iree/hal/vulkan/command_queue.h
+++ b/iree/hal/vulkan/command_queue.h
@@ -59,7 +59,7 @@ class CommandQueue {
   virtual iree_status_t Submit(iree_host_size_t batch_count,
                                const iree_hal_submission_batch_t* batches) = 0;
 
-  virtual iree_status_t WaitIdle(iree_time_t deadline_ns) = 0;
+  virtual iree_status_t WaitIdle(iree_timeout_t timeout) = 0;
 
  protected:
   CommandQueue(VkDeviceHandle* logical_device,

--- a/iree/hal/vulkan/direct_command_queue.cc
+++ b/iree/hal/vulkan/direct_command_queue.cc
@@ -124,7 +124,8 @@ iree_status_t DirectCommandQueue::Submit(
   return iree_ok_status();
 }
 
-iree_status_t DirectCommandQueue::WaitIdle(iree_time_t deadline_ns) {
+iree_status_t DirectCommandQueue::WaitIdle(iree_timeout_t timeout) {
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
   if (deadline_ns == IREE_TIME_INFINITE_FUTURE) {
     // Fast path for using vkQueueWaitIdle, which is usually cheaper (as it
     // requires fewer calls into the driver).

--- a/iree/hal/vulkan/direct_command_queue.h
+++ b/iree/hal/vulkan/direct_command_queue.h
@@ -33,7 +33,7 @@ class DirectCommandQueue final : public CommandQueue {
   iree_status_t Submit(iree_host_size_t batch_count,
                        const iree_hal_submission_batch_t* batches) override;
 
-  iree_status_t WaitIdle(iree_time_t deadline_ns) override;
+  iree_status_t WaitIdle(iree_timeout_t timeout) override;
 
  private:
   iree_status_t TranslateBatchInfo(

--- a/iree/hal/vulkan/emulated_semaphore.h
+++ b/iree/hal/vulkan/emulated_semaphore.h
@@ -155,7 +155,7 @@ iree_status_t iree_hal_vulkan_emulated_semaphore_acquire_signal_handle(
 // |deadline_ns| elapses.
 iree_status_t iree_hal_vulkan_emulated_semaphore_multi_wait(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
     VkSemaphoreWaitFlags wait_flags);
 
 #ifdef __cplusplus

--- a/iree/hal/vulkan/native_semaphore.h
+++ b/iree/hal/vulkan/native_semaphore.h
@@ -41,7 +41,7 @@ VkSemaphore iree_hal_vulkan_native_semaphore_handle(
 // |deadline_ns| elapses.
 iree_status_t iree_hal_vulkan_native_semaphore_multi_wait(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
     VkSemaphoreWaitFlags wait_flags);
 
 #ifdef __cplusplus

--- a/iree/hal/vulkan/serializing_command_queue.cc
+++ b/iree/hal/vulkan/serializing_command_queue.cc
@@ -279,8 +279,10 @@ iree_status_t SerializingCommandQueue::TryProcessDeferredSubmissions(
   return iree_ok_status();
 }
 
-iree_status_t SerializingCommandQueue::WaitIdle(iree_time_t deadline_ns) {
+iree_status_t SerializingCommandQueue::WaitIdle(iree_timeout_t timeout) {
   iree_status_t status = iree_ok_status();
+
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
 
   if (deadline_ns == IREE_TIME_INFINITE_FUTURE) {
     IREE_TRACE_SCOPE0("SerializingCommandQueue::WaitIdle#vkQueueWaitIdle");

--- a/iree/hal/vulkan/serializing_command_queue.h
+++ b/iree/hal/vulkan/serializing_command_queue.h
@@ -64,7 +64,7 @@ class SerializingCommandQueue final : public CommandQueue {
   iree_status_t Submit(iree_host_size_t batch_count,
                        const iree_hal_submission_batch_t* batches) override;
 
-  iree_status_t WaitIdle(iree_time_t deadline_ns) override;
+  iree_status_t WaitIdle(iree_timeout_t timeout) override;
 
   // Releases all deferred submissions ready to submit to the GPU.
   iree_status_t AdvanceQueueSubmission();

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -1041,6 +1041,35 @@ static iree_status_t iree_hal_vulkan_device_queue_submit(
   return queue->Submit(batch_count, batches);
 }
 
+static iree_status_t iree_hal_vulkan_device_submit_and_wait_with_deadline(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_time_t deadline_ns) {
+  // Submit...
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_device_queue_submit(
+      base_device, command_categories, queue_affinity, batch_count, batches));
+
+  // ...and wait.
+  return iree_hal_semaphore_wait_with_deadline(wait_semaphore, wait_value,
+                                               deadline_ns);
+}
+
+static iree_status_t iree_hal_vulkan_device_submit_and_wait_with_timeout(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_duration_t timeout_ns) {
+  return iree_hal_vulkan_device_submit_and_wait_with_deadline(
+      base_device, command_categories, queue_affinity, batch_count, batches,
+      wait_semaphore, wait_value,
+      iree_relative_timeout_to_deadline_ns(timeout_ns));
+}
+
 static iree_status_t iree_hal_vulkan_device_wait_semaphores_with_deadline(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {
@@ -1098,6 +1127,10 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     iree_hal_vulkan_device_create_executable_layout,
     /*.create_semaphore=*/iree_hal_vulkan_device_create_semaphore,
     /*.queue_submit=*/iree_hal_vulkan_device_queue_submit,
+    /*.submit_and_wait_with_deadline=*/
+    iree_hal_vulkan_device_submit_and_wait_with_deadline,
+    /*.submit_and_wait_with_timeout=*/
+    iree_hal_vulkan_device_submit_and_wait_with_timeout,
     /*.wait_semaphores_with_deadline=*/
     iree_hal_vulkan_device_wait_semaphores_with_deadline,
     /*.wait_semaphores_with_timeout=*/

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -1041,38 +1041,24 @@ static iree_status_t iree_hal_vulkan_device_queue_submit(
   return queue->Submit(batch_count, batches);
 }
 
-static iree_status_t iree_hal_vulkan_device_submit_and_wait_with_deadline(
+static iree_status_t iree_hal_vulkan_device_submit_and_wait(
     iree_hal_device_t* base_device,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
     const iree_hal_submission_batch_t* batches,
     iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_time_t deadline_ns) {
+    iree_timeout_t timeout) {
   // Submit...
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_device_queue_submit(
       base_device, command_categories, queue_affinity, batch_count, batches));
 
   // ...and wait.
-  return iree_hal_semaphore_wait_with_deadline(wait_semaphore, wait_value,
-                                               deadline_ns);
+  return iree_hal_semaphore_wait(wait_semaphore, wait_value, timeout);
 }
 
-static iree_status_t iree_hal_vulkan_device_submit_and_wait_with_timeout(
-    iree_hal_device_t* base_device,
-    iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches,
-    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
-    iree_duration_t timeout_ns) {
-  return iree_hal_vulkan_device_submit_and_wait_with_deadline(
-      base_device, command_categories, queue_affinity, batch_count, batches,
-      wait_semaphore, wait_value,
-      iree_relative_timeout_to_deadline_ns(timeout_ns));
-}
-
-static iree_status_t iree_hal_vulkan_device_wait_semaphores_with_deadline(
+static iree_status_t iree_hal_vulkan_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_time_t deadline_ns) {
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
   VkSemaphoreWaitFlags wait_flags = 0;
   if (wait_mode == IREE_HAL_WAIT_MODE_ANY) {
@@ -1080,34 +1066,19 @@ static iree_status_t iree_hal_vulkan_device_wait_semaphores_with_deadline(
   }
   if (device->semaphore_pool != NULL) {
     return iree_hal_vulkan_emulated_semaphore_multi_wait(
-        device->logical_device, semaphore_list, deadline_ns, wait_flags);
+        device->logical_device, semaphore_list, timeout, wait_flags);
   }
   return iree_hal_vulkan_native_semaphore_multi_wait(
-      device->logical_device, semaphore_list, deadline_ns, wait_flags);
+      device->logical_device, semaphore_list, timeout, wait_flags);
 }
 
-static iree_status_t iree_hal_vulkan_device_wait_semaphores_with_timeout(
-    iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list,
-    iree_duration_t timeout_ns) {
-  return iree_hal_vulkan_device_wait_semaphores_with_deadline(
-      base_device, wait_mode, semaphore_list,
-      iree_relative_timeout_to_deadline_ns(timeout_ns));
-}
-
-static iree_status_t iree_hal_vulkan_device_wait_idle_with_deadline(
-    iree_hal_device_t* base_device, iree_time_t deadline_ns) {
+static iree_status_t iree_hal_vulkan_device_wait_idle(
+    iree_hal_device_t* base_device, iree_timeout_t timeout) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
   for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
-    IREE_RETURN_IF_ERROR(device->queues[i]->WaitIdle(deadline_ns));
+    IREE_RETURN_IF_ERROR(device->queues[i]->WaitIdle(timeout));
   }
   return iree_ok_status();
-}
-
-static iree_status_t iree_hal_vulkan_device_wait_idle_with_timeout(
-    iree_hal_device_t* base_device, iree_duration_t timeout_ns) {
-  return iree_hal_vulkan_device_wait_idle_with_deadline(
-      base_device, iree_relative_timeout_to_deadline_ns(timeout_ns));
 }
 
 const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
@@ -1127,16 +1098,8 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     iree_hal_vulkan_device_create_executable_layout,
     /*.create_semaphore=*/iree_hal_vulkan_device_create_semaphore,
     /*.queue_submit=*/iree_hal_vulkan_device_queue_submit,
-    /*.submit_and_wait_with_deadline=*/
-    iree_hal_vulkan_device_submit_and_wait_with_deadline,
-    /*.submit_and_wait_with_timeout=*/
-    iree_hal_vulkan_device_submit_and_wait_with_timeout,
-    /*.wait_semaphores_with_deadline=*/
-    iree_hal_vulkan_device_wait_semaphores_with_deadline,
-    /*.wait_semaphores_with_timeout=*/
-    iree_hal_vulkan_device_wait_semaphores_with_timeout,
-    /*.wait_idle_with_deadline=*/
-    iree_hal_vulkan_device_wait_idle_with_deadline,
-    /*.wait_idle_with_timeout=*/
-    iree_hal_vulkan_device_wait_idle_with_timeout,
+    /*.submit_and_wait=*/
+    iree_hal_vulkan_device_submit_and_wait,
+    /*.wait_semaphores=*/iree_hal_vulkan_device_wait_semaphores,
+    /*.wait_idle=*/iree_hal_vulkan_device_wait_idle,
 };

--- a/iree/modules/hal/hal_module.c
+++ b/iree/modules/hal/hal_module.c
@@ -243,8 +243,7 @@ IREE_VM_ABI_EXPORT(iree_hal_module_ex_submit_and_wait, rr, v) {
   }
 
   // Block and wait for the semaphore to be signaled (or fail).
-  status = iree_hal_semaphore_wait_with_deadline(semaphore, 1ull,
-                                                 IREE_TIME_INFINITE_FUTURE);
+  status = iree_hal_semaphore_wait(semaphore, 1ull, iree_infinite_timeout());
   iree_hal_semaphore_release(semaphore);
   if (!iree_status_is_ok(status)) {
     return status;
@@ -923,8 +922,8 @@ IREE_VM_ABI_EXPORT(iree_hal_module_semaphore_await, ri, i) {
   uint64_t new_value = (uint32_t)args->i1;
 
   // TODO(benvanik): coroutine magic.
-  iree_status_t status = iree_hal_semaphore_wait_with_deadline(
-      semaphore, new_value, IREE_TIME_INFINITE_FUTURE);
+  iree_status_t status =
+      iree_hal_semaphore_wait(semaphore, new_value, iree_infinite_timeout());
   if (iree_status_is_ok(status)) {
     rets->i0 = 0;
   } else if (iree_status_is_deadline_exceeded(status)) {

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -442,8 +442,9 @@ extern "C" int iree_main(int argc, char** argv) {
         // TODO(scotttodd): Samples showing non-blocking async execution
         //   * poll during update loop
         //   * pipeline execution (use signal from one as wait for another)
-        IREE_CHECK_OK(iree_hal_semaphore_wait_with_timeout(
-            signal_semaphore.get(), 1, IREE_TIME_INFINITE_FUTURE));
+        IREE_CHECK_OK(iree_hal_semaphore_wait(
+            signal_semaphore.get(), 1,
+            iree_make_timeout(IREE_TIME_INFINITE_FUTURE)));
 
         // Read back the results.
         IREE_DLOG(INFO) << "Reading back results...";

--- a/iree/task/executor.c
+++ b/iree/task/executor.c
@@ -732,9 +732,15 @@ iree_task_t* iree_task_executor_try_steal_task(
 iree_status_t iree_task_executor_donate_caller(iree_task_executor_t* executor,
                                                iree_wait_handle_t* wait_handle,
                                                iree_time_t deadline_ns) {
-  // Not implemented; just wait. Unclear we want this yet and it's complex.
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Perform an immediate flush/coordination (in case the caller queued).
+  iree_task_executor_flush(executor);
+
+  // Wait until completed.
+  // TODO(benvanik): make this steal tasks until wait_handle resolves.
   iree_status_t status = iree_wait_one(wait_handle, deadline_ns);
+
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/task/executor.h
+++ b/iree/task/executor.h
@@ -352,7 +352,8 @@ void iree_task_executor_submit(iree_task_executor_t* executor,
 void iree_task_executor_flush(iree_task_executor_t* executor);
 
 // Donates the calling thread to the executor until either |wait_handle|
-// resolves or |deadline_ns| is exceeded.
+// resolves or |deadline_ns| is exceeded. Flushes any pending task batches prior
+// to doing any work or waiting.
 //
 // If there are no tasks available then the calling thread will block as if
 // iree_wait_one had been used on |wait_handle|. If tasks are ready then the

--- a/iree/vm/ref.c
+++ b/iree/vm/ref.c
@@ -159,7 +159,7 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_retain(iree_vm_ref_t* ref,
   }
 
   // Assign ref to out_ref and increment the counter.
-  memcpy(out_ref, ref, sizeof(*out_ref));
+  memmove(out_ref, ref, sizeof(*out_ref));
   if (out_ref->ptr) {
     volatile iree_atomic_ref_count_t* counter =
         iree_vm_get_ref_counter_ptr(out_ref);
@@ -185,7 +185,7 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_retain_or_move(
   }
 
   // Assign ref to out_ref and increment the counter if not moving.
-  memcpy(out_ref, ref, sizeof(*out_ref));
+  memmove(out_ref, ref, sizeof(*out_ref));
   if (out_ref->ptr && !is_move) {
     // Retain by incrementing counter and preserving the source ref.
     volatile iree_atomic_ref_count_t* counter =


### PR DESCRIPTION
This prepares for thread donation to the task pool by adding `iree_hal_device_submit_and_wait` to define an atomic operation that will let us avoid thread switches. In the process of adding yet another _with_deadline and _with_timeout I decided to clean that up to keep the API leaner.

This change gets us to the point where we have both the submit and wait happen side-by-side but does not yet implement the task system donation mechanism (tracked in #5507):
![image](https://user-images.githubusercontent.com/75337/115139043-a2587c80-9fe4-11eb-9436-2107c1928dbb.png)
(the improvement stands to save ~12us from this 37us execution of a teeny tiny `++i` dispatch, but that % will be larger on Android which has larger context switch delays - note that not doing this style of work at all is the smartest approach :)