### PR TITLE
Allow CPU translation to be specified using command line options.

### DIFF
--- a/iree/compiler/Conversion/CodegenUtils/FunctionUtils.cpp
+++ b/iree/compiler/Conversion/CodegenUtils/FunctionUtils.cpp
@@ -16,6 +16,17 @@ namespace iree_compiler {
 
 bool isEntryPoint(FuncOp func) { return func.isPublic(); }
 
+FailureOr<FuncOp> getSingleEntryPointFunction(ModuleOp module) {
+  auto entryPointFns = llvm::to_vector<1>(llvm::make_filter_range(
+      module.getOps<FuncOp>(), [&](FuncOp op) { return isEntryPoint(op); }));
+  if (!llvm::hasSingleElement(entryPointFns)) {
+    module.emitError(
+        "cannot handle modules with multiple entry point functions.");
+    return {};
+  }
+  return entryPointFns[0];
+}
+
 unsigned getNumOuterParallelLoops(linalg::LinalgOp op) {
   return op.iterator_types()
       .getValue()

--- a/iree/compiler/Conversion/CodegenUtils/FunctionUtils.h
+++ b/iree/compiler/Conversion/CodegenUtils/FunctionUtils.h
@@ -17,6 +17,9 @@ namespace iree_compiler {
 /// Returns true if the given `func` is a kernel dispatch entry point.
 bool isEntryPoint(FuncOp func);
 
+/// Given a module returns the entrypoint function within the module.
+FailureOr<FuncOp> getSingleEntryPointFunction(ModuleOp module);
+
 /// Returns the number of outer parallel loops of a linalgOp.
 unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
 

--- a/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Conversion/Common/SetNumWorkgroupsPass.cpp
@@ -29,8 +29,7 @@ class SetNumWorkgroupsPass
         .insert<AffineDialect, IREE::HAL::HALDialect, linalg::LinalgDialect>();
   }
 
-  SetNumWorkgroupsPass() = default;
-  SetNumWorkgroupsPass(ArrayRef<int64_t> ws)
+  SetNumWorkgroupsPass(ArrayRef<int64_t> ws = {})
       : workgroupSize(ws.begin(), ws.end()) {}
   SetNumWorkgroupsPass(const SetNumWorkgroupsPass &pass)
       : workgroupSize(pass.workgroupSize) {}
@@ -38,102 +37,42 @@ class SetNumWorkgroupsPass
   void runOnOperation() override;
 
  private:
-  ListOption<int> workgroupSizesOpt{
-      *this, "workgroup-size", llvm::cl::MiscFlags::CommaSeparated,
-      llvm::cl::desc("Specifies the workgroup size to use in x, y, z order")};
-
   SmallVector<int64_t> workgroupSize;
 };
 }  // namespace
-
-/// Returns the workgroup size to use for the flow.dispatch.workgroups
-/// operation, the `linalgOp` is in. This is obtained from the tile size for the
-/// operation at the distributed level.
-static SmallVector<int64_t, 4> getDistributedWorkgroupSize(
-    linalg::LinalgOp linalgOp, ArrayRef<int64_t> tileSizes) {
-  if (tileSizes.empty()) return {};
-  tileSizes = tileSizes.take_front(getNumOuterParallelLoops(linalgOp));
-  // For now we only distribute the inner-parallel loops.
-  if (tileSizes.size() > kNumMaxParallelDims) {
-    tileSizes = tileSizes.take_back(kNumMaxParallelDims);
-  }
-  auto workgroupSize = llvm::to_vector<4>(llvm::reverse(tileSizes));
-  return workgroupSize;
-}
-
-/// Gets the workgroup size to use based on the workgroups sizes set for each
-/// operation in `linalgOps`. Checks that all the ops return a consistent
-/// value.
-static FailureOr<SmallVector<int64_t, 4>> getDistributedWorkgroupSize(
-    ArrayRef<linalg::LinalgOp> linalgOps) {
-  Optional<SmallVector<int64_t, 4>> distributedWorkgroupSize;
-  for (auto linalgOp : linalgOps) {
-    SmallVector<int64_t, 4> opTileSizes = getTileSizes(linalgOp, 0);
-    auto opWorkgroupSize = getDistributedWorkgroupSize(linalgOp, opTileSizes);
-    if (!distributedWorkgroupSize) {
-      distributedWorkgroupSize = std::move(opWorkgroupSize);
-      continue;
-    }
-    if (*distributedWorkgroupSize != opWorkgroupSize) {
-      return static_cast<LogicalResult>(linalgOp.emitError(
-          "mismatch in workgroup size for this op as compared to other linalg "
-          "ops in the dispatch region"));
-    }
-  }
-  return distributedWorkgroupSize ? *distributedWorkgroupSize
-                                  : SmallVector<int64_t, 4>{};
-}
 
 void SetNumWorkgroupsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IREE::HAL::ExecutableTargetOp targetOp = getOperation();
   ModuleOp module = targetOp.getInnerModule();
 
-  for (auto funcOp : module.getOps<FuncOp>()) {
-    if (!isEntryPoint(funcOp)) continue;
-
-    SmallVector<linalg::LinalgOp, 4> linalgOps;
-    SmallVector<Operation *, 4> tiledLoops;
-    if (failed(getLinalgOps(funcOp, linalgOps, tiledLoops))) {
-      // Nothing to do here. Continue.
-      continue;
-    }
-
-    SmallVector<int64_t, 4> workgroupSize;
-    // Get the workgroup size. First check if there is a size specified in the
-    // command line.
-    if (!workgroupSizesOpt.empty()) {
-      workgroupSize.assign(workgroupSizesOpt.begin(), workgroupSizesOpt.end());
-    } else {
-      auto distributedWorkgroupSize = getDistributedWorkgroupSize(linalgOps);
-      if (failed(distributedWorkgroupSize)) {
+  if (workgroupSize.empty()) {
+    // If no workgroup size is specified, leave the workgroup size as is, just
+    // set the number of workgroups to be 1, 1, 1 to have a single invocation.
+    WorkgroupCountRegionBuilder regionBuilder =
+        [](OpBuilder &b, Location loc,
+           std::array<Value, 3> workload) -> std::array<Value, 3> {
+      Value one = b.create<ConstantIndexOp>(loc, 1);
+      return {one, one, one};
+    };
+    OpBuilder builder(context);
+    for (auto funcOp : module.getOps<FuncOp>()) {
+      if (failed(defineWorkgroupCountRegion(builder, funcOp, regionBuilder))) {
         return signalPassFailure();
       }
-
-      // If workgroup size is empty, serialize the operation by setting the
-      // number of workgroups to {1, 1, 1}.
-      if (distributedWorkgroupSize->empty()) {
-        WorkgroupCountRegionBuilder regionBuilder =
-            [](OpBuilder &b, Location loc,
-               std::array<Value, 3> workload) -> std::array<Value, 3> {
-          Value one = b.create<ConstantIndexOp>(loc, 1);
-          return {one, one, one};
-        };
-        OpBuilder builder(context);
-        if (failed(
-                defineWorkgroupCountRegion(builder, funcOp, regionBuilder))) {
-          return signalPassFailure();
-        }
-        continue;
-      }
-
-      workgroupSize = distributedWorkgroupSize.getValue();
     }
+    return;
+  }
 
-    if (failed(materializeStaticLaunchInformation(funcOp, workgroupSize))) {
-      funcOp.emitError("failed to materialize constant workgroup size");
-      return signalPassFailure();
-    }
+  auto entryPointFn = getSingleEntryPointFunction(module);
+  if (failed(entryPointFn)) {
+    return signalPassFailure();
+  }
+  auto funcOp = entryPointFn.getValue();
+
+  if (failed(materializeStaticLaunchInformation(funcOp, workgroupSize))) {
+    funcOp.emitError("failed to materialize constant workgroup size");
+    return signalPassFailure();
   }
 
   // Apply post distribution canonicalization passes.

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
@@ -66,9 +66,20 @@ static llvm::cl::opt<int> genericOpsWorkgroupTileSize(
         "linalg.generic and linalg.indexed_generic workgroup tile size"),
     llvm::cl::init(128));
 
+/// Usually the tile sizes for the first level of tiling decides the workgroup
+/// size for the dispatch on the CPU backend. This is a general helper that
+/// converts tile sizes of the first level into workgroup sizes.
+static SmallVector<int64_t, 3> getWorkgroupSizeFromTileSizes(
+    ArrayRef<int64_t> distributedTileSizes) {
+  if (distributedTileSizes.size() > kNumMaxParallelDims) {
+    distributedTileSizes = distributedTileSizes.take_back(kNumMaxParallelDims);
+  }
+  return llvm::to_vector<3>(llvm::reverse(distributedTileSizes));
+}
+
 /// Sets the lowering configuration for dispatch region with root op that
 /// implements the contraction operation interface.
-static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
+static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
     linalg::ContractionOpInterface contractionOp) {
   assert(!hasLoweringConfig(contractionOp) &&
          "illegal to update configuration of root");
@@ -107,7 +118,9 @@ static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
     IREE::HAL::LoweringConfig config =
         getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
+    return IREE::HAL::TranslateExecutableInfo{
+        IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+        getWorkgroupSizeFromTileSizes(tileSizes[0])};
   }
   if (contractionOp.isRowMajorBatchMatmul()) {
     // TODO(ataei, ravishankarm): This should just use the configuration for
@@ -123,7 +136,9 @@ static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
     IREE::HAL::LoweringConfig config =
         getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
+    return IREE::HAL::TranslateExecutableInfo{
+        IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+        getWorkgroupSizeFromTileSizes(tileSizes[0])};
   }
   return llvm::None;
 }
@@ -132,7 +147,7 @@ static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
 /// (i.e. workgroup-level) to stay consistent with the distribution done at the
 /// Flow dialect level, where the last `kNumMaxParallelDims` of the outer
 /// parallel loops are distributed.
-SmallVector<int64_t, 4> getDistributedWorkgroupTileSizes(
+static SmallVector<int64_t, 4> getTileSizesForWorkgroupDistribution(
     int64_t numOuterParallelLoops, ArrayRef<int64_t> workgroupTileSizes) {
   SmallVector<int64_t, 4> distributedTileSizes =
       llvm::to_vector<4>(workgroupTileSizes);
@@ -144,23 +159,28 @@ SmallVector<int64_t, 4> getDistributedWorkgroupTileSizes(
 
 /// Sets the lowering configuration for dispatch region with root op being a
 /// generic op.
-static Optional<IREE::HAL::DispatchLoweringPassPipeline> setRootConfig(
+static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
     linalg::GenericOp genericOp) {
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(genericOp);
   SmallVector<int64_t, 4> workgroupTileSizes(numOuterParallelLoops,
                                              genericOpsWorkgroupTileSize);
-  workgroupTileSizes = getDistributedWorkgroupTileSizes(numOuterParallelLoops,
-                                                        workgroupTileSizes);
+  workgroupTileSizes = getTileSizesForWorkgroupDistribution(
+      numOuterParallelLoops, workgroupTileSizes);
   TileSizesListType tileSizes = {workgroupTileSizes};
   IREE::HAL::LoweringConfig config =
       getConfigAttr(tileSizes, ArrayRef<int64_t>{}, genericOp->getContext());
   setLoweringConfig(genericOp, config);
-  return IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization;
+  return IREE::HAL::TranslateExecutableInfo{
+      IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+      getWorkgroupSizeFromTileSizes(tileSizes[0])};
 }
 
 /// Sets the configuration for a linalg op that is not the root of the
 /// dispatch. The configuration should use the tile sizes of the first level of
 /// tiling passed in through `firstLevelTileSizes` for correctness.
+// TODO(ravishankarm): This method should be deleted. The root configuration
+// must be enough. The pass pipeline must use the root configuration as the
+// driver of transformations. Leave it as is for now.
 LogicalResult setNonRootConfig(linalg::LinalgOp linalgOp,
                                ArrayRef<int64_t> parallelLoopTileSizes) {
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(linalgOp);
@@ -181,22 +201,22 @@ LogicalResult setNonRootConfig(linalg::LinalgOp linalgOp,
 
 /// Finds the root operation in the given list of linalg operations and sets its
 /// configuration. Returns the root operation.
-static LogicalResult setRootConfig(
+static FailureOr<IREE::HAL::TranslateExecutableInfo> setRootConfig(
     ArrayRef<linalg::LinalgOp> linalgOps,
-    Optional<IREE::HAL::DispatchLoweringPassPipeline> &passPipeline,
     SmallVectorImpl<int64_t> &parallelLoopTileSizes) {
   // First iterate over all operations to find the root operations and set its
   // lowering configuration (that are not linalg.generic).
   linalg::LinalgOp rootOp = nullptr;
 
+  Optional<IREE::HAL::TranslateExecutableInfo> passPipeline;
   auto checkOrUpdatePassPipeline =
       [&](linalg::LinalgOp linalgOp,
-          Optional<IREE::HAL::DispatchLoweringPassPipeline> opPassPipeline)
+          Optional<IREE::HAL::TranslateExecutableInfo> opPassPipeline)
       -> LogicalResult {
     if (!opPassPipeline) return success();
     if (passPipeline && passPipeline.getValue() != opPassPipeline.getValue()) {
       return linalgOp.emitError(
-          "mismatch in pass-pipeline chosen for ops in dispatch region");
+          "mismatch in translation configuration for ops in dispatch region");
     }
     if (!passPipeline) {
       passPipeline = opPassPipeline.getValue();
@@ -208,13 +228,12 @@ static LogicalResult setRootConfig(
   for (auto linalgOp : linalgOps) {
     if (!hasMarker(linalgOp, getWorkgroupMarker())) continue;
     auto opPassPipeline =
-        TypeSwitch<Operation *,
-                   Optional<IREE::HAL::DispatchLoweringPassPipeline>>(
+        TypeSwitch<Operation *, Optional<IREE::HAL::TranslateExecutableInfo>>(
             linalgOp.getOperation())
             .Case<linalg::ContractionOpInterface>(
                 [&](auto op) { return setRootConfig(op); })
             .Default([](Operation *)
-                         -> Optional<IREE::HAL::DispatchLoweringPassPipeline> {
+                         -> Optional<IREE::HAL::TranslateExecutableInfo> {
               return llvm::None;
             });
     auto status = checkOrUpdatePassPipeline(linalgOp, opPassPipeline);
@@ -239,7 +258,7 @@ static LogicalResult setRootConfig(
   }
 
   // If still no root operation, use default.
-  if (!passPipeline) return success();
+  if (!passPipeline) return failure();
 
   parallelLoopTileSizes =
       getTileSizes(rootOp, static_cast<unsigned>(TilingLevel::WorkGroupTiles));
@@ -247,8 +266,9 @@ static LogicalResult setRootConfig(
   // Some consistency checks.
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(rootOp);
   if (parallelLoopTileSizes.size() != numOuterParallelLoops) {
-    return rootOp.emitError(
+    LogicalResult status = rootOp.emitError(
         "expected as many tiles sizes as the parallel loops of the operation");
+    return status;
   }
   auto distributedStart =
       std::max<int64_t>(0, numOuterParallelLoops - kNumMaxParallelDims);
@@ -257,24 +277,33 @@ static LogicalResult setRootConfig(
   if (distributedStart &&
       llvm::any_of(parallelLoopTileSizesRef.take_front(distributedStart),
                    [](int64_t v) -> bool { return v; })) {
-    return rootOp.emitError(
+    LogicalResult status = rootOp.emitError(
         "expected non-distributed parallel loop tile size to be 0");
+    return status;
   }
   if (llvm::any_of(parallelLoopTileSizesRef.take_back(numOuterParallelLoops -
                                                       distributedStart),
                    [](int64_t v) -> bool { return !v; })) {
-    return rootOp.emitError(
+    LogicalResult status = rootOp.emitError(
         "expected distributed parallel loop tile size to be non-zero");
+    return status;
   }
-  return success();
+  return passPipeline.getValue();
 }
 
-FailureOr<IREE::HAL::DispatchLoweringPassPipeline> initCPULaunchConfig(
-    ModuleOp moduleOp) {
+IREE::HAL::TranslateExecutableInfo initCPULaunchConfig(ModuleOp moduleOp) {
+  // By default, the CPU backend will just lower the ops in the dispatch region
+  // as is with no distribution.
+  IREE::HAL::TranslateExecutableInfo pipelineOnFailure = {
+      IREE::HAL::DispatchLoweringPassPipeline::CPUDefault, {}};
   // The current linalg based lowering only tested for a single function case.
+  auto entryPointFn = getSingleEntryPointFunction(moduleOp);
+  if (failed(entryPointFn)) {
+    return pipelineOnFailure;
+  }
   auto funcOps = moduleOp.getOps<FuncOp>();
   if (!llvm::hasSingleElement(funcOps)) {
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+    return pipelineOnFailure;
   }
   FuncOp funcOp = *funcOps.begin();
   SmallVector<linalg::LinalgOp, 4> linalgOps;
@@ -282,34 +311,34 @@ FailureOr<IREE::HAL::DispatchLoweringPassPipeline> initCPULaunchConfig(
   // If there are no linalg ops, not using Linalg based lowering.
   if (failed(getLinalgOps(funcOp, linalgOps, tiledLoops)) ||
       linalgOps.empty()) {
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+    return pipelineOnFailure;
   }
 
-  Optional<IREE::HAL::DispatchLoweringPassPipeline> passPipelineOpt;
   SmallVector<int64_t> parallelLoopTileSizes;
-  if (failed(
-          setRootConfig(linalgOps, passPipelineOpt, parallelLoopTileSizes)) ||
-      !passPipelineOpt) {
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+  auto passPipeline = setRootConfig(linalgOps, parallelLoopTileSizes);
+  if (failed(passPipeline)) {
+    return pipelineOnFailure;
   }
-  auto passPipeline = passPipelineOpt.getValue();
 
   // Set the configuration of all other linalg operations that are not the root
   // operation.
+  // TODO(ravishankarm): The configuration of the root must drive the lowering
+  // completely. This step should be removed.
   LogicalResult status = success();
   for (auto linalgOp : linalgOps) {
     if (hasLoweringConfig(linalgOp)) continue;
     status = setNonRootConfig(linalgOp, parallelLoopTileSizes);
-    if (failed(status)) break;
+    if (failed(status)) {
+      break;
+    }
   }
   if (failed(status)) {
     for (auto linalgOp : linalgOps) {
       eraseLoweringConfig(linalgOp);
     }
-    return IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
+    return pipelineOnFailure;
   }
-
-  return passPipeline;
+  return passPipeline.getValue();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
@@ -20,8 +20,7 @@ enum class TilingLevel : unsigned {
   NumTileLevels = 3
 };
 
-FailureOr<IREE::HAL::DispatchLoweringPassPipeline> initCPULaunchConfig(
-    ModuleOp moduleOp);
+IREE::HAL::TranslateExecutableInfo initCPULaunchConfig(ModuleOp moduleOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}))" -cse -canonicalize -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{test-lowering-configuration=true}))" -cse -canonicalize -split-input-file %s | IreeFileCheck %s
 
 hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
   hal.interface @io {

--- a/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
@@ -1,5 +1,7 @@
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file %s | IreeFileCheck %s
-// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{invoke-lowering-pipelines=false}, module(func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass))))" -split-input-file -iree-codegen-llvm-promote-workgroup-to-full-tiles -cse %s | IreeFileCheck %s -check-prefix=CHECK-PROMOTED
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{use-lowering-pipeline='func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass)'}))" -split-input-file %s | IreeFileCheck %s
+// RUN: iree-opt -pass-pipeline="hal.executable(hal.executable.target(iree-lower-executable-target-pass{use-lowering-pipeline='func(iree-codegen-linalg-to-llvm-workgroups-vectorization-pass{promote-workgroup-to-full-tiles}),cse'}))" -split-input-file %s | IreeFileCheck %s -check-prefix=CHECK-PROMOTED
+
+#config = {nativeVectorSize = [4, 4, 4], tileSizes = [[64, 64], [32, 32, 32], [4, 4, 4]]}
 hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
   hal.interface @io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
@@ -31,7 +33,7 @@ hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
             %7 = memref.subview %0[%arg0, 0] [64, 128] [1, 1] : memref<128x128xf32> to memref<64x128xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
             %8 = memref.subview %1[0, %arg1] [128, 64] [1, 1] : memref<128x128xf32> to memref<128x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
             %9 = memref.subview %2[%arg0, %arg1] [64, 64] [1, 1] : memref<128x128xf32> to memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
-            linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%7, %8 : memref<64x128xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>, memref<128x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) outs(%9 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>)
+            linalg.matmul {__internal_linalg_transform__ = "workgroup", lowering.config = #config} ins(%7, %8 : memref<64x128xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>, memref<128x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) outs(%9 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>)
           }
         }
         return
@@ -112,6 +114,7 @@ hal.executable @dynamic_matmul attributes {sym_visibility = "private"} {
 
 // -----
 
+#config = {nativeVectorSize = [4, 4, 4], tileSizes = [[64, 64], [32, 32, 32], [4, 4, 4]]}
 hal.executable @matmul_i8_i8_i32 attributes {sym_visibility = "private"} {
   hal.interface @io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
@@ -143,7 +146,7 @@ hal.executable @matmul_i8_i8_i32 attributes {sym_visibility = "private"} {
             %7 = memref.subview %0[%arg0, 0] [64, 128] [1, 1] : memref<128x128xi8> to memref<64x128xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
             %8 = memref.subview %1[0, %arg1] [128, 64] [1, 1] : memref<128x128xi8> to memref<128x64xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
             %9 = memref.subview %2[%arg0, %arg1] [64, 64] [1, 1] : memref<128x128xi32> to memref<64x64xi32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
-            linalg.matmul_i8_i8_i32 {__internal_linalg_transform__ = "workgroup"} ins(%7, %8 : memref<64x128xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>, memref<128x64xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) outs(%9 : memref<64x64xi32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>)
+            linalg.matmul_i8_i8_i32 {__internal_linalg_transform__ = "workgroup", lowering.config = #config} ins(%7, %8 : memref<64x128xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>, memref<128x64xi8, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) outs(%9 : memref<64x64xi32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>)
           }
         }
         return

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
@@ -27,6 +27,30 @@
 namespace mlir {
 namespace iree_compiler {
 
+namespace IREE {
+namespace HAL {
+/// Struct that for a given hal.target.executable defines how it is translated.
+// TODO(ravishankarm): This could also be converted to an attribute on the
+// hal.executable.target
+struct TranslateExecutableInfo {
+  DispatchLoweringPassPipeline passPipeline;
+  SmallVector<int64_t, 3> workgroupSize;
+};
+
+inline bool operator==(const TranslateExecutableInfo &lhs,
+                       const TranslateExecutableInfo &rhs) {
+  return lhs.passPipeline == rhs.passPipeline &&
+         lhs.workgroupSize == rhs.workgroupSize;
+}
+
+inline bool operator!=(const TranslateExecutableInfo &lhs,
+                       const TranslateExecutableInfo &rhs) {
+  return !(lhs == rhs);
+}
+
+}  // namespace HAL
+}  // namespace IREE
+
 //===----------------------------------------------------------------------===//
 // Helpers for getting/setting the `hal.lowering.*` attributes that drive the
 // linalg-based lowering.


### PR DESCRIPTION
One advantage of using dynamic pass pipelines is that the translation
of the executable to scalar/native code can be done using a pass
pipeline that itself might be specified as a command line option. The
LowerExecutableTranslation now has an options `use-lowering-pipeline`
that can take a list of passes and then lower them to code that can
then be translated to LLVM using the standard LLVM lowering passes.
The lowering pipeline specified as command line only makes sense if
there is just one executable. If there are multiple executables, then
the same pipeline will be used for all of them.

Also clean up some of the default configuration. This is done by
adding a struct `IREE::HAL::TranslateExecutableInfo` which is right
now a C++ struct. This is mostly staging, since it could potentially
be rolled into `hal.executable.target` operation itself.