### PR TITLE
Add IREE variant of mlir-lsp-server.

### DIFF
--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -230,6 +230,17 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "iree-mlir-lsp-server",
+    srcs = ["iree-mlir-lsp-server.cc"],
+    deps = [
+        ":init_passes_and_dialects",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MlirLspServerLib",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
 cc_binary(
     name = "iree-run-mlir",
     srcs = ["iree-run-mlir-main.cc"],

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -336,6 +336,20 @@ if(${IREE_BUILD_COMPILER})
 
   iree_cc_binary(
     NAME
+      iree-mlir-lsp-server
+    SRCS
+      "iree-mlir-lsp-server.cc"
+    DEPS
+      ::init_passes_and_dialects
+      MLIRIR
+      MLIRLspServerLib
+      MLIRSupport
+      ${IREE_OPT_CONDITIONAL_DEPS}
+    PUBLIC
+  )
+
+  iree_cc_binary(
+    NAME
       iree-run-mlir
     SRCS
       "iree-run-mlir-main.cc"

--- a/iree/tools/iree-mlir-lsp-server.cc
+++ b/iree/tools/iree-mlir-lsp-server.cc
@@ -1,0 +1,20 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Main entry function for the IREE variant of mlir-lsp-server.
+//
+// See https://mlir.llvm.org/docs/Tools/MLIRLSP/
+
+#include "iree/tools/init_dialects.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  mlir::iree_compiler::registerAllDialects(registry);
+  return failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
See https://mlir.llvm.org/docs/Tools/MLIRLSP/

Sample screenshot of this in use within VSCode (this op [has a custom assembly format](https://github.com/google/iree/blob/2c2a21be747a7a772f7df46d1dbb65e54b343cb0/iree/compiler/Dialect/Flow/IR/FlowOps.td#L466-L472), hovering shows the default assembly format):

![image](https://user-images.githubusercontent.com/4010439/121580934-270eb800-c9e2-11eb-8dd1-de77f26af761.png)

Using this requires

* a local build of the MLIR extension at https://github.com/llvm/llvm-project/tree/main/mlir/utils/vscode (until published)
* building this new `iree-mlir-lsp-server` binary
* setting the `mlir.server_path` setting to the binary

cc @River707 