### PR TITLE
Add unsigned support for lowering mhlo concatenate and constant

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -44,6 +44,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
+#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinAttributes.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -140,7 +141,8 @@ struct ConcatenateOpConversion
   LogicalResult matchAndRewrite(
       mhlo::ConcatenateOp op, ArrayRef<Value> args,
       ConversionPatternRewriter &rewriter) const override {
-    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    auto resultType = this->typeConverter->convertType(op.getResult().getType())
+                          .dyn_cast<RankedTensorType>();
     if (!resultType || !resultType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(op,
                                          "expected static shape for output");
@@ -346,15 +348,25 @@ struct ConvertHLOToLinalgOnTensorsPass
 struct ConvertHLOToLinalgOnTensorsPassExperimental
     : public ConvertHLOToLinalgOnTensorsPass {
   ConvertHLOToLinalgOnTensorsPassExperimental()
-      : ConvertHLOToLinalgOnTensorsPass(true){};
+      : ConvertHLOToLinalgOnTensorsPass(true) {}
 };
 
 /// Convert mhlo.constant op into std.const.
-struct ConstOpConversion : public OpRewritePattern<mhlo::ConstOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(mhlo::ConstOp op,
-                                PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<ConstantOp>(op, op.value());
+struct ConstOpConversion : public OpConversionPattern<mhlo::ConstOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::ConstOp op, ArrayRef<Value> /*operands*/,
+      ConversionPatternRewriter &rewriter) const override {
+    auto valueAttr = op.value();
+    Type oldElType = valueAttr.getType().getElementType();
+    Type newElType = this->typeConverter->convertType(oldElType);
+    ElementsAttr newValueAttr = valueAttr;
+    if (newElType != oldElType) {
+      // Values don't change, just their reported type.
+      newValueAttr = valueAttr.mapValues(
+          newElType, [](const APInt &oldEl) { return oldEl; });
+    }
+    rewriter.replaceOpWithNewOp<ConstantOp>(op, newValueAttr);
     return success();
   }
 };
@@ -366,7 +378,7 @@ void populateHLOToLinalgOnTensorsConversionPatterns(
     OwningRewritePatternList &patterns) {
   mhlo::populateHLOToLinalgConversionPattern(context, typeConverter, &patterns);
   patterns.insert<ConstOpConversion, ConcatenateOpConversion, FftOpConversion>(
-      context);
+      typeConverter, context);
 }
 
 static llvm::cl::opt<bool> clUseLinalgOnTensorsPath(

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
@@ -44,7 +45,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
-#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinAttributes.h"
 
 namespace mlir {
 namespace iree_compiler {

--- a/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/concatenate.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -canonicalize %s | IreeFileCheck %s
 
-
+// CHECK-LABEL: concatenate(
 // CHECK-DAG:  %[[IN0:.+]] = hal.interface.load.tensor @io::@arg0, offset = %c0 : tensor<2x2xi32>
 // CHECK-DAG:  %[[IN1:.+]] = hal.interface.load.tensor @io::@arg1, offset = %c0 : tensor<2x3xi32>
 // CHECK:      %[[INIT:.+]] = linalg.init_tensor [2, 5] : tensor<2x5xi32>
@@ -29,6 +29,7 @@ module {
 
 // -----
 
+// CHECK-LABEL: concatenate_constant(
 // CHECK-DAG:  %[[CST:.+]] = constant dense<42> : tensor<3x2xi32>
 // CHECK-DAG:  %[[IN:.+]] = hal.interface.load.tensor @io::@arg0, offset = %c0 : tensor<2x2xi32>
 // CHECK:      %[[INIT:.+]] = linalg.init_tensor [5, 2] : tensor<5x2xi32>
@@ -38,7 +39,7 @@ module {
 // CHECK:      %[[OUT1:.+]] = subtensor_insert %[[CST]] into
 // CHECK-SAME:   %[[OUT0]][2, 0] [3, 2] [1, 1] : tensor<3x2xi32> into tensor<5x2xi32>
 module {
-  func @concatenate() {
+  func @concatenate_constant() {
     %c0 = constant 0 : index
     %0 = hal.interface.load.tensor @io::@arg0, offset = %c0 : tensor<2x2xi32>
     %1 = constant dense<42> : tensor<3x2xi32>
@@ -46,6 +47,36 @@ module {
       dimension = 0
     } : (tensor<2x2xi32>, tensor<3x2xi32>) -> tensor<5x2xi32>
     hal.interface.store.tensor %2, @io::@ret0, offset = %c0 : tensor<5x2xi32>
+    return
+  }
+  hal.interface @io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write"
+  }
+}
+
+// -----
+
+// CHECK-LABEL: concatenate_unsigned(
+// CHECK-DAG:  %[[CST:.+]] = constant dense<42> : tensor<3x2xi32>
+// CHECK-DAG:  %[[IN:.+]] = hal.interface.load.tensor @io::@arg0, offset = %c0 : tensor<2x2xui32>
+// CHECK-DAG:  %[[IN_SIGNLESS:.+]] = unrealized_conversion_cast %[[IN]] : tensor<2x2xui32> to tensor<2x2xi32>
+// CHECK:      %[[INIT:.+]] = linalg.init_tensor [5, 2] : tensor<5x2xi32>
+// CHECK:      %[[FILL:.+]] = linalg.fill(%[[INIT]], %{{.*}}) : tensor<5x2xi32>, i32 -> tensor<5x2xi32>
+// CHECK:      %[[OUT0:.+]] = subtensor_insert %[[IN_SIGNLESS]] into
+// CHECK-SAME:   %[[FILL]][0, 0] [2, 2] [1, 1] : tensor<2x2xi32> into tensor<5x2xi32>
+// CHECK:      %[[OUT1:.+]] = subtensor_insert %[[CST]] into
+// CHECK-SAME:   %[[OUT0]][2, 0] [3, 2] [1, 1] : tensor<3x2xi32> into tensor<5x2xi32>
+// CHECK:      %[[OUT_UNSIGNED:.+]] = unrealized_conversion_cast %[[OUT1]] : tensor<5x2xi32> to tensor<5x2xui32>
+module {
+  func @concatenate_unsigned() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @io::@arg0, offset = %c0 : tensor<2x2xui32>
+    %1 = mhlo.constant dense<42> : tensor<3x2xui32>
+    %2 = "mhlo.concatenate"(%0, %1) {
+      dimension = 0
+    } : (tensor<2x2xui32>, tensor<3x2xui32>) -> tensor<5x2xui32>
+    hal.interface.store.tensor %2, @io::@ret0, offset = %c0 : tensor<5x2xui32>
     return
   }
   hal.interface @io attributes {sym_visibility = "private"} {


### PR DESCRIPTION
All this does is plumb through the type converter.

Part of https://github.com/google/iree/issues/5383 