### PR TITLE
Move linalg.pad_tensor conversion to subtensor_insert into a separate pass

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/test/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/test/BUILD
@@ -24,7 +24,6 @@ iree_lit_test_suite(
             "dynamic_shape.mlir",
             "missing_legalizations.mlir",
             "fft.mlir",
-            "pad_tensor_to_tensor.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Conversion/HLOToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/test/CMakeLists.txt
@@ -19,7 +19,6 @@ iree_lit_test_suite(
     "dynamic_shape.mlir"
     "fft.mlir"
     "missing_legalizations.mlir"
-    "pad_tensor_to_tensor.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Conversion/LinalgToLinalg/BUILD
+++ b/iree/compiler/Conversion/LinalgToLinalg/BUILD
@@ -15,6 +15,7 @@ cc_library(
     srcs = [
         "Conv2D1x1ToMatmul.cpp",
         "Conv2DToImg2Col.cpp",
+        "PadTensorToSubTensorInsert.cpp",
     ],
     hdrs = [
         "Passes.h",
@@ -24,6 +25,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
     ],

--- a/iree/compiler/Conversion/LinalgToLinalg/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLinalg/CMakeLists.txt
@@ -18,11 +18,13 @@ iree_cc_library(
   SRCS
     "Conv2D1x1ToMatmul.cpp"
     "Conv2DToImg2Col.cpp"
+    "PadTensorToSubTensorInsert.cpp"
   DEPS
     LLVMSupport
     MLIRIR
     MLIRLinalg
     MLIRPass
+    MLIRStandard
     MLIRSupport
     MLIRTransformUtils
   PUBLIC

--- a/iree/compiler/Conversion/LinalgToLinalg/PadTensorToSubTensorInsert.cpp
+++ b/iree/compiler/Conversion/LinalgToLinalg/PadTensorToSubTensorInsert.cpp
@@ -1,0 +1,121 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- PadTensorToSubTensorInsert.cpp - Pass to legalize linalg.pad_tensor-===//
+//
+// Pass to convert linalg.pad_tensor to linalg.fill + subtensor_insert
+// operations which is the only way Vulkan backend can lower it to a single
+// kernel.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Pattern to convert a linalg.pad_tensor operation into a fill + subtensor
+/// insert. This is needed till pad_tensor op can be fused with its consumers.
+struct PadTensorOpConversion : public OpRewritePattern<linalg::PadTensorOp> {
+  using OpRewritePattern<linalg::PadTensorOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::PadTensorOp padTensorOp,
+                                PatternRewriter &rewriter) const override {
+    // Check that the region is just a yield operation which is returning a
+    // scalar that is not one of the arguments of the linalg operation.
+    Region &region = padTensorOp.region();
+    Block &block = region.front();
+    if (!llvm::hasSingleElement(block)) return failure();
+    auto yieldOp = cast<linalg::YieldOp>(block.getTerminator());
+    if (!llvm::hasSingleElement(yieldOp.values())) return failure();
+    Value yieldVal = yieldOp.values().front();
+    if (llvm::any_of(block.getArguments(),
+                     [&](Value v) { return v == yieldVal; })) {
+      return failure();
+    }
+
+    OpBuilder::InsertionGuard g(rewriter);
+    Location loc = padTensorOp.getLoc();
+    auto lowPad = padTensorOp.getMixedLowPad();
+    auto highPad = padTensorOp.getMixedHighPad();
+    Value source = padTensorOp.source();
+    RankedTensorType sourceType = padTensorOp.getSourceType();
+    int64_t rank = sourceType.getRank();
+
+    // TODO(ravishankarm): Use shape inference interface to get this.
+    SmallVector<OpFoldResult> sourceShape;
+    SmallVector<OpFoldResult> outputShape;
+    for (int64_t dim : llvm::seq<int64_t>(0, rank)) {
+      SmallVector<Value> mapValues;
+      Value sourceDim = rewriter.createOrFold<memref::DimOp>(loc, source, dim);
+      mapValues.push_back(sourceDim);
+      sourceShape.push_back(sourceDim);
+      AffineExpr expr = rewriter.getAffineDimExpr(0);
+      unsigned numSymbols = 0;
+      auto addValueOrAttr = [&](AffineExpr e, OpFoldResult valueOrAttr) {
+        if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
+          e = e + attr.cast<IntegerAttr>().getInt();
+          return e;
+        }
+        e = e + rewriter.getAffineSymbolExpr(numSymbols++);
+        mapValues.push_back(valueOrAttr.get<Value>());
+        return e;
+      };
+      expr = addValueOrAttr(expr, lowPad[dim]);
+      expr = addValueOrAttr(expr, highPad[dim]);
+      Value v = linalg::applyMapToValues(
+          rewriter, loc, AffineMap::get(1, numSymbols, expr), mapValues)[0];
+      if (auto cst = v.getDefiningOp<ConstantOp>()) {
+        outputShape.push_back(cst.value());
+      } else {
+        outputShape.push_back(v);
+      }
+    }
+    Value initTensor = rewriter.create<linalg::InitTensorOp>(
+        loc, outputShape, sourceType.getElementType());
+    Value fill =
+        rewriter.create<linalg::FillOp>(loc, initTensor, yieldVal).getResult(0);
+    SmallVector<OpFoldResult> strides(rank, rewriter.getI64IntegerAttr(1));
+    rewriter.replaceOpWithNewOp<SubTensorInsertOp>(
+        padTensorOp, source, fill, lowPad, sourceShape, strides);
+    return success();
+  }
+};
+
+struct PadTensorToSubTensorInsertPass
+    : PassWrapper<PadTensorToSubTensorInsertPass, OperationPass<>> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, StandardOpsDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.insert<PadTensorOpConversion>(context);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<>> createPadTensorToSubTensorInsertPass() {
+  return std::make_unique<PadTensorToSubTensorInsertPass>();
+}
+
+static PassRegistration<PadTensorToSubTensorInsertPass> pass(
+    "iree-flow-pad-tensor-to-subtensor-insert",
+    "Convert linalg.pad_tensor into linalg.fill + subtensor_insert.");
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLinalg/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLinalg/Passes.h
@@ -16,6 +16,10 @@ std::unique_ptr<OperationPass<FuncOp>> createConvert1x1ConvToMatmulPass();
 
 std::unique_ptr<OperationPass<FuncOp>> createConvertConv2DToImg2ColPass();
 
+/// Pass to convert a linalg.pad_tensor operation into a linalg.fill +
+/// subtensor_insert. This allows lowering the operation into a single kernel.
+std::unique_ptr<OperationPass<>> createPadTensorToSubTensorInsertPass();
+
 }  // namespace iree_compiler
 }  // namespace mlir
 #endif  // IREE_COMPILER_CONVERSION_LINALGTOLINALG_PASSES_H_

--- a/iree/compiler/Conversion/LinalgToLinalg/test/BUILD
+++ b/iree/compiler/Conversion/LinalgToLinalg/test/BUILD
@@ -19,6 +19,7 @@ iree_lit_test_suite(
         [
             "conv1x1_to_matmul.mlir",
             "conv2d_to_img2col.mlir",
+            "pad_tensor_to_tensor.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Conversion/LinalgToLinalg/test/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLinalg/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "conv1x1_to_matmul.mlir"
     "conv2d_to_img2col.mlir"
+    "pad_tensor_to_tensor.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Conversion/LinalgToLinalg/test/pad_tensor_to_tensor.mlir
+++ b/iree/compiler/Conversion/LinalgToLinalg/test/pad_tensor_to_tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-tensors -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-flow-pad-tensor-to-subtensor-insert -canonicalize %s | IreeFileCheck %s
 
 module  {
   func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -178,6 +178,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
     passManager.addNestedPass<FuncOp>(
         mlir::iree_compiler::createConvertConv2DToImg2ColPass());
   }
+  passManager.addPass(
+      mlir::iree_compiler::createPadTensorToSubTensorInsertPass());
 
   // Elementwise, fusion, tiling and distribution.
   passManager.addNestedPass<FuncOp>(

--- a/iree/test/e2e/tosa_ops/BUILD
+++ b/iree/test/e2e/tosa_ops/BUILD
@@ -163,6 +163,7 @@ VULKAN_SRCS = enforce_glob(
         "minimum.mlir",
         "mul.mlir",
         "negate.mlir",
+        "pad.mlir",
         "reciprocal.mlir",
         "reluN.mlir",
         "reshape.mlir",
@@ -180,8 +181,6 @@ VULKAN_SRCS = enforce_glob(
         "fully_connected.mlir",  # Currently failing on vulkan.
         "reduce.mlir",  # Currently failing on vulkan.
         "max_pool.mlir",  # Currently failing on vulkan.
-        # TODO: Re-enable pad test.
-        "pad.mlir",
     ],
 )
 

--- a/iree/test/e2e/tosa_ops/CMakeLists.txt
+++ b/iree/test/e2e/tosa_ops/CMakeLists.txt
@@ -140,6 +140,7 @@ iree_check_single_backend_test_suite(
     "minimum.mlir"
     "mul.mlir"
     "negate.mlir"
+    "pad.mlir"
     "reciprocal.mlir"
     "reluN.mlir"
     "reshape.mlir"

--- a/iree/test/e2e/tosa_ops/pad.mlir
+++ b/iree/test/e2e/tosa_ops/pad.mlir
@@ -6,18 +6,18 @@ func @pad_1D_test() attributes { iree.module.export } {
     return
 }
 
-func @pad_2D_test() attributes { iree.module.export } {
-    %0 = iree.unfoldable_constant dense<42> : tensor<2x2xi32>
-    %1 = "tosa.const"() { value = dense<[[1, 1], [1, 1]]> : tensor<2x2xi32> } : ()  -> (tensor<2x2xi32>)
-    %result = "tosa.pad"(%0, %1)  : (tensor<2x2xi32>, tensor<2x2xi32>)  -> (tensor<4x4xi32>)
-    check.expect_eq_const(%result, dense<[[0, 0, 0, 0], [0, 42, 42, 0], [0, 42, 42, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>) : tensor<4x4xi32>
-    return
-}
+// func @pad_2D_test() attributes { iree.module.export } {
+//     %0 = iree.unfoldable_constant dense<42> : tensor<2x2xi32>
+//     %1 = "tosa.const"() { value = dense<[[1, 1], [1, 1]]> : tensor<2x2xi32> } : ()  -> (tensor<2x2xi32>)
+//     %result = "tosa.pad"(%0, %1)  : (tensor<2x2xi32>, tensor<2x2xi32>)  -> (tensor<4x4xi32>)
+//     check.expect_eq_const(%result, dense<[[0, 0, 0, 0], [0, 42, 42, 0], [0, 42, 42, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>) : tensor<4x4xi32>
+//     return
+// }
 
-func @pad_3D_test() attributes { iree.module.export } {
-    %0 = iree.unfoldable_constant dense<42> : tensor<1x1x2xi32>
-    %1 = "tosa.const"() { value = dense<[[0, 1], [1, 0], [0, 0]]> : tensor<3x2xi32> } : ()  -> (tensor<3x2xi32>)
-    %result = "tosa.pad"(%0, %1)  : (tensor<1x1x2xi32>, tensor<3x2xi32>)  -> (tensor<2x2x2xi32>)
-    check.expect_eq_const(%result, dense<[[[0, 0], [42, 42]], [[0, 0], [0, 0]]]> : tensor<2x2x2xi32>) : tensor<2x2x2xi32>
-    return
-}
+// func @pad_3D_test() attributes { iree.module.export } {
+//     %0 = iree.unfoldable_constant dense<42> : tensor<1x1x2xi32>
+//     %1 = "tosa.const"() { value = dense<[[0, 1], [1, 0], [0, 0]]> : tensor<3x2xi32> } : ()  -> (tensor<3x2xi32>)
+//     %result = "tosa.pad"(%0, %1)  : (tensor<1x1x2xi32>, tensor<3x2xi32>)  -> (tensor<2x2x2xi32>)
+//     check.expect_eq_const(%result, dense<[[[0, 0], [42, 42]], [[0, 0], [0, 0]]]> : tensor<2x2x2xi32>) : tensor<2x2x2xi32>
+//     return
+// }

--- a/iree/test/e2e/tosa_ops/pad.mlir
+++ b/iree/test/e2e/tosa_ops/pad.mlir
@@ -6,18 +6,18 @@ func @pad_1D_test() attributes { iree.module.export } {
     return
 }
 
-// func @pad_2D_test() attributes { iree.module.export } {
-//     %0 = iree.unfoldable_constant dense<42> : tensor<2x2xi32>
-//     %1 = "tosa.const"() { value = dense<[[1, 1], [1, 1]]> : tensor<2x2xi32> } : ()  -> (tensor<2x2xi32>)
-//     %result = "tosa.pad"(%0, %1)  : (tensor<2x2xi32>, tensor<2x2xi32>)  -> (tensor<4x4xi32>)
-//     check.expect_eq_const(%result, dense<[[0, 0, 0, 0], [0, 42, 42, 0], [0, 42, 42, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>) : tensor<4x4xi32>
-//     return
-// }
+func @pad_2D_test() attributes { iree.module.export } {
+    %0 = iree.unfoldable_constant dense<42> : tensor<2x2xi32>
+    %1 = "tosa.const"() { value = dense<[[1, 1], [1, 1]]> : tensor<2x2xi32> } : ()  -> (tensor<2x2xi32>)
+    %result = "tosa.pad"(%0, %1)  : (tensor<2x2xi32>, tensor<2x2xi32>)  -> (tensor<4x4xi32>)
+    check.expect_eq_const(%result, dense<[[0, 0, 0, 0], [0, 42, 42, 0], [0, 42, 42, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>) : tensor<4x4xi32>
+    return
+}
 
-// func @pad_3D_test() attributes { iree.module.export } {
-//     %0 = iree.unfoldable_constant dense<42> : tensor<1x1x2xi32>
-//     %1 = "tosa.const"() { value = dense<[[0, 1], [1, 0], [0, 0]]> : tensor<3x2xi32> } : ()  -> (tensor<3x2xi32>)
-//     %result = "tosa.pad"(%0, %1)  : (tensor<1x1x2xi32>, tensor<3x2xi32>)  -> (tensor<2x2x2xi32>)
-//     check.expect_eq_const(%result, dense<[[[0, 0], [42, 42]], [[0, 0], [0, 0]]]> : tensor<2x2x2xi32>) : tensor<2x2x2xi32>
-//     return
-// }
+func @pad_3D_test() attributes { iree.module.export } {
+    %0 = iree.unfoldable_constant dense<42> : tensor<1x1x2xi32>
+    %1 = "tosa.const"() { value = dense<[[0, 1], [1, 0], [0, 0]]> : tensor<3x2xi32> } : ()  -> (tensor<3x2xi32>)
+    %result = "tosa.pad"(%0, %1)  : (tensor<1x1x2xi32>, tensor<3x2xi32>)  -> (tensor<2x2x2xi32>)
+    check.expect_eq_const(%result, dense<[[[0, 0], [42, 42]], [[0, 0], [0, 0]]]> : tensor<2x2x2xi32>) : tensor<2x2x2xi32>
+    return
+}


### PR DESCRIPTION
This is currently done on the HLO to Linalg conversion, which meant
the TOSA path didnt get this conversion. This is needed for the vulkan
codegen to handle pad operation.

Fixes #6077