### PR TITLE
Add release step to build iree_jax package.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -47,6 +47,10 @@ jobs:
           - os: ubuntu-18.04
             build_package: py-tf-compiler-tools-pkg
             experimental: false
+          # Only needs to be built on Linux because platform independent.
+          - os: ubuntu-18.04
+            build_package: py-pure-pkgs
+            experimental: true
 
           # Windows packages.
           - os: windows-2019
@@ -166,9 +170,26 @@ jobs:
         if: "matrix.build_package == 'py-runtime-pkg'"
         shell: bash
         run: |
-          # Just need to build for one examplar python3 variant.
           package_dir="./iree-install/python_packages/iree_runtime"
           export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py py-runtime-pkg"
+          # TODO: cibuildwheel sanity checks this, but our setup.py is the
+          # *output* of the build :( Make source packages.
+          mkdir -p $package_dir && touch $package_dir/setup.py
+          python -m cibuildwheel --output-dir bindist $package_dir
+
+      # Pure python packages only need to do a minimal CMake configure and no
+      # actual building, aside from setting up sources. If there are multiples,
+      # it is fairly cheap to build them serially. Using cibuildwheel is a bit
+      # overkill for this, but we keep it the same as the others for maintenance
+      # value.
+      - name: Build pure python wheels
+        if: "matrix.build_package == 'py-pure-pkgs'"
+        shell: bash
+        run: |
+          # Just need to build for one examplar python3 variant.
+          export CIBW_BUILD="cp38-*"
+          package_dir="./iree-install/python_packages/iree_jax"
+          export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py py-pure-pkgs"
           # TODO: cibuildwheel sanity checks this, but our setup.py is the
           # *output* of the build :( Make source packages.
           mkdir -p $package_dir && touch $package_dir/setup.py


### PR DESCRIPTION
* This is the first pure python package and thus warrants its own build step.
* It only runs on Linux since platform independent.