### PR TITLE
Revert " Update MobileNetV2 mako compilation flags for cpu (#5755)"

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -237,10 +237,12 @@ MODEL_BENCHMARKS = [
                     skipped_target=["vlk2"],
                     compilation_flags={
                         'cpu': [
-                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
+                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [
-                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
+                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            "-iree-llvm-loop-unrolling=true"
                         ]
                     })),
             PhoneBenchmarkInfo(
@@ -249,10 +251,12 @@ MODEL_BENCHMARKS = [
                 targets=get_s20_default_target_list(
                     compilation_flags={
                         'cpu': [
-                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
+                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [
-                            "-iree-codegen-llvm-promote-workgroup-to-full-tiles=true"
+                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            "-iree-llvm-loop-unrolling=true"
                         ]
                     })),
         ]),


### PR DESCRIPTION
This reverts commit 871d203660818dff00d252c1351d4b3eee6bafd8 because
it causes segfault. See https://github.com/google/iree/issues/5857