### PR TITLE
Re-implements IREE function dispatch in python on top of the native ABI.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_py_library(
     runtime
   SRCS
     "__init__.py"
+    "function.py"
     "system_api.py"
   PYEXT_DEPS
     ::PyExtRt

--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -1,0 +1,258 @@
+# Lint as: python3
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+
+import numpy as np
+
+from .binding import HalDevice, HalElementType, VmContext, VmFunction, VmVariantList
+
+__all__ = [
+    "FunctionInvoker",
+]
+
+
+class Invocation:
+
+  def __init__(self, device: HalDevice):
+    self.device = device
+
+
+class FunctionInvoker:
+  """Wraps a VmFunction, enabling invocations against it."""
+
+  def __init__(self, vm_context: VmContext, device: HalDevice,
+               vm_function: VmFunction):
+    self._vm_context = vm_context
+    # TODO: Needing to know the precise device to allocate on here is bad
+    # layering and will need to be fixed in some fashion if/when doing
+    # heterogenous dispatch.
+    self._device = device
+    self._vm_function = vm_function
+    self._abi_dict = None
+    self._arg_descs = None
+    self._ret_descs = None
+    self._parse_abi_dict(vm_function)
+
+  @property
+  def vm_function(self) -> VmFunction:
+    return self._vm_function
+
+  def __call__(self, *args):
+    # Initialize the capacity to our total number of args, since we should
+    # be below that when doing a flat invocation. May want to be more
+    # conservative here when considering nesting.
+    inv = Invocation(self._device)
+    ret_descs = self._ret_descs
+    arg_list = VmVariantList(len(args))
+    ret_list = VmVariantList(len(ret_descs) if ret_descs is not None else 1)
+    _merge_python_sequence_to_vm(inv, arg_list, args, self._arg_descs)
+    self._vm_context.invoke(self._vm_function, arg_list, ret_list)
+    returns = _extract_vm_sequence_to_python(inv, ret_list, ret_descs)
+    return_arity = len(returns)
+    if return_arity == 1:
+      return returns[0]
+    elif return_arity == 0:
+      return None
+    else:
+      return tuple(returns)
+
+  def _parse_abi_dict(self, vm_function: VmFunction):
+    reflection = vm_function.reflection
+    abi_json = reflection.get("iree.abi")
+    if abi_json is None:
+      # It is valid to have no reflection data, and rely on pure dynamic
+      # dispatch.
+      logging.warning(
+          "Function lacks reflection data. Interop will be limited: %r",
+          vm_function)
+      return
+    try:
+      self._abi_dict = json.loads(abi_json)
+    except json.JSONDecodeError as e:
+      raise RuntimeError(
+          f"Reflection metadata is not valid JSON: {abi_json}") from e
+    try:
+      self._arg_descs = self._abi_dict["a"]
+      self._ret_descs = self._abi_dict["r"]
+    except KeyError as e:
+      raise RuntimeError(
+          f"Malformed function reflection metadata: {reflection}") from e
+    if not isinstance(self._arg_descs, list) or not isinstance(
+        self._ret_descs, list):
+      raise RuntimeError(
+          f"Malformed function reflection metadata structure: {reflection}")
+
+  def __repr__(self):
+    return repr(self._vm_function)
+
+
+# Python type to VM Type converters. All of these take:
+#   inv: Invocation
+#   target_list: VmVariantList to append to
+#   python_value: The python value of the given type
+#   desc: The ABI descriptor list (or None if in dynamic mode).
+
+
+def _bool_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _int_to_vm(t, int(x), desc)
+
+
+def _int_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _raise_argument_error(inv, "Python int arguments not yet supported")
+
+
+def _float_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _raise_argument_error(inv, "Python float arguments not yet supported")
+
+
+def _list_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _raise_argument_error(inv, "Python list arguments not yet supported")
+
+
+def _tuple_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _raise_argument_error(inv, "Python tuple arguments not yet supported")
+
+
+def _dict_to_vm(inv: Invocation, t: VmVariantList, desc):
+  _raise_argument_error(inv, "Python dict arguments not yet supported")
+
+
+def _str_to_vm(inv: Invocation, t: VmVariantList, x, desc):
+  _raise_argument_error(inv, "Python str arguments not yet supported")
+
+
+def _ndarray_to_vm(inv: Invocation, t: VmVariantList, x, desc):
+  # Validate and implicit conversion against type descriptor.
+  if desc is not None:
+    desc_type = desc[0]
+    if desc_type != "ndarray":
+      _raise_argument_error(inv, f"passed an ndarray but expected {desc_type}")
+    dtype_str = desc[1]
+    try:
+      dtype = ABI_TYPE_TO_DTYPE[dtype_str]
+    except KeyError:
+      _raise_argument_error(inv, f"unrecognized dtype '{dtype_str}'")
+    if dtype != x.dtype:
+      x = x.astype(dtype)
+    shape = desc[2:]
+    if len(shape) != len(x.shape):
+      _raise_argument_error(inv,
+                            f"rank mismatch {len(x.shape)} vs {len(shape)}")
+    for exp_dim, act_dim in zip(shape, x.shape):
+      if exp_dim is not None and exp_dim != act_dim:
+        _raise_argument_error(inv,
+                              f"shape mismatch {x.shape} vs {tuple(shape)}")
+  actual_dtype = x.dtype
+  for match_dtype, element_type in DTYPE_TO_HAL_ELEMENT_TYPE:
+    if match_dtype == actual_dtype:
+      break
+  else:
+    _raise_argument_error(inv, f"unsupported numpy dtype {x.dtype}")
+  t.push_buffer_view(inv.device, x, element_type)
+
+
+PYTHON_TO_VM_CONVERTERS = {
+    bool: _bool_to_vm,
+    int: _int_to_vm,
+    float: _float_to_vm,
+    list: _list_to_vm,
+    tuple: _tuple_to_vm,
+    dict: _dict_to_vm,
+    str: _str_to_vm,
+    np.ndarray: _ndarray_to_vm,
+}
+
+# VM to Python converters. All take:
+#   inv: Invocation
+#   vm_list: VmVariantList to read from
+#   vm_index: Index in the vm_list to extract
+#   desc: The ABI descriptor list (or None if in dynamic mode)
+# Return the corresponding Python object.
+
+
+def _vm_to_ndarray(inv: Invocation, vm_list: VmVariantList, vm_index: int,
+                   desc):
+  return vm_list.get_as_ndarray(vm_index)
+
+
+VM_TO_PYTHON_CONVERTERS = {
+    "ndarray": _vm_to_ndarray,
+}
+
+ABI_TYPE_TO_DTYPE = {
+    # TODO: Others.
+    "f32": np.float32,
+    "i32": np.int32,
+}
+
+# NOTE: Numpy dtypes are not hashable and exist in a hierarchy that should
+# be queried via isinstance checks. This should be done as a fallback but
+# this is a linear list for quick access to the most common.
+DTYPE_TO_HAL_ELEMENT_TYPE = (
+    # TODO: Others.
+    (np.float32, HalElementType.FLOAT_32),
+    (np.float64, HalElementType.FLOAT_64),
+)
+
+
+def _raise_argument_error(inv: Invocation, summary: str):
+  # TODO: Do some fancier back-tracking in reporting error.
+  raise ValueError(f"Error passing argument: {summary}")
+
+
+def _raise_return_error(inv: Invocation, summary: str):
+  # TODO: Do some fancier back-tracking in reporting error.
+  raise ValueError(f"Error processing function return: {summary}")
+
+
+def _merge_python_sequence_to_vm(inv: Invocation, vm_list, py_list, descs):
+  # For dynamic mode, just assume we have the right arity.
+  if descs is None:
+    descs = [None] * len(py_list)
+  elif len(py_list) != len(descs):
+    _raise_argument_error(
+        inv, f"mismatched function call arity: "
+        f"expected={descs}, got={py_list}")
+  for py_value, desc in zip(py_list, descs):
+    py_type = py_value.__class__
+    try:
+      converter = PYTHON_TO_VM_CONVERTERS[py_type]
+    except KeyError:
+      _raise_argument_error(inv, f"cannot map Python type to VM: {py_type}")
+    converter(inv, vm_list, py_value, desc)
+
+
+def _extract_vm_sequence_to_python(inv: Invocation, vm_list, descs):
+  vm_list_arity = len(vm_list)
+  if descs is None:
+    descs = [None] * vm_list_arity
+  elif vm_list_arity != len(descs):
+    _raise_return_error(
+        inv, f"mismatched return arity: {vm_list_arity} vs {len(descs)}")
+  results = []
+  for vm_index, desc in zip(range(vm_list_arity), descs):
+    if desc is None:
+      # Dynamic (non reflection mode).
+      _raise_return_error(
+          inv, "function has no reflection data, which is not yet supported")
+    vm_type = desc[0]
+    try:
+      converter = VM_TO_PYTHON_CONVERTERS[vm_type]
+    except KeyError:
+      _raise_return_error(inv, f"cannot map VM type to python: {vm_type}")
+    results.append(converter(inv, vm_list, vm_index, desc))
+  return results

--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -107,27 +107,27 @@ class FunctionInvoker:
 #   desc: The ABI descriptor list (or None if in dynamic mode).
 
 
-def _bool_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _bool_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _int_to_vm(t, int(x), desc)
 
 
-def _int_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _int_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _raise_argument_error(inv, "Python int arguments not yet supported")
 
 
-def _float_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _float_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _raise_argument_error(inv, "Python float arguments not yet supported")
 
 
-def _list_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _list_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _raise_argument_error(inv, "Python list arguments not yet supported")
 
 
-def _tuple_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _tuple_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _raise_argument_error(inv, "Python tuple arguments not yet supported")
 
 
-def _dict_to_vm(inv: Invocation, t: VmVariantList, desc):
+def _dict_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   _raise_argument_error(inv, "Python dict arguments not yet supported")
 
 

--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -108,7 +108,7 @@ class FunctionInvoker:
 
 
 def _bool_to_vm(inv: Invocation, t: VmVariantList, x, desc):
-  _int_to_vm(t, int(x), desc)
+  _int_to_vm(inv, t, int(x), desc)
 
 
 def _int_to_vm(inv: Invocation, t: VmVariantList, x, desc):

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -20,73 +20,6 @@
 namespace iree {
 namespace python {
 
-namespace {
-
-class HalMappedMemory {
- public:
-  HalMappedMemory(iree_hal_buffer_mapping_t mapped_memory,
-                  iree_hal_buffer_view_t* bv)
-      : mapped_memory_(mapped_memory), bv_(bv) {
-    iree_hal_buffer_view_retain(bv_);
-  }
-  ~HalMappedMemory() {
-    if (bv_) {
-      iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(bv_);
-      iree_hal_buffer_unmap_range(&mapped_memory_);
-      iree_hal_buffer_view_release(bv_);
-    }
-  }
-  HalMappedMemory(HalMappedMemory&& other)
-      : mapped_memory_(other.mapped_memory_), bv_(other.bv_) {
-    other.bv_ = nullptr;
-  }
-
-  static HalMappedMemory Create(HalBufferView& bv) {
-    iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(bv.raw_ptr());
-    iree_device_size_t byte_length = iree_hal_buffer_byte_length(buffer);
-    iree_hal_buffer_mapping_t mapped_memory;
-    CheckApiStatus(iree_hal_buffer_map_range(
-                       buffer, IREE_HAL_MEMORY_ACCESS_READ,
-                       0 /* element_offset */, byte_length, &mapped_memory),
-                   "Could not map memory");
-    return HalMappedMemory(mapped_memory, bv.raw_ptr());
-  }
-
-  py::buffer_info ToBufferInfo() {
-    absl::InlinedVector<int32_t, 6> shape(iree_hal_buffer_view_shape_rank(bv_));
-    CheckApiStatus(
-        iree_hal_buffer_view_shape(bv_, shape.size(), shape.data(), nullptr),
-        "Error getting buffer view shape");
-    iree_hal_element_type_t element_type =
-        iree_hal_buffer_view_element_type(bv_);
-    int32_t element_size = iree_hal_element_byte_count(element_type);
-    absl::InlinedVector<py::ssize_t, 6> dims(shape.size());
-    for (int i = 0; i < shape.size(); ++i) {
-      dims[i] = shape[i];
-    }
-    absl::InlinedVector<py::ssize_t, 8> strides(shape.size());
-    if (!strides.empty()) {
-      strides[shape.size() - 1] = element_size;
-      for (int i = shape.size() - 2; i >= 0; --i) {
-        strides[i] = strides[i + 1] * shape[i + 1];
-      }
-    }
-
-    // TODO(laurenzo): We need to figure out how to propagate dtype in the
-    // buffer view.
-    return py::buffer_info(
-        mapped_memory_.contents.data, element_size,
-        py::format_descriptor<float>::format(),  // TODO(laurenzo): DTYPE!
-        shape.size(), dims, strides);
-  }
-
- private:
-  iree_hal_buffer_mapping_t mapped_memory_;
-  iree_hal_buffer_view_t* bv_;
-};
-
-}  // namespace
-
 //------------------------------------------------------------------------------
 // HalDriver
 //------------------------------------------------------------------------------
@@ -153,6 +86,24 @@ void SetupHalBindings(pybind11::module m) {
       .value("DISCARD", IREE_HAL_MEMORY_ACCESS_DISCARD)
       .value("DISCARD_WRITE", IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE)
       .value("ALL", IREE_HAL_MEMORY_ACCESS_ALL)
+      .export_values();
+  py::enum_<enum iree_hal_element_type_e>(m, "HalElementType")
+      .value("NONE", IREE_HAL_ELEMENT_TYPE_NONE)
+      .value("OPAQUE_8", IREE_HAL_ELEMENT_TYPE_OPAQUE_8)
+      .value("OPAQUE_16", IREE_HAL_ELEMENT_TYPE_OPAQUE_16)
+      .value("OPAQUE_32", IREE_HAL_ELEMENT_TYPE_OPAQUE_32)
+      .value("OPAQUE_64", IREE_HAL_ELEMENT_TYPE_OPAQUE_64)
+      .value("SINT_8", IREE_HAL_ELEMENT_TYPE_SINT_8)
+      .value("SINT_16", IREE_HAL_ELEMENT_TYPE_SINT_16)
+      .value("SINT_32", IREE_HAL_ELEMENT_TYPE_SINT_32)
+      .value("SINT_64", IREE_HAL_ELEMENT_TYPE_SINT_64)
+      .value("UINT_8", IREE_HAL_ELEMENT_TYPE_UINT_8)
+      .value("UINT_16", IREE_HAL_ELEMENT_TYPE_UINT_16)
+      .value("UINT_32", IREE_HAL_ELEMENT_TYPE_UINT_32)
+      .value("UINT_64", IREE_HAL_ELEMENT_TYPE_UINT_64)
+      .value("FLOAT_16", IREE_HAL_ELEMENT_TYPE_FLOAT_16)
+      .value("FLOAT_32", IREE_HAL_ELEMENT_TYPE_FLOAT_32)
+      .value("FLOAT_64", IREE_HAL_ELEMENT_TYPE_FLOAT_64)
       .export_values();
 
   py::class_<HalDevice>(m, "HalDevice");

--- a/bindings/python/iree/runtime/hal.h
+++ b/bindings/python/iree/runtime/hal.h
@@ -167,10 +167,9 @@ class HalMappedMemory {
       }
     }
 
-    return py::buffer_info(
-        mapped_memory_.contents.data, element_size,
-        py::format_descriptor<float>::format(),
-        shape.size(), dims, strides);
+    return py::buffer_info(mapped_memory_.contents.data, element_size,
+                           py::format_descriptor<float>::format(), shape.size(),
+                           dims, strides);
   }
 
  private:

--- a/bindings/python/iree/runtime/hal.h
+++ b/bindings/python/iree/runtime/hal.h
@@ -115,6 +115,71 @@ class HalBuffer : public ApiRefCounted<HalBuffer, iree_hal_buffer_t> {
   }
 };
 
+// Wrapper around an iree_hal_buffer_mapping_t and iree_hal_buffer_view_t
+// which retains the latter and unmaps/releases on deallocation.
+class HalMappedMemory {
+ public:
+  HalMappedMemory(iree_hal_buffer_mapping_t mapped_memory,
+                  iree_hal_buffer_view_t* bv)
+      : mapped_memory_(mapped_memory), bv_(bv) {
+    iree_hal_buffer_view_retain(bv_);
+  }
+  ~HalMappedMemory() {
+    if (bv_) {
+      iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(bv_);
+      iree_hal_buffer_unmap_range(&mapped_memory_);
+      iree_hal_buffer_view_release(bv_);
+    }
+  }
+  HalMappedMemory(HalMappedMemory&& other)
+      : mapped_memory_(other.mapped_memory_), bv_(other.bv_) {
+    other.bv_ = nullptr;
+  }
+
+  static HalMappedMemory Create(HalBufferView& bv) {
+    iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(bv.raw_ptr());
+    iree_device_size_t byte_length = iree_hal_buffer_byte_length(buffer);
+    iree_hal_buffer_mapping_t mapped_memory;
+    CheckApiStatus(iree_hal_buffer_map_range(
+                       buffer, IREE_HAL_MEMORY_ACCESS_READ,
+                       0 /* element_offset */, byte_length, &mapped_memory),
+                   "Could not map memory");
+    return HalMappedMemory(mapped_memory, bv.raw_ptr());
+  }
+
+  py::buffer_info ToBufferInfo() {
+    absl::InlinedVector<int32_t, 6> shape(iree_hal_buffer_view_shape_rank(bv_));
+    CheckApiStatus(
+        iree_hal_buffer_view_shape(bv_, shape.size(), shape.data(), nullptr),
+        "Error getting buffer view shape");
+    iree_hal_element_type_t element_type =
+        iree_hal_buffer_view_element_type(bv_);
+    int32_t element_size = iree_hal_element_byte_count(element_type);
+    absl::InlinedVector<py::ssize_t, 6> dims(shape.size());
+    for (int i = 0; i < shape.size(); ++i) {
+      dims[i] = shape[i];
+    }
+    absl::InlinedVector<py::ssize_t, 8> strides(shape.size());
+    if (!strides.empty()) {
+      strides[shape.size() - 1] = element_size;
+      for (int i = shape.size() - 2; i >= 0; --i) {
+        strides[i] = strides[i + 1] * shape[i + 1];
+      }
+    }
+
+    // TODO(laurenzo): We need to figure out how to propagate dtype in the
+    // buffer view.
+    return py::buffer_info(
+        mapped_memory_.contents.data, element_size,
+        py::format_descriptor<float>::format(),  // TODO(laurenzo): DTYPE!
+        shape.size(), dims, strides);
+  }
+
+ private:
+  iree_hal_buffer_mapping_t mapped_memory_;
+  iree_hal_buffer_view_t* bv_;
+};
+
 void SetupHalBindings(pybind11::module m);
 
 }  // namespace python

--- a/bindings/python/iree/runtime/hal.h
+++ b/bindings/python/iree/runtime/hal.h
@@ -167,11 +167,9 @@ class HalMappedMemory {
       }
     }
 
-    // TODO(laurenzo): We need to figure out how to propagate dtype in the
-    // buffer view.
     return py::buffer_info(
         mapped_memory_.contents.data, element_size,
-        py::format_descriptor<float>::format(),  // TODO(laurenzo): DTYPE!
+        py::format_descriptor<float>::format(),
         shape.size(), dims, strides);
   }
 

--- a/bindings/python/iree/runtime/system_api.py
+++ b/bindings/python/iree/runtime/system_api.py
@@ -39,6 +39,7 @@ import sys
 from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 from . import binding as _binding
+from .function import FunctionInvoker
 
 import numpy as np
 
@@ -243,6 +244,10 @@ class BoundModule:
   def name(self):
     return self._vm_module.name
 
+  @property
+  def vm_module(self):
+    return self._vm_module
+
   def __getattr__(self, name):
     try:
       return self[name]
@@ -256,7 +261,20 @@ class BoundModule:
 
     vm_function = self._vm_module.lookup_function(name)
     if vm_function is None:
-      raise KeyError(f"Function '{name}' not found in module '{self.name}'")
+      raise KeyError(f"Function '{name}' not found in module '{self}'")
+
+    # TODO: Remove this fork and delete the local BoundFunction once SIP is
+    # removed. We take the new path if there is a native IREE ABI attribute
+    # or no SIP ('f') attribute.
+    reflection_dict = vm_function.reflection
+    if "iree.abi" in reflection_dict or "f" not in reflection_dict:
+      # TODO: Needing to know the precise device to allocate on here is bad
+      # layering and will need to be fixed in some fashion if/when doing
+      # heterogenous dispatch.
+      return FunctionInvoker(self._context.vm_context,
+                             self._context.config.device, vm_function)
+
+    # Legacy SIP path.
     bound_function = BoundFunction(self._context, vm_function)
     self._lazy_functions[name] = bound_function
     return bound_function
@@ -299,6 +317,10 @@ class SystemContext:
       self._modules = Modules([
           (m.name, BoundModule(self, m)) for m in init_modules
       ])
+
+  @property
+  def vm_context(self) -> _binding.VmContext:
+    return self._vm_context
 
   @property
   def is_dynamic(self) -> bool:

--- a/bindings/python/iree/runtime/system_api.py
+++ b/bindings/python/iree/runtime/system_api.py
@@ -110,7 +110,7 @@ class Config:
   device: _binding.HalDevice
   vm_instance: _binding.VmInstance
   host_type_factory: _binding.HostTypeFactory
-  default_modules: Tuple[AnyModule]
+  default_modules: Sequence[AnyModule]
 
   def __init__(self, driver_name: Optional[str] = None):
     self.vm_instance = _binding.VmInstance()

--- a/bindings/python/iree/runtime/vm.h
+++ b/bindings/python/iree/runtime/vm.h
@@ -98,6 +98,9 @@ class VmVariantList {
   }
 
   std::string DebugString() const;
+  void PushBufferView(HalDevice& device, py::object py_buffer_object,
+                      iree_hal_element_type_e element_type);
+  py::object GetAsNdarray(int index);
 
  private:
   VmVariantList(iree_vm_list_t* list) : list_(list) {}


### PR DESCRIPTION
* The code is much more straight-line, directly using low level VM facilities instead of indirecting through custom C++ structures. The dispatch itself is in Python but could be hoisted to C++ if it ever became a performance bottleneck (given the type manipulation and switchiness, may not be much faster).
* No tests yet and can only be triggered with modules compiled with as-yet-uncommitted flags and patches. Need to resolve the chicken-and-egg to take it further.
* Once complete, we can fully delete SIP, function_abi.[h|cc], host_type.[h|cc], and old code in system_api.py.
* Provides the bones to fix #5359 correctly (partially fixed now, will be fully fixed once the type converters are fully in place).
* Verified with manually compiled static workloads without nesting.