### PR TITLE
Fix format specifiers for 32-bit architectures

### DIFF
--- a/iree/hal/local/elf/elf_module.c
+++ b/iree/hal/local/elf/elf_module.c
@@ -14,6 +14,8 @@
 
 #include "iree/hal/local/elf/elf_module.h"
 
+#include <inttypes.h>
+
 #include "iree/base/target_platform.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/local/elf/platform.h"
@@ -151,11 +153,12 @@ static iree_status_t iree_elf_module_verify_phdr_table(
     const iree_elf_phdr_t* phdr = &load_state->phdr_table[i];
     if (phdr->p_type != IREE_ELF_PT_LOAD) continue;
     if (phdr->p_offset + phdr->p_filesz > raw_data.data_length) {
-      return iree_make_status(
-          IREE_STATUS_FAILED_PRECONDITION,
-          "phdr reference outside of file extents: %zu-%zu of max %zu",
-          phdr->p_offset, phdr->p_offset + phdr->p_filesz,
-          raw_data.data_length);
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "phdr reference outside of file extents: %" PRIu64
+                              "-%" PRIu64 "of max %" PRIu64,
+                              (uint64_t)phdr->p_offset,
+                              (uint64_t)(phdr->p_offset + phdr->p_filesz),
+                              (uint64_t)raw_data.data_length);
     }
   }
   return iree_ok_status();


### PR DESCRIPTION
Otherwise we get an error about narrowing from 64 to 32 bit on 32-bit
architectures. This wasn't caught because we don't have any tests of
32-bit architectures in OSS (but we do internally at Google).

```
iree/hal/local/elf/elf_module.c:157:11: error: format specifies type
'size_t' (aka 'unsigned int') but the argument has type
'iree_elf64_off_t' (aka 'unsigned long long') [-Werror,-Wformat]
          phdr->p_offset, phdr->p_offset + phdr->p_filesz,
```

So longer term fixes are to add a 32-bit build bot and create format
specifiers for IREE's types (so we don't just have to widen
everywhere), but this unblocks integration for now.