### PR TITLE
Remove OUT option from iree_cc_[binary/test]

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -30,7 +30,8 @@ include(CMakeParseArguments)
 # HOSTONLY: host only; compile using host toolchain when cross-compiling
 #
 # Note:
-# By default, iree_cc_binary will always create a binary named iree_${NAME}.
+# iree_cc_binary will create a binary called ${PACKAGE_NAME}_${NAME}, e.g.
+# iree_base_foo with an alias (readonly) target called ${NAME}.
 #
 # Usage:
 # iree_cc_library(

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -20,7 +20,6 @@ include(CMakeParseArguments)
 #
 # Parameters:
 # NAME: name of target (see Usage below)
-# OUT: OUTPUT_NAME for the target. Defaults to NAME.
 # SRCS: List of source files for the binary
 # DATA: List of other targets and files required for this binary
 # DEPS: List of other libraries to be linked in to the binary targets
@@ -56,7 +55,7 @@ function(iree_cc_binary)
   cmake_parse_arguments(
     _RULE
     "HOSTONLY;TESTONLY"
-    "NAME;OUT"
+    "NAME"
     "SRCS;COPTS;DEFINES;LINKOPTS;DATA;DEPS"
     ${ARGN}
   )
@@ -71,11 +70,7 @@ function(iree_cc_binary)
 
   add_executable(${_NAME} "")
   add_executable(${_RULE_NAME} ALIAS ${_NAME})
-  if(_RULE_OUT)
-    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_OUT}")
-  else()
-    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
-  endif()
+  set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
   if(_RULE_SRCS)
     target_sources(${_NAME}
       PRIVATE

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -31,7 +31,7 @@ include(CMakeParseArguments)
 #
 # Note:
 # iree_cc_binary will create a binary called ${PACKAGE_NAME}_${NAME}, e.g.
-# iree_base_foo with an alias (readonly) target called ${NAME}.
+# iree_base_foo.
 #
 # Usage:
 # iree_cc_library(
@@ -70,7 +70,6 @@ function(iree_cc_binary)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
   add_executable(${_NAME} "")
-  add_executable(${_RULE_NAME} ALIAS ${_NAME})
   set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
   if(_RULE_SRCS)
     target_sources(${_NAME}

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -31,7 +31,7 @@ include(CMakeParseArguments)
 #
 # Note:
 # iree_cc_binary will create a binary called ${PACKAGE_NAME}_${NAME}, e.g.
-# iree_base_foo.
+# iree_base_foo with an alias (readonly) target called ${NAME}.
 #
 # Usage:
 # iree_cc_library(
@@ -70,6 +70,7 @@ function(iree_cc_binary)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
   add_executable(${_NAME} "")
+  add_executable(${_RULE_NAME} ALIAS ${_NAME})
   set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
   if(_RULE_SRCS)
     target_sources(${_NAME}

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -73,11 +73,7 @@ function(iree_cc_test)
 
   add_executable(${_NAME} "")
   add_executable(${_RULE_NAME} ALIAS ${_NAME})
-  if(_RULE_OUT)
-    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_OUT}")
-  else()
-    set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
-  endif()
+  set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
   target_sources(${_NAME}
     PRIVATE
       ${_RULE_SRCS}

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -20,7 +20,7 @@ include(iree_installed_test)
 # CMake function to imitate Bazel's cc_test rule.
 #
 # Parameters:
-# NAME: name of target (see Usage below)
+# NAME: name of target. This name is used for the generated executable and
 # SRCS: List of source files for the binary
 # DATA: List of other targets and files required for this binary
 # DEPS: List of other libraries to be linked in to the binary targets
@@ -31,8 +31,9 @@ include(iree_installed_test)
 #     automatically.
 #
 # Note:
-# By default, iree_cc_test will always create a binary named iree_${NAME}.
-# This will also add it to ctest list as iree_${NAME}.
+# iree_cc_test will create a binary called ${PACKAGE_NAME}_${NAME}, e.g.
+# iree_base_foo_test with an alias (readonly) target called ${NAME}.
+#
 #
 # Usage:
 # iree_cc_library(

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -32,7 +32,7 @@ include(iree_installed_test)
 #
 # Note:
 # iree_cc_test will create a binary called ${PACKAGE_NAME}_${NAME}, e.g.
-# iree_base_foo_test with an alias (readonly) target called ${NAME}.
+# iree_base_foo_test.
 #
 #
 # Usage:
@@ -73,7 +73,6 @@ function(iree_cc_test)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
   add_executable(${_NAME} "")
-  add_executable(${_RULE_NAME} ALIAS ${_NAME})
   set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "${_RULE_NAME}")
   target_sources(${_NAME}
     PRIVATE

--- a/iree/base/testing/CMakeLists.txt
+++ b/iree/base/testing/CMakeLists.txt
@@ -18,8 +18,6 @@
 iree_cc_library(
   NAME
     dynamic_library_test_library.so
-  OUT
-    dynamic_library_test_library.so
   SRCS
     "dynamic_library_test_library.cc"
   TESTONLY

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -58,8 +58,6 @@ endif()
 iree_cc_binary(
   NAME
     iree-benchmark-module
-  OUT
-    iree-benchmark-module
   SRCS
     "iree-benchmark-module-main.cc"
   DEPS
@@ -79,8 +77,6 @@ iree_cc_binary(
 
 iree_cc_binary(
   NAME
-    iree-check-module
-  OUT
     iree-check-module
   SRCS
     "iree-check-module-main.cc"
@@ -104,8 +100,6 @@ iree_cc_binary(
 iree_cc_binary(
   NAME
     iree-dump-module
-  OUT
-    iree-dump-module
   SRCS
     "iree-dump-module-main.cc"
   DEPS
@@ -117,8 +111,6 @@ iree_cc_binary(
 
 iree_cc_binary(
   NAME
-    iree-run-module
-  OUT
     iree-run-module
   SRCS
     "iree-run-module-main.cc"
@@ -328,8 +320,6 @@ if(${IREE_BUILD_COMPILER})
   iree_cc_binary(
     NAME
       iree-translate
-    OUT
-      iree-translate
     DEPS
       ::iree_translate_main
     HOSTONLY
@@ -338,8 +328,6 @@ if(${IREE_BUILD_COMPILER})
   iree_cc_binary(
     NAME
       iree-opt
-    OUT
-      iree-opt
     DEPS
       ::iree_opt_main
     HOSTONLY
@@ -347,8 +335,6 @@ if(${IREE_BUILD_COMPILER})
 
   iree_cc_binary(
     NAME
-      iree-run-mlir
-    OUT
       iree-run-mlir
     SRCS
       "iree-run-mlir-main.cc"


### PR DESCRIPTION
This is never used to set except to set the binary name explicitly to the default, it's not
supported by bazel_to_cmake, and it's not even parsed as an argument in the case of
`iree_cc_test`.