### PR TITLE
Adding `-iree-vm-emit-polyglot-zip` flag.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
@@ -82,6 +82,9 @@ class ExecutableCreateOpConversion
             .str(),
         executableBinaryOp.data());
     rodataOp.setPrivate();
+    if (executableBinaryOp.mime_type().hasValue()) {
+      rodataOp.mime_typeAttr(executableBinaryOp.mime_typeAttr());
+    }
     rewriter.restoreInsertionPoint(insertPoint);
 
     auto executableFormatString = detail::rewriteAttrToOperands(

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2161,7 +2161,8 @@ def HAL_ExecutableBinaryOp : HAL_Op<"executable.binary", [
   let arguments = (ins
     StrAttr:$sym_name,
     StrAttr:$format,
-    HAL_ExecutableDataAttr:$data
+    HAL_ExecutableDataAttr:$data,
+    OptionalAttr<StrAttr>:$mime_type
     // TODO(benvanik): add compatibility and versioning attributes.
   );
 

--- a/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -176,10 +176,12 @@ class CUDATargetBackend final : public TargetBackend {
     iree_CUDAExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.
-    executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+    auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
         targetOp.getLoc(), targetOp.sym_name(),
         executableBuilder.getStringAttr("PTXE"),
         builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.mime_typeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
 
     return success();
   }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -318,9 +318,11 @@ class LLVMAOTTargetBackend final : public TargetBackend {
 
       // Add the binary to the parent hal.executable.
       auto executableFormatAttr = executableBuilder.getStringAttr("EX_ELF");
-      executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+      auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
           targetOp.getLoc(), targetOp.sym_name(), executableFormatAttr,
           bufferAttr);
+      binaryOp.mime_typeAttr(
+          executableBuilder.getStringAttr("application/x-elf"));
     } else {
       FlatbufferBuilder builder;
       iree_DyLibExecutableDef_start_as_root(builder);
@@ -359,9 +361,11 @@ class LLVMAOTTargetBackend final : public TargetBackend {
                                       : executableBuilder.getStringAttr("DLIB");
 
       // Add the binary data to the target executable.
-      executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+      auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
           targetOp.getLoc(), targetOp.sym_name(), executableFormatAttr,
           builder.getBufferAttr(executableBuilder.getContext()));
+      binaryOp.mime_typeAttr(
+          executableBuilder.getStringAttr("application/x-flatbuffers"));
     }
     return success();
   }

--- a/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -132,10 +132,12 @@ class MetalSPIRVTargetBackend : public SPIRVTargetBackend {
     iree_MetalExecutableDef_end_as_root(builder);
 
     // 5. Add the binary data to the target executable.
-    executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+    auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
         targetOp.getLoc(), targetOp.sym_name(),
         executableBuilder.getStringAttr("MTLE"),
         builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.mime_typeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
 
     return success();
   }

--- a/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
@@ -123,10 +123,12 @@ class VMLATargetBackend final : public TargetBackend {
     // Add the binary data to the target executable.
     // NOTE: this snapshots the flatbuffer builder data at the time it is called
     // and future changes will not be observed.
-    executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+    auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
         targetOp.getLoc(), targetOp.sym_name(),
         executableBuilder.getStringAttr("VMLA"),
         builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.mime_typeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
     return success();
   }
 

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -153,10 +153,12 @@ class VulkanSPIRVTargetBackend : public SPIRVTargetBackend {
     iree_SpirVExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.
-    executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+    auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
         targetOp.getLoc(), targetOp.sym_name(),
         executableBuilder.getStringAttr("SPVE"),
         builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.mime_typeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
 
     return success();
   }

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -890,7 +890,8 @@ def VM_RodataOp : VM_Op<"rodata", [
     StrAttr:$sym_name,
     ElementsAttr:$value,
     OptionalAttr<I64Attr>:$alignment,
-    OptionalAttr<VM_Ordinal>:$ordinal
+    OptionalAttr<VM_Ordinal>:$ordinal,
+    OptionalAttr<StrAttr>:$mime_type
   );
 
   let skipDefaultBuilders = 1;

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
@@ -53,6 +53,10 @@ struct BytecodeTargetOptions {
   bool stripSourceMap = false;
   // Strips vm ops with the VM_DebugOnly trait.
   bool stripDebugOps = false;
+
+  // Enables the output .vmfb to be inspected as a ZIP file.
+  // This is only useful for debugging and should be disabled otherwise.
+  bool emitPolyglotZip = false;
 };
 
 // Translates a vm.module to a bytecode module flatbuffer.

--- a/iree/compiler/Dialect/VM/Target/Bytecode/ConstantEncoder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/ConstantEncoder.cpp
@@ -14,6 +14,7 @@
 
 #include "iree/compiler/Dialect/VM/Target/Bytecode/ConstantEncoder.h"
 
+#include "llvm/Support/CRC.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
@@ -25,14 +26,13 @@ namespace VM {
 
 // TODO(benvanik): switch to LLVM's BinaryStreamWriter to handle endianness.
 
-static flatbuffers_uint8_vec_ref_t serializeConstantI8Array(
-    DenseIntElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
+static void serializeConstantI8Array(DenseIntElementsAttr attr,
+                                     size_t alignment, FlatbufferBuilder &fbb) {
   // vm.rodata and other very large constants end up as this; since i8 is i8
   // everywhere (endianness doesn't matter when you have one byte :) we can
   // directly access the data and memcpy.
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr =
-      flatbuffers_uint8_vec_extend(fbb, attr.getNumElements() * sizeof(int8_t));
+  int64_t totalSize = attr.getNumElements() * sizeof(int8_t);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
   if (attr.isSplat()) {
     // NOTE: this is a slow path and we should have eliminated it earlier on
     // during constant op conversion.
@@ -43,96 +43,93 @@ static flatbuffers_uint8_vec_ref_t serializeConstantI8Array(
     auto rawData = attr.getRawData();
     std::memcpy(bytePtr, rawData.data(), rawData.size());
   }
-  return flatbuffers_uint8_vec_end(fbb);
 }
 
-static flatbuffers_uint8_vec_ref_t serializeConstantI16Array(
-    DenseIntElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(
-      fbb, attr.getNumElements() * sizeof(int16_t));
+static void serializeConstantI16Array(DenseIntElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(int16_t);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
   uint16_t *nativePtr = reinterpret_cast<uint16_t *>(bytePtr);
   for (const APInt &value : attr.getIntValues()) {
     *(nativePtr++) = value.extractBitsAsZExtValue(16, 0) & UINT16_MAX;
   }
-  return flatbuffers_uint8_vec_end(fbb);
 }
 
-static flatbuffers_uint8_vec_ref_t serializeConstantI32Array(
-    DenseIntElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(
-      fbb, attr.getNumElements() * sizeof(int32_t));
+static void serializeConstantI32Array(DenseIntElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(int32_t);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
   uint32_t *nativePtr = reinterpret_cast<uint32_t *>(bytePtr);
   for (const APInt &value : attr.getIntValues()) {
     *(nativePtr++) = value.extractBitsAsZExtValue(32, 0) & UINT32_MAX;
   }
-  return flatbuffers_uint8_vec_end(fbb);
 }
 
-static flatbuffers_uint8_vec_ref_t serializeConstantI64Array(
-    DenseIntElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(
-      fbb, attr.getNumElements() * sizeof(int64_t));
+static void serializeConstantI64Array(DenseIntElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(int64_t);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
   uint64_t *nativePtr = reinterpret_cast<uint64_t *>(bytePtr);
   for (const APInt &value : attr.getIntValues()) {
     *(nativePtr++) = value.extractBitsAsZExtValue(64, 0) & UINT64_MAX;
   }
-  return flatbuffers_uint8_vec_end(fbb);
 }
 
-static flatbuffers_uint8_vec_ref_t serializeConstantF32Array(
-    DenseFPElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr =
-      flatbuffers_uint8_vec_extend(fbb, attr.getNumElements() * sizeof(float));
-  float *nativePtr = reinterpret_cast<float *>(bytePtr);
-  for (const APFloat &value : attr.getFloatValues()) {
-    *(nativePtr++) = value.convertToFloat();
-  }
-  return flatbuffers_uint8_vec_end(fbb);
-}
-
-static flatbuffers_uint8_vec_ref_t serializeConstantF64Array(
-    DenseFPElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr =
-      flatbuffers_uint8_vec_extend(fbb, attr.getNumElements() * sizeof(double));
-  double *nativePtr = reinterpret_cast<double *>(bytePtr);
-  for (const APFloat &value : attr.getFloatValues()) {
-    *(nativePtr++) = value.convertToDouble();
-  }
-  return flatbuffers_uint8_vec_end(fbb);
-}
-
-static flatbuffers_uint8_vec_ref_t serializeConstantF16Array(
-    DenseFPElementsAttr attr, size_t alignment, FlatbufferBuilder &fbb) {
-  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
-  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(
-      fbb, attr.getNumElements() * sizeof(uint16_t));
+static void serializeConstantF16Array(DenseFPElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(uint16_t);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
   uint16_t *nativePtr = reinterpret_cast<uint16_t *>(bytePtr);
   for (const APFloat &value : attr.getFloatValues()) {
     *(nativePtr++) =
         value.bitcastToAPInt().extractBitsAsZExtValue(16, 0) & UINT16_MAX;
   }
-  return flatbuffers_uint8_vec_end(fbb);
 }
 
-flatbuffers_uint8_vec_ref_t serializeConstant(Location loc,
-                                              ElementsAttr elementsAttr,
-                                              size_t alignment,
-                                              FlatbufferBuilder &fbb) {
+static void serializeConstantF32Array(DenseFPElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(float);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
+  float *nativePtr = reinterpret_cast<float *>(bytePtr);
+  for (const APFloat &value : attr.getFloatValues()) {
+    *(nativePtr++) = value.convertToFloat();
+  }
+}
+
+static void serializeConstantF64Array(DenseFPElementsAttr attr,
+                                      size_t alignment,
+                                      FlatbufferBuilder &fbb) {
+  int64_t totalSize = attr.getNumElements() * sizeof(double);
+  uint8_t *bytePtr = flatbuffers_uint8_vec_extend(fbb, totalSize);
+  double *nativePtr = reinterpret_cast<double *>(bytePtr);
+  for (const APFloat &value : attr.getFloatValues()) {
+    *(nativePtr++) = value.convertToDouble();
+  }
+}
+
+SerializedConstantRef serializeConstant(Location loc, ElementsAttr elementsAttr,
+                                        size_t alignment, bool calculateCRC32,
+                                        FlatbufferBuilder &fbb) {
+  flatcc_builder_start_vector(fbb, 1, alignment, FLATBUFFERS_COUNT_MAX(1));
   if (auto attr = elementsAttr.dyn_cast<DenseIntElementsAttr>()) {
     switch (attr.getType().getElementTypeBitWidth()) {
       case 8:
-        return serializeConstantI8Array(attr, alignment, fbb);
+        serializeConstantI8Array(attr, alignment, fbb);
+        break;
       case 16:
-        return serializeConstantI16Array(attr, alignment, fbb);
+        serializeConstantI16Array(attr, alignment, fbb);
+        break;
       case 32:
-        return serializeConstantI32Array(attr, alignment, fbb);
+        serializeConstantI32Array(attr, alignment, fbb);
+        break;
       case 64:
-        return serializeConstantI64Array(attr, alignment, fbb);
+        serializeConstantI64Array(attr, alignment, fbb);
+        break;
       default:
         emitError(loc) << "unhandled element bitwidth "
                        << attr.getType().getElementTypeBitWidth();
@@ -141,20 +138,37 @@ flatbuffers_uint8_vec_ref_t serializeConstant(Location loc,
   } else if (auto attr = elementsAttr.dyn_cast<DenseFPElementsAttr>()) {
     switch (attr.getType().getElementTypeBitWidth()) {
       case 16:
-        return serializeConstantF16Array(attr, alignment, fbb);
+        serializeConstantF16Array(attr, alignment, fbb);
+        break;
       case 32:
-        return serializeConstantF32Array(attr, alignment, fbb);
+        serializeConstantF32Array(attr, alignment, fbb);
+        break;
       case 64:
-        return serializeConstantF64Array(attr, alignment, fbb);
+        serializeConstantF64Array(attr, alignment, fbb);
+        break;
       default:
         emitError(loc) << "unhandled element bitwidth "
                        << attr.getType().getElementTypeBitWidth();
         return {};
     }
+  } else {
+    emitError(loc) << "unimplemented attribute encoding: "
+                   << elementsAttr.getType();
+    return {};
   }
-  emitError(loc) << "unimplemented attribute encoding: "
-                 << elementsAttr.getType();
-  return {};
+
+  uint8_t *dataPtr =
+      reinterpret_cast<uint8_t *>(flatcc_builder_vector_edit(fbb));
+  size_t totalSize = flatcc_builder_vector_count(fbb);
+  uint32_t crc32Value = 0;
+  if (calculateCRC32) {
+    crc32Value = llvm::crc32(0u, ArrayRef<uint8_t>(dataPtr, totalSize));
+  }
+  return SerializedConstantRef{
+      flatbuffers_uint8_vec_end(fbb),
+      static_cast<int64_t>(totalSize),
+      crc32Value,
+  };
 }
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Target/Bytecode/ConstantEncoder.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/ConstantEncoder.h
@@ -25,11 +25,19 @@ namespace iree_compiler {
 namespace IREE {
 namespace VM {
 
+struct SerializedConstantRef {
+  flatbuffers_uint8_vec_ref_t ref = 0;
+  int64_t totalSize = 0;
+  uint32_t crc32 = 0;
+};
+
 // Serializes a constant attribute to the FlatBuffer as a binary blob.
-flatbuffers_uint8_vec_ref_t serializeConstant(Location loc,
-                                              ElementsAttr elementsAttr,
-                                              size_t alignment,
-                                              FlatbufferBuilder &fbb);
+// Returns the size in bytes of the serialized value and the flatbuffers offset
+// to the uint8 vec containing the data. If |calculateCRC32| is provided then a
+// CRC32 of the data will be computed and returned as well.
+SerializedConstantRef serializeConstant(Location loc, ElementsAttr elementsAttr,
+                                        size_t alignment, bool calculateCRC32,
+                                        FlatbufferBuilder &fbb);
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
@@ -66,6 +66,13 @@ static llvm::cl::opt<bool> stripDebugOpsFlag{
     llvm::cl::init(false),
 };
 
+static llvm::cl::opt<bool> emitPolyglotZipFlag{
+    "iree-vm-emit-polyglot-zip",
+    llvm::cl::desc(
+        "Enables output files to be viewed as zip files for debugging"),
+    llvm::cl::init(true),
+};
+
 BytecodeTargetOptions getBytecodeTargetOptionsFromFlags() {
   BytecodeTargetOptions targetOptions;
   targetOptions.outputFormat = outputFormatFlag;
@@ -73,6 +80,11 @@ BytecodeTargetOptions getBytecodeTargetOptionsFromFlags() {
   targetOptions.stripSymbols = stripSymbolsFlag;
   targetOptions.stripSourceMap = stripSourceMapFlag;
   targetOptions.stripDebugOps = stripDebugOpsFlag;
+  targetOptions.emitPolyglotZip = emitPolyglotZipFlag;
+  if (outputFormatFlag != BytecodeOutputFormat::kFlatBufferBinary) {
+    // Only allow binary output formats to also be .zip files.
+    targetOptions.emitPolyglotZip = false;
+  }
   return targetOptions;
 }
 

--- a/iree/compiler/Utils/FlatbufferUtils.h
+++ b/iree/compiler/Utils/FlatbufferUtils.h
@@ -169,13 +169,13 @@ class raw_flatbuffer_uint8_vec_ostream : public llvm::raw_ostream {
   void write_impl(const char *Ptr, size_t Size) override {
     flatbuffers_uint8_vec_append(builder,
                                  reinterpret_cast<const uint8_t *>(Ptr), Size);
+    pos += Size;
   }
 
-  uint64_t current_pos() const override {
-    return tell() - GetNumBytesInBuffer();
-  }
+  uint64_t current_pos() const override { return pos - GetNumBytesInBuffer(); }
 
   flatcc_builder_t *builder;
+  uint64_t pos = 0;
 };
 
 }  // namespace iree_compiler


### PR DESCRIPTION
This allows .vmfb outputs to be opened/unzipped as if they were .zip files.
The behavior isn't required by the runtime and this is just to make getting binary blobs out of the flatbuffers easier. Release outputs that would strip debug symbols would likely also want to disable this as it adds a few KB.

Specifically, it's now possible to extract the executable binaries in ELF format. SPIR-V and PTX still have flatbuffer wrappers so they aren't directly usable yet but that will be fixed in the future.

![image](https://user-images.githubusercontent.com/75337/116906592-523d0500-abf5-11eb-8a29-c3cb53226699.png)
