### PR TITLE
Exclude flakey TOSA reduce test on VMVX

### DIFF
--- a/iree/test/e2e/tosa_ops/BUILD
+++ b/iree/test/e2e/tosa_ops/BUILD
@@ -98,7 +98,6 @@ VMVX_SRCS = enforce_glob(
         "mul.mlir",
         "negate.mlir",
         "pad.mlir",
-        "reduce.mlir",
         "reluN.mlir",
         "reshape.mlir",
         "rsqrt.mlir",
@@ -111,6 +110,7 @@ VMVX_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
+        "reduce.mlir", # Currently flakey https://github.com/google/iree/issues/5885
     ],
 )
 

--- a/iree/test/e2e/tosa_ops/BUILD
+++ b/iree/test/e2e/tosa_ops/BUILD
@@ -110,7 +110,7 @@ VMVX_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
-        "reduce.mlir", # Currently flakey https://github.com/google/iree/issues/5885
+        "reduce.mlir",  # Currently flakey https://github.com/google/iree/issues/5885
     ],
 )
 

--- a/iree/test/e2e/tosa_ops/CMakeLists.txt
+++ b/iree/test/e2e/tosa_ops/CMakeLists.txt
@@ -78,7 +78,6 @@ iree_check_single_backend_test_suite(
     "mul.mlir"
     "negate.mlir"
     "pad.mlir"
-    "reduce.mlir"
     "reluN.mlir"
     "reshape.mlir"
     "rsqrt.mlir"


### PR DESCRIPTION
Disables the test until https://github.com/google/iree/issues/5885 is fixed