### PR TITLE
More pre-factoring for native ABI swap.

### DIFF
--- a/bindings/python/iree/compiler/core.py
+++ b/bindings/python/iree/compiler/core.py
@@ -32,7 +32,10 @@ __all__ = [
 ]
 
 # Default testing backend for invoking the compiler.
-DEFAULT_TESTING_BACKENDS = ["vmla"]
+# TODO: Remove these. In the absence of default profiles, though, it is better
+# to centralize.
+DEFAULT_TESTING_BACKENDS = ["dylib-llvm-aot"]
+DEFAULT_TESTING_DRIVER = "dylib"
 
 
 class OutputFormat(Enum):

--- a/bindings/python/iree/runtime/__init__.py
+++ b/bindings/python/iree/runtime/__init__.py
@@ -31,3 +31,5 @@ from .binding import HostTypeFactory
 from .binding import create_hal_module, Linkage, VmVariantList, VmFunction, VmInstance, VmContext, VmModule
 # SystemApi
 from .system_api import *
+# Function
+from .function import *

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -104,6 +104,9 @@ void SetupHalBindings(pybind11::module m) {
       .value("FLOAT_16", IREE_HAL_ELEMENT_TYPE_FLOAT_16)
       .value("FLOAT_32", IREE_HAL_ELEMENT_TYPE_FLOAT_32)
       .value("FLOAT_64", IREE_HAL_ELEMENT_TYPE_FLOAT_64)
+      .value("BOOL_8", static_cast<enum iree_hal_element_type_e>(
+                           IREE_HAL_ELEMENT_TYPE_VALUE(
+                               IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED, 1)))
       .export_values();
 
   py::class_<HalDevice>(m, "HalDevice");

--- a/bindings/python/iree/runtime/system_api.py
+++ b/bindings/python/iree/runtime/system_api.py
@@ -50,7 +50,7 @@ import numpy as np
 PREFERRED_DRIVER_ENV_KEY = "IREE_DEFAULT_DRIVER"
 
 # Default value for IREE_DRIVER
-DEFAULT_IREE_DRIVER_VALUE = "vulkan,vmla"
+DEFAULT_IREE_DRIVER_VALUE = "dylib,vulkan,vmla"
 
 # Mapping from IREE target backends to their corresponding drivers.
 TARGET_BACKEND_TO_DRIVER = {

--- a/bindings/python/iree/runtime/system_api_test.py
+++ b/bindings/python/iree/runtime/system_api_test.py
@@ -35,7 +35,7 @@ def create_simple_mul_module():
         }
       }
       """,
-      target_backends=["vulkan-spirv"],
+      target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
   )
   m = iree.runtime.VmModule.from_flatbuffer(binary)
   return m
@@ -49,7 +49,7 @@ class SystemApiTest(absltest.TestCase):
       config = iree.runtime.Config("nothere1,nothere2")
 
   def test_subsequent_driver(self):
-    config = iree.runtime.Config("nothere1,vmla")
+    config = iree.runtime.Config("nothere1,iree-llvm-aot")
 
   def test_empty_dynamic(self):
     ctx = iree.runtime.SystemContext()

--- a/bindings/python/iree/runtime/system_api_test.py
+++ b/bindings/python/iree/runtime/system_api_test.py
@@ -49,7 +49,7 @@ class SystemApiTest(absltest.TestCase):
       config = iree.runtime.Config("nothere1,nothere2")
 
   def test_subsequent_driver(self):
-    config = iree.runtime.Config("nothere1,iree-llvm-aot")
+    config = iree.runtime.Config("nothere1,dylib")
 
   def test_empty_dynamic(self):
     ctx = iree.runtime.SystemContext()

--- a/bindings/python/iree/runtime/vm.h
+++ b/bindings/python/iree/runtime/vm.h
@@ -98,11 +98,14 @@ class VmVariantList {
   }
 
   std::string DebugString() const;
+  void PushFloat(double fvalue);
+  void PushInt(int64_t ivalue);
   void PushList(VmVariantList& other);
   void PushBufferView(HalDevice& device, py::object py_buffer_object,
                       iree_hal_element_type_e element_type);
-  VmVariantList GetAsList(int index);
+  py::object GetAsList(int index);
   py::object GetAsNdarray(int index);
+  py::object GetVariant(int index);
 
  private:
   VmVariantList(iree_vm_list_t* list) : list_(list) {}

--- a/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
@@ -283,8 +283,7 @@ class CompiledModule(object):
 class _IreeFunctionWrapper(_FunctionWrapper):
   """Wraps an IREE function, making it callable."""
 
-  def __init__(self, context: iree.runtime.SystemContext,
-               f: iree.runtime.system_api.BoundFunction):
+  def __init__(self, context: iree.runtime.SystemContext, f):
     self._context = context
     self._f = f
 


### PR DESCRIPTION
* Some vm_test rework.
* Swap away from vmla.
* Implement non-reflection invocations.
* Handle scalar int/float arguments.
* Handle tensor<i1>.