### PR TITLE
Implement python argument decoding for list/tuple/dict nests.

### DIFF
--- a/bindings/python/iree/runtime/vm.h
+++ b/bindings/python/iree/runtime/vm.h
@@ -98,6 +98,7 @@ class VmVariantList {
   }
 
   std::string DebugString() const;
+  void PushList(VmVariantList& other);
   void PushBufferView(HalDevice& device, py::object py_buffer_object,
                       iree_hal_element_type_e element_type);
   py::object GetAsNdarray(int index);

--- a/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
@@ -179,7 +179,7 @@ struct StructureLevel {
             json::Value(type == LevelType::List ? "slist" : "stuple"));
         int lastIndex = 0;
         for (auto &child : children) {
-          for (int j = lastIndex; j < child.ikey; ++j) {
+          for (int j = children.size(); j < child.ikey; ++j) {
             typeRecord.push_back(json::Value(nullptr));
           }
           lastIndex = child.valueIndex;


### PR DESCRIPTION
* IREE's compiler still has trouble compiling forms that return structured results, so some hacked tests were used to verify.
* Once compiler support is complete, existing tests should be sufficient.
* Keyword argument support was not fully tested because existing tests for it also return structured outputs.
* Also fixes indexing mismatch in null padding of TF nested arguments.