### PR TITLE
HACK: Disable old abi generation and see what breaks.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.cpp
@@ -119,7 +119,10 @@ void buildTFImportPassPipeline(OpPassManager &pm) {
   // - It assumes that tf_saved_model.bound_inputs have been eliminated
   // - It removes tf_saved_model.semantics from the module, which we can only
   //   do at the very end.
-  pm.addPass(createLowerExportedFunctionsPass());
+  // pm.addPass(createLowerExportedFunctionsPass());
+  pm.addPass(createSavedModelToIREEABIPass());
+  // Inline the wrapper functions.
+  pm.addPass(createInlinerPass());
 
   //----------------------------------------------------------------------------
   // Ensure that all Tensorflow has been legalized away

--- a/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
@@ -508,6 +508,10 @@ LogicalResult materializeABIWrapper(ModuleOp module, FuncOp internalFunc,
     wrapperFunc->setAttr("iree.abi", builder.getStringAttr(refStr));
   }
 
+  // Tag it as an IREE exported function.
+  // TODO: Remove this once no longer needed.
+  wrapperFunc->setAttr("iree.module.export", builder.getUnitAttr());
+
   return success();
 }
 

--- a/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/TypeConverter.cpp
@@ -43,7 +43,7 @@ HALTypeConverter::HALTypeConverter(
     // HAL only should be concerned with numeric values.
     if (HALTypeConverter::shouldConvertToBuffer(type)) {
       // TODO(benvanik): composite-type conversion (buffer + dynamic dims).
-      return IREE::HAL::BufferType::get(type.getContext());
+      return IREE::HAL::BufferViewType::get(type.getContext());
     }
     return llvm::None;
   });

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -42,7 +42,7 @@ namespace iree_compiler {
 struct BindingOptions {
   // Whether to include runtime support functions and metadata required for
   // SIP-compatible bindings (like bindings/python/iree).
-  bool sip = true;
+  bool sip = false;
   // Whether to include runtime support functions required for the IREE TFLite
   // API compatibility bindings.
   bool tflite = false;
@@ -55,7 +55,7 @@ static BindingOptions getBindingOptionsFromFlags() {
   static llvm::cl::opt<bool> *bindingsSIPFlag = new llvm::cl::opt<bool>{
       "iree-sip-bindings-support",
       llvm::cl::desc("Include runtime support for SIP-compatible bindings"),
-      llvm::cl::init(true), llvm::cl::cat(bindingOptionsCategory)};
+      llvm::cl::init(false), llvm::cl::cat(bindingOptionsCategory)};
 
   static llvm::cl::opt<bool> *bindingsTFLiteFlag = new llvm::cl::opt<bool>{
       "iree-tflite-bindings-support",


### PR DESCRIPTION
Need to get to where disabling these bits causes us to generate functions on buffer_views. Currently, kind of doesn't.

Simple repro through the new path: https://gist.github.com/stellaraccident/698146598ec460fd97e7bc42c1b295ab (sigs.mlir)

```
./iree/tools/iree-translate --iree-mlir-to-vm-bytecode-module --iree-vm-bytecode-module-output-format=annotated-mlir-text ~/tmp/sigs.mlir
```