### PR TITLE
Remove patterns from VectorToGPU

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorToGPUPass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorToGPUPass.cpp
@@ -112,85 +112,10 @@ void ConvertVectorToGPUPass::tileAndVectorizeLinalgCopy(FuncOp funcOp,
   (void)applyPatternsAndFoldGreedily(funcOp, std::move(vectorizationPatterns));
 }
 
-// Lower elementwise operation from N-D vector to 1-D vectors that can be
-// natively supported.
-// TODO(thomasraoux):  Move this to MLIR core vector transformations.
-class ElementwiseLowering : public RewritePattern {
- public:
-  ElementwiseLowering(MLIRContext *context)
-      : RewritePattern(MatchAnyOpTypeTag(), 0, context) {}
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    if (!OpTrait::hasElementwiseMappableTraits(op) || op->getNumResults() != 1)
-      return failure();
-    auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>();
-    if (!vecType || vecType.getRank() == 1) return failure();
-
-    SmallVector<Value, 4> newOperands;
-    for (Value operand : op->getOperands()) {
-      if (auto opVecType = operand.getType().dyn_cast<VectorType>()) {
-        auto newType = VectorType::get({opVecType.getNumElements()},
-                                       opVecType.getElementType());
-        newOperands.push_back(rewriter.create<vector::ShapeCastOp>(
-            op->getLoc(), newType, operand));
-      } else {
-        newOperands.push_back(operand);
-      }
-    }
-    OperationState state(op->getLoc(), op->getName());
-    state.addAttributes(op->getAttrs());
-    state.addOperands(newOperands);
-    state.addTypes({VectorType::get({vecType.getNumElements()},
-                                    vecType.getElementType())});
-    Operation *newOp = rewriter.createOperation(state);
-    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, vecType,
-                                                     newOp->getResult(0));
-    return success();
-  }
-};
-
-// Lower ExtractStridedSliceOp to an ExtractOp instruction that can be natively
-// converted to SPIR-V. Add a BroadcastOp to keep the type consistent, we expect
-// the Broadcast to be removed by canonicalization.
-class ExtractStridedLowering
-    : public OpRewritePattern<vector::ExtractStridedSliceOp> {
- public:
-  using OpRewritePattern<vector::ExtractStridedSliceOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::ExtractStridedSliceOp op,
-                                PatternRewriter &rewriter) const override {
-    // Only handle cases extracting a degenerated vector so that we can generate
-    // an extractOp with scalar destination.
-    if (op.getResult().getType().cast<VectorType>().getNumElements() != 1)
-      return failure();
-    auto loc = op.getLoc();
-    SmallVector<int64_t, 4> offsets = llvm::to_vector<4>(
-        llvm::map_range(op.offsets().getAsRange<IntegerAttr>(),
-                        [](IntegerAttr attr) { return attr.getInt(); }));
-    offsets.resize(op.getVectorType().getRank(), 0);
-    Value newOp = rewriter.create<vector::ExtractOp>(loc, op.vector(), offsets);
-    newOp = rewriter.create<vector::BroadcastOp>(loc, op.getResult().getType(),
-                                                 newOp);
-    rewriter.replaceOp(op, newOp);
-    return success();
-  }
-};
-
-// Lower vector ops to instructions that can be later converted to SPIR-V.
-void ConvertVectorToGPUPass::lowerVectorOps(FuncOp funcOp,
-                                            MLIRContext *context) {
-  OwningRewritePatternList patterns(&getContext());
-  patterns.insert<ExtractStridedLowering, ElementwiseLowering>(context);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
-}
-
 void ConvertVectorToGPUPass::runOnOperation() {
   MLIRContext *context = &getContext();
   FuncOp funcOp = getOperation();
   tileAndVectorizeLinalgCopy(funcOp, context);
-
-  lowerVectorOps(funcOp, context);
 }
 }  // namespace
 

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/vector_to_gpu.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/vector_to_gpu.mlir
@@ -38,19 +38,3 @@ module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.v
     // CHECK:   %[[LOAD:.+]] = vector.transfer_read %[[SVs]][%c0, %c0], %cst {{.*}} : memref<1x4xf32, {{.*}}>, vector<1x4xf32>
     // CHECK:   vector.transfer_write %[[LOAD]], %[[SVd]][%[[C0]], %[[C0]]] {{.*}} : vector<1x4xf32>, memref<1x4xf32
 }
-
-// -----
-
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  func @extract(%arg0 : vector<1x4xf32>) -> vector<1x1xf32> attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
-    %0 = vector.extract_strided_slice %arg0
-      {offsets = [0, 2], sizes = [1, 1], strides = [1, 1]}
-        : vector<1x4xf32> to vector<1x1xf32>
-    return %0 : vector<1x1xf32>
-  }
-  // CHECK-LABEL: func @extract
-  //  CHECK-SAME: (%[[ARG0:.*]]: vector<1x4xf32>
-  //       CHECK:   %[[A:.*]] = vector.extract %[[ARG0]][0, 2] : vector<1x4xf32>
-  //       CHECK:   %[[B:.*]] = vector.broadcast %[[A]] : f32 to vector<1x1xf32>
-  //       CHECK:   return %[[B]] : vector<1x1xf32>
-}


### PR DESCRIPTION
Those are not needed anymore and are replaced by MLIR core patterns.