### PR TITLE
Update gradle to build TFLilte Java bindings AAR library

### DIFF
--- a/bindings/tflite/java/README.md
+++ b/bindings/tflite/java/README.md
@@ -1,0 +1,24 @@
+# IREE TFLite Android Native Bindings
+
+## Building The Library
+
+Process for building the AAR library:
+
+1. Start AndroidStudio. Select _Open File or Project_ then choose `iree/bindings/tflite/java/gragle.build`
+2. AndroidStudio should sync the project and setup gradlew uner `iree/bindings/tflite/java`
+3. Make the project using AndroidStudio or run the build directly in terminal:
+```shell
+./gradlew build
+```
+
+This produces two libraries under `iree/bindings/tflite/java/build/outputs/aar`:
+* `iree-tflite-bindings-debug.aar`
+* `iree-tflite-bindings-release.aar`
+
+### AAR Contents
+
+![IREE AAR contents](https://user-images.githubusercontent.com/1041731/121963388-e7680900-cd1e-11eb-89d3-4dee40a42eba.png)
+
+## Using the Library
+
+Include either library in another gradle project for IREE TFLite binding support. See "[Adding dependencies with the Project Structure Dialog](https://developer.android.com/studio/projects/android-library#psd-add-dependencies)" for use in AndroidStudio.

--- a/bindings/tflite/java/build.gradle
+++ b/bindings/tflite/java/build.gradle
@@ -23,7 +23,6 @@ def hostInstallDir = "${hostBuildDir}/install"
 
 android {
     compileSdkVersion 29
-
     defaultConfig {
         minSdkVersion 28
         targetSdkVersion 29
@@ -48,9 +47,12 @@ android {
 
     sourceSets {
         main {
-            java.srcDirs = ['java/org/tensorflow/lite']
-            jni.srcDirs = ['java/org/tensorflow/lite/native']
-            manifest.srcFile 'org/tensorflow/lite/tests/TestManifest.xml'
+            manifest.srcFile 'org/tensorflow/lite/AndroidManifest.xml'
+            java {
+                srcDirs('org/tensorflow/lite')
+                exclude('tests/**') // Don't build tests into the library
+            }
+            jni.srcDirs = ['org/tensorflow/lite/native']
         }
     }
 
@@ -60,6 +62,10 @@ android {
             path "../../../CMakeLists.txt"
         }
     }
+}
+
+dependencies {
+    implementation 'com.android.support:support-annotations:22.2.0'
 }
 
 // Task to cmake configure the host

--- a/bindings/tflite/java/build.gradle
+++ b/bindings/tflite/java/build.gradle
@@ -41,6 +41,8 @@ android {
                         "-DIREE_BUILD_SAMPLES=OFF",
                         "-DIREE_BUILD_PYTHON_BINDINGS=OFF",
                         "-DIREE_HOST_BINARY_ROOT=${hostInstallDir}"
+
+                targets "bindings_tflite_java_org_tensorflow_lite_native_native_deps"
             }
         }
     }

--- a/bindings/tflite/java/build.gradle
+++ b/bindings/tflite/java/build.gradle
@@ -42,7 +42,7 @@ android {
                         "-DIREE_BUILD_PYTHON_BINDINGS=OFF",
                         "-DIREE_HOST_BINARY_ROOT=${hostInstallDir}"
 
-                targets "bindings_tflite_java_org_tensorflow_lite_native_native_deps"
+                targets "iree-tflite-bindings"
             }
         }
     }

--- a/bindings/tflite/java/org/tensorflow/lite/AndroidManifest.xml
+++ b/bindings/tflite/java/org/tensorflow/lite/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="org.tensorflow.lite">
+</manifest>

--- a/bindings/tflite/java/org/tensorflow/lite/Interpreter.java
+++ b/bindings/tflite/java/org/tensorflow/lite/Interpreter.java
@@ -8,11 +8,11 @@
 
 package org.tensorflow.lite;
 
+import android.support.annotation.NonNull;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Main driver class for the IREE Java compatibility shim. Provides model

--- a/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
+++ b/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
@@ -6,24 +6,6 @@
 
 iree_add_all_subdirs()
 
-# iree_cc_library(
-#   NAME
-#     native_deps
-#   SRCS
-#     "interpreter_jni.cc"
-#     "tensor_jni.cc"
-#     "tensorflow_lite_jni.cc"
-#   HDRS
-#   DEPS
-#     iree::base
-#     iree::base::logging
-#     bindings::tflite::shim
-#   LINKOPTS
-#     "-landroid"
-#     "-llog"
-#   SHARED
-# )
-
 set(_NAME "iree-tflite-bindings")
 add_library(${_NAME} SHARED "")
 

--- a/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
+++ b/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
@@ -6,20 +6,43 @@
 
 iree_add_all_subdirs()
 
-iree_cc_library(
-  NAME
-    native_deps
-  SRCS
+# iree_cc_library(
+#   NAME
+#     native_deps
+#   SRCS
+#     "interpreter_jni.cc"
+#     "tensor_jni.cc"
+#     "tensorflow_lite_jni.cc"
+#   HDRS
+#   DEPS
+#     iree::base
+#     iree::base::logging
+#     bindings::tflite::shim
+#   LINKOPTS
+#     "-landroid"
+#     "-llog"
+#   SHARED
+# )
+
+set(_NAME "iree-tflite-bindings")
+add_library(${_NAME} SHARED "")
+
+target_sources(${_NAME}
+  PRIVATE
     "interpreter_jni.cc"
     "tensor_jni.cc"
     "tensorflow_lite_jni.cc"
-  HDRS
-  DEPS
+)
+
+target_link_libraries(${_NAME}
+  PUBLIC
     iree::base
     iree::base::logging
     bindings::tflite::shim
-  LINKOPTS
+)
+
+target_link_options(${_NAME}
+  INTERFACE
     "-landroid"
     "-llog"
-  SHARED
 )

--- a/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
+++ b/bindings/tflite/java/org/tensorflow/lite/native/CMakeLists.txt
@@ -16,7 +16,10 @@ iree_cc_library(
   HDRS
   DEPS
     iree::base
+    iree::base::logging
     bindings::tflite::shim
   LINKOPTS
     "-landroid"
+    "-llog"
+  SHARED
 )

--- a/bindings/tflite/java/settings.gradle
+++ b/bindings/tflite/java/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'iree-tflite-bindings'


### PR DESCRIPTION
Process for building the AAR:

1. Start AndroidStudio. Select "Open File or Project" then choose `iree/bindings/tflite/java/gragle.build`.
2. AndroidStudio should sync the project and setup gradlew uner `iree/bindings/tflite/java`.
3. Make the project using android studio or run the build directly in terminal:
```shell
./gradlew build
```

This produces two libraries under `iree/bindings/tflite/java/build/outputs/aar`: 
* `iree-tflite-bindings-debug.aar` 
*  `iree-tflite-bindings-release.aar` 

AAR contents:
![Screen Shot 2021-06-14 at 2 42 38 PM](https://user-images.githubusercontent.com/1041731/121963388-e7680900-cd1e-11eb-89d3-4dee40a42eba.png)

Include either library in another gradle project for iree tflite binding support. 

Addresses #6198