### PR TITLE
Use --first-parent when summarizing branch merge changes

### DIFF
--- a/scripts/git/summarize_changes.sh
+++ b/scripts/git/summarize_changes.sh
@@ -36,6 +36,7 @@ NEW_REF="${2:-HEAD}"
 
 git log \
   "${BASE_REF?}..${NEW_REF?}" \
+  --first-parent \
   --decorate=no \
   --pretty='format:* %h %<(80,trunc)%s' \
   | awk '{$1=$1;print}'


### PR DESCRIPTION
A linear listing of the history including both parents of a merge
commit is confusing (especially with the default sort order). Merge
commit messages should contain the relevant summary of their commits,
and this avoids situations like
https://github.com/google/iree/pull/5526 where the synchronize
submodules commit message is listed twice.