### PR TITLE
Add more patterns to lower to `flow.tensor` ops

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -117,11 +117,13 @@ struct FusionOfTensorOpsPass
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        std::move(fusionPatterns));
 
-    OwningRewritePatternList foldUnitDimReshapes(&getContext());
+    OwningRewritePatternList reshapeCanonicalizations(&getContext());
     linalg::populateFoldUnitDimsReshapeOpsByLinearizationPatterns(
-        foldUnitDimReshapes);
+        reshapeCanonicalizations);
+    linalg::TensorReshapeOp::getCanonicalizationPatterns(
+        reshapeCanonicalizations, context);
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
-                                       std::move(foldUnitDimReshapes));
+                                       std::move(reshapeCanonicalizations));
 
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        frozenInterfacePatterns);

--- a/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/FusionOfTensorOps.cpp
@@ -117,6 +117,12 @@ struct FusionOfTensorOpsPass
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        std::move(fusionPatterns));
 
+    OwningRewritePatternList foldUnitDimReshapes(&getContext());
+    linalg::populateFoldUnitDimsReshapeOpsByLinearizationPatterns(
+        foldUnitDimReshapes);
+    (void)applyPatternsAndFoldGreedily(op->getRegions(),
+                                       std::move(foldUnitDimReshapes));
+
     (void)applyPatternsAndFoldGreedily(op->getRegions(),
                                        frozenInterfacePatterns);
   }

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -567,7 +567,8 @@ static uint64_t getFlattenedIndex(ShapedType type, ArrayRef<uint64_t> index) {
 
 static bool compareShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
                                ShapedType rhsType, ValueRange rhsDynamicDims) {
-  if (lhsType.hasStaticShape() && lhsType == rhsType) {
+  if (lhsType.hasStaticShape() &&
+      lhsType.getNumElements() == rhsType.getNumElements()) {
     // Static shape equivalence means we can fast-path the check.
     return true;
   }

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
@@ -249,6 +249,7 @@ struct ConvertToFlowTensorOpsPass
     patterns.insert<LinalgTensorReshapeToFlowTensorReshape,
                     SubTensorInsertToTensorUpdate, SubTensorToTensorSlice>(
         context);
+    IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
@@ -111,7 +111,6 @@ struct LinalgTensorReshapeToFlowTensorReshape
     if (reshapeOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
-    Location loc = reshapeOp.getLoc();
     SmallVector<SmallVector<Value>> outputShape;
     if (failed(reshapeOp.reifyReturnTypeShapesPerResultDim(rewriter,
                                                            outputShape))) {
@@ -198,7 +197,6 @@ struct SubTensorToTensorSlice : public OpRewritePattern<SubTensorOp> {
     }
     Location loc = subTensorOp.getLoc();
 
-    Value source = subTensorOp.source();
     ShapedType sourceType = subTensorOp.getSourceType();
     ShapedType resultType = subTensorOp.getType();
 

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
@@ -31,6 +31,73 @@ namespace iree_compiler {
 namespace IREE {
 namespace Flow {
 
+/// An operation that uses `offsets`, `sizes` and `strides` (i.e. implements the
+/// `OffsetSizeAndStrideInterface` can be mapped to flow operations that
+/// eventually map to DMA operations if)
+/// - all offsets apart from the first one are 0
+/// - all the sizes apart from the first match the sizes of the source
+/// - all strides are 1.
+static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
+                                                ArrayRef<OpFoldResult> sizes,
+                                                ArrayRef<OpFoldResult> strides,
+                                                ArrayRef<int64_t> baseShape) {
+  if (offsets.size() != baseShape.size()) {
+    // Unhanded rank-reducing case.
+    return false;
+  }
+  for (unsigned dim : llvm::seq<unsigned>(0, offsets.size())) {
+    auto matchVal = [](OpFoldResult valueOrAttr, int64_t val) -> bool {
+      auto attr = valueOrAttr.dyn_cast<Attribute>();
+      return attr && attr.cast<IntegerAttr>().getInt() == val;
+    };
+    if ((dim != 0 && (!matchVal(offsets[dim], 0) ||
+                      !matchVal(sizes[dim], baseShape[dim]))) ||
+        !matchVal(strides[dim], 1)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Returns the `Value`s for a list of `OpFoldResult` by generating std.constant
+/// ops for the static values.
+static SmallVector<Value, 4> getAsValues(
+    OpBuilder &b, Location loc, ArrayRef<OpFoldResult> valueOrAttrList) {
+  SmallVector<Value, 4> values;
+  for (auto valueOrAttr : valueOrAttrList) {
+    if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
+      values.push_back(
+          b.create<ConstantIndexOp>(loc, attr.cast<IntegerAttr>().getInt()));
+      continue;
+    }
+    values.push_back(valueOrAttr.get<Value>());
+  }
+  return values;
+}
+
+/// Gets the list of non-static values from a list of `OpFoldResult`.
+static SmallVector<Value, 4> getDynamicValues(
+    ArrayRef<OpFoldResult> valueOrAttrList) {
+  SmallVector<Value, 4> dynamicDims;
+  for (auto valueOrAttr : valueOrAttrList) {
+    if (auto value = valueOrAttr.dyn_cast<Value>()) {
+      dynamicDims.push_back(value);
+    }
+  }
+  return dynamicDims;
+}
+
+/// Generates `memref.dim` operations to get the dynamic sizes of a value `v`.
+static SmallVector<Value, 4> getDynamicDimValues(OpBuilder &b, Location loc,
+                                                 Value v) {
+  SmallVector<Value, 4> dynamicDims;
+  for (auto dim : llvm::enumerate(v.getType().cast<ShapedType>().getShape())) {
+    if (dim.value() != ShapedType::kDynamicSize) continue;
+    dynamicDims.push_back(b.createOrFold<memref::DimOp>(loc, v, dim.index()));
+  }
+  return dynamicDims;
+}
+
 namespace {
 
 /// Converts linalg.tensor_reshape operations into flow.tensor.reshape
@@ -41,6 +108,9 @@ struct LinalgTensorReshapeToFlowTensorReshape
 
   LogicalResult matchAndRewrite(linalg::TensorReshapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
+    if (reshapeOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+      return failure();
+    }
     Location loc = reshapeOp.getLoc();
     SmallVector<SmallVector<Value>> outputShape;
     if (failed(reshapeOp.reifyReturnTypeShapesPerResultDim(rewriter,
@@ -60,10 +130,55 @@ struct LinalgTensorReshapeToFlowTensorReshape
   }
 };
 
-/// Convert subtensor operation to flow.tensor.slice if
-/// - all offsets apart from the first one are 0
-/// - all the sizes apart from the first match the sizes of the source
-/// - all strides are 1.
+/// Convert subtensor insert operation flow.tensor.update where possible.
+struct SubTensorInsertToTensorUpdate : OpRewritePattern<SubTensorInsertOp> {
+  using OpRewritePattern<SubTensorInsertOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(SubTensorInsertOp insertOp,
+                                PatternRewriter &rewriter) const override {
+    if (insertOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+      return failure();
+    }
+    SmallVector<OpFoldResult, 4> offsets = insertOp.getMixedOffsets();
+    SmallVector<OpFoldResult, 4> sizes = insertOp.getMixedSizes();
+    SmallVector<OpFoldResult, 4> strides = insertOp.getMixedStrides();
+    ArrayRef<int64_t> dstShape = insertOp.getType().getShape();
+    if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides,
+                                             dstShape)) {
+      return failure();
+    }
+    Location loc = insertOp.getLoc();
+    auto sourceDynamicDims = getDynamicValues(sizes);
+    Value source = insertOp.source();
+    ShapedType sourceType = insertOp.getSourceType();
+    ShapedType destType = insertOp.getType();
+
+    // Handle rank-reduced version.
+    if (sourceType.getRank() < destType.getRank()) {
+      // Pad the leading dimensions by 1. By construction, only leading sizes of
+      // the subtensor can be 1 at this stage (and therefore can be
+      // rank-reduced).
+      SmallVector<int64_t> unreducedShape(
+          destType.getRank() - sourceType.getRank(), 1);
+      unreducedShape.append(sourceType.getShape().begin(),
+                            sourceType.getShape().end());
+      sourceType =
+          RankedTensorType::get(unreducedShape, sourceType.getElementType());
+      source = rewriter.create<IREE::Flow::TensorReshapeOp>(
+          loc, sourceType, source, sourceDynamicDims, sourceDynamicDims);
+    }
+
+    auto offsetVals = getAsValues(rewriter, loc, offsets);
+    Value dest = insertOp.dest();
+    auto destDynamicDims = getDynamicDimValues(rewriter, loc, dest);
+    rewriter.replaceOpWithNewOp<TensorUpdateOp>(
+        insertOp, insertOp.getType(), dest, destDynamicDims, offsetVals, source,
+        sourceDynamicDims, nullptr);
+    return success();
+  }
+};
+
+/// Convert subtensor operation to flow.tensor.slice where possible.
 struct SubTensorToTensorSlice : OpRewritePattern<SubTensorOp> {
   using OpRewritePattern<SubTensorOp>::OpRewritePattern;
 
@@ -76,59 +191,43 @@ struct SubTensorToTensorSlice : OpRewritePattern<SubTensorOp> {
     SmallVector<OpFoldResult, 4> sizes = subTensorOp.getMixedSizes();
     SmallVector<OpFoldResult, 4> strides = subTensorOp.getMixedStrides();
     ArrayRef<int64_t> srcShape = subTensorOp.getSourceType().getShape();
-    for (unsigned dim :
-         llvm::seq<unsigned>(0, subTensorOp.getType().getRank())) {
-      auto matchVal = [](OpFoldResult valueOrAttr, int64_t val) -> bool {
-        auto attr = valueOrAttr.dyn_cast<Attribute>();
-        return attr && attr.cast<IntegerAttr>().getInt() == val;
-      };
-      if ((dim != 0 && (!matchVal(offsets[dim], 0) ||
-                        !matchVal(sizes[dim], srcShape[dim]))) ||
-          !matchVal(strides[dim], 1)) {
-        return failure();
-      }
+    if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides,
+                                             srcShape)) {
+      return failure();
     }
     Location loc = subTensorOp.getLoc();
-    auto getAsValues =
-        [&](ArrayRef<OpFoldResult> valueOrAttrList) -> SmallVector<Value, 4> {
-      return llvm::to_vector<4>(llvm::map_range(
-          valueOrAttrList, [&](OpFoldResult valueOrAttr) -> Value {
-            if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-              return rewriter.create<ConstantIndexOp>(
-                  loc, attr.cast<IntegerAttr>().getInt());
-            }
-            return valueOrAttr.get<Value>();
-          }));
-    };
-    auto offsetVals = getAsValues(offsets);
-    auto sizesVals = getAsValues(sizes);
 
     Value source = subTensorOp.source();
-    SmallVector<Value, 4> sourceSizesVals = sizesVals;
-    sourceSizesVals[0] = rewriter.createOrFold<memref::DimOp>(loc, source, 0);
+    ShapedType sourceType = subTensorOp.getSourceType();
+    ShapedType resultType = subTensorOp.getType();
 
-    // Different from SubTensor op, a TensorSliceOp does not have
-    // rank-reducing behavior.
-    Type type = SubTensorOp::inferResultType(subTensorOp.getSourceType(),
-                                             offsets, sizes, strides);
-    Value tensorSliceOp = rewriter.create<TensorSliceOp>(
-        loc, type, subTensorOp.source(), sourceSizesVals, offsetVals, sizesVals,
-        sizesVals);
-
-    if (type == subTensorOp.getType()) {
-      // Not rank-reducing subtensor, can replace with it directly.
-      rewriter.replaceOp(subTensorOp, tensorSliceOp);
-    } else {
-      // Rank-reducing subtensor, need a reshape op.
-      SmallVector<Value, 4> sourceDynSizes, resultDynSizes;
-      auto sourceType = tensorSliceOp.getType().cast<RankedTensorType>();
-      for (auto i : llvm::seq<unsigned>(0, sourceType.getNumDynamicDims())) {
-        sourceDynSizes.push_back(rewriter.create<ConstantIndexOp>(
-            loc, sourceType.getDynamicDimIndex(i)));
-      }
-      rewriter.replaceOpWithNewOp<TensorReshapeOp>(
-          subTensorOp, subTensorOp.getType(), tensorSliceOp, sourceDynSizes);
+    // Handle rank reduced version.
+    if (resultType.getRank() < sourceType.getRank()) {
+      // Pad the leading dimensions by 1. By construction, only leading sizes of
+      // the subtensor can be 1 at this stage (and therefore can be
+      // rank-reduced).
+      SmallVector<int64_t> unreducedShape(
+          sourceType.getRank() - resultType.getRank(), 1);
+      unreducedShape.append(resultType.getShape().begin(),
+                            resultType.getShape().end());
+      resultType =
+          RankedTensorType::get(unreducedShape, sourceType.getElementType());
     }
+
+    auto offsetVals = getAsValues(rewriter, loc, offsets);
+    auto sizeVals = getAsValues(rewriter, loc, sizes);
+    auto sourceDynamicDims =
+        getDynamicDimValues(rewriter, loc, subTensorOp.source());
+    auto resultDynamicDims = getDynamicValues(sizes);
+    Value replacement = rewriter.create<TensorSliceOp>(
+        loc, resultType, subTensorOp.source(), sourceDynamicDims, offsetVals,
+        sizeVals, resultDynamicDims);
+    if (resultType.getRank() > subTensorOp.getType().getRank()) {
+      replacement = rewriter.create<IREE::Flow::TensorReshapeOp>(
+          loc, subTensorOp.getType(), replacement, resultDynamicDims,
+          resultDynamicDims);
+    }
+    rewriter.replaceOp(subTensorOp, replacement);
     return success();
   }
 };
@@ -147,9 +246,9 @@ struct ConvertToFlowTensorOpsPass
     MLIRContext *context = funcOp->getContext();
     context->allowUnregisteredDialects(true);
     OwningRewritePatternList patterns(&getContext());
-    patterns
-        .insert<LinalgTensorReshapeToFlowTensorReshape, SubTensorToTensorSlice>(
-            context);
+    patterns.insert<LinalgTensorReshapeToFlowTensorReshape,
+                    SubTensorInsertToTensorUpdate, SubTensorToTensorSlice>(
+        context);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
@@ -29,13 +29,11 @@ func @subtensor_convert(%arg0 : tensor<?x24x48xf32>, %arg1 : index) ->
 //       CHECK:   %[[D0:.+]] = memref.dim %[[ARG0]], %[[C0]]
 //       CHECK:   %[[SLICE1:.+]] = flow.tensor.slice %[[ARG0]]
 //  CHECK-SAME:       [%[[C0]], %[[C0]], %[[C0]] for %[[ARG1]], %[[C24]], %[[C48]]]
-//  CHECK-SAME:       : tensor<?x24x48xf32>{%[[D0]], %[[C24]], %[[C48]]}
-//  CHECK-SAME:       -> tensor<?x24x48xf32>{%[[ARG1]], %[[C24]], %[[C48]]}
+//  CHECK-SAME:       : tensor<?x24x48xf32>{%[[D0]]} -> tensor<?x24x48xf32>{%[[ARG1]]}
 //       CHECK:   %[[D1:.+]] = subi %[[D0]], %[[ARG1]]
 //       CHECK:   %[[SLICE2:.+]] = flow.tensor.slice %[[ARG0]]
 //  CHECK-SAME:       [%[[ARG1]], %[[C0]], %[[C0]] for %[[D1]], %[[C24]], %[[C48]]]
-//  CHECK-SAME:       : tensor<?x24x48xf32>{%[[D0]], %[[C24]], %[[C48]]}
-//  CHECK-SAME:       -> tensor<?x24x48xf32>{%[[D1]], %[[C24]], %[[C48]]}
+//  CHECK-SAME:       : tensor<?x24x48xf32>{%[[D0]]} -> tensor<?x24x48xf32>{%[[D1]]}
 //   CHECK-DAG:   %[[UNMODIFIED1:.+]] = subtensor %[[SLICE1]][0, 0, 0] [%[[ARG1]], 12, 12] [1, 1, 1]
 //   CHECK-DAG:   %[[UNMODIFIED2:.+]] = subtensor %[[SLICE2]][0, 0, 0] [%[[D1]], 12, 24] [1, 2, 2]
 //   CHECK-DAG:   %[[UNMODIFIED3:.+]] = subtensor %[[ARG0]][0, %[[ARG1]], 0]
@@ -43,22 +41,20 @@ func @subtensor_convert(%arg0 : tensor<?x24x48xf32>, %arg1 : index) ->
 
 // -----
 
-func @rank_reducing_subtensor(%arg0: tensor<2x513xi32>, %arg1: index,
-                              %arg2: index) -> tensor<513xi32> {
-  %0 = subtensor %arg0[%arg1, %arg2] [1, 513] [1, 1] : tensor<2x513xi32> to tensor<513xi32>
+func @rank_reducing_subtensor(%arg0: tensor<?x513xi32>, %arg1: index) -> tensor<513xi32> {
+  %0 = subtensor %arg0[%arg1, 0] [1, 513] [1, 1] : tensor<?x513xi32> to tensor<513xi32>
   return %0 : tensor<513xi32>
 }
 // CHECK-LABEL: func @rank_reducing_subtensor
-//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]*]]
-//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]*]]
-//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]*]]
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = constant 1 : index
 //   CHECK-DAG:   %[[C513:.+]] = constant 513 : index
-//   CHECK-DAG:   %[[C2:.+]] = constant 2 : index
+//       CHECK:   %[[DIM:.+]] = memref.dim %[[ARG0]], %[[C0]]
 //       CHECK:   %[[SLICE:.+]] = flow.tensor.slice %[[ARG0]]
-//  CHECK-SAME:       [%[[ARG1]], %[[ARG2]] for %[[C1]], %[[C513]]]
-//  CHECK-SAME:       : tensor<2x513xi32>{%[[C2]], %[[C513]]}
-//  CHECK-SAME:       -> tensor<1x513xi32>{%[[C1]], %[[C513]]}
+//  CHECK-SAME:       [%[[ARG1]], %[[C0]] for %[[C1]], %[[C513]]]
+//  CHECK-SAME:       : tensor<?x513xi32>{%[[DIM]]} -> tensor<1x513xi32>
 //       CHECK:   %[[RESHAPE:.+]] = flow.tensor.reshape %[[SLICE]] : tensor<1x513xi32> -> tensor<513xi32>
 //       CHECK:   return %[[RESHAPE]] : tensor<513xi32>
 
@@ -85,3 +81,44 @@ func @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32
 //   CHECK-DAG:   %[[R0:.+]] = flow.tensor.reshape %[[ARG0]]
 //   CHECK-DAG:   %[[R1:.+]] = flow.tensor.reshape %[[ARG1]]
 //       CHECK:   return %[[R0]], %[[R1]]
+
+// -----
+
+func @subtensor_insert_convert
+    (%arg0 : tensor<?x24x48xf32>, %arg1 : tensor<?x24x48xf32>, %arg2 : index) ->
+    tensor<?x24x48xf32> {
+  %c0 = constant 0 : index
+  %0 = memref.dim %arg1, %c0 : tensor<?x24x48xf32>
+  %1 = subtensor_insert %arg1 into %arg0[%arg2, 0, 0] [%0, 24, 48] [1, 1, 1] :
+      tensor<?x24x48xf32> into tensor<?x24x48xf32>
+  return %1 : tensor<?x24x48xf32>
+}
+// CHECK-LABEL: func @subtensor_insert_convert
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[DIM0:.+]] = memref.dim %[[ARG1]], %[[C0]]
+//   CHECK-DAG:   %[[DIM1:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//       CHECK:   %[[UPDATE:.+]] = flow.tensor.update %[[ARG1]], %[[ARG0]][%[[ARG2]], %[[C0]], %[[C0]]]
+//  CHECK-SAME:     : tensor<?x24x48xf32>{%[[DIM0]]} -> tensor<?x24x48xf32>{%[[DIM1]]}
+
+// -----
+
+func @subtensor_insert_convert_rank_reducing
+    (%arg0 : tensor<?x24x48xf32>, %arg1 : tensor<24x48xf32>, %arg2 : index) ->
+    tensor<?x24x48xf32> {
+  %c0 = constant 0 : index
+  %0 = subtensor_insert %arg1 into %arg0[%arg2, 0, 0] [1, 24, 48] [1, 1, 1] :
+      tensor<24x48xf32> into tensor<?x24x48xf32>
+  return %0 : tensor<?x24x48xf32>
+}
+// CHECK-LABEL: func @subtensor_insert_convert_rank_reducing
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[C0:.+]] = constant 0
+//   CHECK-DAG:   %[[RESHAPE:.+]] = flow.tensor.reshape %[[ARG1]] : tensor<24x48xf32> -> tensor<1x24x48xf32>
+//   CHECK-DAG:   %[[DIM:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//       CHECK:   %[[UPDATE:.+]] = flow.tensor.update %[[RESHAPE]], %[[ARG0]][%[[ARG2]], %[[C0]], %[[C0]]]
+//  CHECK-SAME:     : tensor<1x24x48xf32> -> tensor<?x24x48xf32>{%[[DIM]]}

--- a/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/convert_to_flow_tensor_ops.mlir
@@ -43,6 +43,27 @@ func @subtensor_convert(%arg0 : tensor<?x24x48xf32>, %arg1 : index) ->
 
 // -----
 
+func @rank_reducing_subtensor(%arg0: tensor<2x513xi32>, %arg1: index,
+                              %arg2: index) -> tensor<513xi32> {
+  %0 = subtensor %arg0[%arg1, %arg2] [1, 513] [1, 1] : tensor<2x513xi32> to tensor<513xi32>
+  return %0 : tensor<513xi32>
+}
+// CHECK-LABEL: func @rank_reducing_subtensor
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]*]]
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]*]]
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]*]]
+//   CHECK-DAG:   %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:   %[[C513:.+]] = constant 513 : index
+//   CHECK-DAG:   %[[C2:.+]] = constant 2 : index
+//       CHECK:   %[[SLICE:.+]] = flow.tensor.slice %[[ARG0]]
+//  CHECK-SAME:       [%[[ARG1]], %[[ARG2]] for %[[C1]], %[[C513]]]
+//  CHECK-SAME:       : tensor<2x513xi32>{%[[C2]], %[[C513]]}
+//  CHECK-SAME:       -> tensor<1x513xi32>{%[[C1]], %[[C513]]}
+//       CHECK:   %[[RESHAPE:.+]] = flow.tensor.reshape %[[SLICE]] : tensor<1x513xi32> -> tensor<513xi32>
+//       CHECK:   return %[[RESHAPE]] : tensor<513xi32>
+
+// -----
+
 func @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32>)
     -> (tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>)
 {


### PR DESCRIPTION
The following operations can be lowered to `flow.tensor.` ops.

1) `linalg.tensor_reshape` -> `flow.tensor.reshape` : Once all reshapes can be folded away, the remaining reshapes only exist at the boundaries of dispatch regions. These are better off converted to `flow.tensor.reshape` so that they could become no-ops when lowered to the `hal` layer.

2) `subtensor` -> `flow.tensor.slice`. A `subtensor` operation can be lowered to a `flow.tensor.slice` operation in some cases. This can become a no-op in many cases.

3) `subtensor_insert` -> `flow.tensor.update`. A `subtensor_insert` operation can be lowered to a `flow.tensor.update` operation which will allow for doign in-place updates.

This will eliminate some dispatch regions that do not need to be created.