### PR TITLE
Fix tracking of result buffer to use if the buffer eventually maps to low dispatch output.

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -677,6 +677,7 @@ static Value getReverseOfCastOp(OpBuilder &b, tensor::CastOp castOp,
 static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
                                     BlockAndValueMapping &bvm) {
   SmallVector<Operation *> traversedOps;
+  SmallVector<Value> traversedValues;
 
   // Traverse the use-def chains to get the `flow.dispatch.tensor.store`
   // operation keeping track of all the traversed operations. Note that the
@@ -688,10 +689,27 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
     user = *(defVal.user_begin());
     // If the user is a store op, we are done.
     if (isa<IREE::Flow::DispatchTensorStoreOp>(user)) break;
-    // If user has more than one results, abort.
-    if (user->getNumResults() != 1) return nullptr;
+    // If user has more than one results, with a `LinalgOp` we can still follow
+    // the chain. For now use the `tiedOperands` cause that might result in
+    // better reuse tracking.
+    if (auto linalgOp = dyn_cast<linalg::LinalgOp>(user)) {
+      OpOperand &use = *defVal.use_begin();
+      auto tiedOperands = getTiedOperandsForLinalgOps(linalgOp);
+      Value useResult = nullptr;
+      for (auto tiedOperand : llvm::enumerate(tiedOperands)) {
+        if (tiedOperand.value() == defVal) {
+          useResult = linalgOp->getResult(tiedOperand.index());
+          break;
+        }
+      }
+      if (!useResult) return nullptr;
+      defVal = useResult;
+    } else {
+      if (user->getNumResults() != 1) return nullptr;
+      defVal = user->getResult(0);
+    }
     traversedOps.push_back(user);
-    defVal = user->getResult(0);
+    traversedValues.push_back(defVal);
   }
   auto storeOp = dyn_cast_or_null<IREE::Flow::DispatchTensorStoreOp>(user);
   if (!storeOp) return nullptr;
@@ -709,7 +727,8 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
 
   // Now replay the instructions that are essentially doing type-conversion, in
   // reverse, to get the type needed for the operation computing the value.
-  for (auto op : traversedOps) {
+  for (auto value : traversedValues) {
+    Operation *op = value.getDefiningOp();
     resultBuffer =
         TypeSwitch<Operation *, Value>(op)
             .Case<linalg::LinalgOp, SubTensorInsertOp, vector::TransferWriteOp>(
@@ -723,9 +742,10 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
             })
             .Default([&](Operation *) { return nullptr; });
     if (!resultBuffer) return nullptr;
-    bvm.map(op->getResult(0), resultBuffer);
+    unsigned resultNumber = value.cast<OpResult>().getResultNumber();
+    bvm.map(op->getResult(resultNumber), resultBuffer);
     DEBUG_WITH_TYPE(DEBUG_TYPE, {
-      llvm::dbgs() << "Pair :\n\tTensor :";
+      llvm::dbgs() << "Pair :\n\tTensor result " << resultNumber << " :";
       op->print(llvm::dbgs());
       llvm::dbgs() << "\nt\tMemref :";
       resultBuffer.print(llvm::dbgs());
@@ -853,7 +873,7 @@ static LogicalResult getOrAllocateResultBuffers(
     }
     bvm.map(result.value(), buffer);
     DEBUG_WITH_TYPE(DEBUG_TYPE, {
-      llvm::dbgs() << "Pair :\n\tTensor :";
+      llvm::dbgs() << "Pair :\n\tTensor result " << result.index() << ":";
       op->print(llvm::dbgs());
       llvm::dbgs() << "\nt\tMemref :";
       buffer.print(llvm::dbgs());

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -676,7 +676,6 @@ static Value getReverseOfCastOp(OpBuilder &b, tensor::CastOp castOp,
 /// gets the buffer to use to compute the value in-place.
 static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
                                     BlockAndValueMapping &bvm) {
-  SmallVector<Operation *> traversedOps;
   SmallVector<Value> traversedValues;
 
   // Traverse the use-def chains to get the `flow.dispatch.tensor.store`
@@ -693,7 +692,6 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
     // the chain. For now use the `tiedOperands` cause that might result in
     // better reuse tracking.
     if (auto linalgOp = dyn_cast<linalg::LinalgOp>(user)) {
-      OpOperand &use = *defVal.use_begin();
       auto tiedOperands = getTiedOperandsForLinalgOps(linalgOp);
       Value useResult = nullptr;
       for (auto tiedOperand : llvm::enumerate(tiedOperands)) {
@@ -708,7 +706,6 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
       if (user->getNumResults() != 1) return nullptr;
       defVal = user->getResult(0);
     }
-    traversedOps.push_back(user);
     traversedValues.push_back(defVal);
   }
   auto storeOp = dyn_cast_or_null<IREE::Flow::DispatchTensorStoreOp>(user);

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -1935,8 +1935,8 @@ func @multi_result_reduce() {
   %c2 = constant 2 : index
   %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
   %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
-  %2 = hal.interface.binding.subspan @io::@wo1[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
-  %3 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
+  %2 = hal.interface.binding.subspan @io::@wo0[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
+  %3 = hal.interface.binding.subspan @io::@wo1[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
   %d0 = hal.interface.load.constant offset = 0 : index
   %d1 = hal.interface.load.constant offset = 1 : index
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -1969,14 +1969,14 @@ func @multi_result_reduce() {
 hal.interface @io attributes {sym_visibility = "private"} {
   hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer", access="Read"
   hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer", access="Read"
-  hal.interface.binding @wo1, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
-  hal.interface.binding @wo2, set=0, binding=3, type="StorageBuffer", access="Write|Discard"
+  hal.interface.binding @wo0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  hal.interface.binding @wo1, set=0, binding=3, type="StorageBuffer", access="Write|Discard"
 }
 // CHECK-LABEL: func @multi_result_reduce
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
-//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@ret1
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@ro0
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@ro1
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@wo0
+//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@wo1
 //       CHECK:   scf.for
 //   CHECK-DAG:     %[[ARG0_SV:.+]] = memref.subview %[[ARG0]]
 //   CHECK-DAG:     %[[ARG1_SV:.+]] = memref.subview %[[ARG1]]

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -1925,3 +1925,65 @@ hal.interface @io attributes {sym_visibility = "private"} {
 //  CHECK-SAME:        outs(%[[ALLOC_RET0_RESHAPE]]
 //       CHECK:      %[[RET0_SV:.+]] = memref.subview %[[RET0]]
 //       CHECK:      linalg.copy(%[[ALLOC_RET0]], %[[RET0_SV]])
+
+// -----
+
+func @multi_result_reduce() {
+  %c0 = constant 0 : index
+  %c0_i32 = constant 0 : i32
+  %c-2147483648_i32 = constant -2147483648 : i32
+  %c2 = constant 2 : index
+  %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
+  %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
+  %2 = hal.interface.binding.subspan @io::@wo1[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
+  %3 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:?xi32>
+  %d0 = hal.interface.load.constant offset = 0 : index
+  %d1 = hal.interface.load.constant offset = 1 : index
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+  %5 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_count_x]
+  scf.for %arg0 = %4 to %d1 step %5 {
+    %6 = affine.min affine_map<(d0)[s0] -> (128, -d0 + s0)>(%arg0)[%d1]
+    %7 = flow.dispatch.tensor.load %0, offsets = [0, %arg0], sizes = [%d0, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
+    %9 = flow.dispatch.tensor.load %1, offsets = [0, %arg0], sizes = [%d0, %6], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
+    %13 = linalg.init_tensor [%6] : tensor<?xi32>
+    %14 = linalg.fill(%13, %c-2147483648_i32) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} : tensor<?xi32>, i32 -> tensor<?xi32> 
+    %17 = linalg.fill(%13, %c0_i32) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} : tensor<?xi32>, i32 -> tensor<?xi32> 
+    %18:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%7, %9 : tensor<?x?xi32>, tensor<?x?xi32>) outs(%14, %17 : tensor<?xi32>, tensor<?xi32>) attrs =  {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[128]]}} {
+    ^bb0(%arg1: i32, %arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
+      %19 = cmpi sge, %arg1, %arg3 : i32
+      %20 = select %19, %arg1, %arg3 : i32
+      %21 = cmpi eq, %arg1, %arg3 : i32
+      %22 = cmpi slt, %arg2, %arg4 : i32
+      %23 = select %22, %arg2, %arg4 : i32
+      %24 = select %19, %arg2, %arg4 : i32
+      %25 = select %21, %23, %24 : i32
+      linalg.yield %20, %25 : i32, i32
+    } -> tensor<?xi32>, tensor<?xi32>
+    flow.dispatch.tensor.store %18#0, %2, offsets = [%arg0], sizes = [%6], strides = [1] : tensor<?xi32> -> !flow.dispatch.tensor<writeonly:?xi32>
+    flow.dispatch.tensor.store %18#1, %3, offsets = [%arg0], sizes = [%6], strides = [1] : tensor<?xi32> -> !flow.dispatch.tensor<writeonly:?xi32>
+  }
+  return
+}
+hal.interface @io attributes {sym_visibility = "private"} {
+  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer", access="Read"
+  hal.interface.binding @wo1, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  hal.interface.binding @wo2, set=0, binding=3, type="StorageBuffer", access="Write|Discard"
+}
+// CHECK-LABEL: func @multi_result_reduce
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@ret1
+//       CHECK:   scf.for
+//   CHECK-DAG:     %[[ARG0_SV:.+]] = memref.subview %[[ARG0]]
+//   CHECK-DAG:     %[[ARG1_SV:.+]] = memref.subview %[[ARG1]]
+//   CHECK-DAG:     %[[RET0_SV:.+]] = memref.subview %[[RET0]]
+//   CHECK-DAG:     linalg.fill(%[[RET0_SV]]
+//   CHECK-DAG:     %[[RET1_SV:.+]] = memref.subview %[[RET1]]
+//   CHECK-DAG:     linalg.fill(%[[RET1_SV]]
+//       CHECK:     linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0_SV]], %[[ARG1_SV]]
+//  CHECK-SAME:       outs(%[[RET0_SV]], %[[RET1_SV]]

--- a/iree/test/e2e/xla_ops/reduce.mlir
+++ b/iree/test/e2e/xla_ops/reduce.mlir
@@ -288,3 +288,23 @@ func @reduce_sum_4x2x3xf32_dims_0_1_2() attributes { iree.module.export } {
   check.expect_almost_eq_const(%res, dense<84.0> : tensor<f32>) : tensor<f32>
   return
 }
+
+func @reducemulti_result() attributes { iree.module.export } {
+  %cst0 = mhlo.constant dense<-2147483648> : tensor<i32>
+  %cst1 = mhlo.constant dense<0> : tensor<i32>
+  %arg0 = iree.unfoldable_constant dense<[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14], [15, 16], [17, 18]]> : tensor<9x2xi32>
+  %arg1 = iree.unfoldable_constant dense<[[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12, 13], [14, 15], [16, 17]]> : tensor<9x2xi32>
+  %res0, %res1 = "mhlo.reduce"(%arg0, %arg1, %cst0, %cst1) ( {
+  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>):  // no predecessors
+    %0 = "mhlo.compare"(%arg2, %arg4) {comparison_direction = "GE"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %1 = "mhlo.select"(%0, %arg2, %arg4) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
+    %2 = "mhlo.compare"(%arg2, %arg4) {comparison_direction = "EQ"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %3 = mhlo.minimum %arg3, %arg5 : tensor<i32>
+    %4 = "mhlo.select"(%0, %arg3, %arg5) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
+    %5 = "mhlo.select"(%2, %3, %4) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
+    "mhlo.return"(%1, %5) : (tensor<i32>, tensor<i32>) -> ()
+  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<9x2xi32>, tensor<9x2xi32>, tensor<i32>, tensor<i32>) -> (tensor<2xi32>, tensor<2xi32>)
+  check.expect_eq_const(%res0, dense<[17, 18]> : tensor<2xi32>) : tensor<2xi32>
+  check.expect_eq_const(%res1, dense<[16, 17]> : tensor<2xi32>) : tensor<2xi32>
+  return
+}


### PR DESCRIPTION
For the case of multiple operands, the tracking to reuse the buffer
for the dispatch region output for the operations needs to be updated
to track across linalg ops that have multiple results.

Fixes  #5838 