### PR TITLE
Propagate diagnostics instead of asserting in stream conversion

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #define DEBUG_TYPE "iree-hal"
@@ -363,8 +364,11 @@ class StreamSchedulingState {
   }
 
   // Maps |tensorValue| to the backing storage buffer defined by |bufferRange|.
-  void mapTensorToBufferRange(Value tensorValue, BufferRange bufferRange) {
-    assert(!bufferRangeMap.count(tensorValue));
+  LogicalResult mapTensorToBufferRange(Value tensorValue,
+                                       BufferRange bufferRange) {
+    if (bufferRangeMap.count(tensorValue)) {
+      return failure();
+    }
     bufferRangeMap.insert(std::make_pair(tensorValue, bufferRange));
 
     // TODO(#5410): make alias propagation map through an indexing map for
@@ -372,6 +376,7 @@ class StreamSchedulingState {
     for (auto alias : valueAliases[tensorValue]) {
       bufferRangeMap.insert(std::make_pair(alias, bufferRange));
     }
+    return success();
   }
 
   // Returns a buffer range backing the given stream |tensorValue|.
@@ -489,10 +494,10 @@ static BufferRange allocateOutputBuffer(Value streamValue, Value externalValue,
 // Allocates all output buffers for the stream and populates the
 // |schedulingState| with the new mappings. Returns the set of output buffers
 // mapping 1:1 with the |streamOp| results.
-static SmallVector<Value> allocateOutputBuffers(
+static LogicalResult allocateOutputBuffers(
     IREE::Flow::ExStreamFragmentOp streamOp,
-    StreamSchedulingState &schedulingState,
-    ConversionPatternRewriter &rewriter) {
+    StreamSchedulingState &schedulingState, ConversionPatternRewriter &rewriter,
+    SmallVectorImpl<Value> &output) {
   auto tiedStreamOp = cast<IREE::TiedOpInterface>(streamOp.getOperation());
   auto &entryBlock = streamOp.body().front();
 
@@ -529,25 +534,33 @@ static SmallVector<Value> allocateOutputBuffers(
       bufferRange = allocateOutputBuffer(streamValue, externalValue,
                                          schedulingState, rewriter);
     }
-    assert(bufferRange.buffer);
+    if (!bufferRange.buffer) {
+      return streamOp.emitOpError() << "buffer range has no buffer";
+    }
     outputBuffers.push_back(bufferRange.buffer);
-    schedulingState.mapTensorToBufferRange(streamValue, bufferRange);
+    if (failed(
+            schedulingState.mapTensorToBufferRange(streamValue, bufferRange))) {
+      return streamOp.emitOpError() << "tensor was mapped to multiple buffer "
+                                       "ranges while allocating output buffers";
+    }
   }
 
-  return outputBuffers;
+  output = outputBuffers;
+  return success();
 }
 
 // Allocates transient buffers to store the intra-stream results and populates
 // the |schedulingState| with the new mappings.
-static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
-                                     LivenessIntervalList &livenessIntervals,
-                                     StreamSchedulingState &schedulingState,
-                                     ConversionPatternRewriter &rewriter) {
+static LogicalResult allocateTransientBuffers(
+    IREE::Flow::ExStreamFragmentOp streamOp,
+    LivenessIntervalList &livenessIntervals,
+    StreamSchedulingState &schedulingState,
+    ConversionPatternRewriter &rewriter) {
   // TODO(#5410): unify with slice/update handling below. We should have a
   // more generic way of handling these special ops and need to be able to hook
   // into ones that directly control aliasing behavior like slice/update.
   SmallPtrSet<Value, 16> coveredValues;
-  streamOp.walk([&](IREE::HAL::ConstantSubspanOp subspanOp) {
+  auto walkResult = streamOp.walk([&](IREE::HAL::ConstantSubspanOp subspanOp) {
     auto tensorValue = subspanOp.result();
     auto bufferValue = schedulingState.loadVariable(
         IREE::HAL::BufferType::get(rewriter.getContext()),
@@ -560,10 +573,21 @@ static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
         subspanOp.getLoc(), bufferValue.getType(), bufferValue, offsetValue,
         lengthValue);
     auto bufferRange = BufferRange{subspanValue, lengthValue};
-    schedulingState.mapTensorToBufferRange(tensorValue, bufferRange);
+    if (failed(
+            schedulingState.mapTensorToBufferRange(tensorValue, bufferRange))) {
+      llvm::errs() << subspanOp << "\n";
+      return WalkResult::interrupt();
+    }
     schedulingState.forEachEquivalentTensorValue(
         tensorValue, [&](Value alias) { coveredValues.insert(alias); });
+    return WalkResult::advance();
   });
+
+  if (walkResult.wasInterrupted()) {
+    return streamOp.emitOpError() << "constant subspan op was mapped to "
+                                     "multiple buffer ranges while allocating "
+                                     "transient buffers";
+  }
 
   // Gather all of the transient values we need to allocate buffers for.
   SmallVector<Value> transientValues;
@@ -603,7 +627,7 @@ static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
   }
   if (transientValues.empty()) {
     // No transients required.
-    return;
+    return success();
   }
 
   // Insert the hal.allocator.pack op to compute the packed offsets and total
@@ -637,8 +661,13 @@ static void allocateTransientBuffers(IREE::Flow::ExStreamFragmentOp streamOp,
         value.getLoc(), allocateOp.result().getType(), allocateOp.result(),
         offset, dynamicSliceSizes[i]);
     auto bufferRange = BufferRange{subspanValue, dynamicSliceSizes[i]};
-    schedulingState.mapTensorToBufferRange(value, bufferRange);
+    if (failed(schedulingState.mapTensorToBufferRange(value, bufferRange))) {
+      return streamOp.emitOpError()
+             << "tensor for buffer subspan was mapped to multiple buffer "
+                "ranges while allocating transient buffers";
+    }
   }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1092,7 +1121,11 @@ class ExStreamFragmentOpConversion
               bufferValue,
               schedulingState.lookupOrComputeSize(streamValue, rewriter)};
         }
-        schedulingState.mapTensorToBufferRange(streamValue, bufferRange);
+        if (failed(schedulingState.mapTensorToBufferRange(streamValue,
+                                                          bufferRange))) {
+          return streamOp.emitOpError()
+                 << "tensor was mapped to multiple buffer ranges";
+        }
 
       } else {
         rewriter.replaceUsesOfBlockArgument(streamValue, bufferValue);
@@ -1102,8 +1135,11 @@ class ExStreamFragmentOpConversion
     // Allocate buffers for values that escape the stream via return.
     // These may alias input buffers above such as when an input is returned or
     // a return value is tied.
-    auto outputBuffers =
-        allocateOutputBuffers(streamOp, schedulingState, rewriter);
+    SmallVector<Value> outputBuffers;
+    if (failed(allocateOutputBuffers(streamOp, schedulingState, rewriter,
+                                     outputBuffers))) {
+      return failure();
+    }
 
     // Allocate all of the transient buffers used entirely within the stream.
     // These all end up aliased from a single slab allocation and use the
@@ -1111,8 +1147,10 @@ class ExStreamFragmentOpConversion
     // after we perform this allocation we can no longer safely rearrange the
     // ops as buffers will start to alias. All reordering must have happened
     // prior to this conversion.
-    allocateTransientBuffers(streamOp, livenessIntervals, schedulingState,
-                             rewriter);
+    if (failed(allocateTransientBuffers(streamOp, livenessIntervals,
+                                        schedulingState, rewriter))) {
+      return failure();
+    }
 
     // Allocate and begin the command buffer.
     // In a real version we would want to pick the device based on the placement

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -575,7 +575,6 @@ static LogicalResult allocateTransientBuffers(
     auto bufferRange = BufferRange{subspanValue, lengthValue};
     if (failed(
             schedulingState.mapTensorToBufferRange(tensorValue, bufferRange))) {
-      llvm::errs() << subspanOp << "\n";
       return WalkResult::interrupt();
     }
     schedulingState.forEachEquivalentTensorValue(


### PR DESCRIPTION
I think this code was written before walking could signal a failure.

This change was important in reproducing
https://github.com/google/iree/issues/5989