### PR TITLE
[MLIR][IREE] Add `shape.from_extent_tensor` to `shapex.*` conversion

### DIFF
--- a/iree/compiler/Dialect/Shape/Conversion/ConvertShapeToShapex.cpp
+++ b/iree/compiler/Dialect/Shape/Conversion/ConvertShapeToShapex.cpp
@@ -273,6 +273,25 @@ class ConvertToExtentTensorOp
   }
 };
 
+class ConvertFromExtentTensorOp
+    : public OpConversionPattern<shape::FromExtentTensorOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      shape::FromExtentTensorOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    if (operands.front().getType().isa<RankedTensorType>()) {
+      rewriter.replaceOpWithNewOp<Shape::FromExtentTensorOp>(op,
+                                                             operands.front());
+      return success();
+    }
+    if (operands.front().getType().isa<RankedShapeType>()) {
+      rewriter.replaceOp(op, operands.front());
+      return success();
+    }
+    return failure();
+  }
+};
+
 // Currently, upstream shape lowering can use tensor<?xindex> to represent a
 // shape, and will insert tensor_cast ops to convert to specific extent tensor
 // types. However, not all tensor_cast ops are shape-related.
@@ -311,6 +330,7 @@ class ConvertShapeToShapex
     patterns.insert<ConvertTensorExtract>(context);
     patterns.insert<ConvertGetExtent>(context);
     patterns.insert<ConvertFromExtents>(context);
+    patterns.insert<ConvertFromExtentTensorOp>(context);
     patterns.insert<ConvertSplitAtOp>(context);
     patterns.insert<ConvertBroadcastOp>(context);
     patterns.insert<ConvertConcatOp>(context);

--- a/iree/compiler/Dialect/Shape/Conversion/test/shape_to_shapex.mlir
+++ b/iree/compiler/Dialect/Shape/Conversion/test/shape_to_shapex.mlir
@@ -68,6 +68,16 @@ func @f(%arg0: index) {
 }
 
 // -----
+// shape.from_extent_tensor
+// CHECK-LABEL: func @f
+func @f(%arg0: tensor<3xindex>) {
+  // CHECK: "shapex.from_extent_tensor"(%arg0) : (tensor<3xindex>) -> !shapex.ranked_shape<[?,?,?]>
+  %result = "shape.from_extent_tensor"(%arg0) : (tensor<3xindex>)
+      -> !shape.shape
+  return
+}
+
+// -----
 // shape.broadcast
 // CHECK-LABEL: func @f
 func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) {
@@ -82,6 +92,22 @@ func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) {
   %2 = "shape.broadcast"(%0, %1) : (!shape.shape, !shape.shape) -> !shape.shape
   // CHECK: "foo.use"(%[[BROADCASTED]])
   "foo.use"(%2) : (!shape.shape) -> ()
+  return
+}
+
+// -----
+// shape.broadcast
+// CHECK-LABEL: func @f
+func @f(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) {
+  // CHECK: %[[LHSRS:.+]] = shapex.get_ranked_shape %arg0
+  // CHECK: %[[RHSRS:.+]] = shapex.get_ranked_shape %arg1
+  // CHECK: %[[BROADCASTED:.+]] = "shapex.ranked_broadcast_shape"(%[[LHSRS]], %[[RHSRS]])
+  // CHECK-SAME: : (!shapex.ranked_shape<[?,?]>, !shapex.ranked_shape<[?,?]>) -> !shapex.ranked_shape<[?,?]>
+  // CHECK: "use"(%[[BROADCASTED]])
+  %0 = "shape.shape_of"(%arg0) : (tensor<?x?xf32>) -> tensor<2xindex>
+  %1 = "shape.shape_of"(%arg1) : (tensor<?x?xf32>) -> tensor<2xindex>
+  %2 = "shape.broadcast"(%0, %1) : (tensor<2xindex>, tensor<2xindex>) -> tensor<2xindex>
+  "use"(%2) : (tensor<2xindex>) -> ()
   return
 }
 


### PR DESCRIPTION
Add missing `shape` to `shapex` conversion for `from_extent_tensor`. Also, add test for `broadcast` operation on ranked extent tensors.