### PR TITLE
Swapping benchmarks to use VMVX instead of VMLA.

### DIFF
--- a/build_tools/mako/config/benchmark_template.config
+++ b/build_tools/mako/config/benchmark_template.config
@@ -43,8 +43,8 @@ metric_info_list: {
   label: "DYLib_AOT"
 }
 metric_info_list: {
-  value_key: "vmla"
-  label: "VMLA"
+  value_key: "vmvx3t"
+  label: "VMVX"
 }
 metric_info_list: {
   value_key: "vlk"

--- a/build_tools/mako/config/mobile-bert-pixel4.config
+++ b/build_tools/mako/config/mobile-bert-pixel4.config
@@ -37,10 +37,6 @@ metric_info_list: {
   label: "DYLib_AOT-3-thread"
 }
 metric_info_list: {
-  value_key: "vmla"
-  label: "VMLA"
-}
-metric_info_list: {
   value_key: "vlk"
   label: "Vulkan-SPIRV"
 }

--- a/build_tools/mako/config/mobile-bert-s20.config
+++ b/build_tools/mako/config/mobile-bert-s20.config
@@ -37,10 +37,6 @@ metric_info_list: {
   label: "DYLib_AOT-3-thread"
 }
 metric_info_list: {
-  value_key: "vmla"
-  label: "VMLA"
-}
-metric_info_list: {
   value_key: "vlk"
   label: "Vulkan-SPIRV"
 }

--- a/build_tools/mako/config/mobilenet-v2-pixel4.config
+++ b/build_tools/mako/config/mobilenet-v2-pixel4.config
@@ -37,8 +37,8 @@ metric_info_list: {
   label: "DYLib_AOT-3-thread"
 }
 metric_info_list: {
-  value_key: "vmla"
-  label: "VMLA"
+  value_key: "vmvx3t"
+  label: "VMVX"
 }
 metric_info_list: {
   value_key: "vlk"

--- a/build_tools/mako/config/mobilenet-v2-s20.config
+++ b/build_tools/mako/config/mobilenet-v2-s20.config
@@ -37,8 +37,8 @@ metric_info_list: {
   label: "DYLib_AOT-3-thread"
 }
 metric_info_list: {
-  value_key: "vmla"
-  label: "VMLA"
+  value_key: "vmvx3t"
+  label: "VMVX"
 }
 metric_info_list: {
   value_key: "vlk"

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -104,10 +104,6 @@ def get_pixel4_default_target_list(skipped_target=None,
   if compilation_flags is None:
     compilation_flags = []
   targets = [
-      TargetInfo(driver="vmla",
-                 hal_target_backend="vmla",
-                 taskset="80",
-                 mako_tag="vmla"),
       TargetInfo(driver="dylib-sync",
                  hal_target_backend="dylib-llvm-aot",
                  taskset="80",
@@ -122,6 +118,16 @@ def get_pixel4_default_target_list(skipped_target=None,
                  mako_tag="cpu3t",
                  compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
+                     "--iree-flow-inline-constants-max-byte-length=2048",
+                 ],
+                 runtime_flags=[
+                     "--task_topology_group_count=3",
+                 ]),
+      TargetInfo(driver="vmvx",
+                 hal_target_backend="vmvx",
+                 taskset="f0",
+                 mako_tag="vmvx3t",
+                 compilation_flags=[
                      "--iree-flow-inline-constants-max-byte-length=2048",
                  ],
                  runtime_flags=[
@@ -158,10 +164,6 @@ def get_s20_default_target_list(skipped_target=None,
   if compilation_flags is None:
     compilation_flags = []
   targets = [
-      TargetInfo(driver="vmla",
-                 hal_target_backend="vmla",
-                 taskset="80",
-                 mako_tag="vmla"),
       TargetInfo(driver="dylib-sync",
                  hal_target_backend="dylib-llvm-aot",
                  taskset="80",
@@ -176,6 +178,16 @@ def get_s20_default_target_list(skipped_target=None,
                  mako_tag="cpu3t",
                  compilation_flags=[
                      "--iree-llvm-target-triple=aarch64-none-linux-android29",
+                     "--iree-flow-inline-constants-max-byte-length=2048",
+                 ],
+                 runtime_flags=[
+                     "--task_topology_group_count=3",
+                 ]),
+      TargetInfo(driver="vmvx",
+                 hal_target_backend="vmvx",
+                 taskset="f0",
+                 mako_tag="vmvx3t",
+                 compilation_flags=[
                      "--iree-flow-inline-constants-max-byte-length=2048",
                  ],
                  runtime_flags=[
@@ -218,11 +230,11 @@ MODEL_BENCHMARKS = [
             PhoneBenchmarkInfo(name="Pixel4",
                                benchmark_key="5538704950034432",
                                targets=get_pixel4_default_target_list(
-                                   skipped_target=["cpu2", "vlk2"],)),
+                                   skipped_target=["cpu2", "vmvx3t", "vlk2"],)),
             PhoneBenchmarkInfo(name="S20",
                                benchmark_key="4699630718681088",
                                targets=get_s20_default_target_list(
-                                   skipped_target=["cpu2", "vlk2"],)),
+                                   skipped_target=["cpu2", "vmvx3t", "vlk2"],)),
         ]),
     ModelBenchmarkInfo(
         name="mobilenet-v2",
@@ -270,7 +282,7 @@ MODEL_BENCHMARKS = [
                 name="S20",
                 benchmark_key="4636549841944576",
                 targets=get_s20_default_target_list(
-                    skipped_target=['cpu', 'vmla', 'cpu2', 'vlk2'])),
+                    skipped_target=['cpu', 'vmvx3t', 'cpu2', 'vlk2'])),
         ])
 ]
 


### PR DESCRIPTION
VMVX MobileBERT is disabled for now until it can be sped up.