### PR TITLE
Misc Python API cleanups to support native ABI uses encountered.

### DIFF
--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -317,14 +317,41 @@ py::object VmVariantList::GetAsNdarray(int index) {
   iree_hal_element_type_t element_type =
       iree_hal_buffer_view_element_type(buffer_view);
   // See: https://docs.python.org/3/c-api/arg.html#numbers
+  // TODO: Handle dtypes that do not map to a code (i.e. fp16).
   const char* dtype_code;
   switch (element_type) {
+    case IREE_HAL_ELEMENT_TYPE_SINT_8:
+      dtype_code = "b";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_UINT_8:
+      dtype_code = "B";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_SINT_16:
+      dtype_code = "h";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_UINT_16:
+      dtype_code = "H";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_SINT_32:
+      dtype_code = "i";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_UINT_32:
+      dtype_code = "I";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_SINT_64:
+      dtype_code = "l";
+      break;
+    case IREE_HAL_ELEMENT_TYPE_UINT_64:
+      dtype_code = "L";
+      break;
     case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
       dtype_code = "f";
       break;
     case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
       dtype_code = "d";
       break;
+    default:
+      throw RaiseValueError("Unsupported VM Buffer -> numpy dtype mapping");
   }
   auto dtype = py::dtype(dtype_code);
 

--- a/docs/developers/design_docs/function_abi.md
+++ b/docs/developers/design_docs/function_abi.md
@@ -180,6 +180,9 @@ type specific fields:
 -   `["sdict", ["key", {slot_type}]...]`: An anonymous structure with named
     slots. Note that when passing these types, the keys are not passed to the
     function (only the slot values).
+-   `["sdict_kwargs", ...]`: Same as `sdict` but signifies to languages that
+    allow keyword-argument passing that this is the keyword-argument dictionary.
+    It can only ever be present as the last entry of the root arguments `slist`.
 
 ## Deprecated V0 ABIs
 

--- a/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
@@ -293,7 +293,13 @@ class _IreeFunctionWrapper(_FunctionWrapper):
 
   def get_serialized_values(self) -> Tuple[Tuple[str], Tuple[str]]:
     """Get cxx serialized inputs and outputs for this function."""
-    return self._f.get_serialized_values()
+    if hasattr(self._f, "get_serialized_values"):
+      # TODO: The native ABI does not implement this, and if still needed,
+      # it should not be implemented this way (maybe a thread local trace
+      # listener).
+      return self._f.get_serialized_values()
+    else:
+      return ("",), ("",)
 
 
 class IreeCompiledModule(CompiledModule):

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
@@ -94,3 +94,17 @@ module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 
     return %0, %1, %2, %3 : tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>
   }
 }
+
+// -----
+// CHECK-LABEL: module @kwargs
+// CHECK: func @dict_nest
+// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22sdict\22,[\22list\22,[\22slist\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]],[\22ndarray\22,\22f32\22,0],[\22sdict_kwargs\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],\22r\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],[\22list\22,[\22slist\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]]],\22v\22:1}"
+module @kwargs attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  func @__inference_dict_nest_190(%arg0: tensor<16xf32> {tf_saved_model.index_path = ["a"]}, %arg1: tensor<16xf32> {tf_saved_model.index_path = ["b"]}, %arg2: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 0]}, %arg3: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 1]}, %arg4: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = ["dict", "a"]}, tensor<16xf32> {tf_saved_model.index_path = ["dict", "b"]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 0]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf.shape<16>, #tf.shape<16>, #tf.shape<16>, #tf.shape<16>, #tf.shape<>], tf_saved_model.exported_names = ["dict_nest"]} {
+    %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
+    %1 = "tf.Identity"(%arg1) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
+    %2 = "tf.Identity"(%arg2) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
+    %3 = "tf.Identity"(%arg3) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
+    return %0, %1, %2, %3 : tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>
+  }
+}


### PR DESCRIPTION
* Add arg/return details to Python error messages.
* Also provides a no-op implementation of get_serialized_values() pending doing something better.
* Add more numpy->HAL types.
* Add VM -> numpy dtype mappings.