### PR TITLE
[ci] Test benchmark artifact generation during cross-compilation

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -47,8 +47,11 @@ cd build-host
   -DCMAKE_INSTALL_PREFIX=./install \
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
+  -DIREE_BUILD_BENCHMARKS=ON \
   -DIREE_BUILD_SAMPLES=OFF
 "${CMAKE_BIN?}" --build . --target install
+# Also make sure that we can generate artifacts for benchmarking on Android.
+"${CMAKE_BIN?}" --build . --target iree-benchmark-suites
 # --------------------------------------------------------------------------- #
 
 cd ${ROOT_DIR?}


### PR DESCRIPTION
We have seen several benchmark artifacts generation issues in
the benchmark pipeline thus far. It's because the benchmark pipeline
is totally detached from the normal CI testing flow and it's not
run pre-submit. This is a step towards addressing the issue.

Right now we aren't covering all models we are benchmarking with
the current pipeline. That will be brought up to equality with
future pull requests, aiming as examples for registering new
benchmarks.