### PR TITLE
Re-implement algebraic complex tensor patterns.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/BUILD
@@ -14,6 +14,7 @@ cc_library(
     name = "HLOToLinalg",
     srcs = [
         "BroadcastingToLinalgPatterns.cpp",
+        "ConvertComplexToReal.cpp",
         "FusionOfTensorOps.cpp",
         "HLOToLinalgOnTensors.cpp",
         "ResolveShapeOps.cpp",
@@ -37,6 +38,7 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
+        "@mlir-hlo//:chlo_legalize_to_hlo",
         "@mlir-hlo//:hlo",
         "@mlir-hlo//:legalize_to_linalg",
     ],

--- a/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     HLOToLinalg
   SRCS
     "BroadcastingToLinalgPatterns.cpp"
+    "ConvertComplexToReal.cpp"
     "FusionOfTensorOps.cpp"
     "HLOToLinalgOnTensors.cpp"
     "ResolveShapeOps.cpp"

--- a/iree/compiler/Conversion/HLOToLinalg/ConvertComplexToReal.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/ConvertComplexToReal.cpp
@@ -1,0 +1,443 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Conversion/PassDetail.h"
+#include "iree/compiler/Conversion/Passes.h"
+#include "iree/compiler/Conversion/Rewriters.h"
+#include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+bool isComplexTensor(Value v) {
+  if (auto tt = v.getType().dyn_cast<TensorType>()) {
+    return tt.getElementType().isa<ComplexType>();
+  }
+  return false;
+}
+
+Type convertComplexTensorTypeToReal(Type complexTensorType) {
+  auto newElementType = complexTensorType.cast<TensorType>()
+                            .getElementType()
+                            .cast<ComplexType>()
+                            .getElementType();
+  if (auto tt = complexTensorType.dyn_cast<RankedTensorType>()) {
+    return RankedTensorType::get(tt.getShape(), newElementType,
+                                 tt.getEncoding());
+  } else if (auto tt = complexTensorType.dyn_cast<UnrankedTensorType>()) {
+    return UnrankedTensorType::get(newElementType);
+  }
+  llvm_unreachable("unknown TensorType subclass");
+}
+
+// Add and subtraction are elementwise and can be distributed across the real
+// and imaginary components.
+template <typename OpTy>
+struct ConvertAddSubOp : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  static Value createOp(OpBuilder &b, mhlo::AddOp op, Value lhs, Value rhs) {
+    return b.create<mhlo::AddOp>(op.getLoc(), lhs, rhs);
+  }
+  static Value createOp(OpBuilder &b, mhlo::SubOp op, Value lhs, Value rhs) {
+    return b.create<mhlo::SubOp>(op.getLoc(), lhs, rhs);
+  }
+  static Value createOp(OpBuilder &b, chlo::BroadcastAddOp op, Value lhs,
+                        Value rhs) {
+    return b.create<chlo::BroadcastAddOp>(op.getLoc(), lhs, rhs, nullptr);
+  }
+  static Value createOp(OpBuilder &b, chlo::BroadcastSubOp op, Value lhs,
+                        Value rhs) {
+    return b.create<chlo::BroadcastSubOp>(op.getLoc(), lhs, rhs, nullptr);
+  }
+
+  LogicalResult matchAndRewrite(
+      OpTy op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    typename OpTy::Adaptor transformed(operands);
+    Location loc = op.getLoc();
+    if (!isComplexTensor(transformed.lhs()) ||
+        !isComplexTensor(transformed.rhs())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+
+    Value real =
+        createOp(rewriter, op,
+                 rewriter.createOrFold<mhlo::RealOp>(loc, transformed.lhs()),
+                 rewriter.createOrFold<mhlo::RealOp>(loc, transformed.rhs()));
+    Value imag =
+        createOp(rewriter, op,
+                 rewriter.createOrFold<mhlo::ImagOp>(loc, transformed.lhs()),
+                 rewriter.createOrFold<mhlo::ImagOp>(loc, transformed.rhs()));
+    Value result = rewriter.create<mhlo::ComplexOp>(loc, real, imag);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+// Complex multiplication results in a cross product multiplication between the
+// real and imaginary components such that:
+//   result.real = lhs.real * rhs.real - lhs.imag * rhs.imag
+//   result.imag = lhs.imag * rhs.real + lhs.real * rhs.imag
+template <typename MulOpTy>
+struct ConvertMulOp : public OpConversionPattern<MulOpTy> {
+  using OpConversionPattern<MulOpTy>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      MulOpTy op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    typename MulOpTy::Adaptor transformed(operands);
+    Location loc = op.getLoc();
+
+    if (!isComplexTensor(transformed.lhs()) ||
+        !isComplexTensor(transformed.rhs())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+
+    auto lhsReal = rewriter.createOrFold<mhlo::RealOp>(loc, transformed.lhs());
+    auto lhsImag = rewriter.createOrFold<mhlo::ImagOp>(loc, transformed.lhs());
+    auto rhsReal = rewriter.createOrFold<mhlo::RealOp>(loc, transformed.rhs());
+    auto rhsImag = rewriter.createOrFold<mhlo::ImagOp>(loc, transformed.rhs());
+
+    auto realComponent = rewriter.create<mhlo::SubOp>(
+        loc,
+        rewriter.create<chlo::BroadcastMulOp>(loc, lhsReal, rhsReal,
+                                              /*broadcast_dimensions=*/nullptr),
+        rewriter.create<chlo::BroadcastMulOp>(
+            loc, lhsImag, rhsImag, /*broadcast_dimensions=*/nullptr));
+    auto imagComponent = rewriter.create<mhlo::AddOp>(
+        loc,
+        rewriter.create<chlo::BroadcastMulOp>(loc, lhsReal, rhsImag,
+                                              /*broadcast_dimensions=*/nullptr),
+        rewriter.create<chlo::BroadcastMulOp>(
+            loc, lhsImag, rhsReal, /*broadcast_dimensions=*/nullptr));
+    Value result = rewriter.createOrFold<mhlo::ComplexOp>(loc, realComponent,
+                                                          imagComponent);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+// Division is performed by normalizing the denominator by multiplying by the
+// conjugate of the rhs.
+//   numerator = lhs * conj(rhs)
+//   denominator = rhs * conj(rhs)
+template <typename DivOpTy>
+struct ConvertDivOp : public OpConversionPattern<DivOpTy> {
+  using OpConversionPattern<DivOpTy>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      DivOpTy op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    typename DivOpTy::Adaptor transformed(operands);
+    Location loc = op.getLoc();
+
+    if (!isComplexTensor(transformed.lhs()) ||
+        !isComplexTensor(transformed.rhs())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+
+    auto lhs = transformed.lhs();
+    auto rhs = transformed.rhs();
+    auto rhsReal = rewriter.createOrFold<mhlo::RealOp>(loc, rhs);
+    auto rhsImag = rewriter.createOrFold<mhlo::ImagOp>(loc, rhs);
+
+    Value conj = rewriter.createOrFold<mhlo::ComplexOp>(
+        loc, rhsReal, rewriter.create<mhlo::NegOp>(loc, rhsImag));
+    Value complexNumerator = rewriter.create<chlo::BroadcastMulOp>(
+        loc, lhs, conj, /*broadcast_dimensions=*/nullptr);
+    Value denominator = rewriter.create<mhlo::AddOp>(
+        loc, rewriter.create<mhlo::MulOp>(loc, rhsReal, rhsReal),
+        rewriter.create<mhlo::MulOp>(loc, rhsImag, rhsImag));
+
+    Value realComponent = rewriter.create<chlo::BroadcastDivOp>(
+        loc, rewriter.create<mhlo::RealOp>(loc, complexNumerator), denominator,
+        /*broadcast_dimensions=*/nullptr);
+    Value imagComponent = rewriter.create<chlo::BroadcastDivOp>(
+        loc, rewriter.create<mhlo::ImagOp>(loc, complexNumerator), denominator,
+        /*broadcast_dimensions=*/nullptr);
+
+    Value result = rewriter.createOrFold<mhlo::ComplexOp>(loc, realComponent,
+                                                          imagComponent);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+// Absolute value is evaluated as:
+//   result = sqrt(val.real * val.real + val.imag * val.imag)
+struct ConvertAbsOp : public OpConversionPattern<mhlo::AbsOp> {
+  using OpConversionPattern<mhlo::AbsOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::AbsOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    mhlo::AbsOpAdaptor transformed(operands);
+    Location loc = op.getLoc();
+
+    if (!isComplexTensor(transformed.operand())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+
+    auto operandReal =
+        rewriter.createOrFold<mhlo::RealOp>(loc, transformed.operand());
+    auto operandImag =
+        rewriter.createOrFold<mhlo::ImagOp>(loc, transformed.operand());
+    rewriter.replaceOpWithNewOp<mhlo::SqrtOp>(
+        op,
+        rewriter.create<mhlo::AddOp>(
+            loc, rewriter.create<mhlo::MulOp>(loc, operandReal, operandReal),
+            rewriter.create<mhlo::MulOp>(loc, operandImag, operandImag)));
+    return success();
+  }
+};
+
+// Exponential can be lowered to an exponential on the real component and a
+// sum of sinusoids of the imaginary component, which equates to a normal
+// exponential operator multiplied by Euler's formula.
+//
+// Exp(a + ib) = Exp(a) * Exp(ib) = Exp(a) * Cos(b) + Exp(a) * iSin(b))
+struct ConvertExpOp : public OpConversionPattern<mhlo::ExpOp> {
+  using OpConversionPattern<mhlo::ExpOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::ExpOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    mhlo::ExpOpAdaptor transformed(operands);
+    Location loc = op.getLoc();
+
+    if (!isComplexTensor(transformed.operand())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+
+    auto operandReal =
+        rewriter.create<mhlo::RealOp>(loc, transformed.operand());
+    auto operandImag =
+        rewriter.create<mhlo::ImagOp>(loc, transformed.operand());
+
+    Value expReal = rewriter.create<mhlo::ExpOp>(loc, operandReal);
+    Value result = rewriter.createOrFold<mhlo::ComplexOp>(
+        loc,
+        rewriter.create<mhlo::MulOp>(
+            loc, rewriter.create<mhlo::CosOp>(loc, operandImag), expReal),
+        rewriter.create<mhlo::MulOp>(
+            loc, rewriter.create<mhlo::SinOp>(loc, operandImag), expReal));
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+template <typename CompareOpTy, typename ComparatorOpTy>
+struct ConvertCompareOp : public OpConversionPattern<CompareOpTy> {
+  using OpConversionPattern<CompareOpTy>::OpConversionPattern;
+  ConvertCompareOp(TypeConverter &typeConverter, MLIRContext *context,
+                   mhlo::ComparisonDirection direction)
+      : OpConversionPattern<CompareOpTy>(typeConverter, context),
+        direction(mhlo::stringifyEnum(direction)) {}
+
+  LogicalResult matchAndRewrite(
+      CompareOpTy op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    typename CompareOpTy::Adaptor transformed(operands);
+    Location loc = op.getLoc();
+
+    if (!isComplexTensor(transformed.lhs()) ||
+        !isComplexTensor(transformed.rhs())) {
+      return rewriter.notifyMatchFailure(op, "not complex tensor");
+    }
+    if (direction != op.comparison_direction()) {
+      return rewriter.notifyMatchFailure(op, "not matching direction");
+    }
+
+    auto lhs = transformed.lhs();
+    auto rhs = transformed.rhs();
+    auto lhsReal = rewriter.createOrFold<mhlo::RealOp>(loc, lhs);
+    auto lhsImag = rewriter.createOrFold<mhlo::ImagOp>(loc, lhs);
+    auto rhsReal = rewriter.createOrFold<mhlo::RealOp>(loc, rhs);
+    auto rhsImag = rewriter.createOrFold<mhlo::ImagOp>(loc, rhs);
+
+    rewriter.replaceOpWithNewOp<ComparatorOpTy>(
+        op,
+        rewriter.create<chlo::BroadcastCompareOp>(
+            loc, lhsReal, rhsReal,
+            /*broadcast_dimensions=*/nullptr, op.comparison_directionAttr(),
+            op.compare_typeAttr()),
+        rewriter.create<chlo::BroadcastCompareOp>(
+            loc, lhsImag, rhsImag,
+            /*broadcast_dimensions=*/nullptr, op.comparison_directionAttr(),
+            op.compare_typeAttr()));
+
+    return success();
+  }
+
+  StringRef direction;
+};
+
+struct ElideComplexPattern : public OpConversionPattern<mhlo::ComplexOp> {
+  using OpConversionPattern<mhlo::ComplexOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::ComplexOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ElideRealPattern : public OpConversionPattern<mhlo::RealOp> {
+  using OpConversionPattern<mhlo::RealOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::RealOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto complexProducer = operands[0].getDefiningOp<mhlo::ComplexOp>();
+    if (complexProducer) {
+      rewriter.replaceOp(op, complexProducer.lhs());
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct ElideImagPattern : public OpConversionPattern<mhlo::ImagOp> {
+  using OpConversionPattern<mhlo::ImagOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::ImagOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto complexProducer = operands[0].getDefiningOp<mhlo::ComplexOp>();
+    if (complexProducer) {
+      rewriter.replaceOp(op, complexProducer.rhs());
+      return success();
+    }
+    return failure();
+  }
+};
+
+}  // namespace
+
+void populateHLOComplexToRealPatterns(MLIRContext *context,
+                                      TypeConverter &typeConverter,
+                                      OwningRewritePatternList &patterns) {
+  // Add an subtract patterns.
+  patterns.insert<ConvertAddSubOp<mhlo::AddOp>>(typeConverter, context);
+  patterns.insert<ConvertAddSubOp<mhlo::SubOp>>(typeConverter, context);
+  patterns.insert<ConvertAddSubOp<chlo::BroadcastAddOp>>(typeConverter,
+                                                         context);
+  patterns.insert<ConvertAddSubOp<chlo::BroadcastSubOp>>(typeConverter,
+                                                         context);
+
+  // Mul patterns.
+  patterns.insert<ConvertMulOp<mhlo::MulOp>>(typeConverter, context);
+  patterns.insert<ConvertMulOp<chlo::BroadcastMulOp>>(typeConverter, context);
+
+  // Div patterns.
+  patterns.insert<ConvertDivOp<mhlo::DivOp>>(typeConverter, context);
+  patterns.insert<ConvertDivOp<chlo::BroadcastDivOp>>(typeConverter, context);
+
+  // Unary ops.
+  patterns.insert<ConvertAbsOp>(typeConverter, context);
+  patterns.insert<ConvertExpOp>(typeConverter, context);
+
+  // Compare ops.
+  patterns.insert<ConvertCompareOp<mhlo::CompareOp, mhlo::OrOp>>(
+      typeConverter, context, mhlo::ComparisonDirection::NE);
+  patterns.insert<ConvertCompareOp<mhlo::CompareOp, mhlo::AndOp>>(
+      typeConverter, context, mhlo::ComparisonDirection::EQ);
+  patterns.insert<ConvertCompareOp<chlo::BroadcastCompareOp, mhlo::OrOp>>(
+      typeConverter, context, mhlo::ComparisonDirection::NE);
+  patterns.insert<ConvertCompareOp<chlo::BroadcastCompareOp, mhlo::AndOp>>(
+      typeConverter, context, mhlo::ComparisonDirection::EQ);
+
+  // Complex/Real/Imag conversions should fold away.
+  // Note that this is an opinion taken because these patterns are targeted
+  // at full conversion scenarios and we would rather know eagerly if
+  // conversion is not possible. A more lax conversion would not include the
+  // ElideComplexPattern.
+  // Doing it this way makes error messages nice because a failure will report
+  // which remaining live op is keeping it from being erased.
+  patterns.insert<ElideComplexPattern>(typeConverter, context);
+  patterns.insert<ElideRealPattern>(typeConverter, context);
+  patterns.insert<ElideImagPattern>(typeConverter, context);
+}
+
+namespace {
+
+struct TestMHLOConvertComplexToRealPass
+    : public TestMHLOConvertComplexToRealBase<
+          TestMHLOConvertComplexToRealPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mhlo::MhloDialect, chlo::HloClientDialect>();
+  }
+
+  void runOnOperation() override {
+    OwningRewritePatternList patterns(&getContext());
+    MLIRContext *context = &getContext();
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type t) { return t; });
+
+    populateHLOComplexToRealPatterns(context, typeConverter, patterns);
+
+    ConversionTarget target(*context);
+    auto hasNoComplexTypes = [](Operation *op) {
+      for (Value operand : op->getOperands()) {
+        if (auto st = operand.getType().dyn_cast<ShapedType>()) {
+          if (st.getElementType().isa<ComplexType>()) {
+            return false;
+          }
+        }
+      }
+      for (Value result : op->getResults()) {
+        if (auto st = result.getType().dyn_cast<ShapedType>()) {
+          if (st.getElementType().isa<ComplexType>()) {
+            return false;
+          }
+        }
+      }
+      return true;
+    };
+
+    target.addLegalDialect<mhlo::MhloDialect>();
+    target.addLegalDialect<chlo::HloClientDialect>();
+    target.addLegalDialect<StandardOpsDialect>();
+
+    // For the test, require that casts fully convert.
+    target.addIllegalOp<mhlo::ComplexOp>();
+    target.addIllegalOp<mhlo::ImagOp>();
+    target.addIllegalOp<mhlo::RealOp>();
+
+    // Binary elementwise.
+    target.addDynamicallyLegalOp<mhlo::AddOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<chlo::BroadcastAddOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<mhlo::SubOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<chlo::BroadcastSubOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<mhlo::MulOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<chlo::BroadcastMulOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<mhlo::DivOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<chlo::BroadcastDivOp>(hasNoComplexTypes);
+
+    // Unary.
+    target.addDynamicallyLegalOp<mhlo::AbsOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<mhlo::ExpOp>(hasNoComplexTypes);
+
+    // Compare.
+    target.addDynamicallyLegalOp<mhlo::CompareOp>(hasNoComplexTypes);
+    target.addDynamicallyLegalOp<chlo::BroadcastCompareOp>(hasNoComplexTypes);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+createTestMHLOConvertComplexToRealPass() {
+  return std::make_unique<TestMHLOConvertComplexToRealPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/HLOToLinalg/test/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "broadcasting.mlir",
+            "convert_complex_to_real.mlir",
             "dynamic_shape.mlir",
             "missing_legalizations.mlir",
             "fft.mlir",

--- a/iree/compiler/Conversion/HLOToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "broadcasting.mlir"
+    "convert_complex_to_real.mlir"
     "dynamic_shape.mlir"
     "fft.mlir"
     "missing_legalizations.mlir"

--- a/iree/compiler/Conversion/HLOToLinalg/test/convert_complex_to_real.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/convert_complex_to_real.mlir
@@ -1,0 +1,147 @@
+// RUN: iree-opt -iree-test-mhlo-convert-complex-to-real %s | IreeFileCheck %s
+
+// CHECK-LABEL: @add
+func @add(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>, %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %2 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %3 = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: [[VAL0:%.+]] = mhlo.add %arg0, %arg2
+  // CHECK-DAG: [[VAL1:%.+]] = mhlo.add %arg1, %arg3
+  %4 = "mhlo.add"(%2, %3) : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> (tensor<2xcomplex<f32>>)
+  %5 = "mhlo.real"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %6 = "mhlo.imag"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return [[VAL0]], [[VAL1]]
+  return %5, %6 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: @sub
+func @sub(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>, %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %2 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %3 = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: [[VAL0:%.+]] = mhlo.subtract %arg0, %arg2
+  // CHECK-DAG: [[VAL1:%.+]] = mhlo.subtract %arg1, %arg3
+  %4 = "mhlo.subtract"(%2, %3) : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> (tensor<2xcomplex<f32>>)
+  %5 = "mhlo.real"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %6 = "mhlo.imag"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return [[VAL0]], [[VAL1]]
+  return %5, %6 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: @mul
+func @mul(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>, %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %2 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %3 = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: %[[VAL0:.+]] = chlo.broadcast_multiply %arg0, %arg2
+  // CHECK-DAG: %[[VAL1:.+]] = chlo.broadcast_multiply %arg1, %arg3
+  // CHECK-DAG: %[[VAL2:.+]] = mhlo.subtract %[[VAL0]], %[[VAL1]]
+  // CHECK-DAG: %[[VAL3:.+]] = chlo.broadcast_multiply %arg0, %arg3
+  // CHECK-DAG: %[[VAL4:.+]] = chlo.broadcast_multiply %arg1, %arg2
+  // CHECK-DAG: %[[VAL5:.+]] = mhlo.add %[[VAL3]], %[[VAL4]]
+  %4 = "mhlo.multiply"(%2, %3) : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> (tensor<2xcomplex<f32>>)
+  %5 = "mhlo.real"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %6 = "mhlo.imag"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return %2, %5 : tensor<2xf32>, tensor<2xf32>
+  return %5, %6 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: @div
+func @div(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>, %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %2 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %3 = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: %[[VAL0:.+]] = "mhlo.negate"(%arg3)
+
+  // Compute the numerator's real component:
+  //   numerator.real = lhs.real * rhs.real  lhs.imag * rhs.imag
+  // CHECK-DAG: %[[VAL1:.+]] = chlo.broadcast_multiply %arg0, %arg2
+  // CHECK-DAG: %[[VAL2:.+]] = chlo.broadcast_multiply %arg1, %[[VAL0]]
+  // CHECK-DAG: %[[VAL3:.+]] = mhlo.subtract %[[VAL1]], %[[VAL2]]
+
+  // Compute the real valued denominator as rhs * con(rhs):
+  //   denominator = rhs.real * rhs.real + rhs.imag * rhs.imag
+  // CHECK-DAG: %[[VAL4:.+]] = mhlo.multiply %arg2, %arg2
+  // CHECK-DAG: %[[VAL5:.+]] = mhlo.multiply %arg3, %arg3
+  // CHECK-DAG: %[[VAL6:.+]] = mhlo.add %[[VAL4]], %[[VAL5]]
+
+  // Compute the numerator's imaginary component:
+  //   numerator.imag = lhs.imag * rhs.real - lhs.real * rhs.imag
+  // CHECK-DAG: %[[VAL7:.+]] = chlo.broadcast_multiply %arg1, %arg2
+  // CHECK-DAG: %[[VAL8:.+]] = chlo.broadcast_multiply %arg0, %[[VAL0]]
+  // CHECK-DAG: %[[VAL9:.+]] = mhlo.add %[[VAL8]], %[[VAL7]]
+
+  // Divide the numerator by the real valued denominator.
+  // CHECK-DAG: %[[VAL10:.+]] = chlo.broadcast_divide %[[VAL3]], %[[VAL6]]
+  // CHECK-DAG: %[[VAL11:.+]] = chlo.broadcast_divide %[[VAL9]], %[[VAL6]]
+  %4 = "mhlo.divide"(%2, %3) : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> (tensor<2xcomplex<f32>>)
+
+  %5 = "mhlo.real"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %6 = "mhlo.imag"(%4) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return %[[VAL10]], %[[VAL11]]
+  return %5, %6 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: @abs
+func @abs(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> (tensor<2xf32>) {
+  %0 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: %[[VAL0:.+]] = mhlo.multiply %arg0, %arg0
+  // CHECK-DAG: %[[VAL1:.+]] = mhlo.multiply %arg1, %arg1
+  // CHECK-DAG: %[[VAL2:.+]] = mhlo.add %[[VAL0]], %[[VAL1]]
+  // CHECK-DAG: %[[VAL3:.+]] = "mhlo.sqrt"(%[[VAL2]])
+  %1 = "mhlo.abs"(%0) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: return %[[VAL3]]
+  return %1 : tensor<2xf32>
+}
+
+// CHECK-LABEL: @exp
+func @exp(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+  %0 = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+
+  // CHECK-DAG: %[[EXP:.+]] = "mhlo.exponential"(%arg0)
+  // CHECK-DAG: %[[COS:.+]] = "mhlo.cosine"(%arg1)
+  // CHECK-DAG: %[[SIN:.+]] = "mhlo.sine"(%arg1)
+  // CHECK-DAG: %[[OUTR:.+]] = mhlo.multiply %[[COS]], %[[EXP]]
+  // CHECK-DAG: %[[OUTI:.+]] = mhlo.multiply %[[SIN]], %[[EXP]]
+  %1 = "mhlo.exponential"(%0) : (tensor<2xcomplex<f32>>) -> (tensor<2xcomplex<f32>>)
+
+  %2 = "mhlo.real"(%1) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+  %3 = "mhlo.imag"(%1) : (tensor<2xcomplex<f32>>) -> (tensor<2xf32>)
+
+  // CHECK: %[[OUTR]], %[[OUTI]]
+  return %2, %3 : tensor<2xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: @compare_eq
+func @compare_eq(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>,
+                 %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xi1>) {
+  %lhs = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %rhs = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  // CHECK-DAG: %[[OUTR:.+]] = chlo.broadcast_compare %arg0, %arg2 {comparison_direction = "EQ"}
+  // CHECK-DAG: %[[OUTI:.+]] = chlo.broadcast_compare %arg1, %arg3 {comparison_direction = "EQ"}
+  // CHECK-DAG: %[[OUT:.+]] = mhlo.and %[[OUTR]], %[[OUTI]]
+  %0 = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "EQ"} : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> tensor<2xi1>
+
+  // CHECK: return %[[OUT]]
+  return %0 : tensor<2xi1>
+}
+
+// CHECK-LABEL: @compare_ne
+func @compare_ne(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>,
+                 %arg2 : tensor<2xf32>, %arg3 : tensor<2xf32>) -> (tensor<2xi1>) {
+  %lhs = "mhlo.complex"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  %rhs = "mhlo.complex"(%arg2, %arg3) : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xcomplex<f32>>)
+  // CHECK-DAG: %[[OUTR:.+]] = chlo.broadcast_compare %arg0, %arg2 {comparison_direction = "NE"}
+  // CHECK-DAG: %[[OUTI:.+]] = chlo.broadcast_compare %arg1, %arg3 {comparison_direction = "NE"}
+  // CHECK-DAG: %[[OUT:.+]] = mhlo.or %[[OUTR]], %[[OUTI]]
+  %0 = "mhlo.compare"(%lhs, %rhs) {comparison_direction = "NE"} : (tensor<2xcomplex<f32>>, tensor<2xcomplex<f32>>) -> tensor<2xi1>
+
+  // CHECK: return %[[OUT]]
+  return %0 : tensor<2xi1>
+}

--- a/iree/compiler/Conversion/Passes.h
+++ b/iree/compiler/Conversion/Passes.h
@@ -39,6 +39,12 @@ std::unique_ptr<OperationPass<FuncOp>> createResolveShapeOpsPass();
 /// using f16.
 std::unique_ptr<OperationPass<ModuleOp>> createDemoteF32ToF16Pass();
 
+//------------------------------------------------------------------------------
+// Test passes
+//------------------------------------------------------------------------------
+
+std::unique_ptr<OperationPass<FuncOp>> createTestMHLOConvertComplexToRealPass();
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/iree/compiler/Conversion/Passes.td
+++ b/iree/compiler/Conversion/Passes.td
@@ -40,4 +40,14 @@ def ResolveShapeOps :
   let constructor = "mlir::iree_compiler::createResolveShapeOpsPass()";
 }
 
+//------------------------------------------------------------------------------
+// Test passes
+//------------------------------------------------------------------------------
+
+def TestMHLOConvertComplexToReal :
+    Pass<"iree-test-mhlo-convert-complex-to-real", "FuncOp"> {
+  let summary = "Test pass that does an MHLO->MHLO conversion of just complex arithmetic ops.";
+  let constructor = "mlir::iree_compiler::createTestMHLOConvertComplexToRealPass()";
+}
+
 #endif  // IREE_DIALECT_FLOW_PASSES


### PR DESCRIPTION
* The original HLO patterns were quite dated, and upon hacking on them a little bit, I determined that a rewrite was called for.
* These new patterns presume a pipeline where CHLO and MHLO are legal and they correctly handle complex broadcasting.
* The MHLO side patterns had issues in this respect.
* Also added a dedicated test pass and patterns to make the conversion self contained so that it can be run as part of a full multi-step dialect conversion.
* When used in this way, the error messages for unsupported conversions are much better.