### PR TITLE
Disable Vulkan-SPIRV build for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,10 @@ set(IREE_ALL_TARGET_BACKENDS
 
 if(IREE_TARGET_BACKENDS_TO_BUILD STREQUAL "all")
   set(IREE_TARGET_BACKENDS_TO_BUILD ${IREE_ALL_TARGET_BACKENDS})
+  # For Apple platforms we need to use Metal instead of Vulkan.
+  if(APPLE)
+    list(REMOVE_ITEM IREE_TARGET_BACKENDS_TO_BUILD Vulkan-SPIRV)
+  endif()
 endif()
 message(STATUS "Building target backends: ${IREE_TARGET_BACKENDS_TO_BUILD}")
 


### PR DESCRIPTION
I discovered that the default macOS build, with Vulkan disabled didn't disable Vulkan-SPIRV and thus failed to build.
This PR aligns disabling Vulkan in both places, making the macOS build work again.

PS! What would it take to get a macOS CI node set up? At least a non-blocking build would be nice.