### PR TITLE
Handle symbol name conflicts during executable linking.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK: vm.rodata @pool_storage0 dense<[102, 102, 6, 64, -51, -52, 76, 64, -102, -103, -119, 64, -51, -52, -84, 64]> : vector<16xi8>
-// CHECK: vm.rodata @pool_storage1 dense<[6, 7, 8, 0]> : vector<4xi8>
+// CHECK: vm.rodata private @pool_storage0 dense<[102, 102, 6, 64, -51, -52, 76, 64, -102, -103, -119, 64, -51, -52, -84, 64]> : vector<16xi8>
+// CHECK: vm.rodata private @pool_storage1 dense<[6, 7, 8, 0]> : vector<4xi8>
 hal.constant_pool @pool attributes {buffer_constraints = #hal.buffer_constraints<max_allocation_size = 1073741824, min_buffer_offset_alignment = 32, max_buffer_range = 134217728, min_buffer_range_alignment = 4>} {
   hal.constant_pool.span @cst0 : tensor<4xf32> = @_storage0[#hal.byte_range<0, 16>] -> @pool_storage0_buffer[#hal.byte_range<0, 16>]
   hal.constant_pool.span @cst1 : tensor<3xi8> = @_storage1[#hal.byte_range<0, 3>] -> @pool_storage1_buffer[#hal.byte_range<0, 3>]

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/executable_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK: vm.rodata @_exe_binary1_binary_format1 dense<[0, 1, 2, 3]> : vector<4xi8>
-// CHECK: vm.rodata @_exe_binary2_binary_format2 dense<[4, 5, 6, 7]> : vector<4xi8>
+// CHECK: vm.rodata private @_exe_binary1_binary_format1 dense<[0, 1, 2, 3]> : vector<4xi8>
+// CHECK: vm.rodata private @_exe_binary2_binary_format2 dense<[4, 5, 6, 7]> : vector<4xi8>
 hal.executable @exe {
   hal.interface @interface {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
@@ -47,7 +47,7 @@ func @executableCreate(
 
 // -----
 
-// CHECK: vm.rodata @_exe1_binary1_binary_format dense<[0, 1, 2, 3]> : vector<4xi8>
+// CHECK: vm.rodata private @_exe1_binary1_binary_format dense<[0, 1, 2, 3]> : vector<4xi8>
 hal.executable @exe1 {
   hal.interface @interface {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
@@ -58,7 +58,7 @@ hal.executable @exe1 {
     format = "format"
   }
 }
-// CHECK: vm.rodata @_exe2_binary2_binary_format dense<[4, 5, 6, 7]> : vector<4xi8>
+// CHECK: vm.rodata private @_exe2_binary2_binary_format dense<[4, 5, 6, 7]> : vector<4xi8>
 hal.executable @exe2 {
   hal.interface @interface {
     hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -95,10 +95,12 @@ class LLVMAOTTargetBackend final : public TargetBackend {
         llvm::to_vector<8>(moduleOp.getOps<IREE::HAL::ExecutableOp>());
     if (sourceExecutableOps.size() <= 1) return success();
 
-    // Private symbols (i.e. llvm dialect private symbols) get deduped
-    // incorrectly by the link executables pass even though they should be
-    // treated as different symbols. For now just change the names of the
-    // private symbols to avoid conflicts.
+    // Ensure any LLVM symbol names we define are unique prior to linking.
+    //
+    // The link executables pass requires that there be no name conflicts
+    // between symbols with public MLIR Symbol visibility. LLVM dialect symbols
+    // use a different visibility mechanism, defaulting to public for MLIR
+    // Symbol visibility.
     unsigned moduleNumber = 0;
     for (auto sourceExecutableOp : enumerate(sourceExecutableOps)) {
       auto targetOps = llvm::to_vector<4>(

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -84,6 +84,19 @@ BufferConstraintsAttr TargetBackend::queryBufferConstraints(
   return makeDefaultBufferConstraints(context);
 }
 
+static void renameWithDisambiguatedName(
+    Operation *op, Operation *moduleOp, llvm::StringRef originalName,
+    llvm::StringMap<unsigned> &symbolOccurrences) {
+  // Note: this assumes that no other names will naturally occur in this format.
+  auto disambiguatedName =
+      llvm::formatv("{0}_{1}", originalName, symbolOccurrences[originalName]++)
+          .str();
+  SymbolTableCollection symbolTable;
+  SymbolUserMap symbolUsers(symbolTable, moduleOp);
+  symbolUsers.replaceAllUsesWith(op, disambiguatedName);
+  SymbolTable::setSymbolName(op, disambiguatedName);
+}
+
 void TargetBackend::declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
                                      IREE::HAL::ExecutableOp executableOp) {
   OpBuilder targetBuilder(&executableOp.getBlock().back());
@@ -94,33 +107,76 @@ void TargetBackend::declareTargetOps(IREE::Flow::ExecutableOp sourceOp,
 }
 
 // Destructively merges |sourceModuleOp| into |targetModuleOp|.
-// |targetSymbolTable| is updated with the new symbols.
-static void mergeModuleInto(Operation *sourceModuleOp,
-                            Operation *targetModuleOp,
-                            DenseMap<StringRef, Operation *> &targetSymbolMap) {
+// |targetSymbolMap| is updated with the new symbols.
+//
+// If a private symbol in |sourceModuleOp| conflicts with another symbol
+// (public or private) tracked in |targetSymbolMap|, it will be renamed and
+// |privateSymbolOccurrences| will be updated to reflect this.
+//
+// Fails if a public symbol in |sourceModuleOp| conflicts with another public
+// symbol tracked in |targetSymbolMap|.
+static LogicalResult mergeModuleInto(
+    Operation *sourceModuleOp, Operation *targetModuleOp,
+    DenseMap<StringRef, Operation *> &targetSymbolMap,
+    llvm::StringMap<unsigned> &privateSymbolOccurrences) {
   auto &sourceBlock = sourceModuleOp->getRegion(0).front();
   auto &targetBlock = targetModuleOp->getRegion(0).front();
   auto allOps = llvm::to_vector<8>(
       llvm::map_range(sourceBlock, [&](Operation &op) { return &op; }));
+
   for (auto &op : allOps) {
     if (op->hasTrait<OpTrait::IsTerminator>()) continue;
-    if (auto symbolInterface = dyn_cast<SymbolOpInterface>(op)) {
-      if (targetSymbolMap.count(symbolInterface.getName())) {
-        // TODO(scotttodd): compare ops to ensure we aren't copying different
-        // things with the same name.
-        continue;
+    if (auto symbolOp = dyn_cast<SymbolOpInterface>(op)) {
+      auto symbolName = symbolOp.getName();
+
+      // Resolve symbol name conflicts.
+      if (auto targetOp = targetSymbolMap[symbolName]) {
+        if (symbolOp.getVisibility() == SymbolTable::Visibility::Private) {
+          // Private symbols can be safely folded into duplicates or renamed.
+          if (OperationEquivalence::isEquivalentTo(targetOp, op)) {
+            // Optimization: skip over duplicate private symbols.
+            // We could let CSE do this later, but we may as well check here.
+            continue;
+          } else {
+            // Preserve the op but give it a unique name.
+            renameWithDisambiguatedName(op, sourceModuleOp, symbolName,
+                                        privateSymbolOccurrences);
+          }
+        } else {
+          // The source symbol has 'nested' or 'public' visibility.
+          if (SymbolTable::getSymbolVisibility(targetOp) !=
+              SymbolTable::Visibility::Private) {
+            // Oops! Both symbols are public and we can't safely rename either.
+            // If you hit this with ops that you think are safe to rename, mark
+            // them private.
+            //
+            // Note: we could also skip linking between executables with
+            // conflicting symbol names. We think such conflicts will be better
+            // fixed in other ways, so we'll emit an error until we find a case
+            // where that isn't true.
+            return op->emitError()
+                   << "multiple public symbols with the name: " << symbolName;
+          } else {
+            // Keep the original name for our new op, rename the target op.
+            renameWithDisambiguatedName(targetOp, targetModuleOp, symbolName,
+                                        privateSymbolOccurrences);
+          }
+        }
       }
-      targetSymbolMap[symbolInterface.getName()] = op;
+      targetSymbolMap[symbolName] = op;
     }
     if (!targetBlock.empty() &&
-        targetBlock.back().hasTrait<OpTrait::IsTerminator>())
+        targetBlock.back().hasTrait<OpTrait::IsTerminator>()) {
       op->moveBefore(&targetBlock.back());
-    else
+    } else {
       op->moveBefore(&targetBlock, targetBlock.end());
+    }
   }
 
   // Now that we're done cloning its ops, delete the original target op.
   sourceModuleOp->erase();
+
+  return success();
 }
 
 // Replaces each usage of an entry point with its original symbol name with a
@@ -147,11 +203,15 @@ LogicalResult TargetBackend::linkExecutablesInto(
     OpBuilder &builder) {
   llvm::SmallVector<IREE::HAL::InterfaceOp, 4> linkedInterfaceOps;
   int nextEntryPointOrdinal = 0;
-  DenseMap<StringRef, Operation *> symbolMap;
+  DenseMap<StringRef, Operation *> targetSymbolMap;
+  llvm::StringMap<unsigned> privateSymbolOccurrences;
   DenseMap<Attribute, Attribute> entryPointRefReplacements;
+
   auto linkedExecutableBuilder =
       OpBuilder::atBlockBegin(linkedExecutableOp.getBody());
   auto linkedTargetBuilder = OpBuilder::atBlockBegin(linkedTargetOp.getBody());
+
+  // Iterate over all source executable ops, linking as many as we can.
   for (auto sourceExecutableOp : sourceExecutableOps) {
     auto targetOps = llvm::to_vector<4>(
         sourceExecutableOp.getOps<IREE::HAL::ExecutableTargetOp>());
@@ -208,7 +268,10 @@ LogicalResult TargetBackend::linkExecutablesInto(
       // Merge the existing module into the new linked module op.
       auto sourceModuleOp = getInnerModuleFn(targetOp.getInnerModule());
       auto linkedModuleOp = getInnerModuleFn(linkedTargetOp.getInnerModule());
-      mergeModuleInto(sourceModuleOp, linkedModuleOp, symbolMap);
+      if (failed(mergeModuleInto(sourceModuleOp, linkedModuleOp,
+                                 targetSymbolMap, privateSymbolOccurrences))) {
+        return failure();
+      }
 
       targetOp.erase();
     }

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -292,3 +292,80 @@ module {
 // CHECK-NEXT:      hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
 // CHECK-NEXT:      hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
 // CHECK-NEXT:    }
+
+// -----
+
+module {
+  hal.executable @dispatch_0 attributes {sym_visibility = "private"} {
+    hal.interface @io {}
+    hal.executable.target @vmvx, filter="vmvx" {
+      hal.executable.entry_point @dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+      module {
+        vm.module @module {
+          vm.rodata public @rodata_a dense<[0]> : tensor<1xi32>
+          vm.rodata public @rodata_b dense<[0]> : tensor<1xi32>
+          vm.rodata public @rodata_c dense<[0]> : tensor<1xi32>
+          vm.rodata private @rodata_d dense<[0]> : tensor<1xi32>
+          vm.rodata private @rodata_e dense<[0]> : tensor<1xi32>
+
+          %buf_a = vm.const.ref.rodata @rodata_a : !vm.buffer
+          %buf_b = vm.const.ref.rodata @rodata_b : !vm.buffer
+          %buf_c = vm.const.ref.rodata @rodata_c : !vm.buffer
+          %buf_d = vm.const.ref.rodata @rodata_d : !vm.buffer
+          %buf_e = vm.const.ref.rodata @rodata_e : !vm.buffer
+        }
+      }
+    }
+  }
+  hal.executable @dispatch_1 attributes {sym_visibility = "private"} {
+    hal.interface @io {}
+    hal.executable.target @vmvx, filter="vmvx" {
+      hal.executable.entry_point @dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+      module {
+        vm.module @module {
+          // Conflict with a public symbol, this should be renamed when linked
+          vm.rodata private @rodata_b dense<[1]> : tensor<1xi32>
+          // Conflict with a private symbol, this should be renamed when linked
+          vm.rodata private @rodata_d dense<[1]> : tensor<1xi32>
+          // Conflict with a private symbol, the other symbol should be renamed
+          vm.rodata public @rodata_e dense<[1]> : tensor<1xi32>
+          // No conflict
+          vm.rodata public @rodata_f dense<[1]> : tensor<1xi32>
+
+          %buf_b = vm.const.ref.rodata @rodata_b : !vm.buffer
+          %buf_d = vm.const.ref.rodata @rodata_d : !vm.buffer
+          %buf_e = vm.const.ref.rodata @rodata_e : !vm.buffer
+          %buf_f = vm.const.ref.rodata @rodata_f : !vm.buffer
+        }
+      }
+    }
+  }
+}
+
+// Public symbols should keep their names, private symbols can be renamed to resolve conflicts.
+// References to renamed symbols should be updated.
+//
+// CHECK-NOT: hal.executable @dispatch_0
+// CHECK-NOT: hal.executable @dispatch_1
+// CHECK:       hal.executable @vmvx_linked attributes {sym_visibility = "private"} {
+// CHECK:       hal.executable.target @vmvx, filter="vmvx" {
+// CHECK:           module {
+// CHECK-NEXT:        vm.module @linked_module {
+// CHECK-NEXT:          vm.rodata public @rodata_a dense<0> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata public @rodata_b dense<0> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata public @rodata_c dense<0> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata private @rodata_d dense<0> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata private @rodata_e_0 dense<0> : tensor<1xi32>
+// CHECK-NEXT:          %[[BUF_rodata_a:.+]] = vm.const.ref.rodata @rodata_a : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_b:.+]] = vm.const.ref.rodata @rodata_b : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_c:.+]] = vm.const.ref.rodata @rodata_c : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_d:.+]] = vm.const.ref.rodata @rodata_d : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_e_0:.+]] = vm.const.ref.rodata @rodata_e_0 : !vm.buffer
+// CHECK-NEXT:          vm.rodata private @rodata_b_0 dense<1> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata private @rodata_d_0 dense<1> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata public @rodata_e dense<1> : tensor<1xi32>
+// CHECK-NEXT:          vm.rodata public @rodata_f dense<1> : tensor<1xi32>
+// CHECK-NEXT:          %[[BUF_rodata_b_0:.+]] = vm.const.ref.rodata @rodata_b_0 : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_d_0:.+]] = vm.const.ref.rodata @rodata_d_0 : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_e:.+]] = vm.const.ref.rodata @rodata_e : !vm.buffer
+// CHECK-NEXT:          %[[BUF_rodata_f:.+]] = vm.const.ref.rodata @rodata_f : !vm.buffer

--- a/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -96,9 +96,10 @@ class ConvertMemRefGlobalOp : public OpConversionPattern<memref::GlobalOp> {
           globalOp, "mutable global memrefs not yet implemented");
     }
 
-    rewriter.replaceOpWithNewOp<IREE::VM::RodataOp>(
+    auto rodataOp = rewriter.replaceOpWithNewOp<IREE::VM::RodataOp>(
         globalOp, globalOp.sym_name(),
         globalOp.initial_valueAttr().cast<ElementsAttr>());
+    rodataOp.setPrivate();
     return success();
   }
 };

--- a/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
@@ -20,7 +20,7 @@ module {
 // -----
 
 module {
-  // CHECK: vm.rodata @__constant dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
+  // CHECK: vm.rodata private @__constant dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
   memref.global "private" constant @__constant : memref<2xf32> = dense<[0.0287729427, 0.0297581609]>
   // CHECK-LABEL: vm.func @load_global
   // CHECK-SAME: (%[[IDX:.+]]: i32) -> f32 {

--- a/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
@@ -41,8 +41,8 @@ vm.module @const_ref_folds {
 
 // CHECK-LABEL: @const_rodata_folds
 vm.module @const_rodata_folds {
-  // CHECK-NEXT: vm.rodata @r2
-  vm.rodata @r2 dense<[9, 9, 9]> : vector<3xi32>
+  // CHECK-NEXT: vm.rodata private @r2
+  vm.rodata private @r2 dense<[9, 9, 9]> : vector<3xi32>
   // CHECK-NEXT: @cse_rodata_loads
   vm.func @cse_rodata_loads() -> (!vm.buffer, !vm.buffer) {
     // CHECK-NEXT: %r2 = vm.const.ref.rodata @r2 : !vm.buffer

--- a/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -36,7 +36,7 @@ vm.module @my_module {
 // -----
 
 vm.module @my_module {
-  vm.rodata @buf0 dense<[0, 1, 2]> : tensor<3xi8>
+  vm.rodata private @buf0 dense<[0, 1, 2]> : tensor<3xi8>
   // CHECK-LABEL: @const_ref_rodata
   vm.func @const_ref_rodata() -> !vm.buffer {
     // CHECK: %buf0 = vm.const.ref.rodata @buf0 : !vm.buffer

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
@@ -14,7 +14,7 @@ vm.module @constants {
   // CHECK-NEXT:   2,
   // CHECK-NEXT:   3
   // CHECK-NEXT: ]
-  vm.rodata @dense_i8s dense<[1, 2, 3]> : tensor<3xi8>
+  vm.rodata private @dense_i8s dense<[1, 2, 3]> : tensor<3xi8>
 
   //      CHECK: "data": [
   // CHECK-NEXT:   0,
@@ -30,7 +30,7 @@ vm.module @constants {
   // CHECK-NEXT:   64,
   // CHECK-NEXT:   64
   // CHECK-NEXT: ]
-  vm.rodata @dense_float32s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
+  vm.rodata private @dense_float32s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
 
   //      CHECK: "data": [
   // CHECK-NEXT:   0,
@@ -46,7 +46,7 @@ vm.module @constants {
   // CHECK-NEXT:   128,
   // CHECK-NEXT:   63
   // CHECK-NEXT: ]
-  vm.rodata @splat_float32s dense<1.000000e+00> : tensor<3xf32>
+  vm.rodata private @splat_float32s dense<1.000000e+00> : tensor<3xf32>
 
   //      CHECK: "data": [
   // CHECK-NEXT:   0,
@@ -56,6 +56,6 @@ vm.module @constants {
   // CHECK-NEXT:   0,
   // CHECK-NEXT:   66
   // CHECK-NEXT: ]
-  vm.rodata @dense_float16s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf16>
+  vm.rodata private @dense_float16s dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf16>
 
 }

--- a/iree/compiler/Dialect/VM/Transforms/test/hoist_inlined_rodata.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/hoist_inlined_rodata.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -iree-vm-hoist-inlined-rodata %s | IreeFileCheck %s
 
 vm.module @module {
-  // CHECK: vm.rodata @fn_const dense<[1, 2, 3]> : tensor<3xi32>
+  // CHECK: vm.rodata private @fn_const dense<[1, 2, 3]> : tensor<3xi32>
   // CHECK-LABEL: vm.func @fn
   vm.func @fn() {
     // CHECK: = vm.const.ref.rodata @fn_const : !vm.buffer

--- a/iree/compiler/Translation/test/do_not_optimize.mlir
+++ b/iree/compiler/Translation/test/do_not_optimize.mlir
@@ -46,7 +46,7 @@ func @unfoldable_constant() -> i32 {
 // -----
 
 // TODO(#5897): enable when vmvx supports dynamic shapes.
-// X-CHECK-LABEL: vm.rodata @dynamic_constant_const dense<3.000000e+00> : tensor<2x3xf32>
+// X-CHECK-LABEL: vm.rodata private @dynamic_constant_const dense<3.000000e+00> : tensor<2x3xf32>
 // X-CHECK: vm.func @dynamic_constant
 // func @dynamic_constant() -> tensor<?x?xf32> {
 //   // X-CHECK: vm.call @hal.buffer_view.dim

--- a/iree/vm/test/buffer_ops.mlir
+++ b/iree/vm/test/buffer_ops.mlir
@@ -1,6 +1,6 @@
 vm.module @buffer_ops {
 
-  vm.rodata @rodata_3xi32 dense<[1, 2, 3]> : tensor<3xi32>
+  vm.rodata private @rodata_3xi32 dense<[1, 2, 3]> : tensor<3xi32>
 
   //===--------------------------------------------------------------------===//
   // Compare
@@ -8,8 +8,8 @@ vm.module @buffer_ops {
   // NOTE: we test this first because all of the other tests rely on it and we
   // can do it with rodata.
 
-  vm.rodata @rodata_cmp_3xi32_a dense<[100, 200, 300]> : tensor<3xi32>
-  vm.rodata @rodata_cmp_3xi32_b dense<[100, 201, 300]> : tensor<3xi32>
+  vm.rodata private @rodata_cmp_3xi32_a dense<[100, 200, 300]> : tensor<3xi32>
+  vm.rodata private @rodata_cmp_3xi32_b dense<[100, 201, 300]> : tensor<3xi32>
 
   // Compares some multi-element buffers. Note that comparisons are bytewise.
   vm.export @test_compare
@@ -169,7 +169,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_copy_partial_ref dense<[2]> : tensor<1xi32>
+  vm.rodata private @test_copy_partial_ref dense<[2]> : tensor<1xi32>
 
   // Tests copying a range of bytes from one buffer to another.
   vm.export @test_copy_partial
@@ -263,7 +263,7 @@ vm.module @buffer_ops {
   // Fill
   //===--------------------------------------------------------------------===//
 
-  vm.rodata @test_fill_i16_ref dense<[0, 51966, 51966, 0]> : tensor<4xi16>
+  vm.rodata private @test_fill_i16_ref dense<[0, 51966, 51966, 0]> : tensor<4xi16>
 
   // Tests filling a buffer with 16-bit values.
   vm.export @test_fill_i16
@@ -289,7 +289,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_fill_i16_misaligned_offset_ref dense<[0xCAFE, 0xCAFE, 0, 0]> : tensor<4xi16>
+  vm.rodata private @test_fill_i16_misaligned_offset_ref dense<[0xCAFE, 0xCAFE, 0, 0]> : tensor<4xi16>
 
   // Tests that misaligned fill offsets will succeed but round down.
   vm.export @test_fill_i16_misaligned_offset
@@ -315,7 +315,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_fill_i16_misaligned_length_ref dense<[0, 0, 0, 0]> : tensor<4xi16>
+  vm.rodata private @test_fill_i16_misaligned_length_ref dense<[0, 0, 0, 0]> : tensor<4xi16>
 
   // Tests that misaligned fill lengths will succeed but round down.
   vm.export @test_fill_i16_misaligned_length
@@ -357,7 +357,7 @@ vm.module @buffer_ops {
   // Load
   //===--------------------------------------------------------------------===//
 
-  vm.rodata @test_load_i8_data dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
+  vm.rodata private @test_load_i8_data dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
 
   vm.export @test_load_i8u
   vm.func @test_load_i8u() {
@@ -411,7 +411,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_load_i16_data dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
+  vm.rodata private @test_load_i16_data dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
 
   vm.export @test_load_i16u
   vm.func @test_load_i16u() {
@@ -465,7 +465,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_load_i32_data dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
+  vm.rodata private @test_load_i32_data dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
 
   vm.export @test_load_i32
   vm.func @test_load_i32() {
@@ -493,7 +493,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_load_i32_unaligned_data dense<[0x00112233, 0x44556677, 0x8899AABB, 0xCCDDEEFF]> : tensor<4xui32>
+  vm.rodata private @test_load_i32_unaligned_data dense<[0x00112233, 0x44556677, 0x8899AABB, 0xCCDDEEFF]> : tensor<4xui32>
 
   // Unaligned loads are not supported and offsets will be rounded down.
   vm.export @test_load_i32_unaligned
@@ -513,7 +513,7 @@ vm.module @buffer_ops {
   // Store
   //===--------------------------------------------------------------------===//
 
-  vm.rodata @test_store_i8_ref dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
+  vm.rodata private @test_store_i8_ref dense<[0x00, 0x01, 0x7F, 0x80, 0xFF]> : tensor<5xui8>
 
   vm.export @test_store_i8
   vm.func @test_store_i8() {
@@ -546,7 +546,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_store_i16_ref dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
+  vm.rodata private @test_store_i16_ref dense<[0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF]> : tensor<5xui16>
 
   vm.export @test_store_i16
   vm.func @test_store_i16() {
@@ -579,7 +579,7 @@ vm.module @buffer_ops {
     vm.return
   }
 
-  vm.rodata @test_store_i32_ref dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
+  vm.rodata private @test_store_i32_ref dense<[0x00000000, 0x00000001, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF]> : tensor<5xui32>
 
   vm.export @test_store_i32
   vm.func @test_store_i32() {

--- a/iree/vm/test/list_variant_ops.mlir
+++ b/iree/vm/test/list_variant_ops.mlir
@@ -52,7 +52,7 @@ vm.module @list_variant_ops {
   // vm.list.* with variant types
   //===--------------------------------------------------------------------===//
 
-  vm.rodata @byte_buffer dense<[1, 2, 3]> : tensor<3xi32>
+  vm.rodata private @byte_buffer dense<[1, 2, 3]> : tensor<3xi32>
 
   vm.export @test_variant
   vm.func @test_variant() {


### PR DESCRIPTION
Executable linking merges multiple modules together into a single module. If a symbol name already exists in the merged module, we previously skipped over it assuming the contents of those symbols were identical. This now resolve conflicts by
* renaming different private symbols
* merging equivalent private symbols
* emitting an error for public symbol conflicts

Fixes https://github.com/google/iree/issues/5946.
Includes a step towards https://github.com/google/iree/issues/4670 that should be made generic in some way.
Issues like https://github.com/google/iree/issues/4897 will still need to use MLIR symbol visibility (not some special visibility) or ensure uniqueness prior to this pass.