### PR TITLE
Drop batch mode for Mako benchmarks.

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -173,16 +173,11 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="5538704950034432",
                                targets=get_pixel4_default_target_list(
-                                   skipped_target=["cpu2", "vlk2"],
-                                   batch_config={"cpu": 8})),
+                                   skipped_target=["cpu2", "vlk2"],)),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="4699630718681088",
                                targets=get_s20_default_target_list(
-                                   skipped_target=["cpu2", "vlk2"],
-                                   batch_config={
-                                       "cpu": 8,
-                                       "vlk": 16
-                                   })),
+                                   skipped_target=["cpu2", "vlk2"],)),
         ]),
     ModelBenchmarkInfo(
         name="mobilenet-v2",
@@ -193,17 +188,10 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="6338759231537152",
                                targets=get_pixel4_default_target_list(
-                                   skipped_target=["vlk2"],
-                                   batch_config={
-                                       "cpu": 16,
-                                   })),
-            PhoneBenchmarkInfo(
-                name="S20",
-                benchmark_key="5618403088793600",
-                targets=get_s20_default_target_list(batch_config={
-                    "cpu": 16,
-                    "vlk": 64,
-                })),
+                                   skipped_target=["vlk2"])),
+            PhoneBenchmarkInfo(name="S20",
+                               benchmark_key="5618403088793600",
+                               targets=get_s20_default_target_list()),
         ]),
     ModelBenchmarkInfo(
         name="mobilebert-f16",


### PR DESCRIPTION
It was a mistake to migrate to benchmark executables. Eventually, we
would like to have both benchmarks. One is for end-to-end, and another
is for CodeGen kernels. The PR disables batch mode because:

- There is an issue in GPU benchmarks with batch mode. See https://github.com/google/iree/issues/5248
- Make CPU and GPU benchmarks consistent. It is weird that one is in
  batch mode and another is not. Plus, this can make mako tags have same
  naming rule if we'd like to enable the executables benchmarks in the
  future. (Otherwise, "cpu" tag would be with batch mode, and "gpu"
  would not.)

note: this will introduce "regression" on Mako dashboard.