### PR TITLE
Adding a little demo library to show both sides of the ABI.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.cpp
@@ -198,13 +198,16 @@ static llvm::Constant *getStringConstant(StringRef value,
 llvm::Function *LibraryBuilder::build(StringRef queryFuncName) {
   auto &context = module->getContext();
   auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *ptrType = llvm::Type::getInt8PtrTy(context);
   auto *libraryHeaderType = makeLibraryHeaderType(context);
 
-  // %struct.iree_hal_executable_library_header_t** @iree_hal_library_query(i32)
+  // %struct.iree_hal_executable_library_header_t**
+  // @iree_hal_library_query(i32, void*)
   auto *queryFuncType =
       llvm::FunctionType::get(libraryHeaderType->getPointerTo(),
                               {
                                   i32Type,
+                                  ptrType,
                               },
                               /*isVarArg=*/false);
   auto *func =

--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -60,6 +60,20 @@ cc_library(
     hdrs = ["executable_library.h"],
 )
 
+cc_test(
+    name = "executable_library_test",
+    srcs = [
+        "executable_library_demo.c",
+        "executable_library_demo.h",
+        "executable_library_test.c",
+    ],
+    deps = [
+        "//iree/base:api",
+        "//iree/base:core_headers",
+        "//iree/hal/local:executable_library",
+    ],
+)
+
 cc_library(
     name = "local",
     srcs = [

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -50,6 +50,19 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    executable_library_test
+  SRCS
+    "executable_library_demo.c"
+    "executable_library_demo.h"
+    "executable_library_test.c"
+  DEPS
+    iree::base::api
+    iree::base::core_headers
+    iree::hal::local::executable_library
+)
+
 iree_cc_library(
   NAME
     local

--- a/iree/hal/local/elf/arch.h
+++ b/iree/hal/local/elf/arch.h
@@ -58,6 +58,9 @@ void iree_elf_call_v_v(const void* symbol_ptr);
 // void*(*)(int)
 void* iree_elf_call_p_i(const void* symbol_ptr, int a0);
 
+// void*(*)(int, void*)
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1);
+
 // int(*)(void*, void*)
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1);
 

--- a/iree/hal/local/elf/arch/arm_32.c
+++ b/iree/hal/local/elf/arch/arm_32.c
@@ -131,6 +131,11 @@ void* iree_elf_call_p_i(const void* symbol_ptr, int a0) {
   return ((ptr_t)symbol_ptr)(a0);
 }
 
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1) {
+  typedef void* (*ptr_t)(int, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1);
+}
+
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1) {
   typedef int (*ptr_t)(void*, void*);
   return ((ptr_t)symbol_ptr)(a0, a1);

--- a/iree/hal/local/elf/arch/arm_64.c
+++ b/iree/hal/local/elf/arch/arm_64.c
@@ -128,6 +128,11 @@ void* iree_elf_call_p_i(const void* symbol_ptr, int a0) {
   return ((ptr_t)symbol_ptr)(a0);
 }
 
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1) {
+  typedef void* (*ptr_t)(int, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1);
+}
+
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1) {
   typedef int (*ptr_t)(void*, void*);
   return ((ptr_t)symbol_ptr)(a0, a1);

--- a/iree/hal/local/elf/arch/riscv.c
+++ b/iree/hal/local/elf/arch/riscv.c
@@ -171,6 +171,11 @@ void* iree_elf_call_p_i(const void* symbol_ptr, int a0) {
   return ((ptr_t)symbol_ptr)(a0);
 }
 
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1) {
+  typedef void* (*ptr_t)(int, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1);
+}
+
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1) {
   typedef int (*ptr_t)(void*, void*);
   return ((ptr_t)symbol_ptr)(a0, a1);

--- a/iree/hal/local/elf/arch/x86_32.c
+++ b/iree/hal/local/elf/arch/x86_32.c
@@ -152,6 +152,11 @@ void* iree_elf_call_p_i(const void* symbol_ptr, int a0) {
   return ((ptr_t)symbol_ptr)(a0);
 }
 
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1) {
+  typedef void* (*ptr_t)(int, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1);
+}
+
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1) {
   typedef int (*ptr_t)(void*, void*);
   return ((ptr_t)symbol_ptr)(a0, a1);

--- a/iree/hal/local/elf/arch/x86_64.c
+++ b/iree/hal/local/elf/arch/x86_64.c
@@ -193,6 +193,11 @@ void* iree_elf_call_p_i(const void* symbol_ptr, int a0) {
   return ((ptr_t)symbol_ptr)(a0);
 }
 
+void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1) {
+  typedef void* (*ptr_t)(int, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1);
+}
+
 int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1) {
   typedef int (*ptr_t)(void*, void*);
   return ((ptr_t)symbol_ptr)(a0, a1);

--- a/iree/hal/local/elf/arch/x86_64_msvc.asm
+++ b/iree/hal/local/elf/arch/x86_64_msvc.asm
@@ -148,6 +148,21 @@ iree_elf_call_p_i PROC FRAME
   ret
 iree_elf_call_p_i ENDP
 
+; void* iree_elf_call_p_ip(const void* symbol_ptr, int a0, void* a1)
+iree_elf_call_p_ip PROC FRAME
+  _sysv_interop_prolog
+
+  ; RCX = symbol_ptr
+  ; RDX = a0
+  ; R8 = a1
+  mov rdi, rdx
+  mov rsi, r8
+  call rcx
+
+  _sysv_interop_epilog
+  ret
+iree_elf_call_p_ip ENDP
+
 ; int iree_elf_call_i_pp(const void* symbol_ptr, void* a0, void* a1)
 iree_elf_call_i_pp PROC FRAME
   _sysv_interop_prolog

--- a/iree/hal/local/elf/elf_module_test.cc
+++ b/iree/hal/local/elf/elf_module_test.cc
@@ -82,8 +82,9 @@ TEST_F(ELFModuleTest, Check) {
     const iree_hal_executable_library_v0_t* v0;
   } library;
   library.header =
-      (const iree_hal_executable_library_header_t**)iree_elf_call_p_i(
-          query_fn_ptr, IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION);
+      (const iree_hal_executable_library_header_t**)iree_elf_call_p_ip(
+          query_fn_ptr, IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
+          /*reserved=*/NULL);
   ASSERT_TRUE(library.header != NULL);
 
   auto* header = *library.header;

--- a/iree/hal/local/executable_library.h
+++ b/iree/hal/local/executable_library.h
@@ -116,7 +116,7 @@ typedef struct {
 // than the max version supported by the caller.
 typedef const iree_hal_executable_library_header_t** (
     *iree_hal_executable_library_query_fn_t)(
-    iree_hal_executable_library_version_t max_version);
+    iree_hal_executable_library_version_t max_version, void* reserved);
 
 // Function name exported from dynamic libraries (pass to dlsym).
 #define IREE_HAL_EXECUTABLE_LIBRARY_EXPORT_NAME \

--- a/iree/hal/local/executable_library_demo.c
+++ b/iree/hal/local/executable_library_demo.c
@@ -1,0 +1,98 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/executable_library_demo.h"
+
+// An executable entry point, called one or more times based on the 3D XYZ
+// workgroup count specified during the dispatch. Each invocation gets access to
+// the dispatch state via |dispatch_state| such as workgroup parameters, push
+// constants providing small arguments, and buffer bindings.
+//
+// See the iree_hal_executable_dispatch_state_v0_t struct for more
+// information on the fields here and how they can be used.
+//
+// WARNING: these functions must not access mutable global state: read-only data
+// may be used but as each invocation may be running concurrently with any
+// number of other invocations (from any number of user sessions!) all
+// communication between invocations must use the buffer bindings for I/O.
+//
+// This is a simple scalar addition:
+//    binding[1] = binding[0] + push_constant[0]
+static int dispatch_tile_a(
+    const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
+    const iree_hal_vec3_t* workgroup_id) {
+  const dispatch_tile_a_push_constants_t* push_constants =
+      (const dispatch_tile_a_push_constants_t*)dispatch_state->push_constants;
+  const float* src = ((const float*)dispatch_state->binding_ptrs[0]);
+  float* dst = ((float*)dispatch_state->binding_ptrs[1]);
+  dst[workgroup_id->x] = src[workgroup_id->x] + push_constants->f0;
+  return 0;
+}
+
+// Just another entry point.
+static int dispatch_tile_b(
+    const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
+    const iree_hal_vec3_t* workgroup_id) {
+  return 0;
+}
+
+// Version/metadata header.
+static const iree_hal_executable_library_header_t header = {
+    // Declares what library version is present: newer runtimes may support
+    // loading older executables but newer executables cannot load on older
+    // runtimes.
+    .version = IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
+    // Name used for logging/diagnostics and rendezvous.
+    .name = "demo_library",
+    .features = IREE_HAL_EXECUTABLE_LIBRARY_FEATURE_NONE,
+    .sanitizer = IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_NONE,
+};
+// Table of export function entry points.
+static const iree_hal_executable_dispatch_v0_t entry_points[2] = {
+    dispatch_tile_a,
+    dispatch_tile_b,
+};
+// Names for each entry point.
+static const char* entry_point_names[2] = {
+    "dispatch_tile_a",
+    "dispatch_tile_b",
+};
+// User tags for debugging/logging; not used for anything but presentation.
+static const char* entry_point_tags[2] = {
+    "matmul+div",
+    "conv2d[512x512]",
+};
+static const iree_hal_executable_library_v0_t library = {
+    .header = &header,
+    .entry_point_count = 2,
+    .entry_points = entry_points,
+    .entry_point_names = entry_point_names,
+    .entry_point_tags = entry_point_tags,
+};
+
+// The primary access point to the executable: in a static library this is
+// just like any other C symbol that can be called from other code (like
+// executable_library_test.c does), and in dynamic libraries this is the symbol
+// that you would be dlsym'ing.
+//
+// This is just code: if the executable wants to return different headers based
+// on the currently executing architecture or the requested version it can. For
+// example, an executable may want to swap out a few entry points to an
+// architecture-specific version.
+const iree_hal_executable_library_header_t** demo_executable_library_query(
+    iree_hal_executable_library_version_t max_version, void* reserved) {
+  return max_version <= 0
+             ? (const iree_hal_executable_library_header_t**)&library
+             : NULL;
+}

--- a/iree/hal/local/executable_library_demo.h
+++ b/iree/hal/local/executable_library_demo.h
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_HAL_LOCAL_EXECUTABLE_LIBRARY_DEMO_H_
+#define IREE_HAL_LOCAL_EXECUTABLE_LIBRARY_DEMO_H_
+
+#include "iree/hal/local/executable_library.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Ideally we would have the IREE compiler generate a header like this so that
+// it's possible to manually call into executables. For now this is just an
+// example for the demo: the real HAL does not require this header as it
+// dlsym's the function pointer and packs the push constants itself.
+
+// Push constants used in the 'dispatch_tile_a' entry point.
+typedef union {
+  uint32_t values[1];
+  struct {
+    float f0;
+  };
+} dispatch_tile_a_push_constants_t;
+
+// Returns a simple demo library with the following structure:
+//
+// Name: 'demo_library'
+//
+// [0] 'dispatch_tile_a': matmul+div
+//       push constants: 1 (dispatch_tile_a_push_constants_t)
+//       bindings: 2
+//         [0] = R
+//         [1] = W
+//
+// [1] 'dispatch_tile_b': conv2d[512x512]
+//       push constants: 0
+//       bindings: 0
+//
+const iree_hal_executable_library_header_t** demo_executable_library_query(
+    iree_hal_executable_library_version_t max_version, void* reserved);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_LOCAL_EXECUTABLE_LIBRARY_DEMO_H_

--- a/iree/hal/local/executable_library_test.c
+++ b/iree/hal/local/executable_library_test.c
@@ -1,0 +1,113 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/hal/local/executable_library.h"
+
+#include <assert.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/local/executable_library_demo.h"
+
+// Demonstration of the HAL-side of the iree_hal_executable_library_t ABI.
+// This is the lowest level of the system right before calling into generated
+// code.
+//
+// This shows what the various execution systems are doing (through a lot
+// of fancy means): all `inline_command_buffer.c` and `task_command_buffer.c`
+// lead up to just calling into the iree_hal_executable_dispatch_v0_t entry
+// point functions with a state structure and a workgroup XYZ.
+//
+// Below walks through acquiring the library pointer (which in this case is a
+// hand-coded example to show the codegen-side), setting up the I/O buffers and
+// state, and calling the function to do some math.
+//
+// See iree/hal/local/executable_library.h for more information.
+int main(int argc, char** argv) {
+  // Query the library header at the requested version.
+  // The query call in this example is going into the handwritten demo code
+  // but could be targeted at generated files or runtime-loaded shared objects.
+  union {
+    const iree_hal_executable_library_header_t** header;
+    const iree_hal_executable_library_v0_t* v0;
+  } library;
+  library.header = demo_executable_library_query(
+      IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION, /*reserved=*/NULL);
+  const iree_hal_executable_library_header_t* header = *library.header;
+  assert(header != NULL && "version may not have matched");
+  assert(header->version <= IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION &&
+         "expecting the library to have the same or older version as us");
+  assert(strcmp(header->name, "demo_library") == 0 &&
+         "library name can be used to rendezvous in a registry");
+  assert(library.v0->entry_point_count > 0 &&
+         "expected at least one entry point");
+
+  // Push constants are an array of 4-byte values that are much more efficient
+  // to specify (no buffer pointer indirection) and more efficient to access
+  // (static struct offset address calculation, all fit in a few cache lines,
+  // etc). They are limited in capacity, though, so only <=64(ish) are usable.
+  dispatch_tile_a_push_constants_t push_constants;
+  memset(&push_constants, 0, sizeof(push_constants));
+  push_constants.f0 = 5.0f;
+
+  // Setup the two buffer bindings the entry point is expecting.
+  // They only need to remain valid for the duration of the invocation and all
+  // memory accessed by the invocation will come from here.
+  float arg0[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float ret0[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+  const float ret0_expected[4] = {6.0f, 7.0f, 8.0f, 9.0f};
+  iree_device_size_t binding_lengths[2] = {
+      sizeof(arg0),
+      sizeof(ret0),
+  };
+  void* binding_ptrs[2] = {
+      arg0,
+      ret0,
+  };
+
+  // Resolve the entry point by ordinal.
+  const iree_hal_executable_dispatch_v0_t entry_fn_ptr =
+      library.v0->entry_points[0];
+
+  // Dispatch each workgroup with the same state.
+  iree_hal_executable_dispatch_state_v0_t dispatch_state = {
+      .workgroup_count = {{4, 1, 1}},
+      .workgroup_size = {{1, 1, 1}},
+      .push_constant_count = IREE_ARRAYSIZE(push_constants.values),
+      .push_constants = push_constants.values,
+      .binding_count = IREE_ARRAYSIZE(binding_ptrs),
+      .binding_ptrs = binding_ptrs,
+      .binding_lengths = binding_lengths,
+      .imports = NULL,  // not yet implemented
+  };
+  for (uint32_t z = 0; z < dispatch_state.workgroup_count.z; ++z) {
+    for (uint32_t y = 0; y < dispatch_state.workgroup_count.y; ++y) {
+      for (uint32_t x = 0; x < dispatch_state.workgroup_count.x; ++x) {
+        // Invoke the workgroup (x, y, z).
+        iree_hal_vec3_t workgroup_id = {{x, y, z}};
+        int ret = entry_fn_ptr(&dispatch_state, &workgroup_id);
+        assert(ret == 0 &&
+               "if we have bounds checking enabled the executable will signal "
+               "us of badness");
+      }
+    }
+  }
+
+  // Ensure it worked.
+  bool all_match = true;
+  for (size_t i = 0; i < IREE_ARRAYSIZE(ret0_expected); ++i) {
+    assert(ret0[i] == ret0_expected[i] && "math is hard");
+    all_match = all_match && ret0[i] == ret0_expected[i];
+  }
+  return all_match ? 0 : 1;
+}

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -51,8 +51,9 @@ static iree_status_t iree_hal_elf_executable_query_library(
 
   // Query for a compatible version of the library.
   executable->library.header =
-      (const iree_hal_executable_library_header_t**)iree_elf_call_p_i(
-          query_fn, IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION);
+      (const iree_hal_executable_library_header_t**)iree_elf_call_p_ip(
+          query_fn, IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION,
+          /*reserved=*/NULL);
   if (!executable->library.header) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,

--- a/iree/hal/local/loaders/legacy_library_loader.c
+++ b/iree/hal/local/loaders/legacy_library_loader.c
@@ -124,7 +124,7 @@ static iree_status_t iree_hal_legacy_executable_query_library(
 
   // Query for a compatible version of the library.
   executable->library.header =
-      query_fn(IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION);
+      query_fn(IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION, /*reserved=*/NULL);
   if (!executable->library.header) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,


### PR DESCRIPTION
The current shared objects we produce from the LLVM AOT backend match
the same ABI as written by hand here in _demo.c.