### PR TITLE
Add further VM f32 ops to EmitC conversions

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1330,6 +1330,10 @@ void populateVMToEmitCPatterns(MLIRContext *context,
   patterns.insert<ConstOpConversion<IREE::VM::ConstF32Op>>(context);
   patterns.insert<ConstZeroOpConversion<IREE::VM::ConstF32ZeroOp>>(context);
 
+  // ExtF32: Conditional assignment
+  patterns.insert<CallOpConversion<IREE::VM::SelectF32Op>>(context,
+                                                           "vm_select_f32");
+
   // ExtF32: Native floating-point arithmetic
   patterns.insert<CallOpConversion<IREE::VM::AddF32Op>>(context, "vm_add_f32");
   patterns.insert<CallOpConversion<IREE::VM::SubF32Op>>(context, "vm_sub_f32");
@@ -1369,6 +1373,16 @@ void populateVMToEmitCPatterns(MLIRContext *context,
                                                          "vm_sqrt_f32");
   patterns.insert<CallOpConversion<IREE::VM::TanhF32Op>>(context,
                                                          "vm_tanh_f32");
+
+  // ExtF32: Casting and type conversion/emulation
+  patterns.insert<CallOpConversion<IREE::VM::CastSI32F32Op>>(context,
+                                                             "vm_cast_si32f32");
+  patterns.insert<CallOpConversion<IREE::VM::CastUI32F32Op>>(context,
+                                                             "vm_cast_ui32f32");
+  patterns.insert<CallOpConversion<IREE::VM::CastF32SI32Op>>(context,
+                                                             "vm_cast_f32si32");
+  patterns.insert<CallOpConversion<IREE::VM::CastF32UI32Op>>(context,
+                                                             "vm_cast_f32ui32");
 
   // ExtF32: Comparison ops
   patterns.insert<CallOpConversion<IREE::VM::CmpEQF32OOp>>(context,

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @select_f32
+vm.module @my_module {
+  vm.func @select_f32(%arg0 : i32, %arg1 : f32, %arg2 : f32) -> f32 {
+    // CHECK: %0 = emitc.call "vm_select_f32"(%arg0, %arg1, %arg2) : (i32, f32, f32) -> f32
+    %0 = vm.select.f32 %arg0, %arg1, %arg2 : f32
+    vm.return %0 : f32
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: vm.func @cast
+vm.module @my_module {
+  vm.func @cast(%arg0 : i32) -> (i32, i32) {
+    // CHECK-NEXT: %0 = emitc.call "vm_cast_si32f32"(%arg0) : (i32) -> f32
+    %0 = vm.cast.si32.f32 %arg0 : i32 -> f32
+    // CHECK-NEXT: %1 = emitc.call "vm_cast_ui32f32"(%arg0) : (i32) -> f32
+    %1 = vm.cast.ui32.f32 %arg0 : i32 -> f32
+    // CHECK-NEXT: %2 = emitc.call "vm_cast_f32si32"(%0) : (f32) -> i32
+    %2 = vm.cast.f32.si32 %0 : f32 -> i32
+    // CHECK-NEXT: %3 = emitc.call "vm_cast_f32ui32"(%1) : (f32) -> i32
+    %3 = vm.cast.f32.ui32 %1 : f32 -> i32
+    vm.return %2, %3 : i32, i32
+  }
+}

--- a/iree/vm/test/assignment_ops_f32.mlir
+++ b/iree/vm/test/assignment_ops_f32.mlir
@@ -4,8 +4,8 @@ vm.module @assignment_ops_f32 {
   // ExtF32: Conditional assignment
   //===--------------------------------------------------------------------===//
 
-  vm.export @test_select_f32 attributes {emitc.exclude}
-  vm.func private @test_select_f32() {
+  vm.export @test_select_f32
+  vm.func @test_select_f32() {
     %c0 = vm.const.i32 0 : i32
     %c0dno = iree.do_not_optimize(%c0) : i32
     %c1 = vm.const.i32 1 : i32

--- a/iree/vm/test/conversion_ops_f32.mlir
+++ b/iree/vm/test/conversion_ops_f32.mlir
@@ -4,8 +4,8 @@ vm.module @conversion_ops_f32 {
   // Casting and type conversion/emulation
   //===----------------------------------------------------------------------===//
 
-  vm.export @test_cast_si32_f32_int_max attributes {emitc.exclude}
-  vm.func private @test_cast_si32_f32_int_max() {
+  vm.export @test_cast_si32_f32_int_max
+  vm.func @test_cast_si32_f32_int_max() {
     %c1 = vm.const.i32 2147483647 : i32
     %c1dno = iree.do_not_optimize(%c1) : i32
     %v = vm.cast.si32.f32 %c1dno : i32 -> f32
@@ -14,8 +14,8 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_si32_f32_int_min attributes {emitc.exclude}
-  vm.func private @test_cast_si32_f32_int_min() {
+  vm.export @test_cast_si32_f32_int_min
+  vm.func @test_cast_si32_f32_int_min() {
     %c1 = vm.const.i32 -2147483648 : i32
     %c1dno = iree.do_not_optimize(%c1) : i32
     %v = vm.cast.si32.f32 %c1dno : i32 -> f32
@@ -24,8 +24,8 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_ui32_f32_int_max attributes {emitc.exclude}
-  vm.func private @test_cast_ui32_f32_int_max() {
+  vm.export @test_cast_ui32_f32_int_max
+  vm.func @test_cast_ui32_f32_int_max() {
     %c1 = vm.const.i32 4294967295 : i32
     %c1dno = iree.do_not_optimize(%c1) : i32
     %v = vm.cast.ui32.f32 %c1dno : i32 -> f32
@@ -34,8 +34,8 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_f32_si32_int_max attributes {emitc.exclude}
-  vm.func private @test_cast_f32_si32_int_max() {
+  vm.export @test_cast_f32_si32_int_max
+  vm.func @test_cast_f32_si32_int_max() {
     %c1 = vm.const.f32 2147483647.0 : f32
     %c1dno = iree.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
@@ -44,8 +44,8 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_f32_si32_int_min attributes {emitc.exclude}
-  vm.func private @test_cast_f32_si32_int_min() {
+  vm.export @test_cast_f32_si32_int_min
+  vm.func @test_cast_f32_si32_int_min() {
     %c1 = vm.const.f32 -2147483648.0 : f32
     %c1dno = iree.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
@@ -54,8 +54,8 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  vm.export @test_cast_f32_ui32_int_max attributes {emitc.exclude}
-  vm.func private @test_cast_f32_ui32_int_max() {
+  vm.export @test_cast_f32_ui32_int_max
+  vm.func @test_cast_f32_ui32_int_max() {
     %c1 = vm.const.f32 4294967295.0 : f32
     %c1dno = iree.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.ui32 %c1dno : f32 -> i32


### PR DESCRIPTION
Enables the conversion of VM f32 select and f32 cast ops to EmitC.