### PR TITLE
Adding support for memref.global in FlattenMemRefSubspanPass.

### DIFF
--- a/iree/compiler/Conversion/Common/Passes.h
+++ b/iree/compiler/Conversion/Common/Passes.h
@@ -59,7 +59,7 @@ std::unique_ptr<FunctionPass> createBufferAllocViewCleanUpPass();
 // Flattens n-D MemRef subspan ops to 1-D MemRef and folds the byte offsets on
 // subspan ops to the consumer load/store ops, in preparation for lowering to
 // backends that require linearized access.
-std::unique_ptr<FunctionPass> createFlattenMemRefSubspanPass();
+std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Passes.cpp
@@ -126,7 +126,7 @@ static void addLinalgToSPIRVPasses(OpPassManager &pm,
   pm.nest<ModuleOp>().addPass(createCanonicalizerPass());
   pm.nest<ModuleOp>().addPass(createCSEPass());
 
-  pm.nest<ModuleOp>().addNestedPass<FuncOp>(createFlattenMemRefSubspanPass());
+  pm.nest<ModuleOp>().addPass(createFlattenMemRefSubspanPass());
   pm.nest<ModuleOp>().addPass(createLowerAffinePass());
   pm.nest<ModuleOp>().addPass(createCanonicalizerPass());
   pm.nest<ModuleOp>().addPass(createCSEPass());


### PR DESCRIPTION
Fixes #5764.