### PR TITLE
Adding experimental synchronous executor using inline command buffers.

### DIFF
--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -841,6 +841,14 @@ static inline iree_timeout_t iree_immediate_timeout() {
   return timeout;
 }
 
+// Returns true if the |timeout| indicates an immediate/polling/nonblocking
+// timeout.
+static inline bool iree_timeout_is_immediate(iree_timeout_t timeout) {
+  return timeout.type == IREE_TIMEOUT_ABSOLUTE
+             ? timeout.nanos == IREE_TIME_INFINITE_PAST
+             : timeout.nanos == IREE_DURATION_ZERO;
+}
+
 // Returns a timeout that will never be reached.
 // This can be used with APIs that can wait to disable the early
 // deadline-exceeded returns when a condition is not met. It should be used with
@@ -850,6 +858,13 @@ static inline iree_timeout_t iree_immediate_timeout() {
 static inline iree_timeout_t iree_infinite_timeout() {
   iree_timeout_t timeout = {IREE_TIMEOUT_ABSOLUTE, IREE_TIME_INFINITE_FUTURE};
   return timeout;
+}
+
+// Returns true if the |timeout| indicates an infinite/forever blocking timeout.
+static inline bool iree_timeout_is_infinite(iree_timeout_t timeout) {
+  return timeout.type == IREE_TIMEOUT_ABSOLUTE
+             ? timeout.nanos == IREE_TIME_INFINITE_FUTURE
+             : timeout.nanos == IREE_DURATION_INFINITE;
 }
 
 // Defines an absolute timeout with the given time in nanoseconds.

--- a/iree/hal/cts/command_buffer_test.cc
+++ b/iree/hal/cts/command_buffer_test.cc
@@ -33,6 +33,12 @@ namespace cts {
 using ::testing::ContainerEq;
 
 class CommandBufferTest : public CtsTestBase {
+ public:
+  CommandBufferTest() {
+    // TODO(#4680): command buffer recording so that this can run on sync HAL.
+    SkipUnavailableDriver("dylib-sync");
+  }
+
  protected:
   static constexpr iree_device_size_t kBufferSize = 4096;
 };

--- a/iree/hal/cts/cts_test_base.h
+++ b/iree/hal/cts/cts_test_base.h
@@ -133,7 +133,7 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
     driver_block_list_.insert(driver_name);
   }
   // Allow skipping tests for unsupported features.
-  void declareUnavailableDriver(const std::string& driver_name) {
+  void SkipUnavailableDriver(const std::string& driver_name) {
     driver_block_list_.insert(driver_name);
   }
 
@@ -170,7 +170,9 @@ struct GenerateTestName {
   template <class ParamType>
   std::string operator()(
       const ::testing::TestParamInfo<ParamType>& info) const {
-    return info.param;
+    std::string name = info.param;
+    std::replace(name.begin(), name.end(), '-', '_');
+    return name;
   }
 };
 

--- a/iree/hal/cts/event_test.cc
+++ b/iree/hal/cts/event_test.cc
@@ -21,7 +21,13 @@ namespace iree {
 namespace hal {
 namespace cts {
 
-class EventTest : public CtsTestBase {};
+class EventTest : public CtsTestBase {
+ public:
+  EventTest() {
+    // TODO(#4680): command buffer recording so that this can run on sync HAL.
+    SkipUnavailableDriver("dylib-sync");
+  }
+};
 
 TEST_P(EventTest, Create) {
   iree_hal_event_t* event;

--- a/iree/hal/cts/semaphore_submission_test.cc
+++ b/iree/hal/cts/semaphore_submission_test.cc
@@ -22,8 +22,12 @@ namespace cts {
 
 class SemaphoreSubmissionTest : public CtsTestBase {
  public:
-  // Disable cuda backend for this test as semaphores are not implemented yet.
-  SemaphoreSubmissionTest() { declareUnavailableDriver("cuda"); }
+  SemaphoreSubmissionTest() {
+    // Disable cuda backend for this test as semaphores are not implemented yet.
+    SkipUnavailableDriver("cuda");
+    // TODO(#4680): command buffer recording so that this can run on sync HAL.
+    SkipUnavailableDriver("dylib-sync");
+  }
 };
 
 TEST_P(SemaphoreSubmissionTest, SubmitWithNoCommandBuffers) {

--- a/iree/hal/cts/semaphore_test.cc
+++ b/iree/hal/cts/semaphore_test.cc
@@ -25,7 +25,7 @@ namespace cts {
 class SemaphoreTest : public CtsTestBase {
  public:
   // Disable cuda backend for this test as semaphores are not implemented yet.
-  SemaphoreTest() { declareUnavailableDriver("cuda"); }
+  SemaphoreTest() { SkipUnavailableDriver("cuda"); }
 };
 
 // Tests that a semaphore that is unused properly cleans itself up.

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -217,9 +217,13 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_submit_and_wait(
 // Returns success if the wait is successful and semaphores have been signaled
 // satisfying the |wait_mode|.
 //
-// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the |wait_mode|
-// being satisfied. Note that even on success only a subset of the semaphores
-// may have been signaled and each can be queried to see which ones.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if the |timeout| elapses without the
+// |wait_mode| being satisfied. Note that even on success only a subset of the
+// semaphores may have been signaled and each can be queried to see which ones.
+//
+// Returns IREE_STATUS_ABORTED if one or more semaphores has failed. Callers can
+// use iree_hal_semaphore_query on the semaphores to find the ones that have
+// failed and get the status.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_device_wait_semaphores(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);

--- a/iree/hal/drivers/BUILD
+++ b/iree/hal/drivers/BUILD
@@ -30,6 +30,7 @@ cc_library(
     ] + [
         # TODO(*): select() and only pull in based on build configuration.
         "//iree/hal/dylib/registration",
+        "//iree/hal/dylib/registration:sync",
         "//iree/hal/vmla/registration",
         "//iree/hal/vulkan/registration",
     ] + IREE_CUDA_DEPS,

--- a/iree/hal/drivers/CMakeLists.txt
+++ b/iree/hal/drivers/CMakeLists.txt
@@ -20,20 +20,14 @@ if(${IREE_HAL_DRIVER_CUDA})
 endif()
 if(${IREE_HAL_DRIVER_DYLIB})
   list(APPEND IREE_HAL_DRIVER_MODULES iree::hal::dylib::registration)
+  # TODO(benvanik): add a IREE_HAL_DRIVER_DYLIB_SYNC or global flag.
+  list(APPEND IREE_HAL_DRIVER_MODULES iree::hal::dylib::registration::sync)
 endif()
 if(${IREE_HAL_DRIVER_VMLA})
   list(APPEND IREE_HAL_DRIVER_MODULES iree::hal::vmla::registration)
 endif()
 if(${IREE_HAL_DRIVER_VULKAN})
   list(APPEND IREE_HAL_DRIVER_MODULES iree::hal::vulkan::registration)
-endif()
-
-# TODO: Move to either hal/metal/CMakeLists.txt or
-# hal/metal/registration/CMakeLists.txt if bazel-to-cmake issues can be
-# resolved.
-if(APPLE)
-  find_library(Foundation Foundation)
-  find_library(Metal Metal)
 endif()
 
 iree_cc_library(
@@ -47,8 +41,5 @@ iree_cc_library(
     iree::base::api
     iree::base::tracing
     ${IREE_HAL_DRIVER_MODULES}
-    # TODO: Also move as above if bazel-to-cmake issues can be resolved.
-    $<$<PLATFORM_ID:Darwin>:${Foundation}>
-    $<$<PLATFORM_ID:Darwin>:${Metal}>
   PUBLIC
 )

--- a/iree/hal/drivers/init.c
+++ b/iree/hal/drivers/init.c
@@ -24,6 +24,10 @@
 #include "iree/hal/dylib/registration/driver_module.h"
 #endif  // IREE_HAL_HAVE_DYLIB_DRIVER_MODULE
 
+#if defined(IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE)
+#include "iree/hal/dylib/registration/driver_module_sync.h"
+#endif  // IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE
+
 #if defined(IREE_HAL_HAVE_VMLA_DRIVER_MODULE)
 #include "iree/hal/vmla/registration/driver_module.h"
 #endif  // IREE_HAL_HAVE_VMLA_DRIVER_MODULE
@@ -45,6 +49,11 @@ iree_hal_register_all_available_drivers(iree_hal_driver_registry_t* registry) {
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_dylib_driver_module_register(registry));
 #endif  // IREE_HAL_HAVE_DYLIB_DRIVER_MODULE
+
+#if defined(IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE)
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_dylib_sync_driver_module_register(registry));
+#endif  // IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE
 
 #if defined(IREE_HAL_HAVE_VMLA_DRIVER_MODULE)
   IREE_RETURN_AND_END_ZONE_IF_ERROR(

--- a/iree/hal/dylib/registration/BUILD
+++ b/iree/hal/dylib/registration/BUILD
@@ -43,3 +43,17 @@ cc_library(
         "@com_google_absl//absl/flags:flag",
     ],
 )
+
+cc_library(
+    name = "sync",
+    srcs = ["driver_module_sync.c"],
+    hdrs = ["driver_module_sync.h"],
+    defines = [
+        "IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE=1",
+    ],
+    deps = [
+        "//iree/hal:api",
+        "//iree/hal/local:sync_driver",
+        "//iree/hal/local/loaders:legacy_library_loader",
+    ],
+)

--- a/iree/hal/dylib/registration/CMakeLists.txt
+++ b/iree/hal/dylib/registration/CMakeLists.txt
@@ -31,4 +31,20 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    sync
+  HDRS
+    "driver_module_sync.h"
+  SRCS
+    "driver_module_sync.c"
+  DEPS
+    iree::hal::api
+    iree::hal::local::loaders::legacy_library_loader
+    iree::hal::local::sync_driver
+  DEFINES
+    "IREE_HAL_HAVE_DYLIB_SYNC_DRIVER_MODULE=1"
+  PUBLIC
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/hal/dylib/registration/driver_module_sync.c
+++ b/iree/hal/dylib/registration/driver_module_sync.c
@@ -1,0 +1,79 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/dylib/registration/driver_module_sync.h"
+
+#include <inttypes.h>
+
+#include "iree/hal/local/loaders/legacy_library_loader.h"
+#include "iree/hal/local/sync_driver.h"
+
+// TODO(#4298): remove this driver registration and wrapper.
+// By having a single iree/hal/local/registration that then has the loaders
+// added to it based on compilation settings we can have a single set of flags
+// for everything.
+
+#define IREE_HAL_DYLIB_SYNC_DRIVER_ID 0x53444C4Cu  // SDLL
+
+static iree_status_t iree_hal_dylib_sync_driver_factory_enumerate(
+    void* self, const iree_hal_driver_info_t** out_driver_infos,
+    iree_host_size_t* out_driver_info_count) {
+  static const iree_hal_driver_info_t default_driver_info = {
+      .driver_id = IREE_HAL_DYLIB_SYNC_DRIVER_ID,
+      .driver_name = iree_string_view_literal("dylib-sync"),
+      .full_name = iree_string_view_literal("AOT compiled dynamic libraries"),
+  };
+  *out_driver_info_count = 1;
+  *out_driver_infos = &default_driver_info;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_dylib_sync_driver_factory_try_create(
+    void* self, iree_hal_driver_id_t driver_id, iree_allocator_t allocator,
+    iree_hal_driver_t** out_driver) {
+  if (driver_id != IREE_HAL_DYLIB_SYNC_DRIVER_ID) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "no driver with ID %016" PRIu64
+                            " is provided by this factory",
+                            driver_id);
+  }
+
+  iree_hal_sync_device_params_t default_params;
+  iree_hal_sync_device_params_initialize(&default_params);
+
+  iree_hal_executable_loader_t* dylib_loader = NULL;
+  iree_status_t status =
+      iree_hal_legacy_library_loader_create(allocator, &dylib_loader);
+  iree_hal_executable_loader_t* loaders[1] = {dylib_loader};
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_sync_driver_create(
+        iree_make_cstring_view("dylib"), &default_params,
+        IREE_ARRAYSIZE(loaders), loaders, allocator, out_driver);
+  }
+
+  iree_hal_executable_loader_release(dylib_loader);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_dylib_sync_driver_module_register(
+    iree_hal_driver_registry_t* registry) {
+  static const iree_hal_driver_factory_t factory = {
+      .self = NULL,
+      .enumerate = iree_hal_dylib_sync_driver_factory_enumerate,
+      .try_create = iree_hal_dylib_sync_driver_factory_try_create,
+  };
+  return iree_hal_driver_registry_register_factory(registry, &factory);
+}

--- a/iree/hal/dylib/registration/driver_module_sync.h
+++ b/iree/hal/dylib/registration/driver_module_sync.h
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_DYLIB_REGISTRATION_DRIVER_MODULE_SYNC_H_
+#define IREE_HAL_DYLIB_REGISTRATION_DRIVER_MODULE_SYNC_H_
+
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// DEPRECATED: this entire driver will be removed soon.
+// TODO(#3580): remove this entire driver w/ iree_hal_executable_library_t.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_hal_dylib_sync_driver_module_register(
+    iree_hal_driver_registry_t* registry);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DYLIB_REGISTRATION_DRIVER_MODULE_SYNC_H_

--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -91,6 +91,34 @@ cc_library(
 )
 
 cc_library(
+    name = "sync_driver",
+    srcs = [
+        "sync_device.c",
+        "sync_driver.c",
+        "sync_event.c",
+        "sync_semaphore.c",
+    ],
+    hdrs = [
+        "sync_device.h",
+        "sync_driver.h",
+        "sync_event.h",
+        "sync_semaphore.h",
+    ],
+    deps = [
+        ":arena",
+        ":local",
+        "//iree/base:api",
+        "//iree/base:core_headers",
+        "//iree/base:synchronization",
+        "//iree/base:tracing",
+        "//iree/base/internal",
+        "//iree/base/internal:wait_handle",
+        "//iree/hal:api",
+        "//iree/task",
+    ],
+)
+
+cc_library(
     name = "task_driver",
     srcs = [
         "task_command_buffer.c",

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -81,6 +81,33 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    sync_driver
+  HDRS
+    "sync_device.h"
+    "sync_driver.h"
+    "sync_event.h"
+    "sync_semaphore.h"
+  SRCS
+    "sync_device.c"
+    "sync_driver.c"
+    "sync_event.c"
+    "sync_semaphore.c"
+  DEPS
+    ::arena
+    ::local
+    iree::base::api
+    iree::base::core_headers
+    iree::base::internal
+    iree::base::internal::wait_handle
+    iree::base::synchronization
+    iree::base::tracing
+    iree::hal::api
+    iree::task
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     task_driver
   HDRS
     "task_command_buffer.h"

--- a/iree/hal/local/executable_library.h
+++ b/iree/hal/local/executable_library.h
@@ -155,7 +155,7 @@ typedef struct {
   const uint32_t* push_constants;
 
   // Total number of binding base pointers in |binding_ptrs| and
-  // |binding_lengths|. The set is packed densely based on which binidngs are
+  // |binding_lengths|. The set is packed densely based on which bindings are
   // used (known at compile-time).
   size_t binding_count;
   // Base pointers to each binding buffer.

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -1,0 +1,300 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/sync_device.h"
+
+#include "iree/base/tracing.h"
+#include "iree/hal/local/inline_command_buffer.h"
+#include "iree/hal/local/local_descriptor_set.h"
+#include "iree/hal/local/local_descriptor_set_layout.h"
+#include "iree/hal/local/local_executable.h"
+#include "iree/hal/local/local_executable_cache.h"
+#include "iree/hal/local/local_executable_layout.h"
+#include "iree/hal/local/sync_event.h"
+#include "iree/hal/local/sync_semaphore.h"
+
+typedef struct {
+  iree_hal_resource_t resource;
+  iree_string_view_t identifier;
+
+  iree_host_size_t loader_count;
+  iree_hal_executable_loader_t** loaders;
+
+  iree_allocator_t host_allocator;
+  iree_hal_allocator_t* device_allocator;
+
+  iree_hal_sync_semaphore_state_t semaphore_state;
+} iree_hal_sync_device_t;
+
+static const iree_hal_device_vtable_t iree_hal_sync_device_vtable;
+
+static iree_hal_sync_device_t* iree_hal_sync_device_cast(
+    iree_hal_device_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_sync_device_vtable);
+  return (iree_hal_sync_device_t*)base_value;
+}
+
+void iree_hal_sync_device_params_initialize(
+    iree_hal_sync_device_params_t* out_params) {
+  memset(out_params, 0, sizeof(*out_params));
+}
+
+static iree_status_t iree_hal_sync_device_check_params(
+    const iree_hal_sync_device_params_t* params) {
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_sync_device_create(
+    iree_string_view_t identifier, const iree_hal_sync_device_params_t* params,
+    iree_host_size_t loader_count, iree_hal_executable_loader_t** loaders,
+    iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
+  IREE_ASSERT_ARGUMENT(params);
+  IREE_ASSERT_ARGUMENT(!loader_count || loaders);
+  IREE_ASSERT_ARGUMENT(out_device);
+  *out_device = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
+                                    iree_hal_sync_device_check_params(params));
+
+  iree_hal_sync_device_t* device = NULL;
+  iree_host_size_t total_size = sizeof(*device) + identifier.size +
+                                loader_count * sizeof(*device->loaders);
+  iree_status_t status =
+      iree_allocator_malloc(host_allocator, total_size, (void**)&device);
+  if (iree_status_is_ok(status)) {
+    memset(device, 0, total_size);
+    iree_hal_resource_initialize(&iree_hal_sync_device_vtable,
+                                 &device->resource);
+    iree_string_view_append_to_buffer(identifier, &device->identifier,
+                                      (char*)device + sizeof(*device));
+    device->host_allocator = host_allocator;
+
+    device->loader_count = loader_count;
+    device->loaders =
+        (iree_hal_executable_loader_t**)((uint8_t*)device->identifier.data +
+                                         identifier.size);
+    for (iree_host_size_t i = 0; i < device->loader_count; ++i) {
+      device->loaders[i] = loaders[i];
+      iree_hal_executable_loader_retain(device->loaders[i]);
+    }
+
+    iree_hal_sync_semaphore_state_initialize(&device->semaphore_state);
+  }
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_create_heap(identifier, host_allocator,
+                                            &device->device_allocator);
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_device = (iree_hal_device_t*)device;
+  } else {
+    iree_hal_device_release((iree_hal_device_t*)device);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_sync_device_destroy(iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_allocator_t host_allocator = iree_hal_device_host_allocator(base_device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_sync_semaphore_state_deinitialize(&device->semaphore_state);
+
+  for (iree_host_size_t i = 0; i < device->loader_count; ++i) {
+    iree_hal_executable_loader_release(device->loaders[i]);
+  }
+  iree_hal_allocator_release(device->device_allocator);
+  iree_allocator_free(host_allocator, device);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_string_view_t iree_hal_sync_device_id(
+    iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return device->identifier;
+}
+
+static iree_allocator_t iree_hal_sync_device_host_allocator(
+    iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return device->host_allocator;
+}
+
+static iree_hal_allocator_t* iree_hal_sync_device_allocator(
+    iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return device->device_allocator;
+}
+
+static iree_status_t iree_hal_sync_device_query_i32(
+    iree_hal_device_t* base_device, iree_string_view_t key,
+    int32_t* out_value) {
+  // iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  *out_value = 0;
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "unknown device configuration key value '%*.s'",
+                          (int)key.size, key.data);
+}
+
+static iree_status_t iree_hal_sync_device_create_command_buffer(
+    iree_hal_device_t* base_device, iree_hal_command_buffer_mode_t mode,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_command_buffer_t** out_command_buffer) {
+  // TODO(#4680): implement a non-inline command buffer that stores its commands
+  // and can be submitted later on/multiple-times.
+  return iree_hal_inline_command_buffer_create(
+      base_device, mode, command_categories, queue_affinity,
+      out_command_buffer);
+}
+
+static iree_status_t iree_hal_sync_device_create_descriptor_set(
+    iree_hal_device_t* base_device,
+    iree_hal_descriptor_set_layout_t* set_layout,
+    iree_host_size_t binding_count,
+    const iree_hal_descriptor_set_binding_t* bindings,
+    iree_hal_descriptor_set_t** out_descriptor_set) {
+  return iree_hal_local_descriptor_set_create(set_layout, binding_count,
+                                              bindings, out_descriptor_set);
+}
+
+static iree_status_t iree_hal_sync_device_create_descriptor_set_layout(
+    iree_hal_device_t* base_device,
+    iree_hal_descriptor_set_layout_usage_type_t usage_type,
+    iree_host_size_t binding_count,
+    const iree_hal_descriptor_set_layout_binding_t* bindings,
+    iree_hal_descriptor_set_layout_t** out_descriptor_set_layout) {
+  return iree_hal_local_descriptor_set_layout_create(
+      usage_type, binding_count, bindings,
+      iree_hal_device_host_allocator(base_device), out_descriptor_set_layout);
+}
+
+static iree_status_t iree_hal_sync_device_create_event(
+    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+  return iree_hal_sync_event_create(iree_hal_device_host_allocator(base_device),
+                                    out_event);
+}
+
+static iree_status_t iree_hal_sync_device_create_executable_cache(
+    iree_hal_device_t* base_device, iree_string_view_t identifier,
+    iree_hal_executable_cache_t** out_executable_cache) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return iree_hal_local_executable_cache_create(
+      identifier, device->loader_count, device->loaders,
+      iree_hal_device_host_allocator(base_device), out_executable_cache);
+}
+
+static iree_status_t iree_hal_sync_device_create_executable_layout(
+    iree_hal_device_t* base_device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
+    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_executable_layout_t** out_executable_layout) {
+  return iree_hal_local_executable_layout_create(
+      push_constants, set_layout_count, set_layouts,
+      iree_hal_device_host_allocator(base_device), out_executable_layout);
+}
+
+static iree_status_t iree_hal_sync_device_create_semaphore(
+    iree_hal_device_t* base_device, uint64_t initial_value,
+    iree_hal_semaphore_t** out_semaphore) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return iree_hal_sync_semaphore_create(&device->semaphore_state, initial_value,
+                                        device->host_allocator, out_semaphore);
+}
+
+static iree_status_t iree_hal_sync_device_queue_submit(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+
+  // TODO(#4680): there is some better error handling here needed; we should
+  // propagate failures to all signal semaphores. Today we aren't as there
+  // shouldn't be any failures or if there are there's not much we'd be able to
+  // do - we already executed everything inline!
+
+  for (iree_host_size_t i = 0; i < batch_count; ++i) {
+    const iree_hal_submission_batch_t* batch = &batches[i];
+
+    // Wait for semaphores to be signaled before performing any work.
+    IREE_RETURN_IF_ERROR(iree_hal_sync_semaphore_multi_wait(
+        &device->semaphore_state, IREE_HAL_WAIT_MODE_ALL,
+        &batch->wait_semaphores, iree_infinite_timeout()));
+
+    // TODO(#4680): if we were doing deferred submissions we would issue them
+    // here. With only inline command buffers we have nothing to do here.
+
+    // Signal all semaphores now that batch work has completed.
+    IREE_RETURN_IF_ERROR(iree_hal_sync_semaphore_multi_signal(
+        &device->semaphore_state, &batch->signal_semaphores));
+  }
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_sync_device_submit_and_wait(
+    iree_hal_device_t* base_device,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
+    const iree_hal_submission_batch_t* batches,
+    iree_hal_semaphore_t* wait_semaphore, uint64_t wait_value,
+    iree_timeout_t timeout) {
+  // Submit...
+  IREE_RETURN_IF_ERROR(iree_hal_sync_device_queue_submit(
+      base_device, command_categories, queue_affinity, batch_count, batches));
+
+  // ...and wait.
+  return iree_hal_semaphore_wait(wait_semaphore, wait_value, timeout);
+}
+
+static iree_status_t iree_hal_sync_device_wait_semaphores(
+    iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return iree_hal_sync_semaphore_multi_wait(&device->semaphore_state, wait_mode,
+                                            semaphore_list, timeout);
+}
+
+static iree_status_t iree_hal_sync_device_wait_idle(
+    iree_hal_device_t* base_device, iree_timeout_t timeout) {
+  // No-op (in intended usages). If we allowed multiple threads to call into
+  // the same device then we may want to change this to an atomic flag as to
+  // whether any thread is actively performing work.
+  return iree_ok_status();
+}
+
+static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
+    .destroy = iree_hal_sync_device_destroy,
+    .id = iree_hal_sync_device_id,
+    .host_allocator = iree_hal_sync_device_host_allocator,
+    .device_allocator = iree_hal_sync_device_allocator,
+    .query_i32 = iree_hal_sync_device_query_i32,
+    .create_command_buffer = iree_hal_sync_device_create_command_buffer,
+    .create_descriptor_set = iree_hal_sync_device_create_descriptor_set,
+    .create_descriptor_set_layout =
+        iree_hal_sync_device_create_descriptor_set_layout,
+    .create_event = iree_hal_sync_device_create_event,
+    .create_executable_cache = iree_hal_sync_device_create_executable_cache,
+    .create_executable_layout = iree_hal_sync_device_create_executable_layout,
+    .create_semaphore = iree_hal_sync_device_create_semaphore,
+    .queue_submit = iree_hal_sync_device_queue_submit,
+    .submit_and_wait = iree_hal_sync_device_submit_and_wait,
+    .wait_semaphores = iree_hal_sync_device_wait_semaphores,
+    .wait_idle = iree_hal_sync_device_wait_idle,
+};

--- a/iree/hal/local/sync_device.h
+++ b/iree/hal/local/sync_device.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_SYNC_DEVICE_H_
+#define IREE_HAL_LOCAL_SYNC_DEVICE_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/local/executable_loader.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Parameters configuring an iree_hal_sync_device_t.
+// Must be initialized with iree_hal_sync_device_params_initialize prior to use.
+typedef struct {
+  int reserved;
+} iree_hal_sync_device_params_t;
+
+// Initializes |out_params| to default values.
+void iree_hal_sync_device_params_initialize(
+    iree_hal_sync_device_params_t* out_params);
+
+// Creates a new synchronous local CPU device that performs execution inline
+// on threads issuing submissions. |loaders| is the set of executable
+// loaders that are available for loading in the device context.
+iree_status_t iree_hal_sync_device_create(
+    iree_string_view_t identifier, const iree_hal_sync_device_params_t* params,
+    iree_host_size_t loader_count, iree_hal_executable_loader_t** loaders,
+    iree_allocator_t host_allocator, iree_hal_device_t** out_device);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_SYNC_DEVICE_H_

--- a/iree/hal/local/sync_driver.c
+++ b/iree/hal/local/sync_driver.c
@@ -1,0 +1,126 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/sync_driver.h"
+
+#include "iree/base/tracing.h"
+
+#define IREE_HAL_SYNC_DEVICE_ID_DEFAULT 0
+
+typedef struct {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+
+  iree_string_view_t identifier;
+  iree_hal_sync_device_params_t default_params;
+
+  iree_host_size_t loader_count;
+  iree_hal_executable_loader_t* loaders[];
+} iree_hal_sync_driver_t;
+
+static const iree_hal_driver_vtable_t iree_hal_sync_driver_vtable;
+
+static iree_hal_sync_driver_t* iree_hal_sync_driver_cast(
+    iree_hal_driver_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_sync_driver_vtable);
+  return (iree_hal_sync_driver_t*)base_value;
+}
+
+iree_status_t iree_hal_sync_driver_create(
+    iree_string_view_t identifier,
+    const iree_hal_sync_device_params_t* default_params,
+    iree_host_size_t loader_count, iree_hal_executable_loader_t** loaders,
+    iree_allocator_t host_allocator, iree_hal_driver_t** out_driver) {
+  IREE_ASSERT_ARGUMENT(default_params);
+  IREE_ASSERT_ARGUMENT(!loader_count || loaders);
+  IREE_ASSERT_ARGUMENT(out_driver);
+  *out_driver = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_sync_driver_t* driver = NULL;
+  iree_host_size_t total_size = sizeof(*driver) +
+                                loader_count * sizeof(*driver->loaders) +
+                                identifier.size;
+  iree_status_t status =
+      iree_allocator_malloc(host_allocator, total_size, (void**)&driver);
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_sync_driver_vtable,
+                                 &driver->resource);
+    driver->host_allocator = host_allocator;
+
+    iree_string_view_append_to_buffer(
+        identifier, &driver->identifier,
+        (char*)driver + total_size - identifier.size);
+    memcpy(&driver->default_params, default_params,
+           sizeof(driver->default_params));
+
+    driver->loader_count = loader_count;
+    for (iree_host_size_t i = 0; i < driver->loader_count; ++i) {
+      driver->loaders[i] = loaders[i];
+      iree_hal_executable_loader_retain(driver->loaders[i]);
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_driver = (iree_hal_driver_t*)driver;
+  } else {
+    iree_hal_driver_release((iree_hal_driver_t*)driver);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_sync_driver_destroy(iree_hal_driver_t* base_driver) {
+  iree_hal_sync_driver_t* driver = iree_hal_sync_driver_cast(base_driver);
+  iree_allocator_t host_allocator = driver->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  for (iree_host_size_t i = 0; i < driver->loader_count; ++i) {
+    iree_hal_executable_loader_release(driver->loaders[i]);
+  }
+  iree_allocator_free(host_allocator, driver);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_sync_driver_query_available_devices(
+    iree_hal_driver_t* base_driver, iree_allocator_t allocator,
+    iree_hal_device_info_t** out_device_infos,
+    iree_host_size_t* out_device_info_count) {
+  static const iree_hal_device_info_t device_infos[1] = {
+      {
+          .device_id = IREE_HAL_SYNC_DEVICE_ID_DEFAULT,
+          .name = iree_string_view_literal("default"),
+      },
+  };
+  *out_device_info_count = IREE_ARRAYSIZE(device_infos);
+  return iree_allocator_clone(
+      allocator, iree_make_const_byte_span(device_infos, sizeof(device_infos)),
+      (void**)out_device_infos);
+}
+
+static iree_status_t iree_hal_sync_driver_create_device(
+    iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
+    iree_allocator_t allocator, iree_hal_device_t** out_device) {
+  iree_hal_sync_driver_t* driver = iree_hal_sync_driver_cast(base_driver);
+  return iree_hal_sync_device_create(
+      driver->identifier, &driver->default_params, driver->loader_count,
+      driver->loaders, allocator, out_device);
+}
+
+static const iree_hal_driver_vtable_t iree_hal_sync_driver_vtable = {
+    .destroy = iree_hal_sync_driver_destroy,
+    .query_available_devices = iree_hal_sync_driver_query_available_devices,
+    .create_device = iree_hal_sync_driver_create_device,
+};

--- a/iree/hal/local/sync_driver.h
+++ b/iree/hal/local/sync_driver.h
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_SYNC_DRIVER_H_
+#define IREE_HAL_LOCAL_SYNC_DRIVER_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/local/executable_loader.h"
+#include "iree/hal/local/sync_device.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Creates a new synchronous local CPU driver that creates devices that perform
+// execution inline on threads issuing submissions. |loaders| is the set of
+// executable loaders that are available for loading in each device context.
+iree_status_t iree_hal_sync_driver_create(
+    iree_string_view_t identifier,
+    const iree_hal_sync_device_params_t* default_params,
+    iree_host_size_t loader_count, iree_hal_executable_loader_t** loaders,
+    iree_allocator_t host_allocator, iree_hal_driver_t** out_driver);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_SYNC_DRIVER_H_

--- a/iree/hal/local/sync_event.c
+++ b/iree/hal/local/sync_event.c
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/sync_event.h"
+
+#include "iree/base/tracing.h"
+
+typedef struct {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+} iree_hal_sync_event_t;
+
+static const iree_hal_event_vtable_t iree_hal_sync_event_vtable;
+
+static iree_hal_sync_event_t* iree_hal_sync_event_cast(
+    iree_hal_event_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_sync_event_vtable);
+  return (iree_hal_sync_event_t*)base_value;
+}
+
+iree_status_t iree_hal_sync_event_create(iree_allocator_t host_allocator,
+                                         iree_hal_event_t** out_event) {
+  IREE_ASSERT_ARGUMENT(out_event);
+  *out_event = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_sync_event_t* event = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(host_allocator, sizeof(*event), (void**)&event);
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_sync_event_vtable, &event->resource);
+    event->host_allocator = host_allocator;
+    *out_event = (iree_hal_event_t*)event;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_sync_event_destroy(iree_hal_event_t* base_event) {
+  iree_hal_sync_event_t* event = iree_hal_sync_event_cast(base_event);
+  iree_allocator_t host_allocator = event->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_allocator_free(host_allocator, event);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static const iree_hal_event_vtable_t iree_hal_sync_event_vtable = {
+    .destroy = iree_hal_sync_event_destroy,
+};

--- a/iree/hal/local/sync_event.h
+++ b/iree/hal/local/sync_event.h
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_SYNC_EVENT_H_
+#define IREE_HAL_LOCAL_SYNC_EVENT_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+iree_status_t iree_hal_sync_event_create(iree_allocator_t host_allocator,
+                                         iree_hal_event_t** out_event);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_SYNC_EVENT_H_

--- a/iree/hal/local/sync_semaphore.c
+++ b/iree/hal/local/sync_semaphore.c
@@ -1,0 +1,419 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/sync_semaphore.h"
+
+#include <inttypes.h>
+
+#include "iree/base/tracing.h"
+
+// Sentinel used the semaphore has failed and an error status is set.
+#define IREE_HAL_SYNC_SEMAPHORE_FAILURE_VALUE UINT64_MAX
+
+//===----------------------------------------------------------------------===//
+// iree_hal_sync_semaphore_state_t
+//===----------------------------------------------------------------------===//
+
+void iree_hal_sync_semaphore_state_initialize(
+    iree_hal_sync_semaphore_state_t* out_shared_state) {
+  memset(out_shared_state, 0, sizeof(*out_shared_state));
+  iree_notification_initialize(&out_shared_state->notification);
+}
+
+void iree_hal_sync_semaphore_state_deinitialize(
+    iree_hal_sync_semaphore_state_t* shared_state) {
+  iree_notification_deinitialize(&shared_state->notification);
+  memset(shared_state, 0, sizeof(*shared_state));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_sync_semaphore_t
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+
+  // Shared across all semaphores.
+  iree_hal_sync_semaphore_state_t* shared_state;
+
+  // Guards all mutable fields. We expect low contention on semaphores and since
+  // iree_slim_mutex_t is (effectively) just a CAS this keeps things simpler
+  // than trying to make the entire structure lock-free.
+  iree_slim_mutex_t mutex;
+
+  // Current signaled value. May be IREE_HAL_SYNC_SEMAPHORE_FAILURE_VALUE to
+  // indicate that the semaphore has been signaled for failure and
+  // |failure_status| contains the error.
+  uint64_t current_value;
+
+  // OK or the status passed to iree_hal_semaphore_fail. Owned by the semaphore.
+  iree_status_t failure_status;
+} iree_hal_sync_semaphore_t;
+
+static const iree_hal_semaphore_vtable_t iree_hal_sync_semaphore_vtable;
+
+static iree_hal_sync_semaphore_t* iree_hal_sync_semaphore_cast(
+    iree_hal_semaphore_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_sync_semaphore_vtable);
+  return (iree_hal_sync_semaphore_t*)base_value;
+}
+
+iree_status_t iree_hal_sync_semaphore_create(
+    iree_hal_sync_semaphore_state_t* shared_state, uint64_t initial_value,
+    iree_allocator_t host_allocator, iree_hal_semaphore_t** out_semaphore) {
+  IREE_ASSERT_ARGUMENT(shared_state);
+  IREE_ASSERT_ARGUMENT(out_semaphore);
+  *out_semaphore = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_sync_semaphore_t* semaphore = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      host_allocator, sizeof(*semaphore), (void**)&semaphore);
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_sync_semaphore_vtable,
+                                 &semaphore->resource);
+    semaphore->host_allocator = host_allocator;
+    semaphore->shared_state = shared_state;
+
+    iree_slim_mutex_initialize(&semaphore->mutex);
+    semaphore->current_value = initial_value;
+    semaphore->failure_status = iree_ok_status();
+
+    *out_semaphore = (iree_hal_semaphore_t*)semaphore;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_sync_semaphore_destroy(
+    iree_hal_semaphore_t* base_semaphore) {
+  iree_hal_sync_semaphore_t* semaphore =
+      iree_hal_sync_semaphore_cast(base_semaphore);
+  iree_allocator_t host_allocator = semaphore->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_free(semaphore->failure_status);
+  iree_slim_mutex_deinitialize(&semaphore->mutex);
+  iree_allocator_free(host_allocator, semaphore);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_sync_semaphore_query(
+    iree_hal_semaphore_t* base_semaphore, uint64_t* out_value) {
+  iree_hal_sync_semaphore_t* semaphore =
+      iree_hal_sync_semaphore_cast(base_semaphore);
+
+  iree_slim_mutex_lock(&semaphore->mutex);
+
+  *out_value = semaphore->current_value;
+
+  iree_status_t status = iree_ok_status();
+  if (*out_value >= IREE_HAL_SYNC_SEMAPHORE_FAILURE_VALUE) {
+    status = iree_status_clone(semaphore->failure_status);
+  }
+
+  iree_slim_mutex_unlock(&semaphore->mutex);
+
+  return status;
+}
+
+// Signals |semaphore| to |new_value| or returns an error if doing so would be
+// invalid. The semaphore mutex must be held.
+static iree_status_t iree_hal_sync_semaphore_signal_unsafe(
+    iree_hal_sync_semaphore_t* semaphore, uint64_t new_value) {
+  if (new_value <= semaphore->current_value) {
+    uint64_t current_value = semaphore->current_value;
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "semaphore values must be monotonically "
+                            "increasing; current_value=%" PRIu64
+                            ", new_value=%" PRIu64,
+                            current_value, new_value);
+  }
+
+  // Update to the new value.
+  semaphore->current_value = new_value;
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_sync_semaphore_signal(
+    iree_hal_semaphore_t* base_semaphore, uint64_t new_value) {
+  iree_hal_sync_semaphore_t* semaphore =
+      iree_hal_sync_semaphore_cast(base_semaphore);
+
+  iree_slim_mutex_lock(&semaphore->mutex);
+  iree_status_t status =
+      iree_hal_sync_semaphore_signal_unsafe(semaphore, new_value);
+  iree_slim_mutex_unlock(&semaphore->mutex);
+
+  if (iree_status_is_ok(status)) {
+    // Post a global notification so that any waiter will wake.
+    // TODO(#4680): make notifications per-semaphore; would make multi-wait
+    // impossible with iree_notification_t and we'd have to use wait handles.
+    iree_notification_post(&semaphore->shared_state->notification,
+                           IREE_ALL_WAITERS);
+  }
+
+  return status;
+}
+
+static void iree_hal_sync_semaphore_fail(iree_hal_semaphore_t* base_semaphore,
+                                         iree_status_t status) {
+  iree_hal_sync_semaphore_t* semaphore =
+      iree_hal_sync_semaphore_cast(base_semaphore);
+
+  iree_slim_mutex_lock(&semaphore->mutex);
+
+  // Try to set our local status - we only preserve the first failure so only
+  // do this if we are going from a valid semaphore to a failed one.
+  if (!iree_status_is_ok(semaphore->failure_status)) {
+    // Previous status was not OK; drop our new status.
+    IREE_IGNORE_ERROR(status);
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return;
+  }
+
+  // Signal to our failure sentinel value.
+  semaphore->current_value = IREE_HAL_SYNC_SEMAPHORE_FAILURE_VALUE;
+  semaphore->failure_status = status;
+
+  iree_slim_mutex_unlock(&semaphore->mutex);
+
+  iree_notification_post(&semaphore->shared_state->notification,
+                         IREE_ALL_WAITERS);
+}
+
+iree_status_t iree_hal_sync_semaphore_multi_signal(
+    iree_hal_sync_semaphore_state_t* shared_state,
+    const iree_hal_semaphore_list_t* semaphore_list) {
+  // Try to signal all semaphores, stopping if we encounter any issues.
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
+    iree_hal_sync_semaphore_t* semaphore =
+        iree_hal_sync_semaphore_cast(semaphore_list->semaphores[i]);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    status = iree_hal_sync_semaphore_signal_unsafe(
+        semaphore, semaphore_list->payload_values[i]);
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  // Notify all waiters that we've updated semaphores. They'll wake and check
+  // to see if they are satisfied.
+  // NOTE: we do this even if there was a failure as we may have signaled some
+  // of the list.
+  iree_notification_post(&shared_state->notification, IREE_ALL_WAITERS);
+
+  return status;
+}
+
+typedef struct {
+  iree_hal_sync_semaphore_t* semaphore;
+  uint64_t value;
+} iree_hal_sync_semaphore_notify_state_t;
+
+static bool iree_hal_sync_semaphore_is_signaled(
+    iree_hal_sync_semaphore_notify_state_t* state) {
+  iree_hal_sync_semaphore_t* semaphore = state->semaphore;
+  iree_slim_mutex_lock(&semaphore->mutex);
+  bool is_signaled = semaphore->current_value >= state->value ||
+                     !iree_status_is_ok(semaphore->failure_status);
+  iree_slim_mutex_unlock(&semaphore->mutex);
+  return is_signaled;
+}
+
+static iree_status_t iree_hal_sync_semaphore_wait(
+    iree_hal_semaphore_t* base_semaphore, uint64_t value,
+    iree_timeout_t timeout) {
+  iree_hal_sync_semaphore_t* semaphore =
+      iree_hal_sync_semaphore_cast(base_semaphore);
+
+  // Try to see if we can return immediately.
+  iree_slim_mutex_lock(&semaphore->mutex);
+  if (!iree_status_is_ok(semaphore->failure_status)) {
+    // Fastest path: failed; return an error to tell callers to query for it.
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return iree_status_from_code(IREE_STATUS_ABORTED);
+  } else if (semaphore->current_value >= value) {
+    // Fast path: already satisfied.
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return iree_ok_status();
+  } else if (iree_timeout_is_immediate(timeout)) {
+    // Not satisfied but a poll, so can avoid the expensive wait handle work.
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  }
+  iree_slim_mutex_unlock(&semaphore->mutex);
+
+  // TODO(#4680): we should be checking for DEADLINE_EXCEEDED here. This is
+  // easy when it's iree_timeout_is_infinite (we can just use the notification
+  // as below) but if it's an actual deadline we'll need to probably switch to
+  // iree_wait_handle_t.
+
+  // Perform wait on the global notification. Will wait forever.
+  iree_hal_sync_semaphore_state_t* shared_state = semaphore->shared_state;
+  iree_hal_sync_semaphore_notify_state_t notify_state = {
+      .semaphore = semaphore,
+      .value = value,
+  };
+  iree_notification_await(
+      &shared_state->notification,
+      (iree_condition_fn_t)iree_hal_sync_semaphore_is_signaled,
+      (void*)&notify_state);
+
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&semaphore->mutex);
+  if (!iree_status_is_ok(semaphore->failure_status)) {
+    // Semaphore has failed.
+    status = iree_status_from_code(IREE_STATUS_ABORTED);
+  } else if (semaphore->current_value < value) {
+    // Deadline expired before the semaphore was signaled.
+    status = iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  }
+  iree_slim_mutex_unlock(&semaphore->mutex);
+  return status;
+}
+
+// Returns true if any semaphore in the list has signaled (or failed).
+// Used with with iree_condition_fn_t and must match that signature.
+static bool iree_hal_sync_semaphore_any_signaled(
+    const iree_hal_semaphore_list_t* semaphore_list) {
+  for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
+    iree_hal_sync_semaphore_t* semaphore =
+        iree_hal_sync_semaphore_cast(semaphore_list->semaphores[i]);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    bool is_signaled =
+        semaphore->current_value >= semaphore_list->payload_values[i] ||
+        !iree_status_is_ok(semaphore->failure_status);
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    if (is_signaled) return true;
+  }
+  return false;
+}
+
+// Returns true if all semaphores in the list has signaled (or any failed).
+// Used with with iree_condition_fn_t and must match that signature.
+static bool iree_hal_sync_semaphore_all_signaled(
+    const iree_hal_semaphore_list_t* semaphore_list) {
+  for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
+    iree_hal_sync_semaphore_t* semaphore =
+        iree_hal_sync_semaphore_cast(semaphore_list->semaphores[i]);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    bool is_signaled =
+        semaphore->current_value >= semaphore_list->payload_values[i] ||
+        !iree_status_is_ok(semaphore->failure_status);
+    iree_slim_mutex_unlock(&semaphore->mutex);
+    if (!is_signaled) return false;
+  }
+  return true;
+}
+
+// Returns a status derived from the |semaphore_list| at the current time:
+// - IREE_STATUS_OK: any or all semaphores signaled (based on |wait_mode|).
+// - IREE_STATUS_ABORTED: one or more semaphores failed.
+// - IREE_STATUS_DEADLINE_EXCEEDED: any or all semaphores unsignaled.
+static iree_status_t iree_hal_sync_semaphore_result_from_state(
+    iree_hal_wait_mode_t wait_mode,
+    const iree_hal_semaphore_list_t* semaphore_list) {
+  bool any_signaled = false;
+  bool all_signaled = true;
+  bool any_failed = false;
+  for (iree_host_size_t i = 0; i < semaphore_list->count; ++i) {
+    iree_hal_sync_semaphore_t* semaphore =
+        iree_hal_sync_semaphore_cast(semaphore_list->semaphores[i]);
+    iree_slim_mutex_lock(&semaphore->mutex);
+    if (!iree_status_is_ok(semaphore->failure_status)) {
+      // Semaphore has failed.
+      any_failed = true;
+    } else if (semaphore->current_value < semaphore_list->payload_values[i]) {
+      // Deadline expired before the semaphore was signaled.
+      all_signaled = false;
+    } else {
+      // Signaled!
+      any_signaled = true;
+    }
+    iree_slim_mutex_unlock(&semaphore->mutex);
+  }
+  if (any_failed) {
+    // Always prioritize failure state.
+    return iree_status_from_code(IREE_STATUS_ABORTED);
+  }
+  switch (wait_mode) {
+    default:
+    case IREE_HAL_WAIT_MODE_ALL:
+      return all_signaled
+                 ? iree_ok_status()
+                 : iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    case IREE_HAL_WAIT_MODE_ANY:
+      return any_signaled
+                 ? iree_ok_status()
+                 : iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  }
+}
+
+iree_status_t iree_hal_sync_semaphore_multi_wait(
+    iree_hal_sync_semaphore_state_t* shared_state,
+    iree_hal_wait_mode_t wait_mode,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
+  IREE_ASSERT_ARGUMENT(semaphore_list);
+  if (semaphore_list->count == 0) {
+    return iree_ok_status();
+  } else if (semaphore_list->count == 1) {
+    // Fast-path for a single semaphore.
+    return iree_hal_semaphore_wait(semaphore_list->semaphores[0],
+                                   semaphore_list->payload_values[0], timeout);
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Fast-path for polling; we'll never wait and can just do a quick query.
+  if (iree_timeout_is_immediate(timeout)) {
+    iree_status_t status =
+        iree_hal_sync_semaphore_result_from_state(wait_mode, semaphore_list);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  // TODO(#4680): we should be checking for DEADLINE_EXCEEDED here. This is
+  // easy when it's iree_timeout_is_infinite (we can just use the notification
+  // as below) but if it's an actual deadline we'll need to probably switch to
+  // iree_wait_handle_t.
+
+  // Perform wait on the global notification. Will wait forever.
+  iree_notification_await(
+      &shared_state->notification,
+      wait_mode == IREE_HAL_WAIT_MODE_ALL
+          ? (iree_condition_fn_t)iree_hal_sync_semaphore_all_signaled
+          : (iree_condition_fn_t)iree_hal_sync_semaphore_any_signaled,
+      (void*)semaphore_list);
+
+  // We may have been successful - or may have a partial failure.
+  iree_status_t status =
+      iree_hal_sync_semaphore_result_from_state(wait_mode, semaphore_list);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static const iree_hal_semaphore_vtable_t iree_hal_sync_semaphore_vtable = {
+    .destroy = iree_hal_sync_semaphore_destroy,
+    .query = iree_hal_sync_semaphore_query,
+    .signal = iree_hal_sync_semaphore_signal,
+    .fail = iree_hal_sync_semaphore_fail,
+    .wait = iree_hal_sync_semaphore_wait,
+};

--- a/iree/hal/local/sync_semaphore.h
+++ b/iree/hal/local/sync_semaphore.h
@@ -1,0 +1,80 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_SYNC_SEMAPHORE_H_
+#define IREE_HAL_LOCAL_SYNC_SEMAPHORE_H_
+
+#include "iree/base/api.h"
+#include "iree/base/synchronization.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_sync_semaphore_state_t
+//===----------------------------------------------------------------------===//
+
+// State shared between all sync semaphores.
+// Owned by the device and guaranteed to remain valid for the lifetime of any
+// semaphore created from it.
+typedef struct {
+  // In-process notification signaled when any semaphore value changes.
+  iree_notification_t notification;
+} iree_hal_sync_semaphore_state_t;
+
+// Initializes state used to perform semaphore synchronization.
+void iree_hal_sync_semaphore_state_initialize(
+    iree_hal_sync_semaphore_state_t* out_shared_state);
+
+// Deinitializes state used to perform semaphore synchronization; no semaphores
+// must be live with references.
+void iree_hal_sync_semaphore_state_deinitialize(
+    iree_hal_sync_semaphore_state_t* shared_state);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_sync_semaphore_t
+//===----------------------------------------------------------------------===//
+
+// Creates a semaphore that allows for ordering of operations on the local host.
+// Backed by a shared iree_notification_t in |shared_state|. Not efficient under
+// high contention or many simultaneous users but that's not what the
+// synchronous backend is intended for - if you want something efficient in the
+// face of hundreds or thousands of active asynchronous operations then use the
+// task system.
+iree_status_t iree_hal_sync_semaphore_create(
+    iree_hal_sync_semaphore_state_t* shared_state, uint64_t initial_value,
+    iree_allocator_t host_allocator, iree_hal_semaphore_t** out_semaphore);
+
+// Performs a signal of a list of semaphores.
+// The semaphores will transition to their new values (nearly) atomically and
+// batching up signals will reduce synchronization overhead.
+iree_status_t iree_hal_sync_semaphore_multi_signal(
+    iree_hal_sync_semaphore_state_t* shared_state,
+    const iree_hal_semaphore_list_t* semaphore_list);
+
+// Performs a multi-wait on one or more semaphores.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
+// |timeout| elapses.
+iree_status_t iree_hal_sync_semaphore_multi_wait(
+    iree_hal_sync_semaphore_state_t* shared_state,
+    iree_hal_wait_mode_t wait_mode,
+    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_SYNC_SEMAPHORE_H_

--- a/iree/hal/semaphore.h
+++ b/iree/hal/semaphore.h
@@ -108,9 +108,13 @@ iree_hal_semaphore_fail(iree_hal_semaphore_t* semaphore, iree_status_t status);
 // Returns success if the wait is successful and the semaphore has met or
 // exceeded the required payload value.
 //
-// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the semaphore
-// reaching the required value. If an asynchronous failure occured this will
-// return the failure status that was set immediately.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if the |timeout| elapses without the
+// semaphore reaching the required value. If an asynchronous failure occured
+// this will return the failure status that was set immediately.
+//
+// Returns IREE_STATUS_ABORTED if one or more semaphores has failed. Callers can
+// use iree_hal_semaphore_query on the semaphores to find the ones that have
+// failed and get the status.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_semaphore_wait(
     iree_hal_semaphore_t* semaphore, uint64_t value, iree_timeout_t timeout);
 


### PR DESCRIPTION
This is mostly just the plumbing to enable #4680 by defining a new `dylib-sync` runtime driver (pending #4298 to cleanup drivers).

This driver does not support recording/replaying command buffers and has some gotchas with semaphores (no deadline waits, probably corner cases for things not covered in the CTS, etc). It should get us something that builds easier on tiny systems, though.

This uses `iree/base/synchronization.h` for the semaphore implementation. The intent is that for bare-metal systems we can implement a version of `iree/base/synchronization.h` observing the specific requirements of the platform while still preserving the semaphore semantics - it's still useful to use this driver with systems with multiple threads (lots of dual-core MCUs/MPUs) or to enable pipelining. Systems that have no threads can no-op the mutex/notification (or disable interrupts/etc).

Trace of bert with `-driver=dylib-sync` looks pretty good:
![image](https://user-images.githubusercontent.com/75337/115169211-3c1a3b00-a072-11eb-9743-c1e5fa63c22c.png)
(the large __init block at startup and free at shutdown will be solved by #5504 and #5472)
Note that due to the design here there are no changes needed in the compiler/runtime besides the single flag added in #5508 so the same exact module runs async as well:
![image](https://user-images.githubusercontent.com/75337/115169953-476e6600-a074-11eb-8e86-ee09dac5cc2c.png)
That's pretty cool :)

Progress on #4680.