### PR TITLE
Generalizing the VM buffer type and adding VM buffer ops.

### DIFF
--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -126,8 +126,8 @@ static iree_status_t _TfLiteInterpreterShapeFrameInitialize(
 // will release any resources that may be retained and is required.
 static void _TfLiteInterpreterShapeFrameDeinitialize(
     _TfLiteInterpreterShapeFrame* frame) {
-  iree_vm_list_deinitialize(frame->shape_list);
   iree_vm_list_deinitialize(frame->arg_list);
+  iree_vm_list_deinitialize(frame->shape_list);
 }
 
 // Reads the shape value in the frame storage from the prior application.

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -348,7 +348,14 @@ def VM_FuncRefAttr : AliasedSymbolRefAttr;
 
 def VM_Ordinal : SignlessIntegerAttrBase<I32, "ordinal value">;
 
+// NOTE: today we only support a single bit width for pointers/indices/sizes.
+// This is to keep our compatability matrix smaller but is not a fundamental
+// limitation of the VM.
+// TODO(#5732): allow for this to change and be specified as an attribute of the
+// compiled module (a module compiled with 32-bit indices may not be usable on
+// a runtime compiled with 64-bit indices).
 def VM_Ptr : I<32>;
+def VM_Index : I<32>;
 
 def VM_CondValue : I<32> {
   let description = [{

--- a/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -150,10 +150,41 @@ def VM_OPC_Print                 : VM_OPC<0x7D, "Print">;
 def VM_OPC_CondBreak             : VM_OPC<0x7E, "CondBreak">;
 def VM_OPC_Break                 : VM_OPC<0x7F, "Break">;
 
+// Buffer load/store:
+// NOTE: though not used today the opcodes are chosen to allow for bit magic to
+// reduce dispatch overhead:
+//                bit 3             bit 2          bit 1-0
+//        +------------+-----------------+----------------+
+//  0xB...| load/store | unsigned/signed | byte count - 1 |
+//        +------------+-----------------+----------------+
+def VM_OPC_BufferLoadI8U         : VM_OPC<0xB0, "BufferLoadI8U">;
+def VM_OPC_BufferLoadI8S         : VM_OPC<0xB4, "BufferLoadI8S">;
+def VM_OPC_BufferLoadI16U        : VM_OPC<0xB1, "BufferLoadI16U">;
+def VM_OPC_BufferLoadI16S        : VM_OPC<0xB5, "BufferLoadI16S">;
+def VM_OPC_BufferLoadI32         : VM_OPC<0xB3, "BufferLoadI32">;
+def VM_OPC_BufferStoreI8         : VM_OPC<0xB8, "BufferStoreI8">;
+def VM_OPC_BufferStoreI16        : VM_OPC<0xB9, "BufferStoreI16">;
+def VM_OPC_BufferStoreI32        : VM_OPC<0xBB, "BufferStoreI32">;
+
+// Buffer manipulation:
+def VM_OPC_BufferAlloc           : VM_OPC<0xC0, "BufferAlloc">;
+def VM_OPC_BufferClone           : VM_OPC<0xC1, "BufferClone">;
+def VM_OPC_BufferLength          : VM_OPC<0xC2, "BufferLength">;
+def VM_OPC_BufferCopy            : VM_OPC<0xC6, "BufferCopy">;
+def VM_OPC_BufferCompare         : VM_OPC<0xC7, "BufferCompare">;
+// NOTE: lower 2 bits are byte count - 1.
+//          b3  b2          bit 1-0
+//        +---+---+----------------+
+//  0xC...| 1 | 1 | byte count - 1 |
+//        +---+---+----------------+
+def VM_OPC_BufferFillI8          : VM_OPC<0xCC, "BufferFillI8">;
+def VM_OPC_BufferFillI16         : VM_OPC<0xCD, "BufferFillI16">;
+def VM_OPC_BufferFillI32         : VM_OPC<0xCF, "BufferFillI32">;
+
 // Extension prefixes:
-def VM_OPC_PrefixExtI64          : VM_OPC<0xA0, "PrefixExtI64">;
-def VM_OPC_PrefixExtF32          : VM_OPC<0xA1, "PrefixExtF32">;
-def VM_OPC_PrefixExtF64          : VM_OPC<0xA2, "PrefixExtF64">;
+def VM_OPC_PrefixExtI64          : VM_OPC<0xE0, "PrefixExtI64">;
+def VM_OPC_PrefixExtF32          : VM_OPC<0xE1, "PrefixExtF32">;
+def VM_OPC_PrefixExtF64          : VM_OPC<0xE2, "PrefixExtF64">;
 
 // Runtime enum iree_vm_core_op_t:
 def VM_CoreOpcodeAttr :
@@ -227,7 +258,25 @@ def VM_CoreOpcodeAttr :
     VM_OPC_CondBreak,
     VM_OPC_Break,
 
-    // Extension opcodes (0xA0-0xFF):
+    VM_OPC_BufferLoadI8U,
+    VM_OPC_BufferLoadI8S,
+    VM_OPC_BufferLoadI16U,
+    VM_OPC_BufferLoadI16S,
+    VM_OPC_BufferLoadI32,
+    VM_OPC_BufferStoreI8,
+    VM_OPC_BufferStoreI16,
+    VM_OPC_BufferStoreI32,
+
+    VM_OPC_BufferAlloc,
+    VM_OPC_BufferClone,
+    VM_OPC_BufferLength,
+    VM_OPC_BufferFillI8,
+    VM_OPC_BufferFillI16,
+    VM_OPC_BufferFillI32,
+    VM_OPC_BufferCopy,
+    VM_OPC_BufferCompare,
+
+    // Extension opcodes (0xE0-0xFF):
     VM_OPC_PrefixExtI64,  // VM_ExtI64OpcodeAttr
     VM_OPC_PrefixExtF32,  // VM_ExtF32OpcodeAttr
     VM_OPC_PrefixExtF64,  // VM_ExtF64OpcodeAttr

--- a/iree/compiler/Dialect/VM/IR/VMOpcodesF32.td
+++ b/iree/compiler/Dialect/VM/IR/VMOpcodesF32.td
@@ -47,6 +47,10 @@ def VM_OPC_CmpNEF32              : VM_OPC<0x41, "CmpNEF32">;
 def VM_OPC_CmpNZF32              : VM_OPC<0x42, "CmpNZF32">;
 def VM_OPC_CmpLTF32              : VM_OPC<0x43, "CmpLTF32">;
 
+def VM_OPC_BufferLoadF32         : VM_OPC<0xB0, "BufferLoadF32">;
+def VM_OPC_BufferStoreF32        : VM_OPC<0xB1, "BufferStoreF32">;
+def VM_OPC_BufferFillF32         : VM_OPC<0xC0, "BufferFillF32">;
+
 // Runtime enum iree_vm_ext_f32_op_t:
 def VM_ExtF32OpcodeAttr :
     VM_OPC_EnumAttr<"ExtF32Opcode",
@@ -77,6 +81,10 @@ def VM_ExtF32OpcodeAttr :
     VM_OPC_CmpNEF32,
     VM_OPC_CmpNZF32,
     VM_OPC_CmpLTF32,
+
+    VM_OPC_BufferLoadF32,
+    VM_OPC_BufferStoreF32,
+    VM_OPC_BufferFillF32,
   ]>;
 
 #endif  // IREE_DIALECT_VM_OPCODES_F32

--- a/iree/compiler/Dialect/VM/IR/VMOpcodesF64.td
+++ b/iree/compiler/Dialect/VM/IR/VMOpcodesF64.td
@@ -49,6 +49,11 @@ def VM_OPC_CmpNEF64              : VM_OPC<0x41, "CmpNEF64">;
 def VM_OPC_CmpNZF64              : VM_OPC<0x42, "CmpNZF64">;
 def VM_OPC_CmpLTF64              : VM_OPC<0x43, "CmpLTF64">;
 
+// Buffer load/store:
+def VM_OPC_BufferLoadF64         : VM_OPC<0xB0, "BufferLoadF64">;
+def VM_OPC_BufferStoreF64        : VM_OPC<0xB1, "BufferStoreF64">;
+def VM_OPC_BufferFillF64         : VM_OPC<0xC0, "BufferFillF64">;
+
 // Runtime enum iree_vm_ext_f64_op_t:
 def VM_ExtF64OpcodeAttr :
     VM_OPC_EnumAttr<"ExtF64Opcode",
@@ -81,6 +86,10 @@ def VM_ExtF64OpcodeAttr :
     VM_OPC_CmpNEF64,
     VM_OPC_CmpNZF64,
     VM_OPC_CmpLTF64,
+
+    VM_OPC_BufferLoadF64,
+    VM_OPC_BufferStoreF64,
+    VM_OPC_BufferFillF64,
   ]>;
 
 #endif  // IREE_DIALECT_VM_OPCODES_F64

--- a/iree/compiler/Dialect/VM/IR/VMOpcodesI64.td
+++ b/iree/compiler/Dialect/VM/IR/VMOpcodesI64.td
@@ -56,6 +56,11 @@ def VM_OPC_CmpLTI64S             : VM_OPC<0x42, "CmpLTI64S">;
 def VM_OPC_CmpLTI64U             : VM_OPC<0x43, "CmpLTI64U">;
 def VM_OPC_CmpNZI64              : VM_OPC<0x4D, "CmpNZI64">;
 
+// Buffer load/store:
+def VM_OPC_BufferLoadI64         : VM_OPC<0xB0, "BufferLoadI64">;
+def VM_OPC_BufferStoreI64        : VM_OPC<0xB1, "BufferStoreI64">;
+def VM_OPC_BufferFillI64         : VM_OPC<0xC0, "BufferFillI64">;
+
 // Runtime enum iree_vm_ext_i64_op_t:
 def VM_ExtI64OpcodeAttr :
     VM_OPC_EnumAttr<"ExtI64Opcode",
@@ -95,6 +100,10 @@ def VM_ExtI64OpcodeAttr :
     VM_OPC_CmpLTI64S,
     VM_OPC_CmpLTI64U,
     VM_OPC_CmpNZI64,
+
+    VM_OPC_BufferLoadI64,
+    VM_OPC_BufferStoreI64,
+    VM_OPC_BufferFillI64,
   ]>;
 
 #endif  // IREE_DIALECT_VM_OPCODES_I64

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -971,6 +971,358 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
 }
 
 //===----------------------------------------------------------------------===//
+// Buffers
+//===----------------------------------------------------------------------===//
+
+def VM_BufferAllocOp :
+    VM_PureOp<"buffer.alloc", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemAlloc]>,
+    ]> {
+  let summary = [{allocates a new zero-initialized buffer}];
+  let description = [{
+    Allocates a new zero-initialized buffer with the given size in bytes.
+  }];
+
+  let arguments = (ins
+    VM_Index:$length
+  );
+  let results = (outs
+    VM_RefOf<VM_BufferType>:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BufferAlloc>,
+    VM_EncOperand<"length", 0>,
+    VM_EncResult<"result">,
+  ];
+}
+
+def VM_BufferCloneOp :
+    VM_PureOp<"buffer.clone", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemAlloc]>,
+      MemoryEffects<[MemRead]>,
+    ]> {
+  let summary = [{clones a buffer}];
+  let description = [{
+    Clones a range of the source buffer to produce a mutable buffer with the
+    same contents.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$source_buffer,
+    VM_Index:$source_offset,
+    VM_Index:$length
+  );
+  let results = (outs
+    VM_RefOf<VM_BufferType>:$result
+  );
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($source_buffer) `->` type($result)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BufferClone>,
+    VM_EncOperand<"source_buffer", 0>,
+    VM_EncOperand<"source_offset", 1>,
+    VM_EncOperand<"length", 2>,
+    VM_EncResult<"result">,
+  ];
+}
+
+def VM_BufferLengthOp :
+    VM_PureOp<"buffer.length", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{returns the byte length of a buffer}];
+  let description = [{
+    Returns the total byte length of the given buffer. This is the exact value
+    as specified during buffer allocation though the underlying system buffer
+    may have additional padding.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$buffer
+  );
+  let results = (outs
+    VM_Index:$result
+  );
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($buffer) `->` type($result)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BufferLength>,
+    VM_EncOperand<"buffer", 0>,
+    VM_EncResult<"result">,
+  ];
+}
+
+def VM_BufferCopyOp :
+    VM_Op<"buffer.copy", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
+      MemoryEffects<[MemWrite]>,
+    ]> {
+  let summary = [{copies a range of a buffer to another}];
+  let description = [{
+    Copies a range of one buffer to another, like memcpy.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$source_buffer,
+    VM_Index:$source_offset,
+    VM_RefOf<VM_BufferType>:$target_buffer,
+    VM_Index:$target_offset,
+    VM_Index:$length
+  );
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($source_buffer) `->` type($target_buffer)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BufferCopy>,
+    VM_EncOperand<"source_buffer", 0>,
+    VM_EncOperand<"source_offset", 1>,
+    VM_EncOperand<"target_buffer", 2>,
+    VM_EncOperand<"target_offset", 3>,
+    VM_EncOperand<"length", 4>
+  ];
+}
+
+def VM_BufferCompareOp :
+    VM_Op<"buffer.compare", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
+      MemoryEffects<[MemWrite]>,
+    ]> {
+  let summary = [{compares a range of a buffer to another}];
+  let description = [{
+    Returns 1 if the two ranges are bitwise equivalent, somewhat like memcmp.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$lhs_buffer,
+    VM_Index:$lhs_offset,
+    VM_RefOf<VM_BufferType>:$rhs_buffer,
+    VM_Index:$rhs_offset,
+    VM_Index:$length
+  );
+  let results = (outs
+    VM_CondValue:$result
+  );
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($lhs_buffer) `,` type($rhs_buffer)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_BufferCompare>,
+    VM_EncOperand<"lhs_buffer", 0>,
+    VM_EncOperand<"lhs_offset", 1>,
+    VM_EncOperand<"rhs_buffer", 2>,
+    VM_EncOperand<"rhs_offset", 3>,
+    VM_EncOperand<"length", 4>,
+    VM_EncResult<"result">
+  ];
+}
+
+class VM_BufferFillOp<Type type, string mnemonic, VM_OPC opcode,
+                      list<OpTrait> traits = []> :
+    VM_Op<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemWrite]>,
+    ])> {
+  let description = [{
+    Fills a range of the buffer with the given value, like memset.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$target_buffer,
+    VM_Index:$target_offset,
+    VM_Index:$length,
+    AnyTypeOf<[type, I32]>:$value
+  );
+
+  let assemblyFormat = [{
+    $target_buffer `,` $target_offset `,` $length `,` $value
+    attr-dict `:` type($value) `->` type($target_buffer)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"target_buffer", 0>,
+    VM_EncOperand<"target_offset", 1>,
+    VM_EncOperand<"length", 2>,
+    VM_EncOperand<"value", 3>
+  ];
+}
+
+def VM_BufferFillI8Op :
+    VM_BufferFillOp<I8, "buffer.fill.i8", VM_OPC_BufferFillI8> {
+  let summary = [{fills the buffer with the given repeating 8-bit value}];
+}
+def VM_BufferFillI16Op :
+    VM_BufferFillOp<I16, "buffer.fill.i16", VM_OPC_BufferFillI16> {
+  let summary = [{fills the buffer with the given repeating 16-bit value}];
+}
+def VM_BufferFillI32Op :
+    VM_BufferFillOp<I32, "buffer.fill.i32", VM_OPC_BufferFillI32> {
+  let summary = [{fills the buffer with the given repeating 32-bit value}];
+}
+def VM_BufferFillI64Op :
+    VM_BufferFillOp<I64, "buffer.fill.i64", VM_OPC_BufferFillI64,
+                    [VM_ExtI64]> {
+  let summary = [{fills the buffer with the given repeating 64-bit value}];
+}
+def VM_BufferFillF32Op :
+    VM_BufferFillOp<F32, "buffer.fill.f32", VM_OPC_BufferFillF32,
+                    [VM_ExtF32]> {
+  let summary = [{fills the buffer with the given repeating 32-bit value}];
+}
+def VM_BufferFillF64Op :
+    VM_BufferFillOp<F64, "buffer.fill.f64", VM_OPC_BufferFillF64,
+                    [VM_ExtF64]> {
+  let summary = [{fills the buffer with the given repeating 64-bit value}];
+}
+
+class VM_BufferLoadOp<Type type, string mnemonic, VM_OPC opcode,
+                      list<OpTrait> traits = []> :
+    VM_PureOp<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemRead]>,
+    ])> {
+  let description = [{
+    Loads a value from the buffer at the given offset. Offsets must match the
+    natural alignment of the loaded type and will be coerced to the alignment
+    at runtime automatically.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$source_buffer,
+    VM_Index:$source_offset
+  );
+  let results = (outs
+    AnyTypeOf<[type, I32]>:$result
+  );
+
+  let assemblyFormat = [{
+    $source_buffer `[` $source_offset `]`
+    attr-dict `:` type($source_buffer) `->` type($result)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"source_buffer", 0>,
+    VM_EncOperand<"source_offset", 1>,
+    VM_EncResult<"result">,
+  ];
+}
+
+class VM_BufferStoreOp<Type type, string mnemonic, VM_OPC opcode,
+                       list<OpTrait> traits = []> :
+    VM_Op<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      MemoryEffects<[MemWrite]>,
+    ])> {
+  let description = [{
+    Stores a value to the buffer at the given offset. Offsets must match the
+    natural alignment of the loaded type and will be coerced to the alignment
+    at runtime automatically.
+  }];
+
+  let arguments = (ins
+    VM_RefOf<VM_BufferType>:$target_buffer,
+    VM_Index:$target_offset,
+    AnyTypeOf<[type, I32]>:$value
+  );
+
+  let assemblyFormat = [{
+    $value `,` $target_buffer `[` $target_offset `]`
+    attr-dict `:` type($value) `->` type($target_buffer)
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"target_buffer", 0>,
+    VM_EncOperand<"target_offset", 1>,
+    VM_EncOperand<"value", 2>,
+  ];
+}
+
+def VM_BufferLoadI8UOp :
+    VM_BufferLoadOp<I32, "buffer.load.i8.u", VM_OPC_BufferLoadI8U, []> {
+  let summary = [{unsigned 8-bit integer load}];
+}
+def VM_BufferLoadI8SOp :
+    VM_BufferLoadOp<I32, "buffer.load.i8.s", VM_OPC_BufferLoadI8S, []> {
+  let summary = [{signed 8-bit integer load}];
+}
+
+def VM_BufferLoadI16UOp :
+    VM_BufferLoadOp<I32, "buffer.load.i16.u", VM_OPC_BufferLoadI16U, []> {
+  let summary = [{unsigned 16-bit integer load}];
+}
+def VM_BufferLoadI16SOp :
+    VM_BufferLoadOp<I32, "buffer.load.i16.s", VM_OPC_BufferLoadI16S, []> {
+  let summary = [{signed 16-bit integer load}];
+}
+
+def VM_BufferLoadI32Op :
+    VM_BufferLoadOp<I32, "buffer.load.i32", VM_OPC_BufferLoadI32, []> {
+  let summary = [{32-bit integer load}];
+}
+def VM_BufferLoadI64Op :
+    VM_BufferLoadOp<I64, "buffer.load.i64", VM_OPC_BufferLoadI64,
+                    [VM_ExtI64]> {
+  let summary = [{64-bit integer load}];
+}
+def VM_BufferLoadF32Op :
+    VM_BufferLoadOp<F32, "buffer.load.f32", VM_OPC_BufferLoadF32,
+                    [VM_ExtF32]> {
+  let summary = [{32-bit floating-point load}];
+}
+def VM_BufferLoadF64Op :
+    VM_BufferLoadOp<F64, "buffer.load.f64", VM_OPC_BufferLoadF64,
+                    [VM_ExtF64]> {
+  let summary = [{64-bit floating-point load}];
+}
+
+def VM_BufferStoreI8Op :
+    VM_BufferStoreOp<I32, "buffer.store.i8", VM_OPC_BufferStoreI8, []> {
+  let summary = [{unsigned 8-bit integer store}];
+}
+def VM_BufferStoreI16Op :
+    VM_BufferStoreOp<I32, "buffer.store.i16", VM_OPC_BufferStoreI16, []> {
+  let summary = [{unsigned 16-bit integer store}];
+}
+def VM_BufferStoreI32Op :
+    VM_BufferStoreOp<I32, "buffer.store.i32", VM_OPC_BufferStoreI32, []> {
+  let summary = [{32-bit integer store}];
+}
+def VM_BufferStoreI64Op :
+    VM_BufferStoreOp<I64, "buffer.store.i64", VM_OPC_BufferStoreI64,
+                     [VM_ExtI64]> {
+  let summary = [{64-bit integer store}];
+}
+def VM_BufferStoreF32Op :
+    VM_BufferStoreOp<F32, "buffer.store.f32", VM_OPC_BufferStoreF32,
+                     [VM_ExtF32]> {
+  let summary = [{32-bit floating-point store}];
+}
+def VM_BufferStoreF64Op :
+    VM_BufferStoreOp<F64, "buffer.store.f64", VM_OPC_BufferStoreF64,
+                     [VM_ExtF64]> {
+  let summary = [{64-bit floating-point store}];
+}
+
+//===----------------------------------------------------------------------===//
 // Lists
 //===----------------------------------------------------------------------===//
 
@@ -990,7 +1342,7 @@ def VM_ListAllocOp :
   }];
 
   let arguments = (ins
-    I32:$initial_capacity
+    VM_Index:$initial_capacity
   );
   let results = (outs
     VM_AnyList:$result
@@ -1018,7 +1370,7 @@ def VM_ListReserveOp :
 
   let arguments = (ins
     VM_AnyList:$list,
-    I32:$minimum_capacity
+    VM_Index:$minimum_capacity
   );
 
   let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($minimum_capacity) `)`";
@@ -1044,7 +1396,7 @@ def VM_ListSizeOp :
     VM_AnyList:$list
   );
   let results = (outs
-    I32:$result
+    VM_Index:$result
   );
 
   let assemblyFormat = "operands attr-dict `:` `(` type($list) `)` `->` type($result)";
@@ -1070,7 +1422,7 @@ def VM_ListResizeOp :
 
   let arguments = (ins
     VM_AnyList:$list,
-    I32:$new_size
+    VM_Index:$new_size
   );
 
   let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($new_size) `)`";
@@ -1095,7 +1447,7 @@ class VM_ListGetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
 
   let arguments = (ins
     VM_ListOf<VM_PrimitiveType>:$list,
-    I32:$index
+    VM_Index:$index
   );
   let results = (outs
     type:$result
@@ -1124,7 +1476,7 @@ class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
 
   let arguments = (ins
     VM_ListOf<VM_PrimitiveType>:$list,
-    I32:$index,
+    VM_Index:$index,
     type:$value
   );
 
@@ -1175,7 +1527,7 @@ def VM_ListGetRefOp :
 
   let arguments = (ins
     VM_AnyList:$list,
-    I32:$index
+    VM_Index:$index
   );
   let results = (outs
     VM_AnyRef:$result
@@ -1206,7 +1558,7 @@ def VM_ListSetRefOp :
 
   let arguments = (ins
     VM_AnyList:$list,
-    I32:$index,
+    VM_Index:$index,
     VM_AnyRef:$value
   );
 
@@ -1340,7 +1692,7 @@ class VM_SwitchIntegerOp<I type, string mnemonic, VM_OPC opcode,
   }];
 
   let arguments = (ins
-    I32:$index,
+    VM_Index:$index,
     type:$default_value,
     Variadic<type>:$values
   );
@@ -1379,7 +1731,7 @@ class VM_SwitchFloatOp<F type, string mnemonic, VM_OPC opcode,
   }];
 
   let arguments = (ins
-    I32:$index,
+    VM_Index:$index,
     type:$default_value,
     Variadic<type>:$values
   );
@@ -1440,7 +1792,7 @@ def VM_SwitchRefOp : VM_PureOp<"switch.ref", [
   }];
 
   let arguments = (ins
-    I32:$index,
+    VM_Index:$index,
     VM_AnyRef:$default_value,
     Variadic<VM_AnyRef>:$values
   );
@@ -2065,7 +2417,7 @@ class VM_UnaryComparisonOp<Type type, string mnemonic, VM_OPC opcode,
     type:$operand
   );
   let results = (outs
-    I32:$result
+    VM_CondValue:$result
   );
 
   let assemblyFormat = "$operand attr-dict `:` type($operand)";
@@ -2092,7 +2444,7 @@ class VM_BinaryComparisonOp<Type type, string mnemonic, VM_OPC opcode,
     type:$rhs
   );
   let results = (outs
-    I32:$result
+    VM_CondValue:$result
   );
 
   let assemblyFormat = "operands attr-dict `:` type($lhs)";
@@ -2120,7 +2472,7 @@ class VM_BinaryComparisonPseudoOp<Type type, string mnemonic,
     type:$rhs
   );
   let results = (outs
-    I32:$result
+    VM_CondValue:$result
   );
 
   let assemblyFormat = "operands attr-dict `:` type($lhs)";

--- a/iree/schemas/bytecode_module_def.fbs
+++ b/iree/schemas/bytecode_module_def.fbs
@@ -14,9 +14,9 @@
 
 namespace iree.vm;
 
-// 'Bytecode MODule'.
-file_identifier "BMOD";
-file_extension "module";
+// IREE bytecode module.
+file_identifier "IREE";
+file_extension "vmfb";
 
 // Arbitrary key/value reflection attribute.
 table ReflectionAttrDef {

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -63,6 +63,7 @@ cc_library(
 cc_library(
     name = "impl",
     srcs = [
+        "buffer.c",
         "builtin_types.c",
         "context.c",
         "instance.c",
@@ -75,6 +76,7 @@ cc_library(
         "stack.c",
     ],
     hdrs = [
+        "buffer.h",
         "builtin_types.h",
         "context.h",
         "instance.h",
@@ -93,6 +95,18 @@ cc_library(
         "//iree/base:core_headers",
         "//iree/base:tracing",
         "//iree/base/internal",
+    ],
+)
+
+cc_test(
+    name = "buffer_test",
+    srcs = ["buffer_test.cc"],
+    deps = [
+        ":cc",
+        ":impl",
+        "//iree/base",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
     ],
 )
 

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
   NAME
     impl
   HDRS
+    "buffer.h"
     "builtin_types.h"
     "context.h"
     "instance.h"
@@ -56,6 +57,7 @@ iree_cc_library(
     "type_def.h"
     "value.h"
   SRCS
+    "buffer.c"
     "builtin_types.c"
     "context.c"
     "instance.c"
@@ -72,6 +74,19 @@ iree_cc_library(
     iree::base::internal
     iree::base::tracing
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    buffer_test
+  SRCS
+    "buffer_test.cc"
+  DEPS
+    ::cc
+    ::impl
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
 )
 
 iree_cc_test(

--- a/iree/vm/api.h
+++ b/iree/vm/api.h
@@ -16,6 +16,7 @@
 #define IREE_VM_API_H_
 
 #include "iree/base/api.h"
+#include "iree/vm/buffer.h"
 #include "iree/vm/builtin_types.h"
 #include "iree/vm/context.h"
 #include "iree/vm/instance.h"

--- a/iree/vm/buffer.c
+++ b/iree/vm/buffer.c
@@ -1,0 +1,315 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/vm/buffer.h"
+
+#include "iree/base/tracing.h"
+
+static iree_vm_ref_type_descriptor_t iree_vm_buffer_descriptor = {0};
+
+IREE_VM_DEFINE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
+
+static iree_status_t iree_vm_buffer_map(const iree_vm_buffer_t* buffer,
+                                        iree_host_size_t offset,
+                                        iree_host_size_t length,
+                                        iree_host_size_t alignment,
+                                        uint8_t** out_data,
+                                        iree_host_size_t* out_data_length) {
+  // Force alignment.
+  offset &= ~(alignment - 1);
+  length &= ~(alignment - 1);
+  const iree_host_size_t end = offset + length;
+  if (IREE_UNLIKELY(end > buffer->data.data_length)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "out-of-bounds access detected (offset=%zu, "
+                            "length=%zu, alignment=%zu, buffer length=%zu)",
+                            offset, length, alignment,
+                            buffer->data.data_length);
+  }
+  *out_data = buffer->data.data + offset;
+  *out_data_length = length;
+  return iree_ok_status();
+}
+
+// Maps a subrange to a span of bytes within the |buffer| for read-only access.
+// |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
+// will be rounded toward zero if they do not.
+static iree_status_t iree_vm_buffer_map_ro(const iree_vm_buffer_t* buffer,
+                                           iree_host_size_t offset,
+                                           iree_host_size_t length,
+                                           iree_host_size_t alignment,
+                                           iree_const_byte_span_t* out_span) {
+  // Always allowed regardless of access.
+  return iree_vm_buffer_map(buffer, offset, length, alignment,
+                            (uint8_t**)&out_span->data, &out_span->data_length);
+}
+
+// Maps a subrange to a span of bytes within the |buffer| for read/write access.
+// |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
+// will be rounded toward zero if they do not.
+static iree_status_t iree_vm_buffer_map_rw(const iree_vm_buffer_t* buffer,
+                                           iree_host_size_t offset,
+                                           iree_host_size_t length,
+                                           iree_host_size_t alignment,
+                                           iree_byte_span_t* out_span) {
+  // Buffer requires mutable access.
+  if (IREE_UNLIKELY(
+          !iree_all_bits_set(buffer->access, IREE_VM_BUFFER_ACCESS_MUTABLE))) {
+    return iree_make_status(
+        IREE_STATUS_PERMISSION_DENIED,
+        "buffer is read-only and cannot be mapped for mutation");
+  }
+  return iree_vm_buffer_map(buffer, offset, length, alignment, &out_span->data,
+                            &out_span->data_length);
+}
+
+IREE_API_EXPORT void iree_vm_buffer_initialize(iree_vm_buffer_access_t access,
+                                               iree_byte_span_t data,
+                                               iree_allocator_t allocator,
+                                               iree_vm_buffer_t* out_buffer) {
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  iree_atomic_ref_count_init(&out_buffer->ref_object.counter);
+  out_buffer->access = access;
+  out_buffer->data = data;
+  out_buffer->allocator = allocator;
+}
+
+IREE_API_EXPORT void iree_vm_buffer_deinitialize(iree_vm_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(buffer);
+  iree_atomic_ref_count_abort_if_uses(&buffer->ref_object.counter);
+  iree_allocator_free(buffer->allocator, buffer->data.data);
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_create(
+    iree_vm_buffer_access_t access, iree_host_size_t length,
+    iree_allocator_t allocator, iree_vm_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // The actual buffer payload is prefixed with the buffer type so we need only
+  // a single allocation.
+  iree_host_size_t prefix_size =
+      iree_host_align(sizeof(iree_vm_buffer_t), iree_max_align_t);
+  iree_host_size_t total_size = prefix_size + length;
+
+  // Allocate combined [prefix | buffer] memory.
+  uint8_t* data_ptr = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(allocator, total_size, (void**)&data_ptr));
+
+  // Initialize the prefix buffer handle.
+  iree_vm_buffer_t* buffer = (iree_vm_buffer_t*)data_ptr;
+  memset(data_ptr, 0, prefix_size - sizeof(*buffer));  // padding
+  iree_byte_span_t target_span =
+      iree_make_byte_span(data_ptr + prefix_size, length);
+  iree_vm_buffer_initialize(access, target_span, allocator, buffer);
+
+  *out_buffer = buffer;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static void iree_vm_buffer_destroy(void* ptr) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Buffers are stored as [prefix | data]; freeing the prefix is all we need
+  // to do to free it all.
+  iree_vm_buffer_t* buffer = (iree_vm_buffer_t*)ptr;
+  iree_allocator_free(buffer->allocator, buffer);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT void iree_vm_buffer_retain(iree_vm_buffer_t* buffer) {
+  iree_vm_ref_object_retain(buffer, &iree_vm_buffer_descriptor);
+}
+
+IREE_API_EXPORT void iree_vm_buffer_release(iree_vm_buffer_t* buffer) {
+  iree_vm_ref_object_release(buffer, &iree_vm_buffer_descriptor);
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_clone(
+    iree_vm_buffer_access_t access, const iree_vm_buffer_t* source_buffer,
+    iree_host_size_t source_offset, iree_host_size_t length,
+    iree_allocator_t allocator, iree_vm_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(source_buffer);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Try to map the source buffer first; no use continuing if we can't read the
+  // data to clone.
+  iree_const_byte_span_t source_span;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_vm_buffer_map_ro(source_buffer, source_offset, length, 1,
+                                &source_span));
+
+  // The actual buffer payload is prefixed with the buffer type so we need only
+  // a single allocation.
+  iree_host_size_t prefix_size =
+      iree_host_align(sizeof(iree_vm_buffer_t), iree_max_align_t);
+  iree_host_size_t total_size = prefix_size + source_span.data_length;
+
+  // Allocate combined [prefix | buffer] memory.
+  // NOTE: we are allocating without initialization here as we will be writing
+  // over all of it.
+  uint8_t* data_ptr = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, allocator.alloc(allocator.self, /*mode=*/0, total_size,
+                          (void**)&data_ptr));
+
+  // Initialize the prefix buffer handle.
+  iree_vm_buffer_t* buffer = (iree_vm_buffer_t*)data_ptr;
+  memset(data_ptr, 0, prefix_size - sizeof(*buffer));  // padding
+  iree_byte_span_t target_span =
+      iree_make_byte_span(data_ptr + prefix_size, length);
+  iree_vm_buffer_initialize(access, target_span, allocator, buffer);
+
+  // Copy the data from the source buffer.
+  memcpy(target_span.data, source_span.data, target_span.data_length);
+
+  *out_buffer = buffer;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_host_size_t
+iree_vm_buffer_length(const iree_vm_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(buffer);
+  return buffer->data.data_length;
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_copy_bytes(
+    const iree_vm_buffer_t* source_buffer, iree_host_size_t source_offset,
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t length) {
+  IREE_ASSERT_ARGUMENT(source_buffer);
+  IREE_ASSERT_ARGUMENT(target_buffer);
+  iree_const_byte_span_t source_span;
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_map_ro(source_buffer, source_offset,
+                                             length, 1, &source_span));
+  iree_byte_span_t target_span;
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_map_rw(target_buffer, target_offset,
+                                             length, 1, &target_span));
+  memcpy(target_span.data, source_span.data, length);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_compare_bytes(
+    const iree_vm_buffer_t* lhs_buffer, iree_host_size_t lhs_offset,
+    const iree_vm_buffer_t* rhs_buffer, iree_host_size_t rhs_offset,
+    iree_host_size_t length, bool* out_result) {
+  IREE_ASSERT_ARGUMENT(lhs_buffer);
+  IREE_ASSERT_ARGUMENT(rhs_buffer);
+  iree_const_byte_span_t lhs_span;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_buffer_map_ro(lhs_buffer, lhs_offset, length, 1, &lhs_span));
+  iree_const_byte_span_t rhs_span;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_buffer_map_ro(rhs_buffer, rhs_offset, length, 1, &rhs_span));
+  *out_result = memcmp(lhs_span.data, rhs_span.data, length) == 0;
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_fill_bytes(
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t length, uint8_t value) {
+  return iree_vm_buffer_fill_elements(target_buffer, target_offset, length, 1,
+                                      &value);
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_fill_elements(
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t element_count, iree_host_size_t element_length,
+    const void* value) {
+  IREE_ASSERT_ARGUMENT(target_buffer);
+  iree_byte_span_t span;
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_map_rw(target_buffer, target_offset,
+                                             element_count * element_length,
+                                             element_length, &span));
+  switch (element_length) {
+    case 1: {
+      const uint8_t pattern_value = *(const uint8_t*)value;
+      memset(span.data, pattern_value, span.data_length);
+    } break;
+    case 2: {
+      const uint16_t pattern_value = *(const uint16_t*)value;
+      uint16_t* target_ptr = (uint16_t*)span.data;
+      for (iree_host_size_t i = 0; i < element_count; ++i) {
+        target_ptr[i] = pattern_value;
+      }
+    } break;
+    case 4: {
+      const uint32_t pattern_value = *(const uint32_t*)value;
+      uint32_t* target_ptr = (uint32_t*)span.data;
+      for (iree_host_size_t i = 0; i < element_count; ++i) {
+        target_ptr[i] = pattern_value;
+      }
+    } break;
+    case 8: {
+      const uint64_t pattern_value = *(const uint64_t*)value;
+      uint64_t* target_ptr = (uint64_t*)span.data;
+      for (iree_host_size_t i = 0; i < element_count; ++i) {
+        target_ptr[i] = pattern_value;
+      }
+    } break;
+    default:
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "invalid element length %d; expected one of [1, 2, 4, 8]",
+          (int)element_length);
+  }
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_read_elements(
+    const iree_vm_buffer_t* source_buffer, iree_host_size_t source_offset,
+    void* target_ptr, iree_host_size_t element_count,
+    iree_host_size_t element_length) {
+  IREE_ASSERT_ARGUMENT(source_buffer);
+  iree_const_byte_span_t source_span;
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_map_ro(source_buffer, source_offset,
+                                             element_count * element_length,
+                                             element_length, &source_span));
+  memcpy(target_ptr, source_span.data, source_span.data_length);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_vm_buffer_write_elements(
+    const void* source_ptr, const iree_vm_buffer_t* target_buffer,
+    iree_host_size_t target_offset, iree_host_size_t element_count,
+    iree_host_size_t element_length) {
+  IREE_ASSERT_ARGUMENT(source_ptr);
+  IREE_ASSERT_ARGUMENT(target_buffer);
+  iree_byte_span_t target_span;
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_map_rw(target_buffer, target_offset,
+                                             element_count * element_length,
+                                             element_length, &target_span));
+  memcpy(target_span.data, source_ptr, target_span.data_length);
+  return iree_ok_status();
+}
+
+iree_status_t iree_vm_buffer_register_types() {
+  if (iree_vm_buffer_descriptor.type != IREE_VM_REF_TYPE_NULL) {
+    // Already registered.
+    return iree_ok_status();
+  }
+
+  iree_vm_buffer_descriptor.destroy = iree_vm_buffer_destroy;
+  iree_vm_buffer_descriptor.offsetof_counter =
+      offsetof(iree_vm_buffer_t, ref_object.counter);
+  iree_vm_buffer_descriptor.type_name = iree_make_cstring_view("vm.buffer");
+  return iree_vm_ref_register_type(&iree_vm_buffer_descriptor);
+}

--- a/iree/vm/buffer.h
+++ b/iree/vm/buffer.h
@@ -1,0 +1,196 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_VM_BUFFER_H_
+#define IREE_VM_BUFFER_H_
+
+#include "iree/base/api.h"
+#include "iree/vm/ref.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Describes where a byte buffer originates from, what guarantees can be made
+// about its lifetime and ownership, and how it may be accessed.
+// Note that buffers may always be read.
+enum iree_vm_buffer_access_e {
+  // The guest is allowed to write to the buffer.
+  // If not specified the buffer is read-only.
+  IREE_VM_BUFFER_ACCESS_MUTABLE = 1u << 0,
+
+  // Buffer references memory in the module space (rodata or rwdata) that is
+  // guaranteed to be live for the lifetime of the module.
+  IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE = 1u << 1,
+  // Buffer references memory created by the guest module code. It has a
+  // lifetime less than that of the module but is always tracked with proper
+  // references (a handle existing to the memory implies it is valid).
+  IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST = 1u << 2,
+  // Buffer references external host memory with an unknown lifetime.
+  IREE_VM_BUFFER_ACCESS_ORIGIN_HOST = 1u << 3,
+};
+typedef uint32_t iree_vm_buffer_access_t;
+
+// A simple byte range with options for ownership and wrapping semantics.
+// The access flags indicate what access is allowed from the VM.
+// Buffers are fixed-length and may only contain primitive values.
+// For resizable lists with mixed element types and ref objects use
+// iree_vm_list_t.
+//
+// Note that because buffers are just bags of bytes endianness issues are very
+// likely depending on usage. In general IREE takes the stance that
+// little-endian is all that is practically relevant nowadays and big-endian
+// targets will need their own modules compiled with such a setting. This is to
+// avoid the significant amount of work trying to ensure cross-endian
+// correctness in things like packed .rodata, cross-device switching (host in
+// a different endianness than HAL device), etc.
+//
+// For stack-allocated buffers setup with iree_vm_buffer_initialize the
+// allocator provided will be used to free the data when the buffer is
+// deinitialized. It may be iree_allocator_null to indicate the data is unowned.
+//
+// For heap-allocated buffers created with iree_vm_buffer_create/clone/etc the
+// allocator is used to free the entire iree_vm_buffer_t and the co-allocated
+// buffer data that lives after it in memory.
+typedef struct {
+  iree_vm_ref_object_t ref_object;
+  iree_vm_buffer_access_t access;
+  iree_byte_span_t data;
+  iree_allocator_t allocator;
+} iree_vm_buffer_t;
+
+// Initializes a buffer in-place with the given byte contents.
+// This can be used to avoid buffer allocation overhead when wrapping existing
+// buffers for API interop but buffer lifetime must be observed carefully by
+// the caller.
+//
+// Some systems may assume that the data is aligned to at least the natural
+// word size of the machine. If possible align to iree_max_align_t.
+//
+// |data| will be freed with |allocator| when the buffer is deinitialized.
+// If the data is not owned then iree_allocator_null can be used to no-op the
+// free.
+//
+// |access| can be used to control who (guest, host, etc) and how (read/write)
+// the buffer may be accessed. If the allocation being wrapped has its own
+// access requirements (read-only, etc) the caller must specify those flags.
+IREE_API_EXPORT void iree_vm_buffer_initialize(iree_vm_buffer_access_t access,
+                                               iree_byte_span_t data,
+                                               iree_allocator_t allocator,
+                                               iree_vm_buffer_t* out_buffer);
+
+// Deinitializes a buffer previously initialized in-place with
+// iree_vm_buffer_initialize. Invalid to call on a buffer that was allocated
+// on the heap via iree_vm_buffer_create. Aborts if there are still references
+// remaining.
+IREE_API_EXPORT void iree_vm_buffer_deinitialize(iree_vm_buffer_t* buffer);
+
+// Creates a new zero-initialized buffer of the given byte |length|.
+// The underlying storage buffer may be allocated larger to ensure alignment.
+// The allocated data will be aligned to iree_max_align_t.
+//
+// |access| can be used to control who (guest, host, etc) and how (read/write)
+// the buffer may be accessed.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_create(
+    iree_vm_buffer_access_t access, iree_host_size_t length,
+    iree_allocator_t allocator, iree_vm_buffer_t** out_buffer);
+
+// Retains the given |buffer| for the caller.
+IREE_API_EXPORT void iree_vm_buffer_retain(iree_vm_buffer_t* buffer);
+
+// Releases the given |buffer| from the caller.
+IREE_API_EXPORT void iree_vm_buffer_release(iree_vm_buffer_t* buffer);
+
+// Clones a range of bytes in |source| to a new buffer.
+// The allocated data will be aligned to iree_max_align_t.
+//
+// |access| can be used to control who (guest, host, etc) and how (read/write)
+// the buffer may be accessed. As this returns a newly allocated buffer the
+// new access may be more permissive than the source buffer.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_clone(
+    iree_vm_buffer_access_t access, const iree_vm_buffer_t* source_buffer,
+    iree_host_size_t source_offset, iree_host_size_t length,
+    iree_allocator_t allocator, iree_vm_buffer_t** out_buffer);
+
+// Returns the user-visible length of the buffer in bytes.
+IREE_API_EXPORT iree_host_size_t
+iree_vm_buffer_length(const iree_vm_buffer_t* buffer);
+
+// Returns the underlying data storage for the buffer.
+// WARNING: this performs no validation of the access allowance on the buffer
+// and the caller is responsible for all range checking. Use with caution and
+// prefer the utility methods instead.
+IREE_API_EXPORT iree_byte_span_t
+iree_vm_buffer_data(const iree_vm_buffer_t* buffer);
+
+// Copies a byte range from |source_buffer| to |target_buffer|.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_copy_bytes(
+    const iree_vm_buffer_t* source_buffer, iree_host_size_t source_offset,
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t length);
+
+// Compares |lhs_buffer| to |rhs_buffer| for bitwise equality.
+// |out_result| will receive 1 if the byte ranges are equal and 0 otherwise.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_compare_bytes(
+    const iree_vm_buffer_t* lhs_buffer, iree_host_size_t lhs_offset,
+    const iree_vm_buffer_t* rhs_buffer, iree_host_size_t rhs_offset,
+    iree_host_size_t length, bool* out_result);
+
+// Fills a byte range of |target_buffer| with the byte pattern.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_fill_bytes(
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t length, uint8_t value);
+
+// Fills an element range of |buffer| with the given pattern.
+// Only |pattern_length| values with 1, 2, 4, or 8 bytes are supported.
+// The |target_offset|, in bytes, must match the alignment of the pattern.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_fill_elements(
+    const iree_vm_buffer_t* target_buffer, iree_host_size_t target_offset,
+    iree_host_size_t element_count, iree_host_size_t element_length,
+    const void* value);
+
+// Reads |element_count| elements each of |element_length| bytes from the
+// |source_buffer| into |out_target_ptr|. The |source_offset|, in bytes, must be
+// aligned to at least the |element_length|.
+// This routine performs checks on bounds, alignment, and access rights.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_read_elements(
+    const iree_vm_buffer_t* source_buffer, iree_host_size_t source_offset,
+    void* target_ptr, iree_host_size_t element_count,
+    iree_host_size_t element_length);
+
+// Writes |element_count| elements each of |element_length| bytes to the
+// |target_buffer| from |source_ptr|. The |target_offset|, in bytes, must be
+// aligned to at least the |element_length|.
+// This routine performs checks on bounds, alignment, and access rights.
+IREE_API_EXPORT iree_status_t iree_vm_buffer_write_elements(
+    const void* source_ptr, const iree_vm_buffer_t* target_buffer,
+    iree_host_size_t target_offset, iree_host_size_t element_count,
+    iree_host_size_t element_length);
+
+// Returns the a string view referencing the given |value| buffer.
+// The returned view will only be valid for as long as the buffer is live.
+static inline iree_string_view_t iree_vm_buffer_as_string(
+    const iree_vm_buffer_t* value) {
+  return value ? iree_make_string_view((const char*)value->data.data,
+                                       value->data.data_length)
+               : iree_string_view_empty();
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+IREE_VM_DECLARE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
+
+#endif  // IREE_VM_BUFFER_H_

--- a/iree/vm/buffer_test.cc
+++ b/iree/vm/buffer_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/vm/buffer.h"
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "iree/vm/builtin_types.h"
+#include "iree/vm/ref_cc.h"
+
+namespace {
+
+class VMBufferTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    IREE_CHECK_OK(iree_vm_register_builtin_types());
+  }
+};
+
+// Tests that the data allocator is correctly called when using stack
+// initialization of a buffer.
+TEST_F(VMBufferTest, Initialize) {
+  bool did_free = false;
+  iree_allocator_t test_allocator = {
+      /*.self=*/&did_free,
+      /*.alloc=*/NULL,
+      /*.free=*/
+      +[](void* self, void* ptr) { *(bool*)self = true; },
+  };
+
+  uint32_t data[] = {0, 1, 2, 3};
+  iree_vm_buffer_t buffer;
+  iree_vm_buffer_initialize(
+      IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_HOST,
+      iree_make_byte_span(data, sizeof(data)), test_allocator, &buffer);
+
+  ASSERT_FALSE(did_free);
+  iree_vm_buffer_deinitialize(&buffer);
+  ASSERT_TRUE(did_free);
+}
+
+}  // namespace

--- a/iree/vm/builtin_types.c
+++ b/iree/vm/builtin_types.c
@@ -14,31 +14,11 @@
 
 #include "iree/vm/builtin_types.h"
 
-static iree_vm_ref_type_descriptor_t iree_vm_buffer_descriptor = {0};
-
-IREE_VM_DEFINE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
-
-static void iree_vm_buffer_destroy(void* ptr) {
-  iree_vm_buffer_t* ref = (iree_vm_buffer_t*)ptr;
-  if (ref->destroy) {
-    ref->destroy(ptr);
-  }
-}
-
+iree_status_t iree_vm_buffer_register_types();
 iree_status_t iree_vm_list_register_types();
 
 IREE_API_EXPORT iree_status_t iree_vm_register_builtin_types() {
-  if (iree_vm_buffer_descriptor.type != IREE_VM_REF_TYPE_NULL) {
-    return iree_ok_status();
-  }
-
-  iree_vm_buffer_descriptor.destroy = iree_vm_buffer_destroy;
-  iree_vm_buffer_descriptor.offsetof_counter =
-      offsetof(iree_vm_buffer_t, ref_object.counter);
-  iree_vm_buffer_descriptor.type_name = iree_make_cstring_view("vm.buffer");
-  IREE_RETURN_IF_ERROR(iree_vm_ref_register_type(&iree_vm_buffer_descriptor));
-
+  IREE_RETURN_IF_ERROR(iree_vm_buffer_register_types());
   IREE_RETURN_IF_ERROR(iree_vm_list_register_types());
-
   return iree_ok_status();
 }

--- a/iree/vm/builtin_types.h
+++ b/iree/vm/builtin_types.h
@@ -16,47 +16,10 @@
 #define IREE_VM_BUILTIN_TYPES_H_
 
 #include "iree/base/api.h"
-#include "iree/vm/ref.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-// Describes where a byte buffer originates from, what guarantees can be made
-// about its lifetime and ownership, and how it may be accessed.
-// Note that buffers may always be read.
-enum iree_vm_buffer_access_e {
-  // The guest is allowed to write to the buffer.
-  IREE_VM_BUFFER_ACCESS_WRITE = 1u << 0,
-
-  // Buffer references memory in the module space (rodata or rwdata) that is
-  // guaranteed to be live for the lifetime of the module.
-  IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE = 1u << 1,
-  // Buffer references memory created by the guest module code. It has a
-  // lifetime less than that of the module but is always tracked with proper
-  // references (a handle existing to the memory implies it is valid).
-  IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST = 1u << 2,
-};
-typedef uint32_t iree_vm_buffer_access_t;
-
-// The built-in buffer type.
-// This simply points at a span of memory. The memory could be owned (in which
-// case a destroy function must be provided) or unowned (NULL destroy function).
-// The access flags indicate what access is allowed from the VM.
-typedef struct {
-  iree_vm_ref_object_t ref_object;
-  iree_vm_buffer_access_t access;
-  iree_byte_span_t data;
-  iree_vm_ref_destroy_t destroy;
-} iree_vm_buffer_t;
-
-// Returns the a string view referencing the given |value| buffer.
-static inline iree_string_view_t iree_vm_buffer_as_string(
-    const iree_vm_buffer_t* value) {
-  return value ? iree_make_string_view((const char*)value->data.data,
-                                       value->data.data_length)
-               : iree_string_view_empty();
-}
 
 // Registers the builtin VM types. This must be called on startup. Safe to call
 // multiple times.
@@ -65,7 +28,5 @@ IREE_API_EXPORT iree_status_t iree_vm_register_builtin_types();
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-IREE_VM_DECLARE_TYPE_ADAPTERS(iree_vm_buffer, iree_vm_buffer_t);
 
 #endif  // IREE_VM_BUILTIN_TYPES_H_

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -584,11 +584,12 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
     iree_vm_RodataSegmentDef_table_t segment =
         iree_vm_RodataSegmentDef_vec_at(rodata_segments, i);
     iree_vm_buffer_t* ref = &state->rodata_ref_table[i];
-    iree_atomic_ref_count_init(&ref->ref_object.counter);
-    ref->access = IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE;
-    ref->data.data = (uint8_t*)iree_vm_RodataSegmentDef_data(segment);
-    ref->data.data_length =
-        flatbuffers_uint8_vec_len(iree_vm_RodataSegmentDef_data(segment));
+    iree_vm_buffer_initialize(
+        IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE,
+        iree_make_byte_span(
+            (uint8_t*)iree_vm_RodataSegmentDef_data(segment),
+            flatbuffers_uint8_vec_len(iree_vm_RodataSegmentDef_data(segment))),
+        iree_allocator_null(), ref);
   }
 
   *out_module_state = (iree_vm_module_state_t*)state;
@@ -607,6 +608,12 @@ static void iree_vm_bytecode_module_free_state(
   // Release remaining global references.
   for (int i = 0; i < state->global_ref_count; ++i) {
     iree_vm_ref_release(&state->global_ref_table[i]);
+  }
+
+  // Ensure all rodata references are unused and deinitialized.
+  for (int i = 0; i < state->rodata_ref_count; ++i) {
+    iree_vm_buffer_t* ref = &state->rodata_ref_table[i];
+    iree_vm_buffer_deinitialize(ref);
   }
 
   iree_allocator_free(state->allocator, module_state);

--- a/iree/vm/bytecode_module_benchmark.mlir
+++ b/iree/vm/bytecode_module_benchmark.mlir
@@ -76,4 +76,68 @@ vm.module @bytecode_module_benchmark {
   ^loop_exit(%ie : i32):
     vm.return %ie : i32
   }
+
+  // Measures the cost of lots of buffer loads.
+  vm.export @buffer_reduce
+  vm.func @buffer_reduce(%count : i32) -> i32 {
+    %c0 = vm.const.i32.zero : i32
+    %c1 = vm.const.i32 1 : i32
+    %c4 = vm.const.i32 4 : i32
+    %max = vm.mul.i32 %count, %c4 : i32
+    %buf = vm.buffer.alloc %max : !vm.buffer
+    vm.buffer.fill.i32 %buf, %c0, %max, %c1 : i32 -> !vm.buffer
+    vm.br ^loop(%c0, %c0 : i32, i32)
+  ^loop(%i : i32, %sum : i32):
+    %element = vm.buffer.load.i32 %buf[%i] : !vm.buffer -> i32
+    %new_sum = vm.add.i32 %sum, %element : i32
+    %ip4 = vm.add.i32 %i, %c4 : i32
+    %cmp = vm.cmp.lt.i32.s %ip4, %max : i32
+    vm.cond_br %cmp, ^loop(%ip4, %new_sum : i32, i32), ^loop_exit(%new_sum : i32)
+  ^loop_exit(%result : i32):
+    vm.return %result : i32
+  }
+
+  // Measures the cost of lots of buffer loads when somewhat unrolled.
+  // NOTE: unrolled 8x, requires %count to be % 8 = 0.
+  vm.export @buffer_reduce_unrolled
+  vm.func @buffer_reduce_unrolled(%count : i32) -> i32 {
+    %c0 = vm.const.i32.zero : i32
+    %c1 = vm.const.i32 1 : i32
+    %c4 = vm.const.i32 4 : i32
+    %max = vm.mul.i32 %count, %c4 : i32
+    %buf = vm.buffer.alloc %max : !vm.buffer
+    vm.buffer.fill.i32 %buf, %c0, %max, %c1 : i32 -> !vm.buffer
+    vm.br ^loop(%c0, %c0 : i32, i32)
+  ^loop(%i0 : i32, %sum : i32):
+    // TODO(#5544): add addression modes to load/store.
+    %e0 = vm.buffer.load.i32 %buf[%i0] : !vm.buffer -> i32
+    %i1 = vm.add.i32 %i0, %c4 : i32
+    %e1 = vm.buffer.load.i32 %buf[%i1] : !vm.buffer -> i32
+    %i2 = vm.add.i32 %i1, %c4 : i32
+    %e2 = vm.buffer.load.i32 %buf[%i2] : !vm.buffer -> i32
+    %i3 = vm.add.i32 %i2, %c4 : i32
+    %e3 = vm.buffer.load.i32 %buf[%i3] : !vm.buffer -> i32
+    %i4 = vm.add.i32 %i3, %c4 : i32
+    %e4 = vm.buffer.load.i32 %buf[%i4] : !vm.buffer -> i32
+    %i5 = vm.add.i32 %i4, %c4 : i32
+    %e5 = vm.buffer.load.i32 %buf[%i5] : !vm.buffer -> i32
+    %i6 = vm.add.i32 %i5, %c4 : i32
+    %e6 = vm.buffer.load.i32 %buf[%i6] : !vm.buffer -> i32
+    %i7 = vm.add.i32 %i6, %c4 : i32
+    %e7 = vm.buffer.load.i32 %buf[%i7] : !vm.buffer -> i32
+    // If we do reductions like this we could add a horizontal-add op.
+    %new_sum0 = vm.add.i32 %sum, %e0 : i32
+    %new_sum1 = vm.add.i32 %new_sum0, %e1 : i32
+    %new_sum2 = vm.add.i32 %new_sum1, %e2 : i32
+    %new_sum3 = vm.add.i32 %new_sum2, %e3 : i32
+    %new_sum4 = vm.add.i32 %new_sum3, %e4 : i32
+    %new_sum5 = vm.add.i32 %new_sum4, %e5 : i32
+    %new_sum6 = vm.add.i32 %new_sum5, %e6 : i32
+    %new_sum7 = vm.add.i32 %new_sum6, %e7 : i32
+    %next_i = vm.add.i32 %i7, %c4 : i32
+    %cmp = vm.cmp.lt.i32.s %next_i, %max : i32
+    vm.cond_br %cmp, ^loop(%next_i, %new_sum7 : i32, i32), ^loop_exit(%new_sum7 : i32)
+  ^loop_exit(%result : i32):
+    vm.return %result : i32
+  }
 }

--- a/iree/vm/generated/bytecode_op_table.h
+++ b/iree/vm/generated/bytecode_op_table.h
@@ -167,9 +167,9 @@ typedef enum {
   IREE_VM_OP_CORE_RSV_0x9D,
   IREE_VM_OP_CORE_RSV_0x9E,
   IREE_VM_OP_CORE_RSV_0x9F,
-  IREE_VM_OP_CORE_PrefixExtI64 = 0xA0,
-  IREE_VM_OP_CORE_PrefixExtF32 = 0xA1,
-  IREE_VM_OP_CORE_PrefixExtF64 = 0xA2,
+  IREE_VM_OP_CORE_RSV_0xA0,
+  IREE_VM_OP_CORE_RSV_0xA1,
+  IREE_VM_OP_CORE_RSV_0xA2,
   IREE_VM_OP_CORE_RSV_0xA3,
   IREE_VM_OP_CORE_RSV_0xA4,
   IREE_VM_OP_CORE_RSV_0xA5,
@@ -183,38 +183,38 @@ typedef enum {
   IREE_VM_OP_CORE_RSV_0xAD,
   IREE_VM_OP_CORE_RSV_0xAE,
   IREE_VM_OP_CORE_RSV_0xAF,
-  IREE_VM_OP_CORE_RSV_0xB0,
-  IREE_VM_OP_CORE_RSV_0xB1,
+  IREE_VM_OP_CORE_BufferLoadI8U = 0xB0,
+  IREE_VM_OP_CORE_BufferLoadI16U = 0xB1,
   IREE_VM_OP_CORE_RSV_0xB2,
-  IREE_VM_OP_CORE_RSV_0xB3,
-  IREE_VM_OP_CORE_RSV_0xB4,
-  IREE_VM_OP_CORE_RSV_0xB5,
+  IREE_VM_OP_CORE_BufferLoadI32 = 0xB3,
+  IREE_VM_OP_CORE_BufferLoadI8S = 0xB4,
+  IREE_VM_OP_CORE_BufferLoadI16S = 0xB5,
   IREE_VM_OP_CORE_RSV_0xB6,
   IREE_VM_OP_CORE_RSV_0xB7,
-  IREE_VM_OP_CORE_RSV_0xB8,
-  IREE_VM_OP_CORE_RSV_0xB9,
+  IREE_VM_OP_CORE_BufferStoreI8 = 0xB8,
+  IREE_VM_OP_CORE_BufferStoreI16 = 0xB9,
   IREE_VM_OP_CORE_RSV_0xBA,
-  IREE_VM_OP_CORE_RSV_0xBB,
+  IREE_VM_OP_CORE_BufferStoreI32 = 0xBB,
   IREE_VM_OP_CORE_RSV_0xBC,
   IREE_VM_OP_CORE_RSV_0xBD,
   IREE_VM_OP_CORE_RSV_0xBE,
   IREE_VM_OP_CORE_RSV_0xBF,
-  IREE_VM_OP_CORE_RSV_0xC0,
-  IREE_VM_OP_CORE_RSV_0xC1,
-  IREE_VM_OP_CORE_RSV_0xC2,
+  IREE_VM_OP_CORE_BufferAlloc = 0xC0,
+  IREE_VM_OP_CORE_BufferClone = 0xC1,
+  IREE_VM_OP_CORE_BufferLength = 0xC2,
   IREE_VM_OP_CORE_RSV_0xC3,
   IREE_VM_OP_CORE_RSV_0xC4,
   IREE_VM_OP_CORE_RSV_0xC5,
-  IREE_VM_OP_CORE_RSV_0xC6,
-  IREE_VM_OP_CORE_RSV_0xC7,
+  IREE_VM_OP_CORE_BufferCopy = 0xC6,
+  IREE_VM_OP_CORE_BufferCompare = 0xC7,
   IREE_VM_OP_CORE_RSV_0xC8,
   IREE_VM_OP_CORE_RSV_0xC9,
   IREE_VM_OP_CORE_RSV_0xCA,
   IREE_VM_OP_CORE_RSV_0xCB,
-  IREE_VM_OP_CORE_RSV_0xCC,
-  IREE_VM_OP_CORE_RSV_0xCD,
+  IREE_VM_OP_CORE_BufferFillI8 = 0xCC,
+  IREE_VM_OP_CORE_BufferFillI16 = 0xCD,
   IREE_VM_OP_CORE_RSV_0xCE,
-  IREE_VM_OP_CORE_RSV_0xCF,
+  IREE_VM_OP_CORE_BufferFillI32 = 0xCF,
   IREE_VM_OP_CORE_RSV_0xD0,
   IREE_VM_OP_CORE_RSV_0xD1,
   IREE_VM_OP_CORE_RSV_0xD2,
@@ -231,9 +231,9 @@ typedef enum {
   IREE_VM_OP_CORE_RSV_0xDD,
   IREE_VM_OP_CORE_RSV_0xDE,
   IREE_VM_OP_CORE_RSV_0xDF,
-  IREE_VM_OP_CORE_RSV_0xE0,
-  IREE_VM_OP_CORE_RSV_0xE1,
-  IREE_VM_OP_CORE_RSV_0xE2,
+  IREE_VM_OP_CORE_PrefixExtI64 = 0xE0,
+  IREE_VM_OP_CORE_PrefixExtF32 = 0xE1,
+  IREE_VM_OP_CORE_PrefixExtF64 = 0xE2,
   IREE_VM_OP_CORE_RSV_0xE3,
   IREE_VM_OP_CORE_RSV_0xE4,
   IREE_VM_OP_CORE_RSV_0xE5,
@@ -426,9 +426,9 @@ typedef enum {
     RSV(0x9D) \
     RSV(0x9E) \
     RSV(0x9F) \
-    OPC(0xA0, PrefixExtI64) \
-    OPC(0xA1, PrefixExtF32) \
-    OPC(0xA2, PrefixExtF64) \
+    RSV(0xA0) \
+    RSV(0xA1) \
+    RSV(0xA2) \
     RSV(0xA3) \
     RSV(0xA4) \
     RSV(0xA5) \
@@ -442,38 +442,38 @@ typedef enum {
     RSV(0xAD) \
     RSV(0xAE) \
     RSV(0xAF) \
-    RSV(0xB0) \
-    RSV(0xB1) \
+    OPC(0xB0, BufferLoadI8U) \
+    OPC(0xB1, BufferLoadI16U) \
     RSV(0xB2) \
-    RSV(0xB3) \
-    RSV(0xB4) \
-    RSV(0xB5) \
+    OPC(0xB3, BufferLoadI32) \
+    OPC(0xB4, BufferLoadI8S) \
+    OPC(0xB5, BufferLoadI16S) \
     RSV(0xB6) \
     RSV(0xB7) \
-    RSV(0xB8) \
-    RSV(0xB9) \
+    OPC(0xB8, BufferStoreI8) \
+    OPC(0xB9, BufferStoreI16) \
     RSV(0xBA) \
-    RSV(0xBB) \
+    OPC(0xBB, BufferStoreI32) \
     RSV(0xBC) \
     RSV(0xBD) \
     RSV(0xBE) \
     RSV(0xBF) \
-    RSV(0xC0) \
-    RSV(0xC1) \
-    RSV(0xC2) \
+    OPC(0xC0, BufferAlloc) \
+    OPC(0xC1, BufferClone) \
+    OPC(0xC2, BufferLength) \
     RSV(0xC3) \
     RSV(0xC4) \
     RSV(0xC5) \
-    RSV(0xC6) \
-    RSV(0xC7) \
+    OPC(0xC6, BufferCopy) \
+    OPC(0xC7, BufferCompare) \
     RSV(0xC8) \
     RSV(0xC9) \
     RSV(0xCA) \
     RSV(0xCB) \
-    RSV(0xCC) \
-    RSV(0xCD) \
+    OPC(0xCC, BufferFillI8) \
+    OPC(0xCD, BufferFillI16) \
     RSV(0xCE) \
-    RSV(0xCF) \
+    OPC(0xCF, BufferFillI32) \
     RSV(0xD0) \
     RSV(0xD1) \
     RSV(0xD2) \
@@ -490,9 +490,9 @@ typedef enum {
     RSV(0xDD) \
     RSV(0xDE) \
     RSV(0xDF) \
-    RSV(0xE0) \
-    RSV(0xE1) \
-    RSV(0xE2) \
+    OPC(0xE0, PrefixExtI64) \
+    OPC(0xE1, PrefixExtF32) \
+    OPC(0xE2, PrefixExtF64) \
     RSV(0xE3) \
     RSV(0xE4) \
     RSV(0xE5) \
@@ -700,8 +700,8 @@ typedef enum {
   IREE_VM_OP_EXT_F32_RSV_0xAD,
   IREE_VM_OP_EXT_F32_RSV_0xAE,
   IREE_VM_OP_EXT_F32_RSV_0xAF,
-  IREE_VM_OP_EXT_F32_RSV_0xB0,
-  IREE_VM_OP_EXT_F32_RSV_0xB1,
+  IREE_VM_OP_EXT_F32_BufferLoadF32 = 0xB0,
+  IREE_VM_OP_EXT_F32_BufferStoreF32 = 0xB1,
   IREE_VM_OP_EXT_F32_RSV_0xB2,
   IREE_VM_OP_EXT_F32_RSV_0xB3,
   IREE_VM_OP_EXT_F32_RSV_0xB4,
@@ -716,7 +716,7 @@ typedef enum {
   IREE_VM_OP_EXT_F32_RSV_0xBD,
   IREE_VM_OP_EXT_F32_RSV_0xBE,
   IREE_VM_OP_EXT_F32_RSV_0xBF,
-  IREE_VM_OP_EXT_F32_RSV_0xC0,
+  IREE_VM_OP_EXT_F32_BufferFillF32 = 0xC0,
   IREE_VM_OP_EXT_F32_RSV_0xC1,
   IREE_VM_OP_EXT_F32_RSV_0xC2,
   IREE_VM_OP_EXT_F32_RSV_0xC3,
@@ -959,8 +959,8 @@ typedef enum {
     RSV(0xAD) \
     RSV(0xAE) \
     RSV(0xAF) \
-    RSV(0xB0) \
-    RSV(0xB1) \
+    OPC(0xB0, BufferLoadF32) \
+    OPC(0xB1, BufferStoreF32) \
     RSV(0xB2) \
     RSV(0xB3) \
     RSV(0xB4) \
@@ -975,7 +975,7 @@ typedef enum {
     RSV(0xBD) \
     RSV(0xBE) \
     RSV(0xBF) \
-    RSV(0xC0) \
+    OPC(0xC0, BufferFillF32) \
     RSV(0xC1) \
     RSV(0xC2) \
     RSV(0xC3) \
@@ -1217,8 +1217,8 @@ typedef enum {
   IREE_VM_OP_EXT_F64_RSV_0xAD,
   IREE_VM_OP_EXT_F64_RSV_0xAE,
   IREE_VM_OP_EXT_F64_RSV_0xAF,
-  IREE_VM_OP_EXT_F64_RSV_0xB0,
-  IREE_VM_OP_EXT_F64_RSV_0xB1,
+  IREE_VM_OP_EXT_F64_BufferLoadF64 = 0xB0,
+  IREE_VM_OP_EXT_F64_BufferStoreF64 = 0xB1,
   IREE_VM_OP_EXT_F64_RSV_0xB2,
   IREE_VM_OP_EXT_F64_RSV_0xB3,
   IREE_VM_OP_EXT_F64_RSV_0xB4,
@@ -1233,7 +1233,7 @@ typedef enum {
   IREE_VM_OP_EXT_F64_RSV_0xBD,
   IREE_VM_OP_EXT_F64_RSV_0xBE,
   IREE_VM_OP_EXT_F64_RSV_0xBF,
-  IREE_VM_OP_EXT_F64_RSV_0xC0,
+  IREE_VM_OP_EXT_F64_BufferFillF64 = 0xC0,
   IREE_VM_OP_EXT_F64_RSV_0xC1,
   IREE_VM_OP_EXT_F64_RSV_0xC2,
   IREE_VM_OP_EXT_F64_RSV_0xC3,
@@ -1476,8 +1476,8 @@ typedef enum {
     RSV(0xAD) \
     RSV(0xAE) \
     RSV(0xAF) \
-    RSV(0xB0) \
-    RSV(0xB1) \
+    OPC(0xB0, BufferLoadF64) \
+    OPC(0xB1, BufferStoreF64) \
     RSV(0xB2) \
     RSV(0xB3) \
     RSV(0xB4) \
@@ -1492,7 +1492,7 @@ typedef enum {
     RSV(0xBD) \
     RSV(0xBE) \
     RSV(0xBF) \
-    RSV(0xC0) \
+    OPC(0xC0, BufferFillF64) \
     RSV(0xC1) \
     RSV(0xC2) \
     RSV(0xC3) \
@@ -1734,8 +1734,8 @@ typedef enum {
   IREE_VM_OP_EXT_I64_RSV_0xAD,
   IREE_VM_OP_EXT_I64_RSV_0xAE,
   IREE_VM_OP_EXT_I64_RSV_0xAF,
-  IREE_VM_OP_EXT_I64_RSV_0xB0,
-  IREE_VM_OP_EXT_I64_RSV_0xB1,
+  IREE_VM_OP_EXT_I64_BufferLoadI64 = 0xB0,
+  IREE_VM_OP_EXT_I64_BufferStoreI64 = 0xB1,
   IREE_VM_OP_EXT_I64_RSV_0xB2,
   IREE_VM_OP_EXT_I64_RSV_0xB3,
   IREE_VM_OP_EXT_I64_RSV_0xB4,
@@ -1750,7 +1750,7 @@ typedef enum {
   IREE_VM_OP_EXT_I64_RSV_0xBD,
   IREE_VM_OP_EXT_I64_RSV_0xBE,
   IREE_VM_OP_EXT_I64_RSV_0xBF,
-  IREE_VM_OP_EXT_I64_RSV_0xC0,
+  IREE_VM_OP_EXT_I64_BufferFillI64 = 0xC0,
   IREE_VM_OP_EXT_I64_RSV_0xC1,
   IREE_VM_OP_EXT_I64_RSV_0xC2,
   IREE_VM_OP_EXT_I64_RSV_0xC3,
@@ -1993,8 +1993,8 @@ typedef enum {
     RSV(0xAD) \
     RSV(0xAE) \
     RSV(0xAF) \
-    RSV(0xB0) \
-    RSV(0xB1) \
+    OPC(0xB0, BufferLoadI64) \
+    OPC(0xB1, BufferStoreI64) \
     RSV(0xB2) \
     RSV(0xB3) \
     RSV(0xB4) \
@@ -2009,7 +2009,7 @@ typedef enum {
     RSV(0xBD) \
     RSV(0xBE) \
     RSV(0xBF) \
-    RSV(0xC0) \
+    OPC(0xC0, BufferFillI64) \
     RSV(0xC1) \
     RSV(0xC2) \
     RSV(0xC3) \

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -160,6 +160,8 @@ IREE_API_EXPORT iree_status_t iree_vm_list_initialize(
 }
 
 IREE_API_EXPORT void iree_vm_list_deinitialize(iree_vm_list_t* list) {
+  IREE_ASSERT_ARGUMENT(list);
+  iree_atomic_ref_count_abort_if_uses(&list->ref_object.counter);
   iree_vm_list_reset_range(list, 0, list->count);
   list->count = 0;
 }
@@ -667,6 +669,11 @@ IREE_API_EXPORT iree_status_t iree_vm_list_push_variant(
 }
 
 iree_status_t iree_vm_list_register_types() {
+  if (iree_vm_list_descriptor.type != IREE_VM_REF_TYPE_NULL) {
+    // Already registered.
+    return iree_ok_status();
+  }
+
   iree_vm_list_descriptor.destroy = iree_vm_list_destroy;
   iree_vm_list_descriptor.offsetof_counter =
       offsetof(iree_vm_list_t, ref_object.counter);

--- a/iree/vm/list.h
+++ b/iree/vm/list.h
@@ -59,7 +59,7 @@ IREE_API_EXPORT iree_status_t iree_vm_list_initialize(
     iree_host_size_t capacity, iree_vm_list_t** out_list);
 
 // Deinitializes a statically-allocated |list| previously initialized with
-// iree_vm_list_initialize.
+// iree_vm_list_initialize. Aborts if there are still references remaining.
 IREE_API_EXPORT void iree_vm_list_deinitialize(iree_vm_list_t* list);
 
 // Creates a growable list containing the given |element_type|, which may either

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -40,6 +40,7 @@ cc_embed_data(
         ":assignment_ops.vmfb",
         ":assignment_ops_f32.vmfb",
         ":assignment_ops_i64.vmfb",
+        ":buffer_ops.vmfb",
         ":comparison_ops.vmfb",
         ":comparison_ops_f32.vmfb",
         ":comparison_ops_i64.vmfb",
@@ -93,6 +94,12 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "assignment_ops_i64",
     src = "assignment_ops_i64.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "buffer_ops",
+    src = "buffer_ops.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_embed_data(
     "assignment_ops.vmfb"
     "assignment_ops_f32.vmfb"
     "assignment_ops_i64.vmfb"
+    "buffer_ops.vmfb"
     "comparison_ops.vmfb"
     "comparison_ops_f32.vmfb"
     "comparison_ops_i64.vmfb"
@@ -102,6 +103,16 @@ iree_bytecode_module(
     assignment_ops_i64
   SRC
     "assignment_ops_i64.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    buffer_ops
+  SRC
+    "buffer_ops.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/buffer_ops.mlir
+++ b/iree/vm/test/buffer_ops.mlir
@@ -1,0 +1,635 @@
+vm.module @buffer_ops {
+
+  vm.rodata @rodata_3xi32 dense<[1, 2, 3]> : tensor<3xi32>
+
+  //===--------------------------------------------------------------------===//
+  // Compare
+  //===--------------------------------------------------------------------===//
+  // NOTE: we test this first because all of the other tests rely on it and we
+  // can do it with rodata.
+
+  vm.rodata @rodata_cmp_3xi32_a dense<[100, 200, 300]> : tensor<3xi32>
+  vm.rodata @rodata_cmp_3xi32_b dense<[100, 201, 300]> : tensor<3xi32>
+
+  // Compares some multi-element buffers. Note that comparisons are bytewise.
+  vm.export @test_compare
+  vm.func @test_compare() {
+    %rodata_a = vm.const.ref.rodata @rodata_cmp_3xi32_a : !vm.buffer
+    %rodata_b = vm.const.ref.rodata @rodata_cmp_3xi32_b : !vm.buffer
+    %rodata_a_dno = iree.do_not_optimize(%rodata_a) : !vm.buffer
+    %rodata_b_dno = iree.do_not_optimize(%rodata_b) : !vm.buffer
+
+    %c0 = vm.const.i32 0 : i32
+    %length = vm.buffer.length %rodata_a_dno : !vm.buffer -> i32
+
+    %cmp0 = vm.buffer.compare %rodata_a_dno, %c0, %rodata_a_dno, %c0, %length : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp0, "buffer a == a" : i32
+
+    %cmp1 = vm.buffer.compare %rodata_a_dno, %c0, %rodata_b_dno, %c0, %length : !vm.buffer, !vm.buffer
+    vm.check.eq %cmp1, %c0, "buffer a != b" : i32
+
+    vm.return
+  }
+
+  // Tests comparing an empty range, which should always be equal.
+  vm.export @test_compare_empty
+  vm.func @test_compare_empty() {
+    %rodata_a = vm.const.ref.rodata @rodata_cmp_3xi32_a : !vm.buffer
+    %rodata_b = vm.const.ref.rodata @rodata_cmp_3xi32_b : !vm.buffer
+    %rodata_a_dno = iree.do_not_optimize(%rodata_a) : !vm.buffer
+    %rodata_b_dno = iree.do_not_optimize(%rodata_b) : !vm.buffer
+
+    %c0 = vm.const.i32 0 : i32
+    %c2 = vm.const.i32 2 : i32
+
+    %cmp = vm.buffer.compare %rodata_a_dno, %c2, %rodata_a_dno, %c2, %c0 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "empty buffer ranges are always equal" : i32
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Allocation
+  //===--------------------------------------------------------------------===//
+
+  // Tests allocating a buffer.
+  vm.export @test_alloc
+  vm.func @test_alloc() {
+    %c128 = vm.const.i32 128 : i32
+    %buf = vm.buffer.alloc %c128 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    %buf_length = vm.buffer.length %buf_dno : !vm.buffer -> i32
+    vm.check.eq %c128, %buf_length, "buffer length == 128" : i32
+
+    vm.return
+  }
+
+  // Tests that zero-length buffers can be allocated.
+  vm.export @test_alloc_empty
+  vm.func @test_alloc_empty() {
+    %c0 = vm.const.i32 0 : i32
+    %buf = vm.buffer.alloc %c0 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    %buf_length = vm.buffer.length %buf_dno : !vm.buffer -> i32
+    vm.check.eq %c0, %buf_length, "buffer length == 0" : i32
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Cloning
+  //===--------------------------------------------------------------------===//
+
+  // Tests cloning a subrange of a buffer.
+  vm.export @test_clone
+  vm.func @test_clone() {
+    // Fetch source .rodata blob.
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+
+    // Clone the last two 32-bit elements.
+    %c4 = vm.const.i32 4 : i32
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.clone %rodata, %c4, %c8 : !vm.buffer -> !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Compare the cloned range to the original.
+    %c0 = vm.const.i32 0 : i32
+    %cmp = vm.buffer.compare %rodata, %c4, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "buffer subspans are equal" : i32
+
+    vm.return
+  }
+
+  // Tests cloning a zero-length buffer.
+  vm.export @test_clone_empty
+  vm.func @test_clone_empty() {
+    // Allocate source zero-length buffer.
+    %c0 = vm.const.i32 0 : i32
+    %buf0 = vm.buffer.alloc %c0 : !vm.buffer
+    %buf0_dno = iree.do_not_optimize(%buf0) : !vm.buffer
+    vm.check.nz %buf0_dno, "!null" : !vm.buffer
+    %buf0_length = vm.buffer.length %buf0_dno : !vm.buffer -> i32
+    vm.check.eq %c0, %buf0_length, "buffer length == 0" : i32
+
+    // Clone it all (or, clone nothing?).
+    %buf1 = vm.buffer.clone %buf0_dno, %c0, %c0 : !vm.buffer -> !vm.buffer
+    %buf1_dno = iree.do_not_optimize(%buf1) : !vm.buffer
+    vm.check.nz %buf1_dno, "!null" : !vm.buffer
+    %buf1_length = vm.buffer.length %buf1_dno : !vm.buffer -> i32
+    vm.check.eq %c0, %buf1_length, "buffer length == 0" : i32
+
+    vm.return
+  }
+
+  // Tests an out-of-bounds cloning subrange.
+  vm.export @fail_clone_out_of_range
+  vm.func @fail_clone_out_of_range() {
+    // Fetch source .rodata blob.
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %rodata_dno = iree.do_not_optimize(%rodata) : !vm.buffer
+    vm.check.nz %rodata_dno, "!null" : !vm.buffer
+
+    // Try to clone off the end of the buffer.
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.clone %rodata, %c8, %c8 : !vm.buffer -> !vm.buffer
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Copy
+  //===--------------------------------------------------------------------===//
+
+  // Tests copying an entire buffer from one buffer to another.
+  vm.export @test_copy_full
+  vm.func @test_copy_full() {
+    // Fetch source .rodata blob.
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %rodata_length = vm.buffer.length %rodata : !vm.buffer -> i32
+    vm.check.nz %rodata, "!null" : !vm.buffer
+
+    // Allocate target buffer.
+    %buf = vm.buffer.alloc %rodata_length : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Copy the entire contents.
+    %c0 = vm.const.i32 0 : i32
+    vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %rodata_length : !vm.buffer -> !vm.buffer
+
+    // Compare to source.
+    %cmp = vm.buffer.compare %rodata, %c0, %buf_dno, %c0, %rodata_length : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "source and target match" : i32
+
+    vm.return
+  }
+
+  vm.rodata @test_copy_partial_ref dense<[2]> : tensor<1xi32>
+
+  // Tests copying a range of bytes from one buffer to another.
+  vm.export @test_copy_partial
+  vm.func @test_copy_partial() {
+    // Allocate target buffer.
+    %c4 = vm.const.i32 4 : i32
+    %buf = vm.buffer.alloc %c4 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Copy the middle 4-byte element.
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %c0 = vm.const.i32 0 : i32
+    vm.buffer.copy %rodata, %c4, %buf, %c0, %c4 : !vm.buffer -> !vm.buffer
+
+    // Compare to reference.
+    %ref = vm.const.ref.rodata @test_copy_partial_ref : !vm.buffer
+    %cmp = vm.buffer.compare %ref, %c0, %buf, %c0, %c4 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "source and target match" : i32
+
+    vm.return
+  }
+
+  // Tests an out-of-bounds copy source.
+  vm.export @fail_copy_out_of_range_source_offset
+  vm.func @fail_copy_out_of_range_source_offset() {
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %c128 = vm.const.i32 128 : i32
+    %buf = vm.buffer.alloc %c128 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Try to clone off the end of the source buffer.
+    %c0 = vm.const.i32 0 : i32
+    vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %c128 : !vm.buffer -> !vm.buffer
+
+    vm.return
+  }
+
+  // Tests an out-of-bounds copy source.
+  vm.export @fail_copy_out_of_range_source_length
+  vm.func @fail_copy_out_of_range_source_length() {
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %c128 = vm.const.i32 128 : i32
+    %buf = vm.buffer.alloc %c128 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Try to clone off the end of the source buffer.
+    %c0 = vm.const.i32 0 : i32
+    %c8 = vm.const.i32 8 : i32
+    vm.buffer.copy %rodata, %c8, %buf_dno, %c0, %c8 : !vm.buffer -> !vm.buffer
+
+    vm.return
+  }
+
+  // Tests an out-of-bounds copy target.
+  vm.export @fail_copy_out_of_range_target_offset
+  vm.func @fail_copy_out_of_range_target_offset() {
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %rodata_length = vm.buffer.length %rodata : !vm.buffer -> i32
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.alloc %c8 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Try to clone off the end of the target buffer.
+    %c0 = vm.const.i32 0 : i32
+    vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %rodata_length : !vm.buffer -> !vm.buffer
+
+    vm.return
+  }
+
+  // Tests an out-of-bounds copy target.
+  vm.export @fail_copy_out_of_range_target_length
+  vm.func @fail_copy_out_of_range_target_length() {
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.alloc %c8 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Try to clone off the end of the target buffer.
+    %c0 = vm.const.i32 0 : i32
+    vm.buffer.copy %rodata, %c0, %buf_dno, %c8, %c8 : !vm.buffer -> !vm.buffer
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Fill
+  //===--------------------------------------------------------------------===//
+
+  vm.rodata @test_fill_i16_ref dense<[0, 51966, 51966, 0]> : tensor<4xi16>
+
+  // Tests filling a buffer with 16-bit values.
+  vm.export @test_fill_i16
+  vm.func @test_fill_i16() {
+    // Allocate zeroed buffer.
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.alloc %c8 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+    vm.check.nz %buf_dno, "!null" : !vm.buffer
+
+    // Fill the middle two elements.
+    %c2 = vm.const.i32 2 : i32
+    %c4 = vm.const.i32 4 : i32
+    %cafe = vm.const.i32 0xCAFE : i32
+    vm.buffer.fill.i16 %buf_dno, %c2, %c4, %cafe : i32 -> !vm.buffer
+
+    // Compare to reference.
+    %c0 = vm.const.i32 0 : i32
+    %rodata_ref = vm.const.ref.rodata @test_fill_i16_ref : !vm.buffer
+    %cmp = vm.buffer.compare %rodata_ref, %c0, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "buffer should match reference" : i32
+
+    vm.return
+  }
+
+  vm.rodata @test_fill_i16_misaligned_offset_ref dense<[0xCAFE, 0xCAFE, 0, 0]> : tensor<4xi16>
+
+  // Tests that misaligned fill offsets will succeed but round down.
+  vm.export @test_fill_i16_misaligned_offset
+  vm.func @test_fill_i16_misaligned_offset() {
+    // Allocate zeroed buffer.
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.alloc %c8 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    // Try filling from offset 1, which is not i16-aligned.
+    %c1 = vm.const.i32 1 : i32
+    %c4 = vm.const.i32 4 : i32
+    %cafe = vm.const.i32 0xCAFE : i32
+    vm.buffer.fill.i16 %buf_dno, %c1, %c4, %cafe : i32 -> !vm.buffer
+
+    // Compare to reference - should have written at offset 0.
+    %c0 = vm.const.i32 0 : i32
+    %rodata_ref = vm.const.ref.rodata @test_fill_i16_misaligned_offset_ref : !vm.buffer
+    %cmp = vm.buffer.compare %rodata_ref, %c0, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "buffer should match reference" : i32
+
+
+    vm.return
+  }
+
+  vm.rodata @test_fill_i16_misaligned_length_ref dense<[0, 0, 0, 0]> : tensor<4xi16>
+
+  // Tests that misaligned fill lengths will succeed but round down.
+  vm.export @test_fill_i16_misaligned_length
+  vm.func @test_fill_i16_misaligned_length() {
+    // Allocate zeroed buffer.
+    %c8 = vm.const.i32 8 : i32
+    %buf = vm.buffer.alloc %c8 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    // Try filling for length 1, which is not i16-aligned.
+    %c0 = vm.const.i32 0 : i32
+    %c1 = vm.const.i32 1 : i32
+    %cafe = vm.const.i32 0xCAFE : i32
+    vm.buffer.fill.i16 %buf_dno, %c0, %c1, %cafe : i32 -> !vm.buffer
+
+    // Compare to reference - should have written 0 bytes.
+    %rodata_ref = vm.const.ref.rodata @test_fill_i16_misaligned_length_ref : !vm.buffer
+    %cmp = vm.buffer.compare %rodata_ref, %c0, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "buffer should match reference" : i32
+
+    vm.return
+  }
+
+  // Tests that trying to fill .rodata will fail.
+  vm.export @fail_fill_i16_rodata
+  vm.func @fail_fill_i16_rodata() {
+    %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
+
+    // Permission denied:
+    %c0 = vm.const.i32 0 : i32
+    %c2 = vm.const.i32 2 : i32
+    %cafe = vm.const.i32 0xCAFE : i32
+    vm.buffer.fill.i16 %rodata, %c0, %c2, %cafe : i32 -> !vm.buffer
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Load
+  //===--------------------------------------------------------------------===//
+
+  vm.rodata @test_load_i8_data dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
+
+  vm.export @test_load_i8u
+  vm.func @test_load_i8u() {
+    %c0 = vm.const.i32 0 : i32
+    %c1 = vm.const.i32 1 : i32
+    %c2 = vm.const.i32 2 : i32
+    %c3 = vm.const.i32 3 : i32
+    %c4 = vm.const.i32 4 : i32
+    %rodata = vm.const.ref.rodata @test_load_i8_data : !vm.buffer
+    %v0 = vm.buffer.load.i8.u %rodata[%c0] : !vm.buffer -> i32
+    %e0 = vm.const.i32 0 : i32
+    vm.check.eq %v0, %e0, "0" : i32
+    %v1 = vm.buffer.load.i8.u %rodata[%c1] : !vm.buffer -> i32
+    %e1 = vm.const.i32 1 : i32
+    vm.check.eq %v1, %e1, "1" : i32
+    %v2 = vm.buffer.load.i8.u %rodata[%c2] : !vm.buffer -> i32
+    %e2 = vm.const.i32 0x7F : i32
+    vm.check.eq %v2, %e2, "0x7F" : i32
+    %v3 = vm.buffer.load.i8.u %rodata[%c3] : !vm.buffer -> i32
+    %e3 = vm.const.i32 0x80 : i32
+    vm.check.eq %v3, %e3, "0x80" : i32
+    %v4 = vm.buffer.load.i8.u %rodata[%c4] : !vm.buffer -> i32
+    %e4 = vm.const.i32 0xFF : i32
+    vm.check.eq %v4, %e4, "0xFF" : i32
+    vm.return
+  }
+
+  vm.export @test_load_i8s
+  vm.func @test_load_i8s() {
+    %c0 = vm.const.i32 0 : i32
+    %c1 = vm.const.i32 1 : i32
+    %c2 = vm.const.i32 2 : i32
+    %c3 = vm.const.i32 3 : i32
+    %c4 = vm.const.i32 4 : i32
+    %rodata = vm.const.ref.rodata @test_load_i8_data : !vm.buffer
+    %v0 = vm.buffer.load.i8.s %rodata[%c0] : !vm.buffer -> i32
+    %e0 = vm.const.i32 0 : i32
+    vm.check.eq %v0, %e0, "0" : i32
+    %v1 = vm.buffer.load.i8.s %rodata[%c1] : !vm.buffer -> i32
+    %e1 = vm.const.i32 1 : i32
+    vm.check.eq %v1, %e1, "1" : i32
+    %v2 = vm.buffer.load.i8.s %rodata[%c2] : !vm.buffer -> i32
+    %e2 = vm.const.i32 0x7F : i32
+    vm.check.eq %v2, %e2, "0x7F" : i32
+    %v3 = vm.buffer.load.i8.s %rodata[%c3] : !vm.buffer -> i32
+    %e3 = vm.const.i32 -128 : i32
+    vm.check.eq %v3, %e3, "-128" : i32
+    %v4 = vm.buffer.load.i8.s %rodata[%c4] : !vm.buffer -> i32
+    %e4 = vm.const.i32 -1 : i32
+    vm.check.eq %v4, %e4, "-1" : i32
+    vm.return
+  }
+
+  vm.rodata @test_load_i16_data dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
+
+  vm.export @test_load_i16u
+  vm.func @test_load_i16u() {
+    %c0 = vm.const.i32 0 : i32
+    %c2 = vm.const.i32 2 : i32
+    %c4 = vm.const.i32 4 : i32
+    %c6 = vm.const.i32 6 : i32
+    %c8 = vm.const.i32 8 : i32
+    %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
+    %v0 = vm.buffer.load.i16.u %rodata[%c0] : !vm.buffer -> i32
+    %e0 = vm.const.i32 0 : i32
+    vm.check.eq %v0, %e0, "0" : i32
+    %v1 = vm.buffer.load.i16.u %rodata[%c2] : !vm.buffer -> i32
+    %e1 = vm.const.i32 1 : i32
+    vm.check.eq %v1, %e1, "1" : i32
+    %v2 = vm.buffer.load.i16.u %rodata[%c4] : !vm.buffer -> i32
+    %e2 = vm.const.i32 0x7FFF : i32
+    vm.check.eq %v2, %e2, "0x7FFF" : i32
+    %v3 = vm.buffer.load.i16.u %rodata[%c6] : !vm.buffer -> i32
+    %e3 = vm.const.i32 0x8000 : i32
+    vm.check.eq %v3, %e3, "0x8000" : i32
+    %v4 = vm.buffer.load.i16.u %rodata[%c8] : !vm.buffer -> i32
+    %e4 = vm.const.i32 0xFFFF : i32
+    vm.check.eq %v4, %e4, "0xFFFF" : i32
+    vm.return
+  }
+
+  vm.export @test_load_i16s
+  vm.func @test_load_i16s() {
+    %c0 = vm.const.i32 0 : i32
+    %c2 = vm.const.i32 2 : i32
+    %c4 = vm.const.i32 4 : i32
+    %c6 = vm.const.i32 6 : i32
+    %c8 = vm.const.i32 8 : i32
+    %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
+    %v0 = vm.buffer.load.i16.s %rodata[%c0] : !vm.buffer -> i32
+    %e0 = vm.const.i32 0 : i32
+    vm.check.eq %v0, %e0, "0" : i32
+    %v1 = vm.buffer.load.i16.s %rodata[%c2] : !vm.buffer -> i32
+    %e1 = vm.const.i32 1 : i32
+    vm.check.eq %v1, %e1, "1" : i32
+    %v2 = vm.buffer.load.i16.s %rodata[%c4] : !vm.buffer -> i32
+    %e2 = vm.const.i32 0x7FFF : i32
+    vm.check.eq %v2, %e2, "0x7FFF" : i32
+    %v3 = vm.buffer.load.i16.s %rodata[%c6] : !vm.buffer -> i32
+    %e3 = vm.const.i32 -32768 : i32
+    vm.check.eq %v3, %e3, "-32768" : i32
+    %v4 = vm.buffer.load.i16.s %rodata[%c8] : !vm.buffer -> i32
+    %e4 = vm.const.i32 -1 : i32
+    vm.check.eq %v4, %e4, "-1" : i32
+    vm.return
+  }
+
+  vm.rodata @test_load_i32_data dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
+
+  vm.export @test_load_i32
+  vm.func @test_load_i32() {
+    %c0 = vm.const.i32 0 : i32
+    %c4 = vm.const.i32 4 : i32
+    %c8 = vm.const.i32 8 : i32
+    %c12 = vm.const.i32 12 : i32
+    %c16 = vm.const.i32 16 : i32
+    %rodata = vm.const.ref.rodata @test_load_i32_data : !vm.buffer
+    %v0 = vm.buffer.load.i32 %rodata[%c0] : !vm.buffer -> i32
+    %e0 = vm.const.i32 0 : i32
+    vm.check.eq %v0, %e0, "0" : i32
+    %v1 = vm.buffer.load.i32 %rodata[%c4] : !vm.buffer -> i32
+    %e1 = vm.const.i32 1 : i32
+    vm.check.eq %v1, %e1, "1" : i32
+    %v2 = vm.buffer.load.i32 %rodata[%c8] : !vm.buffer -> i32
+    %e2 = vm.const.i32 0x7FFFFFFF : i32
+    vm.check.eq %v2, %e2, "0x7FFFFFFF" : i32
+    %v3 = vm.buffer.load.i32 %rodata[%c12] : !vm.buffer -> i32
+    %e3 = vm.const.i32 0x80000000 : i32
+    vm.check.eq %v3, %e3, "0x80000000" : i32
+    %v4 = vm.buffer.load.i32 %rodata[%c16] : !vm.buffer -> i32
+    %e4 = vm.const.i32 0xFFFFFFFF : i32
+    vm.check.eq %v4, %e4, "0xFFFFFFFF" : i32
+    vm.return
+  }
+
+  vm.rodata @test_load_i32_unaligned_data dense<[0x00112233, 0x44556677, 0x8899AABB, 0xCCDDEEFF]> : tensor<4xui32>
+
+  // Unaligned loads are not supported and offsets will be rounded down.
+  vm.export @test_load_i32_unaligned
+  vm.func @test_load_i32_unaligned() {
+    %rodata = vm.const.ref.rodata @test_load_i32_unaligned_data : !vm.buffer
+
+    // Byte offset 5 rounded to byte offset 4 (element 1).
+    %c5 = vm.const.i32 5 : i32
+    %v1 = vm.buffer.load.i32 %rodata[%c5] : !vm.buffer -> i32
+    %e1 = vm.const.i32 0x44556677 : i32
+    vm.check.eq %v1, %e1, "0x44556677" : i32
+
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Store
+  //===--------------------------------------------------------------------===//
+
+  vm.rodata @test_store_i8_ref dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
+
+  vm.export @test_store_i8
+  vm.func @test_store_i8() {
+    %ref = vm.const.ref.rodata @test_store_i8_ref : !vm.buffer
+    %ref_dno = iree.do_not_optimize(%ref) : !vm.buffer
+    %ref_length = vm.buffer.length %ref_dno : !vm.buffer -> i32
+
+    %buf = vm.buffer.alloc %ref_length : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    %c0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0 : i32
+    vm.buffer.store.i8 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
+    %c1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1 : i32
+    vm.buffer.store.i8 %e1, %buf_dno[%c1] : i32 -> !vm.buffer
+    %c2 = vm.const.i32 2 : i32
+    %e2 = vm.const.i32 0x7F : i32
+    vm.buffer.store.i8 %e2, %buf_dno[%c2] : i32 -> !vm.buffer
+    %c3 = vm.const.i32 3 : i32
+    %e3 = vm.const.i32 0x80 : i32
+    vm.buffer.store.i8 %e3, %buf_dno[%c3] : i32 -> !vm.buffer
+    %c4 = vm.const.i32 4 : i32
+    %e4 = vm.const.i32 0xFF : i32
+    vm.buffer.store.i8 %e4, %buf_dno[%c4] : i32 -> !vm.buffer
+
+    %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "source and target match" : i32
+
+    vm.return
+  }
+
+  vm.rodata @test_store_i16_ref dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
+
+  vm.export @test_store_i16
+  vm.func @test_store_i16() {
+    %ref = vm.const.ref.rodata @test_store_i16_ref : !vm.buffer
+    %ref_dno = iree.do_not_optimize(%ref) : !vm.buffer
+    %ref_length = vm.buffer.length %ref_dno : !vm.buffer -> i32
+
+    %buf = vm.buffer.alloc %ref_length : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    %c0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0 : i32
+    vm.buffer.store.i16 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
+    %c2 = vm.const.i32 2 : i32
+    %e1 = vm.const.i32 1 : i32
+    vm.buffer.store.i16 %e1, %buf_dno[%c2] : i32 -> !vm.buffer
+    %c4 = vm.const.i32 4 : i32
+    %e2 = vm.const.i32 0x7FFF : i32
+    vm.buffer.store.i16 %e2, %buf_dno[%c4] : i32 -> !vm.buffer
+    %c6 = vm.const.i32 6 : i32
+    %e3 = vm.const.i32 0x8000 : i32
+    vm.buffer.store.i16 %e3, %buf_dno[%c6] : i32 -> !vm.buffer
+    %c8 = vm.const.i32 8 : i32
+    %e4 = vm.const.i32 0xFFFF : i32
+    vm.buffer.store.i16 %e4, %buf_dno[%c8] : i32 -> !vm.buffer
+
+    %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "source and target match" : i32
+
+    vm.return
+  }
+
+  vm.rodata @test_store_i32_ref dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
+
+  vm.export @test_store_i32
+  vm.func @test_store_i32() {
+    %ref = vm.const.ref.rodata @test_store_i32_ref : !vm.buffer
+    %ref_dno = iree.do_not_optimize(%ref) : !vm.buffer
+    %ref_length = vm.buffer.length %ref_dno : !vm.buffer -> i32
+
+    %buf = vm.buffer.alloc %ref_length : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    %c0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0 : i32
+    vm.buffer.store.i32 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
+    %c4 = vm.const.i32 4 : i32
+    %e1 = vm.const.i32 1 : i32
+    vm.buffer.store.i32 %e1, %buf_dno[%c4] : i32 -> !vm.buffer
+    %c8 = vm.const.i32 8 : i32
+    %e2 = vm.const.i32 0x7FFFFFFF : i32
+    vm.buffer.store.i32 %e2, %buf_dno[%c8] : i32 -> !vm.buffer
+    %c12 = vm.const.i32 12 : i32
+    %e3 = vm.const.i32 0x80000000 : i32
+    vm.buffer.store.i32 %e3, %buf_dno[%c12] : i32 -> !vm.buffer
+    %c16 = vm.const.i32 16 : i32
+    %e4 = vm.const.i32 0xFFFFFFFF : i32
+    vm.buffer.store.i32 %e4, %buf_dno[%c16] : i32 -> !vm.buffer
+
+    %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
+    vm.check.nz %cmp, "source and target match" : i32
+
+    vm.return
+  }
+
+  // Unaligned stores are not supported and offsets will be rounded down.
+  vm.export @test_store_i32_unaligned
+  vm.func @test_store_i32_unaligned() {
+    %c12 = vm.const.i32 12 : i32
+    %buf = vm.buffer.alloc %c12 : !vm.buffer
+    %buf_dno = iree.do_not_optimize(%buf) : !vm.buffer
+
+    // Byte offset 5 rounded to byte offset 4 (element 1).
+    %c5 = vm.const.i32 5 : i32
+    %e1 = vm.const.i32 0x44556677 : i32
+    vm.buffer.store.i32 %e1, %buf_dno[%c5] : i32 -> !vm.buffer
+
+    // Read back at offset 4 (where the data should be).
+    %c4 = vm.const.i32 4 : i32
+    %a1 = vm.buffer.load.i32 %buf_dno[%c4] : !vm.buffer -> i32
+    vm.check.eq %a1, %e1, "0x44556677" : i32
+
+    vm.return
+  }
+
+}


### PR DESCRIPTION
Previously the VM had a special builtin for read-only buffers and it was always just a placeholder for something more meaningful. This is the start of that. This implementation will undergo a lot of changes as VMVX is brought up but is the first wave of work to unblock that exploration.

`vm.list`/`iree_vm_list_t` are useful for storing reference-counted objects and heterogeneous element types and supports resizing, and this new `vm.buffer`/`iree_vm_buffer_t` is useful for fast access to fixed-length sets of primitive values with the ability to bitcast the storage. The buffer is access checked (preventing writes to read-only memory), origin checked (preventing inadvertent lifetime extension), bounds checked/alignment-enforced, and is a ref object like any other so that proper lifetime is tracked across host/guest/module boundaries.

The intent is to have a memory-safe byte buffer that supports external host memory, read-only mapped buffer memory (.rodata sections), and read/write memory allocated from within the user VM code. There's a long list of ops in the HAL that needed this (such as `hal.command_buffer.update_buffer`) and techniques like uniform buffers or mapping memory directly from devices into VM-accessible data.

The op set here is relatively mundane with malloc, memset, memcmp, memcpy, etc and typed load/store routines. Future extensions to this can add more ways of loading/storing such as multi-value loads/stores to reduce overhead - VMVX may use that to emulate vector loads/stores, for example, with a `vm.buffer.load.i16x32`.