### PR TITLE
Fix VM constants to EmitC conversion tests

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -4,7 +4,7 @@
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i32_zero
   vm.func @const_i32_zero() -> i32 {
-    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0 : i32} : () -> i32
+    // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0 : i32} : () -> i32
     %zero = vm.const.i32.zero : i32
     vm.return %zero : i32
   }
@@ -15,11 +15,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i32
   vm.func @const_i32() {
-    // CHECK-NEXT: %0 = "emitc.const"() {value = 0 : i32} : () -> i32
+    // CHECK-NEXT: %0 = "emitc.constant"() {value = 0 : i32} : () -> i32
     %0 = vm.const.i32 0 : i32
-    // CHECK-NEXT: %1 = "emitc.const"() {value = 2 : i32} : () -> i32
+    // CHECK-NEXT: %1 = "emitc.constant"() {value = 2 : i32} : () -> i32
     %1 = vm.const.i32 2 : i32
-    // CHECK-NEXT: %2 = "emitc.const"() {value = -2 : i32} : () -> i32
+    // CHECK-NEXT: %2 = "emitc.constant"() {value = -2 : i32} : () -> i32
     %2 = vm.const.i32 -2 : i32
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
@@ -3,7 +3,7 @@
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_f32_zero
   vm.func @const_f32_zero() -> f32 {
-    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0.000000e+00 : f32} : () -> f32
+    // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0.000000e+00 : f32} : () -> f32
     %zero = vm.const.f32.zero : f32
     vm.return %zero : f32
   }
@@ -14,11 +14,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_f32
   vm.func @const_f32() {
-    // CHECK-NEXT: %0 = "emitc.const"() {value = 5.000000e-01 : f32} : () -> f32
+    // CHECK-NEXT: %0 = "emitc.constant"() {value = 5.000000e-01 : f32} : () -> f32
     %0 = vm.const.f32 0.5 : f32
-    // CHECK-NEXT: %1 = "emitc.const"() {value = 2.500000e+00 : f32} : () -> f32
+    // CHECK-NEXT: %1 = "emitc.constant"() {value = 2.500000e+00 : f32} : () -> f32
     %1 = vm.const.f32 2.5 : f32
-    // CHECK-NEXT: %2 = "emitc.const"() {value = -2.500000e+00 : f32} : () -> f32
+    // CHECK-NEXT: %2 = "emitc.constant"() {value = -2.500000e+00 : f32} : () -> f32
     %2 = vm.const.f32 -2.5 : f32
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -4,7 +4,7 @@
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i64_zero
   vm.func @const_i64_zero() -> i64 {
-    // CHECK: %[[ZERO:.+]] = "emitc.const"() {value = 0 : i64} : () -> i64
+    // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0 : i64} : () -> i64
     %zero = vm.const.i64.zero : i64
     vm.return %zero : i64
   }
@@ -15,11 +15,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: vm.func @const_i64
   vm.func @const_i64() {
-    // CHECK-NEXT: %0 = "emitc.const"() {value = 0 : i64} : () -> i64
+    // CHECK-NEXT: %0 = "emitc.constant"() {value = 0 : i64} : () -> i64
     %0 = vm.const.i64 0 : i64
-    // CHECK-NEXT: %1 = "emitc.const"() {value = 2 : i64} : () -> i64
+    // CHECK-NEXT: %1 = "emitc.constant"() {value = 2 : i64} : () -> i64
     %1 = vm.const.i64 2 : i64
-    // CHECK-NEXT: %2 = "emitc.const"() {value = -2 : i64} : () -> i64
+    // CHECK-NEXT: %2 = "emitc.constant"() {value = -2 : i64} : () -> i64
     %2 = vm.const.i64 -2 : i64
     vm.return
   }


### PR DESCRIPTION
Fixes the lit tests as `emitc.const` was renamed to `emitc.constant` in
upstream.