### PR TITLE
Make traversal order pre-order in bufferization.

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -961,14 +961,6 @@ static LogicalResult convertConstantOp(OpBuilder &b, ConstantOp constantOp,
   return success();
 }
 
-static LogicalResult convertDimOp(OpBuilder &b, memref::DimOp dimOp,
-                                  BlockAndValueMapping &bvm) {
-  if (Value v = bvm.lookupOrNull(dimOp.memrefOrTensor())) {
-    dimOp.memrefOrTensorMutable().assign(v);
-  }
-  return success();
-}
-
 static LogicalResult convertDispatchTieShapeOp(
     OpBuilder &b, IREE::Flow::DispatchTieShapeOp shapeOp,
     BlockAndValueMapping &bvm) {
@@ -982,13 +974,15 @@ static LogicalResult convertDispatchTieShapeOp(
 
 /// Converts a `tensor.extract` operation into a `load`.
 static LogicalResult convertTensorExtractOp(OpBuilder &b, tensor::ExtractOp op,
-                                            BlockAndValueMapping &bvm) {
+                                            const BlockAndValueMapping &bvm) {
   OpBuilder::InsertionGuard g(b);
   b.setInsertionPoint(op);
   Value inputBuffer = bvm.lookup(op.tensor());
   Value load =
       b.createOrFold<memref::LoadOp>(op.getLoc(), inputBuffer, op.indices());
-  bvm.map(op.result(), load);
+  // Since the value is the scalar, and `bvm` is used to only track tensor ->
+  // memref mappings, just replace the uses directly.
+  op.result().replaceAllUsesWith(load);
   return success();
 }
 
@@ -1052,17 +1046,6 @@ static LogicalResult convertSubTensorInsertOp(OpBuilder &b,
   Value subViewOp = createSubviewOp(b, loc, resultBuffer, offsets, sizes,
                                     strides, subViewResultType);
   b.create<linalg::CopyOp>(loc, sourceBuffer, subViewOp);
-  return success();
-}
-
-/// Converts a vector.transfer_read op to use memref operands for source.
-static LogicalResult convertVectorTransferReadOp(
-    OpBuilder &b, vector::TransferReadOp transferReadOp,
-    BlockAndValueMapping &bvm) {
-  Value source = transferReadOp.source();
-  if (!source.getType().isa<RankedTensorType>()) return success();
-  Value memref = bvm.lookup(source);
-  transferReadOp.sourceMutable().assign(memref);
   return success();
 }
 
@@ -1219,13 +1202,13 @@ void LinalgBufferizePass::runOnFunction() {
     bvm.map(op, baseBuffer);
   });
 
-  auto conversionDispatch = [&](Operation *op) -> WalkResult {
+  // Visit all the operations that return `tensor`s and convert them to using
+  // `memref`s.
+  auto convertTensorOps = [&](Operation *op) -> WalkResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
         .Case<ConstantOp>([&](ConstantOp constantOp) {
           return convertConstantOp(b, constantOp, bvm);
         })
-        .Case<memref::DimOp>(
-            [&](memref::DimOp dimOp) { return convertDimOp(b, dimOp, bvm); })
         .Case<IREE::Flow::DispatchTensorStoreOp>(
             [&](IREE::Flow::DispatchTensorStoreOp storeOp) {
               return convertInterfaceStoreTensorOp(b, storeOp, bvm, plan);
@@ -1274,13 +1257,6 @@ void LinalgBufferizePass::runOnFunction() {
           }
           return convertSubTensorInsertOp(b, subTensorInsertOp, bvm, plan);
         })
-        .Case<tensor::ExtractOp>([&](tensor::ExtractOp extractOp) {
-          return convertTensorExtractOp(b, extractOp, bvm);
-        })
-        .Case<vector::TransferReadOp>(
-            [&](vector::TransferReadOp transferReadOp) {
-              return convertVectorTransferReadOp(b, transferReadOp, bvm);
-            })
         .Case<vector::TransferWriteOp>(
             [&](vector::TransferWriteOp transferWriteOp) {
               if (failed(getOrAllocateResultBuffers(b, transferWriteOp,
@@ -1291,24 +1267,40 @@ void LinalgBufferizePass::runOnFunction() {
               return convertVectorTransferWriteOp(b, transferWriteOp, bvm,
                                                   plan);
             })
-        .Default([&](Operation *op) {
-          // Replace any scalar remapped operands to the new values.
-          // TODO(GH-5013): This is really hacky solution, but gets us past for
-          // the time being. This all should be replaced by a pattern.
+        .Default([&](Operation *op) { return success(); });
+  };
+  auto walkResult =
+      funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+        b.setInsertionPoint(op);
+        return convertTensorOps(op);
+      });
+  if (walkResult.wasInterrupted()) {
+    return signalPassFailure();
+  }
+
+  // Lastly visit the non-tensor return operations that still use `tensor`
+  // values. These need to be updated to use the corresponding `memref` values,
+  // but dont need to update the block-and-value mapping.
+  auto convertNonTensorOps = [&](Operation *op) -> LogicalResult {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<tensor::ExtractOp>([&](tensor::ExtractOp op) {
+          return convertTensorExtractOp(b, op, bvm);
+        })
+        .Case<memref::DimOp, vector::TransferReadOp>([&](auto op) {
           for (unsigned i : llvm::seq<unsigned>(0, op->getNumOperands())) {
             Value operand = op->getOperand(i);
-            if (operand.getType().isIntOrIndexOrFloat()) {
+            if (operand.getType().isa<RankedTensorType>()) {
               Value remappedVal = bvm.lookupOrNull(operand);
               if (remappedVal) op->setOperand(i, remappedVal);
             }
           }
           return success();
-        });
+        })
+        .Default([&](Operation *op) { return success(); });
   };
-
-  auto walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
+  walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
     b.setInsertionPoint(op);
-    return conversionDispatch(op);
+    return convertNonTensorOps(op);
   });
   if (walkResult.wasInterrupted()) {
     return signalPassFailure();


### PR DESCRIPTION
Make the traversal order pre-order since for ops with nested regions,
it is necessary to process the op before the region.
Changing to pre-order also means that regions of cloned ops dont get
processed during the work to convert tensor to memrefs. As a result,
move the conversion of ops that are just using the tensor value, and
not creating a tensor to be processed in a separate walk.