### PR TITLE
Add ComplexDialect to DialectRegistry where it was missing.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -20,6 +20,7 @@ EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//mlir:AllPassesAndDialects": ["MLIRAllDialects"],
     "@llvm-project//mlir:AffineToStandardTransforms": ["MLIRAffineToStandard"],
     "@llvm-project//mlir:CFGTransforms": ["MLIRSCFToStandard"],
+    "@llvm-project//mlir:ComplexDialect": ["MLIRComplex"],
     "@llvm-project//mlir:DialectUtils": [""],
     "@llvm-project//mlir:ExecutionEngineUtils": ["MLIRExecutionEngine"],
     "@llvm-project//mlir:GPUDialect": ["MLIRGPU"],

--- a/iree/compiler/Conversion/HLOToLinalg/BUILD
+++ b/iree/compiler/Conversion/HLOToLinalg/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/Shape/IR",
         "@llvm-project//mlir:Affine",
+        "@llvm-project//mlir:ComplexDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:LinalgTransforms",

--- a/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
+++ b/iree/compiler/Conversion/HLOToLinalg/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "ResolveShapeOps.cpp"
   DEPS
     MLIRAffine
+    MLIRComplex
     MLIRIR
     MLIRLinalg
     MLIRLinalgTransforms

--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnTensors.cpp
@@ -23,6 +23,7 @@
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -213,7 +214,7 @@ struct ConvertHLOToLinalgOnTensorsPass
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Flow::FlowDialect, linalg::LinalgDialect,
                     mhlo::MhloDialect, ShapeDialect, math::MathDialect,
-                    memref::MemRefDialect>();
+                    memref::MemRefDialect, complex::ComplexDialect>();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
This fixes some FFT tests that are using complex types on my machine (Windows/MSVC):

```
[build] FAILED: iree/test/e2e/vulkan_specific/check_vulkan-spirv_vulkan_fft.mlir_module.vmfb 
[build] cmd.exe /C "cd /D D:\dev\projects\iree-build\iree\test\e2e\vulkan_specific && D:\dev\projects\iree-build\iree\tools\iree-translate.exe -iree-mlir-to-vm-bytecode-module -mlir-print-op-on-diagnostic=false --iree-hal-target-backends=vulkan-spirv -iree-input-type=mhlo D:/dev/projects/iree/iree/test/e2e/vulkan_specific/fft.mlir -o check_vulkan-spirv_vulkan_fft.mlir_module.vmfb"
[build] LLVM ERROR: Building op `complex.create` but it isn't registered in this MLIRContext
```

Not sure why this wasn't needed on Linux...