### PR TITLE
Explicitly disable include sort for third_party

### DIFF
--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -14,3 +14,4 @@
 
 # Disable formatting for any code under third_party/, since we don't control it.
 DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
This makes older clang-format do the right thing as disableFormat wasn't
disabling include sorting.