### PR TITLE
Fix base result index in DispatchWorkgroupsOp patterns.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -871,7 +871,8 @@ DispatchWorkgroupsOp::cloneReplacementExcludingOperandsAndResults(
       getOperation()->getAttrs());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
-  unsigned baseResultIndex = newOperandsValues.size();
+  // Use old index when erasing ops.
+  unsigned baseResultIndex = operands().size();
   // For dropped results, erase all the store-op uses. It is a pre-requisite
   // that the result can be dropped only if it is written within the dispatch
   // region op.


### PR DESCRIPTION
The index should be for the old block arguments and all excluded*
indices are for the old ones. Thus, we should compute base result index
based on old operands.

Fixes https://github.com/google/iree/issues/6009