### PR TITLE
Add TranslationInfo Attribute.

### DIFF
--- a/iree/compiler/Conversion/CodegenUtils/FunctionUtils.h
+++ b/iree/compiler/Conversion/CodegenUtils/FunctionUtils.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CONVERSION_CODEGENUTILS_FUNCTIONUTILS_H_
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/StringMap.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/IR/BuiltinOps.h"
 
@@ -17,14 +18,15 @@ namespace iree_compiler {
 /// Returns true if the given `func` is a kernel dispatch entry point.
 bool isEntryPoint(FuncOp func);
 
-/// Given a module returns the entrypoint function within the module.
-FailureOr<FuncOp> getSingleEntryPointFunction(ModuleOp module);
-
-/// Returns the number of outer parallel loops of a linalgOp.
-unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
+/// Returns a map from function symbol name to corresponding entry point op.
+llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
+    ModuleOp module);
 
 /// Returns the entry point op for the `funcOp`. Returns `nullptr` on failure.
 IREE::HAL::ExecutableEntryPointOp getEntryPoint(FuncOp funcOp);
+
+/// Returns the number of outer parallel loops of a linalgOp.
+unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
 
 /// Returns the untiled type of a tiled view for both tensor and memref
 /// types. Either walks the `ViewOpInterface` chain (for memrefs) or the

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Conversion/CodegenUtils/MarkerUtils.h"
 #include "iree/compiler/Conversion/Common/Transforms.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
@@ -69,7 +70,7 @@ static llvm::cl::opt<int> genericOpsWorkgroupTileSize(
 /// Usually the tile sizes for the first level of tiling decides the workgroup
 /// size for the dispatch on the CPU backend. This is a general helper that
 /// converts tile sizes of the first level into workgroup sizes.
-static SmallVector<int64_t, 3> getWorkgroupSizeFromTileSizes(
+static SmallVector<int64_t, 3> getWorkloadPerWorkgroup(
     ArrayRef<int64_t> distributedTileSizes) {
   if (distributedTileSizes.size() > kNumMaxParallelDims) {
     distributedTileSizes = distributedTileSizes.take_back(kNumMaxParallelDims);
@@ -77,12 +78,24 @@ static SmallVector<int64_t, 3> getWorkgroupSizeFromTileSizes(
   return llvm::to_vector<3>(llvm::reverse(distributedTileSizes));
 }
 
+/// Sets the translation info on the `hal.executable.entry_point` op
+/// corresponding to the `entryPointFn`. Returns failure if a translation info
+/// is already set on the entry point op and is incompatible with what is being
+/// set.
+static LogicalResult setTranslationInfo(
+    FuncOp entryPointFn, IREE::HAL::DispatchLoweringPassPipeline passPipeline,
+    ArrayRef<int64_t> workloadPerWorkgroup) {
+  auto entryPointOp = getEntryPoint(entryPointFn);
+  auto translationInfo = buildTranslationInfo(
+      passPipeline, workloadPerWorkgroup, entryPointFn.getContext());
+  return setTranslationInfo(entryPointOp, translationInfo);
+}
+
 /// Sets the lowering configuration for dispatch region with root op that
 /// implements the contraction operation interface.
-static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
-    linalg::ContractionOpInterface contractionOp) {
-  assert(!hasLoweringConfig(contractionOp) &&
-         "illegal to update configuration of root");
+static LogicalResult setRootConfig(
+    FuncOp entryPointFn, linalg::ContractionOpInterface contractionOp) {
+  if (hasLoweringConfig(entryPointFn)) return success();
   if (contractionOp.isRowMajorMatmul()) {
     int mWorkgroupSize = matmulWorkgroupTileSize;
     int nWorkgroupSize = matmulWorkgroupTileSize;
@@ -115,12 +128,12 @@ static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
         {matmulVectorSize, matmulVectorSize, matmulVectorSize}};
     SmallVector<int64_t, 4> nativeVectorSize = {
         matmulVectorSize, matmulVectorSize, matmulVectorSize};
-    IREE::HAL::LoweringConfig config =
-        getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
+    IREE::HAL::LoweringConfig config = buildConfigAttr(
+        tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return IREE::HAL::TranslateExecutableInfo{
-        IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
-        getWorkgroupSizeFromTileSizes(tileSizes[0])};
+    return setTranslationInfo(
+        entryPointFn, IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+        getWorkloadPerWorkgroup(tileSizes[0]));
   }
   if (contractionOp.isRowMajorBatchMatmul()) {
     // TODO(ataei, ravishankarm): This should just use the configuration for
@@ -133,14 +146,14 @@ static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
          batchMatmulL2TileSize}};
     SmallVector<int64_t, 4> nativeVectorSize = {
         1, batchMatmulL2TileSize, batchMatmulL2TileSize, batchMatmulL2TileSize};
-    IREE::HAL::LoweringConfig config =
-        getConfigAttr(tileSizes, nativeVectorSize, contractionOp->getContext());
+    IREE::HAL::LoweringConfig config = buildConfigAttr(
+        tileSizes, nativeVectorSize, contractionOp->getContext());
     setLoweringConfig(contractionOp, config);
-    return IREE::HAL::TranslateExecutableInfo{
-        IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
-        getWorkgroupSizeFromTileSizes(tileSizes[0])};
+    return setTranslationInfo(
+        entryPointFn, IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+        getWorkloadPerWorkgroup(tileSizes[0]));
   }
-  return llvm::None;
+  return success();
 }
 
 /// Legalized the tile sizes for the first-level of tiling
@@ -159,8 +172,9 @@ static SmallVector<int64_t, 4> getTileSizesForWorkgroupDistribution(
 
 /// Sets the lowering configuration for dispatch region with root op being a
 /// generic op.
-static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
-    linalg::GenericOp genericOp) {
+static LogicalResult setRootConfig(FuncOp entryPointFn,
+                                   linalg::GenericOp genericOp) {
+  if (hasLoweringConfig(genericOp)) return success();
   int64_t numOuterParallelLoops = getNumOuterParallelLoops(genericOp);
   SmallVector<int64_t, 4> workgroupTileSizes(numOuterParallelLoops,
                                              genericOpsWorkgroupTileSize);
@@ -168,177 +182,88 @@ static Optional<IREE::HAL::TranslateExecutableInfo> setRootConfig(
       numOuterParallelLoops, workgroupTileSizes);
   TileSizesListType tileSizes = {workgroupTileSizes};
   IREE::HAL::LoweringConfig config =
-      getConfigAttr(tileSizes, ArrayRef<int64_t>{}, genericOp->getContext());
+      buildConfigAttr(tileSizes, ArrayRef<int64_t>{}, genericOp->getContext());
   setLoweringConfig(genericOp, config);
-  return IREE::HAL::TranslateExecutableInfo{
-      IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
-      getWorkgroupSizeFromTileSizes(tileSizes[0])};
-}
-
-/// Sets the configuration for a linalg op that is not the root of the
-/// dispatch. The configuration should use the tile sizes of the first level of
-/// tiling passed in through `firstLevelTileSizes` for correctness.
-// TODO(ravishankarm): This method should be deleted. The root configuration
-// must be enough. The pass pipeline must use the root configuration as the
-// driver of transformations. Leave it as is for now.
-LogicalResult setNonRootConfig(linalg::LinalgOp linalgOp,
-                               ArrayRef<int64_t> parallelLoopTileSizes) {
-  int64_t numOuterParallelLoops = getNumOuterParallelLoops(linalgOp);
-  if (parallelLoopTileSizes.size() != numOuterParallelLoops) {
-    return linalgOp.emitError(
-        "expected non root ops to have same number of outer-parallel loops as "
-        "root op");
-  }
-  // TODO(ravishankarm): For now just set the first level of tile-size, but need
-  // to extend this to make op-specific decision.
-  auto vec = llvm::to_vector<4>(parallelLoopTileSizes);
-  TileSizesListType tileSizes = {vec};
-  IREE::HAL::LoweringConfig config =
-      getConfigAttr(tileSizes, ArrayRef<int64_t>{}, linalgOp->getContext());
-  setLoweringConfig(linalgOp, config);
-  return success();
+  return setTranslationInfo(
+      entryPointFn, IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization,
+      getWorkloadPerWorkgroup(tileSizes[0]));
 }
 
 /// Finds the root operation in the given list of linalg operations and sets its
 /// configuration. Returns the root operation.
-static FailureOr<IREE::HAL::TranslateExecutableInfo> setRootConfig(
-    ArrayRef<linalg::LinalgOp> linalgOps,
-    SmallVectorImpl<int64_t> &parallelLoopTileSizes) {
-  // First iterate over all operations to find the root operations and set its
-  // lowering configuration (that are not linalg.generic).
+static LogicalResult setRootConfig(FuncOp entryPointFn,
+                                   ArrayRef<linalg::LinalgOp> linalgOps) {
   linalg::LinalgOp rootOp = nullptr;
-
-  Optional<IREE::HAL::TranslateExecutableInfo> passPipeline;
-  auto checkOrUpdatePassPipeline =
-      [&](linalg::LinalgOp linalgOp,
-          Optional<IREE::HAL::TranslateExecutableInfo> opPassPipeline)
-      -> LogicalResult {
-    if (!opPassPipeline) return success();
-    if (passPipeline && passPipeline.getValue() != opPassPipeline.getValue()) {
-      return linalgOp.emitError(
-          "mismatch in translation configuration for ops in dispatch region");
-    }
-    if (!passPipeline) {
-      passPipeline = opPassPipeline.getValue();
-      rootOp = linalgOp;
-    }
-    return success();
-  };
-
   for (auto linalgOp : linalgOps) {
     if (!hasMarker(linalgOp, getWorkgroupMarker())) continue;
-    auto opPassPipeline =
-        TypeSwitch<Operation *, Optional<IREE::HAL::TranslateExecutableInfo>>(
-            linalgOp.getOperation())
+    auto status =
+        TypeSwitch<Operation *, LogicalResult>(linalgOp.getOperation())
             .Case<linalg::ContractionOpInterface>(
-                [&](auto op) { return setRootConfig(op); })
-            .Default([](Operation *)
-                         -> Optional<IREE::HAL::TranslateExecutableInfo> {
-              return llvm::None;
-            });
-    auto status = checkOrUpdatePassPipeline(linalgOp, opPassPipeline);
+                [&](auto op) { return setRootConfig(entryPointFn, op); })
+            .Default([](Operation *) { return success(); });
     if (failed(status)) {
       return status;
+    }
+    if (hasLoweringConfig(linalgOp)) {
+      if (rootOp) {
+        return linalgOp.emitError(
+            "unhandled multiple roots in dispatch region");
+      }
+      rootOp = linalgOp;
+      continue;
     }
   }
 
   // If no root operation found, check if the dispatch region contains a single
   // generic op and chose pipeline based on that.
-  if (!passPipeline) {
+  if (!rootOp) {
     for (auto linalgOp : linalgOps) {
       if (!hasMarker(linalgOp, getWorkgroupMarker())) continue;
       auto genericOp = dyn_cast<linalg::GenericOp>(linalgOp.getOperation());
       if (!genericOp) continue;
-      auto opPassPipeline = setRootConfig(genericOp);
-      auto status = checkOrUpdatePassPipeline(linalgOp, opPassPipeline);
-      if (failed(status)) {
-        return status;
+      if (failed(setRootConfig(entryPointFn, genericOp))) {
+        return failure();
+      }
+      if (hasLoweringConfig(genericOp)) {
+        if (rootOp) {
+          return genericOp.emitError(
+              "unhandled multiple roots in dispatch region");
+        }
+        rootOp = genericOp;
+        continue;
       }
     }
   }
-
-  // If still no root operation, use default.
-  if (!passPipeline) return failure();
-
-  parallelLoopTileSizes =
-      getTileSizes(rootOp, static_cast<unsigned>(TilingLevel::WorkGroupTiles));
-
-  // Some consistency checks.
-  int64_t numOuterParallelLoops = getNumOuterParallelLoops(rootOp);
-  if (parallelLoopTileSizes.size() != numOuterParallelLoops) {
-    LogicalResult status = rootOp.emitError(
-        "expected as many tiles sizes as the parallel loops of the operation");
-    return status;
-  }
-  auto distributedStart =
-      std::max<int64_t>(0, numOuterParallelLoops - kNumMaxParallelDims);
-  ArrayRef<int64_t> parallelLoopTileSizesRef(parallelLoopTileSizes);
-  // THe outer non-distributed paralle loops must be zero.
-  if (distributedStart &&
-      llvm::any_of(parallelLoopTileSizesRef.take_front(distributedStart),
-                   [](int64_t v) -> bool { return v; })) {
-    LogicalResult status = rootOp.emitError(
-        "expected non-distributed parallel loop tile size to be 0");
-    return status;
-  }
-  if (llvm::any_of(parallelLoopTileSizesRef.take_back(numOuterParallelLoops -
-                                                      distributedStart),
-                   [](int64_t v) -> bool { return !v; })) {
-    LogicalResult status = rootOp.emitError(
-        "expected distributed parallel loop tile size to be non-zero");
-    return status;
-  }
-  return passPipeline.getValue();
+  return success();
 }
 
-IREE::HAL::TranslateExecutableInfo initCPULaunchConfig(ModuleOp moduleOp) {
-  // By default, the CPU backend will just lower the ops in the dispatch region
-  // as is with no distribution.
-  IREE::HAL::TranslateExecutableInfo pipelineOnFailure = {
-      IREE::HAL::DispatchLoweringPassPipeline::CPUDefault, {}};
-  // The current linalg based lowering only tested for a single function case.
-  auto entryPointFn = getSingleEntryPointFunction(moduleOp);
-  if (failed(entryPointFn)) {
-    return pipelineOnFailure;
-  }
-  auto funcOps = moduleOp.getOps<FuncOp>();
-  if (!llvm::hasSingleElement(funcOps)) {
-    return pipelineOnFailure;
-  }
-  FuncOp funcOp = *funcOps.begin();
-  SmallVector<linalg::LinalgOp, 4> linalgOps;
-  SmallVector<Operation *, 4> tiledLoops;
-  // If there are no linalg ops, not using Linalg based lowering.
-  if (failed(getLinalgOps(funcOp, linalgOps, tiledLoops)) ||
-      linalgOps.empty()) {
-    return pipelineOnFailure;
-  }
+LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
+  llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
+      getAllEntryPoints(moduleOp);
+  for (auto funcOp : moduleOp.getOps<FuncOp>()) {
+    auto entryPointOp = entryPointOps.lookup(funcOp.getName());
+    if (!entryPointOp) continue;
+    SmallVector<linalg::LinalgOp, 4> linalgOps;
+    SmallVector<Operation *, 4> tiledLoops;
+    // If there are no linalg ops, not using Linalg based lowering.
+    if (succeeded(getLinalgOps(funcOp, linalgOps, tiledLoops)) &&
+        !linalgOps.empty()) {
+      if (failed(setRootConfig(funcOp, linalgOps))) {
+        return failure();
+      }
+    }
 
-  SmallVector<int64_t> parallelLoopTileSizes;
-  auto passPipeline = setRootConfig(linalgOps, parallelLoopTileSizes);
-  if (failed(passPipeline)) {
-    return pipelineOnFailure;
-  }
-
-  // Set the configuration of all other linalg operations that are not the root
-  // operation.
-  // TODO(ravishankarm): The configuration of the root must drive the lowering
-  // completely. This step should be removed.
-  LogicalResult status = success();
-  for (auto linalgOp : linalgOps) {
-    if (hasLoweringConfig(linalgOp)) continue;
-    status = setNonRootConfig(linalgOp, parallelLoopTileSizes);
-    if (failed(status)) {
-      break;
+    // If the function entry point already doesnt have a lowering info attribute
+    // on it, just add the default.
+    if (!getTranslationInfo(entryPointOp)) {
+      if (failed(setTranslationInfo(
+              funcOp, IREE::HAL::DispatchLoweringPassPipeline::CPUDefault,
+              {}))) {
+        return failure();
+      }
     }
   }
-  if (failed(status)) {
-    for (auto linalgOp : linalgOps) {
-      eraseLoweringConfig(linalgOp);
-    }
-    return pipelineOnFailure;
-  }
-  return passPipeline.getValue();
+  return success();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h
@@ -20,7 +20,7 @@ enum class TilingLevel : unsigned {
   NumTileLevels = 3
 };
 
-IREE::HAL::TranslateExecutableInfo initCPULaunchConfig(ModuleOp moduleOp);
+LogicalResult initCPULaunchConfig(ModuleOp moduleOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/materialize_launch_configuration.mlir
@@ -52,8 +52,7 @@ hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG0:.+]] = {tileSizes = {{\[}}[64, 64]{{\]}}}
-//  CHECK-DAG: #[[CONFIG1:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[64, 64], [32, 32, 32], [4, 4, 4]{{\]}}}
+//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[64, 64], [32, 32, 32], [4, 4, 4]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point @matmul_tensors
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
@@ -63,12 +62,8 @@ hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
 //  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
-//      CHECK: linalg.copy
-// CHECK-SAME:   lowering.config = #[[CONFIG0]]
 //      CHECK: linalg.matmul
-// CHECK-SAME:   lowering.config = #[[CONFIG1]]
-//      CHECK: linalg.copy
-// CHECK-SAME:   lowering.config = #[[CONFIG0]]
+// CHECK-SAME:   lowering.config = #[[CONFIG]]
 
 // -----
 
@@ -91,7 +86,7 @@ hal.executable @add_no_config attributes {sym_visibility = "private"} {
         %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?xf32>
         %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<?xf32>
         %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x?xf32>
-        linalg.generic {__internal_linalg_transform__ = "workgroup"} {
+        linalg.generic {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                            affine_map<(d0, d1) -> (d1)>,
                            affine_map<(d0, d1) -> (d0, d1)>],
@@ -346,8 +341,7 @@ hal.executable @batch_matmul_tensors attributes {sym_visibility = "private"} {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG0:.+]] = {tileSizes = {{\[}}[1, 32, 32]{{\]}}
-//  CHECK-DAG: #[[CONFIG1:.+]] = {nativeVectorSize = [1, 4, 4, 4], tileSizes = {{\[}}[1, 32, 32], [1, 16, 16, 16], [1, 4, 4, 4]{{\]}}
+//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [1, 4, 4, 4], tileSizes = {{\[}}[1, 32, 32], [1, 16, 16, 16], [1, 4, 4, 4]{{\]}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //      CHECK: hal.executable.entry_point @batch_matmul_tensors
 // CHECK-NEXT: (%[[ARG0:[a-zA-Z0-9]+]]: index
@@ -356,9 +350,5 @@ hal.executable @batch_matmul_tensors attributes {sym_visibility = "private"} {
 //  CHECK-DAG:  %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:  %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //      CHECK:  hal.return %[[D0]], %[[D1]], %[[ARG2]]
-//      CHECK:  linalg.copy
-// CHECK-SAME:    lowering.config = #[[CONFIG0]]
 //      CHECK:  linalg.batch_matmul
-// CHECK-SAME:    lowering.config = #[[CONFIG1]]
-//      CHECK:  linalg.copy
-// CHECK-SAME:    lowering.config = #[[CONFIG0]]
+// CHECK-SAME:    lowering.config = #[[CONFIG]]

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -9,6 +9,7 @@
 // Putting this in HAL dialect for now.
 include "iree/compiler/Dialect/HAL/IR/HALDialect.td"
 
+// List of pre-existing pipelines for translating executables.
 def CPU_Default
     : I32EnumAttrCase<"CPUDefault", 0>;
 def CPU_Vectorization
@@ -26,6 +27,14 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
 def TileSizesListAttr :
     TypedArrayAttrBase<I64ArrayAttr,
                        "list of tile sizes for all levels"> { }
+
+// Attribute that captures information needed for translating the executables.
+def TranslationInfoAttr :
+  StructAttr<"TranslationInfo", HAL_Dialect, [
+    StructFieldAttr<"passPipeline", DispatchLoweringPassPipelineEnum>,
+    StructFieldAttr<"workloadPerWorkgroup",
+        DefaultValuedAttr<I64ArrayAttr, "{}">>,
+  ]>;
 
 // Attribute that carries information needed to perform
 // tiling/vectorization, etc.


### PR DESCRIPTION
The decision of the lowering pipeline to use is currently returned as
a value to the caller. This isnt scalable since it would not handle
cases of multiple entry point functions as cleanly. Instead add
another attribute that the configuration selection should add on the
`hal.executable.entry_point` op to defines the pipeline to use for
lowering as well as the workload per workgroup value.

Some cleanups to use `workloadPerWorkgroup` instead of `workgroupSize`
which has overloaded meaning.
Also on the CPU side, only the root operation needs a lowering
configuration. Eventually that should be true for all backends since
the root op should drive the compilation.