### PR TITLE
Revert "Enabling `-Wincompatible-pointer-types` warning."

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -132,7 +132,6 @@ build:generic_clang --copt=-Wfor-loop-analysis
 build:generic_clang --copt=-Wformat-security
 build:generic_clang --copt=-Wgnu-redeclared-enum
 build:generic_clang --copt=-Wimplicit-fallthrough
-build:generic_clang --copt=-Wincompatible-pointer-types
 build:generic_clang --copt=-Winfinite-recursion
 build:generic_clang --copt=-Wliteral-conversion
 build:generic_clang --copt=-Wnon-virtual-dtor

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -141,7 +141,6 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wformat-security"
     "-Wgnu-redeclared-enum"
     "-Wimplicit-fallthrough"
-    "-Wincompatible-pointer-types"
     "-Winfinite-recursion"
     "-Wliteral-conversion"
     "-Wnon-virtual-dtor"


### PR DESCRIPTION
This flag is enabled by default
(https://clang.llvm.org/docs/DiagnosticsReference.html#wincompatible-pointer-types).
The reason we only hit it on integration into google source
is that we don't have a 32-bit build in OSS (yet).

Reverts google/iree#5676