### PR TITLE
Add support for lowering select op to HAL.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertStructuralOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertStructuralOps.cpp
@@ -124,6 +124,21 @@ class ReturnOpConversion : public OpConversionPattern<mlir::ReturnOp> {
   }
 };
 
+class SelectOpConversion : public OpConversionPattern<mlir::SelectOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::SelectOp selectOp, llvm::ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    mlir::SelectOp::Adaptor adaptor(operands);
+    rewriter.replaceOpWithNewOp<mlir::SelectOp>(selectOp, adaptor.condition(),
+                                                adaptor.true_value(),
+                                                adaptor.false_value());
+    return success();
+  }
+};
+
 }  // namespace
 
 void populateStandardStructuralToHALPatterns(MLIRContext *context,
@@ -131,7 +146,8 @@ void populateStandardStructuralToHALPatterns(MLIRContext *context,
                                              TypeConverter &converter) {
   patterns
       .insert<FuncOpSignatureConversion, CallOpConversion, BranchOpConversion,
-              CondBranchOpConversion, ReturnOpConversion>(converter, context);
+              CondBranchOpConversion, ReturnOpConversion, SelectOpConversion>(
+          converter, context);
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/test/structural_ops.mlir
@@ -9,3 +9,13 @@ func @tensorIO(%arg0 : tensor<1x1xi32>) -> tensor<1x1xi32> {
   // CHECK-NEXT: return %[[BB0]] : !hal.buffer
   return %0 : tensor<1x1xi32>
 }
+
+// -----
+
+// CHECK-LABEL: func @select(%arg0: i1, %arg1: !hal.buffer, %arg2: !hal.buffer) -> !hal.buffer
+func @select(%arg0: i1, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<i32> {
+  // CHECK: %[[RES:.+]] = select %arg0, %arg1, %arg2 : !hal.buffer
+  %0 = select %arg0, %arg1, %arg2 : tensor<i32>
+  // CHECK: return %[[RES]] : !hal.buffer
+  return %0 : tensor<i32>
+}


### PR DESCRIPTION
We are able to run select operations in VM. This PR adds missing
lowering for select op to HAL.

Part of https://github.com/google/iree/issues/6034