### PR TITLE
Add test case for dynamic-update-slice into constant

### DIFF
--- a/iree/test/e2e/xla_ops/dynamic_update_slice.mlir
+++ b/iree/test/e2e/xla_ops/dynamic_update_slice.mlir
@@ -24,3 +24,12 @@ func @dynamic_update_slice_1x3() attributes { iree.module.export } {
     [2, 2, 2]]> : tensor<3x3xi32>) : tensor<3x3xi32>
   return
 }
+
+func @into_constant() attributes {iree.module.export} {
+  %update = iree.unfoldable_constant dense<2> : tensor<1xi32>
+  %target = mhlo.constant dense<1> : tensor<4xi32>
+  %index = mhlo.constant dense<0> : tensor<i32>
+  %result = "mhlo.dynamic-update-slice"(%target, %update, %index) : (tensor<4xi32>, tensor<1xi32>, tensor<i32>) -> tensor<4xi32>
+  check.expect_eq_const(%result, dense<[2, 1, 1, 1]> : tensor<4xi32>) : tensor<4xi32>
+  return
+}


### PR DESCRIPTION
Thanks to Lei's https://github.com/google/iree/pull/6174, updating into
a constant now works.

Confirmed that before that commit, this test case reproduces the issue I
was hitting in https://github.com/google/iree/issues/5989.

Fixes https://github.com/google/iree/issues/5989