### PR TITLE
Deduplicate artifacts in generated benchmark suites

### DIFF
--- a/build_tools/android/run_benchmarks.py
+++ b/build_tools/android/run_benchmarks.py
@@ -32,11 +32,11 @@ from common.benchmark_description import (AndroidDeviceInfo, BenchmarkInfo,
 BENCHMARK_SUITE_REL_PATH = "benchmark_suites"
 # Relative path against root benchmark suite directory.
 TENSORFLOW_MODEL_SUITE_REL_PATH = "TensorFlow"
+# Relative path against TensorFlow directory.
+VMFB_REL_PATH = "vmfb"
 
 # The flagfile's filename for compiled Python models.
 MODEL_FLAGFILE_NAME = "flagfile"
-# The artifact's filename for compiled Python models.
-MODEL_VMFB_NAME = "compiled.vmfb"
 
 # Root directory to perform benchmarks in on the Android device.
 ANDROID_TMP_DIR = "/data/local/tmp/iree-benchmarks"
@@ -209,13 +209,16 @@ def run_python_model_benchmark_suite(device_info,
   Returns:
   - A list containing (BenchmarkInfo, context, results) tuples.
   """
-  # Push the benchmark tool to the Android device first.
+  model_root_dir = os.path.join(root_build_dir, BENCHMARK_SUITE_REL_PATH,
+                                TENSORFLOW_MODEL_SUITE_REL_PATH)
+
+  # Push the benchmark vmfb and tool files to the Android device first.
+  adb_push_to_tmp_dir(os.path.join(model_root_dir, VMFB_REL_PATH),
+                      relative_dir="",
+                      verbose=verbose)
   android_tool_path = adb_push_to_tmp_dir(benchmark_tool,
                                           relative_dir="tools",
                                           verbose=verbose)
-
-  model_root_dir = os.path.join(root_build_dir, BENCHMARK_SUITE_REL_PATH,
-                                TENSORFLOW_MODEL_SUITE_REL_PATH)
 
   results = []
 
@@ -225,9 +228,6 @@ def run_python_model_benchmark_suite(device_info,
                                                    model_benchmark_dir)
     print(f"--> benchmark: {benchmark_info} <--")
     android_relative_dir = os.path.relpath(model_benchmark_dir, model_root_dir)
-    adb_push_to_tmp_dir(os.path.join(model_benchmark_dir, MODEL_VMFB_NAME),
-                        android_relative_dir,
-                        verbose=verbose)
     android_flagfile_path = adb_push_to_tmp_dir(os.path.join(
         model_benchmark_dir, MODEL_FLAGFILE_NAME),
                                                 android_relative_dir,

--- a/iree/test/model_benchmarks/CMakeLists.txt
+++ b/iree/test/model_benchmarks/CMakeLists.txt
@@ -79,7 +79,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-flow-inline-constants-max-byte-length=2048"
   DRIVER
     "vmvx"
@@ -110,7 +109,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
@@ -143,7 +141,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
@@ -178,7 +175,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
@@ -212,7 +208,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "GPU-Adreno"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-6086): Turn on the flag.
@@ -244,7 +239,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "GPU-Adreno"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-6086): Turn on the flag.
@@ -279,7 +273,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=16"
     # TODO(GH-6086): Turn on the flag.
@@ -311,7 +304,6 @@ iree_mlir_benchmark_suite(
   TARGET_ARCHITECTURE
     "GPU-Mali-Valhall"
   TRANSLATION_FLAGS
-    "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=16"
     # TODO(GH-6086): Turn on the flag.


### PR DESCRIPTION
Previously we just simply generate a new vmfb file for each benchmark
configuration. This is fine for a small number of benchmarks but
it's becoming problematic as we have more and more models, IREE
drivers, modes that we want to generate products over. It will
bloat the total size of vmfb files. We use buildkite to build in
the cloud and then download to run on the phone. It would mean
downloading probably GBs data per run.

This commit changes to hash according to the input MLIR module name
and all the translation flags, and generate one single copy of vmfb
file. Flagfiles for all the benchmark cases are pointing to the
unique copy.