### PR TITLE
Add conversions for f32 vm.const ops to EmitC

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -141,7 +141,15 @@ class ConstZeroOpConversion : public OpRewritePattern<ConstZeroOpTy> {
   LogicalResult matchAndRewrite(ConstZeroOpTy constZeroOp,
                                 PatternRewriter &rewriter) const final {
     auto type = constZeroOp.getType();
-    IntegerAttr value = rewriter.getIntegerAttr(type, 0);
+    Attribute value;
+
+    if (type.template isa<IntegerType>()) {
+      value = rewriter.getIntegerAttr(type, 0);
+    } else if (type.template isa<FloatType>()) {
+      value = rewriter.getFloatAttr(type, 0.0);
+    } else {
+      return failure();
+    }
 
     rewriter.replaceOpWithNewOp<emitc::ConstOp>(constZeroOp, type, value);
     return success();
@@ -709,6 +717,10 @@ void populateVMToCPatterns(MLIRContext *context,
                                                            "vm_cmp_lt_i32u");
   patterns.insert<CallOpConversion<IREE::VM::CmpNZI32Op>>(context,
                                                           "vm_cmp_nz_i32");
+
+  // ExtF32: Native floating-point constants
+  patterns.insert<ConstOpConversion<IREE::VM::ConstF32Op>>(context);
+  patterns.insert<ConstZeroOpConversion<IREE::VM::ConstF32ZeroOp>>(context);
 
   // ExtI64: Constants
   patterns.insert<ConstOpConversion<IREE::VM::ConstI64Op>>(context);

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
@@ -1,0 +1,25 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+vm.module @my_module {
+  // CHECK-LABEL: vm.func @const_f32_zero
+  vm.func @const_f32_zero() -> f32 {
+    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0.000000e+00 : f32} : () -> f32
+    %zero = vm.const.f32.zero : f32
+    vm.return %zero : f32
+  }
+}
+
+// -----
+
+vm.module @my_module {
+  // CHECK-LABEL: vm.func @const_f32
+  vm.func @const_f32() {
+    // CHECK-NEXT: %0 = "emitc.const"() {value = 5.000000e-01 : f32} : () -> f32
+    %0 = vm.const.f32 0.5 : f32
+    // CHECK-NEXT: %1 = "emitc.const"() {value = 2.500000e+00 : f32} : () -> f32
+    %1 = vm.const.f32 2.5 : f32
+    // CHECK-NEXT: %2 = "emitc.const"() {value = -2.500000e+00 : f32} : () -> f32
+    %2 = vm.const.f32 -2.5 : f32
+    vm.return
+  }
+}


### PR DESCRIPTION
Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>