### PR TITLE
Add barrier after duplicated dispatches for benchmarking

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
@@ -42,10 +42,21 @@ class BenchmarkBatchDispatchesPass
 
     for (auto op : ops) {
       OpBuilder builder(op);
-      for (unsigned i = 0; i < repeatCount_; ++i) {
+      for (unsigned i = 1; i < repeatCount_; ++i) {
         builder.clone(*op.getOperation());
+        // Add a barrier after each clone. If the original dispatch has a small
+        // problem size, simply duplicating without barrier will increase the
+        // number of subgroups and thus "help" filling the GPU. In the end we
+        // will have an over optimistic result. Inserting barriers avoids that,
+        // but it assumes the input model is linear.
+        builder.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
+            op.getLoc(), op.command_buffer(),
+            IREE::HAL::ExecutionStageBitfield::CommandRetire |
+                IREE::HAL::ExecutionStageBitfield::Dispatch,
+            IREE::HAL::ExecutionStageBitfield::CommandIssue |
+                IREE::HAL::ExecutionStageBitfield::Dispatch,
+            IREE::HAL::ExecutionBarrierFlagBitfield::None);
       }
-      op.erase();
     }
   }
 

--- a/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
@@ -48,7 +48,8 @@ class BenchmarkBatchDispatchesPass
         // problem size, simply duplicating without barrier will increase the
         // number of subgroups and thus "help" filling the GPU. In the end we
         // will have an over optimistic result. Inserting barriers avoids that,
-        // but it assumes the input model is linear.
+        // but it assumes that the command buffer has a linear dispatch
+        // structure.
         builder.create<IREE::HAL::CommandBufferExecutionBarrierOp>(
             op.getLoc(), op.command_buffer(),
             IREE::HAL::ExecutionStageBitfield::CommandRetire |

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -44,7 +44,10 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
 static llvm::cl::opt<unsigned> benchmarkDispatchRepeatCount{
     "iree-hal-benchmark-dispatch-repeat-count",
     llvm::cl::desc(
-        "The number of times to repeat each hal.command_buffer.dispatch op."),
+        "The number of times to repeat each hal.command_buffer.dispatch op. "
+        "(Not that this simply duplicates the dispatch op and inserts "
+        "barriers. It's meant for command buffers having linear dispatch "
+        "structures.)"),
     llvm::cl::init(1)};
 
 }  // namespace

--- a/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/benchmark_batch_dispatches.mlir
@@ -2,23 +2,42 @@
 
 hal.variable @_executable : !hal.executable
 
-// CHECK-LABEL: @multiple_reads_no_writes
-//  CHECK-SAME: %[[CMD:.+]]: !hal.command_buffer
-func @multiple_reads_no_writes(%cmd : !hal.command_buffer) {
+// CHECK-LABEL: @duplicate_dispatches
+//  CHECK-SAME: (%[[CMD1:.+]]: !hal.command_buffer,
+//  CHECK-SAME:  %[[CMD2:.+]]: !hal.command_buffer)
+func @duplicate_dispatches(%cmd1 : !hal.command_buffer, %cmd2 : !hal.command_buffer) {
   // CHECK: %[[EXE:.+]] = hal.variable.load @_executable
   %exe = hal.variable.load @_executable : !hal.executable
 
   %c1 = constant 1 : index
-  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[0] workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[1] workgroups([%c1, %c1, %c1])
-  hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+  %c2 = constant 2 : index
+  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.execution_barrier<%cmd1 : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+  hal.command_buffer.dispatch<%cmd1 : !hal.command_buffer> target(%exe : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+
+  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+  hal.command_buffer.dispatch<%cmd2 : !hal.command_buffer> target(%exe : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+  hal.command_buffer.execution_barrier<%cmd2 : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
 
   return
 }
 
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c1, %c1, %c1])
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c1, %c1, %c1])
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
-// CHECK: hal.command_buffer.dispatch<%[[CMD:.+]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[0] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD1]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+// CHECK: hal.command_buffer.dispatch<%[[CMD1]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[1] workgroups([%c2, %c2, %c2])
+// CHECK-NOT: hal.command_buffer.execution_barrier
+
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[2] workgroups([%c1, %c1, %c1])
+// CHECK-NOT: hal.command_buffer.execution_barrier
+
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+// CHECK: hal.command_buffer.dispatch<%[[CMD2]] : !hal.command_buffer> target(%[[EXE]] : !hal.executable)[3] workgroups([%c2, %c2, %c2])
+// CHECK: hal.command_buffer.execution_barrier<%[[CMD2]] : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")


### PR DESCRIPTION
Add a barrier after each clone. If the original dispatch has a small
problem size, simply duplicating without barrier will increasing the
number of subgroups and thus "help" filling the GPU. In the end we
will have an over optimistic result. Put in barriers avoids that,
but it assumes the input model is linear.

With this, the reported number reflects the kernel execution time
for MobileNetv2 with

```
iree-translate ... --iree-hal-benchmark-dispatch-repeat-count=32
iree-benchmark-module ... --batch_size=32
```

This is a step towards https://github.com/google/iree/issues/5248.
Next is working on duplicating the command buffer submission
as a whole.