### PR TITLE
Fixing top-level vm.return of multiple of the same ref type.

### DIFF
--- a/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -259,7 +259,8 @@ LogicalResult RegisterAllocation::recalculate(IREE::VM::FuncOp funcOp) {
 
     for (auto &op : block->getOperations()) {
       for (auto &operand : op.getOpOperands()) {
-        if (liveness_.isLastValueUse(operand.get(), &op)) {
+        if (liveness_.isLastValueUse(operand.get(), &op,
+                                     operand.getOperandNumber())) {
           registerUsage.releaseRegister(map_[operand.get()]);
         }
       }

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -256,7 +256,8 @@ static iree_status_t iree_vm_bytecode_external_leave(
         p += sizeof(int64_t);
       } break;
       case IREE_VM_CCONV_TYPE_REF: {
-        iree_vm_ref_move(
+        iree_vm_ref_retain_or_move(
+            src_reg & IREE_REF_REGISTER_MOVE_BIT,
             &callee_registers->ref[src_reg & callee_registers->ref_mask],
             (iree_vm_ref_t*)p);
         p += sizeof(iree_vm_ref_t);


### PR DESCRIPTION
This works today by chance but with coming native ABI changes needs fixing.