### PR TITLE
Prepare handling for relaxed vectorization for SPIR-V and CUDA backends

### DIFF
--- a/iree/compiler/Conversion/LinalgToNVVM/VectorizationPass.cpp
+++ b/iree/compiler/Conversion/LinalgToNVVM/VectorizationPass.cpp
@@ -98,6 +98,18 @@ struct VectorizationPass
     });
 
     {
+      // Lower transfer op to canonical form.
+      OwningRewritePatternList lowerTransferOpPatterns(funcOp.getContext());
+      vector::populateVectorToVectorCanonicalizationPatterns(
+          lowerTransferOpPatterns);
+      vector::populateVectorToVectorTransformationPatterns(
+          lowerTransferOpPatterns);
+      vector::populateVectorTransferLoweringPatterns(lowerTransferOpPatterns);
+      (void)applyPatternsAndFoldGreedily(funcOp,
+                                         std::move(lowerTransferOpPatterns));
+    }
+
+    {
       // Step 2. Unroll the vetors to native size and canonicalize.
       OwningRewritePatternList vectorUnrollPatterns(context);
       populateVectorUnrollPatterns(vectorUnrollPatterns);


### PR DESCRIPTION
Add vector transfer lowering to handle the IR generated by the vectorization after:
https://reviews.llvm.org/D101165