### PR TITLE
Disable eager buffer view folding optimization.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/ConvertShapeOps.cpp
@@ -58,8 +58,13 @@ class BackingBufferBufferViewDimPattern
     assert(index.hasValue() && "expect constant index in `std.dim` operation");
 
     auto dimIndex = rewriter.getIndexAttr(index.getValue());
+    auto bufferView = adaptor.getBufferView();
+    if (!bufferView) {
+      return rewriter.notifyMatchFailure(
+          dimOp, "could not adapt to producing buffer view");
+    }
     rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewDimOp>(
-        dimOp, dimOp.getResult().getType(), adaptor.getBufferView(), dimIndex);
+        dimOp, dimOp.getResult().getType(), bufferView, dimIndex);
     return success();
   }
 };
@@ -79,9 +84,13 @@ class BackingBufferBufferViewRankPattern : public OpConversionPattern<RankOp> {
     }
     auto adaptor = IREE::HAL::TensorRewriteAdaptor::get(
         rankOp.getLoc(), rankOp.getOperand(), rawOperands[0], rewriter);
-
+    auto bufferView = adaptor.getBufferView();
+    if (!bufferView) {
+      return rewriter.notifyMatchFailure(
+          rankOp, "could not adapt to producing buffer view");
+    }
     rewriter.replaceOpWithNewOp<IREE::HAL::BufferViewRankOp>(
-        rankOp, rankOp.getResult().getType(), adaptor.getBufferView());
+        rankOp, rankOp.getResult().getType(), bufferView);
     return success();
   }
 };


### PR DESCRIPTION
The logic to re-use the producing BufferView is not accounting for situations where it results from a cast that changes metadata (shape). The correct optimization needs to be shape aware and only elide the copy if the same. This is a minor optimization and better done out-of-line with the overall conversion with subsequent canonicalization or a dedicated pass to remove duplicates.

Just disabling for now as it is a correctness problem. This was noted in a test failure for a program that only did a reshape between its input/output. The optimization was just returning the un-reshaped input.

No repro attached as it was found accidentally as part of making other changes.