### PR TITLE
Combining allocations of HAL heap buffer's handle and storage.

### DIFF
--- a/iree/hal/BUILD
+++ b/iree/hal/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "buffer.c",
         "buffer.h",
         "buffer_heap.c",
+        "buffer_heap_impl.h",
         "buffer_view.c",
         "buffer_view.cc",
         "buffer_view.h",

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "buffer.c"
     "buffer.h"
     "buffer_heap.c"
+    "buffer_heap_impl.h"
     "buffer_view.c"
     "buffer_view.cc"
     "buffer_view.h"

--- a/iree/hal/allocator_heap.c
+++ b/iree/hal/allocator_heap.c
@@ -14,6 +14,7 @@
 
 #include "iree/base/tracing.h"
 #include "iree/hal/allocator.h"
+#include "iree/hal/buffer_heap_impl.h"
 #include "iree/hal/detail.h"
 
 typedef struct iree_hal_heap_allocator_s {
@@ -128,19 +129,10 @@ static iree_status_t iree_hal_heap_allocator_allocate_buffer(
   IREE_RETURN_IF_ERROR(iree_hal_heap_allocator_make_compatible(
       &memory_type, &allowed_access, &allowed_usage));
 
-  iree_byte_span_t data = iree_make_byte_span(NULL, allocation_size);
-  if (allocation_size > 0) {
-    // Zero-length buffers are valid but we don't want to try to malloc them.
-    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-        allocator->host_allocator, allocation_size, (void**)&data.data));
-  }
-  iree_status_t status = iree_hal_heap_buffer_wrap(
+  // Allocate and return the buffer.
+  return iree_hal_heap_buffer_create(
       base_allocator, memory_type, allowed_access, allowed_usage,
-      allocation_size, data, allocator->host_allocator, out_buffer);
-  if (!iree_status_is_ok(status)) {
-    iree_allocator_free(allocator->host_allocator, data.data);
-  }
-  return status;
+      allocation_size, allocator->host_allocator, out_buffer);
 }
 
 static iree_status_t iree_hal_heap_allocator_wrap_buffer(

--- a/iree/hal/buffer_heap_impl.h
+++ b/iree/hal/buffer_heap_impl.h
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_BUFFER_HEAP_IMPL_H_
+#define IREE_HAL_BUFFER_HEAP_IMPL_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Private utilities for working with heap buffers
+//===----------------------------------------------------------------------===//
+
+// Allocates a new heap buffer from the specified |host_allocator|.
+// |out_buffer| must be released by the caller.
+iree_status_t iree_hal_heap_buffer_create(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_BUFFER_HEAP_IMPL_H_


### PR DESCRIPTION
Halves the allocation count for buffers, keeps the handle and storage memory close by to hopefully get some caching benefits on initial use, and reduces the noise in allocation traces.