### PR TITLE
Disable CPU workgroup padding

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.cpp
@@ -65,7 +65,11 @@ void buildLLVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createMaterializeCPULaunchConfigurationPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   nestedModulePM.addPass(createCanonicalizerPass());
-  nestedModulePM.addNestedPass<FuncOp>(createPadLinalgWorkgroupTilesPass());
+
+  // TODO(ataei): This causes segmentation fault on Android. Fix it and
+  // re-enable.
+  // nestedModulePM.addNestedPass<FuncOp>(createPadLinalgWorkgroupTilesPass());
+
   // TODO(ataei): We want to enable when tensor -> vector pass is fully
   // supported which requires first moving vector-tiling before this step.
   if (options.useLinalgOnTensorsToVectors) {


### PR DESCRIPTION
This causes segfault on Android devices:
https://buildkite.com/iree/iree-android-arm64-v8a/builds/4235