### PR TITLE
Update MobileNetV2 mako compilation flags for cpu

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -236,12 +236,10 @@ MODEL_BENCHMARKS = [
                     skipped_target=["vlk2"],
                     compilation_flags={
                         'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
+                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
                         ],
                         'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
+                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
                         ]
                     })),
             PhoneBenchmarkInfo(
@@ -250,12 +248,10 @@ MODEL_BENCHMARKS = [
                 targets=get_s20_default_target_list(
                     compilation_flags={
                         'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
+                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
                         ],
                         'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
-                            "-iree-llvm-loop-unrolling=true"
+                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
                         ]
                     })),
         ]),


### PR DESCRIPTION
The current flag `iree-flow-dispatch-formation-enable-operand-fusion` fails compilation.