### PR TITLE
Use nvidia deb files that we control

### DIFF
--- a/build_tools/docker/cmake-bazel-frontends-nvidia/Dockerfile
+++ b/build_tools/docker/cmake-bazel-frontends-nvidia/Dockerfile
@@ -14,6 +14,24 @@
 
 # To use the host GPUs, `docker run` must be called with the `--gpus all` flag.
 
+# We use .deb files that we host because we have to pin the version exactly to
+# match the host machine and packages routinely dissapear from the Ubuntu
+# apt repositories.
+ARG NVIDIA_GL_DEB="libnvidia-gl-460_460.39-0ubuntu0.18.04.1_amd64.deb"
+ARG NVIDIA_COMPUTE_DEB="libnvidia-compute-460_460.39-0ubuntu0.18.04.1_amd64.deb"
+ARG NVIDIA_COMMON_DEB="libnvidia-common-460_460.39-0ubuntu0.18.04.1_all.deb"
+
+FROM gcr.io/iree-oss/util@sha256:40846b4aea5886af3250399d6adfdb3e1195a8b0177706bb0375e812d62dc49c AS fetch-nvidia
+ARG NVIDIA_COMMON_DEB
+ARG NVIDIA_GL_DEB
+ARG NVIDIA_COMPUTE_DEB
+
+WORKDIR /fetch-nvidia
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_COMMON_DEB}"
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_GL_DEB?}"
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_COMPUTE_DEB}"
+
+
 # Set up the image and working directory by inheriting the vulkan CMake
 # configuration.
 # Note that we don't start from NVIDIA's docker base:
@@ -24,8 +42,16 @@
 # This allows to share configuration with base CMake, but it also means we need
 # to MATCH the driver version between the host machine and the docker image.
 FROM gcr.io/iree-oss/cmake-bazel-frontends-vulkan@sha256:02c21884ec62a548992fc62031c41375d5cb7ebc33cb4ecbb8ac0ec2c83a2aa1 AS final
+ARG NVIDIA_COMMON_DEB
+ARG NVIDIA_GL_DEB
+ARG NVIDIA_COMPUTE_DEB
 
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-       libnvidia-gl-460=460.39-0ubuntu0.18.04.1 \
-       libnvidia-compute-460=460.39-0ubuntu0.18.04.1
+COPY --from=fetch-nvidia \
+  "/fetch-nvidia/${NVIDIA_COMMON_DEB}" \
+  "/fetch-nvidia/${NVIDIA_GL_DEB}" \
+  "/fetch-nvidia/${NVIDIA_COMPUTE_DEB}" \
+  /tmp/
+
+RUN apt-get install "/tmp/${NVIDIA_COMMON_DEB?}" \
+  "/tmp/${NVIDIA_GL_DEB?}" \
+  "/tmp/${NVIDIA_COMPUTE_DEB?}"

--- a/build_tools/docker/cmake-python-nvidia/Dockerfile
+++ b/build_tools/docker/cmake-python-nvidia/Dockerfile
@@ -16,6 +16,22 @@
 
 # To use the host GPUs, `docker run` must be called with the `--gpus all` flag.
 
+ARG NVIDIA_GL_DEB="libnvidia-gl-460_460.39-0ubuntu0.18.04.1_amd64.deb"
+ARG NVIDIA_COMPUTE_DEB="libnvidia-compute-460_460.39-0ubuntu0.18.04.1_amd64.deb"
+ARG NVIDIA_COMMON_DEB="libnvidia-common-460_460.39-0ubuntu0.18.04.1_all.deb"
+
+
+FROM gcr.io/iree-oss/util@sha256:40846b4aea5886af3250399d6adfdb3e1195a8b0177706bb0375e812d62dc49c AS fetch-nvidia
+ARG NVIDIA_COMMON_DEB
+ARG NVIDIA_GL_DEB
+ARG NVIDIA_COMPUTE_DEB
+
+WORKDIR /fetch-nvidia
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_COMMON_DEB}"
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_GL_DEB?}"
+RUN wget -q "https://storage.googleapis.com/iree-shared-files/${NVIDIA_COMPUTE_DEB}"
+
+
 # Set up the image and working directory by inheriting the vulkan CMake
 # configuration.
 # Note that we don't start from NVIDIA's docker base:
@@ -26,8 +42,12 @@
 # This allows to share configuration with base CMake, but it also means we need
 # to MATCH the driver version between the host machine and the docker image.
 FROM gcr.io/iree-oss/cmake-python-vulkan@sha256:6722f69c6300749f6bd4b141fc653244990381a6b0111f9c361061adcd65c07c AS final
+ARG NVIDIA_COMMON_DEB
+ARG NVIDIA_GL_DEB
+ARG NVIDIA_COMPUTE_DEB
 
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-       libnvidia-gl-460=460.39-0ubuntu0.18.04.1 \
-       libnvidia-compute-460=460.39-0ubuntu0.18.04.1
+COPY --from=fetch-nvidia "/fetch-nvidia/${NVIDIA_COMMON_DEB}" "/fetch-nvidia/${NVIDIA_GL_DEB}" "/fetch-nvidia/${NVIDIA_COMPUTE_DEB}" /tmp/
+
+RUN apt-get install "/tmp/${NVIDIA_COMMON_DEB?}" \
+  "/tmp/${NVIDIA_GL_DEB?}" \
+  "/tmp/${NVIDIA_COMPUTE_DEB?}"

--- a/build_tools/docker/cmake-python-nvidia/Dockerfile
+++ b/build_tools/docker/cmake-python-nvidia/Dockerfile
@@ -16,6 +16,9 @@
 
 # To use the host GPUs, `docker run` must be called with the `--gpus all` flag.
 
+# We use .deb files that we host because we have to pin the version exactly to
+# match the host machine and packages routinely dissapear from the Ubuntu
+# apt repositories.
 ARG NVIDIA_GL_DEB="libnvidia-gl-460_460.39-0ubuntu0.18.04.1_amd64.deb"
 ARG NVIDIA_COMPUTE_DEB="libnvidia-compute-460_460.39-0ubuntu0.18.04.1_amd64.deb"
 ARG NVIDIA_COMMON_DEB="libnvidia-common-460_460.39-0ubuntu0.18.04.1_all.deb"
@@ -46,7 +49,11 @@ ARG NVIDIA_COMMON_DEB
 ARG NVIDIA_GL_DEB
 ARG NVIDIA_COMPUTE_DEB
 
-COPY --from=fetch-nvidia "/fetch-nvidia/${NVIDIA_COMMON_DEB}" "/fetch-nvidia/${NVIDIA_GL_DEB}" "/fetch-nvidia/${NVIDIA_COMPUTE_DEB}" /tmp/
+COPY --from=fetch-nvidia \
+  "/fetch-nvidia/${NVIDIA_COMMON_DEB}" \
+  "/fetch-nvidia/${NVIDIA_GL_DEB}" \
+  "/fetch-nvidia/${NVIDIA_COMPUTE_DEB}" \
+  /tmp/
 
 RUN apt-get install "/tmp/${NVIDIA_COMMON_DEB?}" \
   "/tmp/${NVIDIA_GL_DEB?}" \

--- a/build_tools/docker/manage_images.py
+++ b/build_tools/docker/manage_images.py
@@ -57,7 +57,7 @@ IMAGES_TO_DEPENDENCIES = {
     'cmake-python': ['cmake'],
     'cmake-python-vulkan': ['cmake-python', 'vulkan'],
     'cmake-python-swiftshader': ['cmake-python-vulkan', 'swiftshader'],
-    'cmake-python-nvidia': ['cmake-python-vulkan'],
+    'cmake-python-nvidia': ['cmake-python-vulkan', 'util'],
     'cmake-riscv': ['cmake', 'util'],
     'cmake-bazel-frontends': ['cmake-python', 'bazel'],
     'cmake-bazel-frontends-android': ['cmake-bazel-frontends', 'cmake-android'],

--- a/build_tools/docker/manage_prod.py
+++ b/build_tools/docker/manage_prod.py
@@ -16,7 +16,7 @@
 """Uses prod_digests.txt to update GCR's :prod tags.
 
 Usage:
-  Pull all images that should have :prod tags, tag the with :prod and push
+  Pull all images that should have :prod tags, tag them with :prod and push
   them to GCR. This will make sure that you are at upstream head on the main
   branch before pushing:
     python3 build_tools/docker/manage_prod.py

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -9,7 +9,7 @@ gcr.io/iree-oss/vulkan@sha256:5812ee64806a7f3df0739ccf0930c27cabce346901488eceb1
 gcr.io/iree-oss/rbe-toolchain@sha256:d69c260b98a97ad430d34c4591fb2399e00888750f5d47ede00c1e6f3e774e5a
 gcr.io/iree-oss/cmake-python-vulkan@sha256:6722f69c6300749f6bd4b141fc653244990381a6b0111f9c361061adcd65c07c
 gcr.io/iree-oss/cmake-python-swiftshader@sha256:0be2b0c735a038365e7cad31f6b440805dd4e231e166a114ef22914a5469cbc8
-gcr.io/iree-oss/cmake-python-nvidia@sha256:0c931cac303791af85c5a717b418997cac9f3319717f59f7a70ac777edfa7b33
+gcr.io/iree-oss/cmake-python-nvidia@sha256:04b8257becb1b2916b1dcec952cf0380963e3ba04f0a7cdcbab1c13995879bb4
 gcr.io/iree-oss/cmake-bazel-frontends@sha256:699f6470e618c151f36cb4769ccaf2cfbf334ddb2fc2b6e69eb60732fe69bb6b
 gcr.io/iree-oss/cmake-bazel-frontends-vulkan@sha256:02c21884ec62a548992fc62031c41375d5cb7ebc33cb4ecbb8ac0ec2c83a2aa1
 gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:79998983c574bb6fd0625a99a541364749c76f8ff6c6ee98411b612a9950470b

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -12,7 +12,7 @@ gcr.io/iree-oss/cmake-python-swiftshader@sha256:0be2b0c735a038365e7cad31f6b44080
 gcr.io/iree-oss/cmake-python-nvidia@sha256:04b8257becb1b2916b1dcec952cf0380963e3ba04f0a7cdcbab1c13995879bb4
 gcr.io/iree-oss/cmake-bazel-frontends@sha256:699f6470e618c151f36cb4769ccaf2cfbf334ddb2fc2b6e69eb60732fe69bb6b
 gcr.io/iree-oss/cmake-bazel-frontends-vulkan@sha256:02c21884ec62a548992fc62031c41375d5cb7ebc33cb4ecbb8ac0ec2c83a2aa1
-gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:79998983c574bb6fd0625a99a541364749c76f8ff6c6ee98411b612a9950470b
+gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:7fa938de1e5b2732f5c9818c5c8d3d5346a2772a2f935f85016710342e72e9f7
 gcr.io/iree-oss/cmake-bazel-frontends-swiftshader@sha256:012dd9b452da5c4f4248edf27a7a7faa0eeca6a7a2a1e21d00bc932b125246e1
 gcr.io/iree-oss/cmake-riscv@sha256:a09ff1e6ab65a436822894acf58ef6c4cbc523581960e918a07ddf4a46c8af95
 gcr.io/iree-oss/cmake-bazel-frontends-android@sha256:dd11a49fa357ac3f96ef53c26b1faaf24ce834383300d1ed464e810bb33fafe7

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build_kokoro.sh
@@ -38,7 +38,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   --gpus all \
-  gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:79998983c574bb6fd0625a99a541364749c76f8ff6c6ee98411b612a9950470b \
+  gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:7fa938de1e5b2732f5c9818c5c8d3d5346a2772a2f935f85016710342e72e9f7 \
   build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build_kokoro.sh
@@ -38,7 +38,7 @@ docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
   --gpus all \
-  gcr.io/iree-oss/cmake-python-nvidia@sha256:0c931cac303791af85c5a717b418997cac9f3319717f59f7a70ac777edfa7b33 \
+  gcr.io/iree-oss/cmake-python-nvidia@sha256:04b8257becb1b2916b1dcec952cf0380963e3ba04f0a7cdcbab1c13995879bb4 \
   build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the


### PR DESCRIPTION
We have had repeated issues where we cannot update our docker images
because the version we're using has disappeared from the apt
repository. We pin to a specific version because it has to match
*exactly* with the version on the underlying VM. For similar reasons,
updating the version is extremely painful.

So instead, let's fetch the deb from somewhere we know isn't going
away. If someone wants to experiment with an official stable source for
these that would be most welcome, but this was something I had high
confidence would work, and currently the inability to update these
images is blocking us updating basically *any* image.

I obtained these debs by running our current docker image and using
`dpkg-repack` to recreate the debs.

This should unblock further work on our docker images.