### PR TITLE
Add python console_scripts for iree-translate, iree-import-tf, iree-import-tflite, iree-import-xla.

### DIFF
--- a/bindings/python/iree/compiler/setup.py.in
+++ b/bindings/python/iree/compiler/setup.py.in
@@ -78,5 +78,10 @@ setup(
         'bdist_wheel': bdist_wheel,
         'install': platlib_install,
     },
+    entry_points={
+        "console_scripts": [
+            "iree-translate = iree.tools.core.scripts.iree_translate.__main__:main",
+        ],
+    },
     zip_safe=False,  # This package is fine but not zipping is more versatile.
 )

--- a/bindings/python/iree/tools/core/CMakeLists.txt
+++ b/bindings/python/iree/tools/core/CMakeLists.txt
@@ -4,11 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(_srcs
+  "__init__.py"
+  "scripts/iree_translate/__main__.py"
+)
+
 iree_py_library(
   NAME
     core
-  SRCS
-    "__init__.py"
+  SRCS ${_srcs}
 )
 
 if(${IREE_BUILD_COMPILER})
@@ -24,6 +28,7 @@ iree_py_install_package(
   COMPONENT IreePythonPackage-compiler
   PACKAGE_NAME iree_compiler
   MODULE_PATH iree/tools/core
+  FILES_MATCHING ${_srcs}
   DEPS
     iree_tools_iree-translate
 )

--- a/bindings/python/iree/tools/core/scripts/iree_translate/__main__.py
+++ b/bindings/python/iree/tools/core/scripts/iree_translate/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import subprocess
+import sys
+
+import iree.tools.core
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = iree.tools.core.get_tool("iree-translate")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -34,16 +34,32 @@ include(iree_installed_test)
 #
 # Also adds a *-stripped target which strips any binaries that are
 # present.
+#
+# Arguments:
+#   AUGMENT_EXISTING_PACKAGE: Whether to add install artifacts to an existing
+#     package.
+#   COMPONENT: Install component
+#   PACKAGE_NAME: Name of the Python package in the install directory tree.
+#   MODULE_PATH: Relative path within the package to the module being installed.
+#   FILES_MATCHING: Explicit arguments to the install FILES_MATCHING directive.
+#     (Defaults to "PATTERN *.py")
+#   DEPS: Dependencies.
 function(iree_py_install_package)
   cmake_parse_arguments(ARG
     "AUGMENT_EXISTING_PACKAGE"
     "COMPONENT;PACKAGE_NAME;MODULE_PATH"
-    "DEPS;ADDL_PACKAGE_FILES"
+    "DEPS;ADDL_PACKAGE_FILES;FILES_MATCHING"
     ${ARGN})
   set(_install_component ${ARG_COMPONENT})
   set(_install_packages_dir "${CMAKE_INSTALL_PREFIX}/python_packages/${ARG_PACKAGE_NAME}")
   set(_install_module_dir "${_install_packages_dir}/${ARG_MODULE_PATH}")
   set(_target_name install-${_install_component})
+
+  if(NOT FILES_MATCHING)
+    set(_files_matching PATTERN "*.py")
+  else()
+    set(_files_matching ${ARG_FILES_MATCHING})
+  endif()
 
   if(NOT ARG_AUGMENT_EXISTING_PACKAGE)
     configure_file(setup.py.in setup.py)
@@ -87,8 +103,7 @@ function(iree_py_install_package)
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
     COMPONENT ${_install_component}
     DESTINATION "${_install_module_dir}"
-    FILES_MATCHING
-      PATTERN "*.py"
+    FILES_MATCHING ${_files_matching}
   )
 
   set(PY_INSTALL_COMPONENT ${_install_component} PARENT_SCOPE)

--- a/integrations/tensorflow/bindings/python/iree/tools/tf/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/tf/CMakeLists.txt
@@ -4,11 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(_srcs
+  "__init__.py"
+  "scripts/iree_import_tf/__main__.py"
+)
+
 iree_py_library(
   NAME
     tf
-  SRCS
-    "__init__.py"
+  SRCS ${_srcs}
   DEPS
   iree_tf_compiler_iree-import-tf
 )
@@ -23,6 +27,7 @@ iree_py_install_package(
   COMPONENT IreePythonPackage-tools-tf
   PACKAGE_NAME iree_tools_tf
   MODULE_PATH iree/tools/tf
+  FILES_MATCHING ${_srcs}
   DEPS
     iree_tf_compiler_iree-import-tf
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/tf/scripts/iree_import_tf/__main__.py
+++ b/integrations/tensorflow/bindings/python/iree/tools/tf/scripts/iree_import_tf/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import subprocess
+import sys
+
+import iree.tools.tf
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = iree.tools.tf.get_tool("iree-import-tf")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/integrations/tensorflow/bindings/python/iree/tools/tf/setup.py.in
+++ b/integrations/tensorflow/bindings/python/iree/tools/tf/setup.py.in
@@ -81,5 +81,10 @@ setup(
         'bdist_wheel': bdist_wheel,
         'install': platlib_install,
     },
+    entry_points={
+        "console_scripts": [
+            "iree-import-tf = iree.tools.tf.scripts.iree_import_tf.__main__:main",
+        ],
+    },
     zip_safe=False,  # This package is fine but not zipping is more versatile.
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/tflite/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/tflite/CMakeLists.txt
@@ -4,11 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(_srcs
+  "__init__.py"
+  "scripts/iree_import_tflite/__main__.py"
+)
+
 iree_py_library(
   NAME
     tflite
-  SRCS
-    "__init__.py"
+  SRCS ${_srcs}
   DEPS
     iree_tf_compiler_iree-import-tflite
 )
@@ -23,6 +27,7 @@ iree_py_install_package(
   COMPONENT IreePythonPackage-tools-tflite
   PACKAGE_NAME iree_tools_tflite
   MODULE_PATH iree/tools/tflite
+  FILES_MATCHING ${_srcs}
   DEPS
     iree_tf_compiler_iree-import-tflite
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/tflite/scripts/iree_import_tflite/__main__.py
+++ b/integrations/tensorflow/bindings/python/iree/tools/tflite/scripts/iree_import_tflite/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import subprocess
+import sys
+
+import iree.tools.tflite
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = iree.tools.tflite.get_tool("iree-import-tflite")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/integrations/tensorflow/bindings/python/iree/tools/tflite/setup.py.in
+++ b/integrations/tensorflow/bindings/python/iree/tools/tflite/setup.py.in
@@ -78,5 +78,10 @@ setup(
         'bdist_wheel': bdist_wheel,
         'install': platlib_install,
     },
+    entry_points={
+        "console_scripts": [
+            "iree-import-tflite = iree.tools.tflite.scripts.iree_import_tflite.__main__:main",
+        ],
+    },
     zip_safe=False,  # This package is fine but not zipping is more versatile.
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/xla/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/xla/CMakeLists.txt
@@ -4,11 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(_srcs
+  "__init__.py"
+  "scripts/iree_import_xla/__main__.py"
+)
+
 iree_py_library(
   NAME
     xla
-  SRCS
-    "__init__.py"
+  SRCS ${_srcs}
   DEPS
     iree_tf_compiler_iree-import-xla
 )
@@ -23,6 +27,7 @@ iree_py_install_package(
   COMPONENT IreePythonPackage-tools-xla
   PACKAGE_NAME iree_tools_xla
   MODULE_PATH iree/tools/xla
+  FILES_MATCHING ${_srcs}
   DEPS
     iree_tf_compiler_iree-import-xla
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/xla/scripts/iree_import_xla/__main__.py
+++ b/integrations/tensorflow/bindings/python/iree/tools/xla/scripts/iree_import_xla/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import subprocess
+import sys
+
+import iree.tools.xla
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = iree.tools.xla.get_tool("iree-import-xla")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/integrations/tensorflow/bindings/python/iree/tools/xla/setup.py.in
+++ b/integrations/tensorflow/bindings/python/iree/tools/xla/setup.py.in
@@ -78,5 +78,10 @@ setup(
         'bdist_wheel': bdist_wheel,
         'install': platlib_install,
     },
+    entry_points={
+        "console_scripts": [
+            "iree-import-xla = iree.tools.xla.scripts.iree_import_xla.__main__:main",
+        ],
+    },
     zip_safe=False,  # This package is fine but not zipping is more versatile.
 )


### PR DESCRIPTION
After this patch, if you install the corresponding python packages, you will (on all platforms) have the above tool binaries on your path.