### PR TITLE
Use full path to ghost in 404 page

### DIFF
--- a/docs/website/overrides/404.html
+++ b/docs/website/overrides/404.html
@@ -2,9 +2,9 @@
 {% block content %}
 <center>
   <h1>
-    <img alt="👻" class="twemoji" src="ghost.svg" title=":ghost:">
+    <img alt="👻" class="twemoji" src="https://google.github.io/iree/ghost.svg" title=":ghost:">
     404 - Not found
-    <img alt="👻" class="twemoji" src="ghost.svg" title=":ghost:">
+    <img alt="👻" class="twemoji" src="https://google.github.io/iree/ghost.svg" title=":ghost:">
   </h1>
 
   <p>Sorry, we couldn't find that page.</p>


### PR DESCRIPTION
In https://github.com/google/iree/pull/5824 I only tested a non-existent page at the root.
Whoops! Currently it can't find the image if the non-existent page is nested, e.g.
https://google.github.io/iree/foo/404

![no_image](https://user-images.githubusercontent.com/5732088/117858136-68287680-b242-11eb-83c9-02f338a1073a.png)

Live preview with this PR available at https://gmngeoffrey.github.io/iree/foo/404

![found_image](https://user-images.githubusercontent.com/5732088/117858238-855d4500-b242-11eb-8bd0-6fb396d55b60.png)

