### PR TITLE
Fix vulkan dynamic library name for MacOS

### DIFF
--- a/iree/hal/vulkan/dynamic_symbols.cc
+++ b/iree/hal/vulkan/dynamic_symbols.cc
@@ -69,6 +69,8 @@ static constexpr const FunctionPtrInfo kDynamicFunctionPtrInfos[] = {
 static const char* kVulkanLoaderSearchNames[] = {
 #if defined(IREE_PLATFORM_ANDROID)
     "libvulkan.so",
+#elif defined(IREE_PLATFORM_IOS) || defined(IREE_PLATFORM_MACOS)
+    "libvulkan.dylib",
 #elif defined(IREE_PLATFORM_WINDOWS)
     "vulkan-1.dll",
 #else


### PR DESCRIPTION
The vulkan dynamic library name is libvulkan.dylib in macos platform.