### PR TITLE
Mark the buffer created from parsing tensors as dispatchable

### DIFF
--- a/iree/hal/buffer_view.cc
+++ b/iree/hal/buffer_view.cc
@@ -103,7 +103,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_parse(
   IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
       buffer_allocator,
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
+      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING |
+          IREE_HAL_BUFFER_USAGE_DISPATCH,
       buffer_length, &buffer));
 
   iree_status_t status;


### PR DESCRIPTION
The buffers containing the parsed tensor elements are typically
used as initial inputs and bound to pipelines in our various
command-line tools. Marking them as suitable for dispatch fixes
the Vulkan validation issue:

[ VUID-VkWriteDescriptorSet-descriptorType-00331 ]
Attempted write update to buffer descriptor failed due to:
Buffer with usage mask 0x3 being used for a descriptor update
of type VK_DESCRIPTOR_TYPE_STORAGE_BUFFER does not have
VK_BUFFER_USAGE_STORAGE_BUFFER_BIT set..
The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, the buffer member
of each element of pBufferInfo must have been created with
VK_BUFFER_USAGE_STORAGE_BUFFER_BIT set.