### PR TITLE
Add a pass to pad linalg workgroup ops

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "LinalgTileAndVectorizePass.cpp",
         "LinalgVectorizePass.cpp",
         "MaterializeCPULaunchConfigurationPass.cpp",
+        "PadLinalgWorkgroupTiles.cpp",
         "Passes.cpp",
         "PlanConvLoopOrder.cpp",
         "UnfuseFMAOps.cpp",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "LinalgTileAndVectorizePass.cpp"
     "LinalgVectorizePass.cpp"
     "MaterializeCPULaunchConfigurationPass.cpp"
+    "PadLinalgWorkgroupTiles.cpp"
     "Passes.cpp"
     "PlanConvLoopOrder.cpp"
     "UnfuseFMAOps.cpp"

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
@@ -39,6 +39,9 @@ struct TileSizeFn {
                                          Operation *operation);
 };
 
+template <TilingLevel tilingLevel>
+llvm::SmallVector<int64_t, 4> getTileSizes(Operation *op);
+
 Optional<LaunchConfig> initCPULaunchConfig(
     MLIRContext *context, const linalg::LinalgDependenceGraph &dependenceGraph,
     ArrayRef<linalg::LinalgOp> linalgOps);

--- a/iree/compiler/Conversion/LinalgToLLVM/PadLinalgWorkgroupTiles.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/PadLinalgWorkgroupTiles.cpp
@@ -1,0 +1,265 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-llvm-pad-linalg-workgroup-tiles"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+// Creates linalg.pad_tensor op with constant padding.
+static linalg::PadTensorOp createPadTensorOpWithStaticPadding(
+    PatternRewriter &rewriter, mlir::Location loc, Type resultType, Value input,
+    Value padding, ArrayRef<int64_t> lowPadding,
+    ArrayRef<int64_t> highPadding) {
+  auto padTensorOp = rewriter.create<linalg::PadTensorOp>(
+      loc, resultType, input, ArrayRef<Value>{}, ArrayRef<Value>{},
+      rewriter.getI64ArrayAttr(lowPadding),
+      rewriter.getI64ArrayAttr(highPadding));
+
+  int rank = padTensorOp.getResultType().getRank();
+  SmallVector<Type, 4> blockArgTypes;
+  blockArgTypes.assign(rank, rewriter.getIndexType());
+  auto &region = padTensorOp.region();
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.createBlock(&region, region.end(), blockArgTypes);
+  rewriter.create<linalg::YieldOp>(loc, padding);
+  return padTensorOp;
+}
+
+// Returns padding for dim to next integer multiple of the vector size.
+static std::pair<int, int> getVectorPaddingSize(int dim, int vecSize) {
+  if (dim < vecSize) {
+    int size = vecSize;
+    int padValue = size - dim;
+    return {vecSize, padValue};
+  } else {
+    int size = ceil((float)dim / (float)vecSize) * vecSize;
+    int padValue = size - dim;
+    return {size, padValue};
+  }
+}
+
+// Returns padding for dim to next integer multiple of the workgroup size.
+// Note: KernelDispatch gurantess workgroup size is the largest integer
+// multiple of the vector size.
+std::pair<int, int> getWorkgroupPaddedTileSize(int dim, int workgoupSize,
+                                               int vecSize) {
+  if (dim > workgoupSize) {
+    int size = ceil((float)dim / (float)workgoupSize) * workgoupSize;
+    int padValue = size - dim;
+    return {workgoupSize, padValue};
+  } else {
+    return getVectorPaddingSize(dim, vecSize);
+  }
+}
+
+// Clones all attributes from src to dst Operation.
+static void cloneAttributes(mlir::Operation *src, mlir::Operation *dst) {
+  for (auto attr : src->getAttrs()) {
+    dst->setAttr(attr.first, attr.second);
+  }
+}
+
+// Returns static full-shape sizes of operand.
+ArrayRef<int64_t> getFullSize(Value operand) {
+  auto defOp = operand.getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+  if (!defOp) return {};
+  TensorType shape = defOp.source()
+                         .getType()
+                         .cast<IREE::Flow::DispatchTensorType>()
+                         .asTensorType();
+  if (!shape.hasStaticShape()) return {};
+  return shape.getShape();
+}
+
+// Creates linalg.matmul with operands padded to the next integer multiple of
+// the workgroup size.
+class MatmulWorkgroupTilesPadding : public OpRewritePattern<linalg::MatmulOp> {
+ public:
+  using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = matmulOp.getLoc();
+    auto lhs = matmulOp.getInput(0);
+    auto rhs = matmulOp.getInput(1);
+    auto result = matmulOp.getOutput(0);
+
+    if (lhs.getDefiningOp<linalg::PadTensorOp>() ||
+        rhs.getDefiningOp<linalg::PadTensorOp>())
+      return failure();
+
+    auto lhsFullSize = getFullSize(lhs);
+    auto rhsFullSize = getFullSize(rhs);
+
+    if (lhsFullSize.empty() || rhsFullSize.empty()) return failure();
+
+    int problemSizeM = lhsFullSize[0];
+    int problemSizeN = rhsFullSize[1];
+    int problemSizeK = lhsFullSize[1];
+
+    auto workgroupTileSizes =
+        getTileSizes<TilingLevel::WorkGroupTiles>(matmulOp);
+    auto vectorTileSizes = getTileSizes<TilingLevel::Level2Tiles>(matmulOp);
+
+    int paddedMSize, paddedNSize, paddedKSize;
+    int paddingForM, paddingForN, paddingForK;
+
+    std::tie(paddedMSize, paddingForM) = getWorkgroupPaddedTileSize(
+        problemSizeM, workgroupTileSizes[0], vectorTileSizes[0]);
+    std::tie(paddedNSize, paddingForN) = getWorkgroupPaddedTileSize(
+        problemSizeN, workgroupTileSizes[1], vectorTileSizes[1]);
+    std::tie(paddedKSize, paddingForK) =
+        getVectorPaddingSize(problemSizeK, vectorTileSizes[2]);
+
+    DEBUG_WITH_TYPE(DEBUG_TYPE, {
+      auto l1TileSizes = getTileSizes<TilingLevel::Level1Tiles>(matmulOp);
+      llvm::dbgs() << "Problem-size: "
+                   << "[" << problemSizeM << "," << problemSizeK << "]"
+                   << ", "
+                   << "[" << problemSizeK << "," << problemSizeN << "]\n";
+      llvm::dbgs() << "Workgroup-tile-sizes:"
+                   << "[" << workgroupTileSizes[0] << ", "
+                   << workgroupTileSizes[1] << "]\n";
+      llvm::dbgs() << "L1-tile-sizes:"
+                   << "[" << l1TileSizes[0] << ", " << l1TileSizes[1] << ","
+                   << l1TileSizes[2] << "]\n";
+      llvm::dbgs() << "Vector-tile-sizes:"
+                   << "[" << vectorTileSizes[0] << ", " << vectorTileSizes[1]
+                   << ", " << vectorTileSizes[2] << "]\n";
+      llvm::dbgs() << "LHS after padding:"
+                   << "[" << paddedMSize << "," << paddedKSize << "]\n";
+      llvm::dbgs() << "RHS after padding:"
+                   << "[" << paddedKSize << "," << problemSizeN << "]\n";
+    });
+
+    // No padding.
+    if (paddingForM == 0 && paddingForN == 0 && paddingForK == 0)
+      return failure();
+
+    auto getPaddedOperand = [&](Value operand, ArrayRef<int64_t> shape,
+                                ArrayRef<int64_t> highPadding) -> Value {
+      if (llvm::all_of(highPadding,
+                       [](int64_t val) -> bool { return val == 0; })) {
+        return operand;
+      }
+      auto elementType =
+          operand.getType().cast<RankedTensorType>().getElementType();
+      auto paddedType = RankedTensorType::get(shape, elementType);
+      auto paddingValue =
+          rewriter.create<ConstantOp>(loc, rewriter.getZeroAttr(elementType));
+      auto paddedOperand =
+          createPadTensorOpWithStaticPadding(rewriter, loc, paddedType, operand,
+                                             paddingValue, {0, 0}, highPadding);
+      return paddedOperand;
+    };
+
+    auto paddedLhs = getPaddedOperand(lhs, {paddedMSize, paddedKSize},
+                                      {paddingForM, paddingForK});
+
+    auto paddedrhs = getPaddedOperand(rhs, {paddedKSize, paddedNSize},
+                                      {paddingForK, paddingForN});
+
+    auto resultType = RankedTensorType::get(
+        {paddedMSize, paddedNSize},
+        result.getType().cast<RankedTensorType>().getElementType());
+
+    // Padding for K-dim only result doesn't change result size.
+    if (paddingForM == 0 && paddingForN == 0) {
+      auto paddedMatmulOp = rewriter.create<linalg::MatmulOp>(
+          loc, resultType, ArrayRef<Value>{paddedLhs, paddedrhs},
+          ArrayRef<Value>{result});
+      cloneAttributes(matmulOp.getOperation(), paddedMatmulOp.getOperation());
+      rewriter.replaceOp(matmulOp, paddedMatmulOp.getResults());
+    } else {
+      // Padding eather M or N requires changing the result size.
+      auto getActualSizes = [](Value operand) {
+        auto defOp = operand.getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+        return defOp.sizes();
+      };
+      // Get the actual output tile size (before padding).
+      auto lhsSizes = getActualSizes(lhs);
+      auto rhsSizes = getActualSizes(rhs);
+      SmallVector<OpFoldResult> sizes;
+      if (lhsSizes.empty()) {
+        sizes.push_back(rewriter.getIndexAttr(paddedMSize));
+      } else {
+        sizes.push_back(lhsSizes.front());
+      }
+      if (rhsSizes.empty()) {
+        sizes.push_back(rewriter.getIndexAttr(paddedNSize));
+      } else {
+        sizes.push_back(rhsSizes.back());
+      }
+      auto elementType = matmulOp.getResults()[0]
+                             .getType()
+                             .cast<ShapedType>()
+                             .getElementType();
+      auto staticResult = rewriter.create<linalg::InitTensorOp>(
+          loc, ArrayRef<int64_t>{paddedMSize, paddedNSize}, elementType);
+
+      Value zero =
+          rewriter.create<ConstantOp>(loc, rewriter.getZeroAttr(elementType));
+      auto filledStaticResult =
+          rewriter.create<linalg::FillOp>(loc, staticResult, zero);
+      auto newOp = rewriter.create<linalg::MatmulOp>(
+          loc, resultType, ArrayRef<Value>{paddedLhs, paddedrhs},
+          ArrayRef<Value>{filledStaticResult.result()});
+      newOp.getOperation()->setAttr("__internal_linalg_transform__",
+                                    rewriter.getStringAttr("workgroup"));
+      SmallVector<OpFoldResult> offsets(2, rewriter.getI64IntegerAttr(0));
+      SmallVector<OpFoldResult> strides(2, rewriter.getI64IntegerAttr(1));
+      auto subtensorOp = rewriter.replaceOpWithNewOp<SubTensorOp>(
+          matmulOp, newOp.getResults()[0], offsets, sizes, strides);
+    }
+    return success();
+  }
+};
+
+struct PadLinalgWorkgroupTilesPass
+    : PassWrapper<PadLinalgWorkgroupTilesPass, FunctionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+  void runOnFunction() override {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(&getContext());
+    patterns.insert<MatmulWorkgroupTilesPadding>(context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createPadLinalgWorkgroupTilesPass() {
+  return std::make_unique<PadLinalgWorkgroupTilesPass>();
+}
+
+static PassRegistration<PadLinalgWorkgroupTilesPass> pass(
+    "iree-codegen-llvm-pad-linalg-workgroup-tiles",
+    "Padding linalg workgroup tiles into an integer multiple of tiling "
+    "parameters.");
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -65,6 +65,7 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createMaterializeCPULaunchConfigurationPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<FuncOp>(createPadLinalgWorkgroupTilesPass());
   // TODO(ataei): We want to enable when tensor -> vector pass is fully
   // supported which requires first moving vector-tiling before this step.
   if (options.useLinalgOnTensorsToVectors) {

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -26,6 +26,14 @@ namespace iree_compiler {
 /// order.
 std::unique_ptr<FunctionPass> createPlanConvLoopOrderPass();
 
+/// Pad linalg ops workgroup tiles into the next integer multiple of the target
+/// vector size.
+std::unique_ptr<FunctionPass> createPadLinalgWorkgroupTilesPass();
+
+/// Distributes linalg ops among hal.interface.workgroup logical threads.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createLinalgTileAndDistributePass();
+
 /// Vectorizes linalg ops executed in the same hal.interface.workgroup.
 std::unique_ptr<FunctionPass> createLinalgTileAndVectorizeWorkgroupsPass();
 

--- a/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "linalg_vectorize.mlir",
             "materialize_launch_configuration.mlir",
             "matmul_vectorization.mlir",
+            "pad_linalg_workgroup_tiles.mlir",
             "plan_conv_loop_order.mlir",
             "unfused_fma.mlir",
         ],

--- a/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "linalg_vectorize.mlir"
     "materialize_launch_configuration.mlir"
     "matmul_vectorization.mlir"
+    "pad_linalg_workgroup_tiles.mlir"
     "plan_conv_loop_order.mlir"
     "unfused_fma.mlir"
   DATA

--- a/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
@@ -105,7 +105,7 @@ hal.executable @add attributes {sym_visibility = "private"} {
         %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?xf32>
         %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<?xf32>
         %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x?xf32>
-        linalg.generic {
+        linalg.generic {__internal_linalg_transform__ = "workgroup"} {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                            affine_map<(d0, d1) -> (d1)>,
                            affine_map<(d0, d1) -> (d0, d1)>],

--- a/iree/compiler/Conversion/LinalgToLLVM/test/pad_linalg_workgroup_tiles.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/pad_linalg_workgroup_tiles.mlir
@@ -1,0 +1,64 @@
+// RUN: iree-opt %s -cse -iree-codegen-llvm-pad-linalg-workgroup-tiles -split-input-file | IreeFileCheck %s
+
+module  {
+  func @matmul_f32_5x3x5() {
+    %c0 = constant 0 : index
+    %cst = constant 0.000000e+00 : f32
+    %c5 = constant 5 : index
+    %c64 = constant 64 : index
+    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:5x3xf32>
+    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x5xf32>
+    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:5x5xf32>
+    %workgroup_id_x = hal.interface.workgroup.id[0] : index
+    %workgroup_count_x = hal.interface.workgroup.count[0] : index
+    %workgroup_id_y = hal.interface.workgroup.id[1] : index
+    %workgroup_count_y = hal.interface.workgroup.count[1] : index
+    %3 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %c64]
+    %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %c64]
+    scf.for %arg0 = %3 to %c5 step %4 {
+      %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %c64]
+      %6 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %c64]
+      scf.for %arg1 = %5 to %c5 step %6 {
+        %7 = affine.min affine_map<(d0) -> (64, -d0 + 5)>(%arg0)
+        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 3], strides = [1, 1] : !flow.dispatch.tensor<readonly:5x3xf32> -> tensor<?x3xf32>
+        %9 = affine.min affine_map<(d0) -> (64, -d0 + 5)>(%arg1)
+        %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [3, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:3x5xf32> -> tensor<3x?xf32>
+        %11 = affine.min affine_map<(d0) -> (64, -d0 + 5)>(%arg0)
+        %12 = affine.min affine_map<(d0) -> (64, -d0 + 5)>(%arg1)
+        %13 = affine.min affine_map<(d0) -> (-d0 + 5, 64)>(%arg0)
+        %14 = affine.min affine_map<(d0) -> (-d0 + 5, 64)>(%arg1)
+        %15 = linalg.init_tensor [%13, %14] : tensor<?x?xf32>
+        %16 = linalg.fill(%15, %cst) {__internal_linalg_transform__ = "workgroup"} : tensor<?x?xf32>, f32 -> tensor<?x?xf32> 
+        %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", is_root_op} ins(%8, %10 : tensor<?x3xf32>, tensor<3x?xf32>) outs(%16 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %17, %2, offsets = [%arg0, %arg1], sizes = [%11, %12], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:5x5xf32>
+      }
+    }
+    return
+  }
+    
+  hal.interface @io attributes {sym_visibility = "private"} {
+    hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: @matmul_f32_5x3x5
+//       CHECK: %[[C0:.+]] = constant 0.000000e+00 : f32
+//       CHECK: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%{{.*}}] : !flow.dispatch.tensor<readonly:5x3xf32>
+//       CHECK: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%{{.*}}] : !flow.dispatch.tensor<readonly:3x5xf32>
+//       CHECK: %[[RESULT:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%{{.*}}] : !flow.dispatch.tensor<writeonly:5x5xf32>
+//       CHECK: flow.dispatch.tensor.load %[[LHS]], offsets = [%{{.*}}, 0], sizes = [%[[LHS_TILE_SIZE:.+]], 3], strides = [1, 1] : !flow.dispatch.tensor<readonly:5x3xf32> -> tensor<?x3xf32>
+//       CHECK: flow.dispatch.tensor.load %[[RHS]], offsets = [0, %{{.*}}], sizes = [3, %[[RHS_TILE_SIZE:.+]]], strides = [1, 1] : !flow.dispatch.tensor<readonly:3x5xf32> -> tensor<3x?xf32>
+//       CHECK: %[[PADDED_LHS:.+]] = linalg.pad_tensor %{{.*}} low[0, 0] high[3, 1]  {
+//  CHECK-NEXT:     ^bb0(%{{.*}}: index, %{{.*}}: index):  // no predecessors
+//  CHECK-NEXT: linalg.yield %[[C0]] : f32
+//  CHECK-NEXT: tensor<?x3xf32> to tensor<8x4xf32>
+//       CHECK: %[[PADDED_RHS:.+]] = linalg.pad_tensor %{{.*}} low[0, 0] high[1, 3]  {
+//  CHECK-NEXT:     ^bb0(%{{.*}}: index, %{{.*}}: index):  // no predecessors
+//  CHECK-NEXT: linalg.yield %[[C0]] : f32
+//  CHECK-NEXT: tensor<3x?xf32> to tensor<4x8xf32>
+//       CHECK: %[[PADDED_RESULT:.+]] = linalg.init_tensor [8, 8] : tensor<8x8xf32>
+//       CHECK: %[[PADDED_RESULT_0:.+]] = linalg.fill(%[[PADDED_RESULT]], %[[C0]]) : tensor<8x8xf32>
+//       CHECK: %[[MATMUL_RESULT:.+]] = linalg.matmul {{.*}} ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<8x4xf32>, tensor<4x8xf32>) outs(%[[PADDED_RESULT_0]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+//       CHECK: %[[CLIPED_RESULT:.+]] = subtensor %[[MATMUL_RESULT]][0, 0] [%[[LHS_TILE_SIZE]], %[[RHS_TILE_SIZE]]] [1, 1] : tensor<8x8xf32> to tensor<?x?xf32>
+//       CHECK:  flow.dispatch.tensor.store %[[CLIPED_RESULT]], %[[RESULT]], offsets = [%{{.*}}, %{{.*}}], sizes = [%[[LHS_TILE_SIZE]], %[[RHS_TILE_SIZE]]], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:5x5xf32>

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -79,6 +79,7 @@ inline void registerLinalgToLLVMPasses() {
     createLinalgTileAndVectorizeWorkgroupsPass();
     createMaterializeCPULaunchConfigurationPass();
     createUnfusedFMAOpsPass();
+    createPadLinalgWorkgroupTilesPass();
     return true;
   }();
   (void)init_once;

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -630,6 +630,8 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     /// and `strides` operands.
     static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 2; }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def FLOW_ReturnOp : FLOW_Op<"return", [Terminator]> {


### PR DESCRIPTION
This pass adds `linalg.pad_tensor` to pad matmul qualified (not an integer multiple of target tiling) workgroup tile operands to the next integer multiple of target tiling-size (vector or workgroup) which enables vectorization for all matmul shapes.

This is a medium term solution to get vectorization enabled for performance until we do tile+pad+hoist on tensors.

With this pass all `img2col` matmul are running with good performance for all conv models we are tracking: 


- MobileNetV2:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time        180 ms          180 ms            4


----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       77.0 ms         76.7 ms            9
```

- MobileNetV3:

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time        117 ms          117 ms            6

----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       58.9 ms         58.7 ms           12

```
- Resnet50:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time       1393 ms         1389 ms            1

----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_predict/process_time/real_time        494 ms          492 ms            2
```
