### PR TITLE
Replacing std::vector use with a simple stack/heap allocated array.

### DIFF
--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -42,6 +42,7 @@ cc_library(
     hdrs = [
         "atomics.h",
         "debugging.h",
+        "inline_array.h",
         "math.h",
     ],
     deps = [

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "atomics.h"
     "debugging.h"
+    "inline_array.h"
     "math.h"
   SRCS
     "atomics_clang.h"

--- a/iree/base/internal/inline_array.h
+++ b/iree/base/internal/inline_array.h
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BASE_INTERNAL_INLINE_ARRAY_H_
+#define IREE_BASE_INTERNAL_INLINE_ARRAY_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//==============================================================================
+// iree_inline_array_t
+//==============================================================================
+
+// Maximum number of bytes that can be allocated from the stack.
+// Arrays exceeding this size will incur a heap allocation.
+#define IREE_INLINE_ARRAY_MAX_STACK_ALLOCATION 512
+
+#define iree_inline_array(type, variable, initial_size, allocator)       \
+  const iree_allocator_t variable##_allocator = (allocator);             \
+  struct {                                                               \
+    iree_host_size_t size;                                               \
+    type* data;                                                          \
+  } variable = {                                                         \
+      (initial_size),                                                    \
+      NULL,                                                              \
+  };                                                                     \
+  if (IREE_UNLIKELY(sizeof(type) * (initial_size) >                      \
+                    IREE_INLINE_ARRAY_MAX_STACK_ALLOCATION)) {           \
+    IREE_CHECK_OK(iree_allocator_malloc(variable##_allocator,            \
+                                        sizeof(type) * (initial_size),   \
+                                        (void**)&(variable).data));      \
+  } else {                                                               \
+    (variable).data = (type*)iree_alloca(sizeof(type) * (initial_size)); \
+  }
+
+#define iree_inline_array_deinitialize(variable)                 \
+  if (IREE_UNLIKELY(sizeof(*(variable).data) * (variable).size > \
+                    IREE_INLINE_ARRAY_MAX_STACK_ALLOCATION)) {   \
+    iree_allocator_free(variable##_allocator, (variable).data);  \
+  }
+
+#define iree_inline_array_size(variable) (variable).size
+
+#define iree_inline_array_capacity(variable) (variable).capacity
+#define iree_inline_array_data(variable) (variable).data
+
+#define iree_inline_array_at(variable, index) &(variable).data[(index)]
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_BASE_INTERNAL_INLINE_ARRAY_H_

--- a/iree/hal/vulkan/native_executable.cc
+++ b/iree/hal/vulkan/native_executable.cc
@@ -34,6 +34,7 @@ typedef struct {
 static iree_status_t iree_hal_vulkan_create_shader_module(
     VkDeviceHandle* logical_device, iree_const_byte_span_t code,
     VkShaderModule* out_shader_module) {
+  IREE_TRACE_SCOPE();
   VkShaderModuleCreateInfo create_info;
   create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
   create_info.pNext = NULL;
@@ -62,6 +63,7 @@ static iree_status_t iree_hal_vulkan_create_pipelines(
     iree_hal_executable_layout_t* const* executable_layouts,
     iree_host_size_t pipeline_count,
     iree_hal_vulkan_entry_point_t* out_entry_points) {
+  IREE_TRACE_SCOPE();
   VkComputePipelineCreateInfo* create_infos = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       logical_device->host_allocator(),
@@ -121,6 +123,7 @@ static iree_status_t iree_hal_vulkan_create_pipelines(
 
 static void iree_hal_vulkan_destroy_pipeline(VkDeviceHandle* logical_device,
                                              VkPipeline handle) {
+  IREE_TRACE_SCOPE();
   if (handle == VK_NULL_HANDLE) return;
   logical_device->syms()->vkDestroyPipeline(*logical_device, handle,
                                             logical_device->allocator());

--- a/iree/modules/hal/hal_module.c
+++ b/iree/modules/hal/hal_module.c
@@ -135,7 +135,7 @@ typedef struct {
   iree_hal_semaphore_t* submit_semaphore;
   uint64_t submit_value;
 
-  void* deferred_lru[4];
+  void* deferred_lru[6];
   iree_vm_list_t* deferred_releases;
 } iree_hal_module_state_t;
 
@@ -203,7 +203,7 @@ void iree_hal_module_ex_defer_release(iree_hal_module_state_t* state,
   // repeated patterns in the common case.
   for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(state->deferred_lru); ++i) {
     if (state->deferred_lru[i] == value.ptr) {
-      // Hit - keep the list sorted my most->least recently used.
+      // Hit - keep the list sorted by most->least recently used.
       state->deferred_lru[i] = state->deferred_lru[0];
       state->deferred_lru[0] = value.ptr;
       return;


### PR DESCRIPTION
The absl::InlinedVector->std::vector change introduced an alloc per barrier recorded. This adds a fixed-size stack/heap array (as that's our common usage of these stack vectors) and returns to 0 allocations during command buffer recording in the steady state.

![image](https://user-images.githubusercontent.com/75337/117559516-df8bb980-b03a-11eb-81e5-ac39334612cf.png)
