### PR TITLE
[cmake] Add missing quote to ${CMAKE_CXX_FLAGS}

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -293,7 +293,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
 #   https://github.com/google/iree/issues/4665.
 #   https://discourse.cmake.org/t/how-to-fix-build-warning-d9025-overriding-gr-with-gr/878
 #   https://gitlab.kitware.com/cmake/cmake/-/issues/20610
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if(CMAKE_CXX_FLAGS AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -294,7 +294,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
 #   https://discourse.cmake.org/t/how-to-fix-build-warning-d9025-overriding-gr-with-gr/878
 #   https://gitlab.kitware.com/cmake/cmake/-/issues/20610
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 if(NOT ANDROID)


### PR DESCRIPTION
Without it, we can see failures like:

```
CMake Error at build_tools/cmake/iree_copts.cmake:297 (string):
  string sub-command REPLACE requires at least four arguments.
```