### PR TITLE
Use 'vulkan-spirv' as the compiler target for consistency

### DIFF
--- a/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
@@ -892,7 +892,7 @@ class BackendInfo:
       "iree_vulkan": {
           "compiled_module_class": IreeCompiledModule,
           "driver": "vulkan",
-          "compiler_targets": ["vulkan-*"]
+          "compiler_targets": ["vulkan-spirv"]
       },
       "iree_llvmaot": {
           "compiled_module_class": IreeCompiledModule,


### PR DESCRIPTION
This is a spin-off of #5837.