### PR TITLE
Tile matmul with at least matmulVectorSize

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
@@ -112,6 +112,7 @@ llvm::SmallVector<int64_t, 4> getTileSizes(Operation *op) {
         if (!lhsShape.empty() && !rhsShape.empty()) {
           // Find largest tile size that is a multiple of the vector size.
           auto getTileSize = [](int dim, int maxSize) {
+            if (dim < matmulVectorSize) return matmulVectorSize.getValue();
             for (int i = std::min(maxSize, dim); i > 0; --i) {
               if (dim % i == 0 && i % matmulVectorSize == 0) {
                 return i;


### PR DESCRIPTION
Otherwise very narrow matmul problems with dim < matmulVectorSize won't get vectorized.

Helps MobileNet V3:

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       93.1 ms         92.8 ms            7
```

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       76.5 ms         76.2 ms            9

```