### PR TITLE
Add -iree-llvm-debug-symbols=false to simple_embedding sample.

### DIFF
--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -123,6 +123,7 @@ iree_bytecode_module(
         "-iree-mlir-to-vm-bytecode-module",
         "-iree-hal-target-backends=dylib-llvm-aot",
         "-iree-hal-target-backends=vulkan-spirv",
+        "-iree-llvm-debug-symbols=false",
     ],
 )
 

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -97,6 +97,7 @@ iree_bytecode_module(
     "-iree-mlir-to-vm-bytecode-module"
     "-iree-hal-target-backends=dylib-llvm-aot"
     "-iree-hal-target-backends=vulkan-spirv"
+    "-iree-llvm-debug-symbols=false"
   PUBLIC
 )
 


### PR DESCRIPTION
Fixes `compiler limit: string exceeds 65535 bytes in length` on MSVC.