### PR TITLE
Handle CPU single threaded with updated driver.

### DIFF
--- a/build_tools/mako/benchmark_modules_on_android.py
+++ b/build_tools/mako/benchmark_modules_on_android.py
@@ -58,12 +58,11 @@ metadata: {{
 
 def benchmark(module_name, flagfile_name, target) -> str:
   samples = []
-  driver = target.get_driver()
   cmd = [
-      "adb", "shell", "LD_LIBRARY_PATH=/data/local/tmp", "taskset", "80",
-      f"{DEVICE_ROOT}/iree-benchmark-module",
+      "adb", "shell", "LD_LIBRARY_PATH=/data/local/tmp", "taskset",
+      target.taskset, f"{DEVICE_ROOT}/iree-benchmark-module",
       f"--flagfile={DEVICE_ROOT}/{flagfile_name}",
-      f"--module_file={DEVICE_ROOT}/{module_name}", f"--driver={driver}",
+      f"--module_file={DEVICE_ROOT}/{module_name}", f"--driver={target.driver}",
       "--benchmark_repetitions=10"
   ] + target.runtime_flags
   print(f"Running cmd: {' '.join(cmd)}")

--- a/build_tools/mako/compile_android_modules.py
+++ b/build_tools/mako/compile_android_modules.py
@@ -37,7 +37,8 @@ def main() -> None:
         subprocess.run(args=[
             IREE_TRANSLATE_PATH, model_benchmark.model_path,
             "--iree-mlir-to-vm-bytecode-module",
-            f"--iree-hal-target-backends={target.name}", "-o", module_name
+            f"--iree-hal-target-backends={target.hal_target_backend}", "-o",
+            module_name
         ] + target.compilation_flags,
                        check=True)
 

--- a/build_tools/mako/config/mobile-bert-pixel4.config
+++ b/build_tools/mako/config/mobile-bert-pixel4.config
@@ -31,7 +31,7 @@ input_value_info: {
 # charts.
 metric_info_list: {
   value_key: "cpu"
-  label: "DYLib_AOT"
+  label: "DYLib_AOT-1-thread"
 }
 metric_info_list: {
   value_key: "vmla"

--- a/build_tools/mako/config/mobile-bert-s20.config
+++ b/build_tools/mako/config/mobile-bert-s20.config
@@ -31,7 +31,7 @@ input_value_info: {
 # charts.
 metric_info_list: {
   value_key: "cpu"
-  label: "DYLib_AOT"
+  label: "DYLib_AOT-1-thread"
 }
 metric_info_list: {
   value_key: "vmla"

--- a/build_tools/mako/config/mobilenet-v2-pixel4.config
+++ b/build_tools/mako/config/mobilenet-v2-pixel4.config
@@ -31,7 +31,7 @@ input_value_info: {
 # charts.
 metric_info_list: {
   value_key: "cpu"
-  label: "DYLib_AOT"
+  label: "DYLib_AOT-1-thread"
 }
 metric_info_list: {
   value_key: "vmla"

--- a/build_tools/mako/config/mobilenet-v2-s20.config
+++ b/build_tools/mako/config/mobilenet-v2-s20.config
@@ -31,7 +31,7 @@ input_value_info: {
 # charts.
 metric_info_list: {
   value_key: "cpu"
-  label: "DYLib_AOT"
+  label: "DYLib_AOT-1-thread"
 }
 metric_info_list: {
   value_key: "vmla"

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -28,7 +28,9 @@ class TargetInfo:
   """
 
   def __init__(self,
-               name,
+               driver,
+               hal_target_backend,
+               taskset,
                mako_tag,
                compilation_flags=None,
                runtime_flags=None):
@@ -38,14 +40,12 @@ class TargetInfo:
       compilation_flags = []
     if runtime_flags is None:
       runtime_flags = []
-    self.name = name
+    self.driver = driver
+    self.hal_target_backend = hal_target_backend
+    self.taskset = taskset,
     self.mako_tag = mako_tag
     self.compilation_flags = compilation_flags
     self.runtime_flags = runtime_flags
-
-  def get_driver(self) -> str:
-    """ Returns a string indicates the driver of the target."""
-    return self.name.split("-")[0]
 
   def add_batch_flag(self, size):
     self.compilation_flags.append(
@@ -100,17 +100,23 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
   if batch_config is None:
     batch_config = []
   targets = [
-      TargetInfo(name="vmla", mako_tag="vmla"),
-      TargetInfo(name="dylib-llvm-aot",
+      TargetInfo(driver="vmla",
+                 hal_target_backend="vmla",
+                 taskset="f0",
+                 mako_tag="vmla"),
+      TargetInfo(driver="dylib-sync",
+                 hal_target_backend="dylib-llvm-aot",
+                 taskset="80",
                  mako_tag="cpu",
                  compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
                      "-iree-flow-inline-constants-max-byte-length=2048",
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
-                 ],
-                 runtime_flags=["--dylib_worker_count=1"]),
+                 ]),
       TargetInfo(
-          name="vulkan-spirv",
+          dirver="vulkan",
+          hal_target_backend="vulkan-spirv",
+          taskset="f0",
           mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10",
@@ -132,17 +138,23 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
   if batch_config is None:
     batch_config = []
   targets = [
-      TargetInfo(name="vmla", mako_tag="vmla"),
-      TargetInfo(name="dylib-llvm-aot",
+      TargetInfo(driver="vmla",
+                 hal_target_backend="vmla",
+                 taskset="f0",
+                 mako_tag="vmla"),
+      TargetInfo(driver="dylib-sync",
+                 hal_target_backend="dylib-llvm-aot",
+                 taskset="80",
                  mako_tag="cpu",
                  compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
                      "-iree-flow-inline-constants-max-byte-length=2048",
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
-                 ],
-                 runtime_flags=["--dylib_worker_count=1"]),
+                 ]),
       TargetInfo(
-          name="vulkan-spirv",
+          dirver="vulkan",
+          hal_target_backend="vulkan-spirv",
+          taskset="f0",
           mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -102,7 +102,7 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
   targets = [
       TargetInfo(driver="vmla",
                  hal_target_backend="vmla",
-                 taskset="f0",
+                 taskset="80",
                  mako_tag="vmla"),
       TargetInfo(driver="dylib-sync",
                  hal_target_backend="dylib-llvm-aot",
@@ -116,7 +116,7 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
       TargetInfo(
           driver="vulkan",
           hal_target_backend="vulkan-spirv",
-          taskset="f0",
+          taskset="80",
           mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=qualcomm-adreno640-unknown-android10",
@@ -140,7 +140,7 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
   targets = [
       TargetInfo(driver="vmla",
                  hal_target_backend="vmla",
-                 taskset="f0",
+                 taskset="80",
                  mako_tag="vmla"),
       TargetInfo(driver="dylib-sync",
                  hal_target_backend="dylib-llvm-aot",
@@ -154,7 +154,7 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
       TargetInfo(
           driver="vulkan",
           hal_target_backend="vulkan-spirv",
-          taskset="f0",
+          taskset="80",
           mako_tag="vlk",
           compilation_flags=[
               "--iree-vulkan-target-triple=valhall-g77-unknown-android10",

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -42,7 +42,7 @@ class TargetInfo:
       runtime_flags = []
     self.driver = driver
     self.hal_target_backend = hal_target_backend
-    self.taskset = taskset,
+    self.taskset = taskset
     self.mako_tag = mako_tag
     self.compilation_flags = compilation_flags
     self.runtime_flags = runtime_flags

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -114,7 +114,7 @@ def get_pixel4_default_target_list(skipped_target=None, batch_config=None):
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
                  ]),
       TargetInfo(
-          dirver="vulkan",
+          driver="vulkan",
           hal_target_backend="vulkan-spirv",
           taskset="f0",
           mako_tag="vlk",
@@ -152,7 +152,7 @@ def get_s20_default_target_list(skipped_target=None, batch_config=None):
                      "-iree-flow-dispatch-formation-enable-operand-fusion"
                  ]),
       TargetInfo(
-          dirver="vulkan",
+          driver="vulkan",
           hal_target_backend="vulkan-spirv",
           taskset="f0",
           mako_tag="vlk",

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -18,7 +18,9 @@ class TargetInfo:
   """Information of a target backend.
 
   Attributes:
-    name: The target name used in iree-translate, e.g., vulkan-spirv.
+    driver: The driver used in iree-benchmark-module, e.g., vulkan.
+    hal_target_backend: The target name used in iree-translate, e.g., vulkan-spirv.
+    taskset: The value used for taskset when benchmarking the IREE module.
     mako_tag: The value_key in Mako config. This will be used in Mako metric
       info, which should match to the config.
     compilation_flags: Addition compilation flags. This is useful to target
@@ -34,8 +36,6 @@ class TargetInfo:
                mako_tag,
                compilation_flags=None,
                runtime_flags=None):
-    if "_" in name:
-      raise ValueError("The target name contains invalid char '_'")
     if compilation_flags is None:
       compilation_flags = []
     if runtime_flags is None:


### PR DESCRIPTION
IREE recently introduced new driver `dylib-sync` which is used for
single threaded. After discussion, this should run with `taskset 80`,
and the multithreaded version should run with `taskset f0`. The PR
also makes taskset configurable.

This is a step towards https://github.com/google/iree/issues/4752