### PR TITLE
Minor change in build instructions of getting_started_python.md

### DIFF
--- a/docs/get_started/getting_started_python.md
+++ b/docs/get_started/getting_started_python.md
@@ -64,7 +64,10 @@ $ python -m pip install numpy absl-py
 Configure:
 
 ```shell
-$ cmake -G Ninja -B ../iree-build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
+cmake -B ../iree-build/ -G Ninja \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DIREE_BUILD_PYTHON_BINDINGS=ON  .
 ```
 
 Build all targets:

--- a/docs/get_started/getting_started_python.md
+++ b/docs/get_started/getting_started_python.md
@@ -78,14 +78,18 @@ $ cmake --build ../iree-build/
 
 ## Running Python Tests
 
-We continue to assume that we are in the build directory where we made the build
-in the previous section.
+Move into the build directory where we made the build in the previous section.
+
+```shell
+$ cd ../iree-build/
+```
 
 To run tests for core Python bindings built with CMake:
 
 ```shell
 $ ctest -L bindings/python
 ```
+
 ## Using Colab
 
 There are some sample colabs in the `colab` folder. If you have built the

--- a/docs/get_started/getting_started_python.md
+++ b/docs/get_started/getting_started_python.md
@@ -61,22 +61,16 @@ $ python -m pip install numpy absl-py
 
 ## Building
 
-From the *parent* directory of the IREE git repository clone, create and enter a
-build directory, such as:
+Configure:
 
 ```shell
-$ mkdir iree-build
-$ cd iree-build
+$ cmake -G Ninja -B ../iree-build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .
 ```
 
-Then build like this:
+Build all targets:
 
 ```shell
-$ cmake ../iree -G Ninja \
-    -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_CXX_COMPILER=clang++ \
-    -DIREE_BUILD_PYTHON_BINDINGS=ON  .
-$ cmake --build .
+$ cmake --build ../iree-build/
 ```
 
 ## Running Python Tests


### PR DESCRIPTION
These instructions are taken from https://google.github.io/iree/get-started/getting-started-linux-cmake#build. If we can build the project without changing the directory it feels better in browsing source code.