### PR TITLE
Support linalg.pad_tensor bufferization

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -1071,11 +1071,15 @@ static LogicalResult convertPadTensorOp(OpBuilder &b,
   Value paddingValue = yeildOp.values()[0];
 
   auto constOp = paddingValue.getDefiningOp<ConstantOp>();
-  assert(constOp &&
-         "Converting linalg.pad_tensor with non-constant padding value");
-  assert(!constOp.getValue().isa<DenseElementsAttr>() &&
-         "Converting linalg.pad_tensor with non-scalar constant padding "
-         "value");
+  if (!constOp) {
+    return padTensorOp.emitError(
+        "Converting linalg.pad_tensor with non-constant padding value");
+  }
+  if (constOp.getValue().isa<DenseElementsAttr>()) {
+    return padTensorOp.emitError(
+        "Converting linalg.pad_tensor with non-scalar constant padding "
+        "value");
+  }
 
   b.create<linalg::FillOp>(loc, resultPaddedBuffer, paddingValue);
 

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -1070,6 +1070,13 @@ static LogicalResult convertPadTensorOp(OpBuilder &b,
       *padTensorOp.region().getOps<linalg::YieldOp>().begin();
   Value paddingValue = yeildOp.values()[0];
 
+  auto constOp = paddingValue.getDefiningOp<ConstantOp>();
+  assert(constOp &&
+         "Converting linalg.pad_tensor with non-constant padding value");
+  assert(!constOp.getValue().isa<DenseElementsAttr>() &&
+         "Converting linalg.pad_tensor with non-scalar constant padding "
+         "value");
+
   b.create<linalg::FillOp>(loc, resultPaddedBuffer, paddingValue);
 
   // Get the interior region.


### PR DESCRIPTION
linalg.pad_tensor will be converted into:
allocation + fill + copy(src, sub_view_interior_region)