### PR TITLE
Fixing unsafe vm.list.alloc CSE and bad returns in bytecode dispatch.

### DIFF
--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -855,6 +855,7 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
 def VM_ListAllocOp :
     VM_PureOp<"list.alloc", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemAlloc]>,
     ]> {
   let summary = [{allocates a new empty list}];
   let description = [{
@@ -905,6 +906,7 @@ def VM_ListReserveOp :
 def VM_ListSizeOp :
     VM_Op<"list.size", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
     ]> {
   let summary = [{the size of the list in elements}];
   let description = [{
@@ -930,6 +932,7 @@ def VM_ListSizeOp :
 def VM_ListResizeOp :
     VM_Op<"list.resize", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemWrite]>,
     ]> {
   let summary = [{resizes the list to a new count in elements}];
   let description = [{
@@ -956,6 +959,7 @@ class VM_ListGetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
                             list<OpTrait> traits = []> :
     VM_PureOp<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
     ])> {
   let summary = [{primitive type element accessor}];
   let description = [{
@@ -984,6 +988,7 @@ class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
                             list<OpTrait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemWrite]>,
     ])> {
   let summary = [{primitive type element mutator}];
   let description = [{
@@ -1021,6 +1026,7 @@ def VM_ListSetI64Op :
 def VM_ListGetRefOp :
     VM_PureOp<"list.get.ref", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
     ]> {
   let summary = [{ref type element accessor}];
   let description = [{
@@ -1052,6 +1058,7 @@ def VM_ListGetRefOp :
 def VM_ListSetRefOp :
     VM_Op<"list.set.ref", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemWrite]>,
     ]> {
   let summary = [{ref type element mutator}];
   let description = [{

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -199,8 +199,7 @@ class V0BytecodeEncoder : public BytecodeEncoder {
   }
 
   LogicalResult encodeResult(Value value) override {
-    uint16_t reg =
-        registerAllocation_->mapUseToRegister(value, currentOp_, 0).encode();
+    uint16_t reg = registerAllocation_->mapToRegister(value).encode();
     return writeUint16(reg);
   }
 

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -74,19 +74,14 @@ static iree_status_t iree_vm_native_module_verify_descriptor(
 
 static void IREE_API_PTR iree_vm_native_module_destroy(void* self) {
   iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  iree_allocator_t allocator = module->allocator;
 
   // Destroy the optional user-provided self.
-  if (module->self == module) {
-    iree_allocator_t allocator = module->allocator;
-    if (module->user_interface.destroy) {
-      module->user_interface.destroy(module->self);
-    }
-    iree_allocator_free(allocator, module);
-  } else {
-    if (module->user_interface.destroy) {
-      module->user_interface.destroy(module->self);
-    }
+  if (module->user_interface.destroy) {
+    module->user_interface.destroy(module->self);
   }
+
+  iree_allocator_free(allocator, module);
 }
 
 static iree_string_view_t IREE_API_PTR iree_vm_native_module_name(void* self) {

--- a/iree/vm/ref.h
+++ b/iree/vm/ref.h
@@ -95,9 +95,6 @@ static_assert(
 
 typedef void(IREE_API_PTR* iree_vm_ref_destroy_t)(void* ptr);
 
-#define IREE_VM_REF_DESTROY_FREE free
-#define IREE_VM_REF_DESTROY_CC_DELETE +[](void* ptr) { delete ptr; }
-
 // Describes a type for the VM.
 typedef struct {
   // Function called when references of this type reach 0 and should be

--- a/iree/vm/test/list_ops.mlir
+++ b/iree/vm/test/list_ops.mlir
@@ -81,6 +81,32 @@ vm.module @list_ops {
   }
 
   //===--------------------------------------------------------------------===//
+  // Multiple lists within the same block
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_multiple_lists
+  vm.func @test_multiple_lists() {
+    %c0 = vm.const.i32 0 : i32
+    %c1 = vm.const.i32 1 : i32
+    %c27 = vm.const.i32 27 : i32
+    %c42 = vm.const.i32 42 : i32
+
+    // These allocs shouldn't be CSE'd.
+    %list0 = vm.list.alloc %c1 : (i32) -> !vm.list<i8>
+    %list1 = vm.list.alloc %c1 : (i32) -> !vm.list<i8>
+    vm.list.resize %list0, %c1 : (!vm.list<i8>, i32)
+    vm.list.resize %list1, %c1 : (!vm.list<i8>, i32)
+    vm.list.set.i32 %list0, %c0, %c27 : (!vm.list<i8>, i32, i32)
+    vm.list.set.i32 %list1, %c0, %c42 : (!vm.list<i8>, i32, i32)
+    %res0 = vm.list.get.i32 %list0, %c0 : (!vm.list<i8>, i32) -> i32
+    %res1 = vm.list.get.i32 %list1, %c0 : (!vm.list<i8>, i32) -> i32
+    vm.check.eq %res0, %c27, "list0.get(0)=27" : i32
+    vm.check.eq %res1, %c42, "list1.get(0)=42" : i32
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
   // Failure tests
   //===--------------------------------------------------------------------===//
 

--- a/iree/vm/test/list_variant_ops.mlir
+++ b/iree/vm/test/list_variant_ops.mlir
@@ -40,7 +40,7 @@ vm.module @list_variant_ops {
     %inner0_e2 = vm.list.get.i32 %inner0_ret, %c2 : (!vm.list<i32>, i32) -> i32
     vm.check.eq %inner0_e2, %c102 : i32
 
-    %inner1_ret = vm.list.get.ref %outer, %c0 : (!vm.list<!vm.list<i32>>, i32) -> !vm.list<i32>
+    %inner1_ret = vm.list.get.ref %outer, %c1 : (!vm.list<!vm.list<i32>>, i32) -> !vm.list<i32>
     vm.check.eq %inner1_ret, %inner1 : !vm.list<i32>
     %inner1_e2 = vm.list.get.i32 %inner1_ret, %c2 : (!vm.list<i32>, i32) -> i32
     vm.check.eq %inner1_e2, %c100 : i32
@@ -89,8 +89,8 @@ vm.module @list_variant_ops {
     vm.return
   }
 
-  vm.export @test_variant_slot_change
-  vm.func @test_variant_slot_change() {
+  vm.export @fail_variant_slot_change
+  vm.func @fail_variant_slot_change() {
     %capacity = vm.const.i32 42 : i32
     %list = vm.list.alloc %capacity : (i32) -> !vm.list<?>
     vm.list.resize %list, %capacity : (!vm.list<?>, i32)
@@ -109,9 +109,10 @@ vm.module @list_variant_ops {
     %e10_buf = vm.list.get.ref %list, %c10 : (!vm.list<?>, i32) -> !vm.ref<!iree.byte_buffer>
     vm.check.eq %e10_buf, %v10_buf : !vm.ref<!iree.byte_buffer>
 
-    // Accessing it as an i32 now that it stores the ref should return a
-    // default (until we support type queries).
+    // Accessing it as an i32 now that it stores the ref should fail at runtime.
+    // TODO(benvanik): support type queries and/or make this silently return 0.
     %e10_any = vm.list.get.i32 %list, %c10 : (!vm.list<?>, i32) -> i32
+    // -- FAILURE HERE --
     %zero = vm.const.i32.zero : i32
     vm.check.eq %e10_any, %zero : i32
 


### PR DESCRIPTION
Fixes #5657.
Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>