### PR TITLE
Enable SourceMgrDiagnosticHandler in importers.

### DIFF
--- a/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
+++ b/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
@@ -41,6 +41,7 @@ class ErrorsModule(tf.Module):
     tf.print(a)
     return a
 
+
 try:
   file_name = sys.argv[1]
 except IndexError:
@@ -48,5 +49,7 @@ except IndexError:
   sys.exit(1)
 
 m = ErrorsModule()
-tf.saved_model.save(m, file_name, options=tf.saved_model.SaveOptions(save_debug_info=True))
+tf.saved_model.save(m,
+                    file_name,
+                    options=tf.saved_model.SaveOptions(save_debug_info=True))
 print(f"Saved to {file_name}")

--- a/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
+++ b/integrations/tensorflow/build_tools/testdata/generate_errors_module.py
@@ -1,0 +1,52 @@
+# Lint as: python3
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates sample models for excercising various function signatures.
+
+Usage:
+  generate_errors_module.py /tmp/errors.sm
+
+This can then be fed into iree-tf-import to process it:
+
+Fully convert to IREE input (run all import passes):
+  iree-tf-import /tmp/errors.sm
+
+Import only (useful for crafting test cases for the import pipeline):
+  iree-tf-import -o /dev/null -save-temp-tf-input=- /tmp/errors.sm
+
+Can be further lightly pre-processed via:
+  | iree-tf-opt --tf-standard-pipeline
+"""
+
+import sys
+
+import tensorflow as tf
+
+
+class ErrorsModule(tf.Module):
+
+  @tf.function(input_signature=[tf.TensorSpec([16], tf.float32)])
+  def string_op(self, a):
+    tf.print(a)
+    return a
+
+try:
+  file_name = sys.argv[1]
+except IndexError:
+  print("Expected output file name")
+  sys.exit(1)
+
+m = ErrorsModule()
+tf.saved_model.save(m, file_name, options=tf.saved_model.SaveOptions(save_debug_info=True))
+print(f"Saved to {file_name}")

--- a/integrations/tensorflow/iree_tf_compiler/TF/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "LowerExportedFunctions.cpp",
         "LowerGlobalTensors.cpp",
         "Passes.cpp",
+        "PrettifyDebugInfo.cpp",
         "PropagateResourceCasts.cpp",
         "SavedModelToIreeABI.cpp",
         "StripAsserts.cpp",

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
@@ -65,6 +65,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createLowerExportedFunctionsPass();
 // functions for any saved model exported functions.
 std::unique_ptr<OperationPass<ModuleOp>> createSavedModelToIREEABIPass();
 
+// Simplifies TensorFlow debug info for the purposes of making it easier to
+// look at.
+std::unique_ptr<OperationPass<ModuleOp>> createPrettifyDebugInfoPass();
+
 // Push resource casts forward to better propagate resource related shapes.
 std::unique_ptr<OperationPass<ModuleOp>> createPropagateResourceCastsPass();
 
@@ -92,6 +96,7 @@ inline void registerAllPasses() {
   createFlattenTuplesInCFGPass();
   createLowerGlobalTensorsPass();
   createLowerExportedFunctionsPass();
+  createPrettifyDebugInfoPass();
   createPropagateResourceCastsPass();
   createSavedModelToIREEABIPass();
   createStripAssertsPass();

--- a/integrations/tensorflow/iree_tf_compiler/TF/PrettifyDebugInfo.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/PrettifyDebugInfo.cpp
@@ -1,0 +1,47 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree_tf_compiler/TF/Passes.h"
+#include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
+
+namespace mlir {
+namespace iree_integrations {
+namespace TF {
+
+class PrettifyDebugInfoPass
+    : public PassWrapper<PrettifyDebugInfoPass, OperationPass<ModuleOp>> {
+ public:
+  void runOnOperation() override {
+    // TODO: Finish algorithm for simplifying TF debug info.
+    // auto moduleOp = getOperation();
+    // moduleOp.walk([&](Operation *op) {
+    //   Location loc = op->getLoc();
+    //   if (auto callSite = loc.dyn_cast<CallSiteLoc>()) {
+    //     callSite.getCallee().dump();
+    //   }
+    // });
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createPrettifyDebugInfoPass() {
+  return std::make_unique<PrettifyDebugInfoPass>();
+}
+
+static PassRegistration<PrettifyDebugInfoPass> modulePass(
+    "iree-tf-prettify-debug-info",
+    "Simplifies TF debug info to make it easier to look at");
+
+}  // namespace TF
+}  // namespace iree_integrations
+}  // namespace mlir

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -75,6 +75,9 @@ int main(int argc, char **argv) {
   MLIRContext context(registry);
   context.loadAllAvailableDialects();
 
+  llvm::SourceMgr sourceMgr;
+  mlir::SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
+
   // Load input buffer.
   std::string errorMessage;
   auto inputFile = openInputFile(inputPath, &errorMessage);

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -178,6 +178,9 @@ int main(int argc, char **argv) {
   context.appendDialectRegistry(registry);
   context.loadAllAvailableDialects();
 
+  llvm::SourceMgr sourceMgr;
+  mlir::SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
+
   auto status =
       ConvertHloToMlirHlo(module.get(), hloProto.mutable_hlo_module());
   if (!status.ok()) {


### PR DESCRIPTION
* This is a strict improvement over not having a diagnostic handler.
* Also introduces a stub pass for cleaning up TensorFlow locations but I have not yet found an algorithm I like so just leaving it as a stub for later.
* Progress on #5295