### PR TITLE
Applies ForOpCanonicalizationPass after LinalgTileAndVectorizeWorkgroupsPass

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -29,9 +29,13 @@ namespace iree_compiler {
 void addLinalgToLLVMPasses(OpPassManager &passManager,
                            LLVMCodegenOptions options) {
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+
+  // Tile and vectorize linalg ops.
   nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<FuncOp>(
       createLinalgTileAndVectorizeWorkgroupsPass());
+  nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
 
   nestedModulePM.addNestedPass<FuncOp>(createPlanConvLoopOrderPass());
 


### PR DESCRIPTION
This fixes the %15 mobilebert perf regression cased by the follwing canonicalization:

```
%86 = vector.outerproduct %84, %85, %83 {kind = #vector.kind<add>} : vector<4xf32>, vector<4xf32>
%87 = vector.shape_cast %86 : vector<4x4xf32> to vector<1x4x4xf32>
scf.yield %87 : vector<1x4x4xf32>
```

```
 %86 = vector.outerproduct %84, %85, %83 {kind = #vector.kind<add>} : vector<4xf32>, vector<4xf32>
 %87 = vector.insert %86, %cst_0 [0] : vector<4x4xf32> into vector<1x4x4xf32>
 scf.yield %87 : vector<1x4x4xf32>
```

While this isn't actually fixing why LLVM is generating bad code for the
snippet above, but it makes both LLVM/SPIR-V backends applies the same
canonicalization for the vector loops.