### PR TITLE
Rebase and work PR #6005:

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -1027,7 +1027,6 @@ static LogicalResult convertInterfaceStoreTensorOp(
     OpBuilder &b, IREE::Flow::DispatchTensorStoreOp storeOp,
     BlockAndValueMapping &bvm, BufferizationPlan &plan) {
   if (plan.isEquivalent(storeOp.target(), storeOp.value())) {
-    storeOp->erase();
     return success();
   }
   OpBuilder::InsertionGuard g(b);
@@ -1039,7 +1038,6 @@ static LogicalResult convertInterfaceStoreTensorOp(
                       storeOp.getMixedSizes(), storeOp.getMixedStrides());
 
   b.create<linalg::CopyOp>(storeOp->getLoc(), storeFrom, subview);
-  storeOp->erase();
   return success();
 }
 
@@ -1366,6 +1364,10 @@ void LinalgBufferizePass::runOnFunction() {
               if (remappedVal) op->setOperand(i, remappedVal);
             }
           }
+          return success();
+        })
+        .Case<IREE::Flow::DispatchTensorStoreOp>([&](auto op) {
+          op.erase();
           return success();
         })
         .Default([&](Operation *op) { return success(); });

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -995,14 +995,6 @@ static LogicalResult convertConstantOp(OpBuilder &b, ConstantOp constantOp,
   return success();
 }
 
-static LogicalResult convertDimOp(OpBuilder &b, memref::DimOp dimOp,
-                                  BlockAndValueMapping &bvm) {
-  if (Value v = bvm.lookupOrNull(dimOp.memrefOrTensor())) {
-    dimOp.memrefOrTensorMutable().assign(v);
-  }
-  return success();
-}
-
 static LogicalResult convertDispatchTieShapeOp(
     OpBuilder &b, IREE::Flow::DispatchTieShapeOp shapeOp,
     BlockAndValueMapping &bvm) {
@@ -1016,13 +1008,15 @@ static LogicalResult convertDispatchTieShapeOp(
 
 /// Converts a `tensor.extract` operation into a `load`.
 static LogicalResult convertTensorExtractOp(OpBuilder &b, tensor::ExtractOp op,
-                                            BlockAndValueMapping &bvm) {
+                                            const BlockAndValueMapping &bvm) {
   OpBuilder::InsertionGuard g(b);
   b.setInsertionPoint(op);
   Value inputBuffer = bvm.lookup(op.tensor());
   Value load =
       b.createOrFold<memref::LoadOp>(op.getLoc(), inputBuffer, op.indices());
-  bvm.map(op.result(), load);
+  // Since the value is the scalar, and `bvm` is used to only track tensor ->
+  // memref mappings, just replace the uses directly.
+  op.result().replaceAllUsesWith(load);
   return success();
 }
 
@@ -1086,17 +1080,6 @@ static LogicalResult convertSubTensorInsertOp(OpBuilder &b,
   Value subViewOp = createSubviewOp(b, loc, resultBuffer, offsets, sizes,
                                     strides, subViewResultType);
   b.create<linalg::CopyOp>(loc, sourceBuffer, subViewOp);
-  return success();
-}
-
-/// Converts a vector.transfer_read op to use memref operands for source.
-static LogicalResult convertVectorTransferReadOp(
-    OpBuilder &b, vector::TransferReadOp transferReadOp,
-    BlockAndValueMapping &bvm) {
-  Value source = transferReadOp.source();
-  if (!source.getType().isa<RankedTensorType>()) return success();
-  Value memref = bvm.lookup(source);
-  transferReadOp.sourceMutable().assign(memref);
   return success();
 }
 
@@ -1265,13 +1248,13 @@ void LinalgBufferizePass::runOnFunction() {
     bvm.map(op, baseBuffer);
   });
 
-  auto conversionDispatch = [&](Operation *op) -> WalkResult {
+  // Visit all the operations that return `tensor`s and convert them to using
+  // `memref`s.
+  auto convertTensorOps = [&](Operation *op) -> WalkResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
         .Case<ConstantOp>([&](ConstantOp constantOp) {
           return convertConstantOp(b, constantOp, bvm);
         })
-        .Case<memref::DimOp>(
-            [&](memref::DimOp dimOp) { return convertDimOp(b, dimOp, bvm); })
         .Case<IREE::Flow::DispatchTensorStoreOp>(
             [&](IREE::Flow::DispatchTensorStoreOp storeOp) {
               return convertInterfaceStoreTensorOp(b, storeOp, bvm, plan);
@@ -1346,13 +1329,6 @@ void LinalgBufferizePass::runOnFunction() {
           }
           return convertSubTensorInsertOp(b, subTensorInsertOp, bvm, plan);
         })
-        .Case<tensor::ExtractOp>([&](tensor::ExtractOp extractOp) {
-          return convertTensorExtractOp(b, extractOp, bvm);
-        })
-        .Case<vector::TransferReadOp>(
-            [&](vector::TransferReadOp transferReadOp) {
-              return convertVectorTransferReadOp(b, transferReadOp, bvm);
-            })
         .Case<vector::TransferWriteOp>(
             [&](vector::TransferWriteOp transferWriteOp) {
               if (failed(getOrAllocateResultBuffers(b, transferWriteOp,
@@ -1363,21 +1339,47 @@ void LinalgBufferizePass::runOnFunction() {
               return convertVectorTransferWriteOp(b, transferWriteOp, bvm,
                                                   plan);
             })
-        .Default([&](Operation *op) {
-          // Replace any scalar remapped operands to the new values.
-          // TODO(GH-5013): This is really hacky solution, but gets us past for
-          // the time being. This all should be replaced by a pattern.
+        .Default([&](Operation *op) { return success(); });
+  };
+  auto walkResult =
+      funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) -> WalkResult {
+        b.setInsertionPoint(op);
+        return convertTensorOps(op);
+      });
+  if (walkResult.wasInterrupted()) {
+    return signalPassFailure();
+  }
+
+  // Lastly visit the non-tensor return operations that still use `tensor`
+  // values. These need to be updated to use the corresponding `memref` values,
+  // but dont need to update the block-and-value mapping.
+  auto convertNonTensorOps = [&](Operation *op) -> LogicalResult {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<tensor::ExtractOp>([&](tensor::ExtractOp op) {
+          return convertTensorExtractOp(b, op, bvm);
+        })
+        .Case<memref::DimOp, vector::TransferReadOp>([&](auto op) {
           for (unsigned i : llvm::seq<unsigned>(0, op->getNumOperands())) {
             Value operand = op->getOperand(i);
-            if (operand.getType().isIntOrIndexOrFloat()) {
+            if (operand.getType().isa<RankedTensorType>()) {
               Value remappedVal = bvm.lookupOrNull(operand);
               if (remappedVal) op->setOperand(i, remappedVal);
             }
           }
           return success();
-        });
+        })
+        .Default([&](Operation *op) { return success(); });
   };
 
+  walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
+    b.setInsertionPoint(op);
+    return convertNonTensorOps(op);
+  });
+  if (walkResult.wasInterrupted()) {
+    return signalPassFailure();
+  }
+
+  // Clean-up scf.for by removing cyclic loop dependainces.
   // Forward init arguments from outer scf.for loop to the inner loops.
   funcOp.walk<WalkOrder::PreOrder>([&](scf::ForOp scfForOp) {
     if (scfForOp.results().empty()) return;
@@ -1393,16 +1395,6 @@ void LinalgBufferizePass::runOnFunction() {
       regionArgs[i].replaceAllUsesWith(initArgs[i]);
     }
   });
-
-  auto walkResult =
-      funcOp.walk<WalkOrder::PostOrder>([&](Operation *op) -> WalkResult {
-        b.setInsertionPoint(op);
-        return conversionDispatch(op);
-      });
-
-  if (walkResult.wasInterrupted()) {
-    return signalPassFailure();
-  }
 }
 
 static Value defaultAllocationFn(OpBuilder &builder, Location loc,


### PR DESCRIPTION
Original commit from #6005:
Make the traversal order pre-order since for ops with nested regions,
it is necessary to process the op before the region.
Changing to pre-order also means that regions of cloned ops dont get
processed during the work to convert tensor to memrefs. As a result,
move the conversion of ops that are just using the tensor value, and
not creating a tensor to be processed in a separate walk.

In this PR:
Move `scf.for` operands forwarding as a post processing step.

