### PR TITLE
Fix pointer size detection

### DIFF
--- a/iree/base/target_platform.h
+++ b/iree/base/target_platform.h
@@ -105,17 +105,17 @@
 //==============================================================================
 
 // See https://stackoverflow.com/q/51616057
-_Static_assert(sizeof(void*) == sizeof(uintptr_t),
-               "can't determine pointer size");
+static_assert(sizeof(void*) == sizeof(uintptr_t),
+              "can't determine pointer size");
 
 #if UINTPTR_MAX == 0xFFFFFFFF
-  #define IREE_PTR_SIZE_32
-  #define IREE_PTR_SIZE 4
+#define IREE_PTR_SIZE_32
+#define IREE_PTR_SIZE 4
 #elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
-  #define IREE_PTR_SIZE_64
-  #define IREE_PTR_SIZE 8
+#define IREE_PTR_SIZE_64
+#define IREE_PTR_SIZE 8
 #else
-  #error "can't determine pointer size"
+#error "can't determine pointer size"
 #endif
 
 //==============================================================================

--- a/iree/base/target_platform.h
+++ b/iree/base/target_platform.h
@@ -15,6 +15,7 @@
 #ifndef IREE_BASE_TARGET_PLATFORM_H_
 #define IREE_BASE_TARGET_PLATFORM_H_
 
+#include <assert.h>
 #include <stdint.h>
 
 // The build system defines one of the following top-level platforms and then
@@ -105,8 +106,8 @@
 //==============================================================================
 
 // See https://stackoverflow.com/q/51616057
-_Static_assert(sizeof(void*) == sizeof(uintptr_t),
-               "can't determine pointer size");
+static_assert(sizeof(void*) == sizeof(uintptr_t),
+              "can't determine pointer size");
 
 #if UINTPTR_MAX == 0xFFFFFFFF
 #define IREE_PTR_SIZE_32

--- a/iree/base/target_platform.h
+++ b/iree/base/target_platform.h
@@ -105,8 +105,8 @@
 //==============================================================================
 
 // See https://stackoverflow.com/q/51616057
-static_assert(sizeof(void*) == sizeof(uintptr_t),
-              "can't determine pointer size");
+_Static_assert(sizeof(void*) == sizeof(uintptr_t),
+               "can't determine pointer size");
 
 #if UINTPTR_MAX == 0xFFFFFFFF
 #define IREE_PTR_SIZE_32

--- a/iree/base/target_platform.h
+++ b/iree/base/target_platform.h
@@ -104,12 +104,18 @@
 // IREE_PTR_SIZE_*
 //==============================================================================
 
-#if UINTPTR_MAX > UINT_MAX
-#define IREE_PTR_SIZE_64
-#define IREE_PTR_SIZE 8
+// See https://stackoverflow.com/q/51616057
+_Static_assert(sizeof(void*) == sizeof(uintptr_t),
+               "can't determine pointer size");
+
+#if UINTPTR_MAX == 0xFFFFFFFF
+  #define IREE_PTR_SIZE_32
+  #define IREE_PTR_SIZE 4
+#elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+  #define IREE_PTR_SIZE_64
+  #define IREE_PTR_SIZE 8
 #else
-#define IREE_PTR_SIZE_32
-#define IREE_PTR_SIZE 4
+  #error "can't determine pointer size"
 #endif
 
 //==============================================================================


### PR DESCRIPTION
This wasn't working on our internal 32-bit arm architecture for some
reason. Unlike many methods one can find on the internet, the one used
here doesn't require listing every possible architecture. It has the
disadvantage (like the one used previously) that it requires uintptr_t,
which is not technically required by the standard and it requires that
`uintptr_t` be the size of a void pointer, which is also not
technically required. Both these properties are checked at compile time
though, so if we ever have to deal with some weird architecture where
that isn't true, I guess we can find some other way.