### PR TITLE
Reduce benchmarking iterations for Adreno GPU kernel execution

### DIFF
--- a/iree/test/model_benchmarks/CMakeLists.txt
+++ b/iree/test/model_benchmarks/CMakeLists.txt
@@ -250,11 +250,11 @@ iree_mlir_benchmark_suite(
     # TODO(GH-6086): Turn on the flag.
     #"--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
   DRIVER
     "vulkan"
   RUNTIME_FLAGS
-    "--batch_size=32"
+    "--batch_size=16"
 )
 
 # GPU, Vulkan, Mali, full-inference


### PR DESCRIPTION
On Snapdragon SoC we can see device lost after 2 seconds.
Our kernels for Adreno GPUs aren't well optmized like Mali GPUs.
So they take longer time to run. Reduce the iterations to avoid
seeing device lost and fail the pipeline.

For more context see https://github.com/google/iree/issues/5052