### PR TITLE
Use the result buffer's length when converting flow.tensor.clone

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -849,7 +849,9 @@ static LogicalResult recordTensorClone(Value device, Value commandBuffer,
   auto zeroOffset = schedulingState.lookupOrCreateIndex(0, rewriter);
   rewriter.create<IREE::HAL::CommandBufferCopyBufferOp>(
       cloneOp.getLoc(), commandBuffer, operandBuffer.buffer, zeroOffset,
-      resultBuffer.buffer, zeroOffset, operandBuffer.length);
+      // Note: we use the result buffer's length here deliberately to handle the
+      // case where the source buffer can be the constant pool buffer.
+      resultBuffer.buffer, zeroOffset, resultBuffer.length);
 
   // Full barriers for now as we aren't scheduling things.
   recordFullExecutionBarrier(commandBuffer, cloneOp.getLoc(), rewriter);


### PR DESCRIPTION
A flow.tensor.clone op by definition should have its operand and
result of the same shape. However, when mapping to buffers, we
could have the case where the operand is a constant subspan. Then
the source buffer will be the constant pool buffer, which can be
larger than the result buffer.