### PR TITLE
Adding an iree/base/config.h and splitting out some of iree/base/api.h.

### DIFF
--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -236,7 +236,7 @@ static iree_status_t _TfLiteInterpreterRefreshIOShapes(
 static iree_host_size_t _TfLiteInterpreterCalculateSize(
     const TfLiteModel* model) {
   iree_host_size_t total_size =
-      iree_math_align(sizeof(TfLiteInterpreter), iree_max_align_t);
+      iree_host_align(sizeof(TfLiteInterpreter), iree_max_align_t);
 
   iree_vm_type_def_t buffer_view_type_def =
       iree_vm_type_def_make_ref_type(iree_hal_buffer_type_id());
@@ -267,7 +267,7 @@ static iree_status_t _TfLiteInterpreterAllocate(
   _TfLiteModelRetain(interpreter->model);
 
   uint8_t* p = (uint8_t*)interpreter +
-               iree_math_align(sizeof(*interpreter), iree_max_align_t);
+               iree_host_align(sizeof(*interpreter), iree_max_align_t);
 
   iree_vm_type_def_t buffer_view_type_def =
       iree_vm_type_def_make_ref_type(iree_hal_buffer_type_id());

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -53,6 +53,7 @@ cc_library(
     hdrs = [
         "alignment.h",
         "attributes.h",
+        "config.h",
         "target_platform.h",
     ],
 )

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -37,7 +37,7 @@ iree_cc_library(
   HDRS
     "alignment.h"
     "attributes.h"
-    "math.h"
+    "config.h"
     "target_platform.h"
   PUBLIC
 )

--- a/iree/base/alignment.h
+++ b/iree/base/alignment.h
@@ -20,11 +20,16 @@
 
 #include <stddef.h>
 
+#include "iree/base/config.h"
 #include "iree/base/target_platform.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+//===----------------------------------------------------------------------===//
+// Alignment utilities
+//===----------------------------------------------------------------------===//
 
 // https://en.cppreference.com/w/c/types/max_align_t
 #if defined(IREE_PLATFORM_WINDOWS)
@@ -44,9 +49,19 @@ extern "C" {
 #define iree_alignof(x) __alignof__(x)
 #endif  // IREE_COMPILER_*
 
-// Rounds up to the next alignment value, if it is not already aligned.
-#define iree_align(value, alignment) \
-  (((value) + (alignment)-1) / (alignment)) * (alignment)
+// Aligns |value| up to the given power-of-two |alignment| if required.
+// https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+static inline iree_host_size_t iree_host_align(iree_host_size_t value,
+                                               iree_host_size_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+// Aligns |value| up to the given power-of-two |alignment| if required.
+// https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+static inline iree_device_size_t iree_device_align(
+    iree_device_size_t value, iree_device_size_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/base/attributes.h
+++ b/iree/base/attributes.h
@@ -18,6 +18,25 @@
 #include "iree/base/target_platform.h"
 
 //===----------------------------------------------------------------------===//
+// API/ABI interop
+//===----------------------------------------------------------------------===//
+
+#ifdef __cplusplus
+#define IREE_API_EXPORT extern "C"
+#else
+#define IREE_API_EXPORT
+#endif  // __cplusplus
+
+#if defined(_WIN32)
+// TODO(benvanik): __stdcall, if exporting as a shared library/DLL.
+#define IREE_API_CALL
+#define IREE_API_PTR
+#else
+#define IREE_API_CALL
+#define IREE_API_PTR
+#endif  // _WIN32
+
+//===----------------------------------------------------------------------===//
 // IREE_HAVE_ATTRIBUTE
 //===----------------------------------------------------------------------===//
 

--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -1,0 +1,133 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//===----------------------------------------------------------------------===//
+//
+//         ██     ██  █████  ██████  ███    ██ ██ ███    ██  ██████
+//         ██     ██ ██   ██ ██   ██ ████   ██ ██ ████   ██ ██
+//         ██  █  ██ ███████ ██████  ██ ██  ██ ██ ██ ██  ██ ██   ███
+//         ██ ███ ██ ██   ██ ██   ██ ██  ██ ██ ██ ██  ██ ██ ██    ██
+//          ███ ███  ██   ██ ██   ██ ██   ████ ██ ██   ████  ██████
+//
+//===----------------------------------------------------------------------===//
+//
+// This file controls global configuration parameters used throughout IREE.
+// Each option added here should be considered something worth enabling an
+// entirely new testing configuration to test and may involve fanning out many
+// configurations depending on which flags are mutually non-exclusive.
+// Err on the side of using runtime flags for options that have minimal impact
+// to code size or toolchain requirements of our more constrained targets.
+//
+// Examples of good configuration settings:
+// - remote HAL device pointer size (cannot be inferred from local config)
+// - no-op override on synchronization primitives (unsafe, untested)
+//
+// Examples of bad configuration settings:
+// - which HAL backend to use (better as build configuration; link what you use)
+
+#ifndef IREE_BASE_CONFIG_H_
+#define IREE_BASE_CONFIG_H_
+
+#include "iree/base/target_platform.h"
+
+//===----------------------------------------------------------------------===//
+// User configuration overrides
+//===----------------------------------------------------------------------===//
+// A user include file always included prior to any IREE configuration. This is
+// used to override the default configuration in this file without needing to
+// modify the IREE code.
+//
+// Specify a custom file with `-DIREE_USER_CONFIG_H="my_config.h"`.
+
+#if defined(IREE_USER_CONFIG_H)
+#include IREE_USER_CONFIG_H
+#endif  // IREE_USER_CONFIG_H
+
+//===----------------------------------------------------------------------===//
+// Pointer size specification
+//===----------------------------------------------------------------------===//
+// IREE uses two pointer classes throughout its code:
+//
+//  `iree_host_size_t`:
+//    The native pointer size of the local "host" code. This is always C's
+//    size_t but is aliased to make it easier to differentiate from
+//    "unspecified" size_t and iree_device_size_t. Always prefer using this for
+//    sizes of pointers that never leave the host.
+//
+//  `iree_device_size_t`:
+//    The pointer size - possibly larger than needed - for remote "device" code.
+//    As the host and device may be running on entirely different machines it is
+//    often best to use a conservative value for this: a 32-bit host may be
+//    submitting work for a 64-bit device, and using a 32-bit size_t for device
+//    pointers would truncate bits and prevent round-tripping.
+//
+// The specific values for these can be overridden with configuration settings:
+
+#if !defined(IREE_HOST_SIZE_T)
+#define IREE_HOST_SIZE_T size_t
+#endif  // !IREE_HOST_SIZE_T
+
+// Size, in bytes, of a buffer on the local host.
+typedef IREE_HOST_SIZE_T iree_host_size_t;
+
+#if !defined(IREE_DEVICE_SIZE_T)
+#define IREE_DEVICE_SIZE_T uint64_t
+#endif  // !IREE_DEVICE_SIZE_T
+
+// Size, in bytes, of a buffer on remote devices.
+typedef IREE_DEVICE_SIZE_T iree_device_size_t;
+
+//===----------------------------------------------------------------------===//
+// Synchronization and threading
+//===----------------------------------------------------------------------===//
+// On ultra-tiny systems where there may only be a single core - or a single
+// core that is guaranteed to ever call an IREE API - all synchronization
+// primitives used throughout IREE can be turned into no-ops. Note that behavior
+// is undefined if there is use of any `iree_*` API call or memory that is
+// owned by IREE. Unless your target system is in a similar class to an Arduino
+// this is definitely not what you want.
+
+#if !defined(IREE_SYNCHRONIZATION_DISABLE_UNSAFE)
+#define IREE_SYNCHRONIZATION_DISABLE_UNSAFE 0
+#endif  // !IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+
+//===----------------------------------------------------------------------===//
+// IREE VM configuration
+//===----------------------------------------------------------------------===//
+// Enables optional VM features. Each of these adds a few KB to the final binary
+// when using the IREE VM. The compiler must be configured to the same set of
+// available extensions in order to ensure that the compiled modules only use
+// features available on the target they are to run on.
+//
+// See the `-iree-vm-target-extensions=` compiler option for more information.
+
+#if !defined(IREE_VM_EXT_I64_ENABLE)
+// Enables the 64-bit integer instruction extension.
+// Targeted from the compiler with `-iree-vm-target-extensions=i64`.
+#define IREE_VM_EXT_I64_ENABLE 1
+#endif  // !IREE_VM_EXT_I64_ENABLE
+
+#if !defined(IREE_VM_EXT_F32_ENABLE)
+// Enables the 32-bit floating-point instruction extension.
+// Targeted from the compiler with `-iree-vm-target-extensions=f32`.
+#define IREE_VM_EXT_F32_ENABLE 0
+#endif  // !IREE_VM_EXT_F32_ENABLE
+
+#if !defined(IREE_VM_EXT_F64_ENABLE)
+// Enables the 64-bit floating-point instruction extension.
+// Targeted from the compiler with `-iree-vm-target-extensions=f64`.
+#define IREE_VM_EXT_F64_ENABLE 0
+#endif  // !IREE_VM_EXT_F64_ENABLE
+
+#endif  // IREE_BASE_CONFIG_H_

--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -47,7 +47,7 @@ static inline void* iree_aligned_alloc(size_t alignment, size_t size) {
 static inline void* iree_aligned_alloc(size_t alignment, size_t size) {
   void* base_ptr = malloc(size + alignment + sizeof(uintptr_t));
   if (!base_ptr) return NULL;
-  uintptr_t* aligned_ptr = (uintptr_t*)iree_math_align(
+  uintptr_t* aligned_ptr = (uintptr_t*)iree_host_align(
       (uintptr_t)base_ptr + sizeof(uintptr_t), alignment);
   aligned_ptr[-1] = (uintptr_t)base_ptr;
   return aligned_ptr;
@@ -424,7 +424,7 @@ iree_status_allocate(iree_status_code_t code, const char* file, uint32_t line,
   // allocating this error from a failed allocation!).
   size_t storage_alignment = (IREE_STATUS_CODE_MASK + 1);
   size_t storage_size =
-      iree_math_align(sizeof(iree_status_storage_t), storage_alignment);
+      iree_host_align(sizeof(iree_status_storage_t), storage_alignment);
   iree_status_storage_t* storage = (iree_status_storage_t*)iree_aligned_alloc(
       storage_alignment, storage_size);
   if (IREE_UNLIKELY(!storage)) return iree_status_from_code(code);
@@ -481,7 +481,7 @@ iree_status_allocate_vf(iree_status_code_t code, const char* file,
   // This avoids additional allocations for the common case of a message coming
   // only from the original status error site.
   size_t storage_alignment = (IREE_STATUS_CODE_MASK + 1);
-  size_t storage_size = iree_math_align(
+  size_t storage_size = iree_host_align(
       sizeof(iree_status_storage_t) + message_size, storage_alignment);
   iree_status_storage_t* storage = (iree_status_storage_t*)iree_aligned_alloc(
       storage_alignment, storage_size);

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -31,6 +31,9 @@ typedef struct iree_hal_allocator_s iree_hal_allocator_t;
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
+// Whole length of the underlying buffer.
+#define IREE_WHOLE_BUFFER ((iree_device_size_t)(-1))
+
 // A bitfield specifying properties for a memory type.
 enum iree_hal_memory_type_e {
   IREE_HAL_MEMORY_TYPE_NONE = 0u,

--- a/iree/hal/buffer_heap.c
+++ b/iree/hal/buffer_heap.c
@@ -36,7 +36,7 @@ iree_status_t iree_hal_heap_buffer_create(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_heap_buffer_t* buffer = NULL;
-  iree_host_size_t header_size = iree_math_align(sizeof(*buffer), 16);
+  iree_host_size_t header_size = iree_host_align(sizeof(*buffer), 16);
   iree_host_size_t total_size = header_size + allocation_size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&buffer);

--- a/iree/hal/driver_registry.c
+++ b/iree/hal/driver_registry.c
@@ -196,7 +196,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_driver_registry_enumerate(
 
   // Allocate the required memory for both the driver infos and the string
   // storage in a single block.
-  iree_host_size_t total_driver_infos_size = iree_math_align(
+  iree_host_size_t total_driver_infos_size = iree_host_align(
       total_driver_info_count * sizeof(iree_hal_driver_info_t), 8);
   if (iree_status_is_ok(status)) {
     status = iree_allocator_malloc(allocator,

--- a/iree/hal/local/arena.c
+++ b/iree/hal/local/arena.c
@@ -148,7 +148,8 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
 
   // Pad length allocated so that each pointer bump is always ending at an
   // aligned address and the next allocation will start aligned.
-  iree_host_size_t aligned_length = iree_align(byte_length, iree_max_align_t);
+  iree_host_size_t aligned_length =
+      iree_host_align(byte_length, iree_max_align_t);
 
   // Check to see if the current block (if any) has space - if not, get another.
   if (arena->block_head == NULL ||

--- a/iree/hal/vulkan/descriptor_set_arena.cc
+++ b/iree/hal/vulkan/descriptor_set_arena.cc
@@ -63,7 +63,7 @@ PopulateDescriptorSetWriteInfos(
     // the shader is considered as out of bounds per the Vulkan spec.
     // See https://github.com/google/iree/issues/2022#issuecomment-640617234
     // for more details.
-    buffer_info.range = iree_align(
+    buffer_info.range = iree_device_align(
         std::min(binding.length,
                  iree_hal_buffer_byte_length(binding.buffer) - binding.offset),
         4);

--- a/iree/task/pool.c
+++ b/iree/task/pool.c
@@ -56,11 +56,11 @@ static iree_status_t iree_task_pool_grow(iree_task_pool_t* pool,
   // Note that we pad out our header to iree_max_align_t bytes so that all tasks
   // are aligned on the same boundaries as required by atomic operations.
   iree_host_size_t header_size =
-      iree_math_align(sizeof(iree_task_allocation_header_t), iree_max_align_t);
+      iree_host_align(sizeof(iree_task_allocation_header_t), iree_max_align_t);
   iree_host_size_t pow2_block_size = iree_math_round_up_to_pow2_u64(
       header_size + minimum_capacity * pool->task_size);
   iree_host_size_t aligned_block_size =
-      iree_math_align(pow2_block_size, IREE_TASK_POOL_BLOCK_ALIGNMENT);
+      iree_host_align(pow2_block_size, IREE_TASK_POOL_BLOCK_ALIGNMENT);
   if (aligned_block_size < IREE_TASK_POOL_MIN_BLOCK_SIZE) {
     aligned_block_size = IREE_TASK_POOL_MIN_BLOCK_SIZE;
   }

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -150,11 +150,11 @@ static iree_status_t iree_vm_bytecode_function_enter(
   // alignment in case the compiler is expecting that (it makes it easier to
   // debug too).
   iree_host_size_t header_size =
-      iree_math_align(sizeof(iree_vm_bytecode_frame_storage_t), 16);
+      iree_host_align(sizeof(iree_vm_bytecode_frame_storage_t), 16);
   iree_host_size_t i32_register_size =
-      iree_math_align(i32_register_count * sizeof(int32_t), 16);
+      iree_host_align(i32_register_count * sizeof(int32_t), 16);
   iree_host_size_t ref_register_size =
-      iree_math_align(ref_register_count * sizeof(iree_vm_ref_t), 16);
+      iree_host_align(ref_register_count * sizeof(iree_vm_ref_t), 16);
   iree_host_size_t frame_size =
       header_size + i32_register_size + ref_register_size;
 

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -19,14 +19,10 @@
 #include <string.h>
 
 #include "iree/base/alignment.h"
+#include "iree/base/config.h"
 #include "iree/base/target_platform.h"
 #include "iree/vm/bytecode_module_impl.h"
 #include "iree/vm/generated/bytecode_op_table.h"
-
-// TODO(benvanik): make a compiler setting.
-#define IREE_VM_EXT_I64_ENABLE 1
-#define IREE_VM_EXT_F32_ENABLE 0
-#define IREE_VM_EXT_F64_ENABLE 0
 
 //===----------------------------------------------------------------------===//
 // Shared data structures

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -515,32 +515,33 @@ static iree_host_size_t iree_vm_bytecode_module_layout_state(
 
   uint8_t* base_ptr = (uint8_t*)state;
   iree_host_size_t offset =
-      iree_align(sizeof(iree_vm_bytecode_module_state_t), 16);
+      iree_host_align(sizeof(iree_vm_bytecode_module_state_t), 16);
 
   if (state) {
     state->rwdata_storage =
         iree_make_byte_span(base_ptr + offset, rwdata_storage_capacity);
   }
-  offset += iree_align(rwdata_storage_capacity, 16);
+  offset += iree_host_align(rwdata_storage_capacity, 16);
 
   if (state) {
     state->global_ref_count = global_ref_count;
     state->global_ref_table = (iree_vm_ref_t*)(base_ptr + offset);
   }
-  offset += iree_align(global_ref_count * sizeof(iree_vm_ref_t), 16);
+  offset += iree_host_align(global_ref_count * sizeof(iree_vm_ref_t), 16);
 
   if (state) {
     state->rodata_ref_count = rodata_ref_count;
     state->rodata_ref_table = (iree_vm_ro_byte_buffer_t*)(base_ptr + offset);
   }
-  offset += iree_align(rodata_ref_count * sizeof(iree_vm_ro_byte_buffer_t), 16);
+  offset +=
+      iree_host_align(rodata_ref_count * sizeof(iree_vm_ro_byte_buffer_t), 16);
 
   if (state) {
     state->import_count = import_function_count;
     state->import_table = (iree_vm_bytecode_import_t*)(base_ptr + offset);
   }
   offset +=
-      iree_align(import_function_count * sizeof(*state->import_table), 16);
+      iree_host_align(import_function_count * sizeof(*state->import_table), 16);
 
   return offset;
 }

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -110,8 +110,8 @@ IREE_API_EXPORT iree_host_size_t iree_vm_list_storage_size(
       element_size = sizeof(iree_vm_variant_t);
     }
   }
-  return iree_align(sizeof(iree_vm_list_t), 8) +
-         iree_align(capacity * element_size, 8);
+  return iree_host_align(sizeof(iree_vm_list_t), 8) +
+         iree_host_align(capacity * element_size, 8);
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_list_initialize(
@@ -132,9 +132,9 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_list_initialize(
     }
   }
 
-  iree_host_size_t storage_offset = iree_align(sizeof(iree_vm_list_t), 8);
+  iree_host_size_t storage_offset = iree_host_align(sizeof(iree_vm_list_t), 8);
   iree_host_size_t required_storage_size =
-      storage_offset + iree_align(capacity * element_size, 8);
+      storage_offset + iree_host_align(capacity * element_size, 8);
   if (storage.data_length < required_storage_size) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
@@ -229,7 +229,7 @@ iree_vm_list_reserve(iree_vm_list_t* list, iree_host_size_t minimum_capacity) {
     return iree_ok_status();
   }
   iree_host_size_t old_capacity = list->capacity;
-  iree_host_size_t new_capacity = iree_align(minimum_capacity, 64);
+  iree_host_size_t new_capacity = iree_host_align(minimum_capacity, 64);
   IREE_RETURN_IF_ERROR(iree_allocator_realloc(
       list->allocator, new_capacity * list->element_size, &list->storage));
   memset((void*)((uintptr_t)list->storage + old_capacity * list->element_size),
@@ -254,7 +254,7 @@ iree_vm_list_resize(iree_vm_list_t* list, iree_host_size_t new_size) {
   } else if (new_size > list->capacity) {
     // Extending beyond capacity.
     IREE_RETURN_IF_ERROR(iree_vm_list_reserve(
-        list, iree_max(list->capacity * 2, iree_align(new_size, 64))));
+        list, iree_max(list->capacity * 2, iree_host_align(new_size, 64))));
   }
   list->count = new_size;
   return iree_ok_status();

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -216,7 +216,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_initialize(
   stack->allocator = allocator;
 
   iree_host_size_t storage_offset =
-      iree_math_align(sizeof(iree_vm_stack_t), 16);
+      iree_host_align(sizeof(iree_vm_stack_t), 16);
   stack->frame_storage_capacity = storage.data_length - storage_offset;
   stack->frame_storage_size = 0;
   stack->frame_storage = storage.data + storage_offset;


### PR DESCRIPTION
This follows the common technique of config.h with defaults + an
optional user config file override (this is what VMA, imgui, stb, etc use).
We may want to move some of these around or create subsystem-specific
config files but for now this should at least let us start paring things
down for tiny IREE.