### PR TITLE
Add support for compilation of Linalg ops with multiple results

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -109,17 +109,8 @@ static bool hasDestructiveUpdateSubTensorUses(
 // Determine whether `tensor` is produced by a destructive update of another
 // tensor. When successful, fill a SpecialTerminatorOpCapture struct that
 // captures the relevant (distributed) pieces of IR that for the destructive
-// update pattern. There are 2 cases.
-//
-// Simple case
-// ===========
-//
-// Just detect a SubTensorInsertOp.
-//
-// Loop case
-// =========
-//
-// Iteratively traverse an (imperfectly nested) loop nest such as:
+// update pattern. Iteratively traverse an (imperfectly nested) loop nest such
+// as:
 //
 // ```
 // %d0 = for  (iter_args %e0 = %0)
@@ -140,13 +131,6 @@ static bool hasDestructiveUpdateSubTensorUses(
 // value.
 static Value isADestructiveUpdatePattern(Value tensor,
                                          SpecialTerminatorOpCapture &capture) {
-  // Simple case: no loops and directly a tensorInsertOp.
-  if (auto tensorInsertOp =
-          dyn_cast_or_null<SubTensorInsertOp>(tensor.getDefiningOp())) {
-    capture.rootDestructiveUpdate = tensorInsertOp;
-    return tensorInsertOp.dest();
-  }
-
   Value returnValue;
   while (auto scfForOp = dyn_cast_or_null<scf::ForOp>(tensor.getDefiningOp())) {
     LLVM_DEBUG(llvm::dbgs()
@@ -252,25 +236,30 @@ static LogicalResult rewriteSubTensorInsertInPlace(OpBuilder &b,
                                                    Value target) {
   LLVM_DEBUG(llvm::dbgs() << "RewriteSubTensorInsertInPlace: "
                           << *(op.getOperation()) << "\n");
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPoint(op);
-  auto dest = op.dest();
-
-  // Sanity check for insert into an initArg that is immediately yielded.
-  if (!dest.isa<BlockArgument>() || !op.getResult().hasOneUse() ||
-      !isa<scf::YieldOp>(op.getResult().getUses().begin()->getOwner())) {
-    LLVM_DEBUG(llvm::dbgs() << "Rewrite failed: no single scf::YieldOp use\n");
-    return failure();
+  if (!op.getResult().hasOneUse()) {
+    return op.emitError("not a single use operation");
   }
 
-  // Kills the SSA use-def chain.
-  op.replaceAllUsesWith(dest);
+  Operation *user = *(op.getResult().getUsers().begin());
+  if (isa<scf::YieldOp>(user)) {
+    auto dest = op.dest();
+    if (!dest.isa<BlockArgument>()) {
+      return op.emitError("dest is not a argument to the loop");
+    }
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(op);
 
-  b.create<IREE::Flow::DispatchTensorStoreOp>(
-      op.getLoc(), op.source(), target, op.offsets(), op.sizes(), op.strides(),
-      op.static_offsets(), op.static_sizes(), op.static_strides());
+    // Kills the SSA use-def chain.
+    op.replaceAllUsesWith(dest);
 
-  return success();
+    b.create<IREE::Flow::DispatchTensorStoreOp>(
+        op.getLoc(), op.source(), target, op.offsets(), op.sizes(),
+        op.strides(), op.static_offsets(), op.static_sizes(),
+        op.static_strides());
+
+    return success();
+  }
+  return failure();
 }
 
 // Return true if any control flow is found in the DispatchWorkgroupsOp besides
@@ -383,15 +372,8 @@ static bool hasNonScfForControlFlow(
 // is elided.
 // This should probably become a dedicated pass based on core alias analysis,
 // when the latter becomes available.
-static LogicalResult rewriteDestructiveUpdateInPlace(OpBuilder &b, Value v,
-                                                     Value target) {
-  SpecialTerminatorOpCapture capture;
-  capture.initValue = v;
-  Value sourceValue = isADestructiveUpdatePattern(capture.initValue, capture);
-
-  // No destructive update semantics, bail.
-  if (!sourceValue || !capture.rootDestructiveUpdate) return success();
-
+static LogicalResult rewriteDestructiveUpdateInPlace(
+    OpBuilder &b, SpecialTerminatorOpCapture &capture, Value target) {
   Operation *outermostProducingOp = (capture.loops.empty())
                                         ? capture.rootDestructiveUpdate
                                         : capture.loops.front();
@@ -403,18 +385,8 @@ static LogicalResult rewriteDestructiveUpdateInPlace(OpBuilder &b, Value v,
           b, cast<SubTensorInsertOp>(capture.rootDestructiveUpdate), target))) {
     // Nothing has changed yet, so return success. SubTensorInserts will be
     // handled later.
-    return success();
+    return failure();
   }
-
-  // Reload the value produced inplace right after the inplace update.
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPointAfter(outermostProducingOp);
-  Value newLoad = b.create<IREE::Flow::DispatchTensorLoadOp>(
-      outermostProducingOp->getLoc(), v.getType(), target);
-  // TODO(nicolasvasilache): this brutally replaces all uses by the result of
-  // this load. In practice we may want more recompute and we may have lost
-  // information. Revisit this when things are more fleshed out.
-  v.replaceAllUsesWith(newLoad);
 
   if (scf::ForOp loopOp = dyn_cast<scf::ForOp>(outermostProducingOp))
     loopOp.walk([&](SubTensorOp op) { (void)propagateSubTensorOp(b, op); });
@@ -449,29 +421,31 @@ LogicalResult rewriteLinalgDestructiveUpdates(
 
   MLIRContext *context = dispatchOp->getContext();
   OpBuilder b(context);
+  SmallVector<IREE::Flow::DispatchTensorStoreOp> processedStores;
   // For each tensor store op, look for destructive updates and replace the
   // destructive pattern by a custom inplace update pattern.
   bool fail = dispatchOp
                   .walk([&](IREE::Flow::DispatchTensorStoreOp op) {
-                    if (failed(rewriteDestructiveUpdateInPlace(b, op.value(),
+                    SpecialTerminatorOpCapture capture;
+                    capture.initValue = op.value();
+                    Value sourceValue =
+                        isADestructiveUpdatePattern(capture.initValue, capture);
+                    if (!sourceValue || !isa_and_nonnull<SubTensorInsertOp>(
+                                            capture.rootDestructiveUpdate))
+                      return WalkResult::advance();
+                    if (failed(rewriteDestructiveUpdateInPlace(b, capture,
                                                                op.target()))) {
                       return WalkResult::interrupt();
                     }
+                    processedStores.push_back(op);
                     return WalkResult::advance();
                   })
                   .wasInterrupted();
   if (fail) return failure();
 
-  // For each tensor store op, redundant load/store optimization.
-  dispatchOp.walk([&](IREE::Flow::DispatchTensorStoreOp storeOp) {
-    auto loadOp = dyn_cast_or_null<IREE::Flow::DispatchTensorLoadOp>(
-        storeOp.value().getDefiningOp());
-    // Bail if there exists an interleaved aliasing.
-    if (!loadOp || hasInterleavedAliases(loadOp, storeOp)) {
-      return;
-    }
-    storeOp.erase();
-  });
+  for (auto op : processedStores) {
+    op.erase();
+  }
 
   // Non-default canonicalization patterns.
   // TODO(nicolasvasilache): add Linalg tiling canonicalization patterns,

--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -383,8 +383,6 @@ static LogicalResult rewriteDestructiveUpdateInPlace(
   // Try to rewrite inplace.
   if (failed(rewriteSubTensorInsertInPlace(
           b, cast<SubTensorInsertOp>(capture.rootDestructiveUpdate), target))) {
-    // Nothing has changed yet, so return success. SubTensorInserts will be
-    // handled later.
     return failure();
   }
 

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -644,9 +644,10 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
 
   // The only existing arguments are for the outputs. Just need to add a new
   // argument for the outputs and remap the value to use the new argument.
-  for (auto ba : block.getArguments().take_front(numOldBBArgs)) {
-    assert(ba.getType().isa<IREE::Flow::DispatchTensorType>());
-    ba.replaceAllUsesWith(block.addArgument(ba.getType()));
+  for (unsigned argNum : llvm::seq<unsigned>(0, numOldBBArgs)) {
+    BlockArgument arg = block.getArgument(argNum);
+    assert(arg.getType().isa<IREE::Flow::DispatchTensorType>());
+    arg.replaceAllUsesWith(block.addArgument(arg.getType()));
   }
   // Drop old BB args.
   block.eraseArguments(
@@ -807,10 +808,47 @@ struct TileAndDistributeOnTensorsPattern
   }
 };
 
+static bool checkAllShapesAreEqual(ArrayRef<SmallVector<Value>> shapes) {
+  assert(!shapes.empty());
+  if (shapes.size() == 1) return true;
+  auto isSameShape = [&](ArrayRef<Value> lhsShape,
+                         ArrayRef<Value> rhsShape) -> bool {
+    if (lhsShape.size() != rhsShape.size()) return false;
+    return llvm::all_of(
+        llvm::zip(lhsShape, rhsShape), [&](std::tuple<Value, Value> vals) {
+          APInt lhsInt, rhsInt;
+          Value lhs = std::get<0>(vals);
+          Value rhs = std::get<1>(vals);
+          return lhs == rhs || (matchPattern(lhs, m_ConstantInt(&lhsInt)) &&
+                                matchPattern(rhs, m_ConstantInt(&rhsInt)) &&
+                                lhsInt == rhsInt);
+        });
+  };
+  return llvm::all_of(
+      llvm::make_range(std::next(shapes.begin()), shapes.end()),
+      [&](ArrayRef<Value> shape) { return isSameShape(shapes[0], shape); });
+}
+
 /// The workload is computed based on the problem size. For a given operation,
 /// return the problem size.
-static Optional<SmallVector<Value>> getResultShape(PatternRewriter &rewriter,
-                                                   Operation *op) {
+static Optional<SmallVector<SmallVector<Value>>> getResultShapes(
+    PatternRewriter &rewriter, Operation *op) {
+  if (op->getNumResults() == 0) return llvm::None;
+  SmallVector<SmallVector<Value>> resultShapes;
+  // Check if the op implements the shape interface.
+  if (auto shapedOp = dyn_cast<InferShapedTypeOpInterface>(op)) {
+    if (failed(shapedOp.reifyReturnTypeShapesPerResultDim(rewriter,
+                                                          resultShapes))) {
+      return llvm::None;
+    }
+    return resultShapes;
+  }
+
+  // Fallback is to get the shape using `dim` of the outputs. Since the
+  // workload depends on the output shape, set the insertion point to after
+  // the operation. After dim canonicalization, the original operation should
+  // become dead.
+  rewriter.setInsertionPointAfter(op);
   Location loc = op->getLoc();
   auto getShapeOfShapedTypeVal = [&](Value v) -> SmallVector<Value> {
     SmallVector<Value> shape;
@@ -820,28 +858,14 @@ static Optional<SmallVector<Value>> getResultShape(PatternRewriter &rewriter,
     }
     return shape;
   };
-  if (op->getNumResults() != 1) return llvm::None;
-
-  // Check if the op implements the shape interface.
-  if (auto shapedOp = dyn_cast<InferShapedTypeOpInterface>(op)) {
-    SmallVector<SmallVector<Value>> resultShape;
-    if (succeeded(shapedOp.reifyReturnTypeShapesPerResultDim(rewriter,
-                                                             resultShape)) &&
-        resultShape.size() == 1) {
-      return resultShape[0];
-    }
-  }
-
-  // TODO(ravishankarm): Since the workload depends on the output shape, set the
-  // insertion point to after the operation. After dim canonicalization, the
-  // original operation should become dead. This needs to be changed after the
-  // output shape interface lands upstream and can be used in IREE.
-  if (auto resultType = op->getResult(0).getType().dyn_cast<ShapedType>()) {
+  for (OpResult result : op->getResults()) {
+    auto resultType = result.getType().dyn_cast<ShapedType>();
+    if (!resultType) return llvm::None;
     rewriter.setInsertionPointAfter(op);
-    return getShapeOfShapedTypeVal(op->getResult(0));
+    auto resultShape = getShapeOfShapedTypeVal(result);
+    resultShapes.emplace_back(std::move(resultShape));
   }
-
-  return llvm::None;
+  return resultShapes;
 }
 
 /// Puts ops that are not-tilable or arent tiled into a
@@ -869,10 +893,13 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
     }
 
     // The workgroup count is based on the result shape.
-    if (op->getNumResults() != 1) return failure();
-    Optional<SmallVector<Value>> resultShapeOpt = getResultShape(rewriter, op);
-    if (!resultShapeOpt) return failure();
-    SmallVector<Value> resultShape = *resultShapeOpt;
+    Optional<SmallVector<SmallVector<Value>>> resultShapesOpt =
+        getResultShapes(rewriter, op);
+    if (!resultShapesOpt) return failure();
+    ArrayRef<SmallVector<Value>> resultShapes = *resultShapesOpt;
+    if (resultShapes.size() != op->getNumResults() ||
+        !checkAllShapesAreEqual(resultShapes))
+      return failure();
 
     // TODO(ravishankarm): For now the Flow -> HAL conversion only handles
     // workload count of 3, though it should be generalized. For now making sure
@@ -880,7 +907,7 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
     // workloads for all higher dimensions greater than or equal to
     // kNumMaxParallelDims.
     Location loc = op->getLoc();
-    SmallVector<Value, 4> count(resultShape.begin(), resultShape.end());
+    SmallVector<Value, 4> count(resultShapes[0].begin(), resultShapes[0].end());
     if (count.size() > kNumMaxParallelDims) {
       unsigned numSymbols = 0;
       AffineExpr expr = rewriter.getAffineSymbolExpr(numSymbols++);
@@ -897,12 +924,13 @@ struct MakeDispatchWorkgroupsOp : public RewritePattern {
     auto workload = convertToWorkload(rewriter, loc, count);
 
     // Capture dynamic result dimensions.
-    assert(op->getNumResults() == 1 && "currently assuming a single result");
-    auto resultType = op->getResult(0).getType().cast<ShapedType>();
     SmallVector<Value, 4> resultDynamicDims;
-    for (unsigned i = 0; i < resultType.getRank(); ++i) {
-      if (resultType.isDynamicDim(i)) {
-        resultDynamicDims.push_back(resultShape[i]);
+    for (auto result : llvm::enumerate(op->getResults())) {
+      auto resultType = result.value().getType().cast<ShapedType>();
+      for (unsigned i = 0; i < resultType.getRank(); ++i) {
+        if (resultType.isDynamicDim(i)) {
+          resultDynamicDims.push_back(resultShapes[result.index()][i]);
+        }
       }
     }
 

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -656,3 +656,74 @@ func @inline_dag_2(
 //       CHECK:     %[[OP3:.+]] = linalg.tensor_reshape %[[LEAF1]]
 //       CHECK:     %[[OP4:.+]] = linalg.tensor_reshape %[[OP1]]
 //       CHECK:     %[[OP5:.+]] = linalg.tensor_reshape %[[OP2]]
+
+// -----
+
+func @multi_result(%arg0: tensor<?x?xi32>, %arg1: tensor<?x?xi32>) -> (tensor<?xi32>, tensor<?xi32>) {
+  %cmin = constant -2147483648 : i32
+  %c0_i32 = constant 0 : i32
+  %c0 = constant 0 : index
+  %0 = memref.dim %arg0, %c0 : tensor<?x?xi32>
+  %1 = linalg.init_tensor [%0] : tensor<?xi32>
+  %2 = linalg.fill(%1, %cmin) : tensor<?xi32>, i32 -> tensor<?xi32>
+  %3 = linalg.fill(%1, %c0_i32) : tensor<?xi32>, i32 -> tensor<?xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>,
+                       affine_map<(d0, d1) -> (d1, d0)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xi32>)
+      outs(%1, %2 : tensor<?xi32>, tensor<?xi32>) {
+  ^bb0(%arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32):  // no predecessors
+    %5 = cmpi sge, %arg2, %arg4 : i32
+    %6 = select %5, %arg2, %arg4 : i32
+    %7 = cmpi eq, %arg2, %arg4 : i32
+    %8 = cmpi slt, %arg3, %arg5 : i32
+    %9 = select %8, %arg3, %arg5 : i32
+    %10 = select %5, %arg3, %arg5 : i32
+    %11 = select %7, %9, %10 : i32
+    linalg.yield %6, %11 : i32, i32
+  } -> tensor<?xi32>, tensor<?xi32>
+  return %4#0, %4#1 : tensor<?xi32>, tensor<?xi32>
+}
+// CHECK-LABEL: func @multi_result
+//       CHECK:   %[[RESULT:.+]]:2 = flow.dispatch.workgroups
+//  CHECK-NEXT:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xi32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?xi32>
+//       CHECK:     scf.for
+//       CHECK:       %[[TILED_RESULT:.+]]:2 = linalg.generic
+//   CHECK-DAG:       flow.dispatch.tensor.store %[[TILED_RESULT]]#0, %[[ARG5]]
+//   CHECK-DAG:       flow.dispatch.tensor.store %[[TILED_RESULT]]#1, %[[ARG6]]
+//       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+func @multi_result_fallback(%arg0: tensor<?x10xi32>, %arg1: tensor<?x10xi32>)
+    -> (tensor<?x10xi32>, tensor<?x10xi32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = memref.dim %arg0, %c0 : tensor<?x10xi32>
+  %1 = linalg.init_tensor [%0, 10] : tensor<?x10xi32>
+  %2:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, 10-d1)>,
+                       affine_map<(d0, d1) -> (d0, 10-d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg1 : tensor<?x10xi32>, tensor<?x10xi32>)
+      outs(%1, %1 : tensor<?x10xi32>, tensor<?x10xi32>) {
+      ^bb0(%arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32):
+        linalg.yield %arg2, %arg3 : i32, i32
+      } -> tensor<?x10xi32>, tensor<?x10xi32>
+  return %2#0, %2#1 : tensor<?x10xi32>, tensor<?x10xi32>
+}
+// CHECK-LABEL: func @multi_result_fallback
+//       CHECK:   %[[RESULT:.+]]:2 = flow.dispatch.workgroup
+//  CHECK-NEXT:     %[[ARG5:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?x10xi32>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9_]+]]: !flow.dispatch.tensor<writeonly:?x10xi32>
+//   CHECK-NOT:     scf.for
+//       CHECK:     %[[OP_RESULT:.+]]:2 = linalg.generic
+//   CHECK-DAG:     flow.dispatch.tensor.store %[[OP_RESULT]]#0, %[[ARG5]]
+//   CHECK-DAG:     flow.dispatch.tensor.store %[[OP_RESULT]]#1, %[[ARG6]]
+//       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -25,6 +25,10 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+BACKEND_TESTS = [
+    "linalg_ops.mlir",
+]
+
 iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
@@ -52,7 +56,7 @@ iree_lit_test_suite(
             "dynamic_linalg_matmul_on_tensors_fuse_0.mlir",
             "dynamic_linalg_matmul_on_tensors_fuse_1.mlir",
             "dynamic_linalg_matmul_on_tensors_fuse_2.mlir",
-        ],
+        ] + BACKEND_TESTS,
     ),
     data = [
         "//iree/tools:IreeFileCheck",
@@ -61,4 +65,18 @@ iree_lit_test_suite(
         "//iree/tools:iree-translate",
     ],
     tags = ["hostonly"],
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_regression_linalg_ops_dylib-llvm-aot",
+    srcs = BACKEND_TESTS,
+    driver = "dylib",
+    target_backend = "dylib-llvm-aot",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_regression_linalg_ops_vulkan-spirv",
+    srcs = BACKEND_TESTS,
+    driver = "vulkan",
+    target_backend = "vulkan-spirv",
 )

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -18,6 +18,7 @@
 
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//iree:lit_test.bzl", "iree_lit_test_suite")
+load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -37,4 +37,26 @@ iree_lit_test_suite(
     "hostonly"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_regression_linalg_ops_dylib-llvm-aot
+  SRCS
+    "linalg_ops.mlir"
+  TARGET_BACKEND
+    "dylib-llvm-aot"
+  DRIVER
+    "dylib"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_regression_linalg_ops_vulkan-spirv
+  SRCS
+    "linalg_ops.mlir"
+  TARGET_BACKEND
+    "vulkan-spirv"
+  DRIVER
+    "vulkan"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/test/e2e/regression/linalg_ops.mlir
+++ b/iree/test/e2e/regression/linalg_ops.mlir
@@ -1,0 +1,33 @@
+func @multi_result() attributes {iree.module.export} {
+  %input1 = iree.unfoldable_constant dense<[
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12]]> : tensor<3x4xi32>
+  %input2 = iree.unfoldable_constant dense<[
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+      [21, 22, 23, 24]]> : tensor<3x4xi32>
+  %init = linalg.init_tensor [3, 4] : tensor<3x4xi32>
+  %0:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%input1, %input2 : tensor<3x4xi32>, tensor<3x4xi32>)
+      outs(%init, %init : tensor<3x4xi32>, tensor<3x4xi32>) {
+      ^bb0(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) :
+          %1 = addi %arg0, %arg1 : i32
+          %2 = muli %arg0, %arg1 : i32
+          linalg.yield %1, %2 : i32, i32
+      } -> tensor<3x4xi32>, tensor<3x4xi32>
+  check.expect_eq_const(%0#0, dense<[
+      [14, 16, 18, 20],
+      [22, 24, 26, 28],
+      [30, 32, 34, 36]]> : tensor<3x4xi32>) : tensor<3x4xi32>
+  check.expect_eq_const(%0#1, dense<[
+      [13, 28, 45, 64],
+      [85, 108, 133, 160],
+      [189, 220, 253, 288]]> : tensor<3x4xi32>) : tensor<3x4xi32>
+  return
+}


### PR DESCRIPTION
- The dispatch region creation is updated to handle multiple operations.
  - Handling multi-result operations seems to hit some issues with destructive update rewrites. Simplifying the logic used for those.
- Change the bufferization pass to handle multi-result linalg operations
- Add an e2e for codegen backends.

Fixes #5538