### PR TITLE
Share scalarization pass between CUDA and ROCM

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToLLVM.cpp
@@ -20,13 +20,64 @@
 #include "mlir/Dialect/GPU/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
 namespace iree_compiler {
 
 namespace {
+
+/// Scalarize math ops. It is needed to lower vector operation that don't have
+/// vector support in CUDA and ROCM device library.
+template <typename MathOpTy>
+struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
+  using OpRewritePattern<MathOpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MathOpTy mathOp,
+                                PatternRewriter &rewriter) const override {
+    auto vecType = mathOp.getType().template dyn_cast<VectorType>();
+    if (!vecType) return failure();
+    Location loc = mathOp.getLoc();
+    Value newVector = rewriter.create<ConstantOp>(
+        loc, vecType, rewriter.getZeroAttr(vecType));
+
+    for (int64_t element : llvm::seq(int64_t(0), vecType.getNumElements())) {
+      llvm::SmallVector<int64_t> indices;
+      int64_t projectIndex = element;
+      for (int64_t dim : llvm::seq(int64_t(0), vecType.getRank())) {
+        int64_t index = projectIndex % vecType.getDimSize(dim);
+        projectIndex = projectIndex / vecType.getDimSize(dim);
+        indices.push_back(index);
+      }
+      SmallVector<Value> newOperands;
+      for (Value operand : mathOp->getOperands()) {
+        newOperands.push_back(
+            rewriter.create<vector::ExtractOp>(loc, operand, indices));
+      }
+      Value scalarOp = rewriter.create<MathOpTy>(loc, newOperands);
+      newVector =
+          rewriter.create<vector::InsertOp>(loc, scalarOp, newVector, indices);
+    }
+    rewriter.replaceOp(mathOp, newVector);
+    return success();
+  }
+};
+
+/// Pass to test scalarization pattern.
+class ScalarizationTestPass
+    : public PassWrapper<ScalarizationTestPass, OperationPass<FuncOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+  void runOnOperation() override {
+    OwningRewritePatternList patterns(&getContext());
+    populateScalarizeMathOps(patterns);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
 
 class ConvertFunc : public ConvertToLLVMPattern {
  public:
@@ -188,6 +239,22 @@ void populateLLVMConversionPatterns(MLIRContext *context,
                         NVVM::BlockDimYOp, NVVM::BlockDimZOp>>(context);
   }
 }
+
+void populateScalarizeMathOps(RewritePatternSet &patterns) {
+  patterns.add<ScalarizeMathOp<math::SqrtOp>, ScalarizeMathOp<AbsFOp>,
+               ScalarizeMathOp<math::AtanOp>, ScalarizeMathOp<math::Atan2Op>,
+               ScalarizeMathOp<CeilFOp>, ScalarizeMathOp<math::CosOp>,
+               ScalarizeMathOp<math::ExpOp>, ScalarizeMathOp<math::ExpM1Op>,
+               ScalarizeMathOp<FloorFOp>, ScalarizeMathOp<math::LogOp>,
+               ScalarizeMathOp<math::Log1pOp>, ScalarizeMathOp<math::Log10Op>,
+               ScalarizeMathOp<math::Log2Op>, ScalarizeMathOp<math::PowFOp>,
+               ScalarizeMathOp<math::RsqrtOp>, ScalarizeMathOp<math::SinOp>,
+               ScalarizeMathOp<math::SqrtOp>, ScalarizeMathOp<math::TanhOp>>(
+      patterns.getContext());
+}
+
+static PassRegistration<ScalarizationTestPass> scalarization_test_pass(
+    "iree-llvmgpu-scalarize-math-op", "Test pass for scalarization patterns.");
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToLLVM.h
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToLLVM.h
@@ -24,6 +24,8 @@ void populateLLVMConversionPatterns(MLIRContext *context,
                                     OwningRewritePatternList &patterns,
                                     LLVMTypeConverter &converter, bool useROCM);
 
+void populateScalarizeMathOps(RewritePatternSet &patterns);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToNVVM.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToNVVM.cpp
@@ -21,7 +21,6 @@
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/GPU/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
-#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Vector/VectorOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -31,68 +30,6 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-
-/// Scalarize math ops. It is needed to lower vector operation that don't have
-/// vector support in CUDA device library.
-template <typename MathOpTy>
-struct ScalarizeMathOp : public OpRewritePattern<MathOpTy> {
-  using OpRewritePattern<MathOpTy>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(MathOpTy mathOp,
-                                PatternRewriter &rewriter) const override {
-    auto vecType = mathOp.getType().template dyn_cast<VectorType>();
-    if (!vecType) return failure();
-    Location loc = mathOp.getLoc();
-    Value newVector = rewriter.create<ConstantOp>(
-        loc, vecType, rewriter.getZeroAttr(vecType));
-
-    for (int64_t element : llvm::seq(int64_t(0), vecType.getNumElements())) {
-      llvm::SmallVector<int64_t> indices;
-      int64_t projectIndex = element;
-      for (int64_t dim : llvm::seq(int64_t(0), vecType.getRank())) {
-        int64_t index = projectIndex % vecType.getDimSize(dim);
-        projectIndex = projectIndex / vecType.getDimSize(dim);
-        indices.push_back(index);
-      }
-      SmallVector<Value> newOperands;
-      for (Value operand : mathOp->getOperands()) {
-        newOperands.push_back(
-            rewriter.create<vector::ExtractOp>(loc, operand, indices));
-      }
-      Value scalarOp = rewriter.create<MathOpTy>(loc, newOperands);
-      newVector =
-          rewriter.create<vector::InsertOp>(loc, scalarOp, newVector, indices);
-    }
-    rewriter.replaceOp(mathOp, newVector);
-    return success();
-  }
-};
-
-void populateScalarizeMathOps(RewritePatternSet &patterns) {
-  patterns.add<ScalarizeMathOp<math::SqrtOp>, ScalarizeMathOp<AbsFOp>,
-               ScalarizeMathOp<math::AtanOp>, ScalarizeMathOp<math::Atan2Op>,
-               ScalarizeMathOp<CeilFOp>, ScalarizeMathOp<math::CosOp>,
-               ScalarizeMathOp<math::ExpOp>, ScalarizeMathOp<math::ExpM1Op>,
-               ScalarizeMathOp<FloorFOp>, ScalarizeMathOp<math::LogOp>,
-               ScalarizeMathOp<math::Log1pOp>, ScalarizeMathOp<math::Log10Op>,
-               ScalarizeMathOp<math::Log2Op>, ScalarizeMathOp<math::PowFOp>,
-               ScalarizeMathOp<math::RsqrtOp>, ScalarizeMathOp<math::SinOp>,
-               ScalarizeMathOp<math::SqrtOp>, ScalarizeMathOp<math::TanhOp>>(
-      patterns.getContext());
-}
-
-/// Pass to test scalarization pattern.
-class ScalarizationTestPass
-    : public PassWrapper<ScalarizationTestPass, OperationPass<FuncOp>> {
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<vector::VectorDialect, NVVM::NVVMDialect>();
-  }
-  void runOnOperation() override {
-    OwningRewritePatternList patterns(&getContext());
-    populateScalarizeMathOps(patterns);
-    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
-  }
-};
 
 /// A pass that replaces all occurrences of GPU device operations with their
 /// corresponding NVVM equivalent.
@@ -162,9 +99,6 @@ static PassRegistration<ConvertToNVVMPass> pass(
     "iree-codegen-convert-to-nvvm",
     "Perform final conversion from builtin/GPU/HAL/standard dialect to LLVM "
     "and NVVM dialects");
-
-static PassRegistration<ScalarizationTestPass> scalarization_test_pass(
-    "iree-cuda-scalarize-math-op", "Test pass for scalarization patterns.");
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToROCDL.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/ConvertToROCDL.cpp
@@ -54,6 +54,7 @@ struct ConvertToROCDLPass
     // Run Vector -> Vector transformations ahead of conversion to LLVM.
     {
       OwningRewritePatternList patterns(&getContext());
+      populateScalarizeMathOps(patterns);
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateVectorSlicesLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/test/scalarize.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/test/scalarize.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -iree-cuda-scalarize-math-op %s | IreeFileCheck %s
+// RUN: iree-opt -iree-llvmgpu-scalarize-math-op %s | IreeFileCheck %s
 
 // CHECK-LABEL: func @scalarize
 func @scalarize(


### PR DESCRIPTION
This patch pulls out the scalarization pass and shares
it between CUDA and ROCM. With this change, Mobilenet
now compiles on ROCM.