### PR TITLE
Allow an implicit cast from buffer_view to buffer on variable store.

### DIFF
--- a/integrations/tensorflow/e2e/resource_ops_test.py
+++ b/integrations/tensorflow/e2e/resource_ops_test.py
@@ -20,6 +20,14 @@ class ResourcesOpsModule(tf.Module):
   def add_assign(self, value):
     return self.counter.assign_add(value)
 
+  @tf.function(input_signature=[tf.TensorSpec([], tf.float32)])
+  def set_value(self, new_value):
+    self.counter.assign(new_value)
+
+  @tf.function(input_signature=[])
+  def get_value(self):
+    return self.counter
+
 
 class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
 
@@ -33,6 +41,14 @@ class ResourcesOpsTest(tf_test_utils.TracedModuleTestCase):
       module.add_assign(np.array(9., dtype=np.float32))
 
     self.compare_backends(add_assign, self._modules)
+
+  def test_assign_get(self):
+
+    def assign_get(module):
+      module.set_value(np.array(9., dtype=np.float32))
+      return module.get_value()
+
+    self.compare_backends(assign_get, self._modules)
 
 
 def main(argv):

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/variable_ops.mlir
@@ -76,14 +76,17 @@ func @fn(%arg0: !hal.buffer_view) {
 }
 
 // -----
-// Checks that stores are only permitted on variables that dominate.
-func @fn(%arg0: !hal.buffer_view) {
+// Checks that stores are permitted for variables that do not dominate the
+// function containing a store.
+// CHECK-LABEL: func @store_var_out_of_order
+// CHECK: %[[buffer:.*]] = hal.buffer_view.buffer %arg0 : !hal.buffer
+// CHECK: hal.variable.store %[[buffer]], @var_out_of_order : !hal.buffer
+func @store_var_out_of_order(%arg0: !hal.buffer_view) {
   %0 = hal.tensor.cast %arg0 : !hal.buffer_view -> tensor<f32>
-  // expected-error @+1 {{failed to legalize operation 'flow.variable.store'}}
-  flow.variable.store %0, @var_with_buffer_view_store : tensor<f32>
+  flow.variable.store %0, @var_out_of_order : tensor<f32>
   return
 }
-flow.variable @var_with_buffer_view_store mutable dense<0.000000e+00> : tensor<f32>
+flow.variable @var_out_of_order mutable dense<0.000000e+00> : tensor<f32>
 
 // -----
 // Checks that the implicit cast allowing a buffer_view to indirect store into

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -314,7 +314,14 @@ SmallVector<int64_t, 4> TensorCastOp::getTiedResultOperandIndices() {
 // For example, this will return true if the variable type is a tensor<?xf32>
 // and the access is tensor<4xf32>.
 static bool isVariableTypeCompatible(Type variableType, Type accessType) {
-  return succeeded(mlir::verifyCompatibleShape(variableType, accessType));
+  // If one is a shaped type, then they both must be and have compatible
+  // shapes.
+  if (variableType.isa<ShapedType>() || accessType.isa<ShapedType>()) {
+    return succeeded(mlir::verifyCompatibleShape(variableType, accessType));
+  }
+
+  // Otherwise, the types must be the same.
+  return variableType == accessType;
 }
 
 static ParseResult parseVariableOp(OpAsmParser &parser,

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -209,7 +209,7 @@ def HAL_VariableLoadOp : HAL_Op<"variable.load", [
   let verifier = [{ return verifyVariableLoadOp(*this); }];
 }
 
-def FLOW_VariableLoadIndirectOp : HAL_Op<"variable.load.indirect"> {
+def HAL_VariableLoadIndirectOp : HAL_Op<"variable.load.indirect"> {
   let summary = [{loads a value from a global variable}];
   let description = [{
     Returns a copy of the variable value.

--- a/iree/compiler/Dialect/HAL/IR/test/BUILD
+++ b/iree/compiler/Dialect/HAL/IR/test/BUILD
@@ -33,6 +33,7 @@ iree_lit_test_suite(
             "executable_ops.mlir",
             "experimental_ops.mlir",
             "interface_ops.mlir",
+            "invalid.mlir",
             "semaphore_ops.mlir",
             "variable_folding.mlir",
             "variable_ops.mlir",

--- a/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "executable_ops.mlir"
     "experimental_ops.mlir"
     "interface_ops.mlir"
+    "invalid.mlir"
     "semaphore_ops.mlir"
     "variable_folding.mlir"
     "variable_ops.mlir"

--- a/iree/compiler/Dialect/HAL/IR/test/invalid.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/invalid.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt -split-input-file -verify-diagnostics %s
+
+hal.variable @var mutable : !hal.buffer
+func @fn(%arg0: !hal.buffer_view) {
+  // expected-error @+1 {{variable var is '!hal.buffer' but store is '!hal.buffer_view'}}
+  hal.variable.store %arg0, @var : !hal.buffer_view
+  return
+}
+
+// -----
+hal.variable @var mutable : !hal.buffer
+func @fn(%arg0: !hal.buffer_view) {
+  %0 = hal.variable.address @var_indirect_with_buffer_view_store : !iree.ptr<!hal.buffer>
+  // expected-error @+1 {{variable pointer is '!hal.buffer' but store is '!hal.buffer_view'}}
+  hal.variable.store.indirect %arg0, %0 : !hal.buffer_view -> !iree.ptr<!hal.buffer>
+  return
+}


### PR DESCRIPTION
* This shows up in simple programs that attempt to store the result of a buffer_view function arg (or result of a custom op) to a variable that has been materialized with the usual mechanics.