### PR TITLE
Adding -iree-llvm-list-targets to list registered targets.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -10,6 +10,7 @@
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Host.h"
+#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Target/TargetOptions.h"
 
 namespace mlir {
@@ -171,6 +172,16 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
           "with a similarly named '.h' file for static linking."),
       llvm::cl::init(llvmTargetOptions.staticLibraryOutput));
   llvmTargetOptions.staticLibraryOutput = clStaticLibraryOutputPath;
+
+  static llvm::cl::opt<bool> clListTargets(
+      "iree-llvm-list-targets",
+      llvm::cl::desc("Lists all registered targets that the LLVM backend can "
+                     "generate code for."),
+      llvm::cl::init(false));
+  if (clListTargets) {
+    llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());
+    exit(0);
+  }
 
   return llvmTargetOptions;
 }


### PR DESCRIPTION
`-iree-hal-target-backends=dylib-llvm-aot` must also be passed.

Outputs something like:
```
  Registered Targets:
    aarch64    - AArch64 (little endian)
    aarch64_32 - AArch64 (little endian ILP32)
    aarch64_be - AArch64 (big endian)
    arm        - ARM
    arm64      - ARM64 (little endian)
    arm64_32   - ARM64 (little endian ILP32)
    armeb      - ARM (big endian)
    riscv32    - 32-bit RISC-V
    riscv64    - 64-bit RISC-V
    thumb      - Thumb
    thumbeb    - Thumb (big endian)
    x86        - 32-bit X86: Pentium-Pro and above
    x86-64     - 64-bit X86: EM64T and AMD64
```