### PR TITLE
Add cmake-riscv docker image

### DIFF
--- a/build_tools/docker/cmake-riscv/Dockerfile
+++ b/build_tools/docker/cmake-riscv/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# An image for cross-compiling IREE towards RISCV using CMake.
+
+FROM gcr.io/iree-oss/util@sha256:40846b4aea5886af3250399d6adfdb3e1195a8b0177706bb0375e812d62dc49c AS install-riscv
+WORKDIR /install-riscv
+RUN wget "https://storage.googleapis.com/iree-shared-files/toolchain_iree_rvv-intrinsic.tar.gz"
+RUN tar -xf "toolchain_iree_rvv-intrinsic.tar.gz" -C /usr/src/
+RUN wget "https://storage.googleapis.com/iree-shared-files/qemu-riscv.tar.gz"
+RUN tar -xf "qemu-riscv.tar.gz" -C /usr/src/
+
+FROM gcr.io/iree-oss/cmake@sha256:9d9953acf5ca0cf1ff3e8de32f10f24dfab1c4e8ec5d1fc047f556024ee4bed6 AS final
+COPY --from=install-riscv "/usr/src/toolchain_iree" "/usr/src/toolchain_iree"
+COPY --from=install-riscv "/usr/src/qemu-riscv" "/usr/src/qemu-riscv"
+ENV RISCV_TOOLCHAIN_ROOT="/usr/src/toolchain_iree"

--- a/build_tools/docker/manage_images.py
+++ b/build_tools/docker/manage_images.py
@@ -58,6 +58,7 @@ IMAGES_TO_DEPENDENCIES = {
     'cmake-python-vulkan': ['cmake-python', 'vulkan'],
     'cmake-python-swiftshader': ['cmake-python-vulkan', 'swiftshader'],
     'cmake-python-nvidia': ['cmake-python-vulkan'],
+    'cmake-riscv': ['cmake', 'util'],
     'cmake-bazel-frontends': ['cmake-python', 'bazel'],
     'cmake-bazel-frontends-vulkan': ['cmake-bazel-frontends', 'vulkan'],
     'cmake-bazel-frontends-swiftshader': [

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -14,3 +14,4 @@ gcr.io/iree-oss/cmake-bazel-frontends@sha256:699f6470e618c151f36cb4769ccaf2cfbf3
 gcr.io/iree-oss/cmake-bazel-frontends-vulkan@sha256:02c21884ec62a548992fc62031c41375d5cb7ebc33cb4ecbb8ac0ec2c83a2aa1
 gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:79998983c574bb6fd0625a99a541364749c76f8ff6c6ee98411b612a9950470b
 gcr.io/iree-oss/cmake-bazel-frontends-swiftshader@sha256:012dd9b452da5c4f4248edf27a7a7faa0eeca6a7a2a1e21d00bc932b125246e1
+gcr.io/iree-oss/cmake-riscv@sha256:a09ff1e6ab65a436822894acf58ef6c4cbc523581960e918a07ddf4a46c8af95


### PR DESCRIPTION
The docker image has the RISC-V crosscompile toolchain and QEMU
installed. It is used to run RISC-V CI checks.

The first PR for https://github.com/google/iree/issues/5751