### PR TITLE
Add publish_website.yml GitHub Action for automated deployment.

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -1,0 +1,31 @@
+# Builds the website sourced from docs/website/ using `mkdocs` and pushes
+# to the gh-pages branch for publishing on GitHub Pages.
+#
+# See https://squidfunk.github.io/mkdocs-material/publishing-your-site/
+
+name: Publish Website
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: docs/website
+
+jobs:
+  publish_website:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout out repository
+        uses: actions/checkout@v2
+      - name: Setting up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Installing Material for MkDocs
+        run: pip install mkdocs-material
+      - name: Deploying to gh-pages
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/5460

Tested on my fork:
* [sample run](https://github.com/ScottTodd/iree/actions/runs/818465974)
* [`gh-pages` history](https://github.com/ScottTodd/iree/commits/gh-pages)

This overwrites the history of the `gh-pages` branch whenever changes are made.