### PR TITLE
Properly using DATA to depend on lld.

### DIFF
--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -326,6 +326,7 @@ if(${IREE_BUILD_COMPILER})
       iree-translate
     DEPS
       ::iree_translate_main
+    DATA
       lld
     HOSTONLY
   )
@@ -335,6 +336,7 @@ if(${IREE_BUILD_COMPILER})
       iree-opt
     DEPS
       ::iree_opt_main
+    DATA
       lld
     HOSTONLY
   )
@@ -361,7 +363,6 @@ if(${IREE_BUILD_COMPILER})
     DEPS
       ::init_passes_and_dialects
       ::init_targets
-      lld
       LLVMSupport
       MLIRIR
       MLIRParser
@@ -385,6 +386,8 @@ if(${IREE_BUILD_COMPILER})
       iree::vm
       iree::vm::bytecode_module
       iree::vm::cc
+    DATA
+      lld
     HOSTONLY
   )
 


### PR DESCRIPTION
cmake on windows does not like executables in target link libraries (as
it shouldn't anywhere, but apparently it only checks on windows...).