### PR TITLE
Add missing config file for riscv64 build on main branch

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/main.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/main.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.


### PR DESCRIPTION
We missed this in https://github.com/google/iree/pull/5762 and now the Kokoro build is
failing because it can't find the config file.