### PR TITLE
Adding initial `iree.natvis` for runtime types.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -316,6 +316,8 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     "-lm"
     ${_IREE_PTHREADS_LINKOPTS}
     ${_IREE_LOGGING_LINKOPTS}
+  MSVC
+    "-natvis:${CMAKE_SOURCE_DIR}/iree/iree.natvis"
 )
 
 # Add to LINKOPTS on a binary to configure it for X/Wayland/Windows/etc

--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -275,6 +275,10 @@ IREE_API_EXPORT const char* iree_status_code_string(iree_status_code_t code) {
 
 // TODO(#55): move payload methods/types to header when API is stabilized.
 
+struct iree_status_handle_t {
+  uintptr_t value;
+};
+
 // Defines the type of an iree_status_payload_t.
 typedef enum iree_status_payload_type_e {
   // Opaque; payload may still be formatted by a formatter but is not possible

--- a/iree/iree.natvis
+++ b/iree/iree.natvis
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+<!--
+  Visual Studio/VSCode Natvis Definitions for the IREE Runtime
+
+  "Documentation":
+  https://code.visualstudio.com/docs/cpp/natvis
+  https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects
+-->
+
+<!--=========================================================================-->
+<!-- iree/base/allocator.h -->
+<!--=========================================================================-->
+
+<!-- TODO(benvanik): iree_allocator_t common usage (system, null, etc) -->
+
+<Type Name="iree_byte_span_t">
+  <AlternativeType Name="iree_const_byte_span_t" />
+
+  <Intrinsic Name="empty" Expression="data_length==0" />
+
+  <DisplayString Condition="empty()">(empty)</DisplayString>
+  <DisplayString>{{size={data_length}}}</DisplayString>
+
+  <StringView>data,[data_length]hv</StringView>
+
+  <Expand HideRawView="true">
+    <Item Name="[ptr]">(void*)data</Item>
+    <Item Name="[size]">data_length</Item>
+    <!-- BUG: (u)int8_t[] always displays as a string ;( -->
+    <!-- https://developercommunity.visualstudio.com/t/natvis-shows-int8-tuint8-t-as-character/140373 -->
+    <Item Name="[sint8_t*]" ExcludeView="simple" Condition="!empty()">(int8_t*)data,[data_length]hv</Item>
+    <Item Name="[uint8_t*]" ExcludeView="simple" Condition="!empty()">(uint8_t*)data,[data_length]hv</Item>
+    <Item Name="[sint16_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%2==0">(int16_t*)data,[data_length/2]hv</Item>
+    <Item Name="[uint16_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%2==0">(uint16_t*)data,[data_length/2]hv</Item>
+    <Item Name="[sint32_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%4==0">(int32_t*)data,[data_length/4]hv</Item>
+    <Item Name="[uint32_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%4==0">(uint32_t*)data,[data_length/4]hv</Item>
+    <Item Name="[sint64_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%8==0">(int64_t*)data,[data_length/8]hv</Item>
+    <Item Name="[uint64_t*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%8==0">(uint64_t*)data,[data_length/8]hv</Item>
+    <Item Name="[float*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%4==0">(float*)data,[data_length/4]hv</Item>
+    <Item Name="[double*]" ExcludeView="simple" Condition="!empty() &amp;&amp; data_length%8==0">(double*)data,[data_length/8]hv</Item>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/base/status.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_status_handle_t">
+  <AlternativeType Name="iree_status_t" />
+
+  <Intrinsic Name="code" Expression="((uintptr_t)&amp;value) &amp; 0x1F" />
+  <Intrinsic Name="storage" Expression="(iree_status_storage_t*)(((uintptr_t)&amp;value) &amp; ~0x1F)" />
+  <Intrinsic Name="has_storage" Expression="(storage() != 0)" />
+  <Intrinsic Name="has_location" Expression="has_storage() &amp;&amp; (storage()->file != 0)" />
+  <Intrinsic Name="has_message" Expression="(storage()->message.size &gt; 0)" />
+
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_OK">OK: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_CANCELLED">CANCELLED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_UNKNOWN">UNKNOWN: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_INVALID_ARGUMENT">INVALID_ARGUMENT: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_DEADLINE_EXCEEDED">DEADLINE_EXCEEDED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_NOT_FOUND">NOT_FOUND: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_ALREADY_EXISTS">ALREADY_EXISTS: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_PERMISSION_DENIED">PERMISSION_DENIED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_RESOURCE_EXHAUSTED">RESOURCE_EXHAUSTED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_FAILED_PRECONDITION">FAILED_PRECONDITION: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_ABORTED">ABORTED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_OUT_OF_RANGE">OUT_OF_RANGE: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_UNIMPLEMENTED">UNIMPLEMENTED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_INTERNAL">INTERNAL: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_UNAVAILABLE">UNAVAILABLE: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_DATA_LOSS">DATA_LOSS: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString Condition="has_message() &amp;&amp; code()==IREE_STATUS_UNAUTHENTICATED">UNAUTHENTICATED: {storage()->message.data,[storage()->message.size]sb}</DisplayString>
+  <DisplayString>{(iree_status_code_t)code(),na}</DisplayString>
+
+  <StringView Condition="has_message()">storage()->message.data,[storage()->message.size]na</StringView>
+
+  <Expand HideRawView="true">
+    <Synthetic Name="[location]" Condition="has_location()">
+      <DisplayString>{storage()->file,sb}:{storage()->line}</DisplayString>
+    </Synthetic>
+    <Item Name="[code]">(iree_status_code_t)code()</Item>
+    <Synthetic Name="[message]" Condition="has_message()">
+      <DisplayString>{storage()->message,na}</DisplayString>
+      <StringView>storage()->message,na</StringView>
+    </Synthetic>
+    <LinkedListItems>
+      <HeadPointer>storage()->payload_head</HeadPointer>
+      <NextPointer>next</NextPointer>
+      <ValueNode>this,na</ValueNode>
+    </LinkedListItems>
+    <Item Name="[storage]" Condition="has_storage()">storage()</Item>
+  </Expand>
+</Type>
+
+<Type Name="iree_status_payload_t">
+  <Intrinsic Name="as_message" Expression="(iree_status_payload_message_t*)this" />
+  <DisplayString Condition="type==IREE_STATUS_PAYLOAD_TYPE_MESSAGE">{as_message()->message,na}</DisplayString>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/base/string_view.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_string_view_t">
+  <DisplayString>{data,[size]na}</DisplayString>
+  <StringView>data,[size]na</StringView>
+  <Expand>
+    <Item Name="[size]" ExcludeView="simple">size</Item>
+    <ArrayItems>
+      <Size>size</Size>
+      <ValuePointer>data</ValuePointer>
+    </ArrayItems>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/base/time.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_timeout_t">
+  <!-- timeout attributes -->
+  <Intrinsic Name="is_relative" Expression="type==IREE_TIMEOUT_RELATIVE" />
+  <Intrinsic Name="is_absolute" Expression="type==IREE_TIMEOUT_ABSOLUTE" />
+  <Intrinsic Name="is_immediate" Expression="(is_relative() &amp;&amp; nanos==0) || (is_absolute() &amp;&amp; nanos==(-9223372036854775807i64-1))" />
+  <Intrinsic Name="is_infinite" Expression="(is_relative() &amp;&amp; nanos==9223372036854775807i64) || (is_absolute() &amp;&amp; nanos==9223372036854775807i64)" />
+  <Intrinsic Name="is_sentinel" Expression="is_immediate() || is_infinite()" />
+  <Intrinsic Name="total_ns" Expression="nanos" />
+
+  <!-- relative duration -->
+  <Intrinsic Name="rel_hours" Expression="total_ns()/3600000000000ll" />
+  <Intrinsic Name="rel_adj_minutes" Expression="total_ns()-3600000000000ll*rel_hours()" />
+  <Intrinsic Name="rel_minutes" Expression="rel_adj_minutes()/60000000000ll" />
+  <Intrinsic Name="rel_seconds" Expression="(rel_adj_minutes()-60000000000ll*rel_minutes())/1000000000ll" />
+  <Intrinsic Name="rel_total_s" Expression="total_ns()/1000000000.0" />
+  <Intrinsic Name="rel_total_ms" Expression="total_ns()/1000000ll" />
+  <Intrinsic Name="rel_total_us" Expression="total_ns()/10000ll" />
+
+  <!-- absolute time -->
+  <Intrinsic Name="abs_total_s" Expression="total_ns()/1000000ll" />
+  <Intrinsic Name="abs_year" Expression="(abs_total_s()/31556926)+1970" />
+  <Intrinsic Name="abs_month" Expression="((abs_total_s()%31556926)/2629743)+1" />
+  <Intrinsic Name="abs_day" Expression="((abs_total_s()%2629743)/86400)+1" />
+  <Intrinsic Name="abs_hour" Expression="(abs_total_s()%86400)/3600" />
+  <Intrinsic Name="abs_minutes" Expression="(abs_total_s()%3600)/60" />
+  <Intrinsic Name="abs_seconds" Expression="abs_total_s()%60" />
+  <Intrinsic Name="abs_milliseconds" Expression="(total_ns()/1000)%1000ll" />
+
+  <DisplayString Condition="is_immediate()">(immediate timeout)</DisplayString>
+  <DisplayString Condition="is_infinite()">(infinite timeout)</DisplayString>
+  <DisplayString Condition="is_relative()">+{rel_hours()/10}{rel_hours()%10}:{rel_minutes()/10}{rel_minutes()%10}:{rel_seconds()/10}{rel_seconds()%10} / {rel_total_ms()}ms / {rel_total_us()}us</DisplayString>
+  <DisplayString Condition="is_absolute()">{abs_year()}-{abs_month()/10}{abs_month()%10}-{abs_day()/10}{abs_day()%10} {abs_hour()/10}{abs_hour()%10}:{abs_minutes()/10}{abs_minutes()%10}:{abs_seconds()/10}{abs_seconds()%10}.{abs_milliseconds()}</DisplayString>
+  
+  <Expand>
+    <!-- relative duration -->
+    <Synthetic Name="[seconds]" Condition="is_relative() &amp;&amp; !is_sentinel()">
+      <DisplayString>{rel_total_s()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[milliseconds]" Condition="is_relative() &amp;&amp; !is_sentinel()">
+      <DisplayString>{rel_total_ms()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[microseconds]" Condition="is_relative() &amp;&amp; !is_sentinel()">
+      <DisplayString>{rel_total_us()}</DisplayString>
+    </Synthetic>
+
+    <!-- absolute time -->
+    <Synthetic Name="[year]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_year()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[month]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_month()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[day]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_day()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[hour]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_hour()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[minute]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_minutes()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[second]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_seconds()}</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[milliseconds]" Condition="is_absolute() &amp;&amp; !is_sentinel()">
+      <DisplayString>{abs_milliseconds()}</DisplayString>
+    </Synthetic>
+
+    <Synthetic Name="[nanoseconds]">
+      <DisplayString>{total_ns()}</DisplayString>
+    </Synthetic>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/base/internal/atomics.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_atomic_int32_t">
+  <DisplayString>{__val}</DisplayString>
+</Type>
+<Type Name="iree_atomic_int64_t">
+  <DisplayString>{__val}</DisplayString>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/hal/allocator.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/buffer.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_hal_buffer_t">
+  <Intrinsic Name="is_subspan" Expression="this!=allocated_buffer" />
+  <Intrinsic Name="is_host_local" Expression="!(memory_type&amp;(1u&lt;&lt;5))" />
+  <Intrinsic Name="is_device_local" Expression="memory_type&amp;(1u&lt;&lt;5)" />
+
+  <Expand>
+    <Item Name="[base]">resource</Item>
+    <Item Name="allocated_buffer" Condition="is_subspan()">allocated_buffer</Item>
+    <Item Name="allocation_size" Condition="is_subspan()">allocation_size</Item>
+    <Item Name="byte_offset" Condition="is_subspan()">byte_offset</Item>
+    <Item Name="byte_length">byte_length</Item>
+    <Synthetic Name="memory_type">
+      <DisplayString>{(iree_hal_memory_type_bits_t)memory_type}</DisplayString>
+      <Expand>
+        <Item Name="host_local" Condition="is_host_local()">true</Item>
+        <Item Name="host_visible" Condition="memory_type&amp;(1u&lt;&lt;0)">true</Item>
+        <Item Name="host_coherent" Condition="memory_type&amp;(1u&lt;&lt;1)">true</Item>
+        <Item Name="host_cached" Condition="memory_type&amp;(1u&lt;&lt;2)">true</Item>
+        <Item Name="device_local" Condition="is_device_local()">true</Item>
+        <Item Name="device_visible" Condition="memory_type&amp;(1u&lt;&lt;4)">true</Item>
+        <Item Name="transient" Condition="memory_type&amp;(1u&lt;&lt;0)">true</Item>
+      </Expand>
+    </Synthetic>
+    <Synthetic Name="allowed_access">
+      <DisplayString>{(iree_hal_memory_access_bits_t)allowed_access}</DisplayString>
+      <Expand>
+        <Item Name="read" Condition="allowed_access&amp;(1u&lt;&lt;0)">true</Item>
+        <Item Name="write" Condition="allowed_access&amp;(1u&lt;&lt;1)">true</Item>
+        <Item Name="discard" Condition="allowed_access&amp;(1u&lt;&lt;2)">true</Item>
+        <Item Name="may_alias" Condition="allowed_access&amp;(1u&lt;&lt;3)">true</Item>
+      </Expand>
+    </Synthetic>
+    <Synthetic Name="allowed_usage">
+      <DisplayString>{(iree_hal_buffer_usage_bits_t)allowed_usage}</DisplayString>
+      <Expand>
+        <Item Name="constant" Condition="allowed_usage&amp;(1u&lt;&lt;0)">true</Item>
+        <Item Name="transfer" Condition="allowed_usage&amp;(1u&lt;&lt;1)">true</Item>
+        <Item Name="mapping" Condition="allowed_usage&amp;(1u&lt;&lt;2)">true</Item>
+        <Item Name="dispatch" Condition="allowed_usage&amp;(1u&lt;&lt;3)">true</Item>
+      </Expand>
+    </Synthetic>
+  </Expand>
+</Type>
+
+<!-- TODO(benvanik): expose host-visible memory as synthetic item -->
+
+<!--=========================================================================-->
+<!-- iree/hal/buffer_view.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_hal_buffer_view_t">
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;si8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;ui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;si16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;ui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;si32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;ui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;si64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;ui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;f16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;f32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==0 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;f64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==1 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==2 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==3 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==4 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==5 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xsi8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_8">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xui8&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xsi16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xui16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xsi32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xui32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_SINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xsi64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_UINT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xui64&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_16">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xf16&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_32">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xf32&gt; size={byte_length}}}</DisplayString>
+  <DisplayString Condition="shape_rank==6 &amp;&amp; element_type==IREE_HAL_ELEMENT_TYPE_FLOAT_64">{{!hal.buffer_view&lt;{shape[0]}x{shape[1]}x{shape[2]}x{shape[3]}x{shape[4]}x{shape[5]}xf64&gt; size={byte_length}}}</DisplayString>
+
+  <Expand>
+    <Item Name="[references]" ExcludeView="simple">ref_count</Item>
+    <Item Name="shape" ExcludeView="simple">shape,[shape_rank]d</Item>
+    <Item Name="element_type" ExcludeView="simple">(iree_hal_element_types_t)element_type</Item>
+    <Item Name="byte_length">byte_length</Item>
+    <Item Name="buffer">buffer</Item>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/hal/command_buffer.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/descriptor_set.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/descriptor_set_layout.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/device.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/driver.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/event.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/executable.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/executable_cache.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/executable_layout.h -->
+<!--=========================================================================-->
+
+<!--=========================================================================-->
+<!-- iree/hal/resource.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_hal_resource_t">
+  <DisplayString>{{references={ref_count}}}</DisplayString>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/hal/semaphore.h -->
+<!--=========================================================================-->
+
+<!-- TODO(benvanik): value, status -->
+
+<!--=========================================================================-->
+<!-- iree/vm/buffer.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_vm_buffer_t">
+  <Intrinsic Name="is_mutable" Expression="(access&amp;IREE_VM_BUFFER_ACCESS_MUTABLE)!=0" />
+
+  <DisplayString Condition="is_mutable()">{{!vm.buffer r/w bytes={data.data_length}}}</DisplayString>
+  <DisplayString>{{!vm.buffer r/o bytes={data.data_length}b}}</DisplayString>
+
+  <Expand>
+    <Item Name="[base]">ref_object</Item>
+    <Synthetic Name="[access]">
+      <DisplayString Condition="access&amp;IREE_VM_BUFFER_ACCESS_MUTABLE">read/write</DisplayString>
+      <DisplayString>read-only</DisplayString>
+    </Synthetic>
+    <Synthetic Name="[origin]">
+      <DisplayString Condition="access&amp;IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE">module</DisplayString>
+      <DisplayString Condition="access&amp;IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">guest</DisplayString>
+      <DisplayString Condition="access&amp;IREE_VM_BUFFER_ACCESS_ORIGIN_HOST">host</DisplayString>
+      <DisplayString>?</DisplayString>
+    </Synthetic>
+    <ExpandedItem>data</ExpandedItem>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/vm/context.h -->
+<!--=========================================================================-->
+
+<!-- TODO(benvanik): list modules -->
+
+<!--=========================================================================-->
+<!-- iree/vm/instance.h -->
+<!--=========================================================================-->
+
+<!-- TODO(benvanik): list global type registry -->
+
+<!--=========================================================================-->
+<!-- iree/vm/list.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_vm_list_t">
+  <Intrinsic Name="is_value" Expression="storage_mode==IREE_VM_LIST_STORAGE_MODE_VALUE" />
+  <Intrinsic Name="is_ref" Expression="storage_mode==IREE_VM_LIST_STORAGE_MODE_REF" />
+  <Intrinsic Name="is_variant" Expression="storage_mode==IREE_VM_LIST_STORAGE_MODE_VARIANT" />
+
+  <DisplayString>{{!vm.list&lt;{element_type}&gt; size={count}}}</DisplayString>
+
+  <Expand>
+    <Item Name="[base]" ExcludeView="simple">ref_object</Item>
+    <Item Name="element_type" ExcludeView="simple">element_type</Item>
+    <Item Name="capacity" ExcludeView="simple">capacity</Item>
+    <Item Name="count" ExcludeView="simple">count</Item>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_I8">
+      <Size>count</Size>
+      <ValuePointer>(int8_t*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_I16">
+      <Size>count</Size>
+      <ValuePointer>(int16_t*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_I32">
+      <Size>count</Size>
+      <ValuePointer>(int32_t*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_I64">
+      <Size>count</Size>
+      <ValuePointer>(int64_t*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_F32">
+      <Size>count</Size>
+      <ValuePointer>(float*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_value() &amp;&amp; element_type.value_type==IREE_VM_VALUE_TYPE_F64">
+      <Size>count</Size>
+      <ValuePointer>(double*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_ref()">
+      <Size>count</Size>
+      <ValuePointer>(iree_vm_ref_t*)storage</ValuePointer>
+    </ArrayItems>
+    <ArrayItems Condition="is_variant()">
+      <Size>count</Size>
+      <ValuePointer>(iree_vm_variant_t*)storage</ValuePointer>
+    </ArrayItems>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/vm/module.h -->
+<!--=========================================================================-->
+
+<!-- TODO(benvanik): list imports/exports/etc (somehow? bytecode only?) -->
+
+<!--=========================================================================-->
+<!-- iree/vm/ref.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_vm_ref_object_t">
+  <DisplayString>{{references={counter}}}</DisplayString>
+</Type>
+
+<!-- NOTE: if you want your type to appear here you must add at least the
+     ExpandedItem expression for it based on name; DisplayString is optional -->
+<Type Name="iree_vm_ref_t">
+  <SmartPointer Usage="Minimal">ptr</SmartPointer>
+
+  <!-- hal -->
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.allocator&quot;)==0">{(iree_hal_allocator_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.buffer&quot;)==0">{(iree_hal_buffer_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.buffer_view&quot;)==0">{(iree_hal_buffer_view_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.command_buffer&quot;)==0">{(iree_hal_command_buffer_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.descriptor_set&quot;)==0">{(iree_hal_descriptor_set_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.descriptor_set_layout&quot;)==0">{(iree_hal_descriptor_set_layout_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.device&quot;)==0">{(iree_hal_device_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.driver&quot;)==0">{(iree_hal_driver_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.event&quot;)==0">{(iree_hal_event_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable&quot;)==0">{(iree_hal_executable_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable_cache&quot;)==0">{(iree_hal_executable_cache_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable_layout&quot;)==0">{(iree_hal_executable_layout_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.semaphore&quot;)==0">{(iree_hal_semaphore_t*)ptr}</DisplayString>
+  <!-- vm -->
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;vm.buffer&quot;)==0">{(iree_vm_buffer_t*)ptr}</DisplayString>
+  <DisplayString Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;vm.list&quot;)==0">{(iree_vm_list_t*)ptr}</DisplayString>
+  <!-- fallback -->
+  <DisplayString Condition="ptr!=0">{ptr}</DisplayString>
+  <DisplayString>(null)</DisplayString>
+
+  <Expand>
+    <!-- hal -->
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.allocator&quot;)==0">(iree_hal_allocator_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.buffer&quot;)==0">(iree_hal_buffer_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.buffer_view&quot;)==0">(iree_hal_buffer_view_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.command_buffer&quot;)==0">(iree_hal_command_buffer_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.descriptor_set&quot;)==0">(iree_hal_descriptor_set_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.descriptor_set_layout&quot;)==0">(iree_hal_descriptor_set_layout_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.device&quot;)==0">(iree_hal_device_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.driver&quot;)==0">(iree_hal_driver_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.event&quot;)==0">(iree_hal_event_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable&quot;)==0">(iree_hal_executable_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable_cache&quot;)==0">(iree_hal_executable_cache_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.executable_layout&quot;)==0">(iree_hal_executable_layout_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;hal.semaphore&quot;)==0">(iree_hal_semaphore_t*)ptr</ExpandedItem>
+    <!-- vm -->
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;vm.buffer&quot;)==0">(iree_vm_buffer_t*)ptr</ExpandedItem>
+    <ExpandedItem Condition="ptr!=0 &amp;&amp; strcmp(iree_vm_ref_type_descriptors[type]->type_name.data, &quot;vm.list&quot;)==0">(iree_vm_list_t*)ptr</ExpandedItem>
+  </Expand>
+</Type>
+
+<Type Name="iree::vm::ref&lt;*&gt;">
+  <SmartPointer Usage="Minimal">($T1*)ref_.ptr</SmartPointer>
+  <DisplayString Condition="ref_.ptr!=0">{($T1*)ref_.ptr}</DisplayString>
+  <DisplayString>(null)</DisplayString>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/vm/type_def.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_vm_type_def_t">
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_I8">i8</DisplayString>
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_I16">i16</DisplayString>
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_I32">i32</DisplayString>
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_I64">i64</DisplayString>
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_F32">f32</DisplayString>
+  <DisplayString Condition="value_type==IREE_VM_VALUE_TYPE_F64">f64</DisplayString>
+  <DisplayString Condition="ref_type==0x00FFFFFFu">?</DisplayString>
+  <DisplayString Condition="ref_type!=0">!{iree_vm_ref_type_descriptors[ref_type]->type_name,sb}</DisplayString>
+  <DisplayString>*</DisplayString>
+</Type>
+
+<Type Name="iree_vm_variant_t">
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_I8">{i8} (i8)</DisplayString>
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_I16">{i16} (i16)</DisplayString>
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_I32">{i32} (i32)</DisplayString>
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_I64">{i64} (i64)</DisplayString>
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_F32">{f32} (f32)</DisplayString>
+  <DisplayString Condition="type.value_type==IREE_VM_VALUE_TYPE_F64">{f64} (f64)</DisplayString>
+  <DisplayString Condition="type.ref_type!=0">{ref} &lt;{type}&gt;</DisplayString>
+  <DisplayString>(empty)</DisplayString>
+  <Expand>
+    <Item Name="type">type</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_I8">i8</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_I16">i16</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_I32">i32</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_I64">i64</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_F32">f32</Item>
+    <Item Name="value" Condition="type.value_type==IREE_VM_VALUE_TYPE_F64">f64</Item>
+    <Item Name="value" Condition="type.ref_type!=0">ref</Item>
+  </Expand>
+</Type>
+
+<!--=========================================================================-->
+<!-- iree/vm/value.h -->
+<!--=========================================================================-->
+
+<Type Name="iree_vm_value_t">
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_I8">{i8} (i8)</DisplayString>
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_I16">{i16} (i16)</DisplayString>
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_I32">{i32} (i32)</DisplayString>
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_I64">{i64} (i64)</DisplayString>
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_F32">{f32} (f32)</DisplayString>
+  <DisplayString Condition="type==IREE_VM_VALUE_TYPE_F64">{f64} (f64)</DisplayString>
+  <DisplayString>(empty)</DisplayString>
+  <Expand>
+    <Item Name="type">type</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_I8">i8</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_I16">i16</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_I32">i32</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_I64">i64</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_F32">f32</Item>
+    <Item Name="value" Condition="type==IREE_VM_VALUE_TYPE_F64">f64</Item>
+  </Expand>
+</Type>
+
+</AutoVisualizer>


### PR DESCRIPTION
This adds some visualizers for IREE runtime types that can be used to display the types in visual studio, vscode, and windbg (and maybe other tools). I'm not sure how it works with gdb in vscode but it'd be cool if it worked.

The initial set covers many base/ API types like status, timeout, and string_view. It also has coverage for the VM types like list, buffer, and the ref types and values. Some select HAL types - namely buffer and buffer_view - are supported with more to come in the future.

Example of an iree_status_t (that has a message as well as an annotation):
![image](https://user-images.githubusercontent.com/75337/120382391-6f3e2400-c2d8-11eb-92fe-0d935fbf4359.png)

Example of various timeouts:
![image](https://user-images.githubusercontent.com/75337/120382422-782ef580-c2d8-11eb-9150-ef7a5a885bf3.png)

Example of vm.buffer (with various typed accessors; they're even mutable!):
![image](https://user-images.githubusercontent.com/75337/120382495-90067980-c2d8-11eb-853c-b74fb8b52d7f.png)

Example of vm.list, here showing a variant list that gets proper type decoding of each element:
![image](https://user-images.githubusercontent.com/75337/120382565-a6acd080-c2d8-11eb-9927-729b05b716d6.png)

Example of buffer_view + buffer, showing shape decoding:
![image](https://user-images.githubusercontent.com/75337/120382633-b9270a00-c2d8-11eb-9348-7a0409510ca1.png)
