### PR TITLE
Disable printing op on diagnostics in iree_check_test targets.

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -53,6 +53,7 @@ def iree_check_test(
         src = src,
         flags = [
             "-iree-mlir-to-vm-bytecode-module",
+            "-mlir-print-op-on-diagnostic=false",
             "--iree-hal-target-backends=%s" % target_backend,
         ] + compiler_flags,
         visibility = ["//visibility:private"],

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -88,6 +88,7 @@ function(iree_check_test)
         "${_RULE_SRC}"
       FLAGS
         "-iree-mlir-to-vm-bytecode-module"
+        "-mlir-print-op-on-diagnostic=false"
         "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
         "--iree-llvm-target-triple=${_TARGET_TRIPLE}"
         ${_RULE_COMPILER_FLAGS}
@@ -101,6 +102,7 @@ function(iree_check_test)
         "${_RULE_SRC}"
       FLAGS
         "-iree-mlir-to-vm-bytecode-module"
+        "-mlir-print-op-on-diagnostic=false"
         "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}"
         ${_RULE_COMPILER_FLAGS}
       TESTONLY


### PR DESCRIPTION
Following https://github.com/google/iree/pull/5806

See https://gist.github.com/ScottTodd/548adea41b07002b03dadedb24a3ffdc for sample build output when several generated targets fail compilation before/after this change.