### PR TITLE
Create ops with static shapes in PadTensorOpConversion if they're static

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -87,7 +87,7 @@ struct PadTensorOpConversion : public OpConversionPattern<linalg::PadTensorOp> {
 
     // TODO(ravishankarm): Use shape inference interface to get this.
     SmallVector<OpFoldResult> sourceShape;
-    SmallVector<Value> outputShape;
+    SmallVector<OpFoldResult> outputShape;
     for (int64_t dim : llvm::seq<int64_t>(0, rank)) {
       SmallVector<Value> mapValues;
       Value sourceDim = rewriter.createOrFold<memref::DimOp>(loc, source, dim);
@@ -106,8 +106,13 @@ struct PadTensorOpConversion : public OpConversionPattern<linalg::PadTensorOp> {
       };
       expr = addValueOrAttr(expr, lowPad[dim]);
       expr = addValueOrAttr(expr, highPad[dim]);
-      outputShape.push_back(linalg::applyMapToValues(
-          rewriter, loc, AffineMap::get(1, numSymbols, expr), mapValues)[0]);
+      Value v = linalg::applyMapToValues(
+          rewriter, loc, AffineMap::get(1, numSymbols, expr), mapValues)[0];
+      if (auto cst = v.getDefiningOp<ConstantOp>()) {
+        outputShape.push_back(cst.value());
+      } else {
+        outputShape.push_back(v);
+      }
     }
     Value initTensor = rewriter.create<linalg::InitTensorOp>(
         loc, outputShape, sourceType.getElementType());
@@ -116,6 +121,7 @@ struct PadTensorOpConversion : public OpConversionPattern<linalg::PadTensorOp> {
     SmallVector<OpFoldResult> strides(rank, rewriter.getI64IntegerAttr(1));
     Value replacement = rewriter.create<SubTensorInsertOp>(
         loc, source, fill, lowPad, sourceShape, strides);
+    // TODO(hanchung): Revisit if this is still the case.
     if (padTensorOp.getResultType() != replacement.getType()) {
       replacement = rewriter.create<tensor::CastOp>(
           loc, padTensorOp.getResultType(), replacement);

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -119,14 +119,8 @@ struct PadTensorOpConversion : public OpConversionPattern<linalg::PadTensorOp> {
     Value fill =
         rewriter.create<linalg::FillOp>(loc, initTensor, yieldVal).getResult(0);
     SmallVector<OpFoldResult> strides(rank, rewriter.getI64IntegerAttr(1));
-    Value replacement = rewriter.create<SubTensorInsertOp>(
-        loc, source, fill, lowPad, sourceShape, strides);
-    // TODO(hanchung): Revisit if this is still the case.
-    if (padTensorOp.getResultType() != replacement.getType()) {
-      replacement = rewriter.create<tensor::CastOp>(
-          loc, padTensorOp.getResultType(), replacement);
-    }
-    rewriter.replaceOp(padTensorOp, replacement);
+    rewriter.replaceOpWithNewOp<SubTensorInsertOp>(
+        padTensorOp, source, fill, lowPad, sourceShape, strides);
     return success();
   }
 };

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path -canonicalize %s | IreeFileCheck %s
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path %s | IreeFileCheck %s --check-prefix=CHECK-NOCAN
 
 module  {
   func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
@@ -32,9 +31,6 @@ module  {
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, %[[ARG2]]] [%[[D0]], %[[D1]]] [1, 1]
 //       CHECK:   return %[[RESULT]]
-//
-// CHECK-NOCAN:      func @pad_tensor
-// CHECK-NOCAN-NOT:    tensor.cast
 
 // -----
 
@@ -60,6 +56,3 @@ module  {
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [12, 4] [1, 1]
 //       CHECK:   return %[[RESULT]]
-//
-// CHECK-NOCAN:      func @pad_tensor_static
-// CHECK-NOCAN-NOT:    tensor.cast

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -61,5 +61,5 @@ module  {
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [12, 4] [1, 1]
 //       CHECK:   return %[[RESULT]]
 //
-// CHECK-NOCAN:      func @pad_tensor
+// CHECK-NOCAN:      func @pad_tensor_static
 // CHECK-NOCAN-NOT:    tensor.cast

--- a/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -iree-linalg-on-tensors-path %s | IreeFileCheck %s --check-prefix=CHECK-NOCAN
 
 module  {
   func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
@@ -31,6 +32,9 @@ module  {
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, %[[ARG2]]] [%[[D0]], %[[D1]]] [1, 1]
 //       CHECK:   return %[[RESULT]]
+//
+// CHECK-NOCAN:      func @pad_tensor
+// CHECK-NOCAN-NOT:    tensor.cast
 
 // -----
 
@@ -56,3 +60,6 @@ module  {
 //       CHECK:   %[[FILL:.+]] = linalg.fill(%[[INIT]], %[[VAL]])
 //       CHECK:   %[[RESULT:.+]] = subtensor_insert %[[ARG0]] into %[[FILL]][4, 5] [12, 4] [1, 1]
 //       CHECK:   return %[[RESULT]]
+//
+// CHECK-NOCAN:      func @pad_tensor
+// CHECK-NOCAN-NOT:    tensor.cast


### PR DESCRIPTION
Currently, the mhlo.pad will be lowered to linalg.pad_tensor and then
lowered to `linalg.init_tensor + linalg.fill + subtensor_insert`. The
init_tensor op will produce a dynamic shape even if the shape is static.
This leads a `tensor.cast` op added and relies on further patterns to
fix them. This is not needed to static shape and will hit some issues
related to https://github.com/google/iree/issues/5385.