### PR TITLE
Fix iree_py_library and iree_pyext_module dependency issue

### DIFF
--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -132,6 +132,10 @@ function(iree_pyext_module)
     ${ARG_SRCS}
   )
 
+  # Alias the iree_package_name library to iree::package::name so that we can
+  # refer to this target with the namespaced format.
+  add_library(${_PACKAGE_NS}::${ARG_NAME} ALIAS ${_NAME})
+
   target_link_libraries(
     ${_NAME}
     PRIVATE ${ARG_DEPS}
@@ -228,11 +232,10 @@ function(iree_py_library)
     )
   endforeach()
 
-  # Add PYEXT_DEPS.
-  if(${ARG_PYEXT_DEPS})
-    foreach(V ${IREE_MULTIPY_VERSIONS_EFFECTIVE})
-      add_dependencies(${_NAME} ${ARG_PYEXT_DEPS})
-    endforeach()
+  # Add PYEXT_DEPS if any.
+  if(ARG_PYEXT_DEPS)
+    list(TRANSFORM ARG_PYEXT_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+    add_dependencies(${_NAME} ${ARG_PYEXT_DEPS})
   endif()
 endfunction()
 


### PR DESCRIPTION
The `bindings_python_iree_runtime_runtime` target tries to
depend on `::PyExtRt`. It requires to have a namespaced alias
for `bindings_python_iree_runtime_PyExtRt`.

By default `if()` in CMake dereferences the variable, after the
normal `${}` evaulation. If we have `if($SOME_VAR)`, it will
dereference twice. More details can be seen at:
https://cmake.org/cmake/help/latest/command/if.html#variable-expansion

`IREE_MULTIPY_VERSIONS_EFFECTIVE` is already gone.