### PR TITLE
Add a pass to verify that input to the compiler is legal.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -85,6 +85,7 @@ cc_library(
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TosaDialect",
         "@llvm-project//mlir:TosaToLinalg",
         "@llvm-project//mlir:TosaToSCF",
         "@llvm-project//mlir:TosaToStandard",

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -48,6 +48,7 @@ cc_library(
         "Passes.cpp",
         "PrePostPartitioningConversion.cpp",
         "StripAndSplatConstantVariables.cpp",
+        "VerifyCompilerInputLegality.cpp",
     ],
     hdrs = [
         "DestructiveUpdateUtils.h",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     "Passes.cpp"
     "PrePostPartitioningConversion.cpp"
     "StripAndSplatConstantVariables.cpp"
+    "VerifyCompilerInputLegality.cpp"
   DEPS
     LLVMSupport
     MLIRIR

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     MLIRStandard
     MLIRSupport
     MLIRTensor
+    MLIRTosa
     MLIRTosaToLinalg
     MLIRTosaToSCF
     MLIRTosaToStandard

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -52,6 +52,10 @@ void registerFlowTransformPassPipeline();
 // Input canonicalization and legalization
 //===----------------------------------------------------------------------===//
 
+// Verifies a module being input to the core compiler pipeline only contains
+// IR structures that are supported at that level.
+std::unique_ptr<OperationPass<ModuleOp>> createVerifyCompilerInputLegality();
+
 // Convert operations to equivalent flow.tensor.* ops. This is run after
 // dispatch region creation to catch operations that were left outside of
 // dispatch regions and could be represented as flow.tensor.* ops.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -94,4 +94,10 @@ def StripAndSplatConstantVariables :
   let constructor = "mlir::iree_compiler::IREE::Flow::createStripAndSplatConstantVariablesPass()";
 }
 
+def VerifyCompilerInputLegality :
+    Pass<"iree-verify-compiler-input-legality", "ModuleOp"> {
+  let summary = "Verifies that only supported IR constructs are passed to the compiler.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createVerifyCompilerInputLegality()";
+}
+
 #endif  // IREE_DIALECT_FLOW_PASSES

--- a/iree/compiler/Dialect/Flow/Transforms/VerifyCompilerInputLegality.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/VerifyCompilerInputLegality.cpp
@@ -8,7 +8,6 @@
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
-#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -32,7 +31,6 @@ struct VerifyCompilerInputLegalityPass
     conversionTarget.addIllegalDialect<tosa::TosaDialect>();
     conversionTarget.addIllegalDialect<mhlo::MhloDialect>();
     conversionTarget.addIllegalDialect<chlo::HloClientDialect>();
-    conversionTarget.addIllegalDialect<lmhlo::LmhloDialect>();
 
     // Exception: ApplyScaleOp is actually a lowered op on par with standard
     // dialect.

--- a/iree/compiler/Dialect/Flow/Transforms/VerifyCompilerInputLegality.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/VerifyCompilerInputLegality.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+struct VerifyCompilerInputLegalityPass
+    : public VerifyCompilerInputLegalityBase<VerifyCompilerInputLegalityPass> {
+  void runOnOperation() override {
+    auto *context = &getContext();
+    ConversionTarget conversionTarget(*context);
+    OwningRewritePatternList conversionPatterns(&getContext());
+
+    // Note that we would prefer allow-lists of what we positively support.
+    // However, it is so common to sneak input-level ops into the pipeline
+    // that we explicitly deny the dialects we know about.
+    conversionTarget.addIllegalDialect<tosa::TosaDialect>();
+    conversionTarget.addIllegalDialect<mhlo::MhloDialect>();
+    conversionTarget.addIllegalDialect<chlo::HloClientDialect>();
+    conversionTarget.addIllegalDialect<lmhlo::LmhloDialect>();
+
+    // Exception: ApplyScaleOp is actually a lowered op on par with standard
+    // dialect.
+    conversionTarget.addLegalOp<tosa::ApplyScaleOp>();
+
+    // NOTE: It is not fully illegal to tunnel input dialect ops through to
+    // backends that expect them. When such situations arise, the container
+    // op should be marked recursively legal here.
+    SmallVector<Diagnostic> failures;
+    {
+      ScopedDiagnosticHandler diag(context,
+                                   [&](Diagnostic &d) -> LogicalResult {
+                                     failures.push_back(std::move(d));
+                                     return success();
+                                   });
+      if (succeeded(applyPartialConversion(getOperation(), conversionTarget,
+                                           std::move(conversionPatterns)))) {
+        return;
+      }
+    }
+
+    // Error fall-through. Attach all reported issues as notes.
+    InFlightDiagnostic errorDiag =
+        emitError(getOperation().getLoc())
+        << "one or more illegal operations were found in the compiler input "
+           "(are you missing an --iree-input-type= flag, or did you mean to "
+           "pre-process through an IREE importer frontend?)";
+    for (auto &failureDiag : failures) {
+      Diagnostic &note = errorDiag.attachNote(failureDiag.getLocation());
+      for (auto &arg : failureDiag.getArguments()) {
+        note.append(arg);
+      }
+    }
+
+    signalPassFailure();
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createVerifyCompilerInputLegality() {
+  return std::make_unique<VerifyCompilerInputLegalityPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "pre_partitioning_conversion.mlir",
             "strip_and_splat_constant_variables.mlir",
             "transformation.mlir",
+            "verify_compiler_input_legality.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "pre_partitioning_conversion.mlir"
     "strip_and_splat_constant_variables.mlir"
     "transformation.mlir"
+    "verify_compiler_input_legality.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Transforms/test/verify_compiler_input_legality.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/verify_compiler_input_legality.mlir
@@ -1,0 +1,31 @@
+// RUN: iree-opt -split-input-file -iree-verify-compiler-input-legality %s
+// -verify-diagnostics
+
+// expected-error@+1 {{one or more illegal operations were found in the compiler input}}
+module {
+func @illegal_chlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // expected-note@+1 {{failed to legalize operation 'chlo.broadcast_add' that was explicitly marked illegal}}
+  %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+}
+
+// -----
+// expected-error@+1 {{one or more illegal operations were found in the compiler input}}
+module {
+func @illegal_mhlo(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // expected-note@+1 {{failed to legalize operation 'mhlo.add' that was explicitly marked illegal}}
+  %0 = mhlo.add %arg0, %arg1 : tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+}
+
+// -----
+// expected-error@+1 {{one or more illegal operations were found in the compiler input}}
+module {
+func @illegal_tosa(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  // expected-note@+1 {{failed to legalize operation 'tosa.add' that was explicitly marked illegal}}
+  %0 = "tosa.add"(%arg0, %arg1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+}

--- a/iree/compiler/Dialect/Flow/Transforms/test/verify_compiler_input_legality.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/verify_compiler_input_legality.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-verify-compiler-input-legality %s
+// RUN: iree-opt -split-input-file -iree-verify-compiler-input-legality -verify-diagnostics %s
 // -verify-diagnostics
 
 // expected-error@+1 {{one or more illegal operations were found in the compiler input}}


### PR DESCRIPTION
* Not used yet: will be added as part of the input pipeline rework.