### PR TITLE
Break operand-result ties for constant operands

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -459,7 +459,7 @@ class UntieConstantOperands final
     return success();
   }
 };
-}
+}  // namespace
 
 void DispatchWorkgroupsOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -804,8 +804,8 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
 }
 
 bool DispatchWorkgroupsOp::isOutputReadWithinRegion(unsigned resultIndex) {
-  BlockArgument arg =
-      body().front().getArgument(operands().size() + resultIndex);
+  unsigned startIndex = getBody()->getNumArguments() - getNumResults();
+  BlockArgument arg = body().front().getArgument(startIndex + resultIndex);
   // If argument is of `writeonly` access, then it is not read by construction.
   if (arg.getType().cast<DispatchTensorType>().getAccess() ==
       TensorAccess::WriteOnly) {


### PR DESCRIPTION
We won't create such ties deliberately, but they can come from
multiple rounds of canonicalization. For example, if we have
`linalg.fill` to prepare the initial result tensor for `subtensor_insert`,
the `linalg.fill` may be folded into a constant. Then the
`subtensor_insert` op will have a tie between the initial
output tensor and its resultant tensor.

In IREE, operand-result tying indicates that we can use the same
buffer. This is unlikely to happen if the operand is constant,
though: constants are typically collected into a dense buffer
that is read only. So having such kind of ties can mess up buffer
allocation in later stages: we will try to reuse the buffer for
the constant in a read-write fashion, which is incorrect. This
becomes a problem with constant pooling after
https://github.com/google/iree/commit/4f86152fda78b7afd2351d4af5b2c85b73805dcf.

Along the way, fixed two other indexing issues related to operand-
result ties.