### PR TITLE
Extend vector transfer scalarization fallback

### DIFF
--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemrefLoadStorePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemrefLoadStorePass.cpp
@@ -356,14 +356,11 @@ class ProcessInterfaceBinding final
   }
 };
 
-/// Translates vector.transfer_read with less than 4 scalars into reading each
-/// scalar and then compose the vector.
-///
-/// This is a very specific pattern for handling corner cases and boundary
-/// cases. For example, in vision models we can have the initial image with
-/// three channels. We cannot perform the native load4 there; by performing
-/// scalar read we lose some benefits of load4 but we can still make sure the
-/// overall vectorization does not fail.
+/// Scalarize remaining vector transfer that couldn't be converted to
+/// vevtor load operations.
+
+/// This is very specific to SPIR-V as pointer cannot be casted to vector type
+/// if any of the memory access is not vector.
 struct ScalarizeVectorTransferRead final
     : public OpRewritePattern<vector::TransferReadOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -371,31 +368,49 @@ struct ScalarizeVectorTransferRead final
                                 PatternRewriter &rewriter) const override {
     VectorType vectorType = readOp.getType();
     Type scalarType = vectorType.getElementType();
-    if (vectorType.getRank() != 1 || vectorType.getDimSize(0) >= 4)
+    if (vectorType.getRank() != 1 ||
+        !readOp.permutation_map().isMinorIdentity())
       return failure();
 
     Location loc = readOp.getLoc();
-
-    SmallVector<Value, 4> scalars;
-    SmallVector<Value, 4> indices(readOp.indices().begin(),
-                                  readOp.indices().end());
-    for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-      indices.back() = rewriter.createOrFold<ConstantIndexOp>(loc, i);
-      scalars.push_back(rewriter.create<memref::LoadOp>(
-          loc, scalarType, readOp.source(), indices));
-    }
-
     Value newVector = rewriter.create<ConstantOp>(
         loc, vectorType, rewriter.getZeroAttr(vectorType));
     for (int i = 0; i < vectorType.getDimSize(0); ++i) {
-      Value index = rewriter.createOrFold<ConstantOp>(
-          loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(i));
-      newVector = rewriter.create<vector::InsertElementOp>(loc, scalars[i],
-                                                           newVector, index);
+      SmallVector<Value, 4> indices(readOp.indices().begin(),
+                                    readOp.indices().end());
+      indices.back() = rewriter.createOrFold<AddIOp>(
+          loc, indices.back(), rewriter.createOrFold<ConstantIndexOp>(loc, i));
+      Value scalar = rewriter.create<memref::LoadOp>(loc, scalarType,
+                                                     readOp.source(), indices);
+      newVector = rewriter.create<vector::InsertOp>(loc, scalar, newVector, i);
     }
-
     rewriter.replaceOp(readOp, newVector);
+    return success();
+  }
+};
 
+struct ScalarizeVectorTransferWrite final
+    : public OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    VectorType vectorType = writeOp.getVectorType();
+    if (vectorType.getRank() != 1 ||
+        !writeOp.permutation_map().isMinorIdentity())
+      return failure();
+
+    Location loc = writeOp.getLoc();
+
+    for (int i = 0; i < vectorType.getDimSize(0); ++i) {
+      SmallVector<Value, 4> indices(writeOp.indices().begin(),
+                                    writeOp.indices().end());
+      indices.back() = rewriter.createOrFold<AddIOp>(
+          loc, indices.back(), rewriter.createOrFold<ConstantIndexOp>(loc, i));
+      Value scalar =
+          rewriter.create<vector::ExtractOp>(loc, writeOp.vector(), i);
+      rewriter.create<memref::StoreOp>(loc, scalar, writeOp.source(), indices);
+    }
+    rewriter.eraseOp(writeOp);
     return success();
   }
 };
@@ -476,7 +491,9 @@ void VectorizeMemRefLoadStorePass::runOnOperation() {
 
   for (FuncOp func : module.getOps<FuncOp>()) {
     RewritePatternSet rewritingPatterns(context);
-    rewritingPatterns.add<ScalarizeVectorTransferRead>(context);
+    rewritingPatterns
+        .add<ScalarizeVectorTransferRead, ScalarizeVectorTransferWrite>(
+            context);
 
     (void)applyPatternsAndFoldGreedily(func, std::move(rewritingPatterns));
   }

--- a/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemrefLoadStorePass.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/VectorizeMemrefLoadStorePass.cpp
@@ -356,7 +356,7 @@ class ProcessInterfaceBinding final
   }
 };
 
-/// Scalarize remaining vector transfer that couldn't be converted to
+/// Scalarizes remaining vector transfer that couldn't be converted to
 /// vevtor load operations.
 
 /// This is very specific to SPIR-V as pointer cannot be casted to vector type

--- a/iree/compiler/Conversion/LinalgToSPIRV/test/vectorize_memref_load_store.mlir
+++ b/iree/compiler/Conversion/LinalgToSPIRV/test/vectorize_memref_load_store.mlir
@@ -156,33 +156,28 @@ hal.interface @io attributes {sym_visibility = "private"} {
 
 // -----
 
-// CHECK-LABEL: func @scalarize_vector_transfer_read
-func @scalarize_vector_transfer_read() {
+// CHECK-LABEL: func @scalarize_vector_transfer_op
+func @scalarize_vector_transfer_op() {
   %c0 = constant 0: index
+  %c3 = constant 3: index
   %f0 = constant 0.0 : f32
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<3xf32>
+  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<20xf32>
   %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<f32>
-  // CHECK-DAG: %[[INDEX0:.+]] = constant 0 : index
-  // CHECK-DAG: %[[INDEX1:.+]] = constant 1 : index
-  // CHECK-DAG: %[[INDEX2:.+]] = constant 2 : index
-  // CHECK-DAG: %[[C0:.+]] = constant 0 : i32
-  // CHECK-DAG: %[[C1:.+]] = constant 1 : i32
-  // CHECK-DAG: %[[C2:.+]] = constant 2 : i32
-  // CHECK-DAG: %[[INIT:.+]] = constant dense<0.000000e+00> : vector<3xf32>
+  %2 = hal.interface.binding.subspan @io::@ret1[%c0] : memref<20xf32>
+  // CHECK-DAG: %[[INDEX0:.+]] = constant 3 : index
+  // CHECK-DAG: %[[INDEX1:.+]] = constant 4 : index
+  // CHECK-DAG: %[[INDEX2:.+]] = constant 5 : index
   // CHECK: %[[ELEM0:.+]] = memref.load %{{.+}}[%[[INDEX0]]]
   // CHECK: %[[ELEM1:.+]] = memref.load %{{.+}}[%[[INDEX1]]]
   // CHECK: %[[ELEM2:.+]] = memref.load %{{.+}}[%[[INDEX2]]]
-  // CHECK: %[[INSERT0:.+]] = vector.insertelement %[[ELEM0]], %[[INIT]][%[[C0]] : i32]
-  // CHECK: %[[INSERT1:.+]] = vector.insertelement %[[ELEM1]], %[[INSERT0]][%[[C1]] : i32]
-  // CHECK: %[[INSERT2:.+]] = vector.insertelement %[[ELEM2]], %[[INSERT1]][%[[C2]] : i32]
-  // CHECK: vector.extract %[[INSERT2]]
-  %2 = vector.transfer_read %0[%c0], %f0 : memref<3xf32>, vector<3xf32>
-  %3 = vector.extract %2[0]: vector<3xf32>
-  memref.store %3, %1[] : memref<f32>
+  // CHECK: memref.store %[[ELEM0]], %{{.*}}[] : memref<f32>
+  // CHECK: memref.store %[[ELEM0]], %{{.*}}[%[[INDEX0]]] : memref<20xf32>
+  // CHECK: memref.store %[[ELEM1]], %{{.*}}[%[[INDEX1]]] : memref<20xf32>
+  // CHECK: memref.store %[[ELEM2]], %{{.*}}[%[[INDEX2]]] : memref<20xf32>
+  %3 = vector.transfer_read %0[%c3], %f0 : memref<20xf32>, vector<3xf32>
+  %4 = vector.extract %3[0]: vector<3xf32>
+  memref.store %4, %1[] : memref<f32>
+  vector.transfer_write %3, %2[%c3] : vector<3xf32>, memref<20xf32>
   return
 }
 
-hal.interface @io attributes {push_constants = 5 : index, sym_visibility = "private"} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write|Discard"
-}


### PR DESCRIPTION
When we fail to vectorize memref we need a fallback to avoid failing
compilation. Convert all the vector transfer left after memref
vectorization to scalar load/store