### PR TITLE
Rename FileToc struct to iree_file_toc_t

### DIFF
--- a/build_tools/embed_data/build_defs.bzl
+++ b/build_tools/embed_data/build_defs.bzl
@@ -29,17 +29,17 @@ def cc_embed_data(
 
     Generates a header like:
       namespace iree {
-        struct FileToc {
+        struct iree_file_toc_t {
           const char* name;             // the file's original name
           const char* data;             // beginning of the file
           size_t size;                  // length of the file
         };
       }
       namespace foo {
-      extern const struct ::iree::FileToc* this_rule_name_create();
+      extern const struct ::iree::iree_file_toc_t* this_rule_name_create();
       }
 
-    The 'this_rule_name()' function will return an array of FileToc
+    The 'this_rule_name()' function will return an array of iree_file_toc_t
     structs terminated by one that has nullptr 'name' and 'data' fields.
     The 'data' field always has an extra null terminator at the end (which
     is not included in the size).
@@ -109,7 +109,7 @@ def c_embed_data(
         #if __cplusplus
         extern "C" {
         #endif // __cplusplus
-        struct FileToc {
+        struct iree_file_toc_t {
           const char* name;             // the file's original name
           const char* data;             // beginning of the file
           size_t size;                  // length of the file
@@ -121,12 +121,12 @@ def c_embed_data(
         #if __cplusplus
         extern "C" {
         #endif // __cplusplus
-        const struct FileToc* this_rule_name__create();
+        const struct iree_file_toc_t* this_rule_name__create();
         #if __cplusplus
         }
         #endif // __cplusplus
 
-    The 'this_rule_name()' function will return an array of FileToc
+    The 'this_rule_name()' function will return an array of iree_file_toc_t
     structs terminated by one that has NULL 'name' and 'data' fields.
     The 'data' field always has an extra null terminator at the end (which
     is not included in the size).

--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -75,7 +75,7 @@ void GenerateTocStruct(std::ofstream& f) {
   } else {
     f << "namespace iree {\n";
   }
-  f << "struct FileToc {\n";
+  f << "struct iree_file_toc_t {\n";
   f << "  const char* name;             // the file's original name\n";
   f << "  const char* data;             // beginning of the file\n";
   if (c_output) {
@@ -100,7 +100,7 @@ bool GenerateHeader(const std::string& header_file,
     f << "#include <stddef.h>\n";
     GenerateTocStruct(f);
     GenerateExternCOpen(f);
-    f << "const struct FileToc* " << absl::GetFlag(FLAGS_identifier)
+    f << "const struct iree_file_toc_t* " << absl::GetFlag(FLAGS_identifier)
       << "_create();\n";
     f << "static inline size_t " << absl::GetFlag(FLAGS_identifier)
       << "_size() {\n";
@@ -111,7 +111,7 @@ bool GenerateHeader(const std::string& header_file,
     f << "#include <cstddef>\n";
     GenerateTocStruct(f);
     GenerateNamespaceOpen(f);
-    f << "extern const struct ::iree::FileToc* "
+    f << "extern const struct ::iree::iree_file_toc_t* "
       << absl::GetFlag(FLAGS_identifier) << "_create();\n";
     f << "static inline std::size_t " << absl::GetFlag(FLAGS_identifier)
       << "_size() { \n";
@@ -175,9 +175,9 @@ bool GenerateImpl(const std::string& impl_file,
     f << "};\n";
   }
   if (c_output) {
-    f << "static const struct FileToc toc[] = {\n";
+    f << "static const struct iree_file_toc_t toc[] = {\n";
   } else {
-    f << "static const struct ::iree::FileToc toc[] = {\n";
+    f << "static const struct ::iree::iree_file_toc_t toc[] = {\n";
   }
   assert(input_files.size() == toc_files.size());
   for (size_t i = 0, e = input_files.size(); i < e; ++i) {
@@ -190,12 +190,12 @@ bool GenerateImpl(const std::string& impl_file,
   if (c_output) {
     f << "  {NULL, NULL, 0},\n";
     f << "};\n";
-    f << "const struct FileToc* " << absl::GetFlag(FLAGS_identifier)
+    f << "const struct iree_file_toc_t* " << absl::GetFlag(FLAGS_identifier)
       << "_create() {\n";
   } else {
     f << "  {nullptr, nullptr, 0},\n";
     f << "};\n";
-    f << "const struct ::iree::FileToc* " << absl::GetFlag(FLAGS_identifier)
+    f << "const struct ::iree::iree_file_toc_t* " << absl::GetFlag(FLAGS_identifier)
       << "_create() {\n";
   }
   f << "  return &toc[0];\n";

--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -195,8 +195,8 @@ bool GenerateImpl(const std::string& impl_file,
   } else {
     f << "  {nullptr, nullptr, 0},\n";
     f << "};\n";
-    f << "const struct ::iree::iree_file_toc_t* " << absl::GetFlag(FLAGS_identifier)
-      << "_create() {\n";
+    f << "const struct ::iree::iree_file_toc_t* "
+      << absl::GetFlag(FLAGS_identifier) << "_create() {\n";
   }
   f << "  return &toc[0];\n";
   f << "}\n";

--- a/iree/vm/bytecode_dispatch_test.cc
+++ b/iree/vm/bytecode_dispatch_test.cc
@@ -32,7 +32,7 @@
 namespace {
 
 struct TestParams {
-  const iree::FileToc& module_file;
+  const iree::iree_file_toc_t& module_file;
   std::string function_name;
 };
 


### PR DESCRIPTION
In C, we've got no namespaces, and in particular in Google's internal
source, something in the toolchain links in an alternative definition
for this struct which causes *extremely* confusing errors.