### PR TITLE
Disable operand fusion for CPU benchmarks

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -249,7 +249,8 @@ MODEL_BENCHMARKS = [
                             "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            # TODO(GH-5857): Enable this after fixing segfault.
+                            #"--iree-flow-dispatch-formation-enable-operand-fusion",
                             "-iree-llvm-loop-unrolling=true"
                         ]
                     })),
@@ -263,7 +264,8 @@ MODEL_BENCHMARKS = [
                             "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            # TODO(GH-5857): Enable this after fixing segfault.
+                            #"--iree-flow-dispatch-formation-enable-operand-fusion",
                             "-iree-llvm-loop-unrolling=true"
                         ]
                     })),

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -245,7 +245,8 @@ MODEL_BENCHMARKS = [
                     skipped_target=["vlk2"],
                     compilation_flags={
                         'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            # TODO(GH-5857): Enable this after fixing segfault.
+                            #"--iree-flow-dispatch-formation-enable-operand-fusion",
                             "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [
@@ -260,7 +261,8 @@ MODEL_BENCHMARKS = [
                 targets=get_s20_default_target_list(
                     compilation_flags={
                         'cpu': [
-                            "--iree-flow-dispatch-formation-enable-operand-fusion",
+                            # TODO(GH-5857): Enable this after fixing segfault.
+                            #"--iree-flow-dispatch-formation-enable-operand-fusion",
                             "-iree-llvm-loop-unrolling=true"
                         ],
                         'cpu3t': [

--- a/iree/test/model_benchmarks/CMakeLists.txt
+++ b/iree/test/model_benchmarks/CMakeLists.txt
@@ -83,7 +83,8 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
+    # TODO(GH-5857): Enable this after fixing segfault.
+    #"--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib-sync"
@@ -115,7 +116,8 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
+    # TODO(GH-5857): Enable this after fixing segfault.
+    #"--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib"

--- a/iree/test/model_benchmarks/CMakeLists.txt
+++ b/iree/test/model_benchmarks/CMakeLists.txt
@@ -123,7 +123,7 @@ iree_mlir_benchmark_suite(
     "--task_topology_group_count=1"
 )
 
-# CPU, Dylib, 3-thread, big-core, full-inference
+# CPU, Dylib, 3-thread, big/little-core, full-inference
 iree_mlir_benchmark_suite(
   MODULE_NAMES
     ${BENCHMARK_MODULE_NAMES}
@@ -149,7 +149,8 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
+    # TODO(GH-5857): Enable this after fixing segfault.
+    #"--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib"


### PR DESCRIPTION
They are causing segfault. Looks it's the same issue as
https://github.com/google/iree/issues/5857.