### PR TITLE
Harmonize integer types of in- and outputs

### DIFF
--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1967,18 +1967,18 @@ iree_status_t iree_vm_bytecode_dispatch(
         *result = vm_cast_si32f32(operand);
       });
       DISPATCH_OP(EXT_F32, CastUI32F32, {
-        uint32_t operand = (uint32_t)VM_DecOperandRegI32("operand");
+        int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
         float* result = VM_DecResultRegF32("result");
         *result = vm_cast_ui32f32(operand);
       });
       DISPATCH_OP(EXT_F32, CastF32SI32, {
         float operand = VM_DecOperandRegF32("operand");
-        int32_t* result = (int32_t*)VM_DecResultRegI32("result");
+        int32_t* result = VM_DecResultRegI32("result");
         *result = vm_cast_f32si32(operand);
       });
       DISPATCH_OP(EXT_F32, CastF32UI32, {
         float operand = VM_DecOperandRegF32("operand");
-        uint32_t* result = (uint32_t*)VM_DecResultRegI32("result");
+        int32_t* result = VM_DecResultRegI32("result");
         *result = vm_cast_f32ui32(operand);
       });
 

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -93,11 +93,13 @@ static inline float vm_ceil_f32(float operand) { return ceilf(operand); }
 static inline float vm_floor_f32(float operand) { return floorf(operand); }
 
 static inline float vm_cast_si32f32(int32_t operand) { return (float)operand; }
-static inline float vm_cast_ui32f32(uint32_t operand) { return (float)operand; }
+static inline float vm_cast_ui32f32(int32_t operand) {
+  return (float)(uint32_t)operand;
+}
 static inline int32_t vm_cast_f32si32(float operand) {
   return (int32_t)roundf(operand);
 }
-static inline uint32_t vm_cast_f32ui32(float operand) {
+static inline int32_t vm_cast_f32ui32(float operand) {
   return (uint32_t)roundf(operand);
 }
 


### PR DESCRIPTION
Makes sure we use `int32_t` as function arguments and for return types
as in the other header only implementations in the shared `ops.h`
header. EmitC always emits `int32_t`.