### PR TITLE
Add C_IDENTIFIER to fix breakage from midair collision

### DIFF
--- a/iree/samples/vision/CMakeLists.txt
+++ b/iree/samples/vision/CMakeLists.txt
@@ -22,7 +22,8 @@ iree_bytecode_module(
     mnist_bytecode_module
   SRC
     "mnist.mlir"
-  C_OUTPUT
+  C_IDENTIFIER
+    "mnist_bytecode_module_c"
   FLAGS
     "-iree-mlir-to-vm-bytecode-module"
     "-iree-hal-target-backends=dylib-llvm-aot"


### PR DESCRIPTION
Collision between https://github.com/google/iree/pull/5655 making use of
`iree_bytecode_module` and https://github.com/google/iree/commit/24fbc70911 modifying
it.