### PR TITLE
[cmake] Fix uninitialized variable

### DIFF
--- a/build_tools/cmake/iree_mlir_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_mlir_benchmark_suite.cmake
@@ -91,6 +91,7 @@ function(iree_mlir_benchmark_suite)
   iree_check_lists_have_same_size(_RULE_MODULE_NAMES _RULE_FUNCTION_INPUTS)
 
   # Loop over all modules and their sources to create targets.
+  list(LENGTH _RULE_MODULE_NAMES _MODULE_NAMES_COUNT)
   math(EXPR _MAX_INDEX "${_MODULE_NAMES_COUNT} - 1")
   foreach(_INDEX RANGE 0 "${_MAX_INDEX}")
     # Generate all benchmarks to the root build directory. This helps for


### PR DESCRIPTION
This was dropped accidentally in previous changes.

But CMake seems quite happy without it and functions properly.
I cannot say I know CMake now..