### PR TITLE
Update workflows to use new token

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -232,7 +232,7 @@ jobs:
         id: upload-release-assets
         uses: dwenegar/upload-release-assets@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
           assets_path: ./bindist/*

--- a/.github/workflows/copybara_fixup.yml
+++ b/.github/workflows/copybara_fixup.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. We're force-pushing here and will otherwise drop
           # all the branch history. This takes a whopping 2 seconds. I think
           # we'll live.

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout out repository
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
       - name: Fetching base gh-pages branch
         # We have to explicitly fetch the gh-pages branch as well to preserve history
         run: git fetch --no-tags --prune --depth=1 origin "gh-pages:gh-pages"

--- a/.github/workflows/schedule_snapshot_release.yml
+++ b/.github/workflows/schedule_snapshot_release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 
       - name: Compute version
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Pushing changes
         uses: ad-m/github-push-action@v0.6.0
         with:
-          github_token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: main
           tags: true
 
@@ -39,7 +39,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           tag_name: ${{ env.tag_name }}
           release_name: iree snapshot ${{ env.tag_name }}
@@ -52,6 +52,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Build Native Release Packages
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: '{"package_suffix": "-snapshot", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'

--- a/.github/workflows/update_llvm_dependent_submodules.yml
+++ b/.github/workflows/update_llvm_dependent_submodules.yml
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           # Personal token is required to trigger additional automation (e.g. presubmits).
-          token: ${{ secrets.GITHUB_WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           commit-message: "Synchronize submodules with LLVM at llvm/llvm-project@${{ env.LLVM_SHA }}"
           title: "Synchronize submodules with LLVM at llvm/llvm-project@${{ env.LLVM_SHA }}"
           body: |


### PR DESCRIPTION
GitHub tokens switched to a new format. I tried to update us in a
seamless way by generating a new token and updating our existing
secret, but apparently since (by a new rule) they don't want repository
secrets to use the `GITHUB_` prefix, it silently didn't take my update,
which I only noticed after deleting the old token...