### PR TITLE
Allow mako upload failure not to fail the Github commit.

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark.yml
@@ -89,3 +89,5 @@ steps:
       - "mako-uploader=true"
       - "test-desktop-gpu=false"
     branches: "main"
+    soft_fail:
+      - exit_status: 1


### PR DESCRIPTION
We can see the regression on Mako webpages. It's annoying to see badges
being red because of "regressions". Turn it off for now. It will still
complain about it if it fails at other stages.