### PR TITLE
Removing use of absl from iree/.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -27,10 +27,7 @@ iree_pyext_module(
     iree::modules::hal
     iree::vm
     iree::vm::bytecode_module
-    absl::inlined_vector
-    absl::strings
     absl::optional
-    absl::span
 )
 
 iree_py_library(

--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -6,7 +6,6 @@
 
 #include "bindings/python/iree/runtime/hal.h"
 
-#include "absl/container/inlined_vector.h"
 #include "iree/hal/api.h"
 
 namespace iree {

--- a/bindings/python/iree/runtime/hal.h
+++ b/bindings/python/iree/runtime/hal.h
@@ -7,7 +7,8 @@
 #ifndef IREE_BINDINGS_PYTHON_IREE_RT_HAL_H_
 #define IREE_BINDINGS_PYTHON_IREE_RT_HAL_H_
 
-#include "absl/container/inlined_vector.h"
+#include <vector>
+
 #include "bindings/python/iree/runtime/binding.h"
 #include "bindings/python/iree/runtime/status_utils.h"
 #include "iree/hal/api.h"
@@ -74,7 +75,7 @@ struct HalShape {
     return s;
   }
 
-  absl::InlinedVector<int32_t, 6> s;
+  std::vector<int32_t> s;
 };
 
 class HalBufferView
@@ -140,18 +141,18 @@ class HalMappedMemory {
   }
 
   py::buffer_info ToBufferInfo() {
-    absl::InlinedVector<int32_t, 6> shape(iree_hal_buffer_view_shape_rank(bv_));
+    std::vector<int32_t> shape(iree_hal_buffer_view_shape_rank(bv_));
     CheckApiStatus(
         iree_hal_buffer_view_shape(bv_, shape.size(), shape.data(), nullptr),
         "Error getting buffer view shape");
     iree_hal_element_type_t element_type =
         iree_hal_buffer_view_element_type(bv_);
     int32_t element_size = iree_hal_element_byte_count(element_type);
-    absl::InlinedVector<py::ssize_t, 6> dims(shape.size());
+    std::vector<py::ssize_t> dims(shape.size());
     for (int i = 0; i < shape.size(); ++i) {
       dims[i] = shape[i];
     }
-    absl::InlinedVector<py::ssize_t, 8> strides(shape.size());
+    std::vector<py::ssize_t> strides(shape.size());
     if (!strides.empty()) {
       strides[shape.size() - 1] = element_size;
       for (int i = shape.size() - 2; i >= 0; --i) {

--- a/bindings/python/iree/runtime/status_utils.cc
+++ b/bindings/python/iree/runtime/status_utils.cc
@@ -6,8 +6,6 @@
 
 #include "bindings/python/iree/runtime/status_utils.h"
 
-#include "absl/strings/str_cat.h"
-
 namespace iree {
 namespace python {
 
@@ -36,12 +34,12 @@ pybind11::error_already_set ApiStatusToPyExc(iree_status_t status,
   char* iree_message;
   size_t iree_message_length;
   if (iree_status_to_string(status, &iree_message, &iree_message_length)) {
-    full_message = absl::StrCat(
-        message, ": ", absl::string_view(iree_message, iree_message_length));
+    full_message = std::string(message) + ": " +
+                   std::string(iree_message, iree_message_length);
     iree_allocator_free(iree_allocator_system(), iree_message);
   } else {
-    full_message = absl::StrCat(
-        message, ": ", iree_status_code_string(iree_status_code(status)));
+    full_message = std::string(message) + ": " +
+                   iree_status_code_string(iree_status_code(status));
   }
 
   PyErr_SetString(ApiStatusToPyExcClass(status), full_message.c_str());

--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -6,8 +6,6 @@
 
 #include "bindings/python/iree/runtime/vm.h"
 
-#include "absl/strings/str_cat.h"
-#include "absl/strings/str_join.h"
 #include "absl/types/optional.h"
 #include "bindings/python/iree/runtime/status_utils.h"
 #include "iree/base/api.h"
@@ -86,7 +84,7 @@ VmContext VmContext::Create(VmInstance* instance,
     CheckApiStatus(status, "Error creating vm context");
   } else {
     // Closed set of modules.
-    absl::InlinedVector<iree_vm_module_t*, 8> module_handles;
+    std::vector<iree_vm_module_t*> module_handles;
     module_handles.resize(modules->size());
     for (size_t i = 0, e = module_handles.size(); i < e; ++i) {
       module_handles[i] = (*modules)[i]->raw_ptr();
@@ -102,7 +100,7 @@ VmContext VmContext::Create(VmInstance* instance,
 }
 
 void VmContext::RegisterModules(std::vector<VmModule*> modules) {
-  absl::InlinedVector<iree_vm_module_t*, 8> module_handles;
+  std::vector<iree_vm_module_t*> module_handles;
   module_handles.resize(modules.size());
   for (size_t i = 0, e = module_handles.size(); i < e; ++i) {
     module_handles[i] = modules[i]->raw_ptr();
@@ -392,6 +390,20 @@ py::object VmVariantList::GetAsNdarray(int index) {
 
 namespace {
 
+static std::string ToHexString(const uint8_t* data, size_t length) {
+  static constexpr char kHexChars[] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                       '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  std::string s(length * 2, ' ');
+  for (size_t i = 0; i < length; ++i) {
+    s[2 * i + 0] = kHexChars[(data[i] & 0xF0) >> 4];
+    s[2 * i + 1] = kHexChars[(data[i] & 0x0F) >> 0];
+  }
+  return s;
+}
+static std::string ToHexString(uint32_t value) {
+  return ToHexString((const uint8_t*)&value, sizeof(value));
+}
+
 void AppendListContents(std::string& out, iree_vm_list_t* list,
                         std::unordered_set<iree_vm_list_t*>& visited) {
   for (iree_host_size_t i = 0, e = iree_vm_list_size(list); i < e; ++i) {
@@ -405,24 +417,27 @@ void AppendListContents(std::string& out, iree_vm_list_t* list,
     if (i > 0) out.append(", ");
 
     if (iree_vm_variant_is_value(variant)) {
-      absl::StrAppend(&out, variant.i32);
+      out += std::to_string(variant.i32);
     } else if (iree_vm_variant_is_ref(variant)) {
       // Pretty print a subset of ABI impacting known types.
       if (iree_hal_buffer_isa(variant.ref)) {
         auto* hal_buffer = iree_hal_buffer_deref(variant.ref);
         assert(hal_buffer);
-        absl::StrAppend(&out, "HalBuffer(",
-                        iree_hal_buffer_byte_length(hal_buffer), ")");
+        out += std::string("HalBuffer(") +
+               std::to_string(iree_hal_buffer_byte_length(hal_buffer)) + ")";
       } else if (iree_hal_buffer_view_isa(variant.ref)) {
         auto hal_bv = iree_hal_buffer_view_deref(variant.ref);
-        absl::StrAppend(&out, "HalBufferView(");
-        absl::InlinedVector<int32_t, 5> shape(
-            iree_hal_buffer_view_shape_rank(hal_bv));
+        out += "HalBufferView(";
+        std::vector<int32_t> shape(iree_hal_buffer_view_shape_rank(hal_bv));
         iree_hal_buffer_view_shape(hal_bv, shape.size(), shape.data(), nullptr);
-        absl::StrAppend(&out, absl::StrJoin(shape, "x"), ":0x",
-                        absl::Hex(static_cast<uint32_t>(
-                            iree_hal_buffer_view_element_type(hal_bv))),
-                        ")");
+        for (size_t i = 0; i < shape.size(); ++i) {
+          if (i > 0) out += 'x';
+          out += std::to_string(shape[i]);
+        }
+        out += ":0x" +
+               ToHexString(static_cast<uint32_t>(
+                   iree_hal_buffer_view_element_type(hal_bv))) +
+               ")";
       } else if (iree_vm_list_isa(variant.ref)) {
         out.append("List[");
         iree_vm_list_t* sub_list = iree_vm_list_deref(variant.ref);
@@ -433,7 +448,7 @@ void AppendListContents(std::string& out, iree_vm_list_t* list,
         }
         out.append("]");
       } else {
-        absl::StrAppend(&out, "Unknown(", variant.type.ref_type, ")");
+        out += "Unknown(" + std::to_string(variant.type.ref_type) + ")";
       }
     } else {
       out.append("None");
@@ -447,8 +462,8 @@ std::string VmVariantList::DebugString() const {
   // The variant list API requires mutability, so we const cast to it internally
   // so we can maintain a const DebugString() for callers.
   auto mutable_this = const_cast<VmVariantList*>(this);
-  std::string s;
-  absl::StrAppend(&s, "<VmVariantList(", size(), "): [");
+  std::string s =
+      std::string("<VmVariantList(") + std::to_string(size()) + "): [";
   iree_vm_list_t* list = mutable_this->raw_ptr();
   std::unordered_set<iree_vm_list_t*> visited;
   visited.insert(list);

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -58,28 +58,28 @@ iree_cc_library(
     iree::base::internal::flags
   PUBLIC
 )
-if(${IREE_ENABLE_THREADING})
-  iree_cc_library(
-    NAME
-      status
-    HDRS
-      "status.h"
-    DEPS
-      iree::base::internal::status_internal
-    PUBLIC
-  )
 
-  iree_cc_test(
-    NAME
-      status_test
-    SRCS
-      "status_test.cc"
-    DEPS
-      ::status
-      iree::testing::gtest
-      iree::testing::gtest_main
-  )
-endif()
+iree_cc_library(
+  NAME
+    status
+  HDRS
+    "status.h"
+  DEPS
+    iree::base::internal::status_internal
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    status_test
+  SRCS
+    "status_test.cc"
+  DEPS
+    ::status
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_test(
   NAME
     string_view_test

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -281,6 +281,28 @@ cc_test(
 )
 
 cc_library(
+    name = "span",
+    hdrs = ["span.h"],
+)
+
+cc_library(
+    name = "status_internal",
+    srcs = [
+        "status.cc",
+        "statusor.cc",
+    ],
+    hdrs = [
+        "status.h",
+        "statusor.h",
+    ],
+    deps = [
+        "//iree/base",
+        "//iree/base:core_headers",
+        "//iree/base:logging",
+    ],
+)
+
+cc_library(
     name = "synchronization",
     srcs = [
         "synchronization.c",
@@ -330,32 +352,11 @@ cc_test(
 
 iree_cmake_extra_content(
     content = """
-# TODO(#3848): absl has a thread dependency, move this condition after statusor
-# is fixed.
 if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
 """,
     inline = True,
-)
-
-# TODO(#3848): statusor has the abseil dependency.
-cc_library(
-    name = "status_internal",
-    srcs = [
-        "status.cc",
-        "statusor.cc",
-    ],
-    hdrs = [
-        "status.h",
-        "statusor.h",
-    ],
-    deps = [
-        "//iree/base",
-        "//iree/base:core_headers",
-        "//iree/base:logging",
-        "@com_google_absl//absl/utility",
-    ],
 )
 
 cc_library(

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -296,6 +296,30 @@ iree_cc_test(
 
 iree_cc_library(
   NAME
+    span
+  HDRS
+    "span.h"
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    status_internal
+  HDRS
+    "status.h"
+    "statusor.h"
+  SRCS
+    "status.cc"
+    "statusor.cc"
+  DEPS
+    iree::base
+    iree::base::core_headers
+    iree::base::logging
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     synchronization
   HDRS
     "call_once.h"
@@ -342,28 +366,9 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
-# TODO(#3848): absl has a thread dependency, move this condition after statusor
-# is fixed.
 if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
-
-iree_cc_library(
-  NAME
-    status_internal
-  HDRS
-    "status.h"
-    "statusor.h"
-  SRCS
-    "status.cc"
-    "statusor.cc"
-  DEPS
-    absl::utility
-    iree::base
-    iree::base::core_headers
-    iree::base::logging
-  PUBLIC
-)
 
 iree_cc_library(
   NAME

--- a/iree/base/internal/span.h
+++ b/iree/base/internal/span.h
@@ -1,0 +1,183 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_INTERNAL_SPAN_H_
+#define IREE_BASE_INTERNAL_SPAN_H_
+#ifdef __cplusplus
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+// std::span is available starting in C++20.
+// Prior to that we fall back to our simplified implementation below.
+#if defined(__has_include)
+#if __has_include(<span>) && __cplusplus >= 202002L
+#define IREE_HAVE_STD_SPAN 1
+#include <span>
+#endif  // __has_include(<span>)
+#endif  // __has_include
+
+namespace iree {
+
+#if defined(IREE_HAVE_STD_SPAN)
+
+// Alias. Once we bump up our minimum C++ version we can drop this entire file.
+template <typename T>
+using span = std::span<T>;
+
+#else
+
+constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
+
+// A pared down version of std::span doing just enough for our uses in IREE.
+// Most of the IREE code started using absl::Span which while close to std::span
+// has some additional functionality of its own and is missing some from std.
+// The benefit here is that means we only need to implement the intersection of
+// the two as none of our code uses those newer std features.
+//
+// https://en.cppreference.com/w/cpp/container/span/subspan
+template <typename T>
+class span {
+ private:
+  template <typename V>
+  using remove_cv_t = typename std::remove_cv<V>::type;
+  template <typename V>
+  using decay_t = typename std::decay<V>::type;
+
+  template <typename C>
+  static constexpr auto GetDataImpl(C& c, char) noexcept -> decltype(c.data()) {
+    return c.data();
+  }
+  static inline char* GetDataImpl(std::string& s, int) noexcept {
+    return &s[0];
+  }
+  template <typename C>
+  static constexpr auto GetData(C& c) noexcept -> decltype(GetDataImpl(c, 0)) {
+    return GetDataImpl(c, 0);
+  }
+
+  template <typename C>
+  using HasSize =
+      std::is_integral<decay_t<decltype(std::declval<C&>().size())> >;
+
+  template <typename V, typename C>
+  using HasData =
+      std::is_convertible<decay_t<decltype(GetData(std::declval<C&>()))>*,
+                          V* const*>;
+
+  template <typename C>
+  using EnableIfConvertibleFrom =
+      typename std::enable_if<HasData<T, C>::value && HasSize<C>::value>::type;
+
+  template <typename U>
+  using EnableIfConstView =
+      typename std::enable_if<std::is_const<T>::value, U>::type;
+
+  template <typename U>
+  using EnableIfMutableView =
+      typename std::enable_if<!std::is_const<T>::value, U>::type;
+
+ public:
+  using value_type = remove_cv_t<T>;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = pointer;
+  using const_iterator = const_pointer;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+
+  constexpr span() noexcept : span(nullptr, 0) {}
+  constexpr span(pointer array, size_type length) noexcept
+      : ptr_(array), len_(length) {}
+
+  template <size_type N>
+  constexpr span(T (&a)[N]) noexcept : span(a, N) {}
+
+  template <typename V, typename = EnableIfConvertibleFrom<V>,
+            typename = EnableIfMutableView<V> >
+  explicit span(V& v) noexcept : span(GetData(v), v.size()) {}
+
+  template <typename V, typename = EnableIfConvertibleFrom<V>,
+            typename = EnableIfConstView<V> >
+  constexpr span(const V& v) noexcept : span(GetData(v), v.size()) {}
+
+  template <typename LazyT = T, typename = EnableIfConstView<LazyT> >
+  span(std::initializer_list<value_type> v) noexcept
+      : span(v.begin(), v.size()) {}
+
+  constexpr pointer data() const noexcept { return ptr_; }
+
+  constexpr size_type size() const noexcept { return len_; }
+
+  constexpr size_type length() const noexcept { return size(); }
+
+  constexpr bool empty() const noexcept { return size() == 0; }
+
+  constexpr reference operator[](size_type i) const noexcept {
+    // MSVC 2015 accepts this as constexpr, but not ptr_[i]
+    assert(i < size());
+    return *(data() + i);
+  }
+
+  constexpr reference at(size_type i) const {
+    return i < size() ? *(data() + i) : (std::abort(), *(data() + i));
+  }
+
+  constexpr reference front() const noexcept {
+    assert(size() > 0);
+    return *data();
+  }
+  constexpr reference back() const noexcept {
+    assert(size() > 0);
+    return *(data() + size() - 1);
+  }
+
+  constexpr iterator begin() const noexcept { return data(); }
+  constexpr iterator end() const noexcept { return data() + size(); }
+
+  constexpr reverse_iterator rbegin() const noexcept {
+    return reverse_iterator(end());
+  }
+  constexpr reverse_iterator rend() const noexcept {
+    return reverse_iterator(begin());
+  }
+
+  constexpr span subspan(size_type pos = 0,
+                         size_type len = iree::dynamic_extent) const {
+    return (pos <= size()) ? span(data() + pos, std::min(size() - pos, len))
+                           : (std::abort(), span());
+  }
+
+  constexpr span first(size_type len) const {
+    return (len <= size()) ? span(data(), len) : (std::abort(), span());
+  }
+
+  constexpr span last(size_type len) const {
+    return (len <= size()) ? span(size() - len + data(), len)
+                           : (std::abort(), span());
+  }
+
+ private:
+  pointer ptr_;
+  size_type len_;
+};
+
+#endif  // IREE_HAVE_STD_SPAN
+
+}  // namespace iree
+
+#endif  // __cplusplus
+#endif  // IREE_BASE_INTERNAL_SPAN_H_

--- a/iree/base/string_view.c
+++ b/iree/base/string_view.c
@@ -212,6 +212,15 @@ IREE_API_EXPORT intptr_t iree_string_view_split(iree_string_view_t value,
   return offset;
 }
 
+IREE_API_EXPORT void iree_string_view_replace_char(iree_string_view_t value,
+                                                   char old_char,
+                                                   char new_char) {
+  char* p = (char*)value.data;
+  for (iree_host_size_t i = 0; i < value.size; ++i) {
+    if (p[i] == old_char) p[i] = new_char;
+  }
+}
+
 static bool iree_string_view_match_pattern_impl(iree_string_view_t value,
                                                 iree_string_view_t pattern) {
   iree_host_size_t next_char_index = iree_string_view_find_first_of(

--- a/iree/hal/BUILD
+++ b/iree/hal/BUILD
@@ -78,9 +78,8 @@ cc_test(
         ":hal",
         "//iree/base",
         "//iree/base:status",
+        "//iree/base/internal:span",
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/hal/CMakeLists.txt
+++ b/iree/hal/CMakeLists.txt
@@ -68,9 +68,8 @@ iree_cc_test(
     "string_util_test.cc"
   DEPS
     ::hal
-    absl::span
-    absl::strings
     iree::base
+    iree::base::internal::span
     iree::base::status
     iree::testing::gtest
     iree::testing::gtest_main

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -249,8 +249,8 @@ typedef struct iree_hal_buffer_mapping_t {
 // be unmapped before any command may use it.
 //
 // Buffers may map (roughly) 1:1 with an allocation either from the host heap or
-// a device. iree_hal_buffer_Subspan can be used to reference subspans of
-// buffers like absl::Span - though unlike absl::Span the returned Buffer holds
+// a device. iree_hal_buffer_subspan can be used to reference subspans of
+// buffers like std::span - though unlike std::span the returned buffer holds
 // a reference to the parent buffer.
 typedef struct iree_hal_buffer_t iree_hal_buffer_t;
 

--- a/iree/hal/string_util_test.cc
+++ b/iree/hal/string_util_test.cc
@@ -11,9 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 #include "iree/base/api.h"
+#include "iree/base/internal/span.h"
 #include "iree/base/status.h"
 #include "iree/hal/api.h"
 #include "iree/testing/gtest.h"
@@ -33,7 +32,7 @@ using Shape = std::vector<iree_hal_dim_t>;
 
 // Parses a serialized set of shape dimensions using the canonical shape format
 // (the same as produced by FormatShape).
-StatusOr<Shape> ParseShape(absl::string_view value) {
+StatusOr<Shape> ParseShape(const std::string& value) {
   Shape shape(6);
   iree_host_size_t actual_rank = 0;
   iree_status_t status;
@@ -48,7 +47,7 @@ StatusOr<Shape> ParseShape(absl::string_view value) {
 }
 
 // Converts shape dimensions into a `4x5x6` format.
-StatusOr<std::string> FormatShape(absl::Span<const iree_hal_dim_t> value) {
+StatusOr<std::string> FormatShape(iree::span<const iree_hal_dim_t> value) {
   std::string buffer(16, '\0');
   iree_host_size_t actual_length = 0;
   iree_status_t status;
@@ -64,7 +63,7 @@ StatusOr<std::string> FormatShape(absl::Span<const iree_hal_dim_t> value) {
 
 // Parses a serialized iree_hal_element_type_t. The format is the same as
 // produced by FormatElementType.
-StatusOr<iree_hal_element_type_t> ParseElementType(absl::string_view value) {
+StatusOr<iree_hal_element_type_t> ParseElementType(const std::string& value) {
   iree_hal_element_type_t element_type = IREE_HAL_ELEMENT_TYPE_NONE;
   iree_status_t status = iree_hal_parse_element_type(
       iree_string_view_t{value.data(), value.size()}, &element_type);
@@ -93,9 +92,9 @@ StatusOr<std::string> FormatElementType(iree_hal_element_type_t value) {
 // For example, "1.2" of type IREE_HAL_ELEMENT_TYPE_FLOAT32 will write the 4
 // byte float value of 1.2 to |buffer|.
 template <typename T>
-Status ParseElement(absl::string_view value,
+Status ParseElement(const std::string& value,
                     iree_hal_element_type_t element_type,
-                    absl::Span<T> buffer) {
+                    iree::span<T> buffer) {
   return iree_hal_parse_element(
       iree_string_view_t{value.data(), value.size()}, element_type,
       iree_byte_span_t{reinterpret_cast<uint8_t*>(buffer.data()),
@@ -126,9 +125,9 @@ StatusOr<std::string> FormatElement(T value,
 // produced by FormatBufferElements. Supports additional inputs of
 // empty to denote a 0 fill and a single element to denote a splat.
 template <typename T>
-Status ParseBufferElements(absl::string_view value,
+Status ParseBufferElements(const std::string& value,
                            iree_hal_element_type_t element_type,
-                           absl::Span<T> buffer) {
+                           iree::span<T> buffer) {
   IREE_RETURN_IF_ERROR(
       iree_hal_parse_buffer_elements(
           iree_string_view_t{value.data(), value.size()}, element_type,
@@ -146,7 +145,7 @@ Status ParseBufferElements(absl::string_view value,
 // |max_element_count| can be used to limit the total number of elements printed
 // when the count may be large. Elided elements will be replaced with `...`.
 template <typename T>
-StatusOr<std::string> FormatBufferElements(absl::Span<const T> data,
+StatusOr<std::string> FormatBufferElements(iree::span<const T> data,
                                            const Shape& shape,
                                            iree_hal_element_type_t element_type,
                                            size_t max_element_count) {
@@ -222,10 +221,10 @@ struct ElementTypeFromCType<double> {
 // For example, "1.2" of type float (IREE_HAL_ELEMENT_TYPE_FLOAT32) will return
 // 1.2f.
 template <typename T>
-inline StatusOr<T> ParseElement(absl::string_view value) {
+inline StatusOr<T> ParseElement(const std::string& value) {
   T result = T();
   IREE_RETURN_IF_ERROR(ParseElement(value, ElementTypeFromCType<T>::value,
-                                    absl::MakeSpan(&result, 1)));
+                                    iree::span<T>(&result, 1)));
   return result;
 }
 
@@ -241,8 +240,8 @@ inline StatusOr<std::string> FormatElement(T value) {
 // produced by FormatBufferElements. Supports additional inputs of
 // empty to denote a 0 fill and a single element to denote a splat.
 template <typename T>
-inline Status ParseBufferElements(absl::string_view value,
-                                  absl::Span<T> buffer) {
+inline Status ParseBufferElements(const std::string& value,
+                                  iree::span<T> buffer) {
   return ParseBufferElements(value, ElementTypeFromCType<T>::value, buffer);
 }
 
@@ -251,14 +250,14 @@ inline Status ParseBufferElements(absl::string_view value,
 // additional inputs of empty to denote a 0 fill and a single element to denote
 // a splat.
 template <typename T>
-inline StatusOr<std::vector<T>> ParseBufferElements(absl::string_view value,
+inline StatusOr<std::vector<T>> ParseBufferElements(const std::string& value,
                                                     const Shape& shape) {
   iree_host_size_t element_count = 1;
   for (size_t i = 0; i < shape.size(); ++i) {
     element_count *= shape[i];
   }
   std::vector<T> result(element_count);
-  IREE_RETURN_IF_ERROR(ParseBufferElements(value, absl::MakeSpan(result)));
+  IREE_RETURN_IF_ERROR(ParseBufferElements(value, iree::span<T>(result)));
   return std::move(result);
 }
 
@@ -270,7 +269,7 @@ inline StatusOr<std::vector<T>> ParseBufferElements(absl::string_view value,
 // when the count may be large. Elided elements will be replaced with `...`.
 template <typename T>
 StatusOr<std::string> FormatBufferElements(
-    absl::Span<const T> data, const Shape& shape,
+    iree::span<const T> data, const Shape& shape,
     size_t max_element_count = SIZE_MAX) {
   return FormatBufferElements(data, shape, ElementTypeFromCType<T>::value,
                               max_element_count);
@@ -426,7 +425,7 @@ struct BufferView final
 
   // Creates a buffer view with a reference to the given |buffer|.
   static StatusOr<BufferView> Create(Buffer buffer,
-                                     absl::Span<const iree_hal_dim_t> shape,
+                                     iree::span<const iree_hal_dim_t> shape,
                                      iree_hal_element_type_t element_type) {
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_create(
@@ -476,7 +475,7 @@ struct BufferView final
 
   // Parses a serialized set of buffer elements in the canonical tensor format
   // (the same as produced by Format).
-  static StatusOr<BufferView> Parse(absl::string_view value,
+  static StatusOr<BufferView> Parse(const std::string& value,
                                     Allocator allocator) {
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_parse(
@@ -678,44 +677,44 @@ TEST(ElementStringUtilTest, ParseElementInvalid) {
 TEST(ElementStringUtilTest, ParseOpaqueElement) {
   std::vector<uint8_t> buffer1(1);
   IREE_EXPECT_OK(ParseElement("FF", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
-                              absl::MakeSpan(buffer1)));
+                              iree::span<uint8_t>(buffer1)));
   EXPECT_THAT(buffer1, Eq(std::vector<uint8_t>{0xFF}));
 
   std::vector<uint16_t> buffer2(1);
   IREE_EXPECT_OK(ParseElement("FFCD", IREE_HAL_ELEMENT_TYPE_OPAQUE_16,
-                              absl::MakeSpan(buffer2)));
+                              iree::span<uint16_t>(buffer2)));
   EXPECT_THAT(buffer2, Eq(std::vector<uint16_t>{0xCDFFu}));
 
   std::vector<uint32_t> buffer4(1);
   IREE_EXPECT_OK(ParseElement("FFCDAABB", IREE_HAL_ELEMENT_TYPE_OPAQUE_32,
-                              absl::MakeSpan(buffer4)));
+                              iree::span<uint32_t>(buffer4)));
   EXPECT_THAT(buffer4, Eq(std::vector<uint32_t>{0xBBAACDFFu}));
 
   std::vector<uint64_t> buffer8(1);
   IREE_EXPECT_OK(ParseElement("FFCDAABBCCDDEEFF",
                               IREE_HAL_ELEMENT_TYPE_OPAQUE_64,
-                              absl::MakeSpan(buffer8)));
+                              iree::span<uint64_t>(buffer8)));
   EXPECT_THAT(buffer8, Eq(std::vector<uint64_t>{0xFFEEDDCCBBAACDFFull}));
 }
 
 TEST(ElementStringUtilTest, ParseOpaqueElementInvalid) {
   std::vector<uint8_t> buffer0(0);
-  EXPECT_THAT(
-      ParseElement("", IREE_HAL_ELEMENT_TYPE_OPAQUE_8, absl::MakeSpan(buffer0)),
-      StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(ParseElement("", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
+                           iree::span<uint8_t>(buffer0)),
+              StatusIs(StatusCode::kInvalidArgument));
   EXPECT_THAT(ParseElement("FF", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
-                           absl::MakeSpan(buffer0)),
+                           iree::span<uint8_t>(buffer0)),
               StatusIs(StatusCode::kInvalidArgument));
 
   std::vector<uint8_t> buffer1(1);
-  EXPECT_THAT(
-      ParseElement("", IREE_HAL_ELEMENT_TYPE_OPAQUE_8, absl::MakeSpan(buffer1)),
-      StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(ParseElement("", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
+                           iree::span<uint8_t>(buffer1)),
+              StatusIs(StatusCode::kInvalidArgument));
   EXPECT_THAT(ParseElement("F", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
-                           absl::MakeSpan(buffer1)),
+                           iree::span<uint8_t>(buffer1)),
               StatusIs(StatusCode::kInvalidArgument));
   EXPECT_THAT(ParseElement("FFC", IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
-                           absl::MakeSpan(buffer1)),
+                           iree::span<uint8_t>(buffer1)),
               StatusIs(StatusCode::kInvalidArgument));
 }
 
@@ -759,28 +758,28 @@ TEST(ElementStringUtilTest, FormatOpaqueElement) {
 TEST(BufferElementsStringUtilTest, ParseBufferElements) {
   // Empty:
   std::vector<int8_t> buffer0(0);
-  IREE_EXPECT_OK(ParseBufferElements<int8_t>("", absl::MakeSpan(buffer0)));
+  IREE_EXPECT_OK(ParseBufferElements<int8_t>("", iree::span<int8_t>(buffer0)));
   EXPECT_THAT(buffer0, Eq(std::vector<int8_t>{}));
   std::vector<int8_t> buffer8(8, 123);
-  IREE_EXPECT_OK(ParseBufferElements<int8_t>("", absl::MakeSpan(buffer8)));
+  IREE_EXPECT_OK(ParseBufferElements<int8_t>("", iree::span<int8_t>(buffer8)));
   EXPECT_THAT(buffer8, Eq(std::vector<int8_t>{0, 0, 0, 0, 0, 0, 0, 0}));
   // Scalar:
   std::vector<int8_t> buffer1(1);
-  IREE_EXPECT_OK(ParseBufferElements<int8_t>("1", absl::MakeSpan(buffer1)));
+  IREE_EXPECT_OK(ParseBufferElements<int8_t>("1", iree::span<int8_t>(buffer1)));
   EXPECT_THAT(buffer1, Eq(std::vector<int8_t>{1}));
   // Splat:
-  IREE_EXPECT_OK(ParseBufferElements<int8_t>("3", absl::MakeSpan(buffer8)));
+  IREE_EXPECT_OK(ParseBufferElements<int8_t>("3", iree::span<int8_t>(buffer8)));
   EXPECT_THAT(buffer8, Eq(std::vector<int8_t>{3, 3, 3, 3, 3, 3, 3, 3}));
   // 1:1:
-  IREE_EXPECT_OK(ParseBufferElements<int8_t>("2", absl::MakeSpan(buffer1)));
+  IREE_EXPECT_OK(ParseBufferElements<int8_t>("2", iree::span<int8_t>(buffer1)));
   EXPECT_THAT(buffer1, Eq(std::vector<int8_t>{2}));
   std::vector<int16_t> buffer8i16(8);
   IREE_EXPECT_OK(ParseBufferElements<int16_t>("0 1 2 3 4 5 6 7",
-                                              absl::MakeSpan(buffer8i16)));
+                                              iree::span<int16_t>(buffer8i16)));
   EXPECT_THAT(buffer8i16, Eq(std::vector<int16_t>{0, 1, 2, 3, 4, 5, 6, 7}));
   std::vector<int32_t> buffer8i32(8);
   IREE_EXPECT_OK(ParseBufferElements<int32_t>("[0 1 2 3] [4 5 6 7]",
-                                              absl::MakeSpan(buffer8i32)));
+                                              iree::span<int32_t>(buffer8i32)));
   EXPECT_THAT(buffer8i32, Eq(std::vector<int32_t>{0, 1, 2, 3, 4, 5, 6, 7}));
 }
 
@@ -788,22 +787,22 @@ TEST(BufferElementsStringUtilTest, ParseBufferElementsOpaque) {
   std::vector<uint16_t> buffer3i16(3);
   IREE_EXPECT_OK(ParseBufferElements("0011 2233 4455",
                                      IREE_HAL_ELEMENT_TYPE_OPAQUE_16,
-                                     absl::MakeSpan(buffer3i16)));
+                                     iree::span<uint16_t>(buffer3i16)));
   EXPECT_THAT(buffer3i16, Eq(std::vector<uint16_t>{0x1100, 0x3322, 0x5544}));
 }
 
 TEST(BufferElementsStringUtilTest, ParseBufferElementsInvalid) {
   std::vector<int8_t> buffer0(0);
-  EXPECT_THAT(ParseBufferElements("abc", absl::MakeSpan(buffer0)),
+  EXPECT_THAT(ParseBufferElements("abc", iree::span<int8_t>(buffer0)),
               StatusIs(StatusCode::kOutOfRange));
   std::vector<int8_t> buffer1(1);
-  EXPECT_THAT(ParseBufferElements("abc", absl::MakeSpan(buffer1)),
+  EXPECT_THAT(ParseBufferElements("abc", iree::span<int8_t>(buffer1)),
               StatusIs(StatusCode::kInvalidArgument));
   std::vector<int8_t> buffer8(8);
-  EXPECT_THAT(ParseBufferElements("1 2 3", absl::MakeSpan(buffer8)),
+  EXPECT_THAT(ParseBufferElements("1 2 3", iree::span<int8_t>(buffer8)),
               StatusIs(StatusCode::kOutOfRange));
   std::vector<int8_t> buffer4(4);
-  EXPECT_THAT(ParseBufferElements("1 2 3 4 5", absl::MakeSpan(buffer4)),
+  EXPECT_THAT(ParseBufferElements("1 2 3 4 5", iree::span<int8_t>(buffer4)),
               StatusIs(StatusCode::kOutOfRange));
 }
 

--- a/iree/modules/check/BUILD
+++ b/iree/modules/check/BUILD
@@ -19,6 +19,7 @@ cc_test(
         "//iree/base:logging",
         "//iree/base:status",
         "//iree/base/internal",
+        "//iree/base/internal:span",
         "//iree/hal",
         "//iree/hal/vmvx/registration",
         "//iree/modules/hal",
@@ -27,7 +28,6 @@ cc_test(
         "//iree/vm",
         "//iree/vm:bytecode_module",
         "//iree/vm:cc",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -45,6 +45,5 @@ cc_library(
         "//iree/testing:gtest",
         "//iree/vm",
         "//iree/vm:cc",
-        "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/modules/check/CMakeLists.txt
+++ b/iree/modules/check/CMakeLists.txt
@@ -15,9 +15,9 @@ if(${IREE_HAL_DRIVER_VMVX})
       "check_test.cc"
     DEPS
       ::native_module
-      absl::span
       iree::base
       iree::base::internal
+      iree::base::internal::span
       iree::base::logging
       iree::base::status
       iree::hal

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -10,9 +10,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "absl/types/span.h"
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
+#include "iree/base/internal/span.h"
 #include "iree/base/logging.h"
 #include "iree/base/status.h"
 #include "iree/hal/api.h"
@@ -73,8 +73,8 @@ class CheckTest : public ::testing::Test {
     iree_vm_context_release(context_);
   }
 
-  void CreateInt32BufferView(absl::Span<const int32_t> contents,
-                             absl::Span<const int32_t> shape,
+  void CreateInt32BufferView(iree::span<const int32_t> contents,
+                             iree::span<const int32_t> shape,
                              iree_hal_buffer_view_t** out_buffer_view) {
     size_t num_elements = 1;
     for (int32_t dim : shape) {
@@ -95,8 +95,8 @@ class CheckTest : public ::testing::Test {
         &*out_buffer_view));
   }
 
-  void CreateFloat16BufferView(absl::Span<const uint16_t> contents,
-                               absl::Span<const int32_t> shape,
+  void CreateFloat16BufferView(iree::span<const uint16_t> contents,
+                               iree::span<const int32_t> shape,
                                iree_hal_buffer_view_t** out_buffer_view) {
     size_t num_elements = 1;
     for (int32_t dim : shape) {
@@ -118,8 +118,8 @@ class CheckTest : public ::testing::Test {
         IREE_HAL_ELEMENT_TYPE_FLOAT_16, &*out_buffer_view));
   }
 
-  void CreateFloat32BufferView(absl::Span<const float> contents,
-                               absl::Span<const int32_t> shape,
+  void CreateFloat32BufferView(iree::span<const float> contents,
+                               iree::span<const int32_t> shape,
                                iree_hal_buffer_view_t** out_buffer_view) {
     size_t num_elements = 1;
     for (int32_t dim : shape) {
@@ -140,8 +140,8 @@ class CheckTest : public ::testing::Test {
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, &*out_buffer_view));
   }
 
-  void CreateFloat64BufferView(absl::Span<const double> contents,
-                               absl::Span<const int32_t> shape,
+  void CreateFloat64BufferView(iree::span<const double> contents,
+                               iree::span<const int32_t> shape,
                                iree_hal_buffer_view_t** out_buffer_view) {
     size_t num_elements = 1;
     for (int32_t dim : shape) {

--- a/iree/samples/custom_modules/BUILD
+++ b/iree/samples/custom_modules/BUILD
@@ -63,6 +63,5 @@ cc_library(
         "//iree/modules/hal",
         "//iree/vm",
         "//iree/vm:cc",
-        "@com_google_absl//absl/types:span",
     ],
 )

--- a/iree/samples/custom_modules/CMakeLists.txt
+++ b/iree/samples/custom_modules/CMakeLists.txt
@@ -58,7 +58,6 @@ iree_cc_library(
   SRCS
     "native_module.cc"
   DEPS
-    absl::span
     iree::base
     iree::base::status
     iree::hal

--- a/iree/samples/custom_modules/native_module.cc
+++ b/iree/samples/custom_modules/native_module.cc
@@ -15,7 +15,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "absl/types/span.h"
 #include "iree/base/api.h"
 #include "iree/base/status.h"
 #include "iree/hal/api.h"
@@ -285,7 +284,9 @@ extern "C" iree_status_t iree_custom_native_module_create(
   IREE_ASSERT_ARGUMENT(out_module);
   *out_module = NULL;
   auto module = std::make_unique<CustomModule>(
-      "custom", allocator, absl::MakeConstSpan(kCustomModuleFunctions));
+      "custom", allocator,
+      iree::span<const vm::NativeFunction<CustomModuleState>>(
+          kCustomModuleFunctions));
   IREE_RETURN_IF_ERROR(module->Initialize());
   *out_module = module.release()->interface();
   return iree_ok_status();

--- a/iree/samples/vulkan/CMakeLists.txt
+++ b/iree/samples/vulkan/CMakeLists.txt
@@ -37,7 +37,6 @@ iree_cc_binary(
   SRCS
     "vulkan_inference_gui.cc"
   DEPS
-    absl::base
     iree::base::internal::main
     iree::hal::vulkan::registration
     iree::modules::hal

--- a/iree/test/BUILD
+++ b/iree/test/BUILD
@@ -4,20 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
-
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
-)
-
-iree_cmake_extra_content(
-    content = """
-# TODO(#3848): Test tools has implicit thread dependency from absl.
-if(NOT ${IREE_ENABLE_THREADING})
-  return()
-endif()
-""",
-    inline = True,
 )

--- a/iree/test/CMakeLists.txt
+++ b/iree/test/CMakeLists.txt
@@ -10,9 +10,4 @@
 
 iree_add_all_subdirs()
 
-# TODO(#3848): Test tools has implicit thread dependency from absl.
-if(NOT ${IREE_ENABLE_THREADING})
-  return()
-endif()
-
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/testing/BUILD
+++ b/iree/testing/BUILD
@@ -6,8 +6,6 @@
 
 # Testing utilities for IREE.
 
-load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
-
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
@@ -40,16 +38,6 @@ cc_library(
     ],
 )
 
-iree_cmake_extra_content(
-    content = """
-# TODO(#3848): gtest library has implicit thread dependency from absl.
-if(NOT ${IREE_ENABLE_THREADING})
-  return()
-endif()
-""",
-    inline = True,
-)
-
 cc_library(
     name = "gtest",
     testonly = True,
@@ -59,8 +47,6 @@ cc_library(
     ],
     deps = [
         "//iree/base:status",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:optional",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/iree/testing/CMakeLists.txt
+++ b/iree/testing/CMakeLists.txt
@@ -37,11 +37,6 @@ iree_cc_library(
   PUBLIC
 )
 
-# TODO(#3848): gtest library has implicit thread dependency from absl.
-if(NOT ${IREE_ENABLE_THREADING})
-  return()
-endif()
-
 iree_cc_library(
   NAME
     gtest
@@ -49,8 +44,6 @@ iree_cc_library(
     "gtest.h"
     "status_matchers.h"
   DEPS
-    absl::optional
-    absl::strings
     gmock
     gtest
     iree::base::status

--- a/iree/testing/status_matchers.h
+++ b/iree/testing/status_matchers.h
@@ -8,9 +8,8 @@
 #define IREE_TESTING_STATUS_MATCHERS_H_
 
 #include <memory>
+#include <string>
 
-#include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "iree/base/status.h"  // IWYU pragma: export
 #include "iree/testing/gtest.h"
 
@@ -93,16 +92,16 @@ class IsOkAndHoldsGenerator {
 template <typename Enum, typename Matchee>
 class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
  public:
-  StatusMatcher(Enum code, absl::optional<absl::string_view> message)
-      : code_(code), message_(message) {}
+  StatusMatcher(Enum code, std::string message)
+      : code_(code), message_(std::move(message)) {}
 
   // From testing::MatcherInterface.
   //
   // Describes the expected error code.
   void DescribeTo(std::ostream *os) const override {
     *os << "error code " << StatusCodeToString(code_);
-    if (message_.has_value()) {
-      *os << "::'" << message_.value() << "'";
+    if (!message_.empty()) {
+      *os << "::'" << message_ << "'";
     }
   }
 
@@ -121,7 +120,7 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
                 << GetMessage(matchee);
       return false;
     }
-    if (message_.has_value() && GetMessage(matchee) != message_.value()) {
+    if (!message_.empty() && GetMessage(matchee) != message_) {
       *listener << "whose error message is '" << GetMessage(matchee) << "'";
       return false;
     }
@@ -161,7 +160,7 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
   const Enum code_;
 
   // Expected error message (empty if none expected and verified).
-  const absl::optional<std::string> message_;
+  const std::string message_;
 };
 
 // StatusMatcherGenerator is an intermediate object returned by
@@ -173,8 +172,8 @@ class StatusMatcher : public ::testing::MatcherInterface<Matchee> {
 template <typename Enum>
 class StatusIsMatcherGenerator {
  public:
-  StatusIsMatcherGenerator(Enum code, absl::optional<absl::string_view> message)
-      : code_(code), message_(message) {}
+  StatusIsMatcherGenerator(Enum code, std::string message)
+      : code_(code), message_(std::move(message)) {}
 
   operator ::testing::Matcher<const StatusCode &>() const {
     return ::testing::MakeMatcher(
@@ -204,7 +203,7 @@ class StatusIsMatcherGenerator {
   const Enum code_;
 
   // Expected error message (empty if none expected and verified).
-  const absl::optional<std::string> message_;
+  const std::string message_;
 };
 
 // Implements a gMock matcher that checks whether a status container (e.g.
@@ -296,15 +295,15 @@ internal::IsOkAndHoldsGenerator<ValueMatcherT> IsOkAndHolds(
 // given |code|.
 template <typename Enum>
 internal::StatusIsMatcherGenerator<Enum> StatusIs(Enum code) {
-  return internal::StatusIsMatcherGenerator<Enum>(code, absl::nullopt);
+  return internal::StatusIsMatcherGenerator<Enum>(code, "");
 }
 
 // Returns a gMock matcher that expects an iree::Status object to have the
 // given |code| and |message|.
 template <typename Enum>
 internal::StatusIsMatcherGenerator<Enum> StatusIs(Enum code,
-                                                  absl::string_view message) {
-  return internal::StatusIsMatcherGenerator<Enum>(code, message);
+                                                  std::string message) {
+  return internal::StatusIsMatcherGenerator<Enum>(code, std::move(message));
 }
 
 // Returns an internal::IsOkMatcherGenerator, which may be typecast to a

--- a/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
+++ b/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
@@ -159,7 +159,7 @@ extern "C" int iree_main(int argc, char** argv) {
   }
 
   // Setup window
-  SDL_WindowFlags window_flags = (SDL_WindowFlags)(
+  SDL_WindowFlags window_flags = (SDL_WindowFlags)(  //
       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
   SDL_Window* window = SDL_CreateWindow(
       "IREE Samples - Vulkan Inference GUI", SDL_WINDOWPOS_CENTERED,
@@ -338,9 +338,11 @@ extern "C" int iree_main(int argc, char** argv) {
                  << "'";
 
   vm::ref<iree_vm_list_t> main_function_inputs;
-  IREE_CHECK_OK(ParseToVariantList(iree_hal_device_allocator(iree_vk_device),
-                                   FLAG_function_inputs,
-                                   &main_function_inputs));
+  IREE_CHECK_OK(ParseToVariantList(
+      iree_hal_device_allocator(iree_vk_device),
+      iree::span<const std::string>{FLAG_function_inputs.data(),
+                                    FLAG_function_inputs.size()},
+      &main_function_inputs));
 
   const std::string window_title = std::string(FLAG_module_file);
   // --------------------------------------------------------------------------

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -261,7 +261,6 @@ cc_binary(
         "//iree/vm",
         "//iree/vm:bytecode_module",
         "//iree/vm:cc",
-        "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMToLLVMIRTranslation",
@@ -288,7 +287,6 @@ cc_binary(
         "//iree/vm",
         "//iree/vm:bytecode_module",
         "//iree/vm:cc",
-        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Doesn't use bazel_to_cmake because of various special logic throughout.
 
-# Tools has thread dependency from iree::hal::drivers and absl
+# Tools has thread dependency from iree::hal::drivers
 if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
@@ -84,8 +84,6 @@ iree_cc_binary(
   SRCS
     "iree-check-module-main.cc"
   DEPS
-    iree::modules::check::native_module
-    absl::strings
     iree::base
     iree::base::core_headers
     iree::base::internal::file_io
@@ -95,6 +93,7 @@ iree_cc_binary(
     iree::base::tracing
     iree::hal
     iree::hal::drivers
+    iree::modules::check::native_module
     iree::modules::hal
     iree::testing::gtest
     iree::tools::utils::vm_util
@@ -367,7 +366,6 @@ if(${IREE_BUILD_COMPILER})
       MLIRPass
       MLIRSupport
       MLIRTargetLLVMIRExport
-      absl::span
       iree::base
       iree::base::internal::flags
       iree::base::logging

--- a/iree/tools/android/run_module_app/CMakeLists.txt
+++ b/iree/tools/android/run_module_app/CMakeLists.txt
@@ -31,7 +31,6 @@ iree_cc_library(
     ${NATIVE_APP_GLUE_DIR}
   DEPS
     ::android_native_app_glue
-    absl::strings
     iree::base::status
     iree::hal::drivers
     iree::modules::hal

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -24,6 +24,7 @@
 #include "iree/modules/hal/hal_module.h"
 #include "iree/tools/utils/vm_util.h"
 #include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
 #include "iree/vm/ref_cc.h"
 
 IREE_FLAG(string, module_file, "-",
@@ -188,8 +189,12 @@ class IREEBenchmark {
 
     // Create IREE's device and module.
     IREE_RETURN_IF_ERROR(iree::CreateDevice(FLAG_driver, &device_));
-    IREE_RETURN_IF_ERROR(CreateHalModule(device_, &hal_module_));
-    IREE_RETURN_IF_ERROR(LoadBytecodeModule(module_data_, &input_module_));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_module_create(device_, iree_allocator_system(), &hal_module_));
+    IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(
+        iree_make_const_byte_span((void*)module_data_.data(),
+                                  module_data_.size()),
+        iree_allocator_null(), iree_allocator_system(), &input_module_));
 
     // Order matters. The input module will likely be dependent on the hal
     // module.
@@ -211,8 +216,11 @@ class IREEBenchmark {
         iree_string_view_t{function_name.data(), function_name.size()},
         &function));
 
-    IREE_CHECK_OK(ParseToVariantList(iree_hal_device_allocator(device_),
-                                     FLAG_function_inputs, &inputs_));
+    IREE_CHECK_OK(ParseToVariantList(
+        iree_hal_device_allocator(device_),
+        iree::span<const std::string>{FLAG_function_inputs.data(),
+                                      FLAG_function_inputs.size()},
+        &inputs_));
     RegisterModuleBenchmarks(function_name, context_, function, inputs_.get());
     return iree_ok_status();
   }

--- a/iree/tools/iree-check-module-main.cc
+++ b/iree/tools/iree-check-module-main.cc
@@ -27,6 +27,7 @@
 #include "iree/testing/status_matchers.h"
 #include "iree/tools/utils/vm_util.h"
 #include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
 
 // On Windows stdin defaults to text mode and will get weird line ending
 // expansion that will corrupt the input binary.
@@ -99,12 +100,15 @@ iree_status_t Run(std::string module_file_path, int* out_exit_code) {
   }
 
   iree_vm_module_t* input_module = nullptr;
-  IREE_RETURN_IF_ERROR(LoadBytecodeModule(module_data, &input_module));
+  IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(
+      iree_make_const_byte_span((void*)module_data.data(), module_data.size()),
+      iree_allocator_null(), iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
   IREE_RETURN_IF_ERROR(CreateDevice(FLAG_driver, &device));
   iree_vm_module_t* hal_module = nullptr;
-  IREE_RETURN_IF_ERROR(CreateHalModule(device, &hal_module));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_module_create(device, iree_allocator_system(), &hal_module));
   iree_vm_module_t* check_module = nullptr;
   check_native_module_create(iree_allocator_system(), &check_module);
 

--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -22,6 +22,7 @@
 #include "iree/modules/hal/hal_module.h"
 #include "iree/tools/utils/vm_util.h"
 #include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
 #include "iree/vm/ref_cc.h"
 
 IREE_FLAG(string, module_file, "-",
@@ -93,12 +94,15 @@ iree_status_t Run() {
   std::string module_data;
   IREE_RETURN_IF_ERROR(GetModuleContentsFromFlags(&module_data));
   iree_vm_module_t* input_module = nullptr;
-  IREE_RETURN_IF_ERROR(LoadBytecodeModule(module_data, &input_module));
+  IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(
+      iree_make_const_byte_span((void*)module_data.data(), module_data.size()),
+      iree_allocator_null(), iree_allocator_system(), &input_module));
 
   iree_hal_device_t* device = nullptr;
   IREE_RETURN_IF_ERROR(CreateDevice(FLAG_driver, &device));
   iree_vm_module_t* hal_module = nullptr;
-  IREE_RETURN_IF_ERROR(CreateHalModule(device, &hal_module));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_module_create(device, iree_allocator_system(), &hal_module));
 
   iree_vm_context_t* context = nullptr;
   // Order matters. The input module will likely be dependent on the hal module.
@@ -123,8 +127,11 @@ iree_status_t Run() {
   }
 
   vm::ref<iree_vm_list_t> inputs;
-  IREE_CHECK_OK(ParseToVariantList(iree_hal_device_allocator(device),
-                                   FLAG_function_inputs, &inputs));
+  IREE_CHECK_OK(ParseToVariantList(
+      iree_hal_device_allocator(device),
+      iree::span<const std::string>{FLAG_function_inputs.data(),
+                                    FLAG_function_inputs.size()},
+      &inputs));
 
   vm::ref<iree_vm_list_t> outputs;
   IREE_RETURN_IF_ERROR(iree_vm_list_create(/*element_type=*/nullptr, 16,

--- a/iree/tools/utils/BUILD
+++ b/iree/tools/utils/BUILD
@@ -21,13 +21,12 @@ cc_library(
         "//iree/base:status",
         "//iree/base:tracing",
         "//iree/base/internal:file_io",
+        "//iree/base/internal:span",
         "//iree/hal",
         "//iree/modules/hal",
         "//iree/vm",
         "//iree/vm:bytecode_module",
         "//iree/vm:cc",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -44,6 +43,5 @@ cc_test(
         "//iree/testing:gtest_main",
         "//iree/vm",
         "//iree/vm:cc",
-        "@com_google_absl//absl/strings",
     ],
 )

--- a/iree/tools/utils/CMakeLists.txt
+++ b/iree/tools/utils/CMakeLists.txt
@@ -18,10 +18,9 @@ iree_cc_library(
   SRCS
     "vm_util.cc"
   DEPS
-    absl::span
-    absl::strings
     iree::base
     iree::base::internal::file_io
+    iree::base::internal::span
     iree::base::logging
     iree::base::status
     iree::base::tracing
@@ -40,7 +39,6 @@ iree_cc_test(
     "vm_util_test.cc"
   DEPS
     ::vm_util
-    absl::strings
     iree::base
     iree::hal
     iree::hal::vmvx::registration

--- a/iree/tools/utils/vm_util.h
+++ b/iree/tools/utils/vm_util.h
@@ -12,8 +12,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"
-#include "absl/types/span.h"
+#include "iree/base/internal/span.h"
 #include "iree/base/status.h"
 #include "iree/hal/api.h"
 #include "iree/vm/api.h"
@@ -36,10 +35,7 @@ Status GetFileContents(const char* path, std::string* out_contents);
 // Uses descriptors in |descs| for type information and validation.
 // The returned variant list must be freed by the caller.
 Status ParseToVariantList(iree_hal_allocator_t* allocator,
-                          absl::Span<const absl::string_view> input_strings,
-                          iree_vm_list_t** out_list);
-Status ParseToVariantList(iree_hal_allocator_t* allocator,
-                          absl::Span<const std::string> input_strings,
+                          iree::span<const std::string> input_strings,
                           iree_vm_list_t** out_list);
 
 // Prints a variant list of VM scalars and buffers to |os|.
@@ -56,16 +52,6 @@ Status PrintVariantList(iree_vm_list_t* variant_list,
 // Creates the default device for |driver| in |out_device|.
 // The returned |out_device| must be released by the caller.
 Status CreateDevice(const char* driver_name, iree_hal_device_t** out_device);
-
-// Creates a hal module |driver| in |out_hal_module|.
-// The returned |out_module| must be released by the caller.
-Status CreateHalModule(iree_hal_device_t* device,
-                       iree_vm_module_t** out_module);
-
-// Loads a VM bytecode from an opaque string.
-// The returned |out_module| must be released by the caller.
-Status LoadBytecodeModule(absl::string_view module_data,
-                          iree_vm_module_t** out_module);
 
 }  // namespace iree
 

--- a/iree/tools/utils/vm_util_test.cc
+++ b/iree/tools/utils/vm_util_test.cc
@@ -6,7 +6,6 @@
 
 #include "iree/tools/utils/vm_util.h"
 
-#include "absl/strings/str_cat.h"
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/vmvx/registration/driver_module.h"
@@ -39,45 +38,49 @@ class VmUtilTest : public ::testing::Test {
 };
 
 TEST_F(VmUtilTest, ParsePrintBuffer) {
-  absl::string_view buf_string = "2x2xi32=[42 43][44 45]";
+  std::string buf_string = "2x2xi32=[42 43][44 45]";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(ParseToVariantList(allocator_, {buf_string}, &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      allocator_, std::vector<std::string>{buf_string}, &variant_list));
   std::stringstream os;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &os));
   EXPECT_EQ(os.str(),
-            absl::StrCat("result[0]: hal.buffer_view\n", buf_string, "\n"));
+            std::string("result[0]: hal.buffer_view\n") + buf_string + "\n");
 }
 
 TEST_F(VmUtilTest, ParsePrintScalar) {
-  absl::string_view input_string = "42";
+  std::string input_string = "42";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(ParseToVariantList(allocator_, {input_string}, &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      allocator_, std::vector<std::string>{input_string}, &variant_list));
   std::stringstream os;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &os));
-  EXPECT_EQ(os.str(), absl::StrCat("result[0]: i32=", input_string, "\n"));
+  EXPECT_EQ(os.str(), std::string("result[0]: i32=") + input_string + "\n");
 }
 
 TEST_F(VmUtilTest, ParsePrintRank0Buffer) {
-  absl::string_view buf_string = "i32=42";
+  std::string buf_string = "i32=42";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(ParseToVariantList(allocator_, {buf_string}, &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      allocator_, std::vector<std::string>{buf_string}, &variant_list));
   std::stringstream os;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &os));
   EXPECT_EQ(os.str(),
-            absl::StrCat("result[0]: hal.buffer_view\n", buf_string, "\n"));
+            std::string("result[0]: hal.buffer_view\n") + buf_string + "\n");
 }
 
 TEST_F(VmUtilTest, ParsePrintMultipleBuffers) {
-  absl::string_view buf_string1 = "2x2xi32=[42 43][44 45]";
-  absl::string_view buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
   vm::ref<iree_vm_list_t> variant_list;
-  IREE_ASSERT_OK(ParseToVariantList(allocator_, {buf_string1, buf_string2},
-                                    &variant_list));
+  IREE_ASSERT_OK(ParseToVariantList(
+      allocator_, std::vector<std::string>{buf_string1, buf_string2},
+      &variant_list));
   std::stringstream os;
   IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &os));
-  EXPECT_EQ(os.str(),
-            absl::StrCat("result[0]: hal.buffer_view\n", buf_string1,
-                         "\nresult[1]: hal.buffer_view\n", buf_string2, "\n"));
+  EXPECT_EQ(os.str(), std::string("result[0]: hal.buffer_view\n") +
+                          buf_string1 + "\nresult[1]: hal.buffer_view\n" +
+                          buf_string2 + "\n");
 }
 
 }  // namespace

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -33,8 +33,8 @@ cc_library(
 cc_library(
     name = "cc",
     hdrs = [
-        "module_abi_packing.h",
         "native_module_cc.h",
+        "native_module_packing.h",
         "ref_cc.h",
     ],
     deps = [
@@ -42,9 +42,7 @@ cc_library(
         "//iree/base",
         "//iree/base:core_headers",
         "//iree/base:status",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:optional",
-        "@com_google_absl//absl/types:span",
+        "//iree/base/internal:span",
     ],
 )
 
@@ -248,8 +246,6 @@ cc_test(
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
         "//iree/vm/test:all_bytecode_modules_c",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -25,16 +25,14 @@ iree_cc_library(
   NAME
     cc
   HDRS
-    "module_abi_packing.h"
     "native_module_cc.h"
+    "native_module_packing.h"
     "ref_cc.h"
   DEPS
     ::vm
-    absl::optional
-    absl::span
-    absl::strings
     iree::base
     iree::base::core_headers
+    iree::base::internal::span
     iree::base::status
   PUBLIC
 )
@@ -201,8 +199,6 @@ iree_cc_test(
   DEPS
     ::bytecode_module
     ::vm
-    absl::span
-    absl::strings
     iree::base::logging
     iree::base::status
     iree::testing::gtest

--- a/iree/vm/bytecode_dispatch_test.cc
+++ b/iree/vm/bytecode_dispatch_test.cc
@@ -10,8 +10,6 @@
 // avoid defining the IR inline here so that we can run this test on platforms
 // that we can't run the full MLIR compiler stack on.
 
-#include "absl/strings/match.h"
-#include "absl/strings/str_replace.h"
 #include "iree/base/logging.h"
 #include "iree/base/status.h"
 #include "iree/testing/gtest.h"
@@ -29,9 +27,11 @@ struct TestParams {
 };
 
 std::ostream& operator<<(std::ostream& os, const TestParams& params) {
-  return os << absl::StrReplaceAll(params.module_file.name,
-                                   {{":", "_"}, {".", "_"}})
-            << "_" << params.function_name;
+  std::string name{params.module_file.name};
+  auto name_sv = iree_make_string_view(name.data(), name.size());
+  iree_string_view_replace_char(name_sv, ':', '_');
+  iree_string_view_replace_char(name_sv, '.', '_');
+  return os << name << "_" << params.function_name;
 }
 
 std::vector<TestParams> GetModuleTestParams() {
@@ -109,7 +109,7 @@ class VMBytecodeDispatchTest
 
 TEST_P(VMBytecodeDispatchTest, Check) {
   const auto& test_params = GetParam();
-  bool expect_failure = absl::StartsWith(test_params.function_name, "fail_");
+  bool expect_failure = test_params.function_name.find("fail_") == 0;
 
   iree_status_t status = RunFunction(test_params.function_name.c_str());
   if (iree_status_is_ok(status)) {

--- a/iree/vm/native_module_cc.h
+++ b/iree/vm/native_module_cc.h
@@ -10,12 +10,11 @@
 #include <cstring>
 #include <memory>
 
-#include "absl/strings/str_cat.h"
-#include "absl/types/span.h"
 #include "iree/base/api.h"
+#include "iree/base/internal/span.h"
 #include "iree/base/status.h"
 #include "iree/vm/module.h"
-#include "iree/vm/module_abi_packing.h"  // IWYU pragma: export
+#include "iree/vm/native_module_packing.h"  // IWYU pragma: export
 #include "iree/vm/stack.h"
 
 #ifndef __cplusplus
@@ -33,7 +32,7 @@ namespace vm {
 // Functions are defined on the State type as member functions returning either
 // Status or StatusOr. Arguments are passed as primitive types (int32_t),
 // wrapped ref objects (vm::ref<my_type_t>&), or some nesting of std::array,
-// std::tuple, and absl::Span to match fixed-length arrays of the same type,
+// std::tuple, and std::span to match fixed-length arrays of the same type,
 // tuples of mixed types, or dynamic arrays (variadic arguments). Results may be
 // returned as either their type or an std::tuple/std::array of types.
 //
@@ -62,13 +61,13 @@ namespace vm {
 //   // Ownership transfers to the caller.
 //   iree_vm_module_t* create_my_module(iree_allocator_t allocator) {
 //     return std::make_unique<MyModule>("my_module", allocator,
-//         absl::MakeConstSpan(kCustomModuleFunctions)).release()->interface();
+//         std::span{kCustomModuleFunctions}).release()->interface();
 //   }
 template <typename State>
 class NativeModule {
  public:
   NativeModule(const char* name, iree_allocator_t allocator,
-               absl::Span<const NativeFunction<State>> dispatch_table)
+               iree::span<const NativeFunction<State>> dispatch_table)
       : name_(name), allocator_(allocator), dispatch_table_(dispatch_table) {
     IREE_CHECK_OK(iree_vm_module_initialize(&interface_, this));
     interface_.destroy = NativeModule::ModuleDestroy;
@@ -242,7 +241,7 @@ class NativeModule {
   const iree_allocator_t allocator_;
   iree_vm_module_t interface_;
 
-  const absl::Span<const NativeFunction<State>> dispatch_table_;
+  const iree::span<const NativeFunction<State>> dispatch_table_;
 };
 
 }  // namespace vm

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -14,7 +14,6 @@ iree_cc_test(
   SRCS
     "module_test.cc"
   DEPS
-    absl::strings
     iree::base::logging
     iree::base::status
     iree::testing::gtest

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "absl/strings/match.h"
-#include "absl/strings/str_replace.h"
 #include "iree/base/logging.h"
 #include "iree/base/status.h"
 #include "iree/testing/gtest.h"
@@ -47,7 +45,11 @@ struct ModuleDescription {
 
 std::ostream& operator<<(std::ostream& os, const TestParams& params) {
   std::string qualified_name = params.module_name + "." + params.local_name;
-  return os << absl::StrReplaceAll(qualified_name, {{":", "_"}, {".", "_"}});
+  auto name_sv =
+      iree_make_string_view(qualified_name.data(), qualified_name.size());
+  iree_string_view_replace_char(name_sv, ':', '_');
+  iree_string_view_replace_char(name_sv, '.', '_');
+  return os << qualified_name;
 }
 
 std::vector<TestParams> GetModuleTestParams() {
@@ -137,7 +139,7 @@ class VMCModuleTest : public ::testing::Test,
 
 TEST_P(VMCModuleTest, Check) {
   const auto& test_params = GetParam();
-  bool expect_failure = absl::StartsWith(test_params.local_name, "fail_");
+  bool expect_failure = test_params.local_name.find("fail_") == 0;
 
   iree::Status result =
       RunFunction(test_params.module_name, test_params.local_name);


### PR DESCRIPTION
All remaining uses of abseil are in the python bindings.

Fixes #3848.