### PR TITLE
Disable large_dot_general2 test case until it gets fixed

### DIFF
--- a/iree/test/e2e/vulkan_specific/dot_general.mlir
+++ b/iree/test/e2e/vulkan_specific/dot_general.mlir
@@ -48,18 +48,19 @@ func @dot_general_nontrivial_batching_dimension() attributes { iree.module.expor
   return
 }
 
-func @large_dot_general2() attributes { iree.module.export } {
-  %lhs = iree.unfoldable_constant dense<1.0> : tensor<4x32x1024xf32>
-  %rhs = iree.unfoldable_constant dense<0.4> : tensor<4x1024x64xf32>
-  %res = "mhlo.dot_general"(%lhs, %rhs) {
-           dot_dimension_numbers = {
-             lhs_batching_dimensions = dense<0> : tensor<1xi64>,
-             lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
-             rhs_batching_dimensions = dense<0> : tensor<1xi64>,
-             rhs_contracting_dimensions = dense<1> : tensor<1xi64>
-           },
-           precision_config = ["DEFAULT", "DEFAULT"]
-         } : (tensor<4x32x1024xf32>, tensor<4x1024x64xf32>) -> tensor<4x32x64xf32>
-  check.expect_almost_eq_const(%res, dense<409.596> : tensor<4x32x64xf32>) : tensor<4x32x64xf32>
-  return
-}
+// TODO(GH-6070): Re-enable this after fixing wrong answer on Pixel 4.
+// func @large_dot_general2() attributes { iree.module.export } {
+//   %lhs = iree.unfoldable_constant dense<1.0> : tensor<4x32x1024xf32>
+//   %rhs = iree.unfoldable_constant dense<0.4> : tensor<4x1024x64xf32>
+//   %res = "mhlo.dot_general"(%lhs, %rhs) {
+//            dot_dimension_numbers = {
+//              lhs_batching_dimensions = dense<0> : tensor<1xi64>,
+//              lhs_contracting_dimensions = dense<2> : tensor<1xi64>,
+//              rhs_batching_dimensions = dense<0> : tensor<1xi64>,
+//              rhs_contracting_dimensions = dense<1> : tensor<1xi64>
+//            },
+//            precision_config = ["DEFAULT", "DEFAULT"]
+//          } : (tensor<4x32x1024xf32>, tensor<4x1024x64xf32>) -> tensor<4x32x64xf32>
+//   check.expect_almost_eq_const(%res, dense<409.596> : tensor<4x32x64xf32>) : tensor<4x32x64xf32>
+//   return
+// }


### PR DESCRIPTION
Right now we don't have a good way to disable per GPU vendor,
but that would be nice to have. For now just disable for all
to avoid marking all commits as failing.