### PR TITLE
Fix missing no-ops under IREE_SYNCHRONIZATION_DISABLE_UNSAFE

### DIFF
--- a/iree/base/internal/call_once.h
+++ b/iree/base/internal/call_once.h
@@ -72,6 +72,13 @@ static inline void iree_call_once(iree_once_flag* flag, void (*func)(void)) {
   InitOnceExecuteOnce(flag, iree_call_once_callback_impl, (PVOID)&param, NULL);
 }
 
+#elif IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+
+// No-op when the thread control is disabled.
+#define IREE_ONCE_FLAG_INIT 1
+#define iree_once_flag uint32_t
+static inline void iree_call_once(iree_once_flag* flag, void (*func)(void)) {}
+
 #else
 
 // Fallback using pthread_once:

--- a/iree/base/internal/synchronization.c
+++ b/iree/base/internal/synchronization.c
@@ -154,7 +154,7 @@ static inline void iree_futex_wake(void* address, int32_t count) {
 #define iree_mutex_impl_initialize(mutex)
 #define iree_mutex_impl_deinitialize(mutex)
 #define iree_mutex_impl_lock(mutex)
-#define iree_mutex_impl_try_lock(mutex)
+#define iree_mutex_impl_try_lock(mutex) true
 #define iree_mutex_impl_unlock(mutex)
 
 #elif defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
@@ -309,7 +309,9 @@ void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
     IREE_DISABLE_THREAD_SAFETY_ANALYSIS {}
 
 bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
-    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {}
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  return iree_mutex_try_lock((iree_mutex_t*)&mutex->reserved);
+}
 
 void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
     IREE_DISABLE_THREAD_SAFETY_ANALYSIS {}


### PR DESCRIPTION
Put iree_run_once() as a no-op with the macro defined. Also fix some
no-op API interfaces.

Part of the cleanup for https://github.com/google/iree/issues/6027