### PR TITLE
Add vmvx_sync HAL device in `iree/samples/simple_embedding`

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
@@ -24,7 +24,10 @@ pushd "${BUILD_RISCV_DIR?}/iree/samples/simple_embedding" > /dev/null
 -L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_dylib
 
 /usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
--L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_local_sync
+-L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_embedded_sync
+
+/usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+-L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_vmvx_sync
 
 popd > /dev/null
 

--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -16,6 +16,55 @@ package(
 
 iree_cmake_extra_content(
     content = """
+if(${IREE_TARGET_BACKEND_VMVX} AND ${IREE_HAL_DRIVER_VMVX})
+""",
+    inline = True,
+)
+
+cc_binary(
+    name = "simple_embedding_vmvx_sync",
+    srcs = [
+        "device_vmvx_sync.c",
+        "simple_embedding.c",
+    ],
+    deps = [
+        ":simple_embedding_test_bytecode_module_vmvx_c",
+        "//iree/base",
+        "//iree/hal",
+        "//iree/hal/local",
+        "//iree/hal/local:sync_driver",
+        "//iree/hal/local/loaders:vmvx_module_loader",
+        "//iree/modules/hal",
+        "//iree/vm",
+        "//iree/vm:bytecode_module",
+    ],
+)
+
+iree_bytecode_module(
+    name = "simple_embedding_test_bytecode_module_vmvx",
+    src = "simple_embedding_test.mlir",
+    c_identifier = "iree_samples_simple_embedding_test_module_vmvx",
+    flags = [
+        "-iree-input-type=mhlo",
+        "-iree-mlir-to-vm-bytecode-module",
+        "-iree-hal-target-backends=vmvx",
+    ],
+)
+
+run_binary_test(
+    name = "simple_embedding_vmvx_sync_test",
+    test_binary = ":simple_embedding_vmvx_sync",
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
+)
+
+iree_cmake_extra_content(
+    content = """
 if(${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} AND ${IREE_HAL_DRIVER_DYLIB})
 """,
     inline = True,
@@ -23,9 +72,9 @@ if(${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} AND ${IREE_HAL_DRIVER_DYLIB})
 
 # TODO(llvm-bazel/#228): re-enable bazel.
 #cc_binary(
-#    name = "simple_embedding_local_sync",
+#    name = "simple_embedding_embedded_sync",
 #    srcs = [
-#        "device_local_sync.c",
+#        "device_embedded_sync.c",
 #        "simple_embedding.c",
 #    ],
 #    deps = [
@@ -124,8 +173,8 @@ if(${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} AND ${IREE_HAL_DRIVER_DYLIB})
 #)
 #
 #run_binary_test(
-#    name = "simple_embedding_local_sync_test",
-#    test_binary = ":simple_embedding_local_sync",
+#    name = "simple_embedding_embedded_sync_test",
+#    test_binary = ":simple_embedding_embedded_sync",
 #)
 
 iree_cmake_extra_content(

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -3,13 +3,56 @@
 
 iree_add_all_subdirs()
 
+if(${IREE_TARGET_BACKEND_VMVX} AND ${IREE_HAL_DRIVER_VMVX})
+
+iree_cc_binary(
+  NAME
+    simple_embedding_vmvx_sync
+  SRCS
+    "device_vmvx_sync.c"
+    "simple_embedding.c"
+  DEPS
+    ::simple_embedding_test_bytecode_module_vmvx_c
+    iree::base
+    iree::hal
+    iree::hal::local
+    iree::hal::local::loaders::vmvx_module_loader
+    iree::hal::local::sync_driver
+    iree::modules::hal
+    iree::vm
+    iree::vm::bytecode_module
+)
+
+iree_bytecode_module(
+  NAME
+    simple_embedding_test_bytecode_module_vmvx
+  SRC
+    "simple_embedding_test.mlir"
+  C_IDENTIFIER
+    "iree_samples_simple_embedding_test_module_vmvx"
+  FLAGS
+    "-iree-input-type=mhlo"
+    "-iree-mlir-to-vm-bytecode-module"
+    "-iree-hal-target-backends=vmvx"
+  PUBLIC
+)
+
+iree_run_binary_test(
+  NAME
+    "simple_embedding_vmvx_sync_test"
+  TEST_BINARY
+    ::simple_embedding_vmvx_sync
+)
+
+endif()
+
 if(${IREE_TARGET_BACKEND_DYLIB-LLVM-AOT} AND ${IREE_HAL_DRIVER_DYLIB})
 
 iree_cc_binary(
   NAME
-    simple_embedding_local_sync
+    simple_embedding_embedded_sync
   SRCS
-    "device_local_sync.c"
+    "device_embedded_sync.c"
     "simple_embedding.c"
   DEPS
     ::simple_embedding_test_bytecode_module_dylib_arm_32_c
@@ -122,9 +165,9 @@ iree_bytecode_module(
 
 iree_run_binary_test(
   NAME
-    "simple_embedding_local_sync_test"
+    "simple_embedding_embedded_sync_test"
   TEST_BINARY
-    ::simple_embedding_local_sync
+    ::simple_embedding_embedded_sync
 )
 
 if(${IREE_ENABLE_THREADING})

--- a/iree/samples/simple_embedding/device_dylib.c
+++ b/iree/samples/simple_embedding/device_dylib.c
@@ -31,18 +31,19 @@ iree_status_t create_sample_device(iree_hal_device_t** device) {
       &loader));
 
   iree_task_executor_t* executor = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_task_executor_create_from_flags(iree_allocator_system(), &executor));
+  iree_status_t status =
+      iree_task_executor_create_from_flags(iree_allocator_system(), &executor);
 
   iree_string_view_t identifier = iree_make_cstring_view("dylib");
-
-  // Create the device and release the executor and loader afterwards.
-  IREE_RETURN_IF_ERROR(iree_hal_task_device_create(
-      identifier, &params, executor, /*loader_count=*/1, &loader,
-      iree_allocator_system(), device));
+  if (iree_status_is_ok(status)) {
+    // Create the device.
+    status = iree_hal_task_device_create(identifier, &params, executor,
+                                         /*loader_count=*/1, &loader,
+                                         iree_allocator_system(), device);
+  }
   iree_task_executor_release(executor);
   iree_hal_executable_loader_release(loader);
-  return iree_ok_status();
+  return status;
 }
 
 const iree_const_byte_span_t load_bytecode_module_data() {

--- a/iree/samples/simple_embedding/device_embedded_sync.c
+++ b/iree/samples/simple_embedding/device_embedded_sync.c
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// A example of setting up the dylib-sync driver.
+// A example of setting up the embedded-sync driver.
 
 #include <stddef.h>
 
@@ -22,7 +22,7 @@
 #include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_x86_64_c.h"
 
 iree_status_t create_sample_device(iree_hal_device_t** device) {
-  // Set paramters for the device created in the next step.
+  // Set parameters for the device created in the next step.
   iree_hal_sync_device_params_t params;
   iree_hal_sync_device_params_initialize(&params);
 
@@ -34,11 +34,11 @@ iree_status_t create_sample_device(iree_hal_device_t** device) {
   iree_string_view_t identifier = iree_make_cstring_view("dylib");
 
   // Create the synchronous device and release the loader afterwards.
-  IREE_RETURN_IF_ERROR(
+  iree_status_t status =
       iree_hal_sync_device_create(identifier, &params, /*loader_count=*/1,
-                                  &loader, iree_allocator_system(), device));
+                                  &loader, iree_allocator_system(), device);
   iree_hal_executable_loader_release(loader);
-  return iree_ok_status();
+  return status;
 }
 
 const iree_const_byte_span_t load_bytecode_module_data() {

--- a/iree/samples/simple_embedding/device_vmvx_sync.c
+++ b/iree/samples/simple_embedding/device_vmvx_sync.c
@@ -1,0 +1,50 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A example of setting up the vmvx-sync driver.
+
+#include <stddef.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/local/executable_loader.h"
+#include "iree/hal/local/loaders/vmvx_module_loader.h"
+#include "iree/hal/local/sync_device.h"
+
+// Compiled module embedded here to avoid file IO:
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_vmvx_c.h"
+
+iree_status_t create_sample_device(iree_hal_device_t** device) {
+  // Set parameters for the device created in the next step.
+  iree_hal_sync_device_params_t params;
+  iree_hal_sync_device_params_initialize(&params);
+
+  iree_vm_instance_t* instance = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_instance_create(iree_allocator_system(), &instance));
+
+  iree_hal_executable_loader_t* loader = NULL;
+  iree_status_t status = iree_hal_vmvx_module_loader_create(
+      instance, iree_allocator_system(), &loader);
+  iree_vm_instance_release(instance);
+
+  iree_string_view_t identifier = iree_make_cstring_view("vmvx");
+  if (iree_status_is_ok(status)) {
+    // Create the synchronous device.
+    status =
+        iree_hal_sync_device_create(identifier, &params, /*loader_count=*/1,
+                                    &loader, iree_allocator_system(), device);
+  }
+  iree_hal_executable_loader_release(loader);
+  return status;
+}
+
+const iree_const_byte_span_t load_bytecode_module_data() {
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_vmvx_create();
+  return iree_make_const_byte_span(module_file_toc->data,
+                                   module_file_toc->size);
+}

--- a/iree/samples/simple_embedding/simple_embedding.c
+++ b/iree/samples/simple_embedding/simple_embedding.c
@@ -164,6 +164,6 @@ int main() {
     iree_status_fprint(stderr, result);
     iree_status_free(result);
   }
-  fprintf(stdout, "simple_embedding passed\n");
+  fprintf(stdout, "simple_embedding done\n");
   return ret;
 }


### PR DESCRIPTION
The device should support all architectures and the bare-metal config.