### PR TITLE
Handle removing unused results of a CloseureInterfaceOp

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
@@ -82,11 +82,11 @@ def FLOW_ClosureOpInterface : OpInterface<"ClosureOpInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Returns true if an argument of the region is read within the region
+        Returns true if the output is also read within the region.
       }],
       /*retTy=*/"bool",
-      /*methodName=*/"isArgumentReadWithinRegion",
-      /*args=*/(ins "BlockArgument":$arg)
+      /*methodName=*/"isOutputReadWithinRegion",
+      /*args=*/(ins "unsigned":$resultIndex)
     >
   ];
 }

--- a/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowInterfaces.td
@@ -80,6 +80,14 @@ def FLOW_ClosureOpInterface : OpInterface<"ClosureOpInterface"> {
       /*args=*/(ins "ArrayRef<unsigned>":$excludedOperandIndices,
                     "ArrayRef<unsigned>":$excludedResultIndices)
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if an argument of the region is read within the region
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isArgumentReadWithinRegion",
+      /*args=*/(ins "BlockArgument":$arg)
+    >
   ];
 }
 

--- a/iree/compiler/Dialect/Flow/IR/FlowOpUtils.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpUtils.cpp
@@ -231,7 +231,7 @@ bool optimizeClosureLikeOp(ClosureOpInterface &closureOp,
       entryBlock.getNumArguments());
   for (auto opArg : llvm::enumerate(closureOp.getClosureOperands())) {
     auto blockArg = entryBlock.getArgument(opArg.index());
-    if (!closureOp.isArgumentReadWithinRegion(blockArg)) {
+    if (blockArg.use_empty()) {
       // Not used - Drop.
       elidedOperands.push_back(opArg.index());
       blockArgReplacements[opArg.index()] = BlockArgument();
@@ -252,12 +252,10 @@ bool optimizeClosureLikeOp(ClosureOpInterface &closureOp,
   SmallVector<Value, 4> preservedResults;
   SmallVector<unsigned, 4> elidedResults;
   for (auto result : llvm::enumerate(closureOp.getClosureResults())) {
-    BlockArgument arg = entryBlock.getArgument(
-        closureOp.getClosureOperands().size() + result.index());
     // You can drop a result if the use is empty, and that it is only written to
     // within the dispatch region.
     if (result.value().use_empty() &&
-        !closureOp.isArgumentReadWithinRegion(arg)) {
+        !closureOp.isOutputReadWithinRegion(result.index())) {
       elidedResults.push_back(result.index());
     } else {
       preservedResults.push_back(result.value());

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -814,10 +814,11 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
 bool DispatchWorkgroupsOp::isOutputReadWithinRegion(unsigned resultIndex) {
   BlockArgument arg =
       body().front().getArgument(operands().size() + resultIndex);
-  // If argument is of `writeonly` access, then it is not read by constructions.
+  // If argument is of `writeonly` access, then it is not read by construction.
   if (arg.getType().cast<DispatchTensorType>().getAccess() ==
-      TensorAccess::WriteOnly)
+      TensorAccess::WriteOnly) {
     return false;
+  }
   // If the argument is a result with `readwrite` access, return false if the
   // value is only written to. Check this by looking at the uses of the argument
   // being only the `target` of `flow.dispatch.tensor.store` ops.

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -811,6 +811,27 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
   return canDispatchRegionContainOp(op);
 }
 
+bool DispatchWorkgroupsOp::isArgumentReadWithinRegion(BlockArgument arg) {
+  // For inputs, just check if the uses are empty.
+  if (arg.getArgNumber() < getClosureOperands().size()) {
+    return !arg.use_empty();
+  }
+  // If argument is of `writeonly` access, then it is not read by constructions.
+  if (arg.getType().cast<DispatchTensorType>().getAccess() ==
+      TensorAccess::WriteOnly)
+    return false;
+  // If the argument is a result with `readwrite` access, return false if the
+  // value is only written to. Check this by looking at the uses of the argument
+  // being only the `target` of `flow.dispatch.tensor.store` ops.
+  for (OpOperand &uses : arg.getUses()) {
+    auto storeOp = dyn_cast<DispatchTensorStoreOp>(uses.getOwner());
+    if (!(storeOp && storeOp.target() == uses.get())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 ClosureOpInterface
 DispatchWorkgroupsOp::cloneReplacementExcludingOperandsAndResults(
     ArrayRef<unsigned> excludedOperandIndices,
@@ -845,18 +866,31 @@ DispatchWorkgroupsOp::cloneReplacementExcludingOperandsAndResults(
   excludeTiedOperandAndResultIndices(
       excludedOperandIndices, excludedResultIndices, newTiedOperandIndices);
 
-  auto newOp = OpBuilder(getContext())
-                   .create<DispatchWorkgroupsOp>(
-                       getLoc(), workgroup_count(), newResultTypes,
-                       newResultDims, newOperandsValues, newOperandDims,
-                       newTiedOperandIndices, getOperation()->getAttrs());
+  OpBuilder builder(getContext());
+  auto newOp = builder.create<DispatchWorkgroupsOp>(
+      getLoc(), workgroup_count(), newResultTypes, newResultDims,
+      newOperandsValues, newOperandDims, newTiedOperandIndices,
+      getOperation()->getAttrs());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
-  newBody.front().eraseArguments(excludedOperandIndices);
-  unsigned baseResultIndex = newBody.front().getNumArguments();
-  newBody.front().eraseArguments(llvm::to_vector<4>(llvm::map_range(
-      excludedResultIndices,
-      [&](unsigned index) { return baseResultIndex + index; })));
+  unsigned baseResultIndex = newOperandsValues.size();
+  // For dropped results, erase all the store-op uses. It is a pre-requisite
+  // that the result can be dropped only if it is written within the dispatch
+  // region op.
+  auto erasedArguments = llvm::to_vector<4>(excludedOperandIndices);
+  for (unsigned i = baseResultIndex, e = newBody.getNumArguments(); i != e;
+       ++i) {
+    if (!is_contained(excludedResultIndices, i - baseResultIndex)) continue;
+    auto arg = newBody.front().getArgument(i);
+    for (OpOperand &user : llvm::make_early_inc_range(arg.getUses())) {
+      auto storeOp = dyn_cast<DispatchTensorStoreOp>(user.getOwner());
+      if (storeOp && storeOp.target() == user.get()) {
+        storeOp->erase();
+      }
+    }
+    erasedArguments.push_back(i);
+  }
+  newBody.front().eraseArguments(erasedArguments);
   return newOp;
 }
 
@@ -1366,6 +1400,10 @@ bool ExStreamFragmentOp::canClosureContainOp(Operation *op) {
     return variableOp.is_mutable() == false;
   }
   return false;
+}
+
+bool ExStreamFragmentOp::isArgumentReadWithinRegion(BlockArgument arg) {
+  return !arg.use_empty();
 }
 
 ClosureOpInterface

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -811,11 +811,9 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
   return canDispatchRegionContainOp(op);
 }
 
-bool DispatchWorkgroupsOp::isArgumentReadWithinRegion(BlockArgument arg) {
-  // For inputs, just check if the uses are empty.
-  if (arg.getArgNumber() < getClosureOperands().size()) {
-    return !arg.use_empty();
-  }
+bool DispatchWorkgroupsOp::isOutputReadWithinRegion(unsigned resultIndex) {
+  BlockArgument arg =
+      body().front().getArgument(operands().size() + resultIndex);
   // If argument is of `writeonly` access, then it is not read by constructions.
   if (arg.getType().cast<DispatchTensorType>().getAccess() ==
       TensorAccess::WriteOnly)
@@ -1402,8 +1400,8 @@ bool ExStreamFragmentOp::canClosureContainOp(Operation *op) {
   return false;
 }
 
-bool ExStreamFragmentOp::isArgumentReadWithinRegion(BlockArgument arg) {
-  return !arg.use_empty();
+bool ExStreamFragmentOp::isOutputReadWithinRegion(unsigned resultIndex) {
+  return false;
 }
 
 ClosureOpInterface

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -155,7 +155,7 @@ func @dontInlineReadWrite(%arg0: tensor<1x4xf32>) -> tensor<4x8xf32> {
 func @remove_unused_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = constant 1 : index
   //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32> =
-  // CHECK-NEXT:   (%arg2: !flow.dispatch.tensor<writeonly:i32>)
+  // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:i32>)
   //      CHECK: flow.dispatch.tensor.store
   //  CHECK-NOT: flow.dispatch.tensor.store
   %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
@@ -180,7 +180,7 @@ func @remove_unused_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (ten
 func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = constant 1 : index
   //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32> =
-  // CHECK-NEXT:   (%arg2: !flow.dispatch.tensor<writeonly:i32>)
+  // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:i32>)
   //      CHECK: flow.dispatch.tensor.store %{{.+}},
   //  CHECK-NOT: flow.dispatch.tensor.store
   %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
@@ -205,7 +205,7 @@ func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi3
 func @keep_used_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
   %c1 = constant 1 : index
   //      CHECK: flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> (tensor<i32>, tensor<i32>) =
-  // CHECK-NEXT:   (%arg2: !flow.dispatch.tensor<writeonly:i32>, %arg3: !flow.dispatch.tensor<readwrite:i32>)
+  // CHECK-NEXT:   (%{{.+}}: !flow.dispatch.tensor<writeonly:i32>, %{{.+}}: !flow.dispatch.tensor<readwrite:i32>)
   %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
       (%arg0: !flow.dispatch.tensor<readonly:9xi32>, %arg1: !flow.dispatch.tensor<readonly:9xi32>, %arg2: !flow.dispatch.tensor<writeonly:i32>, %arg3: !flow.dispatch.tensor<readwrite:i32>) {
     %c-2147483648_i32 = constant -2147483648 : i32

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -148,3 +148,74 @@ func @dontInlineReadWrite(%arg0: tensor<1x4xf32>) -> tensor<4x8xf32> {
   }
   return %0 : tensor<4x8xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func @remove_unused_result
+func @remove_unused_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
+  %c1 = constant 1 : index
+  //      CHECK: %[[RESULT:[a-zA-Z0-9_]+]] = flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32>
+  // CHECK-SAME:   (%[[ARG2:.+]]: !flow.dispatch.tensor<writeonly:i32>)
+  //      CHECK: flow.dispatch.tensor.store %{{.+}},
+  //  CHECK-NOT: flow.dispatch.tensor.store
+  %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
+      (%arg0: !flow.dispatch.tensor<readonly:9xi32>, %arg1: !flow.dispatch.tensor<readonly:9xi32>, %arg2: !flow.dispatch.tensor<writeonly:i32>, %arg3: !flow.dispatch.tensor<writeonly:i32>) {
+    %c0_i32 = constant 0 : i32
+    %c-2147483648_i32 = constant -2147483648 : i32
+    %0 = flow.dispatch.tensor.load %arg0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:9xi32> -> tensor<9xi32>
+    %1 = flow.dispatch.tensor.load %arg1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:9xi32> -> tensor<9xi32>
+    %2 = linalg.init_tensor [] : tensor<i32>
+    %3 = linalg.fill(%2, %c-2147483648_i32) : tensor<i32>, i32 -> tensor<i32> 
+    %4 = linalg.fill(%2, %c0_i32) : tensor<i32>, i32 -> tensor<i32> 
+    flow.dispatch.tensor.store %3, %arg2, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<writeonly:i32>
+    flow.dispatch.tensor.store %4, %arg3, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<writeonly:i32>
+    flow.return
+  }
+  return %0#0 : tensor<i32>
+}
+
+// -----
+
+func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
+  %c1 = constant 1 : index
+  //      CHECK: %[[RESULT:[a-zA-Z0-9_]+]] = flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32>
+  // CHECK-SAME:   (%[[ARG2:.+]]: !flow.dispatch.tensor<readwrite:i32>)
+  //      CHECK: flow.dispatch.tensor.store %{{.+}},
+  //  CHECK-NOT: flow.dispatch.tensor.store
+  %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
+      (%arg0: !flow.dispatch.tensor<readonly:9xi32>, %arg1: !flow.dispatch.tensor<readonly:9xi32>, %arg2: !flow.dispatch.tensor<writeonly:i32>, %arg3: !flow.dispatch.tensor<readwrite:i32>) {
+    %c0_i32 = constant 0 : i32
+    %c-2147483648_i32 = constant -2147483648 : i32
+    %0 = flow.dispatch.tensor.load %arg0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:9xi32> -> tensor<9xi32>
+    %1 = flow.dispatch.tensor.load %arg1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:9xi32> -> tensor<9xi32>
+    %2 = linalg.init_tensor [] : tensor<i32>
+    %3 = linalg.fill(%2, %c-2147483648_i32) : tensor<i32>, i32 -> tensor<i32> 
+    %4 = linalg.fill(%2, %c0_i32) : tensor<i32>, i32 -> tensor<i32> 
+    flow.dispatch.tensor.store %3, %arg2, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<writeonly:i32>
+    flow.dispatch.tensor.store %4, %arg3, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<readwrite:i32>
+    flow.return
+  }
+  return %0#0 : tensor<i32>
+}
+
+// -----
+
+func @remove_unused_read_write_result(%arg0 : tensor<9xi32>, %arg1 : tensor<9xi32>) -> (tensor<i32>) {
+  %c1 = constant 1 : index
+  //      CHECK: %[[RESULT:[a-zA-Z0-9_]+]] = flow.dispatch.workgroups[%c1, %c1, %c1]() : () -> tensor<i32>
+  // CHECK-SAME:   (%[[ARG2:.+]]: !flow.dispatch.tensor<writeonly:i32>, %[[ARG3:.+]]: !flow.dispatch.tensor<readwrite:i33>)
+  %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0, %arg1) : (tensor<9xi32>, tensor<9xi32>) -> (tensor<i32>, tensor<i32>) =
+      (%arg0: !flow.dispatch.tensor<readonly:9xi32>, %arg1: !flow.dispatch.tensor<readonly:9xi32>, %arg2: !flow.dispatch.tensor<writeonly:i32>, %arg3: !flow.dispatch.tensor<readwrite:i32>) {
+    %c-2147483648_i32 = constant -2147483648 : i32
+    %0 = flow.dispatch.tensor.load %arg3, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:i32> -> tensor<i32>
+    %val = tensor.extract %0[] : tensor<i32>
+    %1 = flow.dispatch.tensor.load %arg1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:9xi32> -> tensor<9xi32>
+    %2 = linalg.init_tensor [] : tensor<i32>
+    %3 = linalg.fill(%2, %c-2147483648_i32) : tensor<i32>, i32 -> tensor<i32> 
+    %4 = linalg.fill(%2, %val) : tensor<i32>, i32 -> tensor<i32> 
+    flow.dispatch.tensor.store %3, %arg2, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<writeonly:i32>
+    flow.dispatch.tensor.store %4, %arg3, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<readwrite:i32>
+    flow.return
+  }
+  return %0#0 : tensor<i32>
+}


### PR DESCRIPTION
The canonicalization pattern to remove a result produced by the
ClosureInterfaceOp needs to make sure that all uses within the
dispatch region are write-only and that these operations are erased
before dropping the arguments.
Add an interface method to check if an argument to the
ClosureInterfaceOp region has any read uses. This is used to determine
if the result/operand can be dropped.