### PR TITLE
Add a facility so that the Python API will save off all temporaries.

### DIFF
--- a/bindings/python/iree/compiler/CMakeLists.txt
+++ b/bindings/python/iree/compiler/CMakeLists.txt
@@ -21,4 +21,6 @@ iree_py_install_package(
   COMPONENT IreePythonPackage-compiler
   PACKAGE_NAME iree_compiler
   MODULE_PATH iree/compiler
+  ADDL_PACKAGE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/README.md
 )

--- a/bindings/python/iree/compiler/CMakeLists.txt
+++ b/bindings/python/iree/compiler/CMakeLists.txt
@@ -10,6 +10,7 @@ iree_py_library(
   SRCS
     "__init__.py"
     "core.py"
+    "debugging.py"
     "tf.py"
     "tflite.py"
     "tools.py"

--- a/bindings/python/iree/compiler/README.md
+++ b/bindings/python/iree/compiler/README.md
@@ -18,6 +18,45 @@ func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
 binary = iree.compiler.compile_str(SIMPLE_MUL_ASM, target_backends=["vulkan-spirv"])
 ```
 
+### Debugging
+
+A number of optional arguments to the compiler can be useful for debugging:
+
+* `extended_diagnostics=True` - Outputs verbose attached operations to
+  diagnostics. Can output a large volume of information.
+* `crash_reproducer_path=... some .mlir file path...` - On a crash or error,
+  a reproducer will be output at the listed path.
+* `extra_args=[...]` - Passes extra arguments to the compiler. Useful for
+  various standard features of MLIR based compilers like `-print-ir-after-all`.
+
+In addition, the core compiler and frontend compiler APIs have a unified
+mechanism for saving their temporary files, which are often useful for post
+mortem debugging. Since the need for this is often as part of a larger system,
+it is exposed both via an environment variable and an API.
+
+In order to save all temporaries and reproducers, set the `IREE_SAVE_TEMPS`
+environment variable to a directory in which to dump artifacts. For complex
+programs that invoke the compiler many times, it will typically be necessary
+to further qualify the path, and there are a few placeholders that will be
+expanded:
+
+* `{id}` - A per-process monotonically increasing number for each compiler
+  invocation. Can be overriden by the API if a better symbolic name is
+  available (i.e. test case, etc).
+* `{pid}` - Process ID of the current process.
+* `{main}` - Basename of `sys.argv[0]`, which is typically the name of the
+  Python main file.
+
+For interactive use, the following (on a Unix-like system) should provide
+value:
+
+```shell
+export IREE_SAVE_TEMPS="/tmp/ireedumps/{main}/{id}"
+```
+
+For the context manager based API, refer to the
+`iree.compiler.debugging.TempFileSaver` class.
+
 
 ## TensorFlow compiler
 

--- a/bindings/python/iree/compiler/__init__.py
+++ b/bindings/python/iree/compiler/__init__.py
@@ -6,4 +6,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .core import *
+from .debugging import TempFileSaver
 from .tools import CompilerToolError

--- a/bindings/python/iree/compiler/debugging.py
+++ b/bindings/python/iree/compiler/debugging.py
@@ -1,0 +1,172 @@
+"""Debugging support."""
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional
+
+import logging
+import os
+import shutil
+import sys
+import threading
+
+_thread_locals = threading.local()
+_invocation_id = 0
+
+
+def _get_temp_file_saver_stack():
+  try:
+    return _thread_locals.temp_file_saver_stack
+  except AttributeError:
+    stack = []
+    _thread_locals.temp_file_saver_stack = stack
+    return stack
+
+
+def _interpolate_path_pattern(path_pattern: str, *, invocation_id: str):
+  # We do not use str.format() because we do not know the providence of
+  # path_pattern. Instead, handle a fixed set of replacements.
+  path_pattern = path_pattern.replace("{id}", str(invocation_id))
+  path_pattern = path_pattern.replace("{pid}", str(os.getpid()))
+  path_pattern = path_pattern.replace("{main}", sys.argv[0])
+  return path_pattern
+
+
+class TempFileSaver:
+  """Manages the saving of temp files resulting from tool invocations.
+
+  The TempFileSaver is a thread-local context bound object. An attempt to
+  create a new one will return the most recent instance created and entered
+  as a context manager. This allows up-stack callers to establish the
+  policy for saving temporaries and deep implementations will inherit it.
+
+  Proper usage from users wishing to establish a saver context:
+    with TempFileSaver():
+      # Do things with temp files.
+
+  Proper usage for implementors wishing to use an established saver context
+  or set up a new one:
+    with TempFileSaver.implicit() as tfs:
+      # Do things with temp files.
+
+  The outer-most creator can customize it with explicit arguments to __init__
+  but these will be ignored if an instance is already thread bound.
+  """
+  TEMP_PATH_ENV_KEY = "IREE_SAVE_TEMPS"
+
+  @staticmethod
+  def implicit():
+    stack = _get_temp_file_saver_stack()
+    if stack:
+      return stack[-1]
+    return TempFileSaver()
+
+  def __init__(self,
+               temp_path_pattern: str = None,
+               *,
+               invocation_id: Optional[str] = None):
+    self.retained = False
+    self._refcount = 0
+    if temp_path_pattern is None:
+      temp_path_pattern = os.environ.get(TempFileSaver.TEMP_PATH_ENV_KEY)
+    if temp_path_pattern is None:
+      return
+
+    global _invocation_id
+    if invocation_id is not None:
+      self.invocation_id = invocation_id
+    else:
+      self.invocation_id = _invocation_id
+      _invocation_id += 1
+
+    self.retained_path = _interpolate_path_pattern(
+        temp_path_pattern, invocation_id=self.invocation_id)
+    self.retained = True
+    self._retained_file_names = set()
+    self._copy_on_finalize = list()  # Of (source_path, target_path)
+    self._created_dir = False
+
+  def __enter__(self):
+    _get_temp_file_saver_stack().append(self)
+    self._refcount += 1
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    del _get_temp_file_saver_stack()[-1]
+    self._refcount -= 1
+    if self._refcount == 0:
+      self._finalize()
+
+  @staticmethod
+  def current():
+    try:
+      return _get_temp_file_saver_stack()[0]
+    except KeyError:
+      raise RuntimeError("No current TempFileSaver")
+
+  def alloc_optional(self,
+                     file_name: str,
+                     *,
+                     export_as: Optional[str] = None) -> Optional[str]:
+    """Allocates an optional temporary file.
+
+
+    When in non-retained mode, the return value is 'export_as', meaning that the
+    file is just some user specified output file.
+
+    When in retained mode, the output file will be an index-mangled variant
+    of 'file_name' under the temp_path. In addition, a mapping will be added
+    so that upon finalization, the file is also exported to 'export_as' if
+    specified.
+
+    Returns None if neither a user-specified 'export_as' is specified nor in
+    retained mode.
+    """
+    if not self.retained:
+      return export_as
+    alloced_path = self._alloc_retained_path(file_name)
+    if export_as:
+      self._copy_on_finalize.append((alloced_path, export_as))
+    return alloced_path
+
+  def _alloc_retained_path(self, file_name: str) -> str:
+    assert self.retained
+    index = 0
+    original_file_name = file_name
+    while True:
+      if file_name not in self._retained_file_names:
+        # First use of this name.
+        self._retained_file_names.add(file_name)
+        if not self._created_dir:
+          os.makedirs(self.retained_path, exist_ok=True)
+          self._created_dir = True
+        return os.path.join(self.retained_path, file_name)
+      index += 1
+      stem, ext = os.path.splitext(original_file_name)
+      file_name = f"{stem}_{index}{ext}"
+
+  def _finalize(self):
+    if not self.retained:
+      return
+    # See which files were materialized.
+    was_materialized = []
+    for file_name in self._retained_file_names:
+      file_path = os.path.join(self.retained_path, file_name)
+      if os.path.exists(file_path):
+        was_materialized.append((file_name, file_path))
+    if was_materialized:
+      logging.info(
+          "**** IREE Compiler retained temporary files (%s)***:\n%s",
+          self.invocation_id, "\n".join([
+              f"  * {file_name} : {file_path}"
+              for file_name, file_path in was_materialized
+          ]))
+    for source_path, target_path in self._copy_on_finalize:
+      if os.path.exists(source_path):
+        logging.info("Copy retained file to output: %s -> %s", source_path,
+                     target_path)
+        shutil.copyfile(source_path, target_path)

--- a/bindings/python/iree/compiler/debugging.py
+++ b/bindings/python/iree/compiler/debugging.py
@@ -32,7 +32,7 @@ def _interpolate_path_pattern(path_pattern: str, *, invocation_id: str):
   # path_pattern. Instead, handle a fixed set of replacements.
   path_pattern = path_pattern.replace("{id}", str(invocation_id))
   path_pattern = path_pattern.replace("{pid}", str(os.getpid()))
-  path_pattern = path_pattern.replace("{main}", sys.argv[0])
+  path_pattern = path_pattern.replace("{main}", os.path.basename(sys.argv[0]))
   return path_pattern
 
 

--- a/bindings/python/iree/compiler/setup.py.in
+++ b/bindings/python/iree/compiler/setup.py.in
@@ -14,51 +14,8 @@ import os
 import platform
 from setuptools import setup, find_namespace_packages
 
-README = r'''
-# IREE Compiler Python Bindings
-
-## Core compiler
-
-```py
-import iree.compiler
-
-SIMPLE_MUL_ASM = """
-func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-    %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
-    return %0 : tensor<4xf32>
-}
-"""
-
-# Also see compile_file()
-# There are many keyword options available.
-# See iree.compiler.CompilerOptions
-binary = iree.compiler.compile_str(SIMPLE_MUL_ASM, target_backends=["vulkan-spirv"])
-```
-
-
-## TensorFlow compiler
-
-```py
-import tensorflow as tf
-import iree.compiler.tf
-
-class SimpleArithmeticModule(tf.Module):
-
-  @tf.function(input_signature=[
-      tf.TensorSpec([4], tf.float32),
-      tf.TensorSpec([4], tf.float32)
-  ])
-  def simple_mul(self, a, b):
-    return a * b
-
-# Also see compile_saved_model to directly compile an on-disk saved model.
-# There are many keyword options available.
-# See: iree.compiler.tf.ImportOptions
-binary = iree.compiler.tf.compile_module(
-    SimpleArithmeticModule(), target_backends=["vulkan-spirv"])
-```
-
-'''
+with open(os.path.join(os.path.dirname(__file__), "README.md"), "r") as f:
+  README = f.read()
 
 exe_suffix = ".exe" if platform.system() == "Windows" else ""
 

--- a/bindings/python/tests/compiler_core_test.py
+++ b/bindings/python/tests/compiler_core_test.py
@@ -28,7 +28,6 @@ class CompilerTest(unittest.TestCase):
     if "IREE_SAVE_TEMPS" in os.environ:
       del os.environ["IREE_SAVE_TEMPS"]
 
-
   def testNoTargetBackends(self):
     with self.assertRaisesRegex(
         ValueError, "Expected a non-empty list for 'target_backends'"):
@@ -197,7 +196,6 @@ class CompilerTest(unittest.TestCase):
       temp_contents = f.read()
     self.assertEqual(temp_contents, output_contents)
     temp_dir.cleanup()
-
 
   def testEnvTempFileSaver(self):
     temp_dir = tempfile.TemporaryDirectory()

--- a/bindings/python/tests/compiler_core_test.py
+++ b/bindings/python/tests/compiler_core_test.py
@@ -24,6 +24,11 @@ func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
 
 class CompilerTest(unittest.TestCase):
 
+  def setUp(self):
+    if "IREE_SAVE_TEMPS" in os.environ:
+      del os.environ["IREE_SAVE_TEMPS"]
+
+
   def testNoTargetBackends(self):
     with self.assertRaisesRegex(
         ValueError, "Expected a non-empty list for 'target_backends'"):
@@ -167,6 +172,43 @@ class CompilerTest(unittest.TestCase):
       _ = iree.compiler.compile_str(
           "I'm a little teapot but not a valid program",
           target_backends=iree.compiler.DEFAULT_TESTING_BACKENDS)
+
+  def testExplicitTempFileSaver(self):
+    temp_dir = tempfile.TemporaryDirectory()
+    output_file = tempfile.NamedTemporaryFile("wt")
+    output_file.close()
+    with iree.compiler.TempFileSaver(temp_dir.name):
+      output = iree.compiler.compile_str(
+          SIMPLE_MUL_ASM,
+          input_type="mhlo",
+          output_file=output_file.name,
+          target_backends=iree.compiler.DEFAULT_TESTING_BACKENDS)
+      self.assertIsNone(output)
+
+    # There should be an output file and a core-output.bin in the temp dir.
+    self.assertTrue(os.path.exists(output_file.name))
+    expected_temp_file = os.path.join(temp_dir.name, "core-output.bin")
+    self.assertTrue(os.path.exists(expected_temp_file))
+
+    # And they should have the same contents.
+    with open(output_file.name, "rb") as f:
+      output_contents = f.read()
+    with open(expected_temp_file, "rb") as f:
+      temp_contents = f.read()
+    self.assertEqual(temp_contents, output_contents)
+    temp_dir.cleanup()
+
+
+  def testEnvTempFileSaver(self):
+    temp_dir = tempfile.TemporaryDirectory()
+    os.environ["IREE_SAVE_TEMPS"] = temp_dir.name
+    with iree.compiler.TempFileSaver() as tfs:
+      self.assertTrue(tfs.retained)
+      self.assertEqual(tfs.retained_path, temp_dir.name)
+
+  def testTempFileSaverDisabled(self):
+    with iree.compiler.TempFileSaver() as tfs:
+      self.assertFalse(tfs.retained)
 
 
 if __name__ == "__main__":

--- a/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
@@ -109,11 +109,20 @@ def _incrementally_compile_tf_module(
       backend_info.backend_id,
       needs_temp_saved_model_dir=True,
   ) if artifacts_dir else {})
-  immediate_result = iree.compiler.tf.compile_module(
-      module,
-      target_backends=backend_info.compiler_targets,
-      exported_names=exported_names,
-      **output_kwargs)
+
+  # TODO: Revisit how artifacts_dir is plummed through and figure out how to
+  # get a meaningful invocation name directly. This isn't really load
+  # bearing - just adds a bit of usability so long as we have multiple
+  # methods of saving temp files.
+  if artifacts_dir:
+    invocation_id = (
+        f"{os.path.basename(artifacts_dir)}__{backend_info.backend_id}")
+  with iree.compiler.TempFileSaver(invocation_id=invocation_id):
+    immediate_result = iree.compiler.tf.compile_module(
+        module,
+        target_backends=backend_info.compiler_targets,
+        exported_names=exported_names,
+        **output_kwargs)
 
   output_file = output_kwargs.get("output_file")
   if output_file:

--- a/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/module_utils.py
@@ -117,6 +117,8 @@ def _incrementally_compile_tf_module(
   if artifacts_dir:
     invocation_id = (
         f"{os.path.basename(artifacts_dir)}__{backend_info.backend_id}")
+  else:
+    invocation_id = None
   with iree.compiler.TempFileSaver(invocation_id=invocation_id):
     immediate_result = iree.compiler.tf.compile_module(
         module,

--- a/integrations/tensorflow/bindings/python/iree/tf/support/tf_test_utils.py
+++ b/integrations/tensorflow/bindings/python/iree/tf/support/tf_test_utils.py
@@ -105,6 +105,7 @@ def get_target_backends() -> Sequence[module_utils.BackendInfo]:
     backends = module_utils.BackendInfo.get_all_backends()
   return backends
 
+
 # TODO(#4131) python>=3.7: Consider using a (frozen) dataclass.
 Modules = collections.namedtuple("Modules",
                                  ["ref_module", "tar_modules", "artifacts_dir"])


### PR DESCRIPTION
* This is done at a lower level than the TF test framework and happens automatically if env variables are set (can be customized).
* Intended for debugging and getting dumps of foreign systems where the high level should not be altered to manually pass in artifact retention.
* I'm sure folks will write scripts around this, but the intent is for humans to have a less miserable time when dealing with an arbitrary system.
* To shortcut everything, just set the env var IREE_SAVE_TEMPS to something like "/tmp/ireedumps/{pid}/{id}".