### PR TITLE
Make (most of) flow flags pass pipeline options.

### DIFF
--- a/build_tools/cmake/iree_mlir_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_mlir_benchmark_suite.cmake
@@ -164,8 +164,7 @@ function(iree_mlir_benchmark_suite)
            "${_RULE_TARGET_ARCHITECTURE}")
 
       # The full list of translation flags.
-      set(_TRANSLATION_ARGS "--iree-mlir-to-vm-bytecode-module")
-      list(APPEND _TRANSLATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
+      set(_TRANSLATION_ARGS "--iree-hal-target-backends=${_RULE_TARGET_BACKEND}")
       list(SORT _RULE_TRANSLATION_FLAGS)
       list(APPEND _TRANSLATION_ARGS ${_RULE_TRANSLATION_FLAGS})
 

--- a/build_tools/mako/compile_android_modules.py
+++ b/build_tools/mako/compile_android_modules.py
@@ -28,7 +28,6 @@ def main() -> None:
         print(f"Generating {module_name} ...")
         subprocess.run(args=[
             IREE_TRANSLATE_PATH, model_benchmark.model_path,
-            "--iree-mlir-to-vm-bytecode-module",
             f"--iree-hal-target-backends={target.hal_target_backend}", "-o",
             module_name
         ] + target.compilation_flags,

--- a/build_tools/mako/configuration.py
+++ b/build_tools/mako/configuration.py
@@ -8,10 +8,10 @@
 
 def pipeline_options_to_string(pipeline, options=None):
   if options is not None:
-    options_str = ",".join(options);
-    return f"--{pipeline}={{{options_str}}}";
+    options_str = ",".join(options)
+    return [f"--{pipeline}={{{options_str}}}"]
   else:
-    return f"--{pipeline}";
+    return [f"--{pipeline}"]
 
 class TargetInfo:
   """Information of a target backend.
@@ -146,8 +146,7 @@ def get_pixel4_default_target_list(skipped_target=None,
                  taskset="80",
                  mako_tag="vlk",
                  flow_transformation_flags=[
-                     "enable-operand-fusion",
-                     "enable-fusion-with-reduction-ops"
+                     "enable-operand-fusion", "enable-fusion-with-reduction-ops"
                  ],
                  compilation_flags=[
                      "--iree-vulkan-target-triple=adreno-a640-android11",
@@ -261,12 +260,8 @@ MODEL_BENCHMARKS = [
                     #     "enable-operand-fusion",
                     # ],
                     compilation_flags={
-                        'cpu': [
-                            "-iree-llvm-loop-unrolling=true"
-                        ],
-                        'cpu3t': [
-                            "-iree-llvm-loop-unrolling=true"
-                        ]
+                        'cpu': ["-iree-llvm-loop-unrolling=true"],
+                        'cpu3t': ["-iree-llvm-loop-unrolling=true"]
                     })),
             PhoneBenchmarkInfo(
                 name="S20",
@@ -277,12 +272,8 @@ MODEL_BENCHMARKS = [
                     #     "enable-operand-fusion",
                     # ],
                     compilation_flags={
-                        'cpu': [
-                            "-iree-llvm-loop-unrolling=true"
-                        ],
-                        'cpu3t': [
-                            "-iree-llvm-loop-unrolling=true"
-                        ]
+                        'cpu': ["-iree-llvm-loop-unrolling=true"],
+                        'cpu3t': ["-iree-llvm-loop-unrolling=true"]
                     })),
         ]),
     ModelBenchmarkInfo(

--- a/iree/benchmark/TensorFlow/CMakeLists.txt
+++ b/iree/benchmark/TensorFlow/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_mlir_benchmark_suite(
   TRANSLATION_FLAGS
     "--iree-input-type=mhlo"
     "--iree-flow-inline-constants-max-byte-length=2048"
+    "--iree-mlir-to-vm-bytecode-module"
   DRIVER
     "vmvx"
   RUNTIME_FLAGS
@@ -101,7 +102,10 @@ iree_mlir_benchmark_suite(
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
-    #"--iree-flow-dispatch-formation-enable-operand-fusion"
+    # "--iree-flow-transformation-pipeline={enable-operand-fusion}"
+    "--iree-flow-transformation-pipeline"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib-sync"
@@ -125,7 +129,10 @@ iree_mlir_benchmark_suite(
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
-    #"--iree-flow-dispatch-formation-enable-operand-fusion"
+    # "--iree-flow-transformation-pipeline={enable-operand-fusion}"
+    "--iree-flow-transformation-pipeline"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib"
@@ -151,7 +158,10 @@ iree_mlir_benchmark_suite(
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
     # TODO(GH-5857): Enable this after fixing segfault.
-    #"--iree-flow-dispatch-formation-enable-operand-fusion"
+    # "--iree-flow-transformation-pipeline={enable-operand-fusion}"
+    "--iree-flow-transformation-pipeline"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-llvm-loop-unrolling=true"
   DRIVER
     "dylib"
@@ -176,8 +186,9 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
-    "--iree-enable-fusion-with-reduction-ops"
+    "--iree-flow-transformation-pipeline={enable-operand-fusion,enable-fusion-with-reduction-ops}"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
   DRIVER
     "vulkan"
 )
@@ -197,9 +208,10 @@ iree_mlir_benchmark_suite(
   TRANSLATION_FLAGS
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
+    "--iree-flow-transformation-pipeline={enable-operand-fusion,enable-fusion-with-reduction-ops}"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
-    "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   DRIVER
     "vulkan"
@@ -223,9 +235,10 @@ iree_mlir_benchmark_suite(
   TRANSLATION_FLAGS
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
+    "--iree-flow-transformation-pipeline={enable-operand-fusion,enable-fusion-with-reduction-ops}"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-flow-inline-constants-max-byte-length=16"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
-    "--iree-enable-fusion-with-reduction-ops"
   DRIVER
     "vulkan"
 )
@@ -245,9 +258,10 @@ iree_mlir_benchmark_suite(
   TRANSLATION_FLAGS
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
+    "--iree-flow-transformation-pipeline={enable-operand-fusion,enable-fusion-with-reduction-ops}"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-flow-inline-constants-max-byte-length=16"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
-    "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   DRIVER
     "vulkan"
@@ -270,9 +284,10 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-flow-demote-f32-to-f16"
     "--iree-vulkan-target-triple=valhall-unknown-android11"
+    "--iree-flow-transformation-pipeline={enable-operand-fusion,enable-fusion-with-reduction-ops}"
+    "--iree-hal-transformation-pipeline"
+    "--iree-vm-transformation-pipeline"
     "--iree-flow-inline-constants-max-byte-length=16"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
-    "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   DRIVER
     "vulkan"
@@ -306,6 +321,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
+    "--iree-mlir-to-vm-bytecode-module"
   DRIVER
     "dylib-sync"
 )
@@ -327,6 +343,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
+    "--iree-mlir-to-vm-bytecode-module"
   DRIVER
     "dylib"
   RUNTIME_FLAGS
@@ -350,6 +367,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
     "--iree-flow-inline-constants-max-byte-length=2048"
+    "--iree-mlir-to-vm-bytecode-module"
   DRIVER
     "dylib"
   RUNTIME_FLAGS

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass -iree-flow-dispatch-formation-enable-operand-fusion -canonicalize -cse %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -verify-diagnostics -iree-flow-dispatch-linalg-on-tensors-pass=enable-operand-fusion -canonicalize -cse %s | IreeFileCheck %s
 
 func @fuse_conv2d_elementwise(%input: tensor<1x225x225x16xf32>, %filter: tensor<3x3x16x32xf32>, %offset: tensor<32xf32>) -> tensor<1x112x112x32xf32> {
   %cst = constant 0.000000e+00 : f32

--- a/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-mhlo-input-transformation-pipeline -iree-flow-transformation-pipeline -iree-flow-export-benchmark-funcs %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-mhlo-input-transformation-pipeline -iree-flow-transformation-pipeline=export-benchmark-funcs %s | IreeFileCheck %s
 
 module {
   func @two_dispatch(%arg0: tensor<5x3xf32>, %arg1: tensor<3x5xf32>) -> (tensor<5x5xf32>, tensor<3x5xf32>) {

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -116,7 +116,8 @@ static LogicalResult convertToFlowModule(ModuleOp moduleOp) {
   mlir::applyPassManagerCLOptions(passManager);
   mlir::applyDefaultTimingPassManagerCLOptions(passManager);
   passManager.addInstrumentation(std::make_unique<PassTracing>());
-  IREE::Flow::buildFlowTransformPassPipeline(passManager);
+  IREE::Flow::FlowTransformationPassPipelineOptions options;
+  IREE::Flow::buildFlowTransformPassPipeline(passManager, options);
   if (failed(passManager.run(moduleOp))) {
     return moduleOp.emitError()
            << "failed to run flow transformation pass pipeline";
@@ -179,7 +180,8 @@ static void buildIREEVMTransformPassPipeline(
       break;
   }
 
-  IREE::Flow::buildFlowTransformPassPipeline(passManager);
+  IREE::Flow::FlowTransformationPassPipelineOptions options;
+  IREE::Flow::buildFlowTransformPassPipeline(passManager, options);
   IREE::HAL::buildHALTransformPassPipeline(passManager, executableOptions);
   IREE::VM::buildVMTransformPassPipeline(passManager, targetOptions);
   passManager.addPass(mlir::iree_compiler::IREE::createDropCompilerHintsPass());

--- a/iree/test/e2e/regression/trace_dispatch_tensors.mlir
+++ b/iree/test/e2e/regression/trace_dispatch_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-run-mlir --iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-flow-trace-dispatch-tensors2 %s 2>&1 | IreeFileCheck %s
+// RUN: iree-run-mlir --iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-flow-trace-dispatch-tensors %s 2>&1 | IreeFileCheck %s
 
 func @two_dispatch() -> (tensor<5x5xf32>, tensor<3x5xf32>) {
   %0 = iree.unfoldable_constant dense<1.0> : tensor<5x3xf32>


### PR DESCRIPTION
For the differen CPU/GPU architectures, different options are used for
creating dispatch region formation. While we want to reduce the number
of such configurations, these options represent things that are
WIP. Having LLVM options make these non-reproducible. So making them
pass pipeline options.
Changing the benchmark configuration to use this flags instead.