### PR TITLE
Making C struct and enum usage consistent across the runtime code.

### DIFF
--- a/bindings/python/iree/runtime/function_abi.cc
+++ b/bindings/python/iree/runtime/function_abi.cc
@@ -360,7 +360,7 @@ void MapBufferAttrs(Py_buffer& py_view,
 
 void PackScalar(const RawSignatureParser::Description& desc, py::handle py_arg,
                 VmVariantList& f_args) {
-  iree_vm_value value;
+  iree_vm_value_t value;
   value.type = IREE_VM_VALUE_TYPE_I32;
   switch (desc.scalar.type) {
     case AbiConstants::ScalarType::kUint8:

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -53,7 +53,7 @@ HalDevice HalDriver::CreateDefaultDevice() {
 
 void SetupHalBindings(pybind11::module m) {
   // Enums.
-  py::enum_<enum iree_hal_memory_type_e>(m, "MemoryType")
+  py::enum_<enum iree_hal_memory_type_bits_t>(m, "MemoryType")
       .value("NONE", IREE_HAL_MEMORY_TYPE_NONE)
       .value("TRANSIENT", IREE_HAL_MEMORY_TYPE_TRANSIENT)
       .value("HOST_VISIBLE", IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)
@@ -63,7 +63,7 @@ void SetupHalBindings(pybind11::module m) {
       .value("DEVICE_VISIBLE", IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)
       .value("DEVICE_LOCAL", IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)
       .export_values();
-  py::enum_<enum iree_hal_buffer_usage_e>(m, "BufferUsage")
+  py::enum_<enum iree_hal_buffer_usage_bits_t>(m, "BufferUsage")
       .value("NONE", IREE_HAL_BUFFER_USAGE_NONE)
       .value("CONSTANT", IREE_HAL_BUFFER_USAGE_CONSTANT)
       .value("TRANSFER", IREE_HAL_BUFFER_USAGE_TRANSFER)
@@ -71,7 +71,7 @@ void SetupHalBindings(pybind11::module m) {
       .value("DISPATCH", IREE_HAL_BUFFER_USAGE_DISPATCH)
       .value("ALL", IREE_HAL_BUFFER_USAGE_ALL)
       .export_values();
-  py::enum_<enum iree_hal_memory_access_e>(m, "MemoryAccess")
+  py::enum_<enum iree_hal_memory_access_bits_t>(m, "MemoryAccess")
       .value("NONE", IREE_HAL_MEMORY_ACCESS_NONE)
       .value("READ", IREE_HAL_MEMORY_ACCESS_READ)
       .value("WRITE", IREE_HAL_MEMORY_ACCESS_WRITE)
@@ -79,7 +79,7 @@ void SetupHalBindings(pybind11::module m) {
       .value("DISCARD_WRITE", IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE)
       .value("ALL", IREE_HAL_MEMORY_ACCESS_ALL)
       .export_values();
-  py::enum_<enum iree_hal_element_type_e>(m, "HalElementType")
+  py::enum_<enum iree_hal_element_types_t>(m, "HalElementType")
       .value("NONE", IREE_HAL_ELEMENT_TYPE_NONE)
       .value("OPAQUE_8", IREE_HAL_ELEMENT_TYPE_OPAQUE_8)
       .value("OPAQUE_16", IREE_HAL_ELEMENT_TYPE_OPAQUE_16)
@@ -96,9 +96,9 @@ void SetupHalBindings(pybind11::module m) {
       .value("FLOAT_16", IREE_HAL_ELEMENT_TYPE_FLOAT_16)
       .value("FLOAT_32", IREE_HAL_ELEMENT_TYPE_FLOAT_32)
       .value("FLOAT_64", IREE_HAL_ELEMENT_TYPE_FLOAT_64)
-      .value("BOOL_8", static_cast<enum iree_hal_element_type_e>(
-                           IREE_HAL_ELEMENT_TYPE_VALUE(
-                               IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED, 1)))
+      .value("BOOL_8",
+             static_cast<iree_hal_element_types_t>(IREE_HAL_ELEMENT_TYPE_VALUE(
+                 IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED, 1)))
       .export_values();
 
   py::class_<HalDevice>(m, "HalDevice");

--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -236,7 +236,7 @@ void VmVariantList::PushList(VmVariantList& other) {
 
 void VmVariantList::PushBufferView(HalDevice& device,
                                    py::object py_buffer_object,
-                                   iree_hal_element_type_e element_type) {
+                                   iree_hal_element_type_t element_type) {
   // Request a view of the buffer (use the raw python C API to avoid some
   // allocation and copying at the pybind level).
   Py_buffer py_view;

--- a/bindings/python/iree/runtime/vm.h
+++ b/bindings/python/iree/runtime/vm.h
@@ -94,7 +94,7 @@ class VmVariantList {
   void PushInt(int64_t ivalue);
   void PushList(VmVariantList& other);
   void PushBufferView(HalDevice& device, py::object py_buffer_object,
-                      iree_hal_element_type_e element_type);
+                      iree_hal_element_type_t element_type);
   py::object GetAsList(int index);
   py::object GetAsNdarray(int index);
   py::object GetVariant(int index);

--- a/iree/base/allocator.h
+++ b/iree/base/allocator.h
@@ -45,7 +45,7 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 // A span of mutable bytes (ala std::span of uint8_t).
-typedef struct {
+typedef struct iree_byte_span_t {
   uint8_t* data;
   iree_host_size_t data_length;
 } iree_byte_span_t;
@@ -57,7 +57,7 @@ static inline iree_byte_span_t iree_make_byte_span(
 }
 
 // A span of constant bytes (ala std::span of const uint8_t).
-typedef struct {
+typedef struct iree_const_byte_span_t {
   const uint8_t* data;
   iree_host_size_t data_length;
 } iree_const_byte_span_t;
@@ -90,7 +90,7 @@ static inline iree_const_byte_span_t iree_make_const_byte_span(
 //===----------------------------------------------------------------------===//
 
 // Defines how an allocation from an iree_allocator_t should be made.
-enum iree_allocation_mode_e {
+enum iree_allocation_mode_bits_t {
   // The contents of the allocation *must* be zeroed by the allocator prior to
   // returning. Allocators may be able to elide the zeroing if they allocate
   // fresh pages from the system. It is always safe to zero contents if the
@@ -119,7 +119,7 @@ typedef void(IREE_API_PTR* iree_allocator_free_fn_t)(void* self, void* ptr);
 // An allocator for host-memory allocations.
 // IREE will attempt to use this in place of the system malloc and free.
 // Pass the iree_allocator_system() macro to use the system allocator.
-typedef struct {
+typedef struct iree_allocator_t {
   // User-defined pointer passed to all functions.
   void* self;
   // Allocates |byte_length| of memory and stores the pointer in |out_ptr|.

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -158,7 +158,7 @@ extern "C" {
 // Well-known status codes matching iree::StatusCode.
 // Note that any code within IREE_STATUS_CODE_MASK is valid even if not
 // enumerated here. Always check for unhandled errors/have default conditions.
-typedef enum {
+typedef enum iree_status_code_e {
   IREE_STATUS_OK = 0,
   IREE_STATUS_CANCELLED = 1,
   IREE_STATUS_UNKNOWN = 2,
@@ -568,12 +568,11 @@ IREE_API_EXPORT void iree_status_fprint(FILE* file, iree_status_t status);
 
 // Known versions of the API that can be referenced in code.
 // Out-of-bounds values are possible in forward-versioned changes.
-enum iree_api_version_e {
-  IREE_API_VERSION_0 = 0u,
+typedef enum iree_api_version_e {
+  IREE_API_VERSION_0 = 0,
   // Always set to the latest version of the library from source.
   IREE_API_VERSION_LATEST = IREE_API_VERSION_0,
-};
-typedef uint32_t iree_api_version_t;
+} iree_api_version_t;
 
 // Checks whether the |expected_version| of the caller matches the implemented
 // version of |out_actual_version|. Forward compatibility of the API is

--- a/iree/base/internal/atomic_slist.h
+++ b/iree/base/internal/atomic_slist.h
@@ -26,8 +26,8 @@ extern "C" {
 typedef void* iree_atomic_slist_intrusive_ptr_t;
 
 // DO NOT USE: implementation detail.
-typedef struct iree_atomic_slist_entry_s {
-  struct iree_atomic_slist_entry_s* next;
+typedef struct iree_atomic_slist_entry_t {
+  struct iree_atomic_slist_entry_t* next;
 } iree_atomic_slist_entry_t;
 
 // Lightweight contention-avoiding singly linked list.
@@ -129,15 +129,14 @@ void iree_atomic_slist_push_unsafe(iree_atomic_slist_t* list,
 iree_atomic_slist_entry_t* iree_atomic_slist_pop(iree_atomic_slist_t* list);
 
 // Defines the approximate order in which a span of flushed entries is returned.
-typedef uint32_t iree_atomic_slist_flush_order_t;
-enum {
+typedef enum iree_atomic_slist_flush_order_e {
   // |out_head| and |out_tail| will be set to a span of the entries roughly in
   // the order they were pushed to the list in LIFO (stack) order.
   //
   // Example:
   //    slist: C B A
   //   result: C B A (or when contended possibly C A B)
-  IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO,
+  IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_LIFO = 0,
   // |out_head| and |out_tail| will be set to the first and last entries
   // pushed respectively, turning this LIFO slist into a FIFO queue.
   //
@@ -145,7 +144,7 @@ enum {
   //    slist: C B A
   //   result: A B C (or when contended possibly B A C)
   IREE_ATOMIC_SLIST_FLUSH_ORDER_APPROXIMATE_FIFO,
-};
+} iree_atomic_slist_flush_order_t;
 
 // Removes all items from the list and returns them in **APPROXIMATELY** the
 // |flush_order| requested. As there are no order guarantees there may be slight

--- a/iree/base/internal/dynamic_library.h
+++ b/iree/base/internal/dynamic_library.h
@@ -14,13 +14,13 @@ extern "C" {
 #endif
 
 // Defines the behavior of the dynamic library loader.
-enum iree_dynamic_library_flags_e {
+enum iree_dynamic_library_flag_bits_t {
   IREE_DYNAMIC_LIBRARY_FLAG_NONE = 0u,
 };
 typedef uint32_t iree_dynamic_library_flags_t;
 
 // Dynamic library (aka shared object) cross-platform wrapper.
-typedef struct iree_dynamic_library_s iree_dynamic_library_t;
+typedef struct iree_dynamic_library_t iree_dynamic_library_t;
 
 // Loads a system library using both the system library load paths and the given
 // file name. The path may may be absolute or relative.

--- a/iree/base/internal/dynamic_library_posix.c
+++ b/iree/base/internal/dynamic_library_posix.c
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-struct iree_dynamic_library_s {
+struct iree_dynamic_library_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/base/internal/dynamic_library_win32.c
+++ b/iree/base/internal/dynamic_library_win32.c
@@ -26,7 +26,7 @@ void IREEDbgHelpLock(void);
 void IREEDbgHelpUnlock(void);
 #endif  // TRACY_ENABLE
 
-struct iree_dynamic_library_s {
+struct iree_dynamic_library_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/base/internal/flags.c
+++ b/iree/base/internal/flags.c
@@ -54,7 +54,7 @@ static iree_allocator_t iree_flags_leaky_allocator(void) {
 //===----------------------------------------------------------------------===//
 
 // Storage for registered flags.
-typedef struct {
+typedef struct iree_flag_t {
   // __FILE__ of flag definition.
   const char* file;
   // __LINE__ of flag definition.
@@ -74,7 +74,7 @@ typedef struct {
 } iree_flag_t;
 
 // State used for flag registration and reflection.
-typedef struct {
+typedef struct iree_flag_registry_t {
   const char* program_name;
   const char* usage;
 

--- a/iree/base/internal/flags.h
+++ b/iree/base/internal/flags.h
@@ -89,10 +89,11 @@ extern "C" {
 // Flag definition
 //===----------------------------------------------------------------------===//
 
-typedef enum {
-  IREE_FLAG_DUMP_MODE_DEFAULT = 0,
+enum iree_flag_dump_mode_bits_t {
+  IREE_FLAG_DUMP_MODE_DEFAULT = 0u,
   IREE_FLAG_DUMP_MODE_VERBOSE = 1u << 0,
-} iree_flag_dump_mode_t;
+};
+typedef uint32_t iree_flag_dump_mode_t;
 
 #define IREE_FLAG_CTYPE_bool bool
 #define IREE_FLAG_CTYPE_int32_t int32_t
@@ -104,7 +105,7 @@ typedef enum {
 #if IREE_FLAGS_ENABLE_CLI == 1
 
 // Types of flags supported by the parser.
-typedef enum {
+typedef enum iree_flag_type_e {
   // Empty/unspecified sentinel.
   IREE_FLAG_TYPE_none = 0,
   // Custom parsing callback; see IREE_FLAG_CALLBACK.
@@ -221,7 +222,7 @@ int iree_flag_register(const char* file, int line, iree_flag_type_t type,
 //===----------------------------------------------------------------------===//
 
 // Controls how flag parsing is performed.
-enum iree_flags_parse_mode_e {
+enum iree_flags_parse_mode_bits_t {
   IREE_FLAGS_PARSE_MODE_DEFAULT = 0,
   // Do not error out on undefined flags; leave them in the list.
   // Useful when needing to chain multiple flag parsers together.

--- a/iree/base/internal/fpu_state.h
+++ b/iree/base/internal/fpu_state.h
@@ -21,7 +21,7 @@ extern "C" {
 //==============================================================================
 
 // Flags controlling FPU features.
-enum iree_fpu_state_flags_e {
+enum iree_fpu_state_flag_bits_t {
   // Platform default.
   IREE_FPU_STATE_DEFAULT = 0,
 
@@ -38,7 +38,7 @@ enum iree_fpu_state_flags_e {
 typedef uint32_t iree_fpu_state_flags_t;
 
 // Opaque FPU state vector manipulated with iree_fpu_* functions.
-typedef struct {
+typedef struct iree_fpu_state_t {
   uint64_t previous_value;
   uint64_t current_value;
 } iree_fpu_state_t;

--- a/iree/base/internal/synchronization.h
+++ b/iree/base/internal/synchronization.h
@@ -96,7 +96,8 @@ extern "C" {
 //
 // Windows: Slim Reader/Writer (SRW) Locks
 // All others: pthread_mutex_t
-typedef struct IREE_THREAD_ANNOTATION_ATTRIBUTE(capability("mutex")) {
+typedef struct iree_mutex_t IREE_THREAD_ANNOTATION_ATTRIBUTE(
+    capability("mutex")) {
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   int reserved;
 #elif defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
@@ -209,7 +210,8 @@ void iree_mutex_unlock(iree_mutex_t* mutex)
 //   https://man7.org/linux/man-pages/man2/futex.2.html
 //   https://eli.thegreenplace.net/2018/basics-of-futexes/
 //   https://bartoszmilewski.com/2008/09/01/thin-lock-vs-futex/
-typedef struct IREE_THREAD_ANNOTATION_ATTRIBUTE(capability("mutex")) {
+typedef struct iree_slim_mutex_t IREE_THREAD_ANNOTATION_ATTRIBUTE(
+    capability("mutex")) {
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   int reserved;
 #elif (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_FAST_LOCKS)
@@ -281,7 +283,7 @@ void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
 // https://github.com/r10a/Event-Counts
 // https://github.com/facebook/folly/blob/master/folly/experimental/EventCount.h
 // https://github.com/concurrencykit/ck/blob/master/include/ck_ec.h
-typedef struct {
+typedef struct iree_notification_t {
 #if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   // Nothing required.
 #elif !defined(IREE_PLATFORM_HAS_FUTEX)

--- a/iree/base/internal/threading.c
+++ b/iree/base/internal/threading.c
@@ -42,7 +42,7 @@ void iree_thread_affinity_set_any(iree_thread_affinity_t* out_thread_affinity) {
 // This is shared by multiple platform implementations and gets stripped in LTO
 // when unused.
 
-struct iree_thread_override_s {
+struct iree_thread_override_t {
   iree_thread_override_list_t* list;
   iree_thread_override_t* next;
   iree_thread_override_t* prev;

--- a/iree/base/internal/threading.h
+++ b/iree/base/internal/threading.h
@@ -21,14 +21,14 @@ extern "C" {
 // iree_thread_t
 //==============================================================================
 
-typedef struct iree_thread_s iree_thread_t;
+typedef struct iree_thread_t iree_thread_t;
 
 // Specifies a thread's priority class.
 // These translate roughly to the same thing across all platforms, though they
 // are just a hint and the schedulers on various platforms may behave very
 // differently. When in doubt prefer to write code that works at the extremes
 // of the classes.
-enum iree_thread_priority_class_e {
+typedef enum iree_thread_priority_class_e {
   // Lowest possible priority used for background/idle work.
   // Maps to QOS_CLASS_BACKGROUND.
   IREE_THREAD_PRIORITY_CLASS_LOWEST = -2,
@@ -44,8 +44,7 @@ enum iree_thread_priority_class_e {
   // Highest possible priority used for interactive work.
   // Maps to QOS_CLASS_USER_INTERACTIVE.
   IREE_THREAD_PRIORITY_CLASS_HIGHEST = 2,
-};
-typedef int32_t iree_thread_priority_class_t;
+} iree_thread_priority_class_t;
 
 // Specifies the processor affinity for a particular thread.
 // Each platform handles this differently (if at all).
@@ -69,7 +68,7 @@ typedef int32_t iree_thread_priority_class_t;
 //
 // Windows:
 //   Stuff just works. Love it.
-typedef struct {
+typedef struct iree_thread_affinity_t {
   uint32_t specified : 1;
   uint32_t smt : 1;
   uint32_t group : 7;
@@ -81,7 +80,7 @@ void iree_thread_affinity_set_any(iree_thread_affinity_t* out_thread_affinity);
 
 // Thread creation parameters.
 // All are optional and the entire struct can safely be zero-initialized.
-typedef struct {
+typedef struct iree_thread_create_params_t {
   // Developer-visible name for the thread displayed in tooling.
   // May be omitted for the system-default name (usually thread ID).
   iree_string_view_t name;
@@ -135,7 +134,7 @@ void iree_thread_release(iree_thread_t* thread);
 // Returns a platform-defined thread ID for the given |thread|.
 uintptr_t iree_thread_id(iree_thread_t* thread);
 
-typedef struct iree_thread_override_s iree_thread_override_t;
+typedef struct iree_thread_override_t iree_thread_override_t;
 
 // Begins overriding the priority class of the given |thread|.
 // The priority of the thread will be the max of the base priority and the

--- a/iree/base/internal/threading_darwin.c
+++ b/iree/base/internal/threading_darwin.c
@@ -22,7 +22,7 @@
 // Useful to see how pthreads is implemented on (old) darwin:
 // https://opensource.apple.com/source/Libc/Libc-825.40.1/pthreads/pthread.c.auto.html
 
-struct iree_thread_s {
+struct iree_thread_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/base/internal/threading_impl.h
+++ b/iree/base/internal/threading_impl.h
@@ -43,7 +43,7 @@ int iree_strncpy_s(char* dest, size_t destsz, const char* src, size_t count);
 typedef void (*iree_thread_set_priority_fn_t)(
     iree_thread_t* thread, iree_thread_priority_class_t priority_class);
 
-typedef struct {
+typedef struct iree_thread_override_list_t {
   iree_thread_set_priority_fn_t set_priority_fn;
   iree_thread_priority_class_t base_priority_class;
   iree_allocator_t allocator;

--- a/iree/base/internal/threading_pthreads.c
+++ b/iree/base/internal/threading_pthreads.c
@@ -32,7 +32,7 @@
 #define gettid() syscall(SYS_gettid)
 #endif
 
-struct iree_thread_s {
+struct iree_thread_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/base/internal/threading_test.cc
+++ b/iree/base/internal/threading_test.cc
@@ -28,14 +28,14 @@ TEST(ThreadTest, Lifetime) {
   memset(&params, 0, sizeof(params));
 
   // Our thread: do a bit of math and notify the main test thread when done.
-  struct entry_data_s {
+  struct entry_data_t {
     iree_atomic_int32_t value;
     iree_notification_t barrier;
   } entry_data;
   iree_atomic_store_int32(&entry_data.value, 123, iree_memory_order_relaxed);
   iree_notification_initialize(&entry_data.barrier);
   iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
-    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
     iree_atomic_fetch_add_int32(&entry_data->value, 1,
                                 iree_memory_order_acq_rel);
     iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
@@ -56,7 +56,7 @@ TEST(ThreadTest, Lifetime) {
   iree_notification_await(
       &entry_data.barrier,
       +[](void* entry_arg) -> bool {
-        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
         return iree_atomic_load_int32(&entry_data->value,
                                       iree_memory_order_relaxed) == (123 + 1);
       },
@@ -69,14 +69,14 @@ TEST(ThreadTest, CreateSuspended) {
   memset(&params, 0, sizeof(params));
   params.create_suspended = true;
 
-  struct entry_data_s {
+  struct entry_data_t {
     iree_atomic_int32_t value;
     iree_notification_t barrier;
   } entry_data;
   iree_atomic_store_int32(&entry_data.value, 123, iree_memory_order_relaxed);
   iree_notification_initialize(&entry_data.barrier);
   iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
-    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
     iree_atomic_fetch_add_int32(&entry_data->value, 1,
                                 iree_memory_order_acq_rel);
     iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
@@ -103,7 +103,7 @@ TEST(ThreadTest, CreateSuspended) {
   iree_notification_await(
       &entry_data.barrier,
       +[](void* entry_arg) -> bool {
-        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
         return iree_atomic_load_int32(&entry_data->value,
                                       iree_memory_order_relaxed) == (123 + 1);
       },
@@ -120,14 +120,14 @@ TEST(ThreadTest, PriorityOverride) {
   iree_thread_create_params_t params;
   memset(&params, 0, sizeof(params));
 
-  struct entry_data_s {
+  struct entry_data_t {
     iree_atomic_int32_t value;
     iree_notification_t barrier;
   } entry_data;
   iree_atomic_store_int32(&entry_data.value, 0, iree_memory_order_relaxed);
   iree_notification_initialize(&entry_data.barrier);
   iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
-    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
     iree_atomic_fetch_add_int32(&entry_data->value, 1,
                                 iree_memory_order_acq_rel);
     iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
@@ -154,7 +154,7 @@ TEST(ThreadTest, PriorityOverride) {
   iree_notification_await(
       &entry_data.barrier,
       +[](void* entry_arg) -> bool {
-        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
         return iree_atomic_load_int32(&entry_data->value,
                                       iree_memory_order_relaxed) == 1;
       },

--- a/iree/base/internal/threading_win32.c
+++ b/iree/base/internal/threading_win32.c
@@ -19,7 +19,7 @@
 // Great documentation:
 // https://www.microsoftpressstore.com/articles/article.aspx?p=2233328
 
-struct iree_thread_s {
+struct iree_thread_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/base/internal/wait_handle.h
+++ b/iree/base/internal/wait_handle.h
@@ -40,7 +40,7 @@ extern "C" {
 // runtime surprises).
 
 // Specifies the type of a wait handle.
-enum iree_wait_primitive_type_e {
+enum iree_wait_primitive_type_bits_t {
   // Android/Linux eventfd handle.
   // These are akin to pipe() but require only a single handle and have
   // significantly lower overhead (equivalent if not slightly better than
@@ -123,7 +123,7 @@ typedef union {
 
 // Non-owning handle reference to a waitable object.
 // TODO(benvanik): packing to ensure we are getting the expected alignments.
-typedef struct {
+typedef struct iree_wait_handle_t {
   iree_wait_primitive_type_t type;  // uint8_t
   union {
     // Used by iree_wait_set_t storage to track the number of duplicate
@@ -176,7 +176,7 @@ void iree_wait_handle_deinitialize(iree_wait_handle_t* handle);
 //
 // Thread-compatible; only one thread may be manipulating or waiting on a
 // particular set at any time.
-typedef struct iree_wait_set_s iree_wait_set_t;
+typedef struct iree_wait_set_t iree_wait_set_t;
 
 // Allocates a wait set with the maximum |capacity| of unique handles.
 iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,

--- a/iree/base/internal/wait_handle_epoll.c
+++ b/iree/base/internal/wait_handle_epoll.c
@@ -20,7 +20,7 @@
 // epoll lets us route the wait set operations right to kernel and not need our
 // own duplicate data structure. epoll is great, just not available on mac/ios
 // so we still need poll for that. linux/android/bsd all have epoll, though.
-struct iree_wait_set_s {
+struct iree_wait_set_t {
   // NOTE: we could in theory use the epoll handle directly (iree_wait_set_s
   // then is just a pointer). Then allocate/free just go straight to the system.
   int reserved;

--- a/iree/base/internal/wait_handle_kqueue.c
+++ b/iree/base/internal/wait_handle_kqueue.c
@@ -19,7 +19,7 @@
 // TODO(benvanik): iree_wait_set_s using a kqueue.
 // Could just cast the kqueue() fd to iree_wait_set_s* to avoid allocs.
 // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
-struct iree_wait_set_s {
+struct iree_wait_set_t {
   int reserved;
 };
 

--- a/iree/base/internal/wait_handle_poll.c
+++ b/iree/base/internal/wait_handle_poll.c
@@ -113,7 +113,7 @@ static iree_status_t iree_syscall_poll(struct pollfd* fds, nfds_t nfds,
 // iree_wait_set_t
 //===----------------------------------------------------------------------===//
 
-struct iree_wait_set_s {
+struct iree_wait_set_t {
   iree_allocator_t allocator;
 
   // Total capacity of each handle list.

--- a/iree/base/internal/wait_handle_win32.c
+++ b/iree/base/internal/wait_handle_win32.c
@@ -91,7 +91,7 @@ static bool iree_wait_primitive_compare_identical(
 // iree_wait_set_t
 //===----------------------------------------------------------------------===//
 
-struct iree_wait_set_s {
+struct iree_wait_set_t {
   iree_allocator_t allocator;
 
   // Total capacity of handles in the set (including duplicates).

--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -276,18 +276,18 @@ IREE_API_EXPORT const char* iree_status_code_string(iree_status_code_t code) {
 // TODO(#55): move payload methods/types to header when API is stabilized.
 
 // Defines the type of an iree_status_payload_t.
-typedef enum {
+typedef enum iree_status_payload_type_e {
   // Opaque; payload may still be formatted by a formatter but is not possible
   // to retrieve by the programmatic APIs.
-  IREE_STATUS_PAYLOAD_TYPE_OPAQUE = 0u,
+  IREE_STATUS_PAYLOAD_TYPE_OPAQUE = 0,
   // A string message annotation of type iree_status_payload_message_t.
-  IREE_STATUS_PAYLOAD_TYPE_MESSAGE = 1u,
+  IREE_STATUS_PAYLOAD_TYPE_MESSAGE = 1,
   // Starting type ID for user payloads. IREE reserves all payloads with types
   // less than this.
   IREE_STATUS_PAYLOAD_TYPE_MIN_USER = 0x70000000u,
 } iree_status_payload_type_t;
 
-typedef struct iree_status_payload_s iree_status_payload_t;
+typedef struct iree_status_payload_t iree_status_payload_t;
 
 // Function that formats a payload into a human-readable string form for logs.
 typedef void(IREE_API_PTR* iree_status_payload_formatter_t)(
@@ -298,9 +298,9 @@ typedef void(IREE_API_PTR* iree_status_payload_formatter_t)(
 // Each status may have zero or more payloads associated with it that can later
 // be used to produce more detailed logging or programmatically query
 // information about an error.
-struct iree_status_payload_s {
+struct iree_status_payload_t {
   // Next payload in the status payload linked list.
-  struct iree_status_payload_s* next;
+  struct iree_status_payload_t* next;
   // Payload type identifier used for programmatic access to payloads. May be
   // IREE_STATUS_PAYLOAD_TYPE_OPAQUE if the payload cannot be accessed directly.
   iree_status_payload_type_t type;
@@ -313,7 +313,7 @@ struct iree_status_payload_s {
 };
 
 // A string message (IREE_STATUS_PAYLOAD_TYPE_MESSAGE).
-typedef struct {
+typedef struct iree_status_payload_message_t {
   iree_status_payload_t header;
   // String data reference. May point to an address immediately following this
   // struct (if copied) or a constant string reference in rodata.
@@ -323,7 +323,7 @@ typedef struct {
 // Allocated storage for an iree_status_t.
 // Only statuses that have either source information or payloads will have
 // storage allocated for them.
-typedef struct {
+typedef struct iree_status_storage_t {
   // Optional doubly-linked list of payloads associated with the status.
   // Head = first added, tail = last added.
   iree_status_payload_t* payload_head;

--- a/iree/base/string_view.h
+++ b/iree/base/string_view.h
@@ -21,7 +21,7 @@ extern "C" {
 #define IREE_STRING_VIEW_NPOS SIZE_MAX
 
 // A string view (ala std::string_view) into a non-NUL-terminated string.
-typedef struct {
+typedef struct iree_string_view_t {
   const char* data;
   iree_host_size_t size;
 } iree_string_view_t;

--- a/iree/base/time.h
+++ b/iree/base/time.h
@@ -64,7 +64,7 @@ iree_relative_timeout_to_deadline_ns(iree_duration_t timeout_ns);
 IREE_API_EXPORT iree_duration_t
 iree_absolute_deadline_to_timeout_ns(iree_time_t deadline_ns);
 
-typedef enum {
+typedef enum iree_timeout_type_e {
   // Timeout is defined by an absolute value `deadline_ns`.
   IREE_TIMEOUT_ABSOLUTE = 0,
   // Timeout is defined by a relative value `timeout_ns`.
@@ -72,7 +72,7 @@ typedef enum {
 } iree_timeout_type_t;
 
 // A timeout defined either by an absolute or relative value.
-typedef struct {
+typedef struct iree_timeout_t {
   iree_timeout_type_t type;
   iree_time_t nanos;
 } iree_timeout_t;

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -54,8 +54,8 @@ static LogicalResult printStructDefinitions(IREE::VM::ModuleOp &moduleOp,
   llvm::raw_ostream &output = emitter.ostream();
   std::string moduleName = moduleOp.getName().str();
 
-  output << "struct " << moduleName << "_s;\n";
-  output << "struct " << moduleName << "_state_s {\n";
+  output << "struct " << moduleName << "_t;\n";
+  output << "struct " << moduleName << "_state_t {\n";
 
   output << "iree_allocator_t allocator;\n";
   output << "uint8_t rwdata["
@@ -64,8 +64,8 @@ static LogicalResult printStructDefinitions(IREE::VM::ModuleOp &moduleOp,
          << moduleOp.ordinal_counts().getValue().global_refs() << "];\n";
   output << "};\n";
 
-  output << "typedef struct " << moduleName << "_s " << moduleName << "_t;\n";
-  output << "typedef struct " << moduleName << "_state_s " << moduleName
+  output << "typedef struct " << moduleName << "_t " << moduleName << "_t;\n";
+  output << "typedef struct " << moduleName << "_state_t " << moduleName
          << "_state_t;\n";
 
   output << "\n";

--- a/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
@@ -2,7 +2,7 @@
 
 vm.module @global_ops {
   // check the generated state struct
-  // CHECK-LABEL: struct global_ops_state_s {
+  // CHECK-LABEL: struct global_ops_state_t {
   // CHECK-NEXT: iree_allocator_t allocator;
   // CHECK-NEXT: uint8_t rwdata[8];
   // CHECK-NEXT: iree_vm_ref_t refs[0];

--- a/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
+++ b/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
@@ -48,6 +48,9 @@ spirv::Vendor getVendor(const TargetTriple &triple) {
         default:
           return spirv::Vendor::Unknown;
       }
+    default:
+      llvm_unreachable("unhandled vendor");
+      return spirv::Vendor::Unknown;
   }
 }
 
@@ -66,6 +69,9 @@ spirv::DeviceType getDeviceType(const TargetTriple &triple) {
     case TargetTripleArch::ARM_Valhall:
     case TargetTripleArch::QC_Adreno:
       return spirv::DeviceType::IntegratedGPU;
+    default:
+      llvm_unreachable("unhandled device type");
+      return spirv::DeviceType::Unknown;
   }
 }
 

--- a/iree/hal/allocator.h
+++ b/iree/hal/allocator.h
@@ -23,7 +23,7 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 // A bitfield indicating compatible behavior for buffers in an allocator.
-enum iree_hal_buffer_compatibility_e {
+enum iree_hal_buffer_compatibility_bits_t {
   // Indicates (in the absence of other bits) the buffer is not compatible with
   // the allocator or device at all. Any attempts to use the buffer for any
   // usage will fail. This will happen if the buffer is device-local to another
@@ -57,7 +57,7 @@ typedef uint32_t iree_hal_buffer_compatibility_t;
 // iree_hal_allocator_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_allocator_s iree_hal_allocator_t;
+typedef struct iree_hal_allocator_t iree_hal_allocator_t;
 
 // Retains the given |allocator| for the caller.
 IREE_API_EXPORT void iree_hal_allocator_retain(iree_hal_allocator_t* allocator);
@@ -143,7 +143,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
 // iree_hal_allocator_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_allocator_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/allocator_heap.c
+++ b/iree/hal/allocator_heap.c
@@ -9,7 +9,7 @@
 #include "iree/hal/buffer_heap_impl.h"
 #include "iree/hal/detail.h"
 
-typedef struct iree_hal_heap_allocator_s {
+typedef struct iree_hal_heap_allocator_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_string_view_t identifier;

--- a/iree/hal/buffer.c
+++ b/iree/hal/buffer.c
@@ -593,7 +593,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_copy_data(
 // Mapping / iree_hal_buffer_mapping_impl_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_buffer_mapping_impl_t {
   // Must be first (as in iree_hal_buffer_mapping_t).
   // Stores both the offset data pointer and the byte_length of the mapping.
   iree_byte_span_t contents;

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_allocator_s iree_hal_allocator_t;
+typedef struct iree_hal_allocator_t iree_hal_allocator_t;
 
 //===----------------------------------------------------------------------===//
 // Types and Enums
@@ -27,7 +27,7 @@ typedef struct iree_hal_allocator_s iree_hal_allocator_t;
 #define IREE_WHOLE_BUFFER ((iree_device_size_t)(-1))
 
 // A bitfield specifying properties for a memory type.
-enum iree_hal_memory_type_e {
+enum iree_hal_memory_type_bits_t {
   IREE_HAL_MEMORY_TYPE_NONE = 0u,
 
   // Memory is lazily allocated by the device and only exists transiently.
@@ -82,7 +82,7 @@ enum iree_hal_memory_type_e {
 typedef uint32_t iree_hal_memory_type_t;
 
 // A bitfield specifying how memory will be accessed in a mapped memory region.
-enum iree_hal_memory_access_e {
+enum iree_hal_memory_access_bits_t {
   // Memory is not mapped.
   IREE_HAL_MEMORY_ACCESS_NONE = 0u,
   // Memory will be read.
@@ -116,7 +116,7 @@ typedef uint32_t iree_hal_memory_access_t;
 // Bitfield that defines how a buffer is intended to be used.
 // Usage allows the driver to appropriately place the buffer for more
 // efficient operations of the specified types.
-enum iree_hal_buffer_usage_e {
+enum iree_hal_buffer_usage_bits_t {
   IREE_HAL_BUFFER_USAGE_NONE = 0u,
 
   // The buffer, once defined, will not be mapped or updated again.
@@ -154,24 +154,23 @@ enum iree_hal_buffer_usage_e {
 typedef uint32_t iree_hal_buffer_usage_t;
 
 // Buffer overlap testing results.
-enum iree_hal_buffer_overlap_e {
+typedef enum iree_hal_buffer_overlap_e {
   // No overlap between the two buffers.
   IREE_HAL_BUFFER_OVERLAP_DISJOINT = 0,
   // Partial overlap between the two buffers.
   IREE_HAL_BUFFER_OVERLAP_PARTIAL,
   // Complete overlap between the two buffers (they are the same).
   IREE_HAL_BUFFER_OVERLAP_COMPLETE,
-};
-typedef uint8_t iree_hal_buffer_overlap_t;
+} iree_hal_buffer_overlap_t;
 
-enum iree_hal_mapping_mode_e {
-  IREE_HAL_MAPPING_MODE_SCOPED = 0,
-  IREE_HAL_MAPPING_MODE_PERSISTENT = 0,
+enum iree_hal_mapping_mode_bits_t {
+  IREE_HAL_MAPPING_MODE_SCOPED = 1u << 0,
+  IREE_HAL_MAPPING_MODE_PERSISTENT = 1u << 1,
 };
 typedef uint32_t iree_hal_mapping_mode_t;
 
 // Reference to a buffer's mapped memory.
-typedef struct {
+typedef struct iree_hal_buffer_mapping_t {
   // Contents of the buffer. Behavior is undefined if an access is performed
   // whose type was not specified during mapping.
   //
@@ -253,7 +252,7 @@ typedef struct {
 // a device. iree_hal_buffer_Subspan can be used to reference subspans of
 // buffers like absl::Span - though unlike absl::Span the returned Buffer holds
 // a reference to the parent buffer.
-typedef struct iree_hal_buffer_s iree_hal_buffer_t;
+typedef struct iree_hal_buffer_t iree_hal_buffer_t;
 
 // Returns success iff the buffer was allocated with the given memory type.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_validate_memory_type(
@@ -486,7 +485,7 @@ IREE_API_EXPORT iree_status_t iree_hal_heap_buffer_wrap(
 // iree_hal_buffer_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_buffer_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 
@@ -513,7 +512,7 @@ typedef struct {
       iree_device_size_t local_byte_length);
 } iree_hal_buffer_vtable_t;
 
-struct iree_hal_buffer_s {
+struct iree_hal_buffer_t {
   iree_hal_resource_t resource;
 
   iree_hal_allocator_t* allocator;

--- a/iree/hal/buffer_heap.c
+++ b/iree/hal/buffer_heap.c
@@ -9,7 +9,7 @@
 #include "iree/hal/buffer.h"
 #include "iree/hal/detail.h"
 
-typedef struct iree_hal_heap_buffer_s {
+typedef struct iree_hal_heap_buffer_t {
   iree_hal_buffer_t base;
 
   iree_byte_span_t data;

--- a/iree/hal/buffer_view.c
+++ b/iree/hal/buffer_view.c
@@ -14,7 +14,7 @@
 #include "iree/hal/detail.h"
 #include "iree/hal/string_util.h"
 
-struct iree_hal_buffer_view_s {
+struct iree_hal_buffer_view_t {
   iree_atomic_ref_count_t ref_count;
   iree_hal_buffer_t* buffer;
   iree_hal_element_type_t element_type;

--- a/iree/hal/buffer_view.h
+++ b/iree/hal/buffer_view.h
@@ -25,7 +25,7 @@ extern "C" {
 // NOTE: these values must be in sync with
 //    iree/compiler/Dialect/HAL/IR/HALTypes.cpp
 
-enum iree_hal_numerical_type_e {
+enum iree_hal_numerical_type_bits_t {
   IREE_HAL_NUMERICAL_TYPE_UNKNOWN = 0x00u,
   IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED = 0x01u,
   IREE_HAL_NUMERICAL_TYPE_INTEGER_UNSIGNED = 0x02u,
@@ -55,7 +55,7 @@ typedef uint8_t iree_hal_numerical_type_t;
 //   [numerical type] [reserved] [reserved] [number of bits]
 //
 // clang-format off
-enum iree_hal_element_type_e {
+enum iree_hal_element_types_t {
   IREE_HAL_ELEMENT_TYPE_NONE             = IREE_HAL_ELEMENT_TYPE_VALUE(IREE_HAL_NUMERICAL_TYPE_UNKNOWN,             0),  // NOLINT
   IREE_HAL_ELEMENT_TYPE_OPAQUE_8         = IREE_HAL_ELEMENT_TYPE_VALUE(IREE_HAL_NUMERICAL_TYPE_UNKNOWN,             8),  // NOLINT
   IREE_HAL_ELEMENT_TYPE_OPAQUE_16        = IREE_HAL_ELEMENT_TYPE_VALUE(IREE_HAL_NUMERICAL_TYPE_UNKNOWN,            16),  // NOLINT
@@ -113,7 +113,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_range(
 // effectively just `tuple(shape, type, buffer)`, and if the application is
 // already tracking this information in its own structures this entire type can
 // be ignored.
-typedef struct iree_hal_buffer_view_s iree_hal_buffer_view_t;
+typedef struct iree_hal_buffer_view_t iree_hal_buffer_view_t;
 
 // Creates a buffer view with the given |buffer|.
 // |out_buffer_view| must be released by the caller.

--- a/iree/hal/command_buffer.h
+++ b/iree/hal/command_buffer.h
@@ -22,14 +22,14 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
 // A bitfield specifying the mode of operation for a command buffer.
-enum iree_hal_command_buffer_mode_e {
+enum iree_hal_command_buffer_mode_bits_t {
   // Command buffer will be submitted once and never used again.
   // This may enable in-place patching of command buffers that reduce overhead
   // when it's known that command buffers will not be reused.
@@ -63,7 +63,7 @@ enum iree_hal_command_buffer_mode_e {
 typedef uint32_t iree_hal_command_buffer_mode_t;
 
 // A bitfield specifying the category of commands in a command queue.
-enum iree_hal_command_category_e {
+enum iree_hal_command_category_bits_t {
   // Command is considered a transfer operation (memcpy, etc).
   IREE_HAL_COMMAND_CATEGORY_TRANSFER = 1u << 0,
   // Command is considered a dispatch operation (dispatch/execute).
@@ -96,7 +96,7 @@ typedef uint64_t iree_hal_queue_affinity_t;
 // Bitfield specifying which execution stage a barrier should start/end at.
 //
 // Maps to VkPipelineStageFlagBits.
-enum iree_hal_execution_stage_e {
+enum iree_hal_execution_stage_bits_t {
   // Top of the pipeline when commands are initially issued by the device.
   IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE = 1u << 0,
   // Stage of the pipeline when dispatch parameter data is consumed.
@@ -115,7 +115,7 @@ typedef uint32_t iree_hal_execution_stage_t;
 // Bitfield specifying flags controlling an execution dependency.
 //
 // Maps to VkDependencyFlags.
-enum iree_hal_execution_barrier_flags_e {
+enum iree_hal_execution_barrier_flag_bits_t {
   IREE_HAL_EXECUTION_BARRIER_FLAG_NONE = 0,
 };
 typedef uint32_t iree_hal_execution_barrier_flags_t;
@@ -123,7 +123,7 @@ typedef uint32_t iree_hal_execution_barrier_flags_t;
 // Bitfield specifying which scopes will access memory and how.
 //
 // Maps to VkAccessFlagBits.
-enum iree_hal_access_scope_e {
+enum iree_hal_access_scope_bits_t {
   // Read access to indirect command data as part of an indirect dispatch.
   IREE_HAL_ACCESS_SCOPE_INDIRECT_COMMAND_READ = 1u << 0,
   // Constant uniform buffer reads by the device.
@@ -154,7 +154,7 @@ typedef uint32_t iree_hal_access_scope_t;
 // completely changing execution contexts).
 //
 // Maps to VkMemoryBarrier.
-typedef struct {
+typedef struct iree_hal_memory_barrier_t {
   // All access scopes prior-to the barrier (inclusive).
   iree_hal_access_scope_t source_scope;
   // All access scopes following the barrier (inclusive).
@@ -167,7 +167,7 @@ typedef struct {
 // reordering.
 //
 // Maps to VkBufferMemoryBarrier.
-typedef struct {
+typedef struct iree_hal_buffer_barrier_t {
   // All access scopes prior-to the barrier (inclusive).
   iree_hal_access_scope_t source_scope;
   // All access scopes following the barrier (inclusive).
@@ -218,7 +218,7 @@ typedef struct {
 // to record commands from multiple threads. Command buffers must not be mutated
 // between when they have are submitted for execution on a queue and when the
 // semaphore fires indicating the completion of their execution.
-typedef struct iree_hal_command_buffer_s iree_hal_command_buffer_t;
+typedef struct iree_hal_command_buffer_t iree_hal_command_buffer_t;
 
 // Creates a command buffer ready to begin recording, possibly reusing an
 // existing one from the |device| pool.
@@ -453,7 +453,7 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_wrap_validation(
 // iree_hal_command_buffer_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_command_buffer_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -11,7 +11,7 @@
 #include "iree/hal/command_buffer.h"
 #include "iree/hal/device.h"
 
-typedef struct {
+typedef struct iree_hal_validating_command_buffer_t {
   iree_hal_resource_t resource;
   iree_hal_device_t* device;
   iree_hal_command_buffer_t* target_command_buffer;

--- a/iree/hal/cuda/api.h
+++ b/iree/hal/cuda/api.h
@@ -21,7 +21,7 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 // CUDA driver creation options.
-typedef struct {
+typedef struct iree_hal_cuda_driver_options_t {
   // Index of the default CUDA device to use within the list of available
   // devices.
   int default_device_index;

--- a/iree/hal/cuda/context_wrapper.h
+++ b/iree/hal/cuda/context_wrapper.h
@@ -13,7 +13,7 @@
 
 // Structure to wrap all objects constant within a context. This makes it
 // simpler to pass it to the different objects and saves memory.
-typedef struct {
+typedef struct iree_hal_cuda_context_wrapper_t {
   CUcontext cu_context;
   iree_allocator_t host_allocator;
   iree_hal_cuda_dynamic_symbols_t* syms;

--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -10,7 +10,7 @@
 #include "iree/hal/cuda/cuda_buffer.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct iree_hal_cuda_allocator_s {
+typedef struct iree_hal_cuda_allocator_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
 } iree_hal_cuda_allocator_t;

--- a/iree/hal/cuda/cuda_buffer.c
+++ b/iree/hal/cuda/cuda_buffer.c
@@ -10,7 +10,7 @@
 #include "iree/hal/cuda/cuda_allocator.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct iree_hal_cuda_buffer_s {
+typedef struct iree_hal_cuda_buffer_t {
   iree_hal_buffer_t base;
   void* host_ptr;
   CUdeviceptr device_ptr;

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -22,7 +22,7 @@
 // iree_hal_cuda_device_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_cuda_device_t {
   iree_hal_resource_t resource;
   iree_string_view_t identifier;
 

--- a/iree/hal/cuda/cuda_driver.c
+++ b/iree/hal/cuda/cuda_driver.c
@@ -10,7 +10,7 @@
 #include "iree/hal/cuda/dynamic_symbols.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_driver_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   // Identifier used for the driver in the IREE driver registry.

--- a/iree/hal/cuda/cuda_event.c
+++ b/iree/hal/cuda/cuda_event.c
@@ -10,7 +10,7 @@
 #include "iree/hal/cuda/status_util.h"
 
 // Dummy events for now, don't do anything.
-typedef struct {
+typedef struct iree_hal_cuda_event_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context_wrapper;
 } iree_hal_cuda_event_t;

--- a/iree/hal/cuda/descriptor_set_layout.c
+++ b/iree/hal/cuda/descriptor_set_layout.c
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_descriptor_set_layout_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
 } iree_hal_cuda_descriptor_set_layout_t;

--- a/iree/hal/cuda/dynamic_symbols.h
+++ b/iree/hal/cuda/dynamic_symbols.h
@@ -19,7 +19,7 @@ extern "C" {
 // loads all the function declared in `dynamic_symbol_tables.def` and fail if
 // any of the symbol is not available. The functions signatures are matching
 // the declarations in `cuda.h`.
-typedef struct {
+typedef struct iree_hal_cuda_dynamic_symbols_t {
   iree_dynamic_library_t* loader_library;
 
 #define CU_PFN_DECL(cudaSymbolName, ...) \

--- a/iree/hal/cuda/event_semaphore.c
+++ b/iree/hal/cuda/event_semaphore.c
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_semaphore_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
   uint64_t initial_value;

--- a/iree/hal/cuda/executable_layout.c
+++ b/iree/hal/cuda/executable_layout.c
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/status_util.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_executable_layout_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
   iree_host_size_t set_layout_count;

--- a/iree/hal/cuda/graph_command_buffer.c
+++ b/iree/hal/cuda/graph_command_buffer.c
@@ -15,7 +15,7 @@
 // Command buffer implementation that directly maps to cuda graph.
 // This records the commands on the calling thread without additional threading
 // indirection.
-typedef struct {
+typedef struct iree_hal_cuda_graph_command_buffer_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
   iree_hal_command_buffer_mode_t mode;

--- a/iree/hal/cuda/native_executable.c
+++ b/iree/hal/cuda/native_executable.c
@@ -14,14 +14,14 @@
 #include "iree/schemas/cuda_executable_def_reader.h"
 #include "iree/schemas/cuda_executable_def_verifier.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_native_executable_function_t {
   CUfunction cu_function;
   uint32_t block_size_x;
   uint32_t block_size_y;
   uint32_t block_size_z;
 } iree_hal_cuda_native_executable_function_t;
 
-typedef struct {
+typedef struct iree_hal_cuda_native_executable_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
   iree_host_size_t entry_count;

--- a/iree/hal/cuda/nop_executable_cache.c
+++ b/iree/hal/cuda/nop_executable_cache.c
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/native_executable.h"
 
-typedef struct {
+typedef struct iree_hal_cuda_nop_executable_cache_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
 } iree_hal_cuda_nop_executable_cache_t;

--- a/iree/hal/descriptor_set.h
+++ b/iree/hal/descriptor_set.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // Types and Enums
@@ -35,7 +35,7 @@ typedef struct iree_hal_device_s iree_hal_device_t;
 // be applied at the time the binding is recording into the command buffer.
 //
 // Maps to VkDescriptorSetBinding.
-typedef struct {
+typedef struct iree_hal_descriptor_set_binding_t {
   // The binding number of this entry and corresponds to a resource of the
   // same binding number in the executable interface.
   uint32_t binding;
@@ -65,7 +65,7 @@ typedef struct {
 //
 // Maps to VkDescriptorSet:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSet.html
-typedef struct iree_hal_descriptor_set_s iree_hal_descriptor_set_t;
+typedef struct iree_hal_descriptor_set_t iree_hal_descriptor_set_t;
 
 // Creates a descriptor set of the given layout and bindings.
 // Descriptor sets are immutable and retain their bindings.
@@ -87,7 +87,7 @@ IREE_API_EXPORT void iree_hal_descriptor_set_release(
 // iree_hal_descriptor_set_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_descriptor_set_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/descriptor_set_layout.h
+++ b/iree/hal/descriptor_set_layout.h
@@ -18,34 +18,32 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
 // Specifies the type of a descriptor in a descriptor set.
-enum iree_hal_descriptor_type_e {
-  IREE_HAL_DESCRIPTOR_TYPE_UNIFORM_BUFFER = 6u,
-  IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER = 7u,
-  IREE_HAL_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = 8u,
-  IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = 9u,
-};
-typedef uint32_t iree_hal_descriptor_type_t;
+typedef enum iree_hal_descriptor_type_e {
+  IREE_HAL_DESCRIPTOR_TYPE_UNIFORM_BUFFER = 6,
+  IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER = 7,
+  IREE_HAL_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = 8,
+  IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = 9,
+} iree_hal_descriptor_type_t;
 
 // Specifies the usage type of the descriptor set.
-enum iree_hal_descriptor_set_layout_usage_type_e {
+typedef enum iree_hal_descriptor_set_layout_usage_type_e {
   // Descriptor set will be initialized once and never changed.
-  IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_IMMUTABLE = 0u,
+  IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_IMMUTABLE = 0,
   // Descriptor set is never created and instead used with push descriptors.
-  IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_PUSH_ONLY = 1u,
-};
-typedef uint32_t iree_hal_descriptor_set_layout_usage_type_t;
+  IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_PUSH_ONLY = 1,
+} iree_hal_descriptor_set_layout_usage_type_t;
 
 // Specifies a descriptor set layout binding.
 //
 // Maps to VkDescriptorSetLayoutBinding.
-typedef struct {
+typedef struct iree_hal_descriptor_set_layout_binding_t {
   // The binding number of this entry and corresponds to a resource of the
   // same binding number in the executable interface.
   uint32_t binding;
@@ -69,7 +67,7 @@ typedef struct {
 //
 // Maps to VkDescriptorSetLayout:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayout.html
-typedef struct iree_hal_descriptor_set_layout_s
+typedef struct iree_hal_descriptor_set_layout_t
     iree_hal_descriptor_set_layout_t;
 
 // Creates a descriptor set layout with the given bindings.
@@ -92,7 +90,7 @@ IREE_API_EXPORT void iree_hal_descriptor_set_layout_release(
 // iree_hal_descriptor_set_layout_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_descriptor_set_layout_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -38,8 +38,8 @@ typedef uintptr_t iree_hal_device_id_t;
 // request of the calling application. Note that certain features may disable
 // runtime optimizations or require compilation flags to ensure the required
 // metadata is present in executables.
-enum iree_hal_device_feature_e {
-  IREE_HAL_DEVICE_FEATURE_NONE = 0,
+enum iree_hal_device_feature_bits_t {
+  IREE_HAL_DEVICE_FEATURE_NONE = 0u,
 
   // Device supports executable debugging.
   // When present executables *may* be compiled with
@@ -47,26 +47,26 @@ enum iree_hal_device_feature_e {
   // debugging related methods. Note that if the input executables do not have
   // embedded debugging information they still may not be able to perform
   // disassembly or fine-grained breakpoint insertion.
-  IREE_HAL_DEVICE_FEATURE_SUPPORTS_DEBUGGING = 1 << 0,
+  IREE_HAL_DEVICE_FEATURE_SUPPORTS_DEBUGGING = 1u << 0,
 
   // Device supports executable coverage information.
   // When present executables *may* be compiled with
   // IREE_HAL_EXECUTABLE_CACHING_MODE_ENABLE_COVERAGE and will produce
   // coverage buffers during dispatch. Note that input executables must have
   // partial embedded debug information to allow mapping back to source offsets.
-  IREE_HAL_DEVICE_FEATURE_SUPPORTS_COVERAGE = 1 << 1,
+  IREE_HAL_DEVICE_FEATURE_SUPPORTS_COVERAGE = 1u << 1,
 
   // Device supports executable and command queue profiling.
   // When present executables *may* be compiled with
   // IREE_HAL_EXECUTABLE_CACHING_MODE_ENABLE_PROFILING and will produce
   // profiling buffers during dispatch. Note that input executables must have
   // partial embedded debug information to allow mapping back to source offsets.
-  IREE_HAL_DEVICE_FEATURE_SUPPORTS_PROFILING = 1 << 2,
+  IREE_HAL_DEVICE_FEATURE_SUPPORTS_PROFILING = 1u << 2,
 };
 typedef uint32_t iree_hal_device_feature_t;
 
 // Describes an enumerated HAL device.
-typedef struct {
+typedef struct iree_hal_device_info_t {
   // Opaque handle used by drivers. Not valid across driver instances.
   iree_hal_device_id_t device_id;
   // Name of the device as returned by the API.
@@ -76,7 +76,7 @@ typedef struct {
 // A list of semaphores and their corresponding payloads.
 // When signaling each semaphore will be set to the new payload value provided.
 // When waiting each semaphore must reach or exceed the payload value.
-typedef struct {
+typedef struct iree_hal_semaphore_list_t {
   iree_host_size_t count;
   iree_hal_semaphore_t** semaphores;
   uint64_t* payload_values;
@@ -96,7 +96,7 @@ typedef struct {
 // Note that as the HAL only models timeline semaphores we take the payload
 // values directly in this struct; see:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTimelineSemaphoreSubmitInfo.html
-typedef struct {
+typedef struct iree_hal_submission_batch_t {
   // Semaphores to wait on prior to executing any command buffer.
   iree_hal_semaphore_list_t wait_semaphores;
 
@@ -109,19 +109,18 @@ typedef struct {
 } iree_hal_submission_batch_t;
 
 // Defines how a multi-wait operation treats the results of multiple semaphores.
-enum iree_hal_wait_mode_e {
+typedef enum iree_hal_wait_mode_e {
   // Waits for all semaphores to reach or exceed their specified values.
   IREE_HAL_WAIT_MODE_ALL = 0,
   // Waits for one or more semaphores to reach or exceed their specified values.
   IREE_HAL_WAIT_MODE_ANY = 1,
-};
-typedef uint8_t iree_hal_wait_mode_t;
+} iree_hal_wait_mode_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_device_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 // Retains the given |device| for the caller.
 IREE_API_EXPORT void iree_hal_device_retain(iree_hal_device_t* device);
@@ -235,7 +234,7 @@ iree_hal_device_wait_idle(iree_hal_device_t* device, iree_timeout_t timeout);
 // iree_hal_device_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_device_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/driver.h
+++ b/iree/hal/driver.h
@@ -37,7 +37,7 @@ typedef uint64_t iree_hal_driver_id_t;
 //   only guaranteed to live for as long as the driver is.
 // * When enumerating via factories the information may be valid only while the
 //   driver registry lock is held.
-typedef struct {
+typedef struct iree_hal_driver_info_t {
   IREE_API_UNSTABLE
 
   // Opaque handle used by factories. Unique across all factories.
@@ -61,7 +61,7 @@ typedef struct {
 // iree_hal_driver_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_driver_s iree_hal_driver_t;
+typedef struct iree_hal_driver_t iree_hal_driver_t;
 
 // Retains the given |driver| for the caller.
 IREE_API_EXPORT void iree_hal_driver_retain(iree_hal_driver_t* driver);
@@ -93,7 +93,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_create_default_device(
 // iree_hal_driver_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_driver_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/driver_registry.c
+++ b/iree/hal/driver_registry.c
@@ -27,7 +27,7 @@
 // isolating/sandboxing/multi-versioning).
 #define IREE_HAL_MAX_DRIVER_FACTORY_COUNT 8
 
-struct iree_hal_driver_registry_s {
+struct iree_hal_driver_registry_t {
   iree_slim_mutex_t mutex;
 
   // Factories in registration order. As factories are unregistered the list is

--- a/iree/hal/driver_registry.h
+++ b/iree/hal/driver_registry.h
@@ -35,7 +35,7 @@ extern "C" {
 // cost (and deal with the consequences).
 //
 // WARNING: this API is unstable until the HAL is fully ported. Do not use.
-typedef struct {
+typedef struct iree_hal_driver_factory_t {
   // TODO(benvanik): version field.
   IREE_API_UNSTABLE
 
@@ -77,7 +77,7 @@ typedef struct {
 // iree_hal_driver_registry_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_driver_registry_s iree_hal_driver_registry_t;
+typedef struct iree_hal_driver_registry_t iree_hal_driver_registry_t;
 
 // Returns the default per-process driver registry.
 // In simple applications this is usually where you want to go to register and

--- a/iree/hal/event.h
+++ b/iree/hal/event.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_event_t
@@ -32,7 +32,7 @@ typedef struct iree_hal_device_s iree_hal_device_t;
 //
 // Maps to VkEvent:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkEvent.html
-typedef struct iree_hal_event_s iree_hal_event_t;
+typedef struct iree_hal_event_t iree_hal_event_t;
 
 // Creates an event for recording into command buffers.
 // The returned event object is only usable with this device and events must
@@ -50,7 +50,7 @@ IREE_API_EXPORT void iree_hal_event_release(iree_hal_event_t* event);
 // iree_hal_event_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_event_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/executable.h
+++ b/iree/hal/executable.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_t
@@ -36,7 +36,7 @@ typedef struct iree_hal_device_s iree_hal_device_t;
 //
 //
 // Maps (roughly) to vkShaderModule + VkPipeline[].
-typedef struct iree_hal_executable_s iree_hal_executable_t;
+typedef struct iree_hal_executable_t iree_hal_executable_t;
 
 // Retains the given |executable| for the caller.
 IREE_API_EXPORT void iree_hal_executable_retain(
@@ -50,7 +50,7 @@ IREE_API_EXPORT void iree_hal_executable_release(
 // iree_hal_executable_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_executable_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/executable_cache.h
+++ b/iree/hal/executable_cache.h
@@ -19,14 +19,14 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
 // Defines how the executable cache performs preparation.
-enum iree_hal_executable_caching_mode_e {
+enum iree_hal_executable_caching_mode_bits_t {
   // Allows the cache to reference the provided executable_data after it has
   // prepared the executable. Callers must ensure the data remains valid for the
   // lifetime of the cache. If memory mapping constant executable data from
@@ -72,7 +72,7 @@ enum iree_hal_executable_caching_mode_e {
 typedef uint32_t iree_hal_executable_caching_mode_t;
 
 // Defines an executable compilation specification.
-typedef struct {
+typedef struct iree_hal_executable_spec_t {
   // Specifies what caching the executable cache is allowed to perform and
   // (if supported) which transformations on the executable contents are
   // allowed.
@@ -123,7 +123,7 @@ void iree_hal_executable_spec_initialize(iree_hal_executable_spec_t* out_spec);
 //
 // Thread-safe - multiple threads may prepare executables (including the *same*
 // executable) simultaneously.
-typedef struct iree_hal_executable_cache_s iree_hal_executable_cache_t;
+typedef struct iree_hal_executable_cache_t iree_hal_executable_cache_t;
 
 // Creates an executable cache using the given identifier.
 // The identifier is provided to the backing cache API as way to partition
@@ -170,7 +170,7 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_cache_prepare_executable(
 // iree_hal_executable_cache_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_executable_cache_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/executable_layout.h
+++ b/iree/hal/executable_layout.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_layout_t
@@ -40,7 +40,7 @@ typedef struct iree_hal_device_s iree_hal_device_t;
 //
 // Maps to VkPipelineLayout:
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineLayout.html
-typedef struct iree_hal_executable_layout_s iree_hal_executable_layout_t;
+typedef struct iree_hal_executable_layout_t iree_hal_executable_layout_t;
 
 // Creates an executable layout composed of the given descriptor set layouts.
 // The returned executable layout can be used by multiple executables with the
@@ -63,7 +63,7 @@ IREE_API_EXPORT void iree_hal_executable_layout_release(
 // iree_hal_executable_layout_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_executable_layout_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/local/arena.h
+++ b/iree/hal/local/arena.h
@@ -18,12 +18,14 @@ extern "C" {
 // iree_arena_block_pool_t
 //===----------------------------------------------------------------------===//
 
+struct iree_arena_block_t;
+
 // NOTE: this struct is at the *end* of allocated blocks such that we don't mess
 // with alignment - byte 0 of a block is always byte 0 of the allocation from
 // the system. We can do this as all blocks have the same size so computing the
 // footer offset from a pointer is easy.
-typedef struct iree_arena_block_s {
-  struct iree_arena_block_s* next;
+typedef struct iree_arena_block_t {
+  struct iree_arena_block_t* next;
 } iree_arena_block_t;
 
 // An atomic approximately LIFO singly-linked list.
@@ -39,7 +41,7 @@ IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_atomic_arena_block, iree_arena_block_t,
 //
 // Thread-safe; multiple threads may acquire and release blocks from the pool.
 // The underlying allocator must also be thread-safe.
-typedef struct {
+typedef struct iree_arena_block_pool_t {
   // Block size, in bytes. All blocks in the available_slist will have this
   // byte size which includes the iree_arena_block_t footer.
   iree_host_size_t total_block_size;
@@ -85,8 +87,8 @@ void iree_arena_block_pool_release(iree_arena_block_pool_t* block_pool,
 // iree_arena_allocator_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_arena_oversized_allocation_s {
-  struct iree_arena_oversized_allocation_s* next;
+typedef struct iree_arena_oversized_allocation_t {
+  struct iree_arena_oversized_allocation_t* next;
 } iree_arena_oversized_allocation_t;
 
 // A lightweight bump-pointer arena allocator using a shared block pool.
@@ -103,7 +105,7 @@ typedef struct iree_arena_oversized_allocation_s {
 // Thread-compatible; the shared block pool is thread-safe and may be used by
 // arenas on multiple threads but each arena must only be used by a single
 // thread.
-typedef struct {
+typedef struct iree_arena_allocator_t {
   // Fixed-size block pool used to acquire new blocks for the arena.
   iree_arena_block_pool_t* block_pool;
   // Total bytes allocated to the arena from the block pool or system allocator.

--- a/iree/hal/local/elf/arch.h
+++ b/iree/hal/local/elf/arch.h
@@ -22,7 +22,7 @@ bool iree_elf_arch_is_valid(const iree_elf_ehdr_t* ehdr);
 //==============================================================================
 
 // State used during relocation.
-typedef struct {
+typedef struct iree_elf_relocation_state_t {
   // Bias applied to all relative addresses (from the string table, etc) in the
   // loaded module. This is an offset from the vaddr_base that may not be 0 if
   // host page granularity was larger than the ELF's defined granularity.

--- a/iree/hal/local/elf/elf_module.c
+++ b/iree/hal/local/elf/elf_module.c
@@ -17,7 +17,7 @@
 //==============================================================================
 
 // Fields taken from the ELF headers used only during verification and loading.
-typedef struct {
+typedef struct iree_elf_module_load_state_t {
   iree_memory_info_t memory_info;
   const iree_elf_ehdr_t* ehdr;
   const iree_elf_phdr_t* phdr_table;  // ehdr.e_phnum has count

--- a/iree/hal/local/elf/elf_module.h
+++ b/iree/hal/local/elf/elf_module.h
@@ -15,12 +15,12 @@
 // ELF symbol import table
 //==============================================================================
 
-typedef struct {
+typedef struct iree_elf_import_t {
   const char* sym_name;
   void* thunk_ptr;
 } iree_elf_import_t;
 
-typedef struct {
+typedef struct iree_elf_import_table_t {
   iree_host_size_t import_count;
   const iree_elf_import_t* imports;
 } iree_elf_import_table_t;
@@ -33,7 +33,7 @@ typedef struct {
 //==============================================================================
 
 // An ELF module mapped directly from memory.
-typedef struct {
+typedef struct iree_elf_module_t {
   // Base host virtual address the module is loaded into.
   uint8_t* vaddr_base;
   // Total size, in bytes, of the virtual address space reservation.

--- a/iree/hal/local/elf/platform.h
+++ b/iree/hal/local/elf/platform.h
@@ -21,7 +21,7 @@
 // Most operations will adjust this range by the allocation granularity, meaning
 // that a range that stradles a page boundary will be specifying multiple pages
 // (such as offset=1, length=4096 with a page size of 4096 indicating 2 pages).
-typedef struct {
+typedef struct iree_byte_range_t {
   iree_host_size_t offset;
   iree_host_size_t length;
 } iree_byte_range_t;
@@ -44,7 +44,7 @@ static inline uintptr_t iree_page_align_end(uintptr_t addr,
 // These can be used to control application behavior (such as whether to enable
 // a JIT if executable pages can be allocated) and allow callers to compute
 // memory ranges based on the variable page size of the platform.
-typedef struct {
+typedef struct iree_memory_info_t {
   // The page size and the granularity of page protection and commitment. This
   // is the page size used by the iree_memory_view_t functions.
   iree_host_size_t normal_page_size;
@@ -87,7 +87,7 @@ void iree_memory_jit_context_end(void);
 // defined may result in process termination/exceptions/sadness on platforms
 // with real MMUs and are generally not detectable: treat limited access as a
 // fail-safe mechanism only.
-typedef enum {
+enum iree_memory_access_bits_t {
   // Pages in the view may be read by the process.
   // Some platforms may not respect this value being unset meaning that reads
   // will still succeed.
@@ -100,17 +100,19 @@ typedef enum {
   // true prior to requesting executable memory as certain platforms or release
   // environments may not support allocating/using executable pages.
   IREE_MEMORY_ACCESS_EXECUTE = 1u << 2,
-} iree_memory_access_t;
+};
+typedef uint32_t iree_memory_access_t;
 
 // Flags used to control the behavior of allocated memory views.
-typedef enum {
+enum iree_memory_view_flag_bits_t {
   // TODO(benvanik): pull from memory_object.h.
   IREE_MEMORY_VIEW_FLAG_NONE = 0u,
 
   // Indicates that the memory may be used to execute code.
   // May be used to ask for special privileges (like MAP_JIT on MacOS).
   IREE_MEMORY_VIEW_FLAG_MAY_EXECUTE = 1u << 10,
-} iree_memory_view_flags_t;
+};
+typedef uint32_t iree_memory_view_flags_t;
 
 // Reserves a range of virtual address space in the host process.
 // The base alignment will be that of the page granularity as specified

--- a/iree/hal/local/event_pool.c
+++ b/iree/hal/local/event_pool.c
@@ -9,7 +9,7 @@
 #include "iree/base/internal/synchronization.h"
 #include "iree/base/tracing.h"
 
-struct iree_hal_local_event_pool_s {
+struct iree_hal_local_event_pool_t {
   // Allocator used to create the event pool.
   iree_allocator_t host_allocator;
   // Guards the pool. Since this pool is used to get operating system-level

--- a/iree/hal/local/event_pool.h
+++ b/iree/hal/local/event_pool.h
@@ -17,7 +17,7 @@ extern "C" {
 // A simple pool of iree_event_ts to recycle.
 //
 // Thread-safe; multiple threads may acquire and release events from the pool.
-typedef struct iree_hal_local_event_pool_s iree_hal_local_event_pool_t;
+typedef struct iree_hal_local_event_pool_t iree_hal_local_event_pool_t;
 
 // Allocates a new event pool with up to |available_capacity| events.
 iree_status_t iree_hal_local_event_pool_allocate(

--- a/iree/hal/local/executable_library.h
+++ b/iree/hal/local/executable_library.h
@@ -13,6 +13,7 @@
 // this was a schema: backwards-incompatible changes require version bumps or
 // the ability to feature-detect at runtime.
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -37,7 +38,7 @@
 //===----------------------------------------------------------------------===//
 
 // Defines a bitfield of features that the library requires or supports.
-enum iree_hal_executable_library_feature_e {
+enum iree_hal_executable_library_feature_bits_t {
   IREE_HAL_EXECUTABLE_LIBRARY_FEATURE_NONE = 0u,
   // TODO(benvanik): declare features for debugging/coverage/printf/etc.
   // These will control which symbols are injected into the library at runtime.
@@ -48,38 +49,41 @@ typedef uint32_t iree_hal_executable_library_features_t;
 // Loaders can use this declaration to check as to whether the library is
 // compatible with the hosting environment for cases where the sanitizer
 // requires host support.
-enum iree_hal_executable_library_sanitizer_kind_e {
-  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_NONE = 0u,
+typedef enum iree_hal_executable_library_sanitizer_kind_e {
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_NONE = 0,
   // Indicates the library is compiled to use AddressSanitizer:
   // https://clang.llvm.org/docs/AddressSanitizer.html
   // Equivalent compiler flag: -fsanitize=address
-  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_ADDRESS = 1u,
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_ADDRESS = 1,
   // Indicates the library is compiled to use MemorySanitizer:
   // https://clang.llvm.org/docs/MemorySanitizer.html
   // Equivalent compiler flag: -fsanitize=memory
-  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_MEMORY = 2u,
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_MEMORY = 2,
   // Indicates the library is compiled to use ThreadSanitizer:
   // https://clang.llvm.org/docs/ThreadSanitizer.html
   // Equivalent compiler flag: -fsanitize=thread
-  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD = 3u,
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD = 3,
   // Indicates the library is compiled to use UndefinedBehaviorSanitizer:
   // https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
   // Equivalent compiler flag: -fsanitize=undefined
-  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_UNDEFINED = 4u,
-};
-typedef uint32_t iree_hal_executable_library_sanitizer_kind_t;
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_UNDEFINED = 4,
+
+  IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_MAX_ENUM = INT32_MAX,
+} iree_hal_executable_library_sanitizer_kind_t;
 
 //===----------------------------------------------------------------------===//
 // Versioning and interface querying
 //===----------------------------------------------------------------------===//
 
 // Known valid version values.
-enum iree_hal_executable_library_version_e {
+typedef enum iree_hal_executable_library_version_e {
   // iree_hal_executable_library_v0_t is used as the API communication
   // structure.
-  IREE_HAL_EXECUTABLE_LIBRARY_VERSION_0 = 0u,
-};
-typedef uint32_t iree_hal_executable_library_version_t;
+  IREE_HAL_EXECUTABLE_LIBRARY_VERSION_0 = 0,
+
+  IREE_HAL_EXECUTABLE_LIBRARY_VERSION_MAX_ENUM = INT32_MAX,
+} iree_hal_executable_library_version_t;
+static_assert(sizeof(iree_hal_executable_library_version_t) == 4, "uint32_t");
 
 // The latest version of the library API; can be used to populate the
 // iree_hal_executable_library_header_t::version when building libraries.
@@ -88,7 +92,7 @@ typedef uint32_t iree_hal_executable_library_version_t;
 
 // A header present at the top of all versions of the library API used by the
 // runtime to ensure version compatibility.
-typedef struct {
+typedef struct iree_hal_executable_library_header_t {
   // Version of the API this library was built with, which was likely the value
   // of IREE_HAL_EXECUTABLE_LIBRARY_LATEST_VERSION.
   iree_hal_executable_library_version_t version;
@@ -119,12 +123,12 @@ typedef const iree_hal_executable_library_header_t** (
 //===----------------------------------------------------------------------===//
 
 // TBD: do not use this yet.
-typedef struct {
+typedef struct iree_hal_executable_import_table_v0_t {
   size_t import_count;
   void* import_fns;
 } iree_hal_executable_import_table_v0_t;
 
-typedef union {
+typedef union iree_hal_vec3_t {
   struct {
     uint32_t x;
     uint32_t y;
@@ -134,7 +138,7 @@ typedef union {
 } iree_hal_vec3_t;
 
 // Read-only per-dispatch state passed to each workgroup in a dispatch.
-typedef struct {
+typedef struct iree_hal_executable_dispatch_state_v0_t {
   // Total workgroup count for the dispatch. This is sourced from either the
   // original dispatch call (for iree_hal_command_buffer_dispatch) or the
   // indirection buffer (for iree_hal_command_buffer_dispatch_indirect).
@@ -183,7 +187,7 @@ typedef int (*iree_hal_executable_dispatch_v0_t)(
 // at runtime so long as they observe the thread-safety guarantees. For example,
 // a JIT may default all entry_points to JIT thunk functions and then swap them
 // out for the translated function pointers.
-typedef struct {
+typedef struct iree_hal_executable_library_v0_t {
   // Version/metadata header. Will have a version of
   // IREE_HAL_EXECUTABLE_LIBRARY_VERSION_0.
   const iree_hal_executable_library_header_t* header;

--- a/iree/hal/local/executable_loader.h
+++ b/iree/hal/local/executable_loader.h
@@ -22,7 +22,7 @@ extern "C" {
 // iree_hal_executable_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_executable_loader_vtable_s
+typedef struct iree_hal_executable_loader_vtable_t
     iree_hal_executable_loader_vtable_t;
 
 // Interface for compiled executable loader implementations.
@@ -34,7 +34,7 @@ typedef struct iree_hal_executable_loader_vtable_s
 //
 // Thread-safe - multiple threads may load executables (including the *same*
 // executable) simultaneously.
-typedef struct {
+typedef struct iree_hal_executable_loader_t {
   iree_atomic_ref_count_t ref_count;
   const iree_hal_executable_loader_vtable_t* vtable;
 } iree_hal_executable_loader_t;
@@ -81,7 +81,7 @@ iree_status_t iree_hal_executable_loader_try_load(
 // iree_hal_executable_loader_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_executable_loader_vtable_s {
+typedef struct iree_hal_executable_loader_vtable_t {
   void(IREE_API_PTR* destroy)(iree_hal_executable_loader_t* executable_loader);
 
   bool(IREE_API_PTR* query_support)(

--- a/iree/hal/local/inline_command_buffer.c
+++ b/iree/hal/local/inline_command_buffer.c
@@ -17,7 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 // Inline synchronous one-shot command "buffer".
-typedef struct {
+typedef struct iree_hal_inline_command_buffer_t {
   iree_hal_resource_t resource;
 
   iree_hal_device_t* device;

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -15,7 +15,7 @@
 // iree_hal_elf_executable_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_elf_executable_t {
   iree_hal_local_executable_t base;
 
   // Loaded ELF module.
@@ -202,7 +202,7 @@ const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable = {
 // iree_hal_embedded_library_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_embedded_library_loader_t {
   iree_hal_executable_loader_t base;
   iree_allocator_t host_allocator;
 } iree_hal_embedded_library_loader_t;

--- a/iree/hal/local/loaders/legacy_library_loader.c
+++ b/iree/hal/local/loaders/legacy_library_loader.c
@@ -58,7 +58,7 @@ static iree_status_t iree_hal_dylib_executable_flatbuffer_verify(
 // iree_hal_legacy_executable_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_legacy_executable_t {
   iree_hal_local_executable_t base;
 
   // Flatbuffer definition referencing the executable memory.
@@ -282,7 +282,7 @@ const iree_hal_local_executable_vtable_t iree_hal_legacy_executable_vtable = {
 // iree_hal_legacy_library_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_legacy_library_loader_t {
   iree_hal_executable_loader_t base;
   iree_allocator_t host_allocator;
 } iree_hal_legacy_library_loader_t;

--- a/iree/hal/local/loaders/static_library_loader.c
+++ b/iree/hal/local/loaders/static_library_loader.c
@@ -13,7 +13,7 @@
 // iree_hal_static_executable_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_static_executable_t {
   iree_hal_local_executable_t base;
 
   // Name used for the file field in tracy and debuggers.
@@ -127,7 +127,7 @@ static const iree_hal_local_executable_vtable_t
 // iree_hal_static_library_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_static_library_loader_t {
   iree_hal_executable_loader_t base;
   iree_allocator_t host_allocator;
   iree_host_size_t library_count;

--- a/iree/hal/local/loaders/system_library_loader.c
+++ b/iree/hal/local/loaders/system_library_loader.c
@@ -16,7 +16,7 @@
 // iree_hal_system_executable_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_system_executable_t {
   iree_hal_local_executable_t base;
 
   // TODO(benvanik): library handle for ownership.
@@ -126,7 +126,7 @@ static const iree_hal_local_executable_vtable_t
 // iree_hal_system_library_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_system_library_loader_t {
   iree_hal_executable_loader_t base;
   iree_allocator_t host_allocator;
 } iree_hal_system_library_loader_t;

--- a/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/iree/hal/local/loaders/vmvx_module_loader.c
@@ -27,7 +27,7 @@
 
 #define IREE_VMVX_ENTRY_SIGNATURE "0rrriiiiiiiii_v"
 
-typedef struct {
+typedef struct iree_hal_vmvx_executable_t {
   iree_hal_local_executable_t base;
 
   // Context containing both the VMVX module and the loaded executable.
@@ -333,7 +333,7 @@ const iree_hal_local_executable_vtable_t iree_hal_vmvx_executable_vtable = {
 // iree_hal_vmvx_module_loader_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_vmvx_module_loader_t {
   iree_hal_executable_loader_t base;
   iree_allocator_t host_allocator;
   iree_vm_instance_t* instance;

--- a/iree/hal/local/local_descriptor_set.h
+++ b/iree/hal/local/local_descriptor_set.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct {
+typedef struct iree_hal_local_descriptor_set_t {
   iree_hal_resource_t resource;
   iree_hal_local_descriptor_set_layout_t* layout;
   iree_host_size_t binding_count;

--- a/iree/hal/local/local_descriptor_set_layout.h
+++ b/iree/hal/local/local_descriptor_set_layout.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define IREE_HAL_LOCAL_MAX_DESCRIPTOR_BINDING_COUNT 32
 
-typedef struct {
+typedef struct iree_hal_local_descriptor_set_layout_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_hal_descriptor_set_layout_usage_type_t usage_type;

--- a/iree/hal/local/local_executable.h
+++ b/iree/hal/local/local_executable.h
@@ -16,14 +16,14 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct {
+typedef struct iree_hal_local_executable_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_host_size_t executable_layout_count;
   iree_hal_local_executable_layout_t** executable_layouts;
 } iree_hal_local_executable_t;
 
-typedef struct {
+typedef struct iree_hal_local_executable_vtable_t {
   iree_hal_executable_vtable_t base;
 
   iree_status_t(IREE_API_PTR* issue_call)(

--- a/iree/hal/local/local_executable_cache.c
+++ b/iree/hal/local/local_executable_cache.c
@@ -8,7 +8,7 @@
 
 #include "iree/base/tracing.h"
 
-typedef struct {
+typedef struct iree_hal_local_executable_cache_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_string_view_t identifier;

--- a/iree/hal/local/local_executable_layout.c
+++ b/iree/hal/local/local_executable_layout.c
@@ -72,6 +72,8 @@ iree_status_t iree_hal_local_executable_layout_create(
           case IREE_HAL_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
             ++layout->dynamic_binding_count;
             break;
+          default:
+            continue;
         }
       }
     }

--- a/iree/hal/local/local_executable_layout.h
+++ b/iree/hal/local/local_executable_layout.h
@@ -22,7 +22,7 @@ typedef uint64_t iree_hal_local_binding_mask_t;
 #define IREE_HAL_LOCAL_BINDING_MASK_BITS \
   (sizeof(iree_hal_local_binding_mask_t) * 8)
 
-typedef struct {
+typedef struct iree_hal_local_executable_layout_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_host_size_t push_constants;

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -16,7 +16,7 @@
 #include "iree/hal/local/sync_event.h"
 #include "iree/hal/local/sync_semaphore.h"
 
-typedef struct {
+typedef struct iree_hal_sync_device_t {
   iree_hal_resource_t resource;
   iree_string_view_t identifier;
 

--- a/iree/hal/local/sync_device.h
+++ b/iree/hal/local/sync_device.h
@@ -17,7 +17,7 @@ extern "C" {
 
 // Parameters configuring an iree_hal_sync_device_t.
 // Must be initialized with iree_hal_sync_device_params_initialize prior to use.
-typedef struct {
+typedef struct iree_hal_sync_device_params_t {
   int reserved;
 } iree_hal_sync_device_params_t;
 

--- a/iree/hal/local/sync_driver.c
+++ b/iree/hal/local/sync_driver.c
@@ -10,7 +10,7 @@
 
 #define IREE_HAL_SYNC_DEVICE_ID_DEFAULT 0
 
-typedef struct {
+typedef struct iree_hal_sync_driver_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 

--- a/iree/hal/local/sync_event.c
+++ b/iree/hal/local/sync_event.c
@@ -8,7 +8,7 @@
 
 #include "iree/base/tracing.h"
 
-typedef struct {
+typedef struct iree_hal_sync_event_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 } iree_hal_sync_event_t;

--- a/iree/hal/local/sync_semaphore.c
+++ b/iree/hal/local/sync_semaphore.c
@@ -33,7 +33,7 @@ void iree_hal_sync_semaphore_state_deinitialize(
 // iree_hal_sync_semaphore_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_sync_semaphore_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 
@@ -214,7 +214,7 @@ iree_status_t iree_hal_sync_semaphore_multi_signal(
   return status;
 }
 
-typedef struct {
+typedef struct iree_hal_sync_semaphore_notify_state_t {
   iree_hal_sync_semaphore_t* semaphore;
   uint64_t value;
 } iree_hal_sync_semaphore_notify_state_t;

--- a/iree/hal/local/sync_semaphore.h
+++ b/iree/hal/local/sync_semaphore.h
@@ -22,7 +22,7 @@ extern "C" {
 // State shared between all sync semaphores.
 // Owned by the device and guaranteed to remain valid for the lifetime of any
 // semaphore created from it.
-typedef struct {
+typedef struct iree_hal_sync_semaphore_state_t {
   // In-process notification signaled when any semaphore value changes.
   iree_notification_t notification;
 } iree_hal_sync_semaphore_state_t;

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -26,7 +26,7 @@
 // additional allocations required during recording or execution. That means our
 // command buffer here is essentially just a builder for the task system types
 // and manager of the lifetime of the tasks.
-typedef struct {
+typedef struct iree_hal_task_command_buffer_t {
   iree_hal_resource_t resource;
 
   iree_hal_device_t* device;
@@ -452,7 +452,7 @@ static iree_status_t iree_hal_task_command_buffer_discard_buffer(
 // We'd want to do some measurement for when it's worth it; filling a 200KB
 // buffer: maybe not, filling a 200MB buffer: yeah.
 
-typedef struct {
+typedef struct iree_hal_cmd_fill_buffer_t {
   iree_task_call_t task;
   iree_hal_buffer_t* target_buffer;
   iree_device_size_t target_offset;
@@ -504,7 +504,7 @@ static iree_status_t iree_hal_task_command_buffer_fill_buffer(
 // iree_hal_command_buffer_update_buffer
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_cmd_update_buffer_t {
   iree_task_call_t task;
   iree_hal_buffer_t* target_buffer;
   iree_device_size_t target_offset;
@@ -560,7 +560,7 @@ static iree_status_t iree_hal_task_command_buffer_update_buffer(
 // We'd want to do some measurement for when it's worth it; copying a 200KB
 // buffer: maybe not, copying a 200MB buffer: yeah.
 
-typedef struct {
+typedef struct iree_hal_cmd_copy_buffer_t {
   iree_task_call_t task;
   iree_hal_buffer_t* source_buffer;
   iree_device_size_t source_offset;
@@ -700,7 +700,7 @@ static iree_status_t iree_hal_task_command_buffer_bind_descriptor_set(
 // iree_hal_command_buffer_dispatch
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_cmd_dispatch_t {
   iree_task_dispatch_t task;
   iree_hal_local_executable_t* executable;
   int32_t ordinal;

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -21,7 +21,7 @@
 
 #define IREE_HAL_LOCAL_TASK_EVENT_POOL_CAPACITY 32
 
-typedef struct {
+typedef struct iree_hal_task_device_t {
   iree_hal_resource_t resource;
   iree_string_view_t identifier;
 

--- a/iree/hal/local/task_device.h
+++ b/iree/hal/local/task_device.h
@@ -18,7 +18,7 @@ extern "C" {
 
 // Parameters configuring an iree_hal_task_device_t.
 // Must be initialized with iree_hal_task_device_params_initialize prior to use.
-typedef struct {
+typedef struct iree_hal_task_device_params_t {
   // Number of queues exposed on the device.
   // Each queue acts as a separate synchronization scope where all work executes
   // concurrently unless prohibited by semaphores.

--- a/iree/hal/local/task_driver.c
+++ b/iree/hal/local/task_driver.c
@@ -10,7 +10,7 @@
 
 #define IREE_HAL_TASK_DEVICE_ID_DEFAULT 0
 
-typedef struct {
+typedef struct iree_hal_task_driver_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 

--- a/iree/hal/local/task_event.c
+++ b/iree/hal/local/task_event.c
@@ -8,7 +8,7 @@
 
 #include "iree/base/tracing.h"
 
-typedef struct {
+typedef struct iree_hal_task_event_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 } iree_hal_task_event_t;

--- a/iree/hal/local/task_queue.c
+++ b/iree/hal/local/task_queue.c
@@ -97,7 +97,7 @@ static void iree_hal_semaphore_list_release(iree_hal_semaphore_list_t* list) {
 // to wait as the implicit queue ordering ensures that the signals would have
 // happened prior to the sequence command being executed. Cross-queue semaphores
 // will still cause waits if they have not yet been signaled.
-typedef struct {
+typedef struct iree_hal_task_queue_wait_cmd_t {
   // Call to iree_hal_task_queue_wait_cmd.
   iree_task_call_t task;
 
@@ -167,7 +167,7 @@ static iree_status_t iree_hal_task_queue_wait_cmd_allocate(
 // Task to issue all the command buffers in the batch.
 // After this task completes the commands have been issued but have not yet
 // completed and the issued commands may complete in any order.
-typedef struct {
+typedef struct iree_hal_task_queue_issue_cmd_t {
   // Call to iree_hal_task_queue_issue_cmd.
   iree_task_call_t task;
 
@@ -258,7 +258,7 @@ static iree_status_t iree_hal_task_queue_issue_cmd_allocate(
 // it. The task is issued only once all commands from all command buffers in
 // the submission complete. Semaphores will be signaled and dependent
 // submissions may be issued.
-typedef struct {
+typedef struct iree_hal_task_queue_retire_cmd_t {
   // Call to iree_hal_task_queue_retire_cmd.
   iree_task_call_t task;
 

--- a/iree/hal/local/task_queue.h
+++ b/iree/hal/local/task_queue.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct {
+typedef struct iree_hal_task_queue_t {
   // Shared executor that the queue submits tasks to.
   iree_task_executor_t* executor;
 

--- a/iree/hal/local/task_queue_state.h
+++ b/iree/hal/local/task_queue_state.h
@@ -20,7 +20,7 @@ extern "C" {
 //
 // Thread-compatible: only intended to be used by a queue with the submission
 // lock held.
-typedef struct {
+typedef struct iree_hal_task_queue_state_t {
   // TODO(#4518): track event state.
   int reserved;
 } iree_hal_task_queue_state_t;

--- a/iree/hal/local/task_semaphore.c
+++ b/iree/hal/local/task_semaphore.c
@@ -26,9 +26,9 @@
 // Instances are owned and retained by the caller that requested them - usually
 // in the arena associated with the submission, but could be on the stack of a
 // synchronously waiting thread.
-typedef struct iree_hal_task_timepoint_s {
-  struct iree_hal_task_timepoint_s* next;
-  struct iree_hal_task_timepoint_s* prev;
+typedef struct iree_hal_task_timepoint_t {
+  struct iree_hal_task_timepoint_t* next;
+  struct iree_hal_task_timepoint_t* prev;
   uint64_t payload_value;
   iree_event_t event;
 } iree_hal_task_timepoint_t;
@@ -39,7 +39,7 @@ typedef struct iree_hal_task_timepoint_s {
 //
 // Note that the timepoints are not owned by the list - this just nicely
 // stitches together timepoints for the semaphore.
-typedef struct {
+typedef struct iree_hal_task_timepoint_list_t {
   iree_hal_task_timepoint_t* head;
   iree_hal_task_timepoint_t* tail;
 } iree_hal_task_timepoint_list_t;
@@ -127,7 +127,7 @@ static void iree_hal_task_timepoint_list_notify_ready(
 // iree_hal_task_semaphore_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_task_semaphore_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   iree_hal_local_event_pool_t* event_pool;
@@ -310,7 +310,7 @@ static iree_status_t iree_hal_task_semaphore_acquire_timepoint(
   return iree_ok_status();
 }
 
-typedef struct {
+typedef struct iree_hal_task_semaphore_wait_cmd_t {
   iree_task_wait_t task;
   iree_hal_task_semaphore_t* semaphore;
   iree_hal_task_timepoint_t timepoint;

--- a/iree/hal/resource.h
+++ b/iree/hal/resource.h
@@ -27,7 +27,7 @@ extern "C" {
 // ref count and vtable at predictable locations. Note that this allows for the
 // resource to be at >0 of the allocation but the pointers used with the HAL
 // (iree_hal_event_t*, etc) must point to the iree_hal_resource_t.
-typedef struct iree_hal_resource_s {
+typedef struct iree_hal_resource_t {
   // Reference count used to manage resource lifetime. The vtable->destroy
   // method will be called when the reference count falls to zero.
   iree_atomic_ref_count_t ref_count;

--- a/iree/hal/semaphore.h
+++ b/iree/hal/semaphore.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_device_s iree_hal_device_t;
+typedef struct iree_hal_device_t iree_hal_device_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_semaphore_t
@@ -52,7 +52,7 @@ typedef struct iree_hal_device_s iree_hal_device_t;
 // https://www.youtube.com/watch?v=SpE--Rf516Y
 // https://www.khronos.org/assets/uploads/developers/library/2018-xdc/Vulkan-Timeline-Semaphores-Part-1_Sep18.pdf
 // https://docs.microsoft.com/en-us/windows/win32/direct3d12/user-mode-heap-synchronization
-typedef struct iree_hal_semaphore_s iree_hal_semaphore_t;
+typedef struct iree_hal_semaphore_t iree_hal_semaphore_t;
 
 // Creates a semaphore that can be used with command queues owned by this
 // device. To use the semaphores with other devices or instances they must
@@ -113,7 +113,7 @@ IREE_API_EXPORT iree_status_t iree_hal_semaphore_wait(
 // iree_hal_semaphore_t implementation details
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_semaphore_vtable_t {
   // << HAL C porting in progress >>
   IREE_API_UNSTABLE
 

--- a/iree/hal/vulkan/api.h
+++ b/iree/hal/vulkan/api.h
@@ -9,6 +9,8 @@
 #ifndef IREE_HAL_VULKAN_API_H_
 #define IREE_HAL_VULKAN_API_H_
 
+#include <stdint.h>
+
 // clang-format off: Must be included before all other headers:
 #include "iree/hal/vulkan/vulkan_headers.h"
 // clang-format on
@@ -26,7 +28,7 @@ extern "C" {
 
 // TODO(benvanik): replace with feature list (easier to version).
 // Bitfield that defines sets of Vulkan features.
-enum iree_hal_vulkan_feature_e {
+enum iree_hal_vulkan_feature_bits_t {
   // Use VK_LAYER_KHRONOS_standard_validation to validate Vulkan API usage.
   // Has a significant performance penalty and is *not* a security mechanism.
   IREE_HAL_VULKAN_FEATURE_ENABLE_VALIDATION_LAYERS = 1u << 0,
@@ -44,37 +46,36 @@ enum iree_hal_vulkan_feature_e {
   // tracing with this enabled.
   IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING = 1u << 2,
 };
-typedef uint64_t iree_hal_vulkan_features_t;
+typedef uint32_t iree_hal_vulkan_features_t;
 
 // Describes the type of a set of Vulkan extensions.
-enum iree_hal_vulkan_extensibility_set_e {
+typedef enum iree_hal_vulkan_extensibility_set_e {
   // A set of required instance layer names. These must all be enabled on
   // the VkInstance for IREE to function.
   IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_LAYERS_REQUIRED = 0,
 
   // A set of optional instance layer names. If omitted fallbacks may be
   // used or debugging features may not be available.
-  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_LAYERS_OPTIONAL = 1,
+  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_LAYERS_OPTIONAL,
 
   // A set of required instance extension names. These must all be enabled on
   // the VkInstance for IREE to function.
-  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_REQUIRED = 2,
+  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_REQUIRED,
 
   // A set of optional instance extension names. If omitted fallbacks may be
   // used or debugging features may not be available.
-  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_OPTIONAL = 3,
+  IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_OPTIONAL,
 
   // A set of required device extension names. These must all be enabled on
   // the VkDevice for IREE to function.
-  IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_REQUIRED = 4,
+  IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_REQUIRED,
 
   // A set of optional device extension names. If omitted fallbacks may be
   // used or debugging features may not be available.
-  IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_OPTIONAL = 5,
+  IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_OPTIONAL,
 
-  IREE_HAL_VULKAN_EXTENSIBILITY_SET_COUNT,
-};
-typedef uint32_t iree_hal_vulkan_extensibility_set_t;
+  IREE_HAL_VULKAN_EXTENSIBILITY_SET_COUNT,  // used for sizing lookup tables
+} iree_hal_vulkan_extensibility_set_t;
 
 // Queries the names of the Vulkan layers and extensions used for a given set of
 // IREE |requested_features|. All devices used by IREE must have the required
@@ -105,7 +106,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
 // iree_hal_vulkan_syms_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_vulkan_syms_s iree_hal_vulkan_syms_t;
+typedef struct iree_hal_vulkan_syms_t iree_hal_vulkan_syms_t;
 
 // Loads Vulkan functions by invoking |vkGetInstanceProcAddr|.
 //
@@ -138,7 +139,7 @@ IREE_API_EXPORT void iree_hal_vulkan_syms_release(iree_hal_vulkan_syms_t* syms);
 //===----------------------------------------------------------------------===//
 
 // A set of queues within a specific queue family on a VkDevice.
-typedef struct {
+typedef struct iree_hal_vulkan_queue_set_t {
   // The index of a particular queue family on a VkPhysicalDevice, as described
   // by vkGetPhysicalDeviceQueueFamilyProperties.
   uint32_t queue_family_index;
@@ -148,15 +149,15 @@ typedef struct {
 } iree_hal_vulkan_queue_set_t;
 
 // TODO(benvanik): replace with flag list (easier to version).
-enum iree_hal_vulkan_device_flag_e {
+enum iree_hal_vulkan_device_flag_bits_t {
   // Uses timeline semaphore emulation even if native support exists.
   // May be removed in future versions when timeline semaphores can be assumed
   // present on all platforms (looking at you, Android ಠ_ಠ).
-  IREE_HAL_VULKAN_DEVICE_FORCE_TIMELINE_SEMAPHORE_EMULATION = 1 << 0,
+  IREE_HAL_VULKAN_DEVICE_FORCE_TIMELINE_SEMAPHORE_EMULATION = 1u << 0,
 };
-typedef uint64_t iree_hal_vulkan_device_flags_t;
+typedef uint32_t iree_hal_vulkan_device_flags_t;
 
-typedef struct {
+typedef struct iree_hal_vulkan_device_options_t {
   // Flags controlling device behavior.
   iree_hal_vulkan_device_flags_t flags;
 } iree_hal_vulkan_device_options_t;
@@ -207,7 +208,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_wrap_device(
 //===----------------------------------------------------------------------===//
 
 // Vulkan driver creation options.
-typedef struct {
+typedef struct iree_hal_vulkan_driver_options_t {
   // Vulkan version that will be requested, e.g. `VK_API_VERSION_1_0`.
   // Driver creation will fail if the required version is not available.
   uint32_t api_version;

--- a/iree/hal/vulkan/debug_reporter.cc
+++ b/iree/hal/vulkan/debug_reporter.cc
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/vulkan/status_util.h"
 
-struct iree_hal_vulkan_debug_reporter_s {
+struct iree_hal_vulkan_debug_reporter_t {
   iree_allocator_t host_allocator;
   VkInstance instance;
   iree::hal::vulkan::DynamicSymbols* syms;

--- a/iree/hal/vulkan/debug_reporter.h
+++ b/iree/hal/vulkan/debug_reporter.h
@@ -21,7 +21,7 @@
 // VkInstanceCreateInfo::pNext chain. The callback will only be used this way
 // during the creation call after which users can create the real
 // instance-specific reporter.
-typedef struct iree_hal_vulkan_debug_reporter_s
+typedef struct iree_hal_vulkan_debug_reporter_t
     iree_hal_vulkan_debug_reporter_t;
 
 iree_status_t iree_hal_vulkan_debug_reporter_allocate(

--- a/iree/hal/vulkan/direct_command_buffer.cc
+++ b/iree/hal/vulkan/direct_command_buffer.cc
@@ -22,7 +22,7 @@ using namespace iree::hal::vulkan;
 // Command buffer implementation that directly maps to VkCommandBuffer.
 // This records the commands on the calling thread without additional threading
 // indirection.
-typedef struct {
+typedef struct iree_hal_vulkan_direct_command_buffer_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   iree_hal_command_buffer_mode_t mode;

--- a/iree/hal/vulkan/emulated_semaphore.cc
+++ b/iree/hal/vulkan/emulated_semaphore.cc
@@ -508,7 +508,7 @@ using namespace iree::hal::vulkan;
 // Porting the above to C is ideal but since this is just a fallback layer I'm
 // not sure it's worth it (given that we may require Vulkan 1.2 with timeline
 // semaphores built in at some point soon).
-typedef struct {
+typedef struct iree_hal_vulkan_emulated_semaphore_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   EmulatedTimelineSemaphore* handle;

--- a/iree/hal/vulkan/extensibility_util.h
+++ b/iree/hal/vulkan/extensibility_util.h
@@ -12,7 +12,7 @@
 #include "iree/hal/vulkan/util/arena.h"
 
 // A list of NUL-terminated strings (so they can be passed directly to Vulkan).
-typedef struct {
+typedef struct iree_hal_vulkan_string_list_t {
   iree_host_size_t count;
   const char** values;
 } iree_hal_vulkan_string_list_t;
@@ -55,7 +55,7 @@ iree_status_t iree_hal_vulkan_match_available_device_extensions(
 // We must use this to query support instead of just detecting symbol names as
 // ICDs will resolve the functions sometimes even if they don't support the
 // extension (or we didn't ask for it to be enabled).
-typedef struct {
+typedef struct iree_hal_vulkan_instance_extensions_t {
   // VK_EXT_debug_utils is enabled and a debug messenger is registered.
   // https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/chap44.html#VK_EXT_debug_utils
   bool debug_utils : 1;
@@ -70,7 +70,7 @@ iree_hal_vulkan_populate_enabled_instance_extensions(
 // We must use this to query support instead of just detecting symbol names as
 // ICDs will resolve the functions sometimes even if they don't support the
 // extension (or we didn't ask for it to be enabled).
-typedef struct {
+typedef struct iree_hal_vulkan_device_extensions_t {
   // VK_KHR_push_descriptor is enabled and vkCmdPushDescriptorSetKHR is valid.
   bool push_descriptors : 1;
   // VK_KHR_timeline_semaphore is enabled.

--- a/iree/hal/vulkan/native_descriptor_set.cc
+++ b/iree/hal/vulkan/native_descriptor_set.cc
@@ -10,7 +10,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_descriptor_set_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   VkDescriptorSet handle;

--- a/iree/hal/vulkan/native_descriptor_set_layout.cc
+++ b/iree/hal/vulkan/native_descriptor_set_layout.cc
@@ -11,7 +11,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_descriptor_set_layout_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   VkDescriptorSetLayout handle;

--- a/iree/hal/vulkan/native_event.cc
+++ b/iree/hal/vulkan/native_event.cc
@@ -11,7 +11,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_event_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   VkEvent handle;

--- a/iree/hal/vulkan/native_executable.cc
+++ b/iree/hal/vulkan/native_executable.cc
@@ -18,7 +18,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_entry_point_t {
   VkPipeline pipeline;
   iree_string_view_t name;
 } iree_hal_vulkan_entry_point_t;
@@ -184,7 +184,7 @@ static iree_status_t iree_hal_spirv_executable_flatbuffer_verify(
   return iree_ok_status();
 }
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_executable_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   iree_host_size_t entry_point_count;

--- a/iree/hal/vulkan/native_executable.h
+++ b/iree/hal/vulkan/native_executable.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct {
+typedef struct iree_hal_vulkan_source_location_t {
   iree_string_view_t file_name;
   int line;
   iree_string_view_t func_name;

--- a/iree/hal/vulkan/native_executable_layout.cc
+++ b/iree/hal/vulkan/native_executable_layout.cc
@@ -12,7 +12,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_executable_layout_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   VkPipelineLayout handle;

--- a/iree/hal/vulkan/native_semaphore.cc
+++ b/iree/hal/vulkan/native_semaphore.cc
@@ -31,7 +31,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_native_semaphore_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
   VkSemaphore handle;

--- a/iree/hal/vulkan/nop_executable_cache.cc
+++ b/iree/hal/vulkan/nop_executable_cache.cc
@@ -11,7 +11,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_nop_executable_cache_t {
   iree_hal_resource_t resource;
   VkDeviceHandle* logical_device;
 } iree_hal_vulkan_nop_executable_cache_t;

--- a/iree/hal/vulkan/tracing.cc
+++ b/iree/hal/vulkan/tracing.cc
@@ -27,12 +27,12 @@
 // The more we do the better confidence we have in a lower-bound.
 #define IREE_HAL_VULKAN_TRACING_MAX_DEVIATION_PROBE_COUNT 32
 
-typedef struct {
+typedef struct iree_hal_vulkan_timestamp_query_t {
   uint64_t timestamp;
   uint64_t availability;  // non-zero if available
 } iree_hal_vulkan_timestamp_query_t;
 
-struct iree_hal_vulkan_tracing_context_s {
+struct iree_hal_vulkan_tracing_context_t {
   // Device and queue the context represents.
   iree::hal::vulkan::VkDeviceHandle* logical_device;
   VkQueue queue;

--- a/iree/hal/vulkan/tracing.h
+++ b/iree/hal/vulkan/tracing.h
@@ -63,7 +63,7 @@ extern "C" {
 //
 // Thread-compatible: external synchronization is required if using from
 // multiple threads (same as with VkQueue itself).
-typedef struct iree_hal_vulkan_tracing_context_s
+typedef struct iree_hal_vulkan_tracing_context_t
     iree_hal_vulkan_tracing_context_t;
 
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -12,7 +12,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct iree_hal_vulkan_vma_allocator_s {
+typedef struct iree_hal_vulkan_vma_allocator_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
   VmaAllocator vma;

--- a/iree/hal/vulkan/vma_buffer.cc
+++ b/iree/hal/vulkan/vma_buffer.cc
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/vulkan/status_util.h"
 
-typedef struct iree_hal_vulkan_vma_buffer_s {
+typedef struct iree_hal_vulkan_vma_buffer_t {
   iree_hal_buffer_t base;
 
   VmaAllocator vma;

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -155,7 +155,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
 
 #define IREE_HAL_VULKAN_INVALID_QUEUE_FAMILY_INDEX (-1)
 
-typedef struct {
+typedef struct iree_hal_vulkan_queue_family_info_t {
   uint32_t dispatch_index;
   iree_host_size_t dispatch_queue_count;
   uint32_t transfer_index;
@@ -316,7 +316,7 @@ static iree_status_t iree_hal_vulkan_build_queue_sets(
 // iree_hal_vulkan_device_t
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_vulkan_device_t {
   iree_hal_resource_t resource;
   iree_string_view_t identifier;
 

--- a/iree/hal/vulkan/vulkan_driver.cc
+++ b/iree/hal/vulkan/vulkan_driver.cc
@@ -18,7 +18,7 @@
 
 using namespace iree::hal::vulkan;
 
-typedef struct {
+typedef struct iree_hal_vulkan_driver_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
 

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -173,11 +173,11 @@ class CheckTest : public ::testing::Test {
   }
 
   iree_status_t Invoke(const char* function_name,
-                       std::vector<iree_vm_value> args) {
+                       std::vector<iree_vm_value_t> args) {
     IREE_RETURN_IF_ERROR(
         iree_vm_list_create(/*element_type=*/nullptr, args.size(),
                             iree_allocator_system(), &inputs_));
-    for (iree_vm_value& arg : args) {
+    for (auto& arg : args) {
       IREE_RETURN_IF_ERROR(iree_vm_list_push_value(inputs_.get(), &arg));
     }
     return Invoke(function_name);

--- a/iree/modules/hal/hal_module.c
+++ b/iree/modules/hal/hal_module.c
@@ -110,7 +110,7 @@ IREE_VM_DEFINE_TYPE_ADAPTERS(iree_hal_semaphore, iree_hal_semaphore_t);
 // Module type definitions
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_hal_module_t {
   iree_allocator_t host_allocator;
   iree_hal_device_t* shared_device;
   // TODO(benvanik): types.
@@ -119,7 +119,7 @@ typedef struct {
 #define IREE_HAL_MODULE_CAST(module) \
   (iree_hal_module_t*)((uint8_t*)(module) + iree_vm_native_module_size());
 
-typedef struct {
+typedef struct iree_hal_module_state_t {
   iree_allocator_t host_allocator;
   iree_hal_device_t* shared_device;
   iree_hal_executable_cache_t* executable_cache;

--- a/iree/modules/strings/api.h
+++ b/iree/modules/strings/api.h
@@ -13,8 +13,8 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct strings_string strings_string_t;
-typedef struct strings_string_tensor strings_string_tensor_t;
+typedef struct strings_string_t strings_string_t;
+typedef struct strings_string_tensor_t strings_string_tensor_t;
 
 // Creates a string type.
 iree_status_t strings_string_create(iree_string_view_t value,

--- a/iree/modules/strings/api_detail.h
+++ b/iree/modules/strings/api_detail.h
@@ -14,13 +14,13 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct strings_string {
+typedef struct strings_string_t {
   iree_vm_ref_object_t ref_object;
   iree_allocator_t allocator;
   iree_string_view_t value;
 } strings_string_t;
 
-typedef struct strings_string_tensor {
+typedef struct strings_string_tensor_t {
   iree_vm_ref_object_t ref_object;
   iree_allocator_t allocator;
   iree_string_view_t* values;

--- a/iree/modules/vmvx/module.c
+++ b/iree/modules/vmvx/module.c
@@ -46,7 +46,7 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_register_types() {
 // Module type definitions
 //===----------------------------------------------------------------------===//
 
-typedef struct {
+typedef struct iree_vmvx_module_t {
   iree_allocator_t host_allocator;
   // TODO(benvanik): types when we are not registering them globally.
 } iree_vmvx_module_t;
@@ -54,7 +54,7 @@ typedef struct {
 #define IREE_VMVX_MODULE_CAST(module) \
   (iree_vmvx_module_t*)((uint8_t*)(module) + iree_vm_native_module_size());
 
-typedef struct {
+typedef struct iree_vmvx_module_state_t {
   iree_allocator_t host_allocator;
 
   // If we have any external libraries we want to interact with that are

--- a/iree/runtime/call.h
+++ b/iree/runtime/call.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_runtime_session_s iree_runtime_session_t;
+typedef struct iree_runtime_session_t iree_runtime_session_t;
 
 //===----------------------------------------------------------------------===//
 // iree_runtime_call_t
@@ -25,7 +25,7 @@ typedef struct iree_runtime_session_s iree_runtime_session_t;
 // or whether to consume inputs like this or by having separate call types.
 // For example, an async_call may make things more clear when using semaphores
 // without having to pollute this interface.
-enum iree_runtime_call_flags_e {
+enum iree_runtime_call_flag_bits_t {
   IREE_RUNTIME_CALL_FLAG_RESERVED = 0u,
 };
 typedef uint32_t iree_runtime_call_flags_t;
@@ -41,7 +41,7 @@ typedef uint32_t iree_runtime_call_flags_t;
 //
 // Thread-compatible; these are designed to be stack-local or embedded in a user
 // data structure that can provide synchronization when required.
-typedef struct iree_runtime_call_s {
+typedef struct iree_runtime_call_t {
   iree_runtime_session_t* session;
   iree_vm_function_t function;
   iree_vm_list_t* inputs;

--- a/iree/runtime/instance.c
+++ b/iree/runtime/instance.c
@@ -37,7 +37,7 @@ IREE_API_EXPORT void iree_runtime_instance_options_use_all_available_drivers(
 // iree_runtime_instance_t
 //===----------------------------------------------------------------------===//
 
-struct iree_runtime_instance_s {
+struct iree_runtime_instance_t {
   iree_atomic_ref_count_t ref_count;
 
   // Allocator used to allocate the instance and all of its resources.

--- a/iree/runtime/instance.h
+++ b/iree/runtime/instance.h
@@ -43,14 +43,14 @@ extern "C" {
 // to the lower levels.
 //
 // Thread-safe.
-typedef struct iree_runtime_instance_s iree_runtime_instance_t;
+typedef struct iree_runtime_instance_t iree_runtime_instance_t;
 
 //===----------------------------------------------------------------------===//
 // iree_runtime_instance_options_t
 //===----------------------------------------------------------------------===//
 
 // Options used to configure instance creation.
-typedef struct {
+typedef struct iree_runtime_instance_options_t {
   // Should be set to IREE_API_VERSION_LATEST.
   iree_api_version_t api_version;
 

--- a/iree/runtime/session.c
+++ b/iree/runtime/session.c
@@ -29,7 +29,7 @@ IREE_API_EXPORT void iree_runtime_session_options_initialize(
 // iree_runtime_session_t
 //===----------------------------------------------------------------------===//
 
-struct iree_runtime_session_s {
+struct iree_runtime_session_t {
   iree_atomic_ref_count_t ref_count;
 
   // Allocator used to allocate the session and all of its resources.

--- a/iree/runtime/session.h
+++ b/iree/runtime/session.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_runtime_instance_s iree_runtime_instance_t;
+typedef struct iree_runtime_instance_t iree_runtime_instance_t;
 
 // A session containing a set of loaded VM modules and their runtime state.
 // Each session has its own isolated module state and though multiple sessions
@@ -39,21 +39,21 @@ typedef struct iree_runtime_instance_s iree_runtime_instance_t;
 // the caller must use external synchronization if they will be using it or any
 // resource derived from it concurrently. Any two sessions may be executed
 // concurrently without interference.
-typedef struct iree_runtime_session_s iree_runtime_session_t;
+typedef struct iree_runtime_session_t iree_runtime_session_t;
 
 //===----------------------------------------------------------------------===//
 // iree_runtime_session_options_t
 //===----------------------------------------------------------------------===//
 
 // Builtin modules that are provided by the runtime.
-enum iree_runtime_session_builtins_e {
+enum iree_runtime_session_builtins_bits_t {
   // All built-in modules that are compiled into the runtime will be available.
   IREE_RUNTIME_SESSION_BUILTIN_ALL = UINT64_MAX,
 };
 typedef uint64_t iree_runtime_session_builtins_t;
 
 // Options used to configure session creation.
-typedef struct {
+typedef struct iree_runtime_session_options_t {
   // A bitmask identifying which IREE builtin modules should be enabled.
   // Session creation will fail if a requested module is not built into the
   // runtime binary.

--- a/iree/samples/custom_modules/native_module.cc
+++ b/iree/samples/custom_modules/native_module.cc
@@ -29,7 +29,7 @@ static iree_vm_ref_type_descriptor_t iree_custom_message_descriptor = {0};
 // The descriptor that is registered at startup defines how to manage the
 // lifetime of the type (such as which destruction function is called, if any).
 // See ref.h for more information and additional utilities.
-typedef struct iree_custom_message {
+typedef struct iree_custom_message_t {
   // Ideally first; used to track the reference count of the object.
   iree_vm_ref_object_t ref_object;
   // Allocator the message was created from.

--- a/iree/samples/custom_modules/native_module.h
+++ b/iree/samples/custom_modules/native_module.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_custom_message iree_custom_message_t;
+typedef struct iree_custom_message_t iree_custom_message_t;
 
 // Creates a new !custom.message object with a copy of the given |value|.
 iree_status_t iree_custom_message_create(iree_string_view_t value,

--- a/iree/task/executor.h
+++ b/iree/task/executor.h
@@ -252,7 +252,7 @@ extern "C" {
 
 // A bitfield specifying the scheduling mode used for configuring how (or if)
 // work is balanced across queues.
-enum iree_task_scheduling_mode_e {
+enum iree_task_scheduling_mode_bits_t {
   // TODO(benvanik): batch, round-robin, FCFS, SJF, etc.
   // We can also allow for custom scheduling, though I'm skeptical of the value
   // of that. We should look into what GPUs do in hardware for balancing things
@@ -295,7 +295,7 @@ enum iree_task_scheduling_mode_e {
 typedef uint32_t iree_task_scheduling_mode_t;
 
 // Base task system executor interface.
-typedef struct iree_task_executor_s iree_task_executor_t;
+typedef struct iree_task_executor_t iree_task_executor_t;
 
 // Creates a task executor using the specified topology.
 // |topology| is only used during creation and need not live beyond this call.

--- a/iree/task/executor_impl.h
+++ b/iree/task/executor_impl.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-struct iree_task_executor_s {
+struct iree_task_executor_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 

--- a/iree/task/list.h
+++ b/iree/task/list.h
@@ -31,7 +31,7 @@ void iree_atomic_task_slist_discard(iree_atomic_task_slist_t* slist);
 //
 // Thread-compatible; designed to be used from a single thread manipulating a
 // list for passing to an API that accepts lists.
-typedef struct iree_task_list_s {
+typedef struct iree_task_list_t {
   iree_task_t* head;
   iree_task_t* tail;
 } iree_task_list_t;

--- a/iree/task/pool.h
+++ b/iree/task/pool.h
@@ -21,7 +21,7 @@ extern "C" {
 // This struct is at the head of all task allocations made from the allocator.
 // It is used to form a linked list of all allocations made so that they can be
 // easily freed during pool teardown.
-typedef struct {
+typedef struct iree_task_allocation_header_t {
   // Next allocation in the linked list of allocations.
   iree_atomic_slist_intrusive_ptr_t* next;
 } iree_task_allocation_header_t;
@@ -42,7 +42,7 @@ IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_atomic_task_allocation,
 // Pools can either be fixed-size with a maximum number of available tasks that
 // can be outstanding at any time or growable to allow the pool to be grown
 // unbounded after initialization.
-typedef struct iree_task_pool_s {
+typedef struct iree_task_pool_t {
   // Allocator used for allocating/freeing each allocation block.
   iree_allocator_t allocator;
 

--- a/iree/task/pool_test.cc
+++ b/iree/task/pool_test.cc
@@ -11,7 +11,7 @@
 
 namespace {
 
-typedef struct {
+typedef struct iree_test_task_t {
   iree_task_t base;
   uint8_t payload[32];
 } iree_test_task_t;

--- a/iree/task/post_batch.h
+++ b/iree/task/post_batch.h
@@ -16,13 +16,13 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_task_worker_s iree_task_worker_t;
+typedef struct iree_task_worker_t iree_task_worker_t;
 
 // Transient/stack-allocated structure for batching up tasks for posting to
 // worker mailboxes in single operations. This avoids the need to repeatedly
 // thrash caches during coordination as only during submission are the worker
 // mailboxes touched and only once per worker.
-typedef struct {
+typedef struct iree_task_post_batch_t {
   iree_task_executor_t* executor;
 
   // Local worker constructing the post batch.

--- a/iree/task/queue.h
+++ b/iree/task/queue.h
@@ -100,7 +100,7 @@ extern "C" {
 // list we can't easily just walk backward and we don't want to be introducing
 // cache line contention as thieves start touching the same tasks as the worker
 // is while processing.
-typedef struct {
+typedef struct iree_task_queue_t {
   // Must be held when manipulating the queue. >90% accesses are by the owner.
   iree_slim_mutex_t mutex;
 

--- a/iree/task/scope.h
+++ b/iree/task/scope.h
@@ -39,7 +39,7 @@ extern "C" {
 //
 // Thread-safe; once created scopes are modified exclusively via atomic
 // operations.
-typedef struct iree_task_scope_s {
+typedef struct iree_task_scope_t {
   // Name used for logging and tracing.
   char name[16];
 

--- a/iree/task/submission.h
+++ b/iree/task/submission.h
@@ -36,7 +36,7 @@ extern "C" {
 //
 // Thread-compatible; designed to be used from a single thread producing the
 // submission.
-typedef struct iree_task_submission_s {
+typedef struct iree_task_submission_t {
   // List of tasks that are ready for execution immediately. Upon submission to
   // a queue the tasks will be passed on to the executor with no delay.
   //

--- a/iree/task/task.h
+++ b/iree/task/task.h
@@ -18,17 +18,17 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_task_list_s iree_task_list_t;
-typedef struct iree_task_pool_s iree_task_pool_t;
-typedef struct iree_task_scope_s iree_task_scope_t;
-typedef struct iree_task_submission_s iree_task_submission_t;
+typedef struct iree_task_list_t iree_task_list_t;
+typedef struct iree_task_pool_t iree_task_pool_t;
+typedef struct iree_task_scope_t iree_task_scope_t;
+typedef struct iree_task_submission_t iree_task_submission_t;
 
 //==============================================================================
 // Task header for internal tracking
 //==============================================================================
 
 // Specifies the type of a task and how executors handle it.
-enum iree_task_type_e {
+enum iree_task_type_bits_t {
   // Task is a no-op (performs no work) and exists for flexibility.
   IREE_TASK_TYPE_NOP = 0u,
 
@@ -79,7 +79,7 @@ enum iree_task_type_e {
 };
 typedef uint8_t iree_task_type_t;
 
-enum iree_task_flags_e {
+enum iree_task_flag_bits_t {
   // The wait handle the task is specified to wait on has resolved and the task
   // can now be considered complete.
   IREE_TASK_FLAG_WAIT_COMPLETED = 1u << 0,
@@ -111,7 +111,7 @@ enum iree_task_flags_e {
 };
 typedef uint16_t iree_task_flags_t;
 
-typedef struct iree_task_s iree_task_t;
+typedef struct iree_task_t iree_task_t;
 
 // A function called to cleanup tasks.
 // The provided |status| is unowned and must be cloned if used beyond the scope
@@ -123,7 +123,7 @@ typedef void(IREE_API_PTR* iree_task_cleanup_fn_t)(iree_task_t* task,
 // Tasks have an iree_task_type_t that defines which parameters are valid and
 // how the executor is to treat the task. Dependency edges can be defined that
 // determine the execution order of tasks within the executors.
-struct iree_alignas(iree_max_align_t) iree_task_s {
+struct iree_alignas(iree_max_align_t) iree_task_t {
   // Instrusive pointer used to store tasks within iree_task_list_t and
   // iree_atomic_task_list_t singly-linked lists. This must come first in the
   // structure so that it is at the appropriate alignment.
@@ -231,7 +231,7 @@ typedef iree_status_t(IREE_API_PTR* iree_task_call_closure_fn_t)(
     iree_task_submission_t* pending_submission);
 
 // A function closure representing the function to call and its arguments.
-typedef struct {
+typedef struct iree_task_call_closure_t {
   // Function called per tile invocation.
   iree_task_call_closure_fn_t fn;
 
@@ -349,7 +349,7 @@ void iree_task_fence_initialize(iree_task_scope_t* scope,
 // IREE_TASK_TYPE_WAIT
 //==============================================================================
 
-typedef struct {
+typedef struct iree_task_wait_t {
   // Task header: implementation detail, do not use.
   iree_task_t header;
 
@@ -382,7 +382,7 @@ void iree_task_wait_initialize(iree_task_scope_t* scope,
 // If we find ourselves with a lot of hardware-specific counters (vs more
 // generic ones like 'l2 cache misses' or 'ipc') then we can sprinkle in some
 // #ifdefs.
-typedef struct {
+typedef struct iree_task_dispatch_statistics_t {
   // TODO(benvanik): statistics counters.
   // NOTE: each of these increases the command buffer storage requirements; we
   // should always guard these with a compiler flag.
@@ -396,7 +396,7 @@ void iree_task_dispatch_statistics_merge(
     const iree_task_dispatch_statistics_t* source,
     iree_task_dispatch_statistics_t* target);
 
-typedef struct {
+typedef struct iree_task_tile_storage_t {
   // TODO(benvanik): coroutine storage.
   // Ideally we'll be able to have a fixed coroutine storage size per dispatch
   // (via @llvm.coro.size) such that we can preallocate all of the storage for
@@ -435,7 +435,7 @@ typedef iree_alignas(iree_max_align_t) struct {
   // TODO(benvanik): per-tile coroutine storage.
 } iree_task_tile_context_t;
 
-typedef struct iree_task_dispatch_s iree_task_dispatch_t;
+typedef struct iree_task_dispatch_t iree_task_dispatch_t;
 
 // Shared state for all shards processing a dispatch.
 typedef iree_alignas(iree_max_align_t) struct {
@@ -465,7 +465,7 @@ typedef iree_status_t(IREE_API_PTR* iree_task_dispatch_closure_fn_t)(
     iree_task_submission_t* pending_submission);
 
 // A function closure representing the function to call and its arguments.
-typedef struct {
+typedef struct iree_task_dispatch_closure_t {
   // Function called per tile invocation.
   iree_task_dispatch_closure_fn_t fn;
 
@@ -507,7 +507,7 @@ static inline iree_task_dispatch_closure_t iree_task_make_dispatch_closure(
 //     -> dispatch_slice([2-3, 1, 1])
 //     -> dispatch_slice([4-5, 1, 1])
 //   completion_task run after all slices complete
-typedef iree_alignas(iree_max_align_t) struct iree_task_dispatch_s {
+typedef iree_alignas(iree_max_align_t) struct iree_task_dispatch_t {
   // Task header: implementation detail, do not use.
   iree_task_t header;
 

--- a/iree/task/topology.h
+++ b/iree/task/topology.h
@@ -30,13 +30,13 @@ typedef uint64_t iree_task_topology_group_mask_t;
 // Information about a particular group within the topology.
 // Groups may be of varying levels of granularity even within the same topology
 // based on how the topology is defined.
-typedef struct {
+typedef struct iree_task_topology_group_t {
   // Group index within the topology matching a particular bit in
   // iree_task_topology_group_mask_t.
   uint8_t group_index;
 
   // A name assigned to executor workers used for logging/tracing.
-  char name[16];
+  char name[15];
 
   // Processor index in the cpuinfo set.
   uint32_t processor_index;
@@ -75,7 +75,7 @@ void iree_task_topology_group_initialize(uint8_t group_index,
 // and attempt to derive some (hopefully) useful task system topology from it.
 // We can add the more common heuristics over time to the core and leave the
 // edge cases for applications to construct.
-typedef struct {
+typedef struct iree_task_topology_t {
   iree_host_size_t group_count;
   iree_task_topology_group_t groups[IREE_TASK_EXECUTOR_MAX_WORKER_COUNT];
 } iree_task_topology_t;

--- a/iree/task/worker.h
+++ b/iree/task/worker.h
@@ -30,20 +30,19 @@ extern "C" {
 // NOTE: state values are ordered such that </> comparisons can be used; ensure
 // that for example all states after resuming are > SUSPENDED and all states
 // before exiting are < EXITING.
-enum iree_task_worker_state_e {
+typedef enum iree_task_worker_state_e {
   // Worker has been created in a suspended state and must be resumed to wake.
-  IREE_TASK_WORKER_STATE_SUSPENDED = 0u,
+  IREE_TASK_WORKER_STATE_SUSPENDED = 0,
   // Worker is idle or actively processing tasks (either its own or others).
-  IREE_TASK_WORKER_STATE_RUNNING = 1u,
+  IREE_TASK_WORKER_STATE_RUNNING = 1,
   // Worker should exit (or is exiting) and will soon enter the zombie state.
   // Coordinators can request workers to exit by setting their state to this and
   // then waking.
-  IREE_TASK_WORKER_STATE_EXITING = 2u,
+  IREE_TASK_WORKER_STATE_EXITING = 2,
   // Worker has exited and entered a 🧟 state (waiting for join).
   // The thread handle is still valid and must be destroyed.
-  IREE_TASK_WORKER_STATE_ZOMBIE = 3u,
-};
-typedef int32_t iree_task_worker_state_t;
+  IREE_TASK_WORKER_STATE_ZOMBIE = 3,
+} iree_task_worker_state_t;
 
 // A worker within the executor pool.
 //
@@ -51,7 +50,7 @@ typedef int32_t iree_task_worker_state_t;
 // techniques. The alignment of the entire iree_task_worker_t as well as the
 // alignment and padding between particular fields is carefully (though perhaps
 // not yet correctly) selected; see the 'LAYOUT' comments below.
-typedef struct iree_task_worker_s {
+typedef struct iree_task_worker_t {
   // A LIFO mailbox used by coordinators to post tasks to this worker.
   // As workers self-nominate to be coordinators and fan out dispatch slices
   // they can directly emplace those slices into the workers that should execute

--- a/iree/testing/benchmark.h
+++ b/iree/testing/benchmark.h
@@ -25,7 +25,7 @@ extern "C" {
 // Benchmark state manipulator.
 // Passed to each benchmark during execution to control the benchmark state
 // or append information beyond just timing.
-typedef struct iree_benchmark_state_s {
+typedef struct iree_benchmark_state_t {
   // Internal implementation handle.
   void* impl;
 
@@ -82,21 +82,22 @@ void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
 // iree_benchmark_def_t
 //===----------------------------------------------------------------------===//
 
-typedef enum {
+enum iree_benchmark_flag_bits_t {
   IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME = 1u << 0,
 
   IREE_BENCHMARK_FLAG_USE_REAL_TIME = 1u << 1,
   IREE_BENCHMARK_FLAG_USE_MANUAL_TIME = 1u << 2,
-} iree_benchmark_flags_t;
+};
+typedef uint32_t iree_benchmark_flags_t;
 
-typedef enum {
+typedef enum iree_benchmark_unit_e {
   IREE_BENCHMARK_UNIT_MILLISECOND = 0,
   IREE_BENCHMARK_UNIT_MICROSECOND,
   IREE_BENCHMARK_UNIT_NANOSECOND,
 } iree_benchmark_unit_t;
 
 // A benchmark case definition.
-typedef struct iree_benchmark_def_s {
+typedef struct iree_benchmark_def_t {
   // IREE_BENCHMARK_FLAG_* bitmask controlling benchmark behavior and reporting.
   iree_benchmark_flags_t flags;
 

--- a/iree/vm/buffer.h
+++ b/iree/vm/buffer.h
@@ -17,7 +17,7 @@ extern "C" {
 // Describes where a byte buffer originates from, what guarantees can be made
 // about its lifetime and ownership, and how it may be accessed.
 // Note that buffers may always be read.
-enum iree_vm_buffer_access_e {
+enum iree_vm_buffer_access_bits_t {
   // The guest is allowed to write to the buffer.
   // If not specified the buffer is read-only.
   IREE_VM_BUFFER_ACCESS_MUTABLE = 1u << 0,
@@ -55,7 +55,7 @@ typedef uint32_t iree_vm_buffer_access_t;
 // For heap-allocated buffers created with iree_vm_buffer_create/clone/etc the
 // allocator is used to free the entire iree_vm_buffer_t and the co-allocated
 // buffer data that lives after it in memory.
-typedef struct {
+typedef struct iree_vm_buffer_t {
   iree_vm_ref_object_t ref_object;
   iree_vm_buffer_access_t access;
   iree_byte_span_t data;

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -62,7 +62,7 @@
 // value.
 
 // Pointers to typed register storage.
-typedef struct {
+typedef struct iree_vm_registers_t {
   // Ordinal mask defining which ordinal bits are valid. All i32 indexing must
   // be ANDed with this mask.
   uint16_t i32_mask;
@@ -78,7 +78,7 @@ typedef struct {
 // Storage associated with each stack frame of a bytecode function.
 // NOTE: we cannot store pointers to the stack in here as the stack may be
 // reallocated.
-typedef struct {
+typedef struct iree_vm_bytecode_frame_storage_t {
   // Pointer to a register list within the stack frame where return registers
   // will be stored by callees upon return.
   const iree_vm_register_list_t* return_registers;
@@ -95,7 +95,7 @@ typedef struct {
 // Interleaved src-dst register sets for branch register remapping.
 // This structure is an overlay for the bytecode that is serialized in a
 // matching format.
-typedef struct {
+typedef struct iree_vm_register_remap_list_t {
   uint16_t size;
   struct pair {
     uint16_t src_reg;

--- a/iree/vm/bytecode_module_benchmark.cc
+++ b/iree/vm/bytecode_module_benchmark.cc
@@ -18,8 +18,8 @@ namespace {
 
 struct native_import_module_s;
 struct native_import_module_state_s;
-typedef struct native_import_module_s native_import_module_t;
-typedef struct native_import_module_state_s native_import_module_state_t;
+typedef struct native_import_module_t native_import_module_t;
+typedef struct native_import_module_state_t native_import_module_state_t;
 
 // vm.import @native_import_module.add_1(%arg0 : i32) -> i32
 static iree_status_t native_import_module_add_1(

--- a/iree/vm/bytecode_module_impl.h
+++ b/iree/vm/bytecode_module_impl.h
@@ -42,7 +42,7 @@ extern "C" {
 #define IREE_REF_REGISTER_MASK 0x3FFF
 
 // A loaded bytecode module.
-typedef struct {
+typedef struct iree_vm_bytecode_module_t {
   // Interface routing to the bytecode module functions.
   // Must be first in the struct as we dereference the interface to find our
   // members below.
@@ -76,7 +76,7 @@ typedef struct {
 // only store the absolute minimum information to reduce our fixed overhead.
 // There's a big tradeoff though as a few extra bytes here can avoid non-trivial
 // work per import function invocation.
-typedef struct {
+typedef struct iree_vm_bytecode_import_t {
   // Import function in the source module.
   iree_vm_function_t function;
 
@@ -96,7 +96,7 @@ typedef struct {
 // This is allocated with a provided allocator as a single flat allocation.
 // This struct is a prefix to the allocation pointing into the dynamic offsets
 // of the allocation storage.
-typedef struct {
+typedef struct iree_vm_bytecode_module_state_t {
   // Combined rwdata storage for the entire module, including globals.
   // Aligned to 16 bytes (128-bits) for SIMD usage.
   iree_byte_span_t rwdata_storage;

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -13,7 +13,7 @@
 #include "iree/base/internal/atomics.h"
 #include "iree/base/tracing.h"
 
-struct iree_vm_context {
+struct iree_vm_context_t {
   iree_atomic_ref_count_t ref_count;
   iree_vm_instance_t* instance;
   iree_allocator_t allocator;

--- a/iree/vm/context.h
+++ b/iree/vm/context.h
@@ -27,7 +27,7 @@ extern "C" {
 // functions in previously registered modules.
 //
 // Thread-compatible and must be externally synchronized.
-typedef struct iree_vm_context iree_vm_context_t;
+typedef struct iree_vm_context_t iree_vm_context_t;
 
 // Creates a new context that uses the given |instance| for device management.
 // |out_context| must be released by the caller.

--- a/iree/vm/instance.c
+++ b/iree/vm/instance.c
@@ -10,7 +10,7 @@
 #include "iree/base/tracing.h"
 #include "iree/vm/builtin_types.h"
 
-struct iree_vm_instance {
+struct iree_vm_instance_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 };

--- a/iree/vm/instance.h
+++ b/iree/vm/instance.h
@@ -24,7 +24,7 @@ extern "C" {
 // restrictions it is mandatory to share instances, so plan accordingly.
 //
 // Thread-safe.
-typedef struct iree_vm_instance iree_vm_instance_t;
+typedef struct iree_vm_instance_t iree_vm_instance_t;
 
 // Creates a new instance. This should be shared with all contexts in an
 // application to ensure that resources are tracked properly and threads are

--- a/iree/vm/invocation.h
+++ b/iree/vm/invocation.h
@@ -18,8 +18,8 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_vm_invocation iree_vm_invocation_t;
-typedef struct iree_vm_invocation_policy iree_vm_invocation_policy_t;
+typedef struct iree_vm_invocation_t iree_vm_invocation_t;
+typedef struct iree_vm_invocation_policy_t iree_vm_invocation_policy_t;
 
 // Synchronously invokes a function in the VM.
 //

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -24,17 +24,17 @@ static_assert(IREE_VM_VALUE_TYPE_COUNT ==
 
 // Defines how the iree_vm_list_t storage is allocated and what elements are
 // interpreted as.
-typedef enum iree_vm_list_storage_mode {
+typedef enum iree_vm_list_storage_mode_e {
   // Each element is a primitive value and stored as a dense array.
   IREE_VM_LIST_STORAGE_MODE_VALUE = 0,
   // Each element is an iree_vm_ref_t of some type.
-  IREE_VM_LIST_STORAGE_MODE_REF = 1,
+  IREE_VM_LIST_STORAGE_MODE_REF,
   // Each element is a variant of any type (possibly all different).
-  IREE_VM_LIST_STORAGE_MODE_VARIANT = 2,
+  IREE_VM_LIST_STORAGE_MODE_VARIANT,
 } iree_vm_list_storage_mode_t;
 
 // A list able to hold either flat primitive elements or ref values.
-struct iree_vm_list {
+struct iree_vm_list_t {
   iree_vm_ref_object_t ref_object;
   iree_allocator_t allocator;
 

--- a/iree/vm/list.h
+++ b/iree/vm/list.h
@@ -29,7 +29,7 @@ extern "C" {
 // This type the same performance characteristics as std::vector; pushes may
 // grow the capacity of the list and to ensure minimal wastage it is always
 // better to reserve the exact desired element count first.
-typedef struct iree_vm_list iree_vm_list_t;
+typedef struct iree_vm_list_t iree_vm_list_t;
 
 // Returns the size in bytes required to store a list with the given element
 // type and capacity. This storage size can be used to stack allocate or reserve

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -17,9 +17,9 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_vm_module iree_vm_module_t;
-typedef struct iree_vm_stack iree_vm_stack_t;
-typedef struct iree_vm_stack_frame iree_vm_stack_frame_t;
+typedef struct iree_vm_module_t iree_vm_module_t;
+typedef struct iree_vm_stack_t iree_vm_stack_t;
+typedef struct iree_vm_stack_frame_t iree_vm_stack_frame_t;
 
 // An opaque offset into a source map that a source resolver can calculate.
 // Do not assume that iree_vm_source_offset_t+1 means the next byte offset as
@@ -28,7 +28,7 @@ typedef struct iree_vm_stack_frame iree_vm_stack_frame_t;
 typedef int64_t iree_vm_source_offset_t;
 
 // A key-value pair of module/function reflection information.
-typedef struct {
+typedef struct iree_vm_reflection_attr_t {
   iree_string_view_t key;
   iree_string_view_t value;
 } iree_vm_reflection_attr_t;
@@ -42,7 +42,7 @@ typedef struct {
 // used for toll-free variadic argument lists here. We could just define an
 // identical structure (and static_assert) to at least rename it to something
 // sensible (iree_vm_segment_size_list_t).
-typedef struct {
+typedef struct iree_vm_register_list_t {
   uint16_t size;
   uint16_t registers[];
 } iree_vm_register_list_t;
@@ -52,7 +52,7 @@ static_assert(offsetof(iree_vm_register_list_t, registers) == 2,
               "expect no padding in the struct");
 
 // Describes the type of a function reference.
-enum iree_vm_function_linkage_e {
+typedef enum iree_vm_function_linkage_e {
   // Function is internal to the module and may not be reflectable.
   IREE_VM_FUNCTION_LINKAGE_INTERNAL = 0,
   // Function is an import from another module.
@@ -60,8 +60,7 @@ enum iree_vm_function_linkage_e {
   // Function is an export from the module.
   IREE_VM_FUNCTION_LINKAGE_EXPORT = 2,
   // TODO(#1979): add linkage types for well-known functions like __init.
-};
-typedef uint16_t iree_vm_function_linkage_t;
+} iree_vm_function_linkage_t;
 
 // A function reference that can be used with the iree_vm_function_* methods.
 // These should be treated as opaque and the accessor functions should be used
@@ -71,7 +70,7 @@ typedef uint16_t iree_vm_function_linkage_t;
 // frame management and debugging. They must at least be able to contain all
 // entry arguments for the function. The counts may be omitted if the function
 // will not be referenced by a VM stack frame.
-typedef struct {
+typedef struct iree_vm_function_t {
   // Module the function is contained within.
   iree_vm_module_t* module;
   // Linkage of the function. Note that IREE_VM_FUNCTION_LINKAGE_INTERNAL
@@ -90,7 +89,7 @@ static inline bool iree_vm_function_is_null(iree_vm_function_t function) {
 
 // Describes the expected calling convention and arguments/results of a
 // function.
-typedef struct {
+typedef struct iree_vm_function_signature_t {
   // The VM calling convention declaration used to marshal arguments and
   // results into and out of the function.
   // Optional for imports and internal functions but required for exports.
@@ -119,7 +118,7 @@ typedef struct {
 } iree_vm_function_signature_t;
 
 // Describes the imports, exports, and capabilities of a module.
-typedef struct {
+typedef struct iree_vm_module_signature_t {
   // Total number of imported functions.
   iree_host_size_t import_function_count;
   // Total number of exported functions.
@@ -132,7 +131,7 @@ typedef struct {
 // Internal storage for the module state.
 // Thread-compatible; it's expected that only one thread at a time is executing
 // VM functions and accessing this state.
-typedef struct iree_vm_module_state iree_vm_module_state_t;
+typedef struct iree_vm_module_state_t iree_vm_module_state_t;
 
 // Function call data.
 //
@@ -177,7 +176,7 @@ typedef struct iree_vm_module_state iree_vm_module_state_t;
 // argument/result buffers and map them between independent address spaces.
 // Instead, implementing a native_module-alike of libffi_module would be a
 // better layering for callee modules.
-typedef struct {
+typedef struct iree_vm_function_call_t {
   // Function to call.
   iree_vm_function_t function;
 
@@ -250,7 +249,7 @@ IREE_API_EXPORT void iree_vm_function_call_release(
     const iree_vm_function_signature_t* signature);
 
 // Results of an iree_vm_module_execute request.
-typedef struct {
+typedef struct iree_vm_execution_result_t {
   // TODO(benvanik): yield information.
   // Yield modes:
   // - yield (yield instruction)
@@ -265,7 +264,7 @@ typedef struct {
 // Module implementations must be thread-safe as lookups and executions may
 // occur in any order from any thread.
 // TODO(benvanik): version this interface.
-typedef struct iree_vm_module {
+typedef struct iree_vm_module_t {
   IREE_API_UNSTABLE
 
   void* self;

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -9,7 +9,7 @@
 #include "iree/vm/stack.h"
 
 // Native module implementation allocated for all modules.
-typedef struct {
+typedef struct iree_vm_native_module_t {
   // Interface containing default function pointers.
   // base_interface.self will be the self pointer to iree_vm_native_module_t.
   //

--- a/iree/vm/native_module.h
+++ b/iree/vm/native_module.h
@@ -21,7 +21,7 @@ extern "C" {
 // Describes an imported native function in a native module.
 // All of this information is assumed read-only and will be referenced for the
 // lifetime of any module created with the descriptor.
-typedef struct {
+typedef struct iree_vm_native_import_descriptor_t {
   // Fully-qualified function name (for example, 'other_module.foo').
   iree_string_view_t full_name;
 } iree_vm_native_import_descriptor_t;
@@ -29,7 +29,7 @@ typedef struct {
 // Describes an exported native function in a native module.
 // All of this information is assumed read-only and will be referenced for the
 // lifetime of any module created with the descriptor.
-typedef struct {
+typedef struct iree_vm_native_export_descriptor_t {
   // Module-local function name (for example, 'foo' for function 'module.foo').
   iree_string_view_t local_name;
 
@@ -50,7 +50,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_shim_t)(
     void* module_state, iree_vm_execution_result_t* out_result);
 
 // An entry in the function pointer table.
-typedef struct {
+typedef struct iree_vm_native_function_ptr_t {
   // A shim function that takes the VM ABI and maps it to the target ABI.
   iree_vm_native_function_shim_t shim;
   // Target function passed to the shim.
@@ -64,7 +64,7 @@ typedef struct {
 // The common native module code will use this descriptor to return metadata on
 // query, lookup exported functions, and call module-provided implementation
 // functions for state and call management.
-typedef struct {
+typedef struct iree_vm_native_module_descriptor_t {
   IREE_API_UNSTABLE
 
   // Name of the module prefixed on all exported functions.

--- a/iree/vm/native_module_test.h
+++ b/iree/vm/native_module_test.h
@@ -71,8 +71,8 @@ static iree_status_t call_shim_i32_i32(iree_vm_stack_t* stack,
 
 struct module_a_s;
 struct module_a_state_s;
-typedef struct module_a_s module_a_t;
-typedef struct module_a_state_s module_a_state_t;
+typedef struct module_a_t module_a_t;
+typedef struct module_a_state_t module_a_state_t;
 
 // vm.import @module_a.add_1(%arg0 : i32) -> i32
 static iree_status_t module_a_add_1(iree_vm_stack_t* stack, module_a_t* module,
@@ -135,13 +135,13 @@ static iree_status_t module_a_create(iree_allocator_t allocator,
 
 struct module_b_s;
 struct module_b_state_s;
-typedef struct module_b_s module_b_t;
-typedef struct module_b_state_s module_b_state_t;
+typedef struct module_b_t module_b_t;
+typedef struct module_b_state_t module_b_state_t;
 
 // Stores shared state across all instances of the module.
 // This should generally be treated as read-only and if mutation is possible
 // then users must synchronize themselves.
-typedef struct module_b_s {
+typedef struct module_b_t {
   // Allocator the module must be freed with and that can be used for any other
   // shared dynamic allocations.
   iree_allocator_t allocator;
@@ -153,7 +153,7 @@ typedef struct module_b_s {
 // Stores per-context state; at the minimum imports, but possibly other user
 // state data. No synchronization is required as the VM will not call functions
 // with the same state from multiple threads concurrently.
-typedef struct module_b_state_s {
+typedef struct module_b_state_t {
   // Allocator the state must be freed with and that can be used for any other
   // per-context dynamic allocations.
   iree_allocator_t allocator;

--- a/iree/vm/ref.h
+++ b/iree/vm/ref.h
@@ -23,7 +23,7 @@ extern "C" {
 // are correct at runtime. We don't allow control over the ref types from the
 // VM ops and as such we can use the type specified as a safe way to avoid
 // reinterpreting memory incorrectly.
-typedef enum {
+enum iree_vm_ref_type_bits_t {
   IREE_VM_REF_TYPE_NULL = 0,
 
   // NOTE: these type values are assigned dynamically right now. Treat them as
@@ -35,12 +35,13 @@ typedef enum {
   // Wildcard type that indicates that a value may be a ref type but of an
   // unspecified internal type.
   IREE_VM_REF_TYPE_ANY = 0x00FFFFFFu,
-} iree_vm_ref_type_t;
+};
+typedef uint32_t iree_vm_ref_type_t;
 
 // Base for iree_vm_ref_t object targets.
 //
 // Usage (C):
-//  typedef struct {
+//  typedef struct my_type_t {
 //    iree_vm_ref_object_t ref_object;
 //    int my_fields;
 //  } my_type_t;
@@ -56,7 +57,7 @@ typedef enum {
 //
 // Usage (C++):
 //  Prefer using iree::vm::RefObject as a base type.
-typedef struct {
+typedef struct iree_vm_ref_object_t {
   iree_atomic_ref_count_t counter;
 } iree_vm_ref_object_t;
 
@@ -70,7 +71,7 @@ typedef struct {
 // Ideally the iree_vm_ref_t is in-cache on the stack and the target ptr is
 // either in cache from a previous use or will be used again after manipulating
 // its ref count.
-typedef struct {
+typedef struct iree_vm_ref_t {
   // Pointer to the object. Type is resolved based on the |type| field.
   // Will be NULL if the reference points to nothing.
   void* ptr;
@@ -88,7 +89,7 @@ static_assert(
 typedef void(IREE_API_PTR* iree_vm_ref_destroy_t)(void* ptr);
 
 // Describes a type for the VM.
-typedef struct {
+typedef struct iree_vm_ref_type_descriptor_t {
   // Function called when references of this type reach 0 and should be
   // destroyed.
   iree_vm_ref_destroy_t destroy;

--- a/iree/vm/shims.h
+++ b/iree/vm/shims.h
@@ -28,7 +28,7 @@
                               IREE_VM_ABI_TYPE_NAME(types), body)
 
 #define IREE_VM_ABI_FIXED_STRUCT_IMPL(types, struct_type, body)        \
-  typedef struct iree_vm_abi_##types##_s body IREE_ATTRIBUTE_PACKED    \
+  typedef struct iree_vm_abi_##types##_t body IREE_ATTRIBUTE_PACKED    \
       struct_type;                                                     \
   static inline struct_type* iree_vm_abi_##types##_checked_deref(      \
       iree_byte_span_t buffer) {                                       \
@@ -43,7 +43,7 @@
 #define IREE_VM_ABI_FIELD_SIZE(type, member) sizeof(((type*)NULL)->member)
 #define IREE_VM_ABI_VLA_STRUCT_IMPL(types, vla_count, vla_field, struct_type, \
                                     body)                                     \
-  typedef struct iree_vm_abi_##types##_s body IREE_ATTRIBUTE_PACKED           \
+  typedef struct iree_vm_abi_##types##_t body IREE_ATTRIBUTE_PACKED           \
       struct_type;                                                            \
   static inline struct_type* iree_vm_abi_##types##_checked_deref(             \
       iree_byte_span_t buffer) {                                              \
@@ -148,7 +148,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
 #endif  // IREE_COMPILER_MSVC
 
 // Special case for void (empty args/rets) as C structs can't have a 0 length.
-typedef struct {
+typedef struct iree_vm_abi_v_t {
   int unused;
 } iree_vm_abi_v_t;
 static inline iree_vm_abi_v_t* iree_vm_abi_v_checked_deref(

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -121,7 +121,7 @@
 // frames without exposing their exact structure through the API. This makes it
 // easier for us to add/version additional information or hide implementation
 // details.
-typedef struct iree_vm_stack_frame_header {
+typedef struct iree_vm_stack_frame_header_t {
   // Size, in bytes, of the frame header and frame payload including registers.
   // Adding this value to the base header pointer will yield the next available
   // memory location. Ensure that it does not exceed the total
@@ -130,7 +130,7 @@ typedef struct iree_vm_stack_frame_header {
 
   // Pointer to the parent stack frame, usually immediately preceding this one
   // in the frame storage. May be NULL.
-  struct iree_vm_stack_frame_header* parent;
+  struct iree_vm_stack_frame_header_t* parent;
 
   // Stack frame type used to determine which fields are valid.
   iree_vm_stack_frame_type_t type;
@@ -150,7 +150,7 @@ typedef struct iree_vm_stack_frame_header {
 // Core stack storage. This will be mapped either into dynamic memory allocated
 // by the member allocator or static memory allocated externally. Static stacks
 // cannot grow when storage runs out while dynamic ones will resize their stack.
-struct iree_vm_stack {
+struct iree_vm_stack_t {
   // NOTE: to get better cache hit rates we put the most frequently accessed
   // members first.
 

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -39,7 +39,7 @@ extern "C" {
 // The maximum size of VM stack storage; anything larger is probably a bug.
 #define IREE_VM_STACK_MAX_SIZE (1 * 1024 * 1024)
 
-enum {
+typedef enum iree_vm_stack_frame_type_e {
   // Represents an `[external]` frame that needs to marshal args/results.
   // These frames have no source location and are tracked so that we know when
   // transitions occur into/out-of external code.
@@ -50,8 +50,7 @@ enum {
   IREE_VM_STACK_FRAME_NATIVE = 1,
   // VM stack frame in bytecode using internal register storage.
   IREE_VM_STACK_FRAME_BYTECODE = 2,
-};
-typedef uint8_t iree_vm_stack_frame_type_t;
+} iree_vm_stack_frame_type_t;
 
 // A single stack frame within the VM.
 //
@@ -59,7 +58,7 @@ typedef uint8_t iree_vm_stack_frame_type_t;
 // accessed members **LAST**. This is because the custom frame storage data
 // immediately follows this struct in memory and is highly likely to be touched
 // by the callee immediately and repeatedly.
-typedef struct iree_vm_stack_frame {
+typedef struct iree_vm_stack_frame_t {
   // Function that the stack frame is within.
   iree_vm_function_t function;
 
@@ -94,7 +93,7 @@ typedef void(IREE_API_PTR* iree_vm_stack_frame_cleanup_fn_t)(
     iree_vm_stack_frame_t* frame);
 
 // A state resolver that can allocate or lookup module state.
-typedef struct iree_vm_state_resolver {
+typedef struct iree_vm_state_resolver_t {
   void* self;
   iree_status_t(IREE_API_PTR* query_module_state)(
       void* state_resolver, iree_vm_module_t* module,
@@ -104,7 +103,7 @@ typedef struct iree_vm_state_resolver {
 // A fiber stack used for storing stack frame state during execution.
 // All required state is stored within the stack and no host thread-local state
 // is used allowing us to execute multiple fibers on the same host thread.
-typedef struct iree_vm_stack iree_vm_stack_t;
+typedef struct iree_vm_stack_t iree_vm_stack_t;
 
 // Defines and initializes an inline VM stack.
 // The stack will be ready for use and must be deinitialized with

--- a/iree/vm/type_def.h
+++ b/iree/vm/type_def.h
@@ -23,7 +23,7 @@ extern "C" {
 // * i8: primitive value (value_type != 0)
 // * !vm.ref<?>: any ref value (ref_type == IREE_VM_REF_TYPE_ANY)
 // * !vm.ref<!foo>: ref value of type !foo (ref_type > 0)
-typedef struct {
+typedef struct iree_vm_type_def_t {
   iree_vm_value_type_t value_type : 8;
   iree_vm_ref_type_t ref_type : 24;
 } iree_vm_type_def_t;
@@ -61,7 +61,7 @@ static inline iree_vm_type_def_t iree_vm_type_def_make_ref_type(
 // An variant value that can be either a primitive value type or a ref type.
 // Each variant value stores its type but users are required to check the type
 // prior to accessing any of the data.
-typedef struct {
+typedef struct iree_vm_variant_t {
   iree_vm_type_def_t type;
   union {
     // TODO(benvanik): replace with iree_vm_value_t.

--- a/iree/vm/value.h
+++ b/iree/vm/value.h
@@ -19,7 +19,7 @@ extern "C" {
 typedef int32_t iree_vm_size_t;
 
 // Defines the type of a primitive value.
-typedef enum {
+typedef enum iree_vm_value_type_e {
   // Not a value type.
   IREE_VM_VALUE_TYPE_NONE = 0,
   // int8_t.
@@ -36,14 +36,14 @@ typedef enum {
   IREE_VM_VALUE_TYPE_F64 = 6,
 
   IREE_VM_VALUE_TYPE_MAX = IREE_VM_VALUE_TYPE_F64,
-  IREE_VM_VALUE_TYPE_COUNT = IREE_VM_VALUE_TYPE_MAX + 1,
+  IREE_VM_VALUE_TYPE_COUNT = IREE_VM_VALUE_TYPE_MAX + 1,  // used for lookup
 } iree_vm_value_type_t;
 
 // Maximum size, in bytes, of any value type we can represent.
 #define IREE_VM_VALUE_STORAGE_SIZE 8
 
 // A variant value type.
-typedef struct iree_vm_value {
+typedef struct iree_vm_value_t {
   iree_vm_value_type_t type;
   union {
     int8_t i8;


### PR DESCRIPTION
Named untypedefed structs allow for forward declarations - they're only
needed when you want to forward-declare, but the inconsistency was unclear
and led to a lot of copypasta usages. Typedefed enums only work for actual
enums and not for bitfields, which must be typed specifically. Enums can't
be forward-declared so there's no use naming them.