### PR TITLE
Re-enable operand fusion for Vulkan GPU benchmarks

### DIFF
--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -135,8 +135,7 @@ def get_pixel4_default_target_list(skipped_target=None,
           compilation_flags=[
               "--iree-vulkan-target-triple=adreno-a640-android11",
               "--iree-flow-inline-constants-max-byte-length=2048",
-              # TODO(GH-6086): Turn on the flag.
-              # "--iree-flow-dispatch-formation-enable-operand-fusion",
+              "--iree-flow-dispatch-formation-enable-operand-fusion",
               "--iree-enable-fusion-with-reduction-ops",
           ])
   ]
@@ -197,8 +196,7 @@ def get_s20_default_target_list(skipped_target=None,
               "--iree-vulkan-target-triple=valhall-g77-android11",
               # TODO(GH-5330): Revisit the number or delete the flag.
               "--iree-flow-inline-constants-max-byte-length=16",
-              # TODO(GH-6086): Turn on the flag.
-              # "--iree-flow-dispatch-formation-enable-operand-fusion"
+              "--iree-flow-dispatch-formation-enable-operand-fusion"
           ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -127,17 +127,16 @@ def get_pixel4_default_target_list(skipped_target=None,
                  runtime_flags=[
                      "--task_topology_group_count=3",
                  ]),
-      TargetInfo(
-          driver="vulkan",
-          hal_target_backend="vulkan-spirv",
-          taskset="80",
-          mako_tag="vlk",
-          compilation_flags=[
-              "--iree-vulkan-target-triple=adreno-a640-android11",
-              "--iree-flow-inline-constants-max-byte-length=2048",
-              "--iree-flow-dispatch-formation-enable-operand-fusion",
-              "--iree-enable-fusion-with-reduction-ops",
-          ])
+      TargetInfo(driver="vulkan",
+                 hal_target_backend="vulkan-spirv",
+                 taskset="80",
+                 mako_tag="vlk",
+                 compilation_flags=[
+                     "--iree-vulkan-target-triple=adreno-a640-android11",
+                     "--iree-flow-inline-constants-max-byte-length=2048",
+                     "--iree-flow-dispatch-formation-enable-operand-fusion",
+                     "--iree-enable-fusion-with-reduction-ops",
+                 ])
   ]
   targets = [elem for elem in targets if elem.mako_tag not in skipped_target]
   for target in targets:

--- a/iree/test/model_benchmarks/CMakeLists.txt
+++ b/iree/test/model_benchmarks/CMakeLists.txt
@@ -215,8 +215,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    # TODO(GH-6086): Turn on the flag.
-    # "--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
   DRIVER
     "vulkan"
@@ -247,8 +246,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    # TODO(GH-6086): Turn on the flag.
-    #"--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   DRIVER
@@ -282,8 +280,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=16"
-    # TODO(GH-6086): Turn on the flag.
-    # "--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
   DRIVER
     "vulkan"
@@ -314,8 +311,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=16"
-    # TODO(GH-6086): Turn on the flag.
-    # "--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   DRIVER


### PR DESCRIPTION
The breakage at https://github.com/google/iree/issues/6086
cannot be reproduced now and was fixed by some previous commit.