### PR TITLE
Move check for backends used in simple_embedding

### DIFF
--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -44,6 +44,16 @@ c_embed_data(
     h_file_output = "simple_embedding_test_llvm_aot_rv64.h",
 )
 
+iree_cmake_extra_content(
+    content = """
+if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
+   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
+  return()
+endif()
+""",
+    inline = True,
+)
+
 cc_binary(
     name = "simple_embedding_dylib",
     srcs = [
@@ -102,16 +112,6 @@ cc_binary(
         "//iree/vm",
         "//iree/vm:bytecode_module",
     ],
-)
-
-iree_cmake_extra_content(
-    content = """
-if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
-   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
-  return()
-endif()
-""",
-    inline = True,
 )
 
 iree_bytecode_module(

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -23,6 +23,11 @@ iree_c_embed_data(
   PUBLIC
 )
 
+if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
+   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
+  return()
+endif()
+
 iree_cc_binary(
   NAME
     simple_embedding_dylib
@@ -79,11 +84,6 @@ iree_cc_binary(
     iree::vm
     iree::vm::bytecode_module
 )
-
-if(NOT ${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} OR NOT ${IREE_TARGET_BACKEND_VULKAN-SPIRV}
-   OR NOT ${IREE_HAL_DRIVER_DYLIB} OR NOT ${IREE_HAL_DRIVER_VULKAN})
-  return()
-endif()
 
 iree_bytecode_module(
   NAME


### PR DESCRIPTION
Re-enables building IREE with VMLA only.