### PR TITLE
Update colabs to use renamed python function

### DIFF
--- a/colab/edge_detection.ipynb
+++ b/colab/edge_detection.ipynb
@@ -420,7 +420,7 @@
         "# Register the module with a runtime context.\n",
         "config = ireert.Config(backend.driver)\n",
         "ctx = ireert.SystemContext(config=config)\n",
-        "ctx.add_module(vm_module)"
+        "ctx.add_vm_module(vm_module)"
       ],
       "execution_count": 10,
       "outputs": [

--- a/colab/low_level_invoke_function.ipynb
+++ b/colab/low_level_invoke_function.ipynb
@@ -104,7 +104,7 @@
         "# Use the CPU interpreter (which has the most implementation done):\n",
         "config = ireert.Config(\"vmvx\")\n",
         "ctx = ireert.SystemContext(config=config)\n",
-        "ctx.add_module(vm_module)\n",
+        "ctx.add_vm_module(vm_module)\n",
         "\n",
         "# Invoke the function and print the result.\n",
         "print(\"INVOKE simple_mul\")\n",


### PR DESCRIPTION
add_module was renamed to add_vm_module in https://github.com/google/iree/pull/5697, so this PR updates the usage in colab