### PR TITLE
Cleanup libiree_hal_local_sync_driver dependency

### DIFF
--- a/iree/hal/local/BUILD
+++ b/iree/hal/local/BUILD
@@ -134,9 +134,7 @@ cc_library(
         "//iree/base:tracing",
         "//iree/base/internal",
         "//iree/base/internal:synchronization",
-        "//iree/base/internal:wait_handle",
         "//iree/hal",
-        "//iree/task",
     ],
 )
 

--- a/iree/hal/local/CMakeLists.txt
+++ b/iree/hal/local/CMakeLists.txt
@@ -129,10 +129,8 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal
     iree::base::internal::synchronization
-    iree::base::internal::wait_handle
     iree::base::tracing
     iree::hal
-    iree::task
   PUBLIC
 )
 


### PR DESCRIPTION
sync_driver doesn't depend on the task executor. Remove the dependency
in BUILD and CMakeLists.txt.

Cleanup for https://github.com/google/iree/issues/6027