### PR TITLE
NFC: Upgrade the Flow dialect to use tablegen-based pass declarations.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//build_tools/bazel:tblgen.bzl", "gentbl")
 load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
 
 package(
@@ -65,6 +66,7 @@ cc_library(
         "DestructiveUpdateUtils.h",
         "DispatchConfig.h",
         "Passes.h",
+        "Passes.h.inc",
     ],
     deps = [
         ":Passes_inc_gen",

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -20,6 +20,21 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+gentbl(
+    name = "Passes_inc_gen",
+    tbl_outs = [
+        (
+            "-gen-pass-decls",
+            "Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    td_srcs = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
 cc_library(
     name = "Transforms",
     srcs = [
@@ -41,6 +56,7 @@ cc_library(
         "OutlineDispatchRegions.cpp",
         "OutlineDispatchRegions2.cpp",
         "OutlineLargeConstants.cpp",
+        "PassDetail.h",
         "Passes.cpp",
         "PrePostPartitioningConversion.cpp",
         "StripAndSplatConstantVariables.cpp",
@@ -51,6 +67,7 @@ cc_library(
         "Passes.h",
     ],
     deps = [
+        ":Passes_inc_gen",
         "//iree/compiler/Conversion/HLOToHLO",
         "//iree/compiler/Conversion/HLOToLinalg:HLOToLinalgOnTensors",
         "//iree/compiler/Conversion/LinalgToLinalg",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "DestructiveUpdateUtils.h"
     "DispatchConfig.h"
     "Passes.h"
+    "Passes.h.inc"
   SRCS
     "ConvertToFlowTensorOps.cpp"
     "DeduplicateExecutables.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -10,6 +10,15 @@
 
 iree_add_all_subdirs()
 
+iree_tablegen_library(
+  NAME
+    Passes_inc_gen
+  TD_FILE
+    "Passes.td"
+  OUTS
+    -gen-pass-decls Passes.h.inc
+)
+
 iree_cc_library(
   NAME
     Transforms
@@ -36,6 +45,7 @@ iree_cc_library(
     "OutlineDispatchRegions.cpp"
     "OutlineDispatchRegions2.cpp"
     "OutlineLargeConstants.cpp"
+    "PassDetail.h"
     "Passes.cpp"
     "PrePostPartitioningConversion.cpp"
     "StripAndSplatConstantVariables.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlowTensorOps.cpp
@@ -15,6 +15,8 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -233,7 +235,7 @@ struct SubTensorToTensorSlice : public OpRewritePattern<SubTensorOp> {
 
 /// Converts operations that can map to flow.tensor.* operations.
 struct ConvertToFlowTensorOpsPass
-    : public PassWrapper<ConvertToFlowTensorOpsPass, OperationPass<FuncOp>> {
+    : public ConvertToFlowTensorOpsBase<ConvertToFlowTensorOpsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Flow::FlowDialect, memref::MemRefDialect,
                     mlir::StandardOpsDialect>();
@@ -259,11 +261,6 @@ struct ConvertToFlowTensorOpsPass
 std::unique_ptr<OperationPass<FuncOp>> createConvertToFlowTensorOpsPass() {
   return std::make_unique<ConvertToFlowTensorOpsPass>();
 }
-
-static PassRegistration<ConvertToFlowTensorOpsPass> pass(
-    "iree-flow-convert-to-flow-tensor-ops-pass",
-    "Convert operations to equivalent flow.tensor.* operations",
-    [] { return std::make_unique<ConvertToFlowTensorOpsPass>(); });
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SetVector.h"
@@ -245,7 +246,7 @@ void replaceEntryPointUses(
 }  // namespace
 
 class DeduplicateExecutablesPass
-    : public PassWrapper<DeduplicateExecutablesPass, OperationPass<ModuleOp>> {
+    : public DeduplicateExecutablesBase<DeduplicateExecutablesPass> {
  public:
   explicit DeduplicateExecutablesPass() {}
   DeduplicateExecutablesPass(const DeduplicateExecutablesPass &pass) {}
@@ -322,10 +323,6 @@ class DeduplicateExecutablesPass
 std::unique_ptr<OperationPass<ModuleOp>> createDeduplicateExecutablesPass() {
   return std::make_unique<DeduplicateExecutablesPass>();
 }
-
-static PassRegistration<DeduplicateExecutablesPass> pass(
-    "iree-flow-deduplicate-executables",
-    "Deduplicates executables that are identical");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -16,6 +16,8 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/IR/Builders.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
@@ -105,7 +107,7 @@ struct PatternRewriterWithScopedReplaceOp : public PatternRewriter {
 };
 
 struct DispatchLinalgOnTensorsPass
-    : public PassWrapper<DispatchLinalgOnTensorsPass, OperationPass<FuncOp>> {
+    : public DispatchLinalgOnTensorsBase<DispatchLinalgOnTensorsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
         .insert<AffineDialect, IREE::Flow::FlowDialect, linalg::LinalgDialect,
@@ -1205,11 +1207,6 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
 std::unique_ptr<OperationPass<FuncOp>> createDispatchLinalgOnTensorsPass() {
   return std::make_unique<DispatchLinalgOnTensorsPass>();
 }
-
-static PassRegistration<DispatchLinalgOnTensorsPass> pass(
-    "iree-flow-dispatch-linalg-on-tensors-pass",
-    "Dispatch Linalg operations on tensors by using tile and distribute",
-    [] { return std::make_unique<DispatchLinalgOnTensorsPass>(); });
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchabilityAnalysis.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchabilityAnalysis.cpp
@@ -15,6 +15,8 @@
 #include <utility>
 
 #include "iree/compiler/Dialect/Flow/Analysis/Dispatchability.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -25,7 +27,7 @@ namespace IREE {
 namespace Flow {
 
 class DispatchabilityAnalysisPass
-    : public PassWrapper<DispatchabilityAnalysisPass, OperationPass<ModuleOp>> {
+    : public DispatchabilityAnalysisBase<DispatchabilityAnalysisPass> {
  public:
   DispatchabilityAnalysisPass() = default;
 
@@ -48,10 +50,6 @@ class DispatchabilityAnalysisPass
 std::unique_ptr<OperationPass<ModuleOp>> createDispatchabilityAnalysisPass() {
   return std::make_unique<DispatchabilityAnalysisPass>();
 }
-
-static PassRegistration<DispatchabilityAnalysisPass> pass(
-    "iree-flow-dispatchability-analysis",
-    "Analyzes functions to determine their dispatchability");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/ExpandVariableDynamicDims.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ExpandVariableDynamicDims.cpp
@@ -16,6 +16,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
@@ -29,8 +30,7 @@ namespace IREE {
 namespace Flow {
 
 class ExpandVariableDynamicDimsPass
-    : public PassWrapper<ExpandVariableDynamicDimsPass,
-                         OperationPass<ModuleOp>> {
+    : public ExpandVariableDynamicDimsBase<ExpandVariableDynamicDimsPass> {
  public:
   ExpandVariableDynamicDimsPass() = default;
 
@@ -139,11 +139,6 @@ class ExpandVariableDynamicDimsPass
 std::unique_ptr<OperationPass<ModuleOp>> createExpandVariableDynamicDimsPass() {
   return std::make_unique<ExpandVariableDynamicDimsPass>();
 }
-
-static PassRegistration<ExpandVariableDynamicDimsPass> pass(
-    "iree-flow-expand-variable-dynamic-dims",
-    "Expands !shapex.ranked_shape dynamic dimensions stored in variables.",
-    [] { return std::make_unique<ExpandVariableDynamicDimsPass>(); });
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -33,7 +34,7 @@ namespace Flow {
 //     exported attribute from the old functions.
 // The input are provided using flow.variable and flow.lookup.
 class ExportBenchmarkFuncsPass
-    : public PassWrapper<ExportBenchmarkFuncsPass, OperationPass<ModuleOp>> {
+    : public ExportBenchmarkFuncsBase<ExportBenchmarkFuncsPass> {
  public:
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();

--- a/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
@@ -14,6 +14,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -391,10 +392,11 @@ LogicalResult mergeBlockDispatchRegions(FuncOp func, Block *parentBlock) {
 // This relies on CSE having deduped workloads to simplify the logic to simply
 // looking for dispatch regions using the same values.
 class FoldCompatibleDispatchRegionsPass
-    : public PassWrapper<FoldCompatibleDispatchRegionsPass, FunctionPass> {
+    : public FoldCompatibleDispatchRegionsBase<
+          FoldCompatibleDispatchRegionsPass> {
  public:
-  void runOnFunction() override {
-    auto func = getFunction();
+  void runOnOperation() override {
+    auto func = getOperation();
     for (auto &block : func) {
       if (failed(mergeBlockDispatchRegions(func, &block))) {
         return signalPassFailure();
@@ -407,10 +409,6 @@ std::unique_ptr<OperationPass<FuncOp>>
 createFoldCompatibleDispatchRegionsPass() {
   return std::make_unique<FoldCompatibleDispatchRegionsPass>();
 }
-
-static PassRegistration<FoldCompatibleDispatchRegionsPass> pass(
-    "iree-flow-fold-compatible-dispatch-regions",
-    "Folds dispatch regions that have compatible workloads");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FoldCompatibleDispatchRegions.cpp
@@ -396,7 +396,7 @@ class FoldCompatibleDispatchRegionsPass
           FoldCompatibleDispatchRegionsPass> {
  public:
   void runOnOperation() override {
-    auto func = getOperation();
+    FuncOp func = getOperation();
     for (auto &block : func) {
       if (failed(mergeBlockDispatchRegions(func, &block))) {
         return signalPassFailure();

--- a/iree/compiler/Dialect/Flow/Transforms/FormStreams.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FormStreams.cpp
@@ -16,6 +16,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/IR/Builders.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
@@ -196,10 +197,6 @@ class FormStreamsPass : public PassWrapper<FormStreamsPass, FunctionPass> {
 std::unique_ptr<OperationPass<FuncOp>> createFormStreamsPass() {
   return std::make_unique<FormStreamsPass>();
 }
-
-static PassRegistration<FormStreamsPass> pass(
-    "iree-flow-form-streams",
-    "Identifies dispatches that can be grouped into streams within functions");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/HoistUnstreamableOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HoistUnstreamableOps.cpp
@@ -17,6 +17,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
 #include "llvm/ADT/SmallVector.h"
@@ -66,11 +67,11 @@ namespace {
 //
 // This pass shares similar goals to HoistShapeCalculationsPass, but is not
 // limited to shape calculation operations.
-class HoistUnstreamableOps
-    : public PassWrapper<HoistUnstreamableOps, FunctionPass> {
+class HoistUnstreamableOpsPass
+    : public HoistUnstreamableOpsBase<HoistUnstreamableOpsPass> {
  public:
-  void runOnFunction() override {
-    auto func = getFunction();
+  void runOnOperation() override {
+    auto func = getOperation();
     for (Block &block : func) {
       // TODO(gcmn): isBeforeInBlock is O(n) with repeated block modification,
       // making this quadratic.
@@ -96,12 +97,8 @@ class HoistUnstreamableOps
 }  // namespace
 
 std::unique_ptr<OperationPass<FuncOp>> createHoistUnstreamableOpsPass() {
-  return std::make_unique<HoistUnstreamableOps>();
+  return std::make_unique<HoistUnstreamableOpsPass>();
 }
-
-static PassRegistration<HoistUnstreamableOps> pass(
-    "iree-flow-hoist-unstreamable-ops",
-    "Hoist ops that cannot be captured in streams to the top of their block.");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
@@ -409,7 +409,7 @@ class IdentifyDispatchRegions2Pass
     auto dispatchability = getCachedParentAnalysis<Dispatchability>();
     FuncOp func = getOperation();
     if (!dispatchability.hasValue()) {
-      getOperation().emitError()
+      func.emitError()
           << "dispatchability analysis not performed "
              "on module; run -iree-flow-dispatchability-analysis first";
       return signalPassFailure();

--- a/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOpUtils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Flow/Utils/WorkloadUtils.h"
 #include "llvm/ADT/MapVector.h"
@@ -397,24 +398,24 @@ LogicalResult processBlock(Block &block, OpDispatchPolicy &policy) {
 // Identifies dispatchable ops and moves them into dispatch regions.
 // Some ops, such as call, will be deferred until following passes.
 class IdentifyDispatchRegions2Pass
-    : public PassWrapper<IdentifyDispatchRegions2Pass, FunctionPass> {
+    : public IdentifyDispatchRegions2Base<IdentifyDispatchRegions2Pass> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Flow::FlowDialect>();
   }
 
-  void runOnFunction() override {
+  void runOnOperation() override {
     // NOTE: we require the DispatchabilityAnalysisPass to have run first.
     auto dispatchability = getCachedParentAnalysis<Dispatchability>();
     if (!dispatchability.hasValue()) {
-      getFunction().emitError()
+      getOperation().emitError()
           << "dispatchability analysis not performed "
              "on module; run -iree-flow-dispatchability-analysis first";
       return signalPassFailure();
     }
 
     OpDispatchPolicy policy(*dispatchability);
-    for (auto &block : getFunction()) {
+    for (auto &block : getOperation()) {
       if (failed(processBlock(block, policy))) {
         return signalPassFailure();
       }
@@ -427,10 +428,6 @@ class IdentifyDispatchRegions2Pass
 std::unique_ptr<OperationPass<FuncOp>> createIdentifyDispatchRegions2Pass() {
   return std::make_unique<IdentifyDispatchRegions2Pass>();
 }
-
-static PassRegistration<IdentifyDispatchRegions2Pass> pass(
-    "iree-flow-identify-dispatch-regions2",
-    "Conservatively identifies dispatch regions in functions (v2)");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/IdentifyDispatchRegions2.cpp
@@ -407,6 +407,7 @@ class IdentifyDispatchRegions2Pass
   void runOnOperation() override {
     // NOTE: we require the DispatchabilityAnalysisPass to have run first.
     auto dispatchability = getCachedParentAnalysis<Dispatchability>();
+    FuncOp func = getOperation();
     if (!dispatchability.hasValue()) {
       getOperation().emitError()
           << "dispatchability analysis not performed "

--- a/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/InjectDispatchTracing.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
@@ -36,7 +37,7 @@ static SmallVector<Value, 4> filterTensorValues(ValueRange&& range) {
 }
 
 class InjectDispatchTracingPass
-    : public PassWrapper<InjectDispatchTracingPass, OperationPass<FuncOp>> {
+    : public InjectDispatchTracingBase<InjectDispatchTracingPass> {
  public:
   InjectDispatchTracingPass() = default;
 
@@ -69,10 +70,6 @@ class InjectDispatchTracingPass
 std::unique_ptr<OperationPass<FuncOp>> createInjectDispatchTracingPass() {
   return std::make_unique<InjectDispatchTracingPass>();
 }
-
-static PassRegistration<InjectDispatchTracingPass> pass(
-    "iree-flow-inject-dispatch-tracing",
-    "Outlines dispatch regions into executables");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/LegalizeInputTypes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/LegalizeInputTypes.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "iree/compiler/Dialect/Flow/Conversion/TypeConverter.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
@@ -191,7 +192,7 @@ LogicalResult convertRegion(Region &oldRegion, Region &newRegion,
 }  // namespace
 
 class LegalizeInputTypesPass
-    : public PassWrapper<LegalizeInputTypesPass, OperationPass<ModuleOp>> {
+    : public LegalizeInputTypesBase<LegalizeInputTypesPass> {
  public:
   void runOnOperation() override {
     auto moduleOp = getOperation();
@@ -237,10 +238,6 @@ class LegalizeInputTypesPass
 std::unique_ptr<OperationPass<ModuleOp>> createLegalizeInputTypesPass() {
   return std::make_unique<LegalizeInputTypesPass>();
 }
-
-static PassRegistration<LegalizeInputTypesPass> pass(
-    "iree-flow-legalize-input-types",
-    "Legalizes input types to ones supported by the IREE flow dialect");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -16,6 +16,8 @@
 
 #include "iree/compiler/Dialect/Flow/Analysis/Dispatchability.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Flow/Utils/DispatchUtils.h"
 #include "iree/compiler/Dialect/Shape/IR/Builders.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
@@ -217,7 +219,7 @@ LogicalResult outlineDispatchRegion(
 }  // namespace
 
 class OutlineDispatchRegionsPass
-    : public PassWrapper<OutlineDispatchRegionsPass, OperationPass<ModuleOp>> {
+    : public OutlineDispatchRegionsBase<OutlineDispatchRegionsPass> {
  public:
   OutlineDispatchRegionsPass() = default;
 
@@ -252,10 +254,6 @@ class OutlineDispatchRegionsPass
 std::unique_ptr<OperationPass<ModuleOp>> createOutlineDispatchRegionsPass() {
   return std::make_unique<OutlineDispatchRegionsPass>();
 }
-
-static PassRegistration<OutlineDispatchRegionsPass> pass(
-    "iree-flow-outline-dispatch-regions",
-    "Outlines dispatch regions into standalone functions");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions2.cpp
@@ -16,6 +16,8 @@
 
 #include "iree/compiler/Dialect/Flow/Analysis/Dispatchability.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Flow/Utils/DispatchUtils.h"
 #include "iree/compiler/Dialect/Shape/IR/Builders.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
@@ -203,7 +205,7 @@ static LogicalResult outlineDispatchWorkgroupsOp(
 }  // namespace
 
 class OutlineDispatchRegions2Pass
-    : public PassWrapper<OutlineDispatchRegions2Pass, OperationPass<ModuleOp>> {
+    : public OutlineDispatchRegions2Base<OutlineDispatchRegions2Pass> {
  public:
   OutlineDispatchRegions2Pass() = default;
 
@@ -236,10 +238,6 @@ class OutlineDispatchRegions2Pass
 std::unique_ptr<OperationPass<ModuleOp>> createOutlineDispatchRegions2Pass() {
   return std::make_unique<OutlineDispatchRegions2Pass>();
 }
-
-static PassRegistration<OutlineDispatchRegions2Pass> pass(
-    "iree-flow-outline-dispatch-regions2",
-    "Outlines dispatch regions into executables");
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/OutlineLargeConstants.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineLargeConstants.cpp
@@ -16,6 +16,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
@@ -64,7 +65,7 @@ static std::vector<ConstantOp> findLargeConstantsInModule(
 }
 
 class OutlineLargeConstantsPass
-    : public PassWrapper<OutlineLargeConstantsPass, OperationPass<ModuleOp>> {
+    : public OutlineLargeConstantsBase<OutlineLargeConstantsPass> {
  public:
   OutlineLargeConstantsPass() = default;
   OutlineLargeConstantsPass(size_t minLargeConstantSize)
@@ -125,14 +126,6 @@ std::unique_ptr<OperationPass<ModuleOp>> createOutlineLargeConstantsPass(
     size_t minLargeConstantSize) {
   return std::make_unique<OutlineLargeConstantsPass>(minLargeConstantSize);
 }
-
-static PassRegistration<OutlineLargeConstantsPass> pass(
-    "iree-flow-outline-large-constants",
-    "Outlines large tensor constants into flow.variables at the module level.",
-    [] {
-      // TODO(#5493): add a flag for this.
-      return std::make_unique<OutlineLargeConstantsPass>(256);
-    });
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/PassDetail.h
+++ b/iree/compiler/Dialect/Flow/Transforms/PassDetail.h
@@ -1,0 +1,33 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASS_DETAIL_H_
+#define IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASS_DETAIL_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+#define GEN_PASS_CLASSES
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASS_DETAIL_H_

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -314,6 +314,19 @@ void registerFlowTransformPassPipeline() {
       });
 }
 
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
+}  // namespace
+
+void registerFlowPasses() {
+  // Generated.
+  registerPasses();
+
+  // Pipelines.
+  registerFlowTransformPassPipeline();
+}
+
 }  // namespace Flow
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -325,6 +325,7 @@ void registerFlowPasses() {
 
   // Pipelines.
   registerFlowTransformPassPipeline();
+  registerInputTransformPassPipeline();
 }
 
 }  // namespace Flow

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -163,25 +163,7 @@ createStripAndSplatConstantVariablesPass();
 // Register all Passes
 //===----------------------------------------------------------------------===//
 
-inline void registerFlowPasses() {
-  registerInputTransformPassPipeline();
-  registerFlowTransformPassPipeline();
-  createConvertToFlowTensorOpsPass();
-  createLegalizeInputTypesPass();
-  createHLOToHLOPreprocessingPass();
-  createPrePartitioningConversionPass();
-  createExpandVariableDynamicDimsPass();
-  createDispatchabilityAnalysisPass();
-  createIdentifyDispatchRegions2Pass();
-  createFoldCompatibleDispatchRegionsPass();
-  createOutlineDispatchRegionsPass();
-  createExportBenchmarkFuncsPass();
-  createOutlineLargeConstantsPass();
-  createDeduplicateExecutablesPass();
-  createFormStreamsPass();
-  createHoistUnstreamableOpsPass();
-  createStripAndSplatConstantVariablesPass();
-}
+void registerFlowPasses();
 
 }  // namespace Flow
 }  // namespace IREE

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -1,0 +1,129 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_DIALECT_FLOW_PASSES
+#define IREE_DIALECT_FLOW_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertToFlowTensorOps :
+    Pass<"iree-flow-convert-to-flow-tensor-ops-pass", "FuncOp"> {
+  let summary = "Convert operations to equivalent flow.tensor.* operations";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertToFlowTensorOpsPass()";
+}
+
+def DeduplicateExecutables :
+    Pass<"iree-flow-deduplicate-executables", "ModuleOp"> {
+  let summary = "Deduplicates executables that are identical";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDeduplicateExecutablesPass()";
+}
+
+def DispatchabilityAnalysis :
+    Pass<"iree-flow-dispatchability-analysis", "ModuleOp"> {
+  let summary = "Analyzes functions to determine their dispatchability";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDispatchabilityAnalysisPass()";
+}
+
+def DispatchLinalgOnTensors :
+    Pass<"iree-flow-dispatch-linalg-on-tensors-pass", "FuncOp"> {
+  let summary = "Dispatch Linalg operations on tensors by using tile and distribute";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createDispatchLinalgOnTensorsPass()";
+}
+
+def ExpandVariableDynamicDims :
+    Pass<"iree-flow-expand-variable-dynamic-dims", "ModuleOp"> {
+  let summary = "Expands !shapex.ranked_shape dynamic dimensions stored in variables.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createExpandVariableDynamicDimsPass()";
+}
+
+def ExportBenchmarkFuncs :
+    Pass<"iree-flow-export-benchmark-funcs", "ModuleOp"> {
+  let summary = "Exports benchmark functions";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createExportBenchmarkFuncsPass()";
+}
+
+def FoldCompatibleDispatchRegions :
+    Pass<"iree-flow-fold-compatible-dispatch-regions", "FuncOp"> {
+  let summary = "Folds dispatch regions that have compatible workloads";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createFoldCompatibleDispatchRegionsPass()";
+}
+
+def FormStreams :
+    Pass<"iree-flow-form-streams", "FuncOp"> {
+  let summary = "Identifies dispatches that can be grouped into streams within functions";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createFormStreamsPass()";
+}
+
+def HoistUnstreamableOps :
+    Pass<"iree-flow-hoist-unstreamable-ops", "FuncOp"> {
+  let summary = "Hoist ops that cannot be captured in streams to the top of their block.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createHoistUnstreamableOpsPass()";
+}
+
+def HLOToHLOPreprocessing :
+    Pass<"iree-flow-hlo-to-hlo-preprocessing", "FuncOp"> {
+  let summary = "Apply hlo to hlo transformations for some hlo ops";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createHLOToHLOPreprocessingPass()";
+}
+
+def IdentifyDispatchRegions2 :
+    Pass<"iree-flow-identify-dispatch-regions2", "FuncOp"> {
+  let summary = "Conservatively identifies dispatch regions in functions (v2)";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createIdentifyDispatchRegions2Pass()";
+}
+
+def InjectDispatchTracing :
+    Pass<"iree-flow-inject-dispatch-tracing", "FuncOp"> {
+  let summary = "Injects dispatch region tracing";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createInjectDispatchTracingPass()";
+}
+
+def LegalizeInputTypes :
+    Pass<"iree-flow-legalize-input-types", "ModuleOp"> {
+  let summary = "Legalizes input types to ones supported by the IREE flow dialect";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createLegalizeInputTypesPass()";
+}
+
+def OutlineDispatchRegions :
+    Pass<"iree-flow-outline-dispatch-regions", "ModuleOp"> {
+  let summary = "Outlines dispatch regions into standalone functions";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineDispatchRegionsPass()";
+}
+
+def OutlineDispatchRegions2 :
+    Pass<"iree-flow-outline-dispatch-regions2", "ModuleOp"> {
+  let summary = "Outlines dispatch regions into executables";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineDispatchRegions2Pass()";
+}
+
+def OutlineLargeConstants :
+    Pass<"iree-flow-outline-large-constants", "ModuleOp"> {
+  let summary = "Outlines large tensor constants into flow.variables at the module level.";
+  // TODO(#5493): add a flag for this.
+  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineLargeConstantsPass(25)";
+}
+
+def PrePartitioningConversion :
+    Pass<"iree-flow-pre-partitioning-conversion", "FuncOp"> {
+  let summary = "Dialect conversion prior to partitioning";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createPrePartitioningConversionPass()";
+}
+
+def StripAndSplatConstantVariables :
+    Pass<"iree-flow-strip-and-splat-constant-variables", "ModuleOp"> {
+  let summary = "Strips constant flow.variables and replaces them with splats.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createStripAndSplatConstantVariablesPass()";
+}
+
+#endif  // IREE_DIALECT_FLOW_PASSES

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -48,7 +48,7 @@ def ExpandVariableDynamicDims :
 }
 
 def ExportBenchmarkFuncs :
-    Pass<"iree-flow-export-benchmark-funcs", "ModuleOp"> {
+    Pass<"iree-flow-export-benchmark-funcs-pass", "ModuleOp"> {
   let summary = "Exports benchmark functions";
   let constructor = "mlir::iree_compiler::IREE::Flow::createExportBenchmarkFuncsPass()";
 }

--- a/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/StripAndSplatConstantVariables.cpp
@@ -16,6 +16,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -27,8 +28,8 @@ namespace IREE {
 namespace Flow {
 
 class StripAndSplatConstantVariablesPass
-    : public PassWrapper<StripAndSplatConstantVariablesPass,
-                         OperationPass<ModuleOp>> {
+    : public StripAndSplatConstantVariablesBase<
+          StripAndSplatConstantVariablesPass> {
  public:
   StripAndSplatConstantVariablesPass() = default;
 
@@ -85,11 +86,6 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createStripAndSplatConstantVariablesPass() {
   return std::make_unique<StripAndSplatConstantVariablesPass>();
 }
-
-static PassRegistration<StripAndSplatConstantVariablesPass> pass(
-    "iree-flow-strip-and-splat-constant-variables",
-    "Strips constant flow.variables and replaces them with splats.",
-    [] { return std::make_unique<StripAndSplatConstantVariablesPass>(); });
 
 }  // namespace Flow
 }  // namespace IREE


### PR DESCRIPTION
* Eliminates static registration from the flow dialect.
* While a good idea to do everywhere, this was done while triaging a startup crash in release mode with assertions enabled that appeared to be static initializer based (it was not - and now still happens at registration time).
* We should do this to all passes in the system eventually (but it would be nice to delete old cruft first).