### PR TITLE
Fix SSA use-def violation created by canonicalization of `flow.ex.stream.fragment` op.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -152,7 +152,11 @@ struct InsertImmutabilityPreservingStreamClones
         SmallPtrSet<Operation *, 1> excludedOps;
         excludedOps.insert(tiedOp.getOperation());
         excludedOps.insert(clonedOperand.getDefiningOp());
-        tiedOperand.replaceAllUsesExcept(clonedOperand, excludedOps);
+        tiedOperand.replaceUsesWithIf(clonedOperand, [&](OpOperand &use) {
+          Operation *user = use.getOwner();
+          return !excludedOps.count(user) &&
+                 user->getBlock() == clonedOperand.getDefiningOp()->getBlock();
+        });
         didClone = true;
       }
     }


### PR DESCRIPTION
Pulling in operations from a different basic blocks into `flow.ex.stream.fragment` operation seems to create a ssa use-def violation issue. For now just disable this for operations crossing blocks.

A better fix would be to pull the inlining into a different pass and use dominator information to pull things in legally.