### PR TITLE
Don't drop signedness semantics when narrowing 64-bit ints

### DIFF
--- a/iree/compiler/Dialect/Flow/Conversion/TypeConverter.cpp
+++ b/iree/compiler/Dialect/Flow/Conversion/TypeConverter.cpp
@@ -44,10 +44,9 @@ FlowTypeConverter::FlowTypeConverter() {
   // TODO(benvanik): make whether to narrow integers an option.
   addConversion([](IntegerType integerType) -> Optional<Type> {
     if (integerType.getWidth() > 32) {
-      // Don't support 64-bit types in general. Rewrite to i32 (if desired).
-      // note: std.constant op requires integer result types to be signless, so
-      // we narrow ui64 to i32 as well.
-      return IntegerType::get(integerType.getContext(), 32);
+      // Narrow to i32 preserving signedness semantics.
+      return IntegerType::get(integerType.getContext(), 32,
+                              integerType.getSignedness());
     }
     return llvm::None;
   });

--- a/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/legalize_input_types.mlir
@@ -9,7 +9,7 @@ func @constantI64() -> i64 {
 }
 
 // CHECK-LABEL: func @argUI64
-// CHECK-SAME: (%{{.*}}: i32) -> i32
+// CHECK-SAME: (%{{.*}}: ui32) -> ui32
 func @argUI64(%arg: ui64) -> ui64 {
   return %arg : ui64
 }
@@ -23,9 +23,9 @@ func @hloConstantI64() -> tensor<1xi64> {
 }
 
 // CHECK-LABEL: func @hloConstantUI64
-// CHECK-SAME: () -> tensor<1xi32>
+// CHECK-SAME: () -> tensor<1xui32>
 func @hloConstantUI64() -> tensor<1xui64> {
-  // CHECK-NEXT: mhlo.constant dense<123> : tensor<1xi32>
+  // CHECK-NEXT: mhlo.constant dense<123> : tensor<1xui32>
   %c123 = mhlo.constant dense<123> : tensor<1xui64>
   return %c123 : tensor<1xui64>
 }


### PR DESCRIPTION
This is dangerous and not necessary. The proper fix is to add support for lowering
unsigned ints from mhlo to linalg and dropping the signedness there along with
encoding it in the operations used. I've sent patches to do this for the lowerings we
currently care about to avoid regression on ASR.

Fixes https://github.com/google/iree/issues/5383 