### PR TITLE
Fix two indexing issues regarding TiedOpInterface

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -804,8 +804,8 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
 }
 
 bool DispatchWorkgroupsOp::isOutputReadWithinRegion(unsigned resultIndex) {
-  BlockArgument arg =
-      body().front().getArgument(operands().size() + resultIndex);
+  unsigned startIndex = getBody()->getNumArguments() - getNumResults();
+  BlockArgument arg = body().front().getArgument(startIndex + resultIndex);
   // If argument is of `writeonly` access, then it is not read by construction.
   if (arg.getType().cast<DispatchTensorType>().getAccess() ==
       TensorAccess::WriteOnly) {


### PR DESCRIPTION
If an operand is tied to a result, there won't be a block argument
for the operand; so we cannot use the number of operand as the
start index for result block arguments.

And, `getTiedResultOperandIndices()` returns indices into the full
range of the op, but in the attribute, we expect to store ranges
into the range returned by `getTiedOperandsIndexAndLength`.

This is a spin-off from #6049.