### PR TITLE
Support calls to internal function in EmitC

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -22,6 +22,16 @@ namespace iree_compiler {
 
 namespace {
 
+// TODO(simon-camp): This is duplicated in the CModuleTarget.
+static std::string buildFunctionName(IREE::VM::ModuleOp &moduleOp,
+                                     IREE::VM::FuncOp &funcOp,
+                                     bool implSuffix) {
+  std::string functionName =
+      std::string(moduleOp.getName()) + "_" + std::string(funcOp.getName());
+
+  return implSuffix ? functionName + "_impl" : functionName;
+}
+
 template <typename SrcOpTy>
 Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
                                             SrcOpTy srcOp, Type elementType) {
@@ -79,7 +89,8 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
 
 /// Generate two calls which resemble the IREE_RETURN_IF_ERROR macro. We need
 /// to split it here becasue we cannot produce a macro invocation with a
-/// function call as argument in emitc.
+/// function call as argument in emitc. Locally allocated refs will be released
+/// before the return.
 emitc::CallOp failableCall(ConversionPatternRewriter &rewriter, Location loc,
                            StringAttr callee, ArrayAttr args,
                            ArrayAttr templateArgs, ArrayRef<Value> operands) {
@@ -103,6 +114,33 @@ emitc::CallOp failableCall(ConversionPatternRewriter &rewriter, Location loc,
       /*templateArgs=*/ArrayAttr{},
       /*operands=*/ArrayRef<Value>{callOp.getResult(0)});
   return callOp;
+}
+
+// TODO(simon-camp/marbre): Use this function throughout the conversions.
+Optional<std::string> getCType(Type type) {
+  if (auto iType = type.dyn_cast<IntegerType>()) {
+    switch (iType.getWidth()) {
+      case 32:
+      case 64:
+        return std::string("int") + std::to_string(iType.getWidth()) +
+               std::string("_t");
+    }
+  }
+
+  if (auto fType = type.dyn_cast<FloatType>()) {
+    switch (fType.getWidth()) {
+      case 32:
+        return std::string("float");
+      case 64:
+        return std::string("double");
+    }
+  }
+
+  if (auto oType = type.dyn_cast<emitc::OpaqueType>()) {
+    return std::string(oType.getValue());
+  }
+
+  return None;
 }
 
 SmallVector<Attribute, 4> indexSequence(int64_t n, MLIRContext *ctx) {
@@ -171,6 +209,102 @@ class CallOpConversion : public OpConversionPattern<SrcOpTy> {
   StringRef funcName;
 };
 
+class VMCallOpConversion : public OpConversionPattern<IREE::VM::CallOp> {
+  using OpConversionPattern<IREE::VM::CallOp>::OpConversionPattern;
+
+ private:
+  LogicalResult matchAndRewrite(
+      IREE::VM::CallOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto ctx = op.getContext();
+    auto loc = op.getLoc();
+
+    auto funcOp =
+        lookupSymbolRef<IREE::VM::CallOp, IREE::VM::FuncOp>(op, "callee");
+
+    if (!funcOp) {
+      return op.emitError() << "only calls to internal functions are supported";
+    }
+
+    if (op.getNumResults() > 1) {
+      return op.emitError()
+             << "only internal calls with exactly one result supported for now";
+    }
+
+    auto moduleOp =
+        funcOp.getOperation()->getParentOfType<IREE::VM::ModuleOp>();
+
+    std::string internalFuncName =
+        buildFunctionName(moduleOp, funcOp, /*implSuffix=*/true);
+
+    SmallVector<Value, 4> updatedOperands(operands.begin(), operands.end());
+
+    if (op.getNumResults() == 0) {
+      SmallVector<Attribute, 4> args_ =
+          indexSequence(updatedOperands.size(), ctx);
+
+      args_.push_back(emitc::OpaqueAttr::get(ctx, "state"));
+
+      ArrayAttr args = rewriter.getArrayAttr(args_);
+
+      auto callOp = failableCall(
+          /*rewriter=*/rewriter,
+          /*location=*/loc,
+          /*callee=*/StringAttr::get(ctx, internalFuncName),
+          /*args=*/args,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/updatedOperands);
+
+      rewriter.eraseOp(op);
+
+      return success();
+    }
+
+    Type resultType = op.getType(0);
+    Optional<std::string> cType = getCType(resultType);
+
+    if (!cType.hasValue()) {
+      return op.emitError() << "unable to emit C type";
+    }
+
+    if (op.getNumResults() == 1) {
+      std::string cPtrType = cType.getValue() + std::string("*");
+
+      auto constantOp = rewriter.replaceOpWithNewOp<emitc::ConstantOp>(
+          /*op=*/op,
+          /*resultType=*/resultType,
+          /*value=*/emitc::OpaqueAttr::get(ctx, ""));
+
+      auto ptrOp = rewriter.create<emitc::ApplyOp>(
+          /*location=*/loc,
+          /*result=*/emitc::OpaqueType::get(ctx, cPtrType),
+          /*applicableOperator=*/StringAttr::get(ctx, "&"),
+          /*operand=*/constantOp.getResult());
+
+      updatedOperands.push_back(ptrOp.getResult());
+
+      SmallVector<Attribute, 4> args_ =
+          indexSequence(updatedOperands.size(), ctx);
+
+      args_.push_back(emitc::OpaqueAttr::get(ctx, "state"));
+
+      ArrayAttr args = rewriter.getArrayAttr(args_);
+
+      auto callOp = failableCall(
+          /*rewriter=*/rewriter,
+          /*location=*/loc,
+          /*callee=*/StringAttr::get(ctx, internalFuncName),
+          /*args=*/args,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/updatedOperands);
+
+      return success();
+    }
+
+    return failure();
+  }
+};
+
 template <typename CmpOpTy>
 class CompareRefOpConversion : public OpConversionPattern<CmpOpTy> {
  public:
@@ -212,7 +346,7 @@ class CompareRefOpConversion : public OpConversionPattern<CmpOpTy> {
 
     if (moveLhs) {
       rewriter.create<emitc::CallOp>(
-          /*loc=*/loc,
+          /*location=*/loc,
           /*type=*/TypeRange{},
           /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
           /*args=*/ArrayAttr{},
@@ -223,7 +357,7 @@ class CompareRefOpConversion : public OpConversionPattern<CmpOpTy> {
     // NOTE: If lhs and rhs alias we call release twice on the same argument.
     if (moveRhs) {
       rewriter.create<emitc::CallOp>(
-          /*loc=*/loc,
+          /*location=*/loc,
           /*type=*/TypeRange{},
           /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
           /*args=*/ArrayAttr{},
@@ -275,7 +409,7 @@ class CompareRefNotZeroOpConversion
 
     if (move) {
       rewriter.create<emitc::CallOp>(
-          /*loc=*/loc,
+          /*location=*/loc,
           /*type=*/TypeRange{},
           /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
           /*args=*/ArrayAttr{},
@@ -363,7 +497,7 @@ class ConstRefZeroOpConversion
         /*operands=*/ArrayRef<Value>{});
 
     rewriter.create<emitc::CallOp>(
-        /*loc=*/loc,
+        /*location=*/loc,
         /*type=*/TypeRange{},
         /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
         /*args=*/ArrayAttr{},
@@ -449,7 +583,7 @@ class ConstRefRodataOpConversion
 
     failableCall(
         /*rewriter=*/rewriter,
-        /*loc=*/loc,
+        /*location=*/loc,
         /*callee=*/StringAttr::get(ctx, "iree_vm_ref_wrap_retain"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -613,7 +747,7 @@ class ListOpConversion : public OpConversionPattern<SrcOpTy> {
     if (failable) {
       auto callOp = failableCall(
           /*rewriter=*/rewriter,
-          /*loc=*/loc,
+          /*location=*/loc,
           /*callee=*/StringAttr::get(ctx, funcName),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -918,7 +1052,7 @@ class ListGetRefOpConversion
 
     failableCall(
         /*rewriter=*/rewriter,
-        /*loc=*/loc,
+        /*location=*/loc,
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_get_ref_retain"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -1014,7 +1148,7 @@ class ListSetOpConversion : public OpConversionPattern<SetOpTy> {
 
     auto callOp = failableCall(
         /*rewriter=*/rewriter,
-        /*loc=*/loc,
+        /*location=*/loc,
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_set_value"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -1080,7 +1214,7 @@ class ListSetRefOpConversion
 
     auto callOp = failableCall(
         /*rewriter=*/rewriter,
-        /*loc=*/loc,
+        /*location=*/loc,
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_set_ref_retain"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -1101,6 +1235,8 @@ void populateVMToEmitCPatterns(MLIRContext *context,
                                OwningRewritePatternList &patterns,
                                VMAnalysisCache &vmAnalysisCache) {
   populatePreserveCompilerHintsPatterns(context, patterns);
+  // Calls
+  patterns.insert<VMCallOpConversion>(context);
 
   // Globals
   patterns.insert<
@@ -1359,11 +1495,10 @@ class ConvertVMToEmitCPass
 
     // Control flow ops
     target.addLegalOp<IREE::VM::BranchOp>();
-    target.addLegalOp<IREE::VM::CallOp>();
     target.addLegalOp<IREE::VM::CondBranchOp>();
     // Note: We translate the fail op to two function calls in the
     // end, but we can't simply convert it here because it is a
-    // terminator.
+    // terminator and an EmitC call is not.
     target.addLegalOp<IREE::VM::FailOp>();
     target.addLegalOp<IREE::VM::ReturnOp>();
 

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -137,7 +137,7 @@ static LogicalResult printFuncOpArguments(IREE::VM::FuncOp &funcOp,
       });
 }
 
-// Function results get propagated through pointer arguments
+/// Function results get propagated through pointer arguments
 static LogicalResult printFuncOpResults(
     IREE::VM::FuncOp &funcOp, mlir::emitc::CppEmitter &emitter,
     SmallVector<std::string, 4> &resultNames) {
@@ -212,11 +212,6 @@ static LogicalResult translateBranchOp(IREE::VM::BranchOp branchOp,
     return branchOp.emitOpError() << "Unable to find label for successor block";
   }
   output << emitter.getOrCreateName(successor) << ";\n";
-  return success();
-}
-
-static LogicalResult translateCallOpToC(IREE::VM::CallOp callOp,
-                                        mlir::emitc::CppEmitter &emitter) {
   return success();
 }
 
@@ -309,8 +304,6 @@ static LogicalResult translateOpToC(Operation &op,
                                     bool hasRefs) {
   if (auto branchOp = dyn_cast<IREE::VM::BranchOp>(op))
     return translateBranchOp(branchOp, emitter);
-  if (auto callOp = dyn_cast<IREE::VM::CallOp>(op))
-    return translateCallOpToC(callOp, emitter);
   if (auto condBranchOp = dyn_cast<IREE::VM::CondBranchOp>(op))
     return translateCondBranchOp(condBranchOp, emitter);
   if (auto failOp = dyn_cast<IREE::VM::FailOp>(op))
@@ -327,7 +320,8 @@ static LogicalResult translateOpToC(Operation &op,
 
 static LogicalResult translateFunctionToC(IREE::VM::ModuleOp &moduleOp,
                                           IREE::VM::FuncOp &funcOp,
-                                          mlir::emitc::CppEmitter &emitter) {
+                                          mlir::emitc::CppEmitter &emitter,
+                                          bool declareOnly) {
   std::string moduleName = moduleOp.getName().str();
   emitc::CppEmitter::Scope scope(emitter);
   llvm::raw_ostream &output = emitter.ostream();
@@ -336,7 +330,7 @@ static LogicalResult translateFunctionToC(IREE::VM::ModuleOp &moduleOp,
   std::string functionName =
       buildFunctionName(moduleOp, funcOp, /*implSuffix=*/true);
 
-  output << "iree_status_t " << functionName << "(";
+  output << "static iree_status_t " << functionName << "(";
 
   if (failed(printFuncOpArguments(funcOp, emitter))) {
     return failure();
@@ -362,7 +356,13 @@ static LogicalResult translateFunctionToC(IREE::VM::ModuleOp &moduleOp,
 
   // TODO(simon-camp): We can't represent structs in emitc (yet maybe), so the
   // struct argument name here must not be changed.
-  output << moduleName << "_state_t* state) {\n";
+  output << moduleName << "_state_t* state)";
+
+  if (declareOnly) {
+    output << ";\n";
+    return success();
+  }
+  output << " {\n";
 
   // We forward declare all result variables except for the ones with RefType.
   output << "// VARIABLE DECLARATIONS\n";
@@ -406,11 +406,21 @@ static LogicalResult translateFunctionToC(IREE::VM::ModuleOp &moduleOp,
   // We reuse the register allocation pass and emit an array for all Values with
   // ref type instead of generating one variable per Value. This makes the
   // deallocation process easier for us.
+
   RegisterAllocation registerAllocation;
   if (failed(registerAllocation.recalculate(funcOp))) {
     return funcOp.emitOpError() << "unable to perform register allocation";
   }
 
+  // TODO(simon-camp): We sometimes get a to high number of refs used. This may
+  // be because the IR is in a mixed state of VM and EmitC dialect and the
+  // RegisterAllocation pass doesn't handle the 'emitc.opaque' type correctly.
+  // We could either
+  //  - annotate the function with correct number of refs in the
+  //    conversion or
+  //  - define the array in the conversion (which would need to be
+  //    done through a macro at the moment because array types are not handled
+  //    by EmitC).
   const size_t numRefs = registerAllocation.getMaxRefRegisterOrdinal() + 1;
   const bool hasRefs = numRefs > 0;
 
@@ -463,7 +473,7 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
       return failure();
     }
 
-    if (funcOp.getNumArguments() > 0) {
+    if (funcOp.getNumResults() > 0) {
       output << ", ";
     }
 
@@ -488,18 +498,14 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
       argNames.push_back(argName);
     }
 
+    for (std::string &resultName : resultNames) {
+      argNames.push_back(resultName);
+    }
+
+    argNames.push_back("state");
+
     output << llvm::join(argNames, ", ");
-
-    if (funcOp.getNumResults() > 0) {
-      output << ", ";
-    }
-
-    output << llvm::join(resultNames, ", ");
-
-    if (funcOp.getNumArguments() + funcOp.getNumResults() > 0) {
-      output << ", ";
-    }
-    output << "state);\n}\n";
+    output << ");\n}\n";
   }
 
   auto printCStringView = [](std::string s) -> std::string {
@@ -559,16 +565,13 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
   output << "static const iree_vm_native_function_ptr_t " << functionName
          << "[] = {\n";
 
-  // sort func ops
-  SmallVector<IREE::VM::FuncOp, 4> funcOps(moduleOp.getOps<IREE::VM::FuncOp>());
-  llvm::sort(funcOps, [&moduleOp](auto &lhs, auto &rhs) {
-    std::string lhsStr =
-        buildFunctionName(moduleOp, lhs, /*implSufffix=*/false);
-    std::string rhsStr =
-        buildFunctionName(moduleOp, rhs, /*implSufffix=*/false);
-    return lhsStr.compare(rhsStr) < 0;
-  });
-  for (auto funcOp : funcOps) {
+  // We only add exported functions to the table, as calls to internal functions
+  // are directly mapped to C function calls of the generated implementation.
+  for (auto exportOp : exportOps) {
+    auto funcOp = symbolTable.lookup<IREE::VM::FuncOp>(exportOp.function_ref());
+    if (!funcOp) {
+      return exportOp.emitError("Couldn't find referenced FuncOp");
+    }
     output << "{"
            << "(iree_vm_native_function_shim_t)";
 
@@ -653,7 +656,7 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
   return success();
 }
 
-// Adapted from BytecodeModuleTarget and extended by C specific passes
+/// Adapted from BytecodeModuleTarget and extended by C specific passes
 static LogicalResult canonicalizeModule(
     IREE::VM::ModuleOp moduleOp, IREE::VM::CTargetOptions targetOptions) {
   OwningRewritePatternList patterns(moduleOp.getContext());
@@ -763,9 +766,24 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
     return failure();
   }
 
+  output << "// DECLARE FUNCTIONS\n";
+
+  // forward declare functions
+  for (auto funcOp : moduleOp.getOps<IREE::VM::FuncOp>()) {
+    if (failed(translateFunctionToC(moduleOp, funcOp, emitter,
+                                    /*declareOnly=*/true))) {
+      return failure();
+    }
+
+    output << "\n";
+  }
+
+  output << "// DEFINE FUNCTIONS\n";
+
   // translate functions
   for (auto funcOp : moduleOp.getOps<IREE::VM::FuncOp>()) {
-    if (failed(translateFunctionToC(moduleOp, funcOp, emitter))) {
+    if (failed(translateFunctionToC(moduleOp, funcOp, emitter,
+                                    /*declareOnly=*/false))) {
       return failure();
     }
 

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -413,10 +413,10 @@ static LogicalResult translateFunctionToC(IREE::VM::ModuleOp &moduleOp,
   }
 
   // TODO(simon-camp): We sometimes get a to high number of refs used. This may
-  // be because the IR is in a mixed state of VM and EmitC dialect and the
-  // RegisterAllocation pass doesn't handle the 'emitc.opaque' type correctly.
+  // be because the IR is in a mixed state of VM and EmitC dialects and the
+  // register allocation pass doesn't handle the 'emitc.opaque' type correctly.
   // We could either
-  //  - annotate the function with correct number of refs in the
+  //  - annotate the function with the correct number of refs in the
   //    conversion or
   //  - define the array in the conversion (which would need to be
   //    done through a macro at the moment because array types are not handled

--- a/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
@@ -2,7 +2,7 @@
 
 // CHECK: #include "iree/vm/ops.h"
 vm.module @calling_convention_test {
-  // CHECK: iree_status_t calling_convention_test_no_in_no_return_impl(calling_convention_test_state_t* state) {
+  // CHECK: static iree_status_t calling_convention_test_no_in_no_return_impl(calling_convention_test_state_t* state) {
   vm.func @no_in_no_return() -> () {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS
@@ -12,7 +12,7 @@ vm.module @calling_convention_test {
     vm.return
   }
 
-  // CHECK: iree_status_t calling_convention_test_i32_in_no_return_impl(int32_t v1, calling_convention_test_state_t* state) {
+  // CHECK: static iree_status_t calling_convention_test_i32_in_no_return_impl(int32_t v1, calling_convention_test_state_t* state) {
   vm.func @i32_in_no_return(%arg0 : i32) -> () {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS
@@ -22,7 +22,7 @@ vm.module @calling_convention_test {
     vm.return
   }
 
-  // CHECK: iree_status_t calling_convention_test_no_in_i32_return_impl(int32_t *out0, calling_convention_test_state_t* state) {
+  // CHECK: static iree_status_t calling_convention_test_no_in_i32_return_impl(int32_t *out0, calling_convention_test_state_t* state) {
   vm.func @no_in_i32_return() -> (i32) {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS
@@ -36,7 +36,7 @@ vm.module @calling_convention_test {
     vm.return %0 : i32
   }
 
-  // CHECK: iree_status_t calling_convention_test_i32_in_i32_return_impl(int32_t v1, int32_t *out0, calling_convention_test_state_t* state) {
+  // CHECK: static iree_status_t calling_convention_test_i32_in_i32_return_impl(int32_t v1, int32_t *out0, calling_convention_test_state_t* state) {
   vm.func @i32_in_i32_return(%arg0 : i32) -> (i32) {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS

--- a/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
@@ -15,7 +15,7 @@ vm.module @control_flow_module {
     vm.return %0 : i32
   }
 }
-// CHECK: iree_status_t control_flow_module_control_flow_test_impl(int32_t [[A:[^ ]*]], int32_t [[COND:[^ ]*]], int32_t *[[RESULT:[^ ]*]], control_flow_module_state_t* [[STATE:[^ ]*]]) {
+// CHECK: static iree_status_t control_flow_module_control_flow_test_impl(int32_t [[A:[^ ]*]], int32_t [[COND:[^ ]*]], int32_t *[[RESULT:[^ ]*]], control_flow_module_state_t* [[STATE:[^ ]*]]) {
   // CHECK-NEXT: VARIABLE DECLARATIONS
   // CHECK-NEXT: RESULTS
   // CHECK-NEXT: int32_t [[B:[^ ]*]];

--- a/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
@@ -12,8 +12,11 @@ vm.module @global_ops {
   vm.global.i32 @c42 42 : i32
   vm.global.i32 @c107_mut mutable 107 : i32
 
+  // Skip forward declarations
+  // CHECK: DEFINE FUNCTIONS
+
   vm.export @test_global_load_i32
-  // CHECK-LABEL: iree_status_t global_ops_test_global_load_i32_impl(
+  // CHECK: static iree_status_t global_ops_test_global_load_i32_impl(
   vm.func @test_global_load_i32() -> i32 {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS
@@ -26,7 +29,7 @@ vm.module @global_ops {
   }
 
   vm.export @test_global_store_i32
-  // CHECK-LABEL: iree_status_t global_ops_test_global_store_i32_impl(
+  // CHECK: static iree_status_t global_ops_test_global_store_i32_impl(
   vm.func @test_global_store_i32() -> i32 {
     // CHECK-NEXT: VARIABLE DECLARATIONS
     // CHECK-NEXT: RESULTS
@@ -44,7 +47,7 @@ vm.module @global_ops {
   }
 
   // check state initialization inside the alloc_state function
-  // CHECK-LABEL: static iree_status_t global_ops_alloc_state(
+  // CHECK: static iree_status_t global_ops_alloc_state(
   // CHECK: vm_global_store_i32(state->rwdata, 0, 42);
   // CHECK-NEXT: vm_global_store_i32(state->rwdata, 4, 107);
 }

--- a/iree/samples/emitc_modules/CMakeLists.txt
+++ b/iree/samples/emitc_modules/CMakeLists.txt
@@ -19,6 +19,7 @@ if(${IREE_ENABLE_EMITC})
       add_module_test
     SRCS
       "add_module_test.cc"
+      "add_module.h"
     DEPS
       ::add_module
       iree::base

--- a/iree/samples/emitc_modules/add.mlir
+++ b/iree/samples/emitc_modules/add.mlir
@@ -1,16 +1,15 @@
 vm.module @add_module {
-  vm.func @add(%arg0 : i32, %arg1 : i32) -> i32 {
+  vm.func @add_and_double(%arg0 : i32, %arg1 : i32) -> i32 attributes {noinline} {
     %0 = vm.add.i32 %arg0, %arg1 : i32
     %1 = vm.add.i32 %0, %0 : i32
     vm.return %1 : i32
   }
-  vm.export @add
+  vm.export @add_and_double
 
-  vm.func @add_call(%arg0: i32) -> i32 {
-    %0 = vm.call @add(%arg0, %arg0) : (i32, i32) -> i32
-    // TODO(simon-camp): use %0 as arguments when the call operation is properly implemented
-    %1 = vm.add.i32 %arg0, %arg0 : i32
+  vm.func @test_call(%arg0: i32) -> i32 {
+    %0 = vm.call @add_and_double(%arg0, %arg0) : (i32, i32) -> i32
+    %1 = vm.add.i32 %0, %0 : i32
     vm.return %1 : i32
   }
-  vm.export @add_call
+  vm.export @test_call
 }

--- a/iree/samples/emitc_modules/add_module_test.cc
+++ b/iree/samples/emitc_modules/add_module_test.cc
@@ -112,15 +112,16 @@ class VMAddModuleTest : public ::testing::Test {
 
 TEST_F(VMAddModuleTest, AddTest) {
   IREE_ASSERT_OK_AND_ASSIGN(
-      int32_t v, RunFunction(iree_make_cstring_view("add_module.add"), 17, 42));
+      int32_t v,
+      RunFunction(iree_make_cstring_view("add_module.add_and_double"), 17, 42));
   ASSERT_EQ(v, 118);
 }
 
 TEST_F(VMAddModuleTest, AddCallTest) {
   IREE_ASSERT_OK_AND_ASSIGN(
       int32_t v,
-      RunFunction(iree_make_cstring_view("add_module.add_call"), 17));
-  ASSERT_EQ(v, 34);
+      RunFunction(iree_make_cstring_view("add_module.test_call"), 17));
+  ASSERT_EQ(v, 136);
 }
 
 }  // namespace

--- a/iree/vm/shims_emitc.h
+++ b/iree/vm/shims_emitc.h
@@ -25,6 +25,24 @@ static iree_status_t call_0v_v_shim(iree_vm_stack_t* stack,
   return target_fn(stack, module, module_state);
 }
 
+// 0v_i
+typedef iree_status_t (*call_0v_i_t)(iree_vm_stack_t* stack, void* module_ptr,
+                                     void* module_state, int32_t* res0);
+
+static iree_status_t call_0v_i_shim(iree_vm_stack_t* stack,
+                                    const iree_vm_function_call_t* call,
+                                    call_0v_i_t target_fn, void* module,
+                                    void* module_state,
+                                    iree_vm_execution_result_t* out_result) {
+  typedef struct {
+    int32_t ret0;
+  } results_t;
+
+  results_t* results = (results_t*)call->results.data;
+
+  return target_fn(stack, module, module_state, &results->ret0);
+}
+
 // 0i_i
 typedef iree_status_t (*call_0i_i_t)(iree_vm_stack_t* stack, void* module_ptr,
                                      void* module_state, int32_t arg0,

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -33,6 +33,7 @@ c_embed_data(
         ":assignment_ops_f32.vmfb",
         ":assignment_ops_i64.vmfb",
         ":buffer_ops.vmfb",
+        ":call_ops.vmfb",
         ":comparison_ops.vmfb",
         ":comparison_ops_f32.vmfb",
         ":comparison_ops_i64.vmfb",
@@ -93,6 +94,12 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "buffer_ops",
     src = "buffer_ops.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "call_ops",
+    src = "call_ops.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_c_embed_data(
     "assignment_ops_f32.vmfb"
     "assignment_ops_i64.vmfb"
     "buffer_ops.vmfb"
+    "call_ops.vmfb"
     "comparison_ops.vmfb"
     "comparison_ops_f32.vmfb"
     "comparison_ops_i64.vmfb"
@@ -113,6 +114,16 @@ iree_bytecode_module(
     buffer_ops
   SRC
     "buffer_ops.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    call_ops
+  SRC
+    "call_ops.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -30,8 +30,8 @@ vm.module @call_ops {
   }
 
   vm.func @_v_i() -> i32 attributes {noinline} {
-      %c1 = vm.const.i32 1 : i32
-      vm.return %c1 : i32
+    %c1 = vm.const.i32 1 : i32
+    vm.return %c1 : i32
   }
 
 }

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -1,0 +1,37 @@
+vm.module @call_ops {
+
+  vm.export @test_call_void
+  vm.func @test_call_void() {
+    vm.call @_v_v() : () -> ()
+    vm.return
+  }
+
+  vm.export @fail_call_void
+  vm.func @fail_call_void() {
+    vm.call @_v_v_fail() : () -> ()
+    vm.return
+  }
+
+  vm.export @test_call_i32
+  vm.func @test_call_i32() {
+    %c1 = vm.const.i32 1 : i32
+    %0 = vm.call @_v_i() : () -> (i32)
+    vm.check.eq %0, %c1, "_v_i()=1" : i32
+    vm.return
+  }
+
+  vm.func @_v_v() attributes {noinline} {
+    vm.return
+  }
+
+  vm.func @_v_v_fail() attributes {noinline} {
+    %c2 = vm.const.i32 2 : i32
+    vm.fail %c2
+  }
+
+  vm.func @_v_i() -> i32 attributes {noinline} {
+      %c1 = vm.const.i32 1 : i32
+      vm.return %c1 : i32
+  }
+
+}

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_test(
     ::arithmetic_ops_i64
     # ::assignment_ops
     ::assignment_ops_i64
+    ::call_ops
     ::comparison_ops
     ::comparison_ops_f32
     ::comparison_ops_i64
@@ -85,6 +86,15 @@ iree_c_module(
     "../assignment_ops_i64.mlir"
   H_FILE_OUTPUT
     "assignment_ops_i64.h"
+)
+
+iree_c_module(
+  NAME
+    call_ops
+  SRC
+    "../call_ops.mlir"
+  H_FILE_OUTPUT
+    "call_ops.h"
 )
 
 iree_c_module(

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -15,6 +15,7 @@
 #include "iree/vm/test/emitc/arithmetic_ops_i64.h"
 // #include "iree/vm/test/emitc/assignment_ops.h"
 #include "iree/vm/test/emitc/assignment_ops_i64.h"
+#include "iree/vm/test/emitc/call_ops.h"
 #include "iree/vm/test/emitc/comparison_ops.h"
 #include "iree/vm/test/emitc/comparison_ops_f32.h"
 #include "iree/vm/test/emitc/comparison_ops_i64.h"
@@ -59,6 +60,7 @@ std::vector<TestParams> GetModuleTestParams() {
       {arithmetic_ops_i64_descriptor_, arithmetic_ops_i64_create},
       // {assignment_ops_descriptor_, assignment_ops_create},
       {assignment_ops_i64_descriptor_, assignment_ops_i64_create},
+      {call_ops_descriptor_, call_ops_create},
       {comparison_ops_descriptor_, comparison_ops_create},
       {comparison_ops_f32_descriptor_, comparison_ops_f32_create},
       {comparison_ops_i64_descriptor_, comparison_ops_i64_create},


### PR DESCRIPTION
This adds support for internal function calls in the CModuleTarget.

* This only supports function with zero or one integer results for now.

Co-authored-by: Marius Brehler <marius.brehler@iml.fraunhofer.de>