### PR TITLE
Implements MHLO SelectV2 broadcast semantics (ternary broadcast).

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/BroadcastingToLinalgPatterns.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/BroadcastingToLinalgPatterns.cpp
@@ -48,13 +48,13 @@ class Extent {
   Extent(int64_t extent) : extent(extent) {}
   Extent(Value value) : value(value) {}
 
-  bool isStatic() { return !value; }
-  bool isUnitExtent() { return isStatic() && getStatic() == 1; }
-  int64_t getStatic() {
+  bool isStatic() const { return !value; }
+  bool isUnitExtent() const { return isStatic() && getStatic() == 1; }
+  int64_t getStatic() const {
     assert(isStatic());
     return extent;
   }
-  Value getValue() {
+  Value getValue() const {
     assert(!isStatic());
     return value;
   }
@@ -68,6 +68,16 @@ class Extent {
   int64_t extent;
   Value value;
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const Extent &extent) {
+  if (extent.isStatic()) {
+    os << "DIM[" << extent.getStatic() << "]";
+  } else {
+    os << "DIM[" << extent.getValue() << "]";
+  }
+  return os;
+}
 
 Value broadcast(OpBuilder &builder, Location loc, Value operand,
                 SmallVectorImpl<Extent> &resultExtents,
@@ -125,10 +135,10 @@ Value broadcastScalar(OpBuilder &builder, Location loc, Value scalarValue,
   return broadcast(builder, loc, scalarValue, resultExtents, isExpansion);
 }
 
-Optional<Extent> computeResultExtent(OpBuilder &builder, Location loc,
-                                     Extent &lhsDim, Extent &rhsDim,
-                                     bool &isLhsExpansion,
-                                     bool &isRhsExpansion) {
+Optional<Extent> computeBinaryResultExtent(OpBuilder &builder, Location loc,
+                                           Extent &lhsDim, Extent &rhsDim,
+                                           bool &isLhsExpansion,
+                                           bool &isRhsExpansion) {
   if (lhsDim.isStatic() && rhsDim.isStatic()) {
     // Both are static. Just check.
     if (lhsDim.getStatic() != rhsDim.getStatic() &&
@@ -192,11 +202,85 @@ Optional<Extent> computeResultExtent(OpBuilder &builder, Location loc,
   }
 
   // Both are dynamic. Compute the max.
-  Value lhsIsGreater = builder.create<CmpIOp>(loc, CmpIPredicate::sge,
-                                              lhsExtentValue, rhsExtentValue);
-  Value resultExtent = builder.create<SelectOp>(loc, lhsIsGreater,
-                                                lhsExtentValue, rhsExtentValue);
-  return Extent(resultExtent);
+  // TODO: Remove this.
+  // Value lhsIsGreater = builder.create<CmpIOp>(loc, CmpIPredicate::sge,
+  //                                             lhsExtentValue,
+  //                                             rhsExtentValue);
+  // Value resultExtent = builder.create<SelectOp>(loc, lhsIsGreater,
+  //                                               lhsExtentValue,
+  //                                               rhsExtentValue);
+  return Extent(lhsExtentValue);
+}
+
+Optional<Extent> computeTernaryResultExtent(OpBuilder &builder, Location loc,
+                                            Extent &aValue, Extent &bValue,
+                                            Extent &cValue, bool &isAExpansion,
+                                            bool &isBExpansion,
+                                            bool &isCExpansion) {
+  // Collect non unit extents (which includes, implicitly, dynamic dims).
+  SmallVector<Extent> nonUnitExtents;
+  if (!aValue.isUnitExtent()) nonUnitExtents.push_back(aValue);
+  if (!bValue.isUnitExtent()) nonUnitExtents.push_back(bValue);
+  if (!cValue.isUnitExtent()) nonUnitExtents.push_back(cValue);
+
+  // Early exit if all unit extents.
+  if (nonUnitExtents.empty()) {
+    isAExpansion = false;
+    isBExpansion = false;
+    isCExpansion = false;
+    return aValue;
+  }
+
+  // Are any a unit?
+  bool hasUnitExtent = false;
+  if (aValue.isUnitExtent()) hasUnitExtent = true;
+  if (bValue.isUnitExtent()) hasUnitExtent = true;
+  if (cValue.isUnitExtent()) hasUnitExtent = true;
+
+  // Mark expansion for any unit.
+  if (hasUnitExtent) {
+    if (aValue.isUnitExtent()) isAExpansion = true;
+    if (bValue.isUnitExtent()) isBExpansion = true;
+    if (cValue.isUnitExtent()) isCExpansion = true;
+  }
+
+  // By default, compare against the first non unit extent; however, prefer
+  // a static extent if present.
+  int nonUnitCompareExtentIndex = 0;
+  for (int i = 0, e = nonUnitExtents.size(); i < e; i++) {
+    if (nonUnitExtents[i].isStatic()) nonUnitCompareExtentIndex = i;
+  }
+
+  // Generate checks for each non unit extent.
+  for (int i = 0, e = nonUnitExtents.size(); i < e; i++) {
+    if (i == nonUnitCompareExtentIndex) continue;
+    Extent &cmpLhs = nonUnitExtents[nonUnitCompareExtentIndex];
+    Extent &cmpRhs = nonUnitExtents[i];
+    // Static check.
+    if (cmpLhs.isStatic() && cmpRhs.isStatic()) {
+      if (cmpLhs.getStatic() != cmpRhs.getStatic()) {
+        // Statically illegal.
+        emitError(loc) << "cannot broadcast extents of differing size unless "
+                          "if one of them is 1 (got "
+                       << cmpLhs.getStatic() << ", " << cmpRhs.getStatic()
+                       << ")";
+        return llvm::None;
+      }
+      continue;
+    }
+    // Dynamic check.
+    Value cmpLhsValue = cmpLhs.convertToValue(builder, loc);
+    Value cmpRhsValue = cmpRhs.convertToValue(builder, loc);
+    Value isEqual = builder.create<CmpIOp>(loc, CmpIPredicate::eq, cmpLhsValue,
+                                           cmpRhsValue);
+    builder.create<AssertOp>(
+        loc, isEqual,
+        builder.getStringAttr("mismatched dynamic broadcast extents"));
+  }
+
+  // The result must be one of the non unit extents. Just take the one
+  // used for comparison.
+  return nonUnitExtents[nonUnitCompareExtentIndex];
 }
 
 void padExtents(SmallVectorImpl<Extent> &extents, int size) {
@@ -408,7 +492,7 @@ struct ConvertRankedBroadcastBinaryOp : public ConversionPattern {
     bool lhsNeedsBroadcast = resultRank != lhsType.getRank();
     bool rhsNeedsBroadcast = resultRank != rhsType.getRank();
     for (int i = 0; i < resultRank; i++) {
-      auto resultExtent = computeResultExtent(
+      auto resultExtent = computeBinaryResultExtent(
           rewriter, loc, lhsBcastExtents[i], rhsBcastExtents[i],
           isLhsExpansion[i], isRhsExpansion[i]);
       if (!resultExtent)
@@ -506,20 +590,9 @@ struct ConvertTrivialNonBroadcastBinaryOp : public ConversionPattern {
 // -----------------------------------------------------------------------------
 
 // Sepecial case conversion for the BroadcastSelectOp into primitives.
-// Note that the "specification" for this op is totally self-contradictory and
-// no one seems to know what its broadcasting semantics actually are.
-// The most canonical documentation
-// (https://www.tensorflow.org/xla/operation_semantics#select) has a completely
-// different set of constraints expressed than the (minimal) descriptions
-// of both the BroadcastSelectOp and the SelectOp, the original conversions
-// from BroadcastSelectOp, and the XlaBuilder implementation. The implementation
-// in XlaBuilder::TernaryOp is taken as authoritative, since that is the oldest
-// code. Note that in that code, pred=lhs, onTrue=rhs, onFalse=ehs.
-// In that implementation, there can only be one non-scalar shape in
-// {pred, onTrue, onFalse} and any of them can be scalar (in violation of the
-// specification). Since they are all assumed to be the same shape, the
-// result shape is the first non-scalar of {pred, onTrue, onFalse}. Then
-// any scalars are broadcast to that shape.
+// This follows the new convention of SelectV2, which allows a true ternary
+// select (whereas the original definition only supported one broadcasting
+// value).
 struct ConvertSelectOp : public OpConversionPattern<chlo::BroadcastSelectOp> {
   using OpConversionPattern<chlo::BroadcastSelectOp>::OpConversionPattern;
 
@@ -531,13 +604,13 @@ struct ConvertSelectOp : public OpConversionPattern<chlo::BroadcastSelectOp> {
 
     // Only support ranked operands.
     Value pred = transformed.pred();
-    Value onTrue = transformed.on_true();
-    Value onFalse = transformed.on_false();
+    Value thenValue = transformed.on_true();
+    Value elseValue = transformed.on_false();
     auto predType = pred.getType().dyn_cast<RankedTensorType>();
-    auto onTrueType = onTrue.getType().dyn_cast<RankedTensorType>();
-    auto onFalseType = onFalse.getType().dyn_cast<RankedTensorType>();
+    auto thenType = thenValue.getType().dyn_cast<RankedTensorType>();
+    auto elseType = elseValue.getType().dyn_cast<RankedTensorType>();
     auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
-    if (!predType || !onTrueType || !onFalseType || !resultType) {
+    if (!predType || !thenType || !elseType || !resultType) {
       return rewriter.notifyMatchFailure(op, "cannot convert unranked tensors");
     }
     if (!isElementTypeLegalForCodegen(resultType.getElementType())) {
@@ -546,54 +619,82 @@ struct ConvertSelectOp : public OpConversionPattern<chlo::BroadcastSelectOp> {
     }
 
     // Short-circuit if all types are statically equal.
-    if (predType == onTrueType && predType == onFalseType) {
+    if (predType == thenType && predType == elseType) {
       // No broadcasting. This includes the 0d -> 0d case.
-      rewriter.replaceOpWithNewOp<mhlo::SelectOp>(op, resultType, pred, onTrue,
-                                                  onFalse);
+      rewriter.replaceOpWithNewOp<mhlo::SelectOp>(op, resultType, pred,
+                                                  thenValue, elseValue);
       return success();
     }
 
-    // Determine which component will be taken as the result shape.
-    SmallVector<Value, 3> resultCandidates = {pred, onTrue, onFalse};
-    Value nonScalarResult;
-    for (Value resultCandidate : resultCandidates) {
-      auto t = resultCandidate.getType().cast<RankedTensorType>();
-      if (t.getRank() > 0) {
-        if (nonScalarResult &&
-            nonScalarResult.getType().cast<RankedTensorType>().getShape() !=
-                t.getShape()) {
-          // Since the spec is ill-defined on this point, don't trust the
-          // verifier and make sure to avoid the situation in all builds.
-          return rewriter.notifyMatchFailure(op, "mismatched select shapes");
-        }
-        nonScalarResult = resultCandidate;
-      }
-    }
-    // Must be true per the equality early-exit above.
-    assert(nonScalarResult && "must have a non-scalar result");
-    auto nonScalarResultType =
-        nonScalarResult.getType().cast<RankedTensorType>();
+    // Full ternary broadcast. See ConvertBroadcastBinaryOp for the
+    // simplified version.
+    // Extract the original extents.
+    SmallVector<Extent> predOrigExtents;
+    predOrigExtents.reserve(predType.getRank());
+    appendExtents(rewriter, loc, predOrigExtents, pred, predType);
+    SmallVector<Extent> thenOrigExtents;
+    thenOrigExtents.reserve(thenType.getRank());
+    appendExtents(rewriter, loc, thenOrigExtents, thenValue, thenType);
+    SmallVector<Extent> elseOrigExtents;
+    elseOrigExtents.reserve(elseType.getRank());
+    appendExtents(rewriter, loc, elseOrigExtents, elseValue, elseType);
 
-    // Compute result extents.
-    int resultRank = nonScalarResultType.getRank();
-    SmallVector<Extent> resultExtents;
-    resultExtents.reserve(resultRank);
-    appendExtents(rewriter, loc, resultExtents, nonScalarResult,
-                  nonScalarResultType);
+    // Left pad with 1-extents to the result rank.
+    int resultRank = std::max(std::max(predType.getRank(), thenType.getRank()),
+                              elseType.getRank());
+    SmallVector<Extent> predBcastExtents;
+    predBcastExtents.reserve(resultRank);
+    padExtents(predBcastExtents, resultRank - predType.getRank());
+    predBcastExtents.append(predOrigExtents);
 
-    // Broadcast any scalars.
-    if (predType.getRank() == 0) {
-      pred = broadcastScalar(rewriter, loc, pred, resultExtents);
-    }
-    if (onTrueType.getRank() == 0) {
-      onTrue = broadcastScalar(rewriter, loc, onTrue, resultExtents);
-    }
-    if (onFalseType.getRank() == 0) {
-      onFalse = broadcastScalar(rewriter, loc, onFalse, resultExtents);
+    SmallVector<Extent> thenBcastExtents;
+    thenBcastExtents.reserve(resultRank);
+    padExtents(thenBcastExtents, resultRank - thenType.getRank());
+    thenBcastExtents.append(thenOrigExtents);
+
+    SmallVector<Extent> elseBcastExtents;
+    elseBcastExtents.reserve(resultRank);
+    padExtents(elseBcastExtents, resultRank - elseType.getRank());
+    elseBcastExtents.append(elseOrigExtents);
+
+    // Compute the result extents.
+    SmallVector<Extent> resultExtents(resultRank);
+    SmallVector<bool> isPredExpansion(resultRank);
+    SmallVector<bool> isThenExpansion(resultRank);
+    SmallVector<bool> isElseExpansion(resultRank);
+    bool predNeedsBroadcast = resultRank != predType.getRank();
+    bool thenNeedsBroadcast = resultRank != thenType.getRank();
+    bool elseNeedsBroadcast = resultRank != elseType.getRank();
+    for (int i = 0; i < resultRank; i++) {
+      auto resultExtent = computeTernaryResultExtent(
+          rewriter, loc, predBcastExtents[i], thenBcastExtents[i],
+          elseBcastExtents[i], isPredExpansion[i], isThenExpansion[i],
+          isElseExpansion[i]);
+      if (!resultExtent)
+        return rewriter.notifyMatchFailure(op,
+                                           "could not compute result extent");
+      resultExtents[i] = *resultExtent;
+      if (isPredExpansion[i]) predNeedsBroadcast = true;
+      if (isThenExpansion[i]) thenNeedsBroadcast = true;
+      if (isElseExpansion[i]) elseNeedsBroadcast = true;
     }
 
-    rewriter.replaceOpWithNewOp<mhlo::SelectOp>(op, resultType, pred, onTrue,
-                                                onFalse);
+    // Broadcast all.
+    Value predBcast =
+        predNeedsBroadcast
+            ? broadcast(rewriter, loc, pred, resultExtents, isPredExpansion)
+            : pred;
+    Value thenBcast = thenNeedsBroadcast
+                          ? broadcast(rewriter, loc, thenValue, resultExtents,
+                                      isThenExpansion)
+                          : thenValue;
+    Value elseBcast = elseNeedsBroadcast
+                          ? broadcast(rewriter, loc, elseValue, resultExtents,
+                                      isElseExpansion)
+                          : elseValue;
+
+    rewriter.replaceOpWithNewOp<mhlo::SelectOp>(op, resultType, predBcast,
+                                                thenBcast, elseBcast);
     return success();
   }
 };

--- a/iree/compiler/Conversion/HLOToLinalg/test/broadcasting.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/broadcasting.mlir
@@ -32,9 +32,7 @@ func @dynamicBroadcast(%arg0: tensor<?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?
   // CHECK: %[[EQ:.*]] = cmpi eq, %[[ARG0_D0]], %[[ARG1_D1]] : index
   // CHECK: assert %[[EQ]], "mismatched dynamic broadcast extents"
 
-  // CHECK: %[[GE:.*]] = cmpi sge, %[[ARG0_D0]], %[[ARG1_D1]] : index
-  // CHECK: %[[BCAST_D1:.*]] = select %[[GE]], %[[ARG0_D0]], %[[ARG1_D1]] : index
-  // CHECK: %[[INIT_0:.*]] = linalg.init_tensor [%[[ARG1_D0]], %[[BCAST_D1]]] : tensor<?x?xf32>
+  // CHECK: %[[INIT_0:.*]] = linalg.init_tensor [%[[ARG1_D0]], %[[ARG0_D0]]] : tensor<?x?xf32>
   // CHECK: %[[BCAST_ARG0:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]}
   // CHECK-SAME: ins(%arg0 : tensor<?xf32>) outs(%[[INIT_0]] : tensor<?x?xf32>)
 
@@ -108,6 +106,169 @@ func @selectv2_pred_scalar(%arg0: tensor<i1>, %arg1: tensor<2xi32>, %arg2: tenso
   // CHECK-SAME: ins(%[[BCAST_PRED]], %arg1, %arg2 : tensor<2xi1>, tensor<2xi32>, tensor<2xi32>) outs(%[[INIT_1]] : tensor<2xi32>)
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
   return %0: tensor<2xi32>
+}
+
+// -----
+// CHECK: #map0 = affine_map<(d0, d1, d2) -> ()>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: #map2 = affine_map<(d0, d1, d2) -> (d1, 0)>
+// CHECK-LABEL: func @selectv2_broadcast_then
+func @selectv2_broadcast_then(%arg0: tensor<i1>, %arg1: tensor<8x1xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<i1>)
+  // CHECK: %[[BCAST_THEN:.*]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1 : tensor<8x1xi32>)
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[BCAST_PRED]], %[[BCAST_THEN]], %arg2 : tensor<2x8x8xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>)
+  // CHECK: select
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<8x1xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
+  return %0: tensor<2x8x8xi32>
+}
+
+// -----
+// CHECK: #map0 = affine_map<(d0, d1, d2) -> ()>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: #map2 = affine_map<(d0, d1, d2) -> (d1, 0)>
+// CHECK-LABEL: func @selectv2_broadcast_else
+func @selectv2_broadcast_else(%arg0: tensor<i1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<8x1xi32>) -> tensor<2x8x8xi32> {
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<i1>)
+  // CHECK: %[[BCAST_ELSE:.*]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg2 : tensor<8x1xi32>)
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[BCAST_PRED]], %arg1, %[[BCAST_ELSE]] : tensor<2x8x8xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>)
+  // CHECK: select
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2x8x8xi32>, tensor<8x1xi32>) -> tensor<2x8x8xi32>
+  return %0: tensor<2x8x8xi32>
+}
+
+// -----
+// CHECK: #map0 = affine_map<(d0, d1, d2) -> (0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-LABEL: func @selectv2_broadcast_pred
+func @selectv2_broadcast_pred(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<1xi1>)
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[BCAST_PRED]], %arg1, %arg2 : tensor<2x8x8xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>)
+  // CHECK: select
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<1xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
+  return %0: tensor<2x8x8xi32>
+}
+
+// -----
+// CHECK: #map0 = affine_map<(d0, d1, d2) -> (d0, 0, 0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: #map2 = affine_map<(d0, d1, d2) -> (0, d1, 0)>
+// CHECK: #map3 = affine_map<(d0, d1, d2) -> (0, 0, d2)>
+// CHECK-LABEL: func @selectv2_broadcast_all
+func @selectv2_broadcast_all(%arg0: tensor<8x1x1xi1>, %arg1: tensor<1x8x1xi32>, %arg2: tensor<1x1x8xi32>) -> tensor<8x8x8xi32> {
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<8x1x1xi1>)
+  // CHECK: %[[BCAST_THEN:.*]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1 : tensor<1x8x1xi32>)
+  // CHECK: %[[BCAST_ELSE:.*]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg2 : tensor<1x1x8xi32>)
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[BCAST_PRED]], %[[BCAST_THEN]], %[[BCAST_ELSE]] : tensor<8x8x8xi1>, tensor<8x8x8xi32>, tensor<8x8x8xi32>)
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<8x1x1xi1>, tensor<1x8x1xi32>, tensor<1x1x8xi32>) -> tensor<8x8x8xi32>
+  return %0: tensor<8x8x8xi32>
+}
+
+// -----
+// CHECK: #map0 = affine_map<(d0, d1, d2) -> (d0, 0, 0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: #map2 = affine_map<(d0, d1, d2) -> (0, d1, 0)>
+// CHECK: #map3 = affine_map<(d0, d1, d2) -> (0, 0, d2)>
+// CHECK-LABEL: func @selectv2_broadcast_dyn_pred
+func @selectv2_broadcast_dyn_pred(%arg0: tensor<?x1x1xi1>, %arg1: tensor<1x8x1xi32>, %arg2: tensor<1x1x8xi32>) -> tensor<?x8x8xi32> {
+  // CHECK: %[[C0_0:.*]] = constant 0 : index
+  // CHECK: %[[DIM_PRED_0:.*]] = memref.dim %arg0, %[[C0_0]]
+  // CHECK: %[[INIT_PRED:.*]] = linalg.init_tensor [%[[DIM_PRED_0]], 8, 8]
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map0, #map1]
+  //     CHECK-SAME: ins(%arg0 : tensor<?x1x1xi1>) outs(%[[INIT_PRED]] : tensor<?x8x8xi1>)
+  // CHECK: %[[INIT_THEN:.*]] = linalg.init_tensor [%[[DIM_PRED_0]], 8, 8]
+  // CHECK: %[[BCAST_THEN:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map2, #map1]
+  //     CHECK-SAME: ins(%arg1 : tensor<1x8x1xi32>) outs(%[[INIT_THEN]] : tensor<?x8x8xi32>)
+  // CHECK: %[[INIT_ELSE:.*]] = linalg.init_tensor [%[[DIM_PRED_0]], 8, 8]
+  // CHECK: %[[BCAST_ELSE:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map3, #map1]
+  //     CHECK-SAME: ins(%arg2 : tensor<1x1x8xi32>) outs(%[[INIT_ELSE]] : tensor<?x8x8xi32>)
+  // CHECK: %[[C0_1:.*]] = constant 0 : index
+  // CHECK: %[[DIM_BCAST_PRED_0:.*]] = memref.dim %[[BCAST_PRED]], %[[C0_1]]
+  // CHECK: %[[INIT_RESULT:.*]] = linalg.init_tensor [%[[DIM_BCAST_PRED_0]], 8, 8]
+  // CHECK: linalg.generic
+  //     CHECK-SAME: ins(%[[BCAST_PRED]], %[[BCAST_THEN]], %[[BCAST_ELSE]] : tensor<?x8x8xi1>, tensor<?x8x8xi32>, tensor<?x8x8xi32>) outs(%[[INIT_RESULT]] : tensor<?x8x8xi32>)
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<?x1x1xi1>, tensor<1x8x1xi32>, tensor<1x1x8xi32>) -> tensor<?x8x8xi32>
+  return %0: tensor<?x8x8xi32>
+}
+
+// -----
+// CHECK-LABEL: func @selectv2_broadcast_dyn_then
+func @selectv2_broadcast_dyn_then(%arg0: tensor<8x1x1xi1>, %arg1: tensor<1x?x1xi32>, %arg2: tensor<1x1x8xi32>) -> tensor<8x?x8xi32> {
+  // CHECK: %[[C1_0:.*]] = constant 1 : index
+  // CHECK: %[[DIM_THEN_1:.*]] = memref.dim %arg1, %[[C1_0]]
+  // CHECK: %[[INIT_PRED:.*]] = linalg.init_tensor [8, %[[DIM_THEN_1]], 8]
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map0, #map1]
+  //     CHECK-SAME: ins(%arg0 : tensor<8x1x1xi1>) outs(%[[INIT_PRED]] : tensor<8x?x8xi1>)
+  // CHECK: %[[INIT_THEN:.*]] = linalg.init_tensor [8, %[[DIM_THEN_1]], 8]
+  // CHECK: %[[BCAST_THEN:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map2, #map1]
+  //     CHECK-SAME: ins(%arg1 : tensor<1x?x1xi32>) outs(%[[INIT_THEN]] : tensor<8x?x8xi32>)
+  // CHECK: %[[INIT_ELSE:.*]] = linalg.init_tensor [8, %[[DIM_THEN_1]], 8]
+  // CHECK: %[[BCAST_ELSE:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map3, #map1]
+  //     CHECK-SAME: ins(%arg2 : tensor<1x1x8xi32>) outs(%[[INIT_ELSE]] : tensor<8x?x8xi32>)
+  // CHECK: %[[C1_1:.*]] = constant 1 : index
+  // CHECK: %[[DIM_BCAST_PRED_1:.*]] = memref.dim %[[BCAST_PRED]], %[[C1_1]]
+  // CHECK: %[[INIT_RESULT:.*]] = linalg.init_tensor [8, %[[DIM_BCAST_PRED_1]], 8]
+  // CHECK: linalg.generic
+  //     CHECK-SAME: ins(%2, %4, %6 : tensor<8x?x8xi1>, tensor<8x?x8xi32>, tensor<8x?x8xi32>) outs(%8 : tensor<8x?x8xi32>)
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<8x1x1xi1>, tensor<1x?x1xi32>, tensor<1x1x8xi32>) -> tensor<8x?x8xi32>
+  return %0: tensor<8x?x8xi32>
+}
+
+// -----
+// CHECK-LABEL: func @selectv2_broadcast_dyn_else
+func @selectv2_broadcast_dyn_else(%arg0: tensor<8x1x1xi1>, %arg1: tensor<1x8x1xi32>, %arg2: tensor<1x1x?xi32>) -> tensor<8x8x?xi32> {
+  // CHECK: %[[C2_0:.*]] = constant 2 : index
+  // CHECK: %[[DIM_ELSE_2:.*]] = memref.dim %arg2, %[[C2_0]]
+  // CHECK: %[[INIT_PRED:.*]] = linalg.init_tensor [8, 8, %[[DIM_ELSE_2]]]
+  // CHECK: %[[BCAST_PRED:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map0, #map1]
+  //     CHECK-SAME: ins(%arg0 : tensor<8x1x1xi1>) outs(%[[INIT_PRED]] : tensor<8x8x?xi1>)
+
+  // CHECK: %[[INIT_THEN:.*]] = linalg.init_tensor [8, 8, %[[DIM_ELSE_2]]]
+  // CHECK: %[[BCAST_THEN:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map2, #map1]
+  //     CHECK-SAME: ins(%arg1 : tensor<1x8x1xi32>) outs(%[[INIT_THEN]] : tensor<8x8x?xi32>)
+  // CHECK: %[[INIT_ELSE:.*]] = linalg.init_tensor [8, 8, %[[DIM_ELSE_2]]]
+  // CHECK: %[[BCAST_ELSE:.*]] = linalg.generic
+  //     CHECK-SAME: indexing_maps = [#map3, #map1]
+  //     CHECK-SAME: ins(%arg2 : tensor<1x1x?xi32>) outs(%[[INIT_ELSE]] : tensor<8x8x?xi32>)
+  // CHECK: %[[C2_1:.*]] = constant 2 : index
+  // CHECK: %[[DIM_BCAST_PRED_1:.*]] = memref.dim %[[BCAST_PRED]], %[[C2_1]]
+  // CHECK: %[[INIT_RESULT:.*]] = linalg.init_tensor [8, 8, %[[DIM_BCAST_PRED_1]]]
+  // CHECK: linalg.generic
+  //     CHECK-SAME: ins(%2, %4, %6 : tensor<8x8x?xi1>, tensor<8x8x?xi32>, tensor<8x8x?xi32>) outs(%8 : tensor<8x8x?xi32>)
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<8x1x1xi1>, tensor<1x8x1xi32>, tensor<1x1x?xi32>) -> tensor<8x8x?xi32>
+  return %0: tensor<8x8x?xi32>
+}
+
+// -----
+// CHECK-LABEL: func @selectv2_broadcast_dyn_all
+func @selectv2_broadcast_dyn_all(%arg0: tensor<?x1x1xi1>, %arg1: tensor<?x8x1xi32>, %arg2: tensor<?x1x?xi32>) -> tensor<?x8x?xi32> {
+  // CHECK: %[[C0:.*]] = constant 0 : index
+  // CHECK: %[[PRED_D0:.*]] = memref.dim %arg0, %[[C0]] : tensor<?x1x1xi1>
+  // CHECK: %[[C0_0:.*]] = constant 0 : index
+  // CHECK: %[[THEN_D0:.*]] = memref.dim %arg1, %[[C0_0]] : tensor<?x8x1xi32>
+  // CHECK: %[[C0_1:.*]] = constant 0 : index
+  // CHECK: %[[ELSE_D0:.*]] = memref.dim %arg2, %[[C0_1]] : tensor<?x1x?xi32>
+  // CHECK: %[[C2:.*]] = constant 2 : index
+  // CHECK: %[[ELSE_D2:.*]] = memref.dim %arg2, %[[C2]] : tensor<?x1x?xi32>
+  // CHECK: %[[CMP_0:.*]] = cmpi eq, %[[PRED_D0]], %[[THEN_D0]] : index
+  // CHECK: assert %[[CMP_0]], "mismatched dynamic broadcast extents"
+  // CHECK: %[[CMP_1:.*]] = cmpi eq, %[[PRED_D0]], %[[ELSE_D0]] : index
+  // CHECK: assert %[[CMP_1]], "mismatched dynamic broadcast extents"
+  // Only two asserts are needed. The rest are statically verified.
+  // CHECK-NOT: assert
+  %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<?x1x1xi1>, tensor<?x8x1xi32>, tensor<?x1x?xi32>) -> tensor<?x8x?xi32>
+  return %0: tensor<?x8x?xi32>
 }
 
 // -----


### PR DESCRIPTION
* I'm not going to claim this is the most elegant implementation (I probably could have gotten clever and collapsed the binary and ternary broadcast codegen), but it preserves the straight-forwardness that I've come to appreciate after having written this kind of thing several times.
* Also removes a redundant comparison in the binary broadcast case (which cannot happen due to preceding assert).
* Should fix #6152