### PR TITLE
[CUDA] Enable dynamic pipeline

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LowerExecutableTargetPass.cpp
@@ -149,6 +149,8 @@ void LowerExecutableTargetPass::runOnOperation() {
         case IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization:
           addCPUVectorizationPassPipeline(nestedModulePM, lowerToVectors);
           break;
+        default:
+          llvm_unreachable("Unsupported pipeline on CPU target.");
       }
     }
   }

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",
         "KernelConfig.cpp",
+        "LowerExecutableTargetPass.cpp",
         "Passes.cpp",
         "RemoveTrivialLoops.cpp",
         "TileAndDistribute.cpp",

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/BUILD
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//iree/compiler/Dialect/Shape/Transforms",
         "@llvm-project//mlir:Affine",
         "@llvm-project//mlir:AffineToStandard",
+        "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:GPUToNVVMTransforms",
         "@llvm-project//mlir:GPUToROCDLTransforms",
         "@llvm-project//mlir:GPUTransforms",

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"
     "KernelConfig.cpp"
+    "LowerExecutableTargetPass.cpp"
     "Passes.cpp"
     "RemoveTrivialLoops.cpp"
     "TileAndDistribute.cpp"

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
@@ -16,18 +16,27 @@ using namespace mlir::iree_compiler;
 
 static constexpr unsigned cudaWarpSize = 32;
 
-static LaunchConfig getOpLaunchConfig(linalg::GenericOp op) {
-  LaunchConfig config;
+static void setConfig(TileSizesListType tileSizes, Operation* op) {
+  IREE::HAL::LoweringConfig config =
+      getConfigAttr(tileSizes, ArrayRef<int64_t>{}, op->getContext());
+  setLoweringConfig(op, config);
+}
+
+static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::GenericOp op) {
+  IREE::HAL::TranslateExecutableInfo info;
+  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+  TileSizesListType tileSizes;
   size_t numLoops = getNumOuterParallelLoops(op);
   if (numLoops == 0) {
     // Pure reduction, we serialize the operation on a single thread.
     // TODO: Use atomic to allow distributing reduction loops.
-    config.setWorkgroupSize({1, 1, 1});
-    config.setTileSizes(op, {}, 0);
-    return config;
+    info.workgroupSize.append({1, 1, 1});
+    tileSizes.push_back({});
+    setConfig(tileSizes, op);
+    return info;
   }
 
-  config.setWorkgroupSize({cudaWarpSize, 1, 1});
+  info.workgroupSize.append({cudaWarpSize, 1, 1});
   // Pick a fixed tile size independent of the original shape.
   // TODO(thomasraoux): Currently the original shape information is lost during
   // tiling at the flow level. We need way to access it to be able to make a
@@ -36,82 +45,105 @@ static LaunchConfig getOpLaunchConfig(linalg::GenericOp op) {
   SmallVector<int64_t, 4> ts;
   ts.resize(numLoops, 1);
   ts.back() = lowerTs;
-  config.setTileSizes(op, ts, 0);  // Workgroup level.
-  config.setTileSizes(op, {}, 1);  // Subgroup level.
+  tileSizes.push_back(ts);  // Workgroup level.
+  tileSizes.push_back({});  // Subgroup level.
   ts.back() = lowerTs / cudaWarpSize;
-  config.setTileSizes(op, ts, 2);  // Thread level.
-  return config;
+  tileSizes.push_back(ts);  // Thread level.
+  setConfig(tileSizes, op);
+  return info;
 }
 
-static LaunchConfig getOpLaunchConfig(linalg::MatmulOp op) {
-  LaunchConfig config;
+static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::MatmulOp op) {
+  IREE::HAL::TranslateExecutableInfo info;
+  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+  TileSizesListType tileSizes;
   const int64_t numWarp = 2;
-  std::array<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
-  config.setWorkgroupSize(workgroupSize);
+  SmallVector<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
+  info.workgroupSize = workgroupSize;
   // Currently just a basic tile size to enable tiling and vectorization.
   // TODO: pick a more efficient tile size and tile at subgroup level.
   SmallVector<int64_t, 4> ts = {2, 256, 4};
-  config.setTileSizes(op, ts, 0);  // Workgroup level.
-  config.setTileSizes(op, {}, 1);  // Subgroup level.
+  tileSizes.push_back(ts);  // Workgroup level.
+  tileSizes.push_back({});  // Subgroup level.
   SmallVector<int64_t, 4> invocationLevelTs = {ts[0] / workgroupSize[1],
                                                ts[1] / workgroupSize[0]};
-  config.setTileSizes(op, invocationLevelTs, 2);  // Thread level.
-  return config;
+  tileSizes.push_back(invocationLevelTs);  // Thread level.
+  setConfig(tileSizes, op);
+  return info;
 }
 
-static LaunchConfig getOpLaunchConfig(linalg::BatchMatmulOp op) {
-  LaunchConfig config;
+static IREE::HAL::TranslateExecutableInfo setRootConfig(
+    linalg::BatchMatmulOp op) {
+  IREE::HAL::TranslateExecutableInfo info;
+  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+  TileSizesListType tileSizes;
   const int64_t numWarp = 2;
-  std::array<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
-  config.setWorkgroupSize(workgroupSize);
+  SmallVector<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
+  info.workgroupSize = workgroupSize;
   SmallVector<int64_t, 4> ts = {1, 2, 256, 4};
-  config.setTileSizes(op, ts, 0);  // Workgroup level.
-  config.setTileSizes(op, {}, 1);  // Subgroup level.
+  tileSizes.push_back(ts);  // Workgroup level.
+  tileSizes.push_back({});  // Subgroup level.
   SmallVector<int64_t, 4> invocationLevelTs = {ts[0], ts[1] / workgroupSize[1],
                                                ts[2] / workgroupSize[0]};
-  config.setTileSizes(op, invocationLevelTs, 2);  // Thread level.
-  return config;
+  tileSizes.push_back(invocationLevelTs);  // Thread level.
+  setConfig(tileSizes, op);
+  return info;
 }
 
 // Basic default properties for linalg ops that haven't been tuned.
-static LaunchConfig getDefaultOpLaunchConfig(linalg::LinalgOp op) {
-  LaunchConfig config;
+static IREE::HAL::TranslateExecutableInfo setRootDefaultConfig(
+    linalg::LinalgOp op) {
+  IREE::HAL::TranslateExecutableInfo info;
+  info.passPipeline =
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute;
+  TileSizesListType tileSizes;
   size_t numLoops = getNumOuterParallelLoops(op);
-  if (numLoops == 0) return config;
+  if (numLoops == 0) {
+    info.workgroupSize.append({1, 1, 1});
+    return info;
+  }
 
-  config.setWorkgroupSize({cudaWarpSize, 1, 1});
+  info.workgroupSize.append({cudaWarpSize, 1, 1});
   int64_t lowerTs = 4 * cudaWarpSize;
   SmallVector<int64_t, 4> ts;
   ts.resize(numLoops, 1);
   ts.back() = lowerTs;
-  config.setTileSizes(op, ts, 0);  // Workgroup level.
-  config.setTileSizes(op, {}, 1);  // Subgroup level.
+  tileSizes.push_back(ts);
+  tileSizes.push_back({});  // Subgroup level.
   ts.back() = lowerTs / cudaWarpSize;
-  config.setTileSizes(op, ts, 2);  // Thread level.
-  return config;
+  tileSizes.push_back(ts);  // Thread level.
+  setConfig(tileSizes, op);
+  return info;
 }
 
-static LaunchConfig getOpLaunchConfig(linalg::LinalgOp linalgOp) {
+static IREE::HAL::TranslateExecutableInfo setRootConfig(
+    linalg::LinalgOp linalgOp) {
   if (auto genericOp = dyn_cast<linalg::GenericOp>(linalgOp.getOperation()))
-    return getOpLaunchConfig(genericOp);
+    return setRootConfig(genericOp);
   if (auto matmul = dyn_cast<linalg::MatmulOp>(linalgOp.getOperation()))
-    return getOpLaunchConfig(matmul);
+    return setRootConfig(matmul);
   if (auto batchMatmul =
           dyn_cast<linalg::BatchMatmulOp>(linalgOp.getOperation()))
-    return getOpLaunchConfig(batchMatmul);
-  return getDefaultOpLaunchConfig(linalgOp);
+    return setRootConfig(batchMatmul);
+  return setRootDefaultConfig(linalgOp);
 }
 
 namespace mlir {
 namespace iree_compiler {
 
-Optional<LaunchConfig> getLLVMGPULaunchConfig(
-    MLIRContext *context, const linalg::LinalgDependenceGraph &dependenceGraph,
-    ArrayRef<linalg::LinalgOp> linalgOps) {
-  LaunchConfig launchConfig;
-
+IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp) {
+  IREE::HAL::TranslateExecutableInfo info;
+  info.passPipeline =
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute;
+  info.workgroupSize.append({1, 1, 1});
+  auto entryPointFn = getSingleEntryPointFunction(moduleOp);
   linalg::LinalgOp rootOperation;
-  if (linalgOps.empty()) return llvm::None;
+  auto funcOps = moduleOp.getOps<FuncOp>();
+  assert(llvm::hasSingleElement(funcOps));
+  FuncOp funcOp = *funcOps.begin();
+  SmallVector<linalg::LinalgOp, 4> linalgOps;
+  funcOp.walk([&](linalg::LinalgOp op) { linalgOps.push_back(op); });
+  if (linalgOps.empty()) return info;
   if (linalgOps.size() == 1) rootOperation = *linalgOps.begin();
   // if there is more than one linalg op, look for the root one.
   for (linalg::LinalgOp op : linalgOps) {
@@ -142,14 +174,13 @@ Optional<LaunchConfig> getLLVMGPULaunchConfig(
       }
     }
   }
-  launchConfig = getOpLaunchConfig(rootOperation);
-  launchConfig.setRootOperation(rootOperation.getOperation());
-  if (!launchConfig.getTileSizes(rootOperation, 0).empty()) {
-    if (failed(propogateRootOperationLaunchConfig(launchConfig, rootOperation,
-                                                  dependenceGraph)))
-      return llvm::None;
+  info = setRootConfig(rootOperation);
+  IREE::HAL::LoweringConfig config = getLoweringConfig(rootOperation);
+  for (linalg::LinalgOp op : linalgOps) {
+    if (op == rootOperation) continue;
+    setLoweringConfig(op, config);
   }
-  return launchConfig;
+  return info;
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
@@ -136,7 +136,6 @@ IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp) {
   info.passPipeline =
       IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute;
   info.workgroupSize.append({1, 1, 1});
-  auto entryPointFn = getSingleEntryPointFunction(moduleOp);
   linalg::LinalgOp rootOperation;
   auto funcOps = moduleOp.getOps<FuncOp>();
   assert(llvm::hasSingleElement(funcOps));

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.cpp
@@ -18,25 +18,38 @@ static constexpr unsigned cudaWarpSize = 32;
 
 static void setConfig(TileSizesListType tileSizes, Operation* op) {
   IREE::HAL::LoweringConfig config =
-      getConfigAttr(tileSizes, ArrayRef<int64_t>{}, op->getContext());
+      buildConfigAttr(tileSizes, ArrayRef<int64_t>{}, op->getContext());
   setLoweringConfig(op, config);
 }
 
-static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::GenericOp op) {
-  IREE::HAL::TranslateExecutableInfo info;
-  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+/// Sets the translation info on the `hal.executable.entry_point` op
+/// corresponding to the `entryPointFn`. Returns failure if a translation info
+/// is already set on the entry point op and is incompatible with what is being
+/// set.
+static LogicalResult setTranslationInfo(
+    FuncOp entryPointFn, IREE::HAL::DispatchLoweringPassPipeline passPipeline,
+    ArrayRef<int64_t> workloadPerWorkgroup) {
+  auto entryPointOp = getEntryPoint(entryPointFn);
+  auto translationInfo = buildTranslationInfo(
+      passPipeline, workloadPerWorkgroup, entryPointFn.getContext());
+  return setTranslationInfo(entryPointOp, translationInfo);
+}
+
+static LogicalResult setRootConfig(FuncOp entryPoint, linalg::GenericOp op) {
+  IREE::HAL::DispatchLoweringPassPipeline passPipeline =
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+  std::array<int64_t, 3> workgroupSize = {1, 1, 1};
   TileSizesListType tileSizes;
   size_t numLoops = getNumOuterParallelLoops(op);
   if (numLoops == 0) {
     // Pure reduction, we serialize the operation on a single thread.
     // TODO: Use atomic to allow distributing reduction loops.
-    info.workgroupSize.append({1, 1, 1});
     tileSizes.push_back({});
     setConfig(tileSizes, op);
-    return info;
+    return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
   }
 
-  info.workgroupSize.append({cudaWarpSize, 1, 1});
+  workgroupSize = {cudaWarpSize, 1, 1};
   // Pick a fixed tile size independent of the original shape.
   // TODO(thomasraoux): Currently the original shape information is lost during
   // tiling at the flow level. We need way to access it to be able to make a
@@ -50,16 +63,15 @@ static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::GenericOp op) {
   ts.back() = lowerTs / cudaWarpSize;
   tileSizes.push_back(ts);  // Thread level.
   setConfig(tileSizes, op);
-  return info;
+  return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
 }
 
-static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::MatmulOp op) {
-  IREE::HAL::TranslateExecutableInfo info;
-  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+static LogicalResult setRootConfig(FuncOp entryPoint, linalg::MatmulOp op) {
+  IREE::HAL::DispatchLoweringPassPipeline passPipeline =
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
   TileSizesListType tileSizes;
   const int64_t numWarp = 2;
   SmallVector<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
-  info.workgroupSize = workgroupSize;
   // Currently just a basic tile size to enable tiling and vectorization.
   // TODO: pick a more efficient tile size and tile at subgroup level.
   SmallVector<int64_t, 4> ts = {2, 256, 4};
@@ -69,17 +81,16 @@ static IREE::HAL::TranslateExecutableInfo setRootConfig(linalg::MatmulOp op) {
                                                ts[1] / workgroupSize[0]};
   tileSizes.push_back(invocationLevelTs);  // Thread level.
   setConfig(tileSizes, op);
-  return info;
+  return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
 }
 
-static IREE::HAL::TranslateExecutableInfo setRootConfig(
-    linalg::BatchMatmulOp op) {
-  IREE::HAL::TranslateExecutableInfo info;
-  info.passPipeline = IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+static LogicalResult setRootConfig(FuncOp entryPoint,
+                                   linalg::BatchMatmulOp op) {
+  IREE::HAL::DispatchLoweringPassPipeline passPipeline =
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize;
   TileSizesListType tileSizes;
   const int64_t numWarp = 2;
   SmallVector<int64_t, 3> workgroupSize = {numWarp * cudaWarpSize, 1, 1};
-  info.workgroupSize = workgroupSize;
   SmallVector<int64_t, 4> ts = {1, 2, 256, 4};
   tileSizes.push_back(ts);  // Workgroup level.
   tileSizes.push_back({});  // Subgroup level.
@@ -87,23 +98,22 @@ static IREE::HAL::TranslateExecutableInfo setRootConfig(
                                                ts[2] / workgroupSize[0]};
   tileSizes.push_back(invocationLevelTs);  // Thread level.
   setConfig(tileSizes, op);
-  return info;
+  return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
 }
 
 // Basic default properties for linalg ops that haven't been tuned.
-static IREE::HAL::TranslateExecutableInfo setRootDefaultConfig(
-    linalg::LinalgOp op) {
-  IREE::HAL::TranslateExecutableInfo info;
-  info.passPipeline =
+static LogicalResult setRootDefaultConfig(FuncOp entryPoint,
+                                          linalg::LinalgOp op) {
+  IREE::HAL::DispatchLoweringPassPipeline passPipeline =
       IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute;
+  std::array<int64_t, 3> workgroupSize = {1, 1, 1};
   TileSizesListType tileSizes;
   size_t numLoops = getNumOuterParallelLoops(op);
   if (numLoops == 0) {
-    info.workgroupSize.append({1, 1, 1});
-    return info;
+    return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
   }
 
-  info.workgroupSize.append({cudaWarpSize, 1, 1});
+  workgroupSize = {cudaWarpSize, 1, 1};
   int64_t lowerTs = 4 * cudaWarpSize;
   SmallVector<int64_t, 4> ts;
   ts.resize(numLoops, 1);
@@ -113,36 +123,36 @@ static IREE::HAL::TranslateExecutableInfo setRootDefaultConfig(
   ts.back() = lowerTs / cudaWarpSize;
   tileSizes.push_back(ts);  // Thread level.
   setConfig(tileSizes, op);
-  return info;
+  return setTranslationInfo(entryPoint, passPipeline, workgroupSize);
 }
 
-static IREE::HAL::TranslateExecutableInfo setRootConfig(
-    linalg::LinalgOp linalgOp) {
+static LogicalResult setRootConfig(FuncOp entryPointFn,
+                                   linalg::LinalgOp linalgOp) {
   if (auto genericOp = dyn_cast<linalg::GenericOp>(linalgOp.getOperation()))
-    return setRootConfig(genericOp);
+    return setRootConfig(entryPointFn, genericOp);
   if (auto matmul = dyn_cast<linalg::MatmulOp>(linalgOp.getOperation()))
-    return setRootConfig(matmul);
+    return setRootConfig(entryPointFn, matmul);
   if (auto batchMatmul =
           dyn_cast<linalg::BatchMatmulOp>(linalgOp.getOperation()))
-    return setRootConfig(batchMatmul);
-  return setRootDefaultConfig(linalgOp);
+    return setRootConfig(entryPointFn, batchMatmul);
+  return setRootDefaultConfig(entryPointFn, linalgOp);
 }
 
 namespace mlir {
 namespace iree_compiler {
 
-IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp) {
-  IREE::HAL::TranslateExecutableInfo info;
-  info.passPipeline =
-      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute;
-  info.workgroupSize.append({1, 1, 1});
+LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
   linalg::LinalgOp rootOperation;
   auto funcOps = moduleOp.getOps<FuncOp>();
   assert(llvm::hasSingleElement(funcOps));
   FuncOp funcOp = *funcOps.begin();
   SmallVector<linalg::LinalgOp, 4> linalgOps;
   funcOp.walk([&](linalg::LinalgOp op) { linalgOps.push_back(op); });
-  if (linalgOps.empty()) return info;
+  if (linalgOps.empty()) {
+    return ::setTranslationInfo(
+        funcOp, IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute,
+        {1, 1, 1});
+  }
   if (linalgOps.size() == 1) rootOperation = *linalgOps.begin();
   // if there is more than one linalg op, look for the root one.
   for (linalg::LinalgOp op : linalgOps) {
@@ -173,13 +183,13 @@ IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp) {
       }
     }
   }
-  info = setRootConfig(rootOperation);
+  if (failed(setRootConfig(funcOp, rootOperation))) return failure();
   IREE::HAL::LoweringConfig config = getLoweringConfig(rootOperation);
   for (linalg::LinalgOp op : linalgOps) {
     if (op == rootOperation) continue;
     setLoweringConfig(op, config);
   }
-  return info;
+  return success();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.h
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.h
@@ -13,7 +13,7 @@
 namespace mlir {
 namespace iree_compiler {
 
-IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp);
+LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.h
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.h
@@ -7,16 +7,13 @@
 #ifndef IREE_COMPILER_CONVERSION_LINALGTOLLVMGPU_KERNELCONFIG_H_
 #define IREE_COMPILER_CONVERSION_LINALGTOLLVMGPU_KERNELCONFIG_H_
 
-#include "iree/compiler/Conversion/Common/LaunchConfig.h"
-#include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
+#include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 namespace iree_compiler {
 
-Optional<LaunchConfig> getLLVMGPULaunchConfig(
-    MLIRContext *context, const linalg::LinalgDependenceGraph &dependenceGraph,
-    ArrayRef<linalg::LinalgOp> linalgOps);
+IREE::HAL::TranslateExecutableInfo initGPULaunchConfig(ModuleOp moduleOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/LowerExecutableTargetPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/LowerExecutableTargetPass.cpp
@@ -1,0 +1,96 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Conversion/CodegenUtils/FunctionUtils.h"
+#include "iree/compiler/Conversion/Common/Passes.h"
+#include "iree/compiler/Conversion/LinalgToLLVMGPU/KernelConfig.h"
+#include "iree/compiler/Conversion/LinalgToLLVMGPU/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Lowers an hal.executable.target operation to scalar/native-vector
+/// code. Invokes different compilation pipeline to
+/// - first lower to scalar/native-vector code
+/// - then convert to NVVM/ROCDL dialect.
+/// This should be merged with the equivalent pass in LinalgToLLVM. Fo
+/// simplicity it is currently a separate pass.
+class LowerExecutableTargetPass
+    : public PassWrapper<LowerExecutableTargetPass,
+                         OperationPass<IREE::HAL::ExecutableTargetOp>> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<IREE::HAL::HALDialect, linalg::LinalgDialect, LLVM::LLVMDialect,
+                vector::VectorDialect, gpu::GPUDialect>();
+  }
+
+  LowerExecutableTargetPass() = default;
+  LowerExecutableTargetPass(const LowerExecutableTargetPass &pass) = default;
+
+  void runOnOperation() override;
+};
+}  // namespace
+
+void LowerExecutableTargetPass::runOnOperation() {
+  IREE::HAL::ExecutableTargetOp targetOp = getOperation();
+  ModuleOp moduleOp = targetOp.getInnerModule();
+
+  OpPassManager executableLoweringPipeline(
+      IREE::HAL::ExecutableTargetOp::getOperationName());
+
+  FailureOr<IREE::HAL::TranslateExecutableInfo> translationInfo =
+      initGPULaunchConfig(moduleOp);
+  if (failed(translationInfo)) {
+    return signalPassFailure();
+  }
+  auto funcOps = moduleOp.getOps<FuncOp>();
+  FuncOp funcOp = *funcOps.begin();
+  // Attach the workgroup size as an attribute. This will be used when
+  // creating the flatbuffer.
+  funcOp->setAttr(
+      "llvmgpu_workgroup_size",
+      DenseElementsAttr::get<int64_t>(
+          VectorType::get(3, IntegerType::get(moduleOp.getContext(), 64)),
+          translationInfo->workgroupSize));
+
+  switch (translationInfo->passPipeline) {
+    case IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute:
+      addGPUSimpleDistributePassPipeline(executableLoweringPipeline);
+      break;
+    case IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize:
+      addGPUVectorizationPassPipeline(executableLoweringPipeline);
+      break;
+    default:
+      llvm_unreachable("Unsupported pipeline on GPU target.");
+  }
+
+  if (failed(runPipeline(executableLoweringPipeline, targetOp))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createLowerExecutableTargetGPUPass() {
+  return std::make_unique<LowerExecutableTargetPass>();
+}
+
+static PassRegistration<LowerExecutableTargetPass> pass(
+    "iree-lower-executable-target-gpu-pass",
+    "Perform lowering of executable target using one of the "
+    "IREE::HAL::DispatchLoweringPassPipeline",
+    [] { return std::make_unique<LowerExecutableTargetPass>(); });
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/LowerExecutableTargetPass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/LowerExecutableTargetPass.cpp
@@ -11,7 +11,6 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -31,9 +30,8 @@ class LowerExecutableTargetPass
                          OperationPass<IREE::HAL::ExecutableTargetOp>> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry
-        .insert<IREE::HAL::HALDialect, linalg::LinalgDialect, LLVM::LLVMDialect,
-                vector::VectorDialect, gpu::GPUDialect>();
+    registry.insert<IREE::HAL::HALDialect, linalg::LinalgDialect,
+                    vector::VectorDialect, gpu::GPUDialect>();
   }
 
   LowerExecutableTargetPass() = default;

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.cpp
@@ -21,7 +21,17 @@
 namespace mlir {
 namespace iree_compiler {
 
-static void addLinalgToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
+static Value gpuAllocationFunction(OpBuilder &builder, Location loc,
+                                   ArrayRef<int64_t> staticShape,
+                                   Type elementType,
+                                   ArrayRef<Value> dynamicSizes) {
+  MemRefType allocType = MemRefType::get(staticShape, elementType, {}, 3);
+  return builder.create<memref::AllocOp>(loc, allocType, dynamicSizes);
+}
+
+void addGPUVectorizationPassPipeline(OpPassManager &pm) {
+  // Convert tensor to buffers.
+  addLinalgBufferizePasses(pm.nest<ModuleOp>(), gpuAllocationFunction);
   //===--------------------------------------------------------------------===//
   // Initial clean up.
   //===--------------------------------------------------------------------===//
@@ -40,13 +50,32 @@ static void addLinalgToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.nest<ModuleOp>().addNestedPass<FuncOp>(createVectorizationPass());
   pm.nest<ModuleOp>().addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.nest<ModuleOp>().addNestedPass<FuncOp>(createCSEPass());
+}
 
+void addGPUSimpleDistributePassPipeline(OpPassManager &pm) {
+  // Convert tensor to buffers.
+  addLinalgBufferizePasses(pm.nest<ModuleOp>(), gpuAllocationFunction);
+
+  //===--------------------------------------------------------------------===//
+  // Initial clean up.
+  //===--------------------------------------------------------------------===//
+  pm.addNestedPass<ModuleOp>(createCanonicalizerPass());
+  pm.addNestedPass<ModuleOp>(createCSEPass());
+
+  // Distribute linalg onto threads within the workgroup.
+  pm.addPass(createTileAndDistributeToThreads());
+  pm.addNestedPass<ModuleOp>(createCanonicalizerPass());
+  pm.addNestedPass<ModuleOp>(createCSEPass());
+
+  pm.nest<ModuleOp>().addNestedPass<FuncOp>(
+      createRemoveSingleIterationLoopPass());
+}
+
+static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addNestedPass<ModuleOp>(createLowerAffinePass());
   pm.addNestedPass<ModuleOp>(createCanonicalizerPass());
   pm.addNestedPass<ModuleOp>(createCSEPass());
 
-  // TODO: This currently maps to a single thread. We should share Tile and
-  // distribute with other GPU backends.
   // Linalg -> SCF
   pm.nest<ModuleOp>().addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
   pm.nest<ModuleOp>().addNestedPass<FuncOp>(createCanonicalizerPass());
@@ -76,17 +105,8 @@ static void addLinalgToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 }
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
+  pm.addPass(createLowerExecutableTargetGPUPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
-  nestedModulePM.addPass(createInlinerPass());
-
-  WorkgroupMemoryAllocationFn allocationFn =
-      [](OpBuilder &builder, Location loc, ArrayRef<int64_t> staticShape,
-         Type elementType, ArrayRef<Value> dynamicSizes) {
-        MemRefType allocType = MemRefType::get(staticShape, elementType, {}, 3);
-        return builder.create<memref::AllocOp>(loc, allocType, dynamicSizes);
-      };
-  addLinalgBufferizePasses(nestedModulePM, allocationFn);
-
   //===--------------------------------------------------------------------===//
   // Convert Linalg ops to LLVM+NVVM/ROCDL ops.
   //
@@ -94,35 +114,19 @@ void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   //   - All Linalg/Loops/GPU/Affine/Standard ops are converted away.
   //   - The module contains the final llvm.module ready to be serialized.
   //===--------------------------------------------------------------------===//
-  addLinalgToLLVMGPUPasses(pm, useROCM);
+  addLowerToLLVMGPUPasses(pm, useROCM);
 }
 
-static PassPipelineRegistration<> linalgToNVVMPipeline(
+static PassPipelineRegistration<> LinalgNVVMPipeline(
     "iree-codegen-linalg-to-nvvm-pipeline",
     "Runs the progressive lowering pipeline from Linalg to NVVM",
-    [](OpPassManager &passManager) {
-      addLinalgToLLVMGPUPasses(passManager, false);
-    });
-
-static PassPipelineRegistration<> linalgToROCDLPipeline(
-    "iree-codegen-linalg-to-rocdl-pipeline",
-    "Runs the progressive lowering pipeline from Linalg to ROCDL",
-    [](OpPassManager &passManager) {
-      addLinalgToLLVMGPUPasses(passManager, true);
-    });
-
-static PassPipelineRegistration<> hloToLinalgNVVMPipeline(
-    "iree-codegen-hlo-to-nvvm-pipeline",
-    "Runs the progressive lowering pipeline from XLA HLO to Linalg to "
-    "NVVM",
     [](OpPassManager &passManager) {
       buildLLVMGPUTransformPassPipeline(passManager, false);
     });
 
-static PassPipelineRegistration<> hloToLinalgROCDLPipeline(
-    "iree-codegen-hlo-to-rocdl-pipeline",
-    "Runs the progressive lowering pipeline from XLA HLO to Linalg to "
-    "ROCDL",
+static PassPipelineRegistration<> LinalgROCDLPipeline(
+    "iree-codegen-linalg-to-rocdl-pipeline",
+    "Runs the progressive lowering pipeline from Linalg to ROCDL",
     [](OpPassManager &passManager) {
       buildLLVMGPUTransformPassPipeline(passManager, true);
     });

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.cpp
@@ -106,7 +106,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   pm.addPass(createLowerExecutableTargetGPUPass());
-  OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   //===--------------------------------------------------------------------===//
   // Convert Linalg ops to LLVM+NVVM/ROCDL ops.
   //

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.h
@@ -28,12 +28,15 @@ createTileAndDistributeToThreads();
 
 std::unique_ptr<OperationPass<FuncOp>> createRemoveSingleIterationLoopPass();
 
-//
+/// Create pass calling the dynamic pipeline for LLVMGPU.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
 createLowerExecutableTargetGPUPass();
 
+/// Lowering calling vectorization patterns.
 void addGPUVectorizationPassPipeline(OpPassManager &passManager);
 
+/// Simple lowering only distributute linalg ops on blocks and threads. This
+/// will result in scalar operations.
 void addGPUSimpleDistributePassPipeline(OpPassManager &passManager);
 
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via the

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/Passes.h
@@ -28,6 +28,14 @@ createTileAndDistributeToThreads();
 
 std::unique_ptr<OperationPass<FuncOp>> createRemoveSingleIterationLoopPass();
 
+//
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createLowerExecutableTargetGPUPass();
+
+void addGPUVectorizationPassPipeline(OpPassManager &passManager);
+
+void addGPUSimpleDistributePassPipeline(OpPassManager &passManager);
+
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the
 /// module within the IREE::HAL::ExecutableOp.

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-hlo-to-nvvm-pipeline))" %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-linalg-to-nvvm-pipeline))" %s | IreeFileCheck %s
 
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect.

--- a/iree/compiler/Conversion/LinalgToLLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVMGPU/test/rocdl_pipeline_test.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-hlo-to-rocdl-pipeline))" %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline="hal.executable(hal.executable.target(iree-codegen-linalg-to-rocdl-pipeline))" %s | IreeFileCheck %s
 
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect.

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -14,13 +14,18 @@ def CPU_Default
     : I32EnumAttrCase<"CPUDefault", 0>;
 def CPU_Vectorization
     : I32EnumAttrCase<"CPUVectorization", 1>;
+def LLVMGPU_SimpleDistribute
+    : I32EnumAttrCase<"LLVMGPUDistribute", 2>;
+def LLVMGPU_Vectorize
+    : I32EnumAttrCase<"LLVMGPUVectorize", 3>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
 def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
-    [CPU_Default, CPU_Vectorization]> {
+    [CPU_Default, CPU_Vectorization, LLVMGPU_SimpleDistribute,
+     LLVMGPU_Vectorize]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }
 


### PR DESCRIPTION
Add infrastructure to enable dynamic pipeline. Currently There are only
two different pipelines with and without vectorization. This will allow
adding different pipelines for differnt ops like convolutions.