### PR TITLE
Disable mobilenet-v2 benchmark while it fails to compile.

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -223,42 +223,43 @@ MODEL_BENCHMARKS = [
                                targets=get_s20_default_target_list(
                                    skipped_target=["cpu2", "vlk2"],)),
         ]),
-    ModelBenchmarkInfo(
-        name="mobilenet-v2",
-        model_artifacts_name="mobilenet-v2.tar.gz",
-        model_path="mobilenet-v2/iree_input.mlir",
-        flagfile_path="mobilenet-v2/flagfile",
-        phones=[
-            PhoneBenchmarkInfo(
-                name="Pixel4",
-                benchmark_key="6338759231537152",
-                targets=get_pixel4_default_target_list(
-                    skipped_target=["vlk2"],
-                    compilation_flags={
-                        'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
-                        ],
-                        'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
-                        ]
-                    })),
-            PhoneBenchmarkInfo(
-                name="S20",
-                benchmark_key="5618403088793600",
-                targets=get_s20_default_target_list(
-                    compilation_flags={
-                        'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
-                        ],
-                        'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
-                        ]
-                    })),
-        ]),
+    # TODO(thomasraoux): re-enable once this compiles successfully again
+    # ModelBenchmarkInfo(
+    #     name="mobilenet-v2",
+    #     model_artifacts_name="mobilenet-v2.tar.gz",
+    #     model_path="mobilenet-v2/iree_input.mlir",
+    #     flagfile_path="mobilenet-v2/flagfile",
+    #     phones=[
+    #         PhoneBenchmarkInfo(
+    #             name="Pixel4",
+    #             benchmark_key="6338759231537152",
+    #             targets=get_pixel4_default_target_list(
+    #                 skipped_target=["vlk2"],
+    #                 compilation_flags={
+    #                     'cpu': [
+    #                         "--iree-flow-dispatch-formation-enable-operand-fusion",
+    #                         "-iree-llvm-loop-unrolling=true"
+    #                     ],
+    #                     'cpu3t': [
+    #                         "--iree-flow-dispatch-formation-enable-operand-fusion",
+    #                         "-iree-llvm-loop-unrolling=true"
+    #                     ]
+    #                 })),
+    #         PhoneBenchmarkInfo(
+    #             name="S20",
+    #             benchmark_key="5618403088793600",
+    #             targets=get_s20_default_target_list(
+    #                 compilation_flags={
+    #                     'cpu': [
+    #                         "--iree-flow-dispatch-formation-enable-operand-fusion",
+    #                         "-iree-llvm-loop-unrolling=true"
+    #                     ],
+    #                     'cpu3t': [
+    #                         "--iree-flow-dispatch-formation-enable-operand-fusion",
+    #                         "-iree-llvm-loop-unrolling=true"
+    #                     ]
+    #                 })),
+    #     ]),
     ModelBenchmarkInfo(
         name="mobilebert-f16",
         model_artifacts_name="mobilebert-f16.tar.gz",


### PR DESCRIPTION
First failure: https://buildkite.com/iree/iree-android-benchmark/builds/2428

```
subprocess.CalledProcessError: Command '['build-host/iree/tools/iree-translate', 'mobilenet-v2/iree_input.mlir', '--iree-mlir-to-vm-bytecode-module', '--iree-hal-target-backends=vulkan-spirv', '-o', 'mobilenet-v2_S20_vlk.vmfb', '--iree-vulkan-target-triple=valhall-g77-unknown-android10', '--iree-flow-inline-constants-max-byte-length=16', '--iree-flow-dispatch-formation-enable-operand-fusion']' returned non-zero exit status 1.
```

Tested at https://buildkite.com/iree/iree-android-benchmark/builds/2447