### PR TITLE
Remove extra unnecessary allocations

### DIFF
--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -410,8 +410,6 @@ static LogicalResult analyseSubTensorOp(SubTensorOp subTensorOp,
   }
   return analyseSingleOperandResultOp(subTensorOp.source(),
                                       subTensorOp.result(), plan);
-  // plan.unionSets(subTensorOp.source(), subTensorOp.result());
-  // return success();
 }
 
 /// Adds the `dest` and `result` tensor of a subtensor insert operation into the

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -373,11 +373,25 @@ static LogicalResult analyseLinalgOps(linalg::LinalgOp linalgOp,
   return success();
 }
 
+/// Returns true if there is a only one use that
+static bool hasOneUseExecludingDimOp(Value value) {
+  int numUsers = 0;
+  int numSubTensorInsertUsers = 0;
+  for (auto user : value.getUsers()) {
+    if (isa<SubTensorInsertOp>(user)) {
+      numSubTensorInsertUsers++;
+    } else if (!isa<memref::DimOp>(user)) {
+      numUsers++;
+    }
+  }
+  return numUsers == 1 && numSubTensorInsertUsers <= 1;
+}
+
 /// For operations that have a single operand and result, adds both to the same
 /// equivalence class.
 static LogicalResult analyseSingleOperandResultOp(Value source, Value result,
                                                   BufferizationPlan &plan) {
-  if (source.hasOneUse() || isFromReadOnlyTensor(source)) {
+  if (hasOneUseExecludingDimOp(source) || isFromReadOnlyTensor(source)) {
     plan.unionSets(source, result);
     return success();
   }
@@ -395,6 +409,8 @@ static LogicalResult analyseSubTensorOp(SubTensorOp subTensorOp,
   }
   return analyseSingleOperandResultOp(subTensorOp.source(),
                                       subTensorOp.result(), plan);
+  // plan.unionSets(subTensorOp.source(), subTensorOp.result());
+  // return success();
 }
 
 /// Adds the `dest` and `result` tensor of a subtensor insert operation into the
@@ -405,10 +421,8 @@ static LogicalResult analyseDestructiveUpdateOp(Operation *op, Value source,
                                                 BufferizationPlan &plan) {
   if (dest.hasOneUse() && !isFromReadOnlyTensor(dest)) {
     plan.unionSets(dest, result);
-  }
-  if (source && plan.isEquivalent(source, dest)) {
-    return op->emitError(
-        "unexpected source and dest being mapped to same buffer");
+  } else if (source && plan.isEquivalent(source, dest)) {
+    return success();
   }
   plan.insert(dest);
   plan.insert(result);
@@ -747,7 +761,8 @@ static Value getInplaceResultBuffer(OpBuilder &b, OpResult resultValue,
     Operation *op = value.getDefiningOp();
     resultBuffer =
         TypeSwitch<Operation *, Value>(op)
-            .Case<linalg::LinalgOp, SubTensorInsertOp, vector::TransferWriteOp>(
+            .Case<scf::ForOp, linalg::LinalgOp, SubTensorInsertOp,
+                  vector::TransferWriteOp>(
                 [&](auto op) { return resultBuffer; })
             .Case<linalg::TensorReshapeOp>(
                 [&](linalg::TensorReshapeOp reshapeOp) {

--- a/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Conversion/Common/LinalgBufferizePass.cpp
@@ -373,8 +373,8 @@ static LogicalResult analyseLinalgOps(linalg::LinalgOp linalgOp,
   return success();
 }
 
-/// Returns true if there is a only one use that
-static bool hasOneUseExecludingDimOp(Value value) {
+/// Returns true if there is a a single use that is a subtensor_insert.
+static bool hasSingleSubTensorInsertNotDimUse(Value value) {
   int numUsers = 0;
   int numSubTensorInsertUsers = 0;
   for (auto user : value.getUsers()) {
@@ -391,7 +391,8 @@ static bool hasOneUseExecludingDimOp(Value value) {
 /// equivalence class.
 static LogicalResult analyseSingleOperandResultOp(Value source, Value result,
                                                   BufferizationPlan &plan) {
-  if (hasOneUseExecludingDimOp(source) || isFromReadOnlyTensor(source)) {
+  if (hasSingleSubTensorInsertNotDimUse(source) ||
+      isFromReadOnlyTensor(source)) {
     plan.unionSets(source, result);
     return success();
   }

--- a/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Conversion/Common/test/linalg_bufferize.mlir
@@ -2077,7 +2077,7 @@ module  {
 //    CHECK-DAG:        %[[LHS_WORKGROUP_TILE:.+]] = memref.subview %[[LHS]][%[[WORKGROUP_I]], 0] [%[[WORKGROUP_I_SIZE]], 144] [1, 1] : memref<250x144xf32> to memref<?x144xf32
 //    CHECK-DAG:        %[[WORKGROUP_J_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_J]])
 //    CHECK-DAG:        %[[RHS_WORKGROUP_TILE:.+]] = memref.subview %[[RHS]][0, %[[WORKGROUP_J]]] [144, %[[WORKGROUP_J_SIZE]]] [1, 1] : memref<144x370xf32> to memref<144x?xf32
-//    CHECK-DAG:            %[[DST_WORKGROUP_TILE:.+]] = memref.alloc(%[[WORKGROUP_I_SIZE]], %[[WORKGROUP_J_SIZE]]) : memref<?x?xf32>
+//    CHECK-DAG:            %[[DST_WORKGROUP_TILE:.+]] = memref.subview %[[DST]][%[[WORKGROUP_I]], %[[WORKGROUP_J]]] [%[[WORKGROUP_I_SIZE]], %[[WORKGROUP_J_SIZE]]]
 //        CHECK:            scf.for %[[L1_I:.+]] = %{{.*}} to %[[M]] step %[[L1_MN_SIZE]] {
 //        CHECK:              scf.for %[[L1_J:.+]] = %{{.*}} to %[[N]] step %[[L1_MN_SIZE]] {
 //        CHECK:                scf.for %[[L1_K:.+]] = %{{.*}} to %[[K]] step %[[L1_K_SIZE]] {
@@ -2086,9 +2086,7 @@ module  {
 //    CHECK-DAG:                    %[[L1_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I_SIZE]], %[[L1_I]])
 //    CHECK-DAG:                    %[[L1_J_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_J_SIZE]], %[[L1_J]])
 //    CHECK-DAG:                    %[[DST_L1_TILE:.+]] = memref.subview %[[DST_WORKGROUP_TILE]][%[[L1_I]], %[[L1_J]]]
-//    CHECK-DAG:                    %[[L1DST:.+]] = memref.alloc(%[[L1_I_SIZE]], %[[L1_J_SIZE]])
-//        CHECK:                    linalg.copy(%[[DST_L1_TILE]], %[[L1DST]])
 //        CHECK:                    linalg.matmul
 //   CHECK-SAME:                    ins(%[[LHS_L1_TILE]], %[[RHS_L1_TILE]]
-//   CHECK-SAME:                    outs(%[[L1DST]]
-//        CHECK:                    linalg.copy(%[[L1DST]], %[[DST_L1_TILE]])
+//   CHECK-SAME:                    outs(%[[DST_L1_TILE]]
+//        CHECK:                    linalg.copy(%[[DST_L1_TILE]], %[[DST_L1_TILE]])


### PR DESCRIPTION
- Reuse the same result buffer for scf.for
- Handle subtensor inserts that alise result buffer.