### PR TITLE
Adding a `!vm.buffer` to start supporting low-level but safe buffer access in the VM.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "//iree/compiler/Dialect/HAL/Utils",
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/VM/Conversion",
+        "//iree/compiler/Dialect/VM/Conversion/IREEToVM",
         "//iree/compiler/Dialect/VM/Conversion/StandardToVM",
         "//iree/compiler/Dialect/VM/IR",
         "@llvm-project//llvm:Support",

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::hal_imports
     iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::VM::Conversion
+    iree::compiler::Dialect::VM::Conversion::IREEToVM
     iree::compiler::Dialect::VM::Conversion::StandardToVM
     iree::compiler::Dialect::VM::IR
   PUBLIC

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
@@ -20,6 +20,7 @@
 #include "iree/compiler/Dialect/IREE/IR/IREEDialect.h"
 #include "iree/compiler/Dialect/IREE/IR/IREETypes.h"
 #include "iree/compiler/Dialect/VM/Conversion/ConversionTarget.h"
+#include "iree/compiler/Dialect/VM/Conversion/IREEToVM/ConvertIREEToVM.h"
 #include "iree/compiler/Dialect/VM/Conversion/ImportUtils.h"
 #include "iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.h"
 #include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
@@ -129,6 +130,7 @@ class ConvertHALToVMPass
 
     OwningRewritePatternList conversionPatterns(&getContext());
     populateStandardToVMPatterns(context, typeConverter, conversionPatterns);
+    populateIREEToVMPatterns(context, typeConverter, conversionPatterns);
 
     SymbolTable importSymbols(innerModuleOp);
     populateHALToVMPatterns(context, importSymbols, conversionPatterns,

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
@@ -26,7 +26,7 @@ func @allocatorAllocate(%arg0 : !hal.allocator) -> !hal.buffer {
 func @allocatorMapByteBuffer(%arg0 : !hal.allocator, %arg1 : !iree.byte_buffer) -> !hal.buffer {
   %offset = constant 128 : index
   %length = constant 256 : index
-  // CHECK: = vm.call @hal.allocator.wrap.byte_buffer(%arg0, %c6, %c2, %arg1, %c128, %c256) : (!vm.ref<!hal.allocator>, i32, i32, !vm.ref<!iree.byte_buffer>, i32, i32) -> !vm.ref<!hal.buffer>
+  // CHECK: = vm.call @hal.allocator.wrap.byte_buffer(%arg0, %c6, %c2, %arg1, %c128, %c256) : (!vm.ref<!hal.allocator>, i32, i32, !vm.buffer, i32, i32) -> !vm.ref<!hal.buffer>
   %buffer = hal.allocator.map<%arg0 : !hal.allocator> source(%arg1 : !iree.byte_buffer)[%offset, %length] type("HostVisible|HostCoherent") usage(Transfer) : !hal.buffer
   return %buffer : !hal.buffer
 }

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
@@ -19,7 +19,7 @@ func private @pool_storage0_buffer_initializer() -> !hal.buffer {
   %c16 = constant 16 : index
   %dev = hal.ex.shared_device : !hal.device
   %allocator = hal.device.allocator<%dev : !hal.device> : !hal.allocator
-  // CHECK: [[STORAGE_REF:%.+]] = vm.const.ref.rodata @pool_storage0 : !vm.ref<!iree.byte_buffer>
+  // CHECK: [[STORAGE_REF:%.+]] = vm.const.ref.rodata @pool_storage0 : !vm.buffer
   %storage = hal.constant_storage.lookup @pool::@_storage0 : !iree.byte_buffer
   // CHECK: = vm.call @hal.allocator.wrap.byte_buffer({{.+}}, %c22, %c15, [[STORAGE_REF]], %zero, %c16)
   %mapped = hal.allocator.map<%allocator : !hal.allocator>

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/device_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/device_ops.mlir
@@ -14,7 +14,7 @@ func @device_allocator(%device: !hal.device) -> !hal.allocator {
 // CHECK-SAME: (%[[DEVICE:.+]]: !vm.ref<!hal.device>)
 func @device_query_i32(%device: !hal.device) -> (i1, i32) {
   // CHECK: %[[KEY:.+]] = vm.rodata.inline "_utf8_foo_
-  // CHECK: %[[RET:.+]]:2 = vm.call @hal.device.query.i32(%[[DEVICE]], %[[KEY]]) : (!vm.ref<!hal.device>, !vm.ref<!iree.byte_buffer>) -> (i32, i32)
+  // CHECK: %[[RET:.+]]:2 = vm.call @hal.device.query.i32(%[[DEVICE]], %[[KEY]]) : (!vm.ref<!hal.device>, !vm.buffer) -> (i32, i32)
   %ok, %value = hal.device.query<%device : !hal.device> key("foo") : i1, i32
   // CHECK: return %[[RET]]#0, %[[RET]]#1
   return %ok, %value : i1, i32

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
@@ -27,18 +27,18 @@ func @executableCreate(
     %layout1 : !hal.executable_layout
   ) -> (!hal.executable, !hal.executable) {
 
-  // CHECK-DAG: %[[BINARY1:.+]] = vm.const.ref.rodata @_exe_binary1_binary_format1 : !vm.ref<!iree.byte_buffer>
+  // CHECK-DAG: %[[BINARY1:.+]] = vm.const.ref.rodata @_exe_binary1_binary_format1 : !vm.buffer
   // CHECK-DAG: %[[FORMAT1:.+]] = vm.rodata.inline "_utf8_format1_
   // CHECK: %[[EXE1:.+]] = vm.call.variadic @hal.executable.create(
   // CHECK-SAME: %[[DEV]], %[[FORMAT1]], %[[BINARY1]], [%[[LAYOUT0]], %[[LAYOUT1]]]
-  // CHECK-SAME: ) : (!vm.ref<!hal.device>, !vm.ref<!iree.byte_buffer>, !vm.ref<!iree.byte_buffer>, !vm.ref<!hal.executable_layout> ...) -> !vm.ref<!hal.executable>
+  // CHECK-SAME: ) : (!vm.ref<!hal.device>, !vm.buffer, !vm.buffer, !vm.ref<!hal.executable_layout> ...) -> !vm.ref<!hal.executable>
   %0 = hal.executable.create device(%device : !hal.device) target(@exe::@binary1) layouts([%layout0, %layout1]) : !hal.executable
 
-  // CHECK-DAG: %[[BINARY2:.+]] = vm.const.ref.rodata @_exe_binary2_binary_format2 : !vm.ref<!iree.byte_buffer>
+  // CHECK-DAG: %[[BINARY2:.+]] = vm.const.ref.rodata @_exe_binary2_binary_format2 : !vm.buffer
   // CHECK-DAG: %[[FORMAT2:.+]] = vm.rodata.inline "_utf8_format2_
   // CHECK: %[[EXE2:.+]] = vm.call.variadic @hal.executable.create(
   // CHECK-SAME: %[[DEV]], %[[FORMAT2]], %[[BINARY2]], [%[[LAYOUT1]], %[[LAYOUT0]]]
-  // CHECK-SAME: ) : (!vm.ref<!hal.device>, !vm.ref<!iree.byte_buffer>, !vm.ref<!iree.byte_buffer>, !vm.ref<!hal.executable_layout> ...) -> !vm.ref<!hal.executable>
+  // CHECK-SAME: ) : (!vm.ref<!hal.device>, !vm.buffer, !vm.buffer, !vm.ref<!hal.executable_layout> ...) -> !vm.ref<!hal.executable>
   %1 = hal.executable.create device(%device : !hal.device) target(@exe::@binary2) layouts([%layout1, %layout0]) : !hal.executable
 
   // CHECK: vm.return %[[EXE1]], %[[EXE2]]
@@ -76,10 +76,10 @@ func @multipleExecutables(
     %layout0 : !hal.executable_layout,
     %layout1 : !hal.executable_layout
   ) -> (!hal.executable, !hal.executable) {
-  // CHECK-DAG: %[[BINARY1:.+]] = vm.const.ref.rodata @_exe1_binary1_binary_format : !vm.ref<!iree.byte_buffer>
+  // CHECK-DAG: %[[BINARY1:.+]] = vm.const.ref.rodata @_exe1_binary1_binary_format : !vm.buffer
   // CHECK-DAG: %[[FORMAT1:.+]] = vm.rodata.inline "_utf8_format_
   %0 = hal.executable.create device(%device : !hal.device) target(@exe1::@binary1) layouts([%layout0, %layout1]) : !hal.executable
-  // CHECK-DAG: %[[BINARY2:.+]] = vm.const.ref.rodata @_exe2_binary2_binary_format : !vm.ref<!iree.byte_buffer>
+  // CHECK-DAG: %[[BINARY2:.+]] = vm.const.ref.rodata @_exe2_binary2_binary_format : !vm.buffer
   // CHECK-DAG: %[[FORMAT2:.+]] = vm.rodata.inline "_utf8_format_
   %1 = hal.executable.create device(%device : !hal.device) target(@exe2::@binary2) layouts([%layout1, %layout0]) : !hal.executable
   return %0, %1 : !hal.executable, !hal.executable

--- a/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/test/smoketest.mlir
@@ -107,7 +107,7 @@ flow.executable @reduction_ex_dispatch_0 {
 //  CHECK-NEXT:     module {
 //  CHECK-NEXT:       vm.module @module {
 //  CHECK-DAG:         vm.import @vmla.interface.binding(%interface : !vm.ref<!vmla.interface>, %set : i32, %binding : i32) -> !vm.ref<!vmla.buffer>
-//  CHECK-DAG:         vm.import @vmla.buffer.const(%value : !vm.ref<!iree.byte_buffer>) -> !vm.ref<!vmla.buffer>
+//  CHECK-DAG:         vm.import @vmla.buffer.const(%value : !vm.buffer) -> !vm.ref<!vmla.buffer>
 //  CHECK-DAG:         vm.import @vmla.buffer.alloc(%byte_length : i32) -> !vm.ref<!vmla.buffer>
 //  CHECK-DAG:         vm.import @vmla.buffer.view(%src : !vm.ref<!vmla.buffer>, %byte_offset : i32, %byte_length : i32) -> !vm.ref<!vmla.buffer>
 //  CHECK-DAG:         vm.import @vmla.buffer.copy(%src : !vm.ref<!vmla.buffer>, %src_byte_offset : i32, %dst : !vm.ref<!vmla.buffer>, %dst_byte_offset : i32, %byte_length : i32)
@@ -121,8 +121,8 @@ flow.executable @reduction_ex_dispatch_0 {
 //   CHECK-DAG:           %c4 = vm.const.i32 4 : i32
 //   CHECK-DAG:           %c8 = vm.const.i32 8 : i32
 //   CHECK-DAG:           %c1 = vm.const.i32 1 : i32
-//  CHECK-NEXT:           %reduction_ex_dispatch_0_const = vm.const.ref.rodata @reduction_ex_dispatch_0_const : !vm.ref<!iree.byte_buffer>
-//  CHECK-NEXT:           %ref = vm.call @vmla.buffer.const(%reduction_ex_dispatch_0_const) : (!vm.ref<!iree.byte_buffer>) -> !vm.ref<!vmla.buffer>
+//  CHECK-NEXT:           %reduction_ex_dispatch_0_const = vm.const.ref.rodata @reduction_ex_dispatch_0_const : !vm.buffer
+//  CHECK-NEXT:           %ref = vm.call @vmla.buffer.const(%reduction_ex_dispatch_0_const) : (!vm.buffer) -> !vm.ref<!vmla.buffer>
 //  CHECK-NEXT:           %ref_0 = vm.call @vmla.buffer.alloc(%c4) : (i32) -> !vm.ref<!vmla.buffer>
 //  CHECK-NEXT:           vm.call @vmla.buffer.fill(%ref, %ref_0) : (!vm.ref<!vmla.buffer>, !vm.ref<!vmla.buffer>) -> ()
 //  CHECK-NEXT:           %ref_1 = vm.call @vmla.interface.binding(%arg0, %zero, %zero) : (!vm.ref<!vmla.interface>, i32, i32) -> !vm.ref<!vmla.buffer>

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -34,7 +34,7 @@ vm.import @allocator.wrap.byte_buffer(
   %allocator : !vm.ref<!hal.allocator>,
   %memory_types : i32,
   %buffer_usage : i32,
-  %source : !vm.ref<!iree.byte_buffer>,
+  %source : !vm.buffer,
   %offset : i32,
   %length : i32
 ) -> !vm.ref<!hal.buffer>
@@ -115,7 +115,7 @@ attributes {nosideeffects}
 
 // Prints out the content of buffer views.
 vm.import @buffer_view.trace(
-  %key : !vm.ref<!iree.byte_buffer>,
+  %key : !vm.buffer,
   %operands : !vm.ref<!hal.buffer_view> ...
 )
 
@@ -255,14 +255,14 @@ attributes {nosideeffects}
 // Returns a tuple of (ok, value) for the given configuration key.
 vm.import @device.query.i32(
   %device : !vm.ref<!hal.device>,
-  %key : !vm.ref<!iree.byte_buffer>
+  %key : !vm.buffer
 ) -> (i32, i32)
 attributes {nosideeffects}
 
 // Returns true if the device ID matches the pattern.
 vm.import @device.match.id(
   %device : !vm.ref<!hal.device>,
-  %pattern : !vm.ref<!iree.byte_buffer>
+  %pattern : !vm.buffer
 ) -> i32
 attributes {nosideeffects}
 
@@ -273,8 +273,8 @@ attributes {nosideeffects}
 // Creates an executable for use with the specified device.
 vm.import @executable.create(
   %device : !vm.ref<!hal.device>,
-  %executable_format : !vm.ref<!iree.byte_buffer>,
-  %executable_data : !vm.ref<!iree.byte_buffer>,
+  %executable_format : !vm.buffer,
+  %executable_data : !vm.buffer,
   %executable_layouts : !vm.ref<!hal.executable_layout>...
 ) -> !vm.ref<!hal.executable>
 attributes {nosideeffects}

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/byte_buffer_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/byte_buffer_ops.mlir
@@ -5,7 +5,7 @@ module @byte_buffer_constant {
 module {
   // CHECK: vm.func @my_fn
   func @my_fn() {
-    // CHECK-NEXT: = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<[1, 2, 3]> : tensor<3xi32>
+    // CHECK-NEXT: = vm.rodata.inline : !vm.buffer = dense<[1, 2, 3]> : tensor<3xi32>
     %0 = iree.byte_buffer.constant : !iree.byte_buffer = dense<[1, 2, 3]> : tensor<3xi32>
     return
   }

--- a/iree/compiler/Dialect/VM/Conversion/ImportUtils.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/ImportUtils.cpp
@@ -116,7 +116,7 @@ static Value createStringTableValue(Location loc, StringAttr attrValue,
   // Embed the UTF-8 bytes as a vm.rodata blob.
   return rewriter.create<IREE::VM::RodataInlineOp>(
       loc,
-      IREE::VM::RefType::get(IREE::ByteBufferType::get(rewriter.getContext())),
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(rewriter.getContext())),
       rewriter.getStringAttr(safeIdentifier), utf8Bytes,
       /*alignment=*/rewriter.getI64IntegerAttr(1));
 }

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -83,7 +83,7 @@ class FuncOpConversion : public OpConversionPattern<FuncOp> {
     for (unsigned i = 0, e = srcFuncType.getNumInputs(); i < e; ++i) {
       if (failed(getTypeConverter()->convertSignatureArg(
               i, srcFuncType.getInput(i), signatureConversion))) {
-        return failure();
+        return rewriter.notifyMatchFailure(srcOp, "argument failed to convert");
       }
     }
 
@@ -91,7 +91,7 @@ class FuncOpConversion : public OpConversionPattern<FuncOp> {
     SmallVector<Type, 1> convertedResultTypes;
     if (failed(getTypeConverter()->convertTypes(srcFuncType.getResults(),
                                                 convertedResultTypes))) {
-      return failure();
+      return rewriter.notifyMatchFailure(srcOp, "results failed to convert");
     }
 
     // Create new function with converted argument and result types.

--- a/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/TypeConverter.cpp
@@ -118,7 +118,7 @@ TypeConverter::TypeConverter(TargetOptions targetOptions)
   // Vectors are used for arbitrary byte storage.
   addConversion([](VectorType vectorType) -> Optional<Type> {
     return IREE::VM::RefType::get(
-        IREE::ByteBufferType::get(vectorType.getContext()));
+        IREE::VM::BufferType::get(vectorType.getContext()));
   });
 
   // Convert ranked shape types (expanding all dims).

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -295,6 +295,20 @@ class VM_RefOf<Type type> :
 }
 
 //===----------------------------------------------------------------------===//
+// Buffer types
+//===----------------------------------------------------------------------===//
+
+def VM_BufferType : DialectType<
+    IREE_Dialect,
+    CPred<"$_self.isa<IREE::VM::BufferType>()">,
+    "buffer"> {
+  let description = [{
+    A byte buffer.
+  }];
+  let builderCall = "$_builder.getType<IREE::VM::BufferType>()";
+}
+
+//===----------------------------------------------------------------------===//
 // List types
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -787,7 +787,8 @@ void ConstRefRodataOp::build(OpBuilder &builder, OperationState &result,
                              StringRef rodataName,
                              ArrayRef<NamedAttribute> attrs) {
   result.addAttribute("rodata", builder.getSymbolRefAttr(rodataName));
-  auto type = IREE::VM::RefType::get(ByteBufferType::get(builder.getContext()));
+  auto type =
+      IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext()));
   result.addTypes({type});
   result.addAttributes(attrs);
 }

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -912,11 +912,11 @@ def VM_ConstRefRodataOp : VM_PureOp<"const.ref.rodata", [
   }];
 
   let arguments = (ins
-    ByteBufferRefAttr:$rodata
+    FlatSymbolRefAttr:$rodata
   );
 
   let results = (outs
-    VM_RefOf<ByteBufferType>:$value
+    VM_RefOf<VM_BufferType>:$value
   );
 
   let assemblyFormat = "$rodata attr-dict `:` type($value)";
@@ -955,7 +955,7 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
   );
 
   let results = (outs
-    VM_RefOf<ByteBufferType>:$result
+    VM_RefOf<VM_BufferType>:$result
   );
 
   let assemblyFormat = "($name^)? attr-dict `:` type($result) `=` $value";

--- a/iree/compiler/Dialect/VM/IR/VMTypes.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.cpp
@@ -196,7 +196,8 @@ void VMDialect::registerAttributes() {
   addAttributes<IREE::VM::OrdinalCountsAttr>();
 }
 void VMDialect::registerTypes() {
-  addTypes<IREE::VM::ListType, IREE::VM::OpaqueType, IREE::VM::RefType>();
+  addTypes<IREE::VM::BufferType, IREE::VM::ListType, IREE::VM::OpaqueType,
+           IREE::VM::RefType>();
 }
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/IR/VMTypes.h
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.h
@@ -38,6 +38,12 @@ struct ListTypeStorage;
 struct RefTypeStorage;
 }  // namespace detail
 
+/// A byte buffer.
+class BufferType : public Type::TypeBase<BufferType, Type, TypeStorage> {
+ public:
+  using Base::Base;
+};
+
 /// A list containing an optional element type.
 class ListType
     : public Type::TypeBase<ListType, Type, detail::ListTypeStorage> {

--- a/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
@@ -43,13 +43,13 @@ vm.module @my_module {
 
 // CHECK-LABEL: @switch_ref
 vm.module @my_module {
-  vm.func @switch_ref(%arg0 : i32) -> !vm.ref<!iree.byte_buffer> {
-    %0 = "make_buffer"() : () -> !vm.ref<!iree.byte_buffer>
-    %1 = "make_buffer"() : () -> !vm.ref<!iree.byte_buffer>
-    %2 = "make_buffer"() : () -> !vm.ref<!iree.byte_buffer>
-    %3 = "make_buffer"() : () -> !vm.ref<!iree.byte_buffer>
-    // CHECK: vm.switch.ref %arg0[%0, %1, %2] else %3 : !vm.ref<!iree.byte_buffer>
-    %4 = vm.switch.ref %arg0[%0, %1, %2] else %3 : !vm.ref<!iree.byte_buffer>
-    vm.return %4 : !vm.ref<!iree.byte_buffer>
+  vm.func @switch_ref(%arg0 : i32) -> !vm.buffer {
+    %0 = "make_buffer"() : () -> !vm.buffer
+    %1 = "make_buffer"() : () -> !vm.buffer
+    %2 = "make_buffer"() : () -> !vm.buffer
+    %3 = "make_buffer"() : () -> !vm.buffer
+    // CHECK: vm.switch.ref %arg0[%0, %1, %2] else %3 : !vm.buffer
+    %4 = vm.switch.ref %arg0[%0, %1, %2] else %3 : !vm.buffer
+    vm.return %4 : !vm.buffer
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
@@ -44,11 +44,11 @@ vm.module @const_rodata_folds {
   // CHECK-NEXT: vm.rodata @r2
   vm.rodata @r2 dense<[9, 9, 9]> : vector<3xi32>
   // CHECK-NEXT: @cse_rodata_loads
-  vm.func @cse_rodata_loads() -> (!vm.ref<!iree.byte_buffer>, !vm.ref<!iree.byte_buffer>) {
-    // CHECK-NEXT: %r2 = vm.const.ref.rodata @r2 : !vm.ref<!iree.byte_buffer>
-    // CHECK-NEXT: vm.return %r2, %r2 : !vm.ref<!iree.byte_buffer>, !vm.ref<!iree.byte_buffer>
-    %0 = vm.const.ref.rodata @r2 : !vm.ref<!iree.byte_buffer>
-    %1 = vm.const.ref.rodata @r2 : !vm.ref<!iree.byte_buffer>
-    vm.return %0, %1 : !vm.ref<!iree.byte_buffer>, !vm.ref<!iree.byte_buffer>
+  vm.func @cse_rodata_loads() -> (!vm.buffer, !vm.buffer) {
+    // CHECK-NEXT: %r2 = vm.const.ref.rodata @r2 : !vm.buffer
+    // CHECK-NEXT: vm.return %r2, %r2 : !vm.buffer, !vm.buffer
+    %0 = vm.const.ref.rodata @r2 : !vm.buffer
+    %1 = vm.const.ref.rodata @r2 : !vm.buffer
+    vm.return %0, %1 : !vm.buffer, !vm.buffer
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -38,10 +38,10 @@ vm.module @my_module {
 vm.module @my_module {
   vm.rodata @buf0 dense<[0, 1, 2]> : tensor<3xi8>
   // CHECK-LABEL: @const_ref_rodata
-  vm.func @const_ref_rodata() -> !vm.ref<!iree.byte_buffer> {
-    // CHECK: %buf0 = vm.const.ref.rodata @buf0 : !vm.ref<!iree.byte_buffer>
-    %buf0 = vm.const.ref.rodata @buf0 : !vm.ref<!iree.byte_buffer>
-    vm.return %buf0 : !vm.ref<!iree.byte_buffer>
+  vm.func @const_ref_rodata() -> !vm.buffer {
+    // CHECK: %buf0 = vm.const.ref.rodata @buf0 : !vm.buffer
+    %buf0 = vm.const.ref.rodata @buf0 : !vm.buffer
+    vm.return %buf0 : !vm.buffer
   }
 }
 
@@ -49,9 +49,9 @@ vm.module @my_module {
 
 vm.module @my_module {
   // CHECK-LABEL: @inlined_rodata
-  vm.func @inlined_rodata() -> !vm.ref<!iree.byte_buffer> {
-    // CHECK-NEXT: = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<[0, 1, 2]> : tensor<3xi8>
-    %0 = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<[0, 1, 2]> : tensor<3xi8>
-    vm.return %0 : !vm.ref<!iree.byte_buffer>
+  vm.func @inlined_rodata() -> !vm.buffer {
+    // CHECK-NEXT: = vm.rodata.inline : !vm.buffer = dense<[0, 1, 2]> : tensor<3xi8>
+    %0 = vm.rodata.inline : !vm.buffer = dense<[0, 1, 2]> : tensor<3xi8>
+    vm.return %0 : !vm.buffer
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
@@ -25,10 +25,10 @@ vm.module @module {
 // -----
 
 vm.module @module {
-  vm.func @strongly_typed_ref_type_mismatch(%arg0 : !vm.list<!vm.ref<!iree.byte_buffer>>) {
+  vm.func @strongly_typed_ref_type_mismatch(%arg0 : !vm.list<!vm.buffer>) {
     %c100 = vm.const.i32 100 : i32
     // expected-error @+1 {{cannot be accessed as '!vm.ref<!iree.mutable_byte_buffer>'}}
-    %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.mutable_byte_buffer>
+    %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.ref<!iree.mutable_byte_buffer>
     vm.return
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
@@ -63,11 +63,11 @@ vm.module @module {
   vm.func @list_ref_any(%arg0: !vm.list<!vm.ref<?>>) {
     %c100 = vm.const.i32 100 : i32
 
-    // CHECK: %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<!iree.byte_buffer>
-    %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<!iree.byte_buffer>
+    // CHECK: %[[BUFFER:.+]] = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
+    %buffer = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
 
-    // CHECK: vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<?>>, i32, !vm.ref<!iree.byte_buffer>)
-    vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<?>>, i32, !vm.ref<!iree.byte_buffer>)
+    // CHECK: vm.list.set.ref %arg0, %c100, %[[BUFFER]] : (!vm.list<!vm.ref<?>>, i32, !vm.buffer)
+    vm.list.set.ref %arg0, %c100, %buffer : (!vm.list<!vm.ref<?>>, i32, !vm.buffer)
 
     vm.return
   }
@@ -78,14 +78,14 @@ vm.module @module {
 // Typed accessors for lists with strongly-typed ref elements.
 vm.module @module {
   // CHECK: @list_ref_typed
-  vm.func @list_ref_typed(%arg0: !vm.list<!vm.ref<!iree.byte_buffer>>) {
+  vm.func @list_ref_typed(%arg0: !vm.list<!vm.buffer>) {
     %c100 = vm.const.i32 100 : i32
 
-    // CHECK: %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.byte_buffer>
-    %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.byte_buffer>
+    // CHECK: %[[BUFFER:.+]] = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
+    %buffer = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
 
-    // CHECK: vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32, !vm.ref<!iree.byte_buffer>)
-    vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32, !vm.ref<!iree.byte_buffer>)
+    // CHECK: vm.list.set.ref %arg0, %c100, %[[BUFFER]] : (!vm.list<!vm.buffer>, i32, !vm.buffer)
+    vm.list.set.ref %arg0, %c100, %buffer : (!vm.list<!vm.buffer>, i32, !vm.buffer)
 
     vm.return
   }
@@ -115,11 +115,11 @@ vm.module @module {
     // CHECK: vm.list.set.i32 %arg0, %c100, %0 : (!vm.list<?>, i32, i32)
     vm.list.set.i32 %arg0, %c100, %0 : (!vm.list<?>, i32, i32)
 
-    // CHECK: %ref = vm.list.get.ref %arg0, %c101 : (!vm.list<?>, i32) -> !vm.ref<!iree.byte_buffer>
-    %ref = vm.list.get.ref %arg0, %c101 : (!vm.list<?>, i32) -> !vm.ref<!iree.byte_buffer>
+    // CHECK: %[[BUFFER:.+]] = vm.list.get.ref %arg0, %c101 : (!vm.list<?>, i32) -> !vm.buffer
+    %buffer = vm.list.get.ref %arg0, %c101 : (!vm.list<?>, i32) -> !vm.buffer
 
-    // CHECK: vm.list.set.ref %arg0, %c101, %ref : (!vm.list<?>, i32, !vm.ref<!iree.byte_buffer>)
-    vm.list.set.ref %arg0, %c101, %ref : (!vm.list<?>, i32, !vm.ref<!iree.byte_buffer>)
+    // CHECK: vm.list.set.ref %arg0, %c101, %[[BUFFER]] : (!vm.list<?>, i32, !vm.buffer)
+    vm.list.set.ref %arg0, %c101, %buffer : (!vm.list<?>, i32, !vm.buffer)
 
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Transforms/test/hoist_inlined_rodata.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/hoist_inlined_rodata.mlir
@@ -4,8 +4,8 @@ vm.module @module {
   // CHECK: vm.rodata @fn_const dense<[1, 2, 3]> : tensor<3xi32>
   // CHECK-LABEL: vm.func @fn
   vm.func @fn() {
-    // CHECK: = vm.const.ref.rodata @fn_const : !vm.ref<!iree.byte_buffer>
-    %0 = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<[1, 2, 3]> : tensor<3xi32>
+    // CHECK: = vm.const.ref.rodata @fn_const : !vm.buffer
+    %0 = vm.rodata.inline : !vm.buffer = dense<[1, 2, 3]> : tensor<3xi32>
     vm.return
   }
 }

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/ConvertVMLAToVM.cpp
@@ -187,7 +187,7 @@ class VMLAConstantOpConversion
       // Encode just a single splat element and use a buffer fill.
       auto rodataValue = rewriter.createOrFold<IREE::VM::RodataInlineOp>(
           op.getLoc(),
-          IREE::VM::RefType::get(IREE::ByteBufferType::get(op.getContext())),
+          IREE::VM::RefType::get(IREE::VM::BufferType::get(op.getContext())),
           DenseElementsAttr::get(
               RankedTensorType::get({1}, splatAttr.getSplatValue().getType()),
               splatAttr.getSplatValue()));
@@ -209,7 +209,7 @@ class VMLAConstantOpConversion
       // deduped and combined.
       auto rodataValue = rewriter.createOrFold<IREE::VM::RodataInlineOp>(
           op.getLoc(),
-          IREE::VM::RefType::get(IREE::ByteBufferType::get(op.getContext())),
+          IREE::VM::RefType::get(IREE::VM::BufferType::get(op.getContext())),
           op.value());
       rewriter.replaceOpWithNewOp<IREE::VMLA::BufferConstOp>(
           op, IREE::VMLA::BufferType::get(op.getContext()), rodataValue);

--- a/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/VMLA/Conversion/VMLAToVM/test/constant_ops.mlir
@@ -2,8 +2,8 @@
 
 // CHECK-LABEL: vm.func @denseConstant
 func @denseConstant() -> !vmla.buffer {
-  // CHECK-NEXT: [[RODATA:%.+]] = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32
-  // CHECK-NEXT: = vm.call @vmla.buffer.const([[RODATA]]) : (!vm.ref<!iree.byte_buffer>) -> !vm.ref<!vmla.buffer>
+  // CHECK-NEXT: [[RODATA:%.+]] = vm.rodata.inline : !vm.buffer = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32
+  // CHECK-NEXT: = vm.call @vmla.buffer.const([[RODATA]]) : (!vm.buffer) -> !vm.ref<!vmla.buffer>
   %0 = vmla.constant dense<[1.0, 2.0, 3.0]> : tensor<3xf32> -> !vmla.buffer
   return %0 : !vmla.buffer
 }
@@ -12,8 +12,8 @@ func @denseConstant() -> !vmla.buffer {
 
 // CHECK-LABEL: @splatConstant
 func @splatConstant() -> !vmla.buffer {
-  // CHECK-NEXT: [[RODATA:%.+]] = vm.rodata.inline : !vm.ref<!iree.byte_buffer> = dense<0.176776692> : tensor<1xf32>
-  // CHECK-NEXT: [[SPLATTED:%.+]] = vm.call @vmla.buffer.const([[RODATA]]) : (!vm.ref<!iree.byte_buffer>) -> !vm.ref<!vmla.buffer>
+  // CHECK-NEXT: [[RODATA:%.+]] = vm.rodata.inline : !vm.buffer = dense<0.176776692> : tensor<1xf32>
+  // CHECK-NEXT: [[SPLATTED:%.+]] = vm.call @vmla.buffer.const([[RODATA]]) : (!vm.buffer) -> !vm.ref<!vmla.buffer>
   // CHECK-NEXT: [[LENGTH:%.+]] = vm.const.i32 2359296 : i32
   // CHECK-NEXT: [[RESULT:%.+]] = vm.call @vmla.buffer.alloc([[LENGTH]]) : (i32) -> !vm.ref<!vmla.buffer>
   // CHECK-NEXT: vm.call @vmla.buffer.fill([[SPLATTED]], [[RESULT]]) : (!vm.ref<!vmla.buffer>, !vm.ref<!vmla.buffer>) -> ()

--- a/iree/compiler/Dialect/VMLA/vmla.imports.mlir
+++ b/iree/compiler/Dialect/VMLA/vmla.imports.mlir
@@ -39,7 +39,7 @@ attributes {nosideeffects}
 //===----------------------------------------------------------------------===//
 
 vm.import @buffer.const(
-  %value : !vm.ref<!iree.byte_buffer>
+  %value : !vm.buffer
 ) -> !vm.ref<!vmla.buffer>
 attributes {nosideeffects}
 

--- a/iree/modules/vmla/op_module.cc
+++ b/iree/modules/vmla/op_module.cc
@@ -218,13 +218,12 @@ class VMLAModuleState final {
   // vmla.buffer.*
   //===--------------------------------------------------------------------===//
 
-  StatusOr<vm::ref<Buffer>> BufferConst(
-      vm::ref<iree_vm_ro_byte_buffer_t> value) {
+  StatusOr<vm::ref<Buffer>> BufferConst(vm::ref<iree_vm_buffer_t> value) {
     IREE_TRACE_SCOPE0("VMLAModuleState::BufferConst");
     iree_allocator_t external_allocator = {0};
     external_allocator.self = vm::retain_ref(value).release();
     external_allocator.free = +[](void* self, void* ptr) {
-      vm::assign_ref(reinterpret_cast<iree_vm_ro_byte_buffer_t*>(self)).reset();
+      vm::assign_ref(reinterpret_cast<iree_vm_buffer_t*>(self)).reset();
     };
     return Buffer::Wrap(value->data.data, value->data.data_length,
                         external_allocator);

--- a/iree/vm/builtin_types.c
+++ b/iree/vm/builtin_types.c
@@ -35,8 +35,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_register_builtin_types() {
   iree_vm_buffer_descriptor.destroy = iree_vm_buffer_destroy;
   iree_vm_buffer_descriptor.offsetof_counter =
       offsetof(iree_vm_buffer_t, ref_object.counter);
-  iree_vm_buffer_descriptor.type_name =
-      iree_make_cstring_view("iree.byte_buffer");
+  iree_vm_buffer_descriptor.type_name = iree_make_cstring_view("vm.buffer");
   IREE_RETURN_IF_ERROR(iree_vm_ref_register_type(&iree_vm_buffer_descriptor));
 
   IREE_RETURN_IF_ERROR(iree_vm_list_register_types());

--- a/iree/vm/builtin_types.c
+++ b/iree/vm/builtin_types.c
@@ -14,21 +14,12 @@
 
 #include "iree/vm/builtin_types.h"
 
-static iree_vm_ref_type_descriptor_t iree_vm_ro_byte_buffer_descriptor = {0};
-static iree_vm_ref_type_descriptor_t iree_vm_rw_byte_buffer_descriptor = {0};
+static iree_vm_ref_type_descriptor_t iree_vm_buffer_descriptor = {0};
 
-IREE_VM_DEFINE_TYPE_ADAPTERS(iree_vm_ro_byte_buffer, iree_vm_ro_byte_buffer_t);
-IREE_VM_DEFINE_TYPE_ADAPTERS(iree_vm_rw_byte_buffer, iree_vm_rw_byte_buffer_t);
+IREE_VM_DEFINE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
 
-static void iree_vm_ro_byte_buffer_destroy(void* ptr) {
-  iree_vm_ro_byte_buffer_t* ref = (iree_vm_ro_byte_buffer_t*)ptr;
-  if (ref->destroy) {
-    ref->destroy(ptr);
-  }
-}
-
-static void iree_vm_rw_byte_buffer_destroy(void* ptr) {
-  iree_vm_rw_byte_buffer_t* ref = (iree_vm_rw_byte_buffer_t*)ptr;
+static void iree_vm_buffer_destroy(void* ptr) {
+  iree_vm_buffer_t* ref = (iree_vm_buffer_t*)ptr;
   if (ref->destroy) {
     ref->destroy(ptr);
   }
@@ -37,25 +28,16 @@ static void iree_vm_rw_byte_buffer_destroy(void* ptr) {
 iree_status_t iree_vm_list_register_types();
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_register_builtin_types() {
-  if (iree_vm_ro_byte_buffer_descriptor.type != IREE_VM_REF_TYPE_NULL) {
+  if (iree_vm_buffer_descriptor.type != IREE_VM_REF_TYPE_NULL) {
     return iree_ok_status();
   }
 
-  iree_vm_ro_byte_buffer_descriptor.destroy = iree_vm_ro_byte_buffer_destroy;
-  iree_vm_ro_byte_buffer_descriptor.offsetof_counter =
-      offsetof(iree_vm_ro_byte_buffer_t, ref_object.counter);
-  iree_vm_ro_byte_buffer_descriptor.type_name =
+  iree_vm_buffer_descriptor.destroy = iree_vm_buffer_destroy;
+  iree_vm_buffer_descriptor.offsetof_counter =
+      offsetof(iree_vm_buffer_t, ref_object.counter);
+  iree_vm_buffer_descriptor.type_name =
       iree_make_cstring_view("iree.byte_buffer");
-  IREE_RETURN_IF_ERROR(
-      iree_vm_ref_register_type(&iree_vm_ro_byte_buffer_descriptor));
-
-  iree_vm_rw_byte_buffer_descriptor.destroy = iree_vm_rw_byte_buffer_destroy;
-  iree_vm_rw_byte_buffer_descriptor.offsetof_counter =
-      offsetof(iree_vm_rw_byte_buffer_t, ref_object.counter);
-  iree_vm_rw_byte_buffer_descriptor.type_name =
-      iree_make_cstring_view("iree.mutable_byte_buffer");
-  IREE_RETURN_IF_ERROR(
-      iree_vm_ref_register_type(&iree_vm_rw_byte_buffer_descriptor));
+  IREE_RETURN_IF_ERROR(iree_vm_ref_register_type(&iree_vm_buffer_descriptor));
 
   IREE_RETURN_IF_ERROR(iree_vm_list_register_types());
 

--- a/iree/vm/builtin_types.h
+++ b/iree/vm/builtin_types.h
@@ -22,46 +22,41 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Describes where a byte buffer originates from and what guarantees can be made
-// about its lifetime and ownership.
-enum iree_vm_byte_buffer_origin_e {
+// Describes where a byte buffer originates from, what guarantees can be made
+// about its lifetime and ownership, and how it may be accessed.
+// Note that buffers may always be read.
+enum iree_vm_buffer_access_e {
+  // The guest is allowed to write to the buffer.
+  IREE_VM_BUFFER_ACCESS_WRITE = 1u << 0,
+
   // Buffer references memory in the module space (rodata or rwdata) that is
   // guaranteed to be live for the lifetime of the module.
-  IREE_VM_BYTE_BUFFER_ORIGIN_MODULE = 0,
+  IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE = 1u << 1,
   // Buffer references memory created by the guest module code. It has a
   // lifetime less than that of the module but is always tracked with proper
   // references (a handle existing to the memory implies it is valid).
-  IREE_VM_BYTE_BUFFER_ORIGIN_GUEST = 1,
+  IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST = 1u << 2,
 };
-typedef uint32_t iree_vm_byte_buffer_origin_t;
+typedef uint32_t iree_vm_buffer_access_t;
 
-// The built-in constant buffer type.
+// The built-in buffer type.
 // This simply points at a span of memory. The memory could be owned (in which
 // case a destroy function must be provided) or unowned (NULL destroy function).
+// The access flags indicate what access is allowed from the VM.
 typedef struct {
   iree_vm_ref_object_t ref_object;
-  iree_vm_byte_buffer_origin_t origin;
-  iree_const_byte_span_t data;
+  iree_vm_buffer_access_t access;
+  iree_byte_span_t data;
   iree_vm_ref_destroy_t destroy;
-} iree_vm_ro_byte_buffer_t;
+} iree_vm_buffer_t;
 
 // Returns the a string view referencing the given |value| buffer.
-static inline iree_string_view_t iree_vm_ro_byte_buffer_as_string(
-    const iree_vm_ro_byte_buffer_t* value) {
+static inline iree_string_view_t iree_vm_buffer_as_string(
+    const iree_vm_buffer_t* value) {
   return value ? iree_make_string_view((const char*)value->data.data,
                                        value->data.data_length)
                : iree_string_view_empty();
 }
-
-// The built-in mutable buffer type.
-// This simply points at a span of memory. The memory could be owned (in which
-// case a destroy function must be provided) or unowned (NULL destroy function).
-typedef struct {
-  iree_vm_ref_object_t ref_object;
-  iree_vm_byte_buffer_origin_t origin;
-  iree_byte_span_t data;
-  iree_vm_ref_destroy_t destroy;
-} iree_vm_rw_byte_buffer_t;
 
 // Registers the builtin VM types. This must be called on startup. Safe to call
 // multiple times.
@@ -71,7 +66,6 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_register_builtin_types();
 }  // extern "C"
 #endif  // __cplusplus
 
-IREE_VM_DECLARE_TYPE_ADAPTERS(iree_vm_ro_byte_buffer, iree_vm_ro_byte_buffer_t);
-IREE_VM_DECLARE_TYPE_ADAPTERS(iree_vm_rw_byte_buffer, iree_vm_rw_byte_buffer_t);
+IREE_VM_DECLARE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
 
 #endif  // IREE_VM_BUILTIN_TYPES_H_

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -811,7 +811,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_ref_t* result = VM_DecResultRegRef("value", &result_is_move);
       IREE_RETURN_IF_ERROR(iree_vm_ref_wrap_retain(
           &module_state->rodata_ref_table[rodata_ordinal],
-          iree_vm_ro_byte_buffer_type_id(), result));
+          iree_vm_buffer_type_id(), result));
     });
 
     //===------------------------------------------------------------------===//

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -539,10 +539,9 @@ static iree_host_size_t iree_vm_bytecode_module_layout_state(
 
   if (state) {
     state->rodata_ref_count = rodata_ref_count;
-    state->rodata_ref_table = (iree_vm_ro_byte_buffer_t*)(base_ptr + offset);
+    state->rodata_ref_table = (iree_vm_buffer_t*)(base_ptr + offset);
   }
-  offset +=
-      iree_host_align(rodata_ref_count * sizeof(iree_vm_ro_byte_buffer_t), 16);
+  offset += iree_host_align(rodata_ref_count * sizeof(iree_vm_buffer_t), 16);
 
   if (state) {
     state->import_count = import_function_count;
@@ -584,10 +583,10 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
   for (int i = 0; i < state->rodata_ref_count; ++i) {
     iree_vm_RodataSegmentDef_table_t segment =
         iree_vm_RodataSegmentDef_vec_at(rodata_segments, i);
-    iree_vm_ro_byte_buffer_t* ref = &state->rodata_ref_table[i];
+    iree_vm_buffer_t* ref = &state->rodata_ref_table[i];
     iree_atomic_ref_count_init(&ref->ref_object.counter);
-    ref->origin = IREE_VM_BYTE_BUFFER_ORIGIN_MODULE;
-    ref->data.data = iree_vm_RodataSegmentDef_data(segment);
+    ref->access = IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE;
+    ref->data.data = (uint8_t*)iree_vm_RodataSegmentDef_data(segment);
     ref->data.data_length =
         flatbuffers_uint8_vec_len(iree_vm_RodataSegmentDef_data(segment));
   }

--- a/iree/vm/bytecode_module_impl.h
+++ b/iree/vm/bytecode_module_impl.h
@@ -118,7 +118,7 @@ typedef struct {
   // Right now these don't do much, however we can perform lazy caching and
   // on-the-fly decompression using this information.
   iree_host_size_t rodata_ref_count;
-  iree_vm_ro_byte_buffer_t* rodata_ref_table;
+  iree_vm_buffer_t* rodata_ref_table;
 
   // Resolved function imports.
   iree_host_size_t import_count;

--- a/iree/vm/module_abi_packing.h
+++ b/iree/vm/module_abi_packing.h
@@ -426,10 +426,8 @@ struct ParamUnpack<absl::string_view> {
   static void Load(Status& status, params_ptr_t& ptr, storage_type& out_param) {
     auto* reg_ptr = reinterpret_cast<iree_vm_ref_t*>(ptr);
     ptr += sizeof(iree_vm_ref_t);
-    if (reg_ptr->type ==
-        ref_type_descriptor<iree_vm_ro_byte_buffer_t>::get()->type) {
-      auto byte_span =
-          reinterpret_cast<iree_vm_ro_byte_buffer_t*>(reg_ptr->ptr)->data;
+    if (reg_ptr->type == ref_type_descriptor<iree_vm_buffer_t>::get()->type) {
+      auto byte_span = reinterpret_cast<iree_vm_buffer_t*>(reg_ptr->ptr)->data;
       out_param = absl::string_view{
           reinterpret_cast<const char*>(byte_span.data), byte_span.data_length};
     } else if (IREE_UNLIKELY(reg_ptr->type != IREE_VM_REF_TYPE_NULL)) {
@@ -439,9 +437,8 @@ struct ParamUnpack<absl::string_view> {
           "have %.*s but expected %.*s",
           (int)iree_vm_ref_type_name(reg_ptr->type).size,
           iree_vm_ref_type_name(reg_ptr->type).data,
-          (int)ref_type_descriptor<iree_vm_ro_byte_buffer_t>::get()
-              ->type_name.size,
-          ref_type_descriptor<iree_vm_ro_byte_buffer_t>::get()->type_name.data);
+          (int)ref_type_descriptor<iree_vm_buffer_t>::get()->type_name.size,
+          ref_type_descriptor<iree_vm_buffer_t>::get()->type_name.data);
     } else {
       // NOTE: empty string is allowed here!
       out_param = {};

--- a/iree/vm/native_module_test.h
+++ b/iree/vm/native_module_test.h
@@ -286,13 +286,13 @@ static iree_status_t module_b_create(iree_allocator_t allocator,
 
   // Resolve types used by the module once so that we can share it across all
   // instances of the module.
-  module->types[0] = iree_vm_ref_lookup_registered_type(
-      iree_make_cstring_view("iree.byte_buffer"));
+  module->types[0] =
+      iree_vm_ref_lookup_registered_type(iree_make_cstring_view("vm.buffer"));
   if (!module->types[0]) {
     iree_allocator_free(allocator, module);
     return iree_make_status(
         IREE_STATUS_NOT_FOUND,
-        "required type iree.byte_buffer not registered with the type system");
+        "required type vm.buffer not registered with the type system");
   }
 
   // Setup the interface with the functions we implement ourselves. Any function

--- a/iree/vm/test/list_variant_ops.mlir
+++ b/iree/vm/test/list_variant_ops.mlir
@@ -75,10 +75,10 @@ vm.module @list_variant_ops {
 
     // Access element 11 as a ref object.
     %c11 = vm.const.i32 11 : i32
-    %v11_buf = vm.const.ref.rodata @byte_buffer : !vm.ref<!iree.byte_buffer>
-    vm.list.set.ref %list, %c11, %v11_buf : (!vm.list<?>, i32, !vm.ref<!iree.byte_buffer>)
-    %e11_buf = vm.list.get.ref %list, %c11 : (!vm.list<?>, i32) -> !vm.ref<!iree.byte_buffer>
-    vm.check.eq %e11_buf, %v11_buf : !vm.ref<!iree.byte_buffer>
+    %v11_buf = vm.const.ref.rodata @byte_buffer : !vm.buffer
+    vm.list.set.ref %list, %c11, %v11_buf : (!vm.list<?>, i32, !vm.buffer)
+    %e11_buf = vm.list.get.ref %list, %c11 : (!vm.list<?>, i32) -> !vm.buffer
+    vm.check.eq %e11_buf, %v11_buf : !vm.buffer
 
     // Access element 11 as a different kind of ref object (incompatible).
     // Should return null.
@@ -104,10 +104,10 @@ vm.module @list_variant_ops {
     vm.check.eq %e10_i32, %v10_i32 : i32
 
     // Access element 10 as a ref object.
-    %v10_buf = vm.const.ref.rodata @byte_buffer : !vm.ref<!iree.byte_buffer>
-    vm.list.set.ref %list, %c10, %v10_buf : (!vm.list<?>, i32, !vm.ref<!iree.byte_buffer>)
-    %e10_buf = vm.list.get.ref %list, %c10 : (!vm.list<?>, i32) -> !vm.ref<!iree.byte_buffer>
-    vm.check.eq %e10_buf, %v10_buf : !vm.ref<!iree.byte_buffer>
+    %v10_buf = vm.const.ref.rodata @byte_buffer : !vm.buffer
+    vm.list.set.ref %list, %c10, %v10_buf : (!vm.list<?>, i32, !vm.buffer)
+    %e10_buf = vm.list.get.ref %list, %c10 : (!vm.list<?>, i32) -> !vm.buffer
+    vm.check.eq %e10_buf, %v10_buf : !vm.buffer
 
     // Accessing it as an i32 now that it stores the ref should fail at runtime.
     // TODO(benvanik): support type queries and/or make this silently return 0.


### PR DESCRIPTION
The existing built-in was a hack; this starts to standardize it a bit. Future changes will add VM ops operating on the new built-in type.