### PR TITLE
 Use dynamic pass pipelines while lowering on CPU backends.

### DIFF
--- a/iree/compiler/Conversion/Common/BUILD
+++ b/iree/compiler/Conversion/Common/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "LaunchConfig.cpp",
         "LinalgBufferizePass.cpp",
         "Passes.cpp",
+        "SetNumWorkgroupsPass.cpp",
         "Transforms.cpp",
         "VectorTransferOptimization.cpp",
     ],

--- a/iree/compiler/Conversion/Common/CMakeLists.txt
+++ b/iree/compiler/Conversion/Common/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "LaunchConfig.cpp"
     "LinalgBufferizePass.cpp"
     "Passes.cpp"
+    "SetNumWorkgroupsPass.cpp"
     "Transforms.cpp"
     "VectorTransferOptimization.cpp"
   DEPS

--- a/iree/compiler/Conversion/Common/Passes.h
+++ b/iree/compiler/Conversion/Common/Passes.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -64,6 +65,11 @@ std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 /// Create a pass to convert a model using f32 type to the equivalent one
 /// using 16.
 std::unique_ptr<OperationPass<ModuleOp>> createDemoteF32ToF16Pass();
+
+/// Sets the number of workgroups to use for each entry point in the dispatch
+/// region.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createSetNumWorkgroupsPass(ArrayRef<int64_t> workgroupSize = {});
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
@@ -96,9 +96,7 @@ void SetNumWorkgroupsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IREE::HAL::ExecutableTargetOp targetOp = getOperation();
   ModuleOp module = targetOp.getInnerModule();
-  auto funcOps = module.getOps<FuncOp>();
 
-  FuncOp funcOp = *funcOps.begin();
   for (auto funcOp : module.getOps<FuncOp>()) {
     if (!isEntryPoint(funcOp)) continue;
 

--- a/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,22 +13,14 @@
 // limitations under the License.
 
 #include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
-#include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
+#include "iree/compiler/Conversion/Common/Passes.h"
 #include "iree/compiler/Conversion/Common/Transforms.h"
-#include "iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h"
-#include "iree/compiler/Conversion/LinalgToLLVM/Passes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "mlir/Dialect/Linalg/Transforms/CodegenStrategy.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Matchers.h"
-#include "mlir/IR/PatternMatch.h"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-
-#define DEBUG_TYPE "iree-linalg-to-llvm-tile-and-distribute"
 
 static const unsigned kNumMaxParallelDims = 3;
 
@@ -36,19 +28,29 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-class MaterializeCPULaunchConfigurationPass
-    : public PassWrapper<MaterializeCPULaunchConfigurationPass,
+class SetNumWorkgroupsPass
+    : public PassWrapper<SetNumWorkgroupsPass,
                          OperationPass<IREE::HAL::ExecutableTargetOp>> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, IREE::HAL::HALDialect, AffineDialect,
-                    scf::SCFDialect>();
+    registry
+        .insert<AffineDialect, IREE::HAL::HALDialect, linalg::LinalgDialect>();
   }
 
-  MaterializeCPULaunchConfigurationPass() = default;
-  MaterializeCPULaunchConfigurationPass(
-      const MaterializeCPULaunchConfigurationPass &pass) {}
+  SetNumWorkgroupsPass() = default;
+  SetNumWorkgroupsPass(ArrayRef<int64_t> ws)
+      : workgroupSize(ws.begin(), ws.end()) {}
+  SetNumWorkgroupsPass(const SetNumWorkgroupsPass &pass)
+      : workgroupSize(pass.workgroupSize) {}
+
   void runOnOperation() override;
+
+ private:
+  ListOption<int> workgroupSizesOpt{
+      *this, "workgroup-size", llvm::cl::MiscFlags::CommaSeparated,
+      llvm::cl::desc("Specifies the workgroup size to use in x, y, z order")};
+
+  SmallVector<int64_t> workgroupSize;
 };
 }  // namespace
 
@@ -74,8 +76,7 @@ static FailureOr<SmallVector<int64_t, 4>> getDistributedWorkgroupSize(
     ArrayRef<linalg::LinalgOp> linalgOps) {
   Optional<SmallVector<int64_t, 4>> distributedWorkgroupSize;
   for (auto linalgOp : linalgOps) {
-    SmallVector<int64_t, 4> opTileSizes = getTileSizes(
-        linalgOp, static_cast<unsigned>(TilingLevel::WorkGroupTiles));
+    SmallVector<int64_t, 4> opTileSizes = getTileSizes(linalgOp, 0);
     auto opWorkgroupSize = getDistributedWorkgroupSize(linalgOp, opTileSizes);
     if (!distributedWorkgroupSize) {
       distributedWorkgroupSize = std::move(opWorkgroupSize);
@@ -91,12 +92,14 @@ static FailureOr<SmallVector<int64_t, 4>> getDistributedWorkgroupSize(
                                   : SmallVector<int64_t, 4>{};
 }
 
-void MaterializeCPULaunchConfigurationPass::runOnOperation() {
+void SetNumWorkgroupsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IREE::HAL::ExecutableTargetOp targetOp = getOperation();
   ModuleOp module = targetOp.getInnerModule();
+  auto funcOps = module.getOps<FuncOp>();
 
-  for (FuncOp funcOp : module.getOps<FuncOp>()) {
+  FuncOp funcOp = *funcOps.begin();
+  for (auto funcOp : module.getOps<FuncOp>()) {
     if (!isEntryPoint(funcOp)) continue;
 
     SmallVector<linalg::LinalgOp, 4> linalgOps;
@@ -105,60 +108,62 @@ void MaterializeCPULaunchConfigurationPass::runOnOperation() {
       // Nothing to do here. Continue.
       continue;
     }
-    if (failed(initCPULaunchConfig(linalgOps))) {
-      return signalPassFailure();
-    }
 
-    // Get the workgroup size to use.
-    auto distributedWorkgroupSize = getDistributedWorkgroupSize(linalgOps);
-    if (failed(distributedWorkgroupSize)) {
-      return signalPassFailure();
-    }
-
-    // If workgroup size is empty, serialize the operation by setting the number
-    // of workgroups to {1, 1, 1}.
-    if (distributedWorkgroupSize->empty()) {
-      WorkgroupCountRegionBuilder regionBuilder =
-          [](OpBuilder &b, Location loc,
-             std::array<Value, 3> workload) -> std::array<Value, 3> {
-        Value one = b.create<ConstantIndexOp>(loc, 1);
-        return {one, one, one};
-      };
-      OpBuilder builder(context);
-      if (failed(defineWorkgroupCountRegion(builder, funcOp, regionBuilder))) {
+    SmallVector<int64_t, 4> workgroupSize;
+    // Get the workgroup size. First check if there is a size specified in the
+    // command line.
+    if (!workgroupSizesOpt.empty()) {
+      workgroupSize.assign(workgroupSizesOpt.begin(), workgroupSizesOpt.end());
+    } else {
+      auto distributedWorkgroupSize = getDistributedWorkgroupSize(linalgOps);
+      if (failed(distributedWorkgroupSize)) {
         return signalPassFailure();
       }
-      return;
+
+      // If workgroup size is empty, serialize the operation by setting the
+      // number of workgroups to {1, 1, 1}.
+      if (distributedWorkgroupSize->empty()) {
+        WorkgroupCountRegionBuilder regionBuilder =
+            [](OpBuilder &b, Location loc,
+               std::array<Value, 3> workload) -> std::array<Value, 3> {
+          Value one = b.create<ConstantIndexOp>(loc, 1);
+          return {one, one, one};
+        };
+        OpBuilder builder(context);
+        if (failed(
+                defineWorkgroupCountRegion(builder, funcOp, regionBuilder))) {
+          return signalPassFailure();
+        }
+        continue;
+      }
+
+      workgroupSize = distributedWorkgroupSize.getValue();
     }
 
-    // Materialize the computed workgroup size.
-    if (failed(materializeStaticLaunchInformation(
-            funcOp, distributedWorkgroupSize.getValue()))) {
-      funcOp.emitOpError("failed to materialize static launch information");
+    if (failed(materializeStaticLaunchInformation(funcOp, workgroupSize))) {
+      funcOp.emitError("failed to materialize constant workgroup size");
       return signalPassFailure();
     }
-
-    // Apply post distribution canonicalization passes.
-    {
-      OwningRewritePatternList canonicalization(&getContext());
-      AffineMinOp::getCanonicalizationPatterns(canonicalization, context);
-      populateAffineMinSCFCanonicalizationPattern(canonicalization);
-      IREE::Flow::populateFlowDispatchCanonicalizationPatterns(canonicalization,
-                                                               context);
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(canonicalization));
-    }
   }
+
+  // Apply post distribution canonicalization passes.
+  OwningRewritePatternList canonicalization(context);
+  AffineMinOp::getCanonicalizationPatterns(canonicalization, context);
+  populateAffineMinSCFCanonicalizationPattern(canonicalization);
+  IREE::Flow::populateFlowDispatchCanonicalizationPatterns(canonicalization,
+                                                           context);
+  (void)applyPatternsAndFoldGreedily(module, std::move(canonicalization));
 }
 
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
-createMaterializeCPULaunchConfigurationPass() {
-  return std::make_unique<MaterializeCPULaunchConfigurationPass>();
+createSetNumWorkgroupsPass(ArrayRef<int64_t> workgroupSize) {
+  return std::make_unique<SetNumWorkgroupsPass>(workgroupSize);
 }
 
-static PassRegistration<MaterializeCPULaunchConfigurationPass> pass(
-    "iree-codegen-llvm-materialize-launch-configuration",
-    "Tile and distribute Linalg operations on buffers",
-    [] { return std::make_unique<MaterializeCPULaunchConfigurationPass>(); });
+static PassRegistration<SetNumWorkgroupsPass> pass(
+    "iree-set-num-workgroups",
+    "Set the number of workgroups to use for every entry point function in the "
+    "dispatch region");
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVM/BUILD
@@ -46,7 +46,7 @@ cc_library(
         "LLVMCodeGenOptions.cpp",
         "LinalgTileAndVectorizePass.cpp",
         "LinalgVectorizePass.cpp",
-        "MaterializeCPULaunchConfigurationPass.cpp",
+        "LowerExecutableTargetPass.cpp",
         "PadLinalgWorkgroupTiles.cpp",
         "Passes.cpp",
         "PlanConvLoopOrder.cpp",

--- a/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVM/CMakeLists.txt
@@ -33,7 +33,7 @@ iree_cc_library(
     "LLVMCodeGenOptions.cpp"
     "LinalgTileAndVectorizePass.cpp"
     "LinalgVectorizePass.cpp"
-    "MaterializeCPULaunchConfigurationPass.cpp"
+    "LowerExecutableTargetPass.cpp"
     "PadLinalgWorkgroupTiles.cpp"
     "Passes.cpp"
     "PlanConvLoopOrder.cpp"

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +16,7 @@
 
 #include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
 #include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
+#include "iree/compiler/Conversion/Common/Transforms.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
@@ -25,7 +25,7 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/IR/Operation.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 static const unsigned kNumMaxParallelDims = 3;
 
@@ -76,10 +76,10 @@ static llvm::cl::opt<int> genericOpsWorkgroupTileSize(
 
 /// Sets the lowering configuration for dispatch region with root op that
 /// implements the contraction operation interface.
-static LogicalResult setRootConfig(
+static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
     linalg::ContractionOpInterface contractionOp) {
-  if (hasLoweringConfig(contractionOp))
-    return contractionOp.emitError("overriding previously set configuration");
+  assert(!hasLoweringConfig(contractionOp) &&
+         "illegal to update configuration of root");
   if (contractionOp.isRowMajorMatmul()) {
     int mWorkgroupSize = matmulWorkgroupTileSize;
     int nWorkgroupSize = matmulWorkgroupTileSize;
@@ -115,7 +115,7 @@ static LogicalResult setRootConfig(
     IREE::HAL::LoweringConfig config =
         getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return success();
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
   }
   if (contractionOp.isRowMajorBatchMatmul()) {
     // TODO(ataei, ravishankarm): This should just use the configuration for
@@ -131,41 +131,55 @@ static LogicalResult setRootConfig(
     IREE::HAL::LoweringConfig config =
         getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return success();
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
   }
-  return failure();
+  return llvm::None;
+}
+
+/// Legalized the tile sizes for the first-level of tiling
+/// (i.e. workgroup-level) to stay consistent with the distribution done at the
+/// Flow dialect level, where the last `kNumMaxParallelDims` of the outer
+/// parallel loops are distributed.
+SmallVector<int64_t, 4> getDistributedWorkgroupTileSizes(
+    int64_t numOuterParallelLoops, ArrayRef<int64_t> workgroupTileSizes) {
+  SmallVector<int64_t, 4> distributedTileSizes =
+      llvm::to_vector<4>(workgroupTileSizes);
+  for (int64_t i = 0; i < numOuterParallelLoops - kNumMaxParallelDims; i++) {
+    distributedTileSizes[i] = 0;
+  }
+  return distributedTileSizes;
 }
 
 /// Sets the lowering configuration for dispatch region with root op being a
 /// generic op.
-LogicalResult setRootConfig(linalg::GenericOp genericOp) {
+static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
+    linalg::GenericOp genericOp) {
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(genericOp);
   SmallVector<int64_t, 4> workgroupTileSizes(numOuterParallelLoops,
                                              genericOpsWorkgroupTileSize);
-  SmallVector<int64_t, 4> innerTileSizes(numOuterParallelLoops, 1);
-  // At the HAL level only the inner `kNumMaxParallelDims` parallel loops are
-  // tiled. Set the tile size as 0 for all the parallel loops that are not tiled
-  // at HAL level
-  for (int64_t i = 0; i < numOuterParallelLoops - kNumMaxParallelDims; i++) {
-    workgroupTileSizes[i] = 0;
-  }
+  workgroupTileSizes = getDistributedWorkgroupTileSizes(numOuterParallelLoops,
+                                                        workgroupTileSizes);
   TileSizesListType tileSizes = {workgroupTileSizes};
   IREE::HAL::LoweringConfig config =
       getConfigAttr(tileSizes, ArrayRef<int64_t>{}, genericOp->getContext());
   setLoweringConfig(genericOp, config);
-  return success();
+  return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
 }
 
 /// Sets the configuration for a linalg op that is not the root of the
 /// dispatch. The configuration should use the tile sizes of the first level of
 /// tiling passed in through `firstLevelTileSizes` for correctness.
 LogicalResult setNonRootConfig(linalg::LinalgOp linalgOp,
-                               ArrayRef<int64_t> firstLevelTileSizes) {
-  auto vec = llvm::to_vector<4>(firstLevelTileSizes);
+                               ArrayRef<int64_t> parallelLoopTileSizes) {
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(linalgOp);
-  vec.resize(numOuterParallelLoops, 0);
+  if (parallelLoopTileSizes.size() != numOuterParallelLoops) {
+    return linalgOp.emitError(
+        "expected non root ops to have same number of outer-parallel loops as "
+        "root op");
+  }
   // TODO(ravishankarm): For now just set the first level of tile-size, but need
   // to extend this to make op-specific decision.
+  auto vec = llvm::to_vector<4>(parallelLoopTileSizes);
   TileSizesListType tileSizes = {vec};
   IREE::HAL::LoweringConfig config =
       getConfigAttr(tileSizes, ArrayRef<int64_t>{}, linalgOp->getContext());
@@ -175,74 +189,135 @@ LogicalResult setNonRootConfig(linalg::LinalgOp linalgOp,
 
 /// Finds the root operation in the given list of linalg operations and sets its
 /// configuration. Returns the root operation.
-static FailureOr<linalg::LinalgOp> setRootConfig(
-    ArrayRef<linalg::LinalgOp> linalgOps) {
-  linalg::LinalgOp rootOperation = nullptr;
+static LogicalResult setRootConfig(
+    ArrayRef<linalg::LinalgOp> linalgOps,
+    Optional<IREE::HAL::DispatchLoweringPassPipeline> &passPipeline,
+    SmallVectorImpl<int64_t> &parallelLoopTileSizes) {
   // First iterate over all operations to find the root operations and set its
   // lowering configuration (that are not linalg.generic).
+  linalg::LinalgOp rootOp = nullptr;
+
+  auto checkOrUpdatePassPipeline =
+      [&](linalg::LinalgOp linalgOp,
+          Optional<IREE::HAL::DispatchLoweringPassPipeline> opPassPipeline)
+      -> LogicalResult {
+    if (!opPassPipeline) return success();
+    if (passPipeline && passPipeline.getValue() != opPassPipeline.getValue()) {
+      return linalgOp.emitError(
+          "mismatch in pass-pipeline chosen for ops in dispatch region");
+    }
+    if (!passPipeline) {
+      passPipeline = opPassPipeline.getValue();
+      rootOp = linalgOp;
+    }
+    return success();
+  };
+
   for (auto linalgOp : linalgOps) {
     if (!hasMarker(linalgOp, getWorkgroupMarker())) continue;
-    auto status =
-        TypeSwitch<Operation *, LogicalResult>(linalgOp.getOperation())
+    auto opPassPipeline =
+        TypeSwitch<Operation *,
+                   Optional<IREE::HAL::DispatchLoweringPassPipeline>>(
+            linalgOp.getOperation())
             .Case<linalg::ContractionOpInterface>(
                 [&](auto op) { return setRootConfig(op); })
-            .Default([](Operation *) { return failure(); });
-    if (succeeded(status)) {
-      if (rootOperation) {
-        return static_cast<LogicalResult>(linalgOp.emitError(
-            "unhandled multiple root operations in dispatch region"));
-      }
-      rootOperation = linalgOp;
+            .Default([](Operation *)
+                         -> Optional<IREE::HAL::DispatchLoweringPassPipeline> {
+              return llvm::None;
+            });
+    auto status = checkOrUpdatePassPipeline(linalgOp, opPassPipeline);
+    if (failed(status)) {
+      return status;
     }
   }
 
   // If no root operation found, check if the dispatch region contains a single
-  // generic op and set its configuration.
-  if (!rootOperation) {
+  // generic op and chose pipeline based on that.
+  if (!passPipeline) {
     for (auto linalgOp : linalgOps) {
       if (!hasMarker(linalgOp, getWorkgroupMarker())) continue;
-      auto status =
-          TypeSwitch<Operation *, LogicalResult>(linalgOp.getOperation())
-              .Case<linalg::GenericOp>(
-                  [&](auto op) { return setRootConfig(op); })
-              .Default([](Operation *) { return failure(); });
-      if (succeeded(status)) {
-        if (rootOperation) {
-          return static_cast<LogicalResult>(linalgOp.emitError(
-              "unhandled multiple root operations in dispatch region"));
-        }
-        rootOperation = linalgOp;
+      auto genericOp = dyn_cast<linalg::GenericOp>(linalgOp.getOperation());
+      if (!genericOp) continue;
+      auto opPassPipeline = setRootConfig(genericOp);
+      auto status = checkOrUpdatePassPipeline(linalgOp, opPassPipeline);
+      if (failed(status)) {
+        return status;
       }
     }
   }
-  return rootOperation;
+
+  // If still no root operation, use default.
+  if (!passPipeline) return success();
+
+  parallelLoopTileSizes =
+      getTileSizes(rootOp, static_cast<unsigned>(TilingLevel::WorkGroupTiles));
+
+  // Some consistency checks.
+  int64_t numOuterParallelLoops = getNumOuterParallelLoops(rootOp);
+  if (parallelLoopTileSizes.size() != numOuterParallelLoops) {
+    return rootOp.emitError(
+        "expected as many tiles sizes as the parallel loops of the operation");
+  }
+  auto distributedStart =
+      std::max<int64_t>(0, numOuterParallelLoops - kNumMaxParallelDims);
+  ArrayRef<int64_t> parallelLoopTileSizesRef(parallelLoopTileSizes);
+  // THe outer non-distributed paralle loops must be zero.
+  if (distributedStart &&
+      llvm::any_of(parallelLoopTileSizesRef.take_front(distributedStart),
+                   [](int64_t v) -> bool { return v; })) {
+    return rootOp.emitError(
+        "expected non-distributed parallel loop tile size to be 0");
+  }
+  if (llvm::any_of(parallelLoopTileSizesRef.take_back(numOuterParallelLoops -
+                                                      distributedStart),
+                   [](int64_t v) -> bool { return !v; })) {
+    return rootOp.emitError(
+        "expected distributed parallel loop tile size to be non-zero");
+  }
+  return success();
 }
 
-LogicalResult initCPULaunchConfig(ArrayRef<linalg::LinalgOp> linalgOps) {
-  if (linalgOps.empty()) return success();
-
-  SmallVector<int64_t, 4> firstLevelTileSizes;
-  if (!clLLVMTileSizes.empty()) {
-    firstLevelTileSizes.assign(clLLVMTileSizes.begin(), clLLVMTileSizes.end());
-  } else {
-    auto rootOperation = setRootConfig(linalgOps);
-    if (failed(rootOperation)) return failure();
-    // If root operation is null. Nothing to do.
-    if (!rootOperation.getValue()) return success();
-    firstLevelTileSizes = getTileSizes(
-        *rootOperation, static_cast<unsigned>(TilingLevel::WorkGroupTiles));
+FailureOr<IREE::HAL::DispatchLoweringPassPipeline> initCPULaunchConfig(
+    ModuleOp moduleOp) {
+  // The current linalg based lowering only tested for a single function case.
+  auto funcOps = moduleOp.getOps<FuncOp>();
+  if (!llvm::hasSingleElement(funcOps)) {
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
   }
+  FuncOp funcOp = *funcOps.begin();
+  SmallVector<linalg::LinalgOp, 4> linalgOps;
+  SmallVector<Operation *, 4> tiledLoops;
+  // If there are no linalg ops, not using Linalg based lowering.
+  if (failed(getLinalgOps(funcOp, linalgOps, tiledLoops)) ||
+      linalgOps.empty()) {
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+  }
+
+  Optional<IREE::HAL::DispatchLoweringPassPipeline> passPipelineOpt;
+  SmallVector<int64_t> parallelLoopTileSizes;
+  if (failed(
+          setRootConfig(linalgOps, passPipelineOpt, parallelLoopTileSizes)) ||
+      !passPipelineOpt) {
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+  }
+  auto passPipeline = passPipelineOpt.getValue();
 
   // Set the configuration of all other linalg operations that are not the root
   // operation.
+  LogicalResult status = success();
   for (auto linalgOp : linalgOps) {
     if (hasLoweringConfig(linalgOp)) continue;
-    auto status = setNonRootConfig(linalgOp, firstLevelTileSizes);
-    if (failed(status)) {
-      return failure();
-    }
+    status = setNonRootConfig(linalgOp, parallelLoopTileSizes);
+    if (failed(status)) break;
   }
-  return success();
+  if (failed(status)) {
+    for (auto linalgOp : linalgOps) {
+      eraseLoweringConfig(linalgOp);
+    }
+    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+  }
+
+  return passPipeline;
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
-
 #include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
-#include "llvm/ADT/SmallVector.h"
-#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Operation.h"
-#include "mlir/IR/Value.h"
+#include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -35,7 +28,8 @@ enum class TilingLevel : unsigned {
   NumTileLevels = 3
 };
 
-LogicalResult initCPULaunchConfig(ArrayRef<linalg::LinalgOp> linalgOps);
+FailureOr<IREE::HAL::DispatchLoweringPassPipeline> initCPULaunchConfig(
+    ModuleOp moduleOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
@@ -1,0 +1,111 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
+#include "iree/compiler/Conversion/Common/Passes.h"
+#include "iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h"
+#include "iree/compiler/Conversion/LinalgToLLVM/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Lowers an hal.executable.target operation to scalar/native-vector
+/// code. Invokes different compilation pipeline to
+/// - first lower to scalar/native-vector code
+/// - then convert to LLVM dialect.
+/// In due course this could be used to generate code for all backends.
+class LowerExecutableTargetPass
+    : public PassWrapper<LowerExecutableTargetPass,
+                         OperationPass<IREE::HAL::ExecutableTargetOp>> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect, linalg::LinalgDialect,
+                    LLVM::LLVMDialect>();
+  }
+
+  LowerExecutableTargetPass(LLVMCodegenOptions options) : options(options) {}
+  LowerExecutableTargetPass(const LowerExecutableTargetPass &pass)
+      : options(pass.options) {}
+
+  void runOnOperation() override;
+
+ private:
+  Option<bool> invokeLoweringPipelines{
+      *this, "invoke-lowering-pipelines",
+      llvm::cl::desc(
+          "Invokes the pass pipeline to lower an hal.executable.target "
+          "operation into scalar/native-vector code. Defaults to true, but "
+          "can be set to false for testing purposes."),
+      llvm::cl::init(true)};
+
+  LLVMCodegenOptions options;
+};
+}  // namespace
+
+void LowerExecutableTargetPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  IREE::HAL::ExecutableTargetOp targetOp = getOperation();
+  ModuleOp moduleOp = targetOp.getInnerModule();
+
+  FailureOr<IREE::HAL::DispatchLoweringPassPipeline> setPipeline =
+      initCPULaunchConfig(moduleOp);
+  if (failed(setPipeline)) {
+    return signalPassFailure();
+  }
+
+  OpPassManager executableLoweringPipeline(
+      IREE::HAL::ExecutableTargetOp::getOperationName());
+  executableLoweringPipeline.addPass(createSetNumWorkgroupsPass());
+
+  if (invokeLoweringPipelines) {
+    IREE::HAL::DispatchLoweringPassPipeline passPipeline =
+        setPipeline.getValue();
+    switch (passPipeline) {
+      case IREE::HAL::DispatchLoweringPassPipeline::CPUDefault:
+        addCPUDefaultPassPipeline(executableLoweringPipeline, options);
+        break;
+      case IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization:
+        addCPUVectorizationPassPipeline(executableLoweringPipeline, options);
+        break;
+    }
+    addLowerToLLVMPasses(executableLoweringPipeline, options);
+  }
+
+  if (failed(runPipeline(executableLoweringPipeline, targetOp))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createLowerExecutableTargetPass(LLVMCodegenOptions options) {
+  return std::make_unique<LowerExecutableTargetPass>(options);
+}
+
+static PassRegistration<LowerExecutableTargetPass> pass(
+    "iree-lower-executable-target-pass",
+    "Perform lowering of executable target to export dialects. Currently "
+    "lowers to LLVM dialect",
+    [] {
+      return std::make_unique<LowerExecutableTargetPass>(
+          getLLVMCodegenOptionsFromClOptions());
+    });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
@@ -60,7 +60,6 @@ class LowerExecutableTargetPass
 }  // namespace
 
 void LowerExecutableTargetPass::runOnOperation() {
-  MLIRContext *context = &getContext();
   IREE::HAL::ExecutableTargetOp targetOp = getOperation();
   ModuleOp moduleOp = targetOp.getInnerModule();
 

--- a/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
@@ -1,5 +1,4 @@
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-materialize-launch-configuration))" -cse -canonicalize -split-input-file %s | IreeFileCheck %s
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-materialize-launch-configuration))" -cse -canonicalize -split-input-file -iree-llvm-tile-size=4,2,1 %s | IreeFileCheck --check-prefix=CHECK_FLAG %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}))" -cse -canonicalize -split-input-file %s | IreeFileCheck %s
 
 hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
   hal.interface @io {
@@ -71,28 +70,9 @@ hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
 //      CHECK: linalg.copy
 // CHECK-SAME:   lowering.config = #[[CONFIG0]]
 
-//  CHECK_FLAG-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[4, 2]{{\]}}}
-//  CHECK_FLAG-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
-//  CHECK_FLAG-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
-//      CHECK_FLAG: hal.executable.entry_point @matmul_tensors
-// CHECK_FLAG-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK_FLAG-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK_FLAG-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK_FLAG-DAG:    %[[C1:.+]] = constant 1 : index
-//  CHECK_FLAG-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK_FLAG-DAG:    %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
-//      CHECK_FLAG:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
-//      CHECK_FLAG: linalg.copy
-// CHECK_FLAG-SAME:   lowering.config = #[[CONFIG]]
-//      CHECK_FLAG: linalg.matmul
-// CHECK_FLAG-SAME:   lowering.config = #[[CONFIG]]
-//      CHECK_FLAG: linalg.copy
-// CHECK_FLAG-SAME:   lowering.config = #[[CONFIG]]
-
 // -----
 
 // CHECK-NOT: #config
-// CHECK_FLAG-NOT: #config
 
 hal.executable @add_no_config attributes {sym_visibility = "private"} {
   hal.interface @io {
@@ -207,19 +187,101 @@ hal.executable @add attributes {sym_visibility = "private"} {
 //      CHECK: linalg.generic
 // CHECK-SAME:  lowering.config = #[[CONFIG]]
 
-//  CHECK_FLAG-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[4, 2]{{\]}}}
-//  CHECK_FLAG-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
-//  CHECK_FLAG-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
-//      CHECK_FLAG: hal.executable.entry_point @add
-// CHECK_FLAG-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
-// CHECK_FLAG-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
-// CHECK_FLAG-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
-//  CHECK_FLAG-DAG:    %[[C1:.+]] = constant 1 : index
-//  CHECK_FLAG-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
-//  CHECK_FLAG-DAG:    %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
-//      CHECK_FLAG:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
-//      CHECK_FLAG: linalg.generic
-// CHECK_FLAG-SAME:  lowering.config = #[[CONFIG]]
+// -----
+
+hal.executable @add4D attributes {sym_visibility = "private"} {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.target @llvm_aot, filter="dylib*" {
+    hal.executable.entry_point @add4D attributes {
+      interface = @io, ordinal = 0 : index,
+      signature = (!flow.dispatch.tensor<readonly:?x?x?x?xf32>, !flow.dispatch.tensor<readonly:?xf32>,
+        !flow.dispatch.tensor<writeonly:?x?x?x?xf32>) -> ()}
+    module  {
+      func @add4D() {
+        %c0 = constant 0 : index
+        %c1 = constant 1 : index
+        %c2 = constant 2 : index
+        %c3 = constant 3 : index
+        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?x?x?xf32>
+        %2 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<?x?x?x?xf32>
+        %6 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x?x?x?xf32>
+        %B = memref.dim %0, %c0 : memref<?x?x?x?xf32>
+        %M = memref.dim %0, %c1 : memref<?x?x?x?xf32>
+        %N = memref.dim %0, %c2 : memref<?x?x?x?xf32>
+        %K = memref.dim %0, %c3 : memref<?x?x?x?xf32>
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        %28 = muli %workgroup_size_z, %workgroup_id_z : index
+        %29 = muli %workgroup_size_z, %workgroup_count_z : index
+        scf.for %arg20 = %28 to %M step %29 {
+          %8 = muli %workgroup_size_y, %workgroup_id_y : index
+          %9 = muli %workgroup_size_y, %workgroup_count_y : index
+          scf.for %arg0 = %8 to %N step %9 {
+            %10 = muli %workgroup_size_x, %workgroup_id_x : index
+            %11 = muli %workgroup_size_x, %workgroup_count_x : index
+            scf.for %arg1 = %10 to %K step %11 {
+              %212 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg20)[%workgroup_size_z, %M]
+              %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %N]
+              %13 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %K]
+              %14 = memref.subview %0[0, %arg20, %arg0, %arg1] [%B, %212, %12, %13] [1, 1, 1, 1]
+                : memref<?x?x?x?xf32> to
+                  memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>
+              %15 = memref.subview %2[0, %arg20, %arg0, %arg1] [%B, %212, %12, %13] [1, 1, 1, 1]
+                : memref<?x?x?x?xf32> to
+                  memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>
+              %16 = memref.subview %6[0, %arg20, %arg0, %arg1] [%B, %212, %12, %13] [1, 1, 1, 1]
+                 : memref<?x?x?x?xf32> to
+                   memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>
+              linalg.generic {
+                __internal_linalg_transform__ = "workgroup",
+                indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                                 affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                                 affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+                iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+                ins(%14, %15 :
+                      memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>,
+                      memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>)
+                outs(%16 :  memref<?x?x?x?xf32, affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0 * s1 + s0 + d1 * s2 + d2 * s3 + d3)>>) {
+                ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors
+                  %3 = addf %arg2, %arg3 : f32
+                  linalg.yield %3 : f32
+                }
+              }
+            }
+          }
+          return
+        }
+        hal.interface @io attributes {sym_visibility = "private"} {
+          hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+          hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+          hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+        }
+      }
+    }
+  }
+//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[0, 128, 128, 128]{{\]}}}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
+//      CHECK: hal.executable.entry_point @add4D
+// CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
+//      CHECK:    hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
+//      CHECK: linalg.generic
+// CHECK-SAME:  lowering.config = #[[CONFIG]]
 
 // -----
 
@@ -300,20 +362,3 @@ hal.executable @batch_matmul_tensors attributes {sym_visibility = "private"} {
 // CHECK-SAME:    lowering.config = #[[CONFIG1]]
 //      CHECK:  linalg.copy
 // CHECK-SAME:    lowering.config = #[[CONFIG0]]
-
-//  CHECK_FLAG-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[4, 2, 1]{{\]}}
-//  CHECK_FLAG-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
-//  CHECK_FLAG-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
-//      CHECK_FLAG: hal.executable.entry_point @batch_matmul_tensors
-// CHECK_FLAG-NEXT: (%[[ARG0:[a-zA-Z0-9]+]]: index
-// CHECK_FLAG-SAME:  %[[ARG1:[a-zA-Z0-9]+]]: index
-// CHECK_FLAG-SAME:  %[[ARG2:[a-zA-Z0-9]+]]: index)
-//  CHECK_FLAG-DAG:  %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//  CHECK_FLAG-DAG:  %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
-//      CHECK_FLAG:  hal.return %[[ARG0]], %[[D0]], %[[D1]]
-//      CHECK_FLAG:  linalg.copy
-// CHECK_FLAG-SAME:    lowering.config = #[[CONFIG]]
-//      CHECK_FLAG:  linalg.batch_matmul
-// CHECK_FLAG-SAME:    lowering.config = #[[CONFIG]]
-//      CHECK_FLAG:  linalg.copy
-// CHECK_FLAG-SAME:    lowering.config = #[[CONFIG]]

--- a/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-materialize-launch-configuration, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-llvm-materialize-launch-configuration, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file -iree-codegen-llvm-promote-workgroup-to-full-tiles -cse %s | IreeFileCheck %s -check-prefix=CHECK-PROMOTED
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file -iree-codegen-llvm-promote-workgroup-to-full-tiles -cse %s | IreeFileCheck %s -check-prefix=CHECK-PROMOTED
 hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
   hal.interface @io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"

--- a/iree/compiler/Conversion/init_conversions.h
+++ b/iree/compiler/Conversion/init_conversions.h
@@ -36,6 +36,7 @@ inline void registerCommonConversionPasses() {
     createFlattenMemRefSubspanPass();
     createForOpCanonicalizationPass();
     createLinalgBufferizePass();
+    createSetNumWorkgroupsPass();
     return true;
   }();
   (void)init_once;
@@ -73,9 +74,9 @@ inline void registerLinalgToSPIRVPasses() {
 
 inline void registerLinalgToLLVMPasses() {
   static bool init_once = []() {
+    createLowerExecutableTargetPass(LLVMCodegenOptions());
     // LinalgToLLVM
     createLinalgTileAndVectorizeWorkgroupsPass();
-    createMaterializeCPULaunchConfigurationPass();
     createUnfusedFMAOpsPass();
     createPadLinalgWorkgroupTilesPass();
     return true;

--- a/iree/compiler/Dialect/HAL/IR/BUILD
+++ b/iree/compiler/Dialect/HAL/IR/BUILD
@@ -22,13 +22,17 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-exports_files(["HALBase.td"])
+exports_files([
+    "HALBase.td",
+    "HALDialect.td",
+])
 
 filegroup(
     name = "td_files",
     srcs = enforce_glob(
         [
             "HALBase.td",
+            "HALDialect.td",
             "HALInterfaces.td",
             "HALOps.td",
             "LoweringConfig.td",
@@ -64,12 +68,15 @@ cc_library(
         "HALTypeInterfaces.h.inc",
         "LoweringConfig.h.inc",
         "LoweringConfig.cpp.inc",
+        "LoweringConfigEnums.h.inc",
+        "LoweringConfigEnums.cpp.inc",
     ],
     deps = [
         ":HALInterfacesGen",
         ":HALOpsGen",
         ":HALStructsGen",
         ":HALTypesGen",
+        ":LoweringConfigEnumGen",
         ":LoweringConfigGen",
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/Shape/IR",
@@ -232,6 +239,27 @@ gentbl_cc_library(
         (
             ["-gen-struct-attr-defs"],
             "LoweringConfig.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LoweringConfig.td",
+    td_srcs = [
+        ":td_files",
+        "//iree/compiler/Dialect/IREE/IR:td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "LoweringConfigEnumGen",
+    tbl_outs = [
+        (
+            ["-gen-enum-decls"],
+            "LoweringConfigEnums.h.inc",
+        ),
+        (
+            ["-gen-enum-defs"],
+            "LoweringConfigEnums.cpp.inc",
         ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -31,6 +31,8 @@ iree_cc_library(
     "HALTypeInterfaces.h.inc"
     "LoweringConfig.cpp.inc"
     "LoweringConfig.h.inc"
+    "LoweringConfigEnums.cpp.inc"
+    "LoweringConfigEnums.h.inc"
   SRCS
     "HALOpFolders.cpp"
     "HALOps.cpp"
@@ -136,6 +138,16 @@ iree_tablegen_library(
   OUTS
     -gen-struct-attr-decls LoweringConfig.h.inc
     -gen-struct-attr-defs LoweringConfig.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    LoweringConfigEnumGen
+  TD_FILE
+    "LoweringConfig.td"
+  OUTS
+    -gen-enum-decls LoweringConfigEnums.h.inc
+    -gen-enum-defs LoweringConfigEnums.cpp.inc
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -15,36 +15,7 @@
 #ifndef IREE_DIALECT_HAL_BASE
 #define IREE_DIALECT_HAL_BASE
 
-include "iree/compiler/Dialect/IREE/IR/IREEBase.td"
-
-//===----------------------------------------------------------------------===//
-// IREE HAL (Hardware Abstraction Layer) dialect
-//===----------------------------------------------------------------------===//
-
-def HAL_Dialect : Dialect {
-  let name = "hal";
-  let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
-
-  let summary = [{
-    A dialect representing operations against the IREE HAL.
-  }];
-  let description = [{
-    This can be thought of as a Vulkan-like model with all of the graphics bits
-    chopped out.
-
-    The type set is limited to those that can be represented in the IREE HAL
-    design: buffers and views, synchronization primitives like semaphores, and
-    and command buffers. The intent is that if a device could implement the HAL
-    interface the sequencer ops could run on that device, such as being able to
-    run on a GPU via indirect command buffers.
-
-    Though this is mostly a 1:1 mapping to the iree::hal API there are some
-    methods omitted as they are not likely to be needed in IR. It's assumed that
-    either sequencer interfaces will encapsulate the logic (such as device
-    resolution) or that certain features are unsafe to expose to user-defined
-    input.
-  }];
-}
+include "iree/compiler/Dialect/HAL/IR/HALDialect.td"
 
 //===----------------------------------------------------------------------===//
 // HAL enums

--- a/iree/compiler/Dialect/HAL/IR/HALDialect.td
+++ b/iree/compiler/Dialect/HAL/IR/HALDialect.td
@@ -1,0 +1,49 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_DIALECT_HAL_DIALECT
+#define IREE_DIALECT_HAL_DIALECT
+
+include "iree/compiler/Dialect/IREE/IR/IREEBase.td"
+
+//===----------------------------------------------------------------------===//
+// IREE HAL (Hardware Abstraction Layer) dialect
+//===----------------------------------------------------------------------===//
+
+def HAL_Dialect : Dialect {
+  let name = "hal";
+  let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
+
+  let summary = [{
+    A dialect representing operations against the IREE HAL.
+  }];
+  let description = [{
+    This can be thought of as a Vulkan-like model with all of the graphics bits
+    chopped out.
+
+    The type set is limited to those that can be represented in the IREE HAL
+    design: buffers and views, synchronization primitives like semaphores, and
+    and command buffers. The intent is that if a device could implement the HAL
+    interface the sequencer ops could run on that device, such as being able to
+    run on a GPU via indirect command buffers.
+
+    Though this is mostly a 1:1 mapping to the iree::hal API there are some
+    methods omitted as they are not likely to be needed in IR. It's assumed that
+    either sequencer interfaces will encapsulate the logic (such as device
+    resolution) or that certain features are unsafe to expose to user-defined
+    input.
+  }];
+}
+
+#endif // IREE_DIALECT_HAL_DIALECT

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
@@ -18,9 +18,9 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 static const char kConfigAttrName[] = "lowering.config";
-static const char kPipelineNameAttrName[] = "lowering.pipeline";
 
 #include "iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp.inc"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfigEnums.cpp.inc"
 
 namespace mlir {
 namespace iree_compiler {
@@ -44,24 +44,7 @@ bool setLoweringConfig(Operation *op, IREE::HAL::LoweringConfig config) {
   return true;
 }
 
-StringRef getPipelineName(Operation *op) {
-  auto targetOp = op->getParentOfType<IREE::HAL::ExecutableTargetOp>();
-  if (!targetOp) return "";
-  auto attr = targetOp->getAttrOfType<StringAttr>(kPipelineNameAttrName);
-  if (!attr) return "";
-  return attr.getValue();
-}
-
-bool setPipelineName(Operation *op, StringRef name) {
-  auto targetOp = op->getParentOfType<IREE::HAL::ExecutableTargetOp>();
-  if (!targetOp) return false;
-  if (targetOp->hasAttrOfType<StringAttr>(kPipelineNameAttrName)) {
-    return false;
-  }
-  targetOp->setAttr(kPipelineNameAttrName,
-                    StringAttr::get(op->getContext(), name));
-  return true;
-}
+void eraseLoweringConfig(Operation *op) { op->removeAttr(kConfigAttrName); }
 
 //===----------------------------------------------------------------------===//
 // Helpers for accessing values from the LoweringConfig attribute.

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
@@ -29,6 +29,7 @@
 
 // clang-format off
 #include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h.inc"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfigEnums.h.inc"
 // clang-format on
 
 namespace mlir {
@@ -49,16 +50,8 @@ bool hasLoweringConfig(Operation *op);
 /// true. Returns false if a configuration already exists.
 bool setLoweringConfig(Operation *op, IREE::HAL::LoweringConfig config);
 
-/// Returns the StringAttr that identifies the lowering pipeline to use. Returns
-/// an empty-string if the pipeline hasnt been set.
-StringRef getPipelineName(Operation *op);
-
-/// Sets the name of the pipeline to use for the `hal.executable.target` if not
-/// set. Note that this modifies the `hal.executable.target` operation, so
-/// calling this method from within a pipeline nested within this op would be
-/// illegal. Returns false if the name wasnt set (possibly due to the name being
-/// already set)
-bool setPipelineName(Operation *op, StringRef name);
+/// Removes the lowering configuration on the operation if it exists.
+void eraseLoweringConfig(Operation *op);
 
 //===----------------------------------------------------------------------===//
 // Helpers for accessing values from the LoweringConfig attribute.

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -15,12 +15,28 @@
 #define IREE_COMPILER_DIALECT_HAL_IR_LOWERINGCONFIG
 
 // Putting this in HAL dialect for now.
-include "iree/compiler/Dialect/HAL/IR/HALBase.td"
+include "iree/compiler/Dialect/HAL/IR/HALDialect.td"
+
+def CPU_Default
+    : I32EnumAttrCase<"CPUDefault", 0>;
+def CPU_Vectorization
+    : I32EnumAttrCase<"CPUVectorization", 1>;
+
+// EnumAttrCase for all known lowerings for ops within dispatch region
+// to scalar/native-vector code.
+def DispatchLoweringPassPipelineEnum : I32EnumAttr<
+    "DispatchLoweringPassPipeline",
+    "identifier for pass pipeline use to lower dispatch region",
+    [CPU_Default, CPU_Vectorization]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
+}
 
 def TileSizesListAttr :
     TypedArrayAttrBase<I64ArrayAttr,
                        "list of tile sizes for all levels"> { }
 
+// Attribute that carries information needed to perform
+// tiling/vectorization, etc.
 def HAL_LoweringConfigAttr :
   StructAttr<"LoweringConfig", HAL_Dialect, [
     StructFieldAttr<"tileSizes",

--- a/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.cpp
@@ -50,7 +50,10 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   // Configuration
   // ---------------------------------------------------------------------------
 
-  passManager.addPass(createMaterializeCPULaunchConfigurationPass());
+  // TODO(#5925): This can also be modified to just use the dynamic pass
+  // pipeline like the CPU side.
+  // passManager.addPass(createMaterializeCPULaunchConfigurationPass());
+  passManager.addPass(createSetNumWorkgroupsPass());
 
   // ---------------------------------------------------------------------------
   // Linalg -> Vectors
@@ -76,6 +79,8 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
 
   // Tiling and distribution.
   nestedModulePM.addNestedPass<FuncOp>(createCanonicalizerPass());
+  // TODO(#5925): This can also be modified to just use the dynamic pass
+  // pipeline like the CPU side.
   // nestedModulePM.addNestedPass<FuncOp>(
   //     createLinalgTileAndVectorizeWorkgroupsPass());
 


### PR DESCRIPTION
The lowering of linalg operations to scalar/vector code is modified to
use dynamic pass pipelines. A new pass `LowerExecutableTargetPass` is
added that lowers an executable to the scalar/vector code. This pass
sets the configuration to use when lowering the module within the
target operation. At the time of setting the configuration, the pass
to use is also decided. This is used to dynamically select the pass
pipeline to use for the lowering.

Currently only two pipelines exist. One for vectorization based
lowering and other to lower to scalar code directly. The existing
pipeline is reordered to make the distinction between lowering a
Linalg operation to scalar/native-vector operations and the pipeline
needed to convert those into LLVM Dialect. The latter must be
re-usable across all pipelines used for CPU lowering.