### PR TITLE
Bufferization support for scf.for

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -441,15 +441,6 @@ static LogicalResult analyseScfForOp(scf::ForOp forOp,
   return success();
 }
 
-static LogicalResult analyseTensorExtractOp(tensor::ExtractOp extractOp,
-                                            BufferizationPlan &plan) {
-  auto resultType = extractOp.result().getType();
-  if (resultType && resultType.isa<TensorType>()) {
-    plan.unionSets(extractOp.tensor(), extractOp.result());
-  }
-  return success();
-}
-
 static LogicalResult analyseOperations(FuncOp funcOp, BufferizationPlan &plan) {
   auto bufferMappingFn = [&](Operation *op) -> WalkResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
@@ -509,9 +500,6 @@ static LogicalResult analyseOperations(FuncOp funcOp, BufferizationPlan &plan) {
             })
         .Case<scf::ForOp>(
             [&](scf::ForOp forOp) { return analyseScfForOp(forOp, plan); })
-        .Case<tensor::ExtractOp>([&](tensor::ExtractOp extractOp) {
-          return analyseTensorExtractOp(extractOp, plan);
-        })
         .Default([&](Operation *op) { return success(); });
   };
   if (funcOp.walk(bufferMappingFn).wasInterrupted()) {
@@ -851,13 +839,13 @@ static Value getAliasingBufferForResult(OpBuilder &b, SubTensorOp op,
 /// Returns output buffers that aliases inputs.
 static SmallVector<Value> getScfForAliasingBuffers(scf::ForOp scfFor,
                                                    BlockAndValueMapping &bvm) {
-  SmallVector<Value> allisedBuffers;
+  SmallVector<Value> alisedBuffers;
   for (int i = 0; i < scfFor.results().size(); ++i) {
     Value inputTensor = scfFor.initArgs()[i];
     Value inputBuffer = bvm.lookup(inputTensor);
-    allisedBuffers.push_back(inputBuffer);
+    alisedBuffers.push_back(inputBuffer);
   }
-  return allisedBuffers;
+  return alisedBuffers;
 }
 
 /// Returns a `memref` for every result that aliases the buffer for one of its

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -1987,3 +1987,106 @@ hal.interface @io attributes {sym_visibility = "private"} {
 //       CHECK:     linalg.generic
 //  CHECK-SAME:       ins(%[[ARG0_SV]], %[[ARG1_SV]]
 //  CHECK-SAME:       outs(%[[RET0_SV]], %[[RET1_SV]]
+
+
+// -----
+
+module  {
+  func @l1_tiled_matmul() {
+    %cst = constant 0.000000e+00 : f32
+    %c32 = constant 32 : index
+    %c24 = constant 24 : index
+    %c144 = constant 144 : index
+    %c0 = constant 0 : index
+    %c1 = constant 1 : index
+    %c250 = constant 250 : index
+    %c370 = constant 370 : index
+    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:250x144xf32>
+    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:144x370xf32>
+    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:250x370xf32>
+    %workgroup_id_x = hal.interface.workgroup.id[0] : index
+    %workgroup_count_x = hal.interface.workgroup.count[0] : index
+    %workgroup_id_y = hal.interface.workgroup.id[1] : index
+    %workgroup_count_y = hal.interface.workgroup.count[1] : index
+    %3 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+    %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_y]
+    scf.for %arg0 = %3 to %c250 step %4 {
+      %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+      %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
+      scf.for %arg1 = %5 to %c370 step %6 {
+        %7 = affine.min affine_map<(d0) -> (64, -d0 + 250)>(%arg0)
+        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
+        %9 = affine.min affine_map<(d0) -> (64, -d0 + 370)>(%arg1)
+        %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
+        %11 = affine.min affine_map<(d0) -> (64, -d0 + 250)>(%arg0)
+        %12 = affine.min affine_map<(d0) -> (64, -d0 + 370)>(%arg1)
+        %13 = affine.min affine_map<(d0) -> (-d0 + 250, 64)>(%arg0)
+        %14 = affine.min affine_map<(d0) -> (-d0 + 370, 64)>(%arg1)
+        %15 = linalg.init_tensor [%13, %14] : tensor<?x?xf32>
+        %16 = linalg.fill(%15, %cst) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[64, 64]]}} : tensor<?x?xf32>, f32 -> tensor<?x?xf32> 
+        %17 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %16) -> (tensor<?x?xf32>) {
+          %18 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
+            %19 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
+              %20 = affine.min affine_map<(d0) -> (32, -d0 + 250)>(%arg2)
+              %21 = affine.min affine_map<(d0) -> (24, -d0 + 144)>(%arg6)
+              %22 = subtensor %8[%arg2, %arg6] [%20, %21] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
+              %23 = affine.min affine_map<(d0) -> (24, -d0 + 144)>(%arg6)
+              %24 = affine.min affine_map<(d0) -> (32, -d0 + 370)>(%arg4)
+              %25 = subtensor %10[%arg6, %arg4] [%23, %24] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
+              %26 = memref.dim %arg7, %c0 : tensor<?x?xf32>
+              %27 = affine.min affine_map<(d0, d1) -> (32, d0 - d1)>(%26, %arg2)
+              %28 = memref.dim %arg7, %c1 : tensor<?x?xf32>
+              %29 = affine.min affine_map<(d0, d1) -> (32, d0 - d1)>(%28, %arg4)
+              %30 = subtensor %arg7[%arg2, %arg4] [%27, %29] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+              %31 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = {nativeVectorSize = [4, 4, 4], tileSizes = [[64, 64], [32, 32, 24], [4, 4, 4]]}} ins(%22, %25 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%30 : tensor<?x?xf32>) -> tensor<?x?xf32>
+              %32 = subtensor_insert %31 into %arg7[%arg2, %arg4] [%27, %29] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
+              scf.yield %32 : tensor<?x?xf32>
+            }
+            scf.yield %19 : tensor<?x?xf32>
+          }
+          scf.yield %18 : tensor<?x?xf32>
+        }
+        flow.dispatch.tensor.store %17, %2, offsets = [%arg0, %arg1], sizes = [%11, %12], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:250x370xf32>
+      }
+    }
+    return
+  }
+  hal.interface @io attributes {sym_visibility = "private"} {
+    hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+}
+
+// CHECK-LABEL: l1_tiled_matmul
+//    CHECK-DAG: %[[M:.+]] = constant 250 : index
+//    CHECK-DAG: %[[N:.+]] = constant 370 : index
+//    CHECK-DAG: %[[K:.+]] = constant 144 : index
+//    CHECK-DAG: %[[L1_MN_SIZE:.+]] = constant 32 : index
+//    CHECK-DAG: %[[L1_K_SIZE:.+]] = constant 24 : index
+//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%{{.*}}] : memref<250x144xf32>
+//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%{{.*}}] : memref<144x370xf32>
+//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%{{.*}}] : memref<250x370xf32>
+//        CHECK: scf.for %[[WORKGROUP_I:.+]] = %{{.*}} to %[[M]] step %{{.*}} {
+//        CHECK:    scf.for %[[WORKGROUP_J:.+]] = %{{.*}} to %[[N]] step %{{.*}} {
+//    CHECK-DAG:        %[[WORKGROUP_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I]])
+//    CHECK-DAG:        %[[LHS_WORKGROUP_TILE:.+]] = memref.subview %[[LHS]][%[[WORKGROUP_I]], 0] [%[[WORKGROUP_I_SIZE]], 144] [1, 1] : memref<250x144xf32> to memref<?x144xf32
+//    CHECK-DAG:        %[[WORKGROUP_J_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_J]])
+//    CHECK-DAG:        %[[RHS_WORKGROUP_TILE:.+]] = memref.subview %[[RHS]][0, %[[WORKGROUP_J]]] [144, %[[WORKGROUP_J_SIZE]]] [1, 1] : memref<144x370xf32> to memref<144x?xf32
+//    CHECK-DAG:            %[[WORKGROUP_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I]])
+//    CHECK-DAG:            %[[WORKGROUP_J_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_J]])
+//    CHECK-DAG:            %[[DST_WORKGROUP_TILE:.+]] = memref.alloc(%[[WORKGROUP_I_SIZE]], %[[WORKGROUP_J_SIZE]]) : memref<?x?xf32>
+//        CHECK:            scf.for %[[L1_I:.+]] = %{{.*}} to %[[M]] step %[[L1_MN_SIZE]] {
+//        CHECK:              scf.for %[[L1_J:.+]] = %{{.*}} to %[[N]] step %[[L1_MN_SIZE]] {
+//        CHECK:                scf.for %[[L1_K:.+]] = %{{.*}} to %[[K]] step %[[L1_K_SIZE]] {
+//    CHECK-DAG:                    %[[LHS_L1_TILE:.+]] = memref.subview %[[LHS_WORKGROUP_TILE]][%[[L1_I]], %[[L1_K]]]
+//    CHECK-DAG:                    %[[RHS_L1_TILE:.+]] = memref.subview %[[RHS_WORKGROUP_TILE]][%[[L1_K]], %[[L1_J]]]
+//    CHECK-DAG:                    %[[L1_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I_SIZE]], %[[L1_I]])
+//    CHECK-DAG:                    %[[L1_J_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_J_SIZE]], %[[L1_J]])
+//    CHECK-DAG:                    %[[DST_L1_TILE:.+]] = memref.subview %[[DST_WORKGROUP_TILE]][%[[L1_I]], %[[L1_J]]]
+//    CHECK-DAG:                    %[[L1DST:.+]] = memref.alloc(%[[L1_I_SIZE]], %[[L1_J_SIZE]])
+//        CHECK:                    linalg.copy(%[[DST_L1_TILE]], %[[L1DST]])
+//        CHECK:                    linalg.matmul
+//   CHECK-SAME:                    ins(%[[LHS_L1_TILE]], %[[RHS_L1_TILE]]
+//   CHECK-SAME:                    outs(%[[L1DST]]
+//        CHECK:                    linalg.copy(%[[L1DST]], %[[DST_L1_TILE]])


### PR DESCRIPTION
The main idea is to break loop cyclic dependency (not the case in the buffer case) and forward `init_arg` tensors from outer most loop to inner most loop, because all these tensors are going to be mapped to the same buffer by construction this forwarding allows the `PostOder` walk to replace all tensors in the inner most loops which are in this case they won't depend on any of the operands / arguments of the `scf.for`. As a result all tensors arguments and results are going to be unused and `canonicalize` will create a tensor free `scf.for` (there is no need to create clone new scf.forOp` YaY!!!)