### PR TITLE
Removing usage of the abseil c++ library from IREE.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,8 +9,6 @@
 # matching.
 #
 #  "@absl_py//absl/"
-#  "@com_google_absl//absl/"
-#  "@com_google_absl//absl/"
 #  "@bazel_skylib//"
 #  "@com_google_benchmark//"
 #  "@cpuinfo//"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,6 @@ endforeach()
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
   ${CMAKE_CURRENT_LIST_DIR}/bindings/python/build_tools/cmake/
-  ${CMAKE_CURRENT_LIST_DIR}/third_party/abseil-cpp/absl/copts/
 )
 
 #-------------------------------------------------------------------------------

--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -27,7 +27,6 @@ iree_pyext_module(
     iree::modules::hal
     iree::vm
     iree::vm::bytecode_module
-    absl::optional
 )
 
 iree_py_library(

--- a/bindings/python/iree/runtime/binding.h
+++ b/bindings/python/iree/runtime/binding.h
@@ -7,24 +7,12 @@
 #ifndef IREE_BINDINGS_PYTHON_IREE_BINDING_H_
 #define IREE_BINDINGS_PYTHON_IREE_BINDING_H_
 
+#include <optional>
 #include <vector>
 
-#include "absl/types/optional.h"
 #include "iree/base/api.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
-
-namespace pybind11 {
-namespace detail {
-#if !defined(ABSL_HAVE_STD_OPTIONAL)
-// Make absl::optional act like the future C++17 optional for pybind11.
-// If ABSL_HAVE_STD_OPTIONAL is defined then absl::optional == std::optional
-// and the default type caster is sufficient.
-template <typename T>
-struct type_caster<absl::optional<T>> : optional_caster<absl::optional<T>> {};
-#endif
-}  // namespace detail
-}  // namespace pybind11
 
 namespace iree {
 namespace python {

--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -6,7 +6,6 @@
 
 #include "bindings/python/iree/runtime/vm.h"
 
-#include "absl/types/optional.h"
 #include "bindings/python/iree/runtime/status_utils.h"
 #include "iree/base/api.h"
 #include "iree/base/status.h"
@@ -75,7 +74,7 @@ VmInstance VmInstance::Create() {
 //------------------------------------------------------------------------------
 
 VmContext VmContext::Create(VmInstance* instance,
-                            absl::optional<std::vector<VmModule*>> modules) {
+                            std::optional<std::vector<VmModule*>> modules) {
   iree_vm_context_t* context;
   if (!modules) {
     // Simple create with open allowed modules.
@@ -147,14 +146,14 @@ VmModule VmModule::FromFlatbufferBlob(py::buffer flatbuffer_blob) {
   return VmModule::CreateRetained(module);
 }
 
-absl::optional<iree_vm_function_t> VmModule::LookupFunction(
+std::optional<iree_vm_function_t> VmModule::LookupFunction(
     const std::string& name, iree_vm_function_linkage_t linkage) {
   iree_vm_function_t f;
   auto status = iree_vm_module_lookup_function_by_name(
       raw_ptr(), linkage, {name.data(), name.size()}, &f);
   if (iree_status_is_not_found(status)) {
     iree_status_ignore(status);
-    return absl::nullopt;
+    return std::nullopt;
   }
   CheckApiStatus(status, "Error looking up function");
   return f;
@@ -525,7 +524,7 @@ void SetupVmBindings(pybind11::module m) {
 
   py::class_<VmContext>(m, "VmContext")
       .def(py::init(&VmContext::Create), py::arg("instance"),
-           py::arg("modules") = absl::optional<std::vector<VmModule*>>())
+           py::arg("modules") = std::optional<std::vector<VmModule*>>())
       .def("register_modules", &VmContext::RegisterModules)
       .def_property_readonly("context_id", &VmContext::context_id)
       .def("invoke", &VmContext::Invoke);

--- a/bindings/python/iree/runtime/vm.h
+++ b/bindings/python/iree/runtime/vm.h
@@ -7,7 +7,8 @@
 #ifndef IREE_BINDINGS_PYTHON_IREE_RT_VM_H_
 #define IREE_BINDINGS_PYTHON_IREE_RT_VM_H_
 
-#include "absl/types/optional.h"
+#include <optional>
+
 #include "bindings/python/iree/runtime/binding.h"
 #include "bindings/python/iree/runtime/hal.h"
 #include "iree/base/api.h"
@@ -117,7 +118,7 @@ class VmModule : public ApiRefCounted<VmModule, iree_vm_module_t> {
  public:
   static VmModule FromFlatbufferBlob(py::buffer flatbuffer_blob);
 
-  absl::optional<iree_vm_function_t> LookupFunction(
+  std::optional<iree_vm_function_t> LookupFunction(
       const std::string& name, iree_vm_function_linkage_t linkage);
 
   std::string name() const {
@@ -132,7 +133,7 @@ class VmContext : public ApiRefCounted<VmContext, iree_vm_context_t> {
   // static, disallowing further module registration (and may be more
   // efficient).
   static VmContext Create(VmInstance* instance,
-                          absl::optional<std::vector<VmModule*>> modules);
+                          std::optional<std::vector<VmModule*>> modules);
 
   // Registers additional modules. Only valid for non static contexts (i.e.
   // those created without modules.

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -320,10 +320,6 @@ build:_msvc_base --define=iree_is_msvc=true
 # Bazel gets confused and sometimes loses track of Bash.
 build:_msvc_base --action_env BAZEL_SH='bash'
 
-# Disable warnings for dependencies. We don't control these.
-# absl forces /W3 in their copts, so we exclude them to avoid D9025
-build:_msvc_base --per_file_copt=+external,-com_google_absl@/w
-
 # Find the source of truth for these in iree_copts.cmake.
 build:_msvc_base --copt=/DWIN32_LEAN_AND_MEAN
 build:_msvc_base --copt=/DNOMINMAX

--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -24,12 +24,6 @@ def configure_iree_submodule_deps(iree_repo_alias = "@", iree_path = "./"):
 
     maybe(
         native.local_repository,
-        name = "com_google_absl",
-        path = paths.join(iree_path, "third_party/abseil-cpp"),
-    )
-
-    maybe(
-        native.local_repository,
         name = "com_google_googletest",
         path = paths.join(iree_path, "third_party/googletest"),
     )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -11,9 +11,6 @@ EXPLICIT_TARGET_MAPPING = {
     # Internal utilities to emulate various binary/library options.
     "//build_tools:default_linkopts": [],
 
-    # absl
-    "@com_google_absl//absl/flags:flag": ["absl::flags"],
-    "@com_google_absl//absl/flags:parse": ["absl::flags_parse"],
     # LLVM
     "@llvm-project//llvm:IPO": ["LLVMipo"],
     # MLIR
@@ -64,18 +61,6 @@ EXPLICIT_TARGET_MAPPING = {
 }
 
 
-def _convert_absl_target(target):
-  # Default to a pattern substitution approach.
-  # Take "absl::" and append the name part of the full target identifier, e.g.
-  #   "@com_google_absl//absl/types:optional" -> "absl::optional"
-  #   "@com_google_absl//absl/types:span"     -> "absl::span"
-  if ":" in target:
-    target_name = target.rsplit(":")[-1]
-  else:
-    target_name = target.rsplit("/")[-1]
-  return ["absl::" + target_name]
-
-
 def _convert_mlir_target(target):
   # Default to a pattern substitution approach.
   # Take "MLIR" and append the name part of the full target identifier, e.g.
@@ -110,8 +95,6 @@ def convert_external_target(target):
   """
   if target in EXPLICIT_TARGET_MAPPING:
     return EXPLICIT_TARGET_MAPPING[target]
-  if target.startswith("@com_google_absl//absl"):
-    return _convert_absl_target(target)
   if target.startswith("@llvm-project//llvm"):
     return _convert_llvm_target(target)
   if target.startswith("@llvm-project//mlir"):

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -5,20 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #-------------------------------------------------------------------------------
-# Abseil configuration
-#-------------------------------------------------------------------------------
-
-include(AbseilConfigureCopts)
-
-# By default Abseil strips string literals on mobile platforms, which means
-# we cannot run IREE binaries via command-line with proper options. Turn off
-# the stripping.
-# TODO(#3814): remove ABSL flags.
-if(ANDROID)
-  add_definitions(-DABSL_FLAGS_STRIP_NAMES=0)
-endif()
-
-#-------------------------------------------------------------------------------
 # C/C++ options as used within IREE
 #-------------------------------------------------------------------------------
 #
@@ -315,18 +301,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Generic")
   )
 endif()
 
-# TODO(benvanik): remove the ABSL usage here; we aren't abseil.
-If(${IREE_ENABLE_THREADING})
-  iree_select_compiler_opts(_IREE_ABSL_LINKOPTS
-    ALL
-      "${ABSL_DEFAULT_LINKOPTS}"
-  )
-endif()
-
 iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
-  ALL
-    # TODO(benvanik): remove the ABSL usage here; we aren't abseil.
-    ${_IREE_ABSL_LINKOPTS}
   CLANG_OR_GCC
     # Required by all modern software, effectively:
     "-lm"
@@ -344,9 +319,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 else()
   set(IREE_TARGET_GUI_LINKOPTS "")
 endif()
-
-# TODO(benvanik): remove the ABSL usage here; we aren't abseil.
-set(IREE_TEST_COPTS "${ABSL_TEST_COPTS}")
 
 #-------------------------------------------------------------------------------
 # Size-optimized build flags

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -184,13 +184,15 @@ function(iree_pyext_module)
       "/GR"
   )
 
+  set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD 17)
+  set_property(TARGET ${_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+
   target_compile_options(
     ${_NAME} PRIVATE
     ${ARG_COPTS}
     ${IREE_DEFAULT_COPTS}
     ${_RTTI_AND_EXCEPTION_COPTS}
   )
-
 
   # Link flags.
   if(UNIX AND NOT APPLE)  # Apple does not support linker scripts.

--- a/build_tools/embed_data/BUILD
+++ b/build_tools/embed_data/BUILD
@@ -18,9 +18,7 @@ cc_binary(
     name = "generate_embed_data",
     srcs = ["generate_embed_data_main.cc"],
     deps = [
-        "@com_google_absl//absl/flags:flag",
-        "@com_google_absl//absl/flags:parse",
-        "@com_google_absl//absl/strings",
+        "//iree/base/internal:flags",
     ],
 )
 

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -10,9 +10,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   set_target_properties(generate_embed_data PROPERTIES OUTPUT_NAME generate_embed_data)
 
   target_link_libraries(generate_embed_data
-    absl::flags
-    absl::flags_parse
-    absl::strings
+    iree::base::internal::flags
   )
 
   install(TARGETS generate_embed_data


### PR DESCRIPTION
Python abseil is still used within IREE and the tensorflow tools use
the C++ one for interop but that's fine as it's restricted to that
workspace and fetched using bazel magic.
Assuming this works the next change will remove the submodule.