### PR TITLE
Save IREE input for XLA import after running passes

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -216,11 +216,6 @@ int main(int argc, char **argv) {
     return success();
   };
 
-  // Save temp output.
-  if (!saveTempIreeImport.empty()) {
-    if (failed(saveToFile(saveTempIreeImport))) return 10;
-  }
-
   // Run passes.
   PassManager pm(&context, PassManager::Nesting::Implicit);
   applyPassManagerCLOptions(pm);
@@ -230,6 +225,11 @@ int main(int argc, char **argv) {
     llvm::errs()
         << "Running iree-xla-import pass pipeline failed (see diagnostics)\n";
     return 2;
+  }
+
+  // Save temp output.
+  if (!saveTempIreeImport.empty()) {
+    if (failed(saveToFile(saveTempIreeImport))) return 10;
   }
 
   // Save output.


### PR DESCRIPTION
This is the output we need to repro in IREE core and matches the behavior of the other
import tools:
https://github.com/google/iree/blob/5f36903a3638424d68b5acbba611988e4b17320e/integrations/tensorflow/iree_tf_compiler/iree-tf-import-main.cpp#L227-L240

Maybe saving the the temp input from before the pipeline would also be useful, as we
do for for tf-import:
https://github.com/google/iree/blob/5f36903a3638424d68b5acbba611988e4b17320e/integrations/tensorflow/iree_tf_compiler/iree-tf-import-main.cpp#L215-L217

But that's a separate change :-)