### PR TITLE
Optionally apply Conv -> Img2col transformation at the flow level

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -53,6 +53,11 @@ static llvm::cl::opt<bool> clEnable1x1ConvToMatmul(
                    "matmul ops pass."),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> clEnableConvToImg2Col(
+    "iree-flow-enable-conv-img2col-transform",
+    llvm::cl::desc("Enable converting convolution ops to img2col form."),
+    llvm::cl::init(false));
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
@@ -206,6 +211,10 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
     if (clEnable1x1ConvToMatmul) {
       passManager.addNestedPass<FuncOp>(
           mlir::iree_compiler::createConvert1x1ConvToMatmulPass());
+    }
+    if (clEnableConvToImg2Col) {
+      passManager.addNestedPass<FuncOp>(
+          mlir::iree_compiler::createConvertConv2DToImg2ColPass());
     }
 
     passManager.addNestedPass<FuncOp>(


### PR DESCRIPTION
- An alternative is to apply img2col after dispatching into workgroup tiles, but its running through multiple hops of issues related to introduced reshapes semantics.

Benchmarking resent50 (a model with lots of conv) on Pixel4:

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       8384 ms         8361 ms            1
```

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       3800 ms         3790 ms            1
```