### PR TITLE
Defining a C-compatible benchmark header.

### DIFF
--- a/iree/base/internal/flags.h
+++ b/iree/base/internal/flags.h
@@ -17,6 +17,10 @@
 
 #include "iree/base/api.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 //===----------------------------------------------------------------------===//
 // Flag parsing
 //===----------------------------------------------------------------------===//
@@ -55,5 +59,9 @@ iree_status_t iree_flags_parse(int* argc, char*** argv);
 // what you want when embedded in a host process. You don't want to have a flag
 // typo and shut down your entire server/sandbox/Android app/etc.
 void iree_flags_parse_checked(int* argc, char*** argv);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // IREE_BASE_INTERNAL_FLAGS_H_

--- a/iree/testing/BUILD
+++ b/iree/testing/BUILD
@@ -21,12 +21,28 @@ package(
 )
 
 cc_library(
+    name = "benchmark",
+    testonly = True,
+    srcs = [
+        "benchmark_full.cc",
+    ],
+    hdrs = [
+        "benchmark.h",
+    ],
+    deps = [
+        "//iree/base:api",
+        "//iree/base:tracing",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
+cc_library(
     name = "benchmark_main",
     testonly = True,
-    srcs = ["benchmark_main.cc"],
+    srcs = ["benchmark_main.c"],
     deps = [
+        ":benchmark",
         "//iree/base/internal:flags",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/iree/testing/CMakeLists.txt
+++ b/iree/testing/CMakeLists.txt
@@ -12,11 +12,26 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
-    benchmark_main
+    benchmark
+  HDRS
+    "benchmark.h"
   SRCS
-    "benchmark_main.cc"
+    "benchmark_full.cc"
   DEPS
     benchmark
+    iree::base::api
+    iree::base::tracing
+  TESTONLY
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    benchmark_main
+  SRCS
+    "benchmark_main.c"
+  DEPS
+    ::benchmark
     iree::base::internal::flags
   TESTONLY
   PUBLIC

--- a/iree/testing/benchmark.h
+++ b/iree/testing/benchmark.h
@@ -1,0 +1,148 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_TESTING_BENCHMARK_H_
+#define IREE_TESTING_BENCHMARK_H_
+
+// This is a C API shim for a benchmark-like interface.
+// The intent is that we can write benchmarks that are portable to bare-metal
+// systems and use some simple tooling while also allowing them to run on
+// the full benchmark library with all its useful reporting and statistics.
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_benchmark_state_t
+//===----------------------------------------------------------------------===//
+
+// Benchmark state manipulator.
+// Passed to each benchmark during execution to control the benchmark state
+// or append information beyond just timing.
+typedef struct iree_benchmark_state_s {
+  // Internal implementation handle.
+  void* impl;
+
+  // Allocator that can be used for host allocations required during benchmark
+  // execution.
+  iree_allocator_t host_allocator;
+} iree_benchmark_state_t;
+
+// Returns a range argument with the given ordial.
+int64_t iree_benchmark_get_range(iree_benchmark_state_t* state,
+                                 iree_host_size_t ordinal);
+
+// Returns true while the benchmark should keep running its step loop.
+//
+// Usage:
+//  while (iree_benchmark_keep_running(state, 1000)) {
+//    // process 1000 elements
+//  }
+bool iree_benchmark_keep_running(iree_benchmark_state_t* state,
+                                 uint64_t batch_count);
+
+// Reports that the currently executing benchmark cannot be run.
+// Callers should return after calling as further benchmark-related calls may
+// fail.
+void iree_benchmark_skip(iree_benchmark_state_t* state, const char* message);
+
+// Suspends the benchmark timer until iree_benchmark_resume_timing is called.
+// This can be used to guard per-step code that is required to initialze the
+// work but not something that needs to be accounted for in the benchmark
+// timing. Introduces non-trivial overhead: only use this ~once per step when
+// then going on to perform large amounts of batch work in the step.
+void iree_benchmark_pause_timing(iree_benchmark_state_t* state);
+
+// Resumes the benchmark timer after a prior iree_benchmark_suspend_timing.
+void iree_benchmark_resume_timing(iree_benchmark_state_t* state);
+
+// Sets a label string that will be displayed alongside the report line from the
+// currently executing benchmark.
+void iree_benchmark_set_label(iree_benchmark_state_t* state, const char* label);
+
+// Adds a 'bytes/s' label with the given value.
+//
+// REQUIRES: must only be called outside of the benchmark step loop.
+void iree_benchmark_set_bytes_processed(iree_benchmark_state_t* state,
+                                        int64_t bytes);
+
+// Adds an `items/s` label with the given value.
+//
+// REQUIRES: must only be called outside of the benchmark step loop.
+void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
+                                        int64_t items);
+
+//===----------------------------------------------------------------------===//
+// iree_benchmark_def_t
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME = 1u << 0,
+
+  IREE_BENCHMARK_FLAG_USE_REAL_TIME = 1u << 1,
+  IREE_BENCHMARK_FLAG_USE_MANUAL_TIME = 1u << 2,
+} iree_benchmark_flags_t;
+
+typedef enum {
+  IREE_BENCHMARK_UNIT_MILLISECOND = 0,
+  IREE_BENCHMARK_UNIT_MICROSECOND,
+  IREE_BENCHMARK_UNIT_NANOSECOND,
+} iree_benchmark_unit_t;
+
+// A benchmark case definition.
+typedef struct iree_benchmark_def_s {
+  // IREE_BENCHMARK_FLAG_* bitmask controlling benchmark behavior and reporting.
+  iree_benchmark_flags_t flags;
+
+  // Time unit used in display.
+  iree_benchmark_unit_t time_unit;  // MILLISECOND by default
+
+  // Optional minimum duration the benchmark should run for in nanoseconds.
+  iree_duration_t minimum_duration_ns;  // 0 if unspecified to autodetect
+  // Optional iteration count the benchmark should run for.
+  uint64_t iteration_count;  // 0 if unspecified to autodetect
+
+  // TODO(benvanik): add range arguments.
+
+  // Runs the benchmark to completion.
+  // Implementations must call iree_benchmark_keep_running in a loop until it
+  // returns false.
+  iree_status_t (*run)(iree_benchmark_state_t* state);
+} iree_benchmark_def_t;
+
+// Registers a benchmark with the given definition.
+void iree_benchmark_register(iree_string_view_t name,
+                             iree_benchmark_def_t* benchmark_def);
+
+//===----------------------------------------------------------------------===//
+// Benchmark infra management
+//===----------------------------------------------------------------------===//
+
+// Initializes the benchmark framework.
+// Must be called before any other iree_benchmark_* functions.
+void iree_benchmark_initialize(int* argc, char** argv);
+
+// Runs all registered benchmarks specified by the command line flags.
+// Must be called after iree_benchmark_initialize and zero or more benchmarks
+// have been registered with iree_benchmark_register.
+void iree_benchmark_run_specified();
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_TESTING_BENCHMARK_H_

--- a/iree/testing/benchmark_full.cc
+++ b/iree/testing/benchmark_full.cc
@@ -1,0 +1,164 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark/benchmark.h"
+#include "iree/base/tracing.h"
+#include "iree/testing/benchmark.h"
+
+//===----------------------------------------------------------------------===//
+// iree_benchmark_state_t
+//===----------------------------------------------------------------------===//
+
+benchmark::State& GetBenchmarkState(iree_benchmark_state_t* state) {
+  return *(benchmark::State*)state->impl;
+}
+
+int64_t iree_benchmark_get_range(iree_benchmark_state_t* state,
+                                 iree_host_size_t ordinal) {
+  auto& s = GetBenchmarkState(state);
+  return s.range(ordinal);
+}
+
+bool iree_benchmark_keep_running(iree_benchmark_state_t* state,
+                                 uint64_t batch_count) {
+  auto& s = GetBenchmarkState(state);
+  return s.KeepRunningBatch(batch_count);
+}
+
+void iree_benchmark_skip(iree_benchmark_state_t* state, const char* message) {
+  auto& s = GetBenchmarkState(state);
+  s.SkipWithError(message);
+}
+
+void iree_benchmark_pause_timing(iree_benchmark_state_t* state) {
+  auto& s = GetBenchmarkState(state);
+  s.PauseTiming();
+}
+
+void iree_benchmark_resume_timing(iree_benchmark_state_t* state) {
+  auto& s = GetBenchmarkState(state);
+  s.ResumeTiming();
+}
+
+void iree_benchmark_set_label(iree_benchmark_state_t* state,
+                              const char* label) {
+  auto& s = GetBenchmarkState(state);
+  s.SetLabel(label);
+}
+
+void iree_benchmark_set_bytes_processed(iree_benchmark_state_t* state,
+                                        int64_t bytes) {
+  auto& s = GetBenchmarkState(state);
+  s.SetBytesProcessed(bytes);
+}
+
+void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
+                                        int64_t items) {
+  auto& s = GetBenchmarkState(state);
+  s.SetItemsProcessed(items);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_benchmark_def_t
+//===----------------------------------------------------------------------===//
+
+static std::string StatusToString(iree_status_t status) {
+  if (iree_status_is_ok(status)) {
+    return "OK";
+  }
+  iree_host_size_t buffer_length = 0;
+  if (IREE_UNLIKELY(!iree_status_format(status, /*buffer_capacity=*/0,
+                                        /*buffer=*/NULL, &buffer_length))) {
+    return "<!>";
+  }
+  std::string result(buffer_length, '\0');
+  if (IREE_UNLIKELY(!iree_status_format(status, result.size() + 1,
+                                        const_cast<char*>(result.data()),
+                                        &buffer_length))) {
+    return "<!>";
+  }
+  return result;
+}
+
+static void iree_benchmark_run(const char* benchmark_name,
+                               const iree_benchmark_def_t* benchmark_def,
+                               benchmark::State& benchmark_state) {
+  IREE_TRACE_SCOPE_DYNAMIC(benchmark_name);
+  IREE_TRACE_FRAME_MARK();
+
+  iree_benchmark_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.impl = &benchmark_state;
+  state.host_allocator = iree_allocator_system();
+
+  iree_status_t status = benchmark_def->run(&state);
+  if (!iree_status_is_ok(status)) {
+    auto status_str = StatusToString(status);
+    iree_status_ignore(status);
+    benchmark_state.SkipWithError(status_str.c_str());
+  }
+}
+
+void iree_benchmark_register(iree_string_view_t name,
+                             const iree_benchmark_def_t* benchmark_def) {
+  std::string name_str(name.data, name.size);
+  std::string prefixed_str = "BM_" + name_str;
+  auto* instance = benchmark::RegisterBenchmark(
+      prefixed_str.c_str(),
+      [name_str, benchmark_def](benchmark::State& state) -> void {
+        iree_benchmark_run(name_str.c_str(), benchmark_def, state);
+      });
+
+  if (iree_all_bits_set(benchmark_def->flags,
+                        IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME)) {
+    instance->MeasureProcessCPUTime();
+  }
+  if (iree_all_bits_set(benchmark_def->flags,
+                        IREE_BENCHMARK_FLAG_USE_REAL_TIME)) {
+    instance->UseRealTime();
+  }
+  if (iree_all_bits_set(benchmark_def->flags,
+                        IREE_BENCHMARK_FLAG_USE_MANUAL_TIME)) {
+    instance->UseManualTime();
+  }
+
+  if (benchmark_def->minimum_duration_ns != 0) {
+    instance->MinTime((double)benchmark_def->minimum_duration_ns / 1e-9);
+  } else if (benchmark_def->iteration_count != 0) {
+    instance->Iterations(benchmark_def->iteration_count);
+  }
+
+  switch (benchmark_def->time_unit) {
+    default:
+    case IREE_BENCHMARK_UNIT_MILLISECOND:
+      instance->Unit(benchmark::kMillisecond);
+      break;
+    case IREE_BENCHMARK_UNIT_MICROSECOND:
+      instance->Unit(benchmark::kMicrosecond);
+      break;
+    case IREE_BENCHMARK_UNIT_NANOSECOND:
+      instance->Unit(benchmark::kNanosecond);
+      break;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Benchmark infra management
+//===----------------------------------------------------------------------===//
+
+void iree_benchmark_initialize(int* argc, char** argv) {
+  benchmark::Initialize(argc, argv);
+}
+
+void iree_benchmark_run_specified() { benchmark::RunSpecifiedBenchmarks(); }

--- a/iree/testing/benchmark_main.c
+++ b/iree/testing/benchmark_main.c
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "benchmark/benchmark.h"
 #include "iree/base/internal/flags.h"
+#include "iree/testing/benchmark.h"
 
-namespace iree {
-
-extern "C" int main(int argc, char** argv) {
-  ::benchmark::Initialize(&argc, argv);
+int main(int argc, char** argv) {
+  iree_benchmark_initialize(&argc, argv);
   iree_flags_parse_checked(&argc, &argv);
-  ::benchmark::RunSpecifiedBenchmarks();
+  iree_benchmark_run_specified();
   return 0;
 }
-
-}  // namespace iree


### PR DESCRIPTION
This will let us substitute other benchmarking frameworks for use on
bare-metal platforms or other places the full benchmark library can't run.
This initial pass exposes what we use in iree-benchmark-module today and
additional features can be added as needed (like range parameters).