### PR TITLE
Remap hyperlinks following website migration.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,8 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-If you believe this is an issue with IREE core (not integrations) please provide a reproduction (including artifacts) that does not require integrations ([Instructions for extracting artifacts from TF tests](https://google.github.io/iree/developing-iree/tensorflow-integrations#generated-artifacts))
+If you believe this is an issue with IREE core (not integrations) please provide a reproduction (including artifacts) that does not require integrations
+([Instructions for extracting artifacts from TF tests](https://github.com/google/iree/blob/main/docs/developers/developing_iree/e2e_benchmarking.md))
 
 1. Go to '...'
 2. Click on '....'

--- a/docs/developers/design_docs/hal_driver_features.md
+++ b/docs/developers/design_docs/hal_driver_features.md
@@ -103,7 +103,7 @@ overall steps are as follows:
 [d89364]: https://reviews.llvm.org/D89364
 [iree-hal]: https://github.com/google/iree/tree/main/iree/hal
 [iree-hal-c-api]: https://github.com/google/iree/blob/main/iree/hal/api.h
-[iree-hal-dialect]: https://google.github.io/iree/Dialects/HALDialect
+[iree-hal-dialect]: https://github.com/google/iree/tree/main/iree/compiler/Dialect/HAL
 [iree-vulkan-dialect]: https://github.com/google/iree/tree/main/iree/compiler/Dialect/Vulkan
 [iree-vulkan-base-td]: https://github.com/google/iree/blob/main/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
 [iree-vulkan-cap-td]: https://github.com/google/iree/blob/main/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.td

--- a/docs/developers/developing_iree/e2e_benchmarking.md
+++ b/docs/developers/developing_iree/e2e_benchmarking.md
@@ -14,7 +14,7 @@ This allows us to validate that our benchmarks are behaving as we expect them
 to, and to run them using valid inputs for each model.
 
 This guide assumes that you can run the tensorflow integration tests. See
-[this doc](https://google.github.io/iree/get-started/getting-started-python)
+[this doc](https://google.github.io/iree/building-from-source/optional-features/)
 for more information. That doc also covers writing new tests, which you'll need
 to do if you'd like to benchmark a new TensorFlow model.
 
@@ -232,7 +232,7 @@ $ ./bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model \
 
 IREE only supports compiling to Android with CMake. Documentation on setting up
 your environment to cross-compile to Android can be found
-[here](https://google.github.io/iree/get-started/getting-started-android-cmake).
+[here](https://google.github.io/iree/building-from-source/android/).
 
 ```shell
 # After following the instructions above up to 'Build all targets', the

--- a/docs/developers/developing_iree/testing_guide.md
+++ b/docs/developers/developing_iree/testing_guide.md
@@ -27,7 +27,7 @@ $ bazel test iree/base:arena_test
 
 ### Setting test environments
 
-Parallel testing for `ctest` can be enabled via the `CTEST_PARALLEL_LEVEL` 
+Parallel testing for `ctest` can be enabled via the `CTEST_PARALLEL_LEVEL`
 environment variable. For example:
 
 ```shell
@@ -254,20 +254,18 @@ func @negative() attributes { iree.module.export } {
 The test case functions are exported using the `iree.module.export` attribute.
 Each of these exported functions will be used to create a test case in gtest.
 
-Note the use of
-[`iree.unfoldable_constant`](https://google.github.io/iree/Dialects/IREEDialect#ireeunfoldable_constant-ireeunfoldableconstantop)
-to specify test constants. If we were to use a regular constant, the compiler
-would "helpfully" fold away everything at compile time and our test would not
-actually test the runtime. `unfoldable_constant` hides the value of the constant
-from the compiler so it cannot use it at compile time. To hide an arbitrary
-SSA-value, you can use
-[`iree.do_not_optimize`](https://google.github.io/iree/Dialects/IREEDialect#ireedo_not_optimize-ireedonotoptimizeop).
-This wraps any value in an unoptimizable identity function.
+Note the use of `iree.unfoldable_constant` to specify test constants. If we were
+to use a regular constant, the compiler would "helpfully" fold away everything
+at compile time and our test would not actually test the runtime.
+`unfoldable_constant` hides the value of the constant from the compiler so it
+cannot use it at compile time. To hide an arbitrary SSA-value, you can use
+`iree.do_not_optimize`. This wraps any value in an unoptimizable identity
+function.
 
 Next we use this input constant to exercise the runtime feature under test (in
 this case, just a single floor operation). Finally, we use a check dialect
 operation to make an assertion about the output. There are a few different
-[assertion operations](https://google.github.io/iree/Dialects/CheckDialect).
+[assertion operations](https://github.com/google/iree/tree/main/iree/compiler/Dialect/Modules/Check).
 Here we use the `expect_almost_eq_const` op: *almost* because we are comparing
 floats and want to allow for floating-point imprecision, and *const* because we
 want to compare it to a constant value. This last part is just syntactic sugar

--- a/integrations/tensorflow/e2e/README.md
+++ b/integrations/tensorflow/e2e/README.md
@@ -5,7 +5,7 @@
 > Note:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The TensorFlow integrations are currently being
   refactored. The `bazel` build is deprecated. Refer to
-  https://google.github.io/iree/get-started/getting-started-python for a general
+  https://google.github.io/iree/building-from-source/optional-features/ for a general
   overview of how to build and execute the e2e tests.
 
 This is a collection of e2e tests that compile a TensorFlow model with IREE (and
@@ -24,7 +24,7 @@ instructions.
 ## Vulkan Setup
 
 If you do not have your environment setup to use IREE with Vulkan (see
-[this doc](https://google.github.io/iree/get-started/generic-vulkan-env-setup)),
+[this doc](https://google.github.io/iree/deployment-configurations/gpu-vulkan/)),
 then you can run the manual test targets with
 `--target_backends=tf,iree_vmla,iree_llvmaot` (that is, by omitting
 `iree_vulkan` from the list of backends to run the tests on).
@@ -344,7 +344,8 @@ We use our end-to-end TensorFlow integrations tests to generate tested
 compilation and benchmarking artifacts. This allows us to validate that our
 benchmarks are behaving as we expect them to, and to run them using valid inputs
 for each model. An overview of how to run benchmarks on IREE and TFLite can be
-found in [this doc](https://google.github.io/iree/developing-iree/e2e-benchmarking).
+found in
+[this doc](https://github.com/google/iree/blob/main/docs/developers/developing_iree/e2e_benchmarking.md).
 
 ## Debugging Tests
 

--- a/iree/test/e2e/tosa_ops/BUILD
+++ b/iree/test/e2e/tosa_ops/BUILD
@@ -16,7 +16,7 @@
 # Each test file should have a name matching the corresponding TOSA op and test only the
 # functionality of that op (though may make use of other ops where necessary). Tests should be
 # written using the IREE Check framework.
-# See https://google.github.io/iree/developing-iree/testing-guide#iree-core-end-to-end-tests.
+# See https://github.com/google/iree/blob/main/docs/developers/developing_iree/testing_guide.md#iree-core-end-to-end-tests.
 
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -16,7 +16,7 @@
 # Each test file should have a name matching the corresponding XLA HLO op and test only the
 # functionality of that op (though may make use of other ops where necessary). Tests should be
 # written using the IREE Check framework and should always pass on the reference VMLA backend.
-# See https://google.github.io/iree/TestingGuide#iree-core-end-to-end-tests.
+# See https://github.com/google/iree/blob/main/docs/developers/developing_iree/testing_guide.md#iree-core-end-to-end-tests.
 
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")

--- a/iree/test/e2e/xla_ops/partial/BUILD
+++ b/iree/test/e2e/xla_ops/partial/BUILD
@@ -21,7 +21,7 @@
 # the functionality of that op should be tessted (though it may make use of
 # other ops where necessary). Tests should be written using the IREE Check
 # framework and should always pass on the reference VMLA backend. See
-# https://google.github.io/iree/TestingGuide#iree-core-end-to-end-tests.
+# https://github.com/google/iree/blob/main/docs/developers/developing_iree/testing_guide.md#iree-core-end-to-end-tests.
 
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 

--- a/scripts/get_e2e_artifacts.py
+++ b/scripts/get_e2e_artifacts.py
@@ -157,8 +157,8 @@ def main(argv):
 
   print("The bazel integrations build and tests are deprecated. This script "
         "may be reworked in the future. For the time being refer to "
-        "https://google.github.io/iree/get-started/getting-started-python "
-        "and https://google.github.io/iree/developing-iree/e2e-benchmarking "
+        "https://google.github.io/iree/building-from-source/optional-features/ "
+        "and https://github.com/google/iree/blob/main/docs/developers/developing_iree/e2e_benchmarking.md "
         "for information on how to run TensorFlow benchmarks.")
   exit(1)
 

--- a/scripts/get_e2e_artifacts.py
+++ b/scripts/get_e2e_artifacts.py
@@ -155,11 +155,12 @@ def extract_artifacts(test_path: str, test_name: str, written_paths: Set[str],
 def main(argv):
   del argv  # Unused.
 
-  print("The bazel integrations build and tests are deprecated. This script "
-        "may be reworked in the future. For the time being refer to "
-        "https://google.github.io/iree/building-from-source/optional-features/ "
-        "and https://github.com/google/iree/blob/main/docs/developers/developing_iree/e2e_benchmarking.md "
-        "for information on how to run TensorFlow benchmarks.")
+  print(
+      "The bazel integrations build and tests are deprecated. This script "
+      "may be reworked in the future. For the time being refer to "
+      "https://google.github.io/iree/building-from-source/optional-features/ "
+      "and https://github.com/google/iree/blob/main/docs/developers/developing_iree/e2e_benchmarking.md "
+      "for information on how to run TensorFlow benchmarks.")
   exit(1)
 
   # Convert test suite shorthands to full test suite targets.

--- a/scripts/git/update_to_llvm_syncpoint.py
+++ b/scripts/git/update_to_llvm_syncpoint.py
@@ -21,7 +21,7 @@ third_party/mlir-hlo submodules to commits that match the LLVM commit in the
 third_party/llvm-project submodule. We have special conditions around these
 submodules since they are synced as part of the integration of LLVM into
 Google's source repository. See
-https://google.github.io/iree/developing-iree/repository-management#the-special-relationship-with-llvm-and-tensorflow.
+https://github.com/google/iree/blob/main/docs/developers/developing_iree/repository_management.md#the-special-relationship-with-llvm-and-tensorflow.
 
 Typical usage:
   Syntax: ./scripts/git/update_to_llvm_syncpoint.py


### PR DESCRIPTION
Updated some links to point to the new website (GitHub Pages) and others to point to pages directly on GitHub that are no longer published.