### PR TITLE
Restructure ops and bytecode dispatcher

### DIFF
--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1964,6 +1964,26 @@ iree_status_t iree_vm_bytecode_dispatch(
       DISPATCH_OP_EXT_F32_UNARY_F32(CeilF32, vm_ceil_f32);
       DISPATCH_OP_EXT_F32_UNARY_F32(FloorF32, vm_floor_f32);
 
+      DISPATCH_OP_EXT_F32_UNARY_F32(AtanF32, vm_atan_f32);
+      DISPATCH_OP_EXT_F32_BINARY_F32(Atan2F32, vm_atan2_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(CosF32, vm_cos_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(SinF32, vm_sin_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(ExpF32, vm_exp_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(Exp2F32, vm_exp2_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(ExpM1F32, vm_expm1_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(LogF32, vm_log_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(Log10F32, vm_log10_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(Log1pF32, vm_log1p_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(Log2F32, vm_log2_f32);
+      DISPATCH_OP_EXT_F32_BINARY_F32(PowF32, vm_pow_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(RsqrtF32, vm_rsqrt_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(SqrtF32, vm_sqrt_f32);
+      DISPATCH_OP_EXT_F32_UNARY_F32(TanhF32, vm_tanh_f32);
+
+      //===----------------------------------------------------------------===//
+      // ExtF32: Casting and type conversion/emulation
+      //===----------------------------------------------------------------===//
+
       DISPATCH_OP(EXT_F32, CastSI32F32, {
         int32_t operand = (int32_t)VM_DecOperandRegI32("operand");
         float* result = VM_DecResultRegF32("result");
@@ -1984,26 +2004,6 @@ iree_status_t iree_vm_bytecode_dispatch(
         int32_t* result = VM_DecResultRegI32("result");
         *result = vm_cast_f32ui32(operand);
       });
-
-      DISPATCH_OP_EXT_F32_UNARY_F32(AtanF32, vm_atan_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(Atan2F32, vm_atan2_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(CosF32, vm_cos_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(SinF32, vm_sin_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(ExpF32, vm_exp_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Exp2F32, vm_exp2_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(ExpM1F32, vm_expm1_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(LogF32, vm_log_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log10F32, vm_log10_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log1pF32, vm_log1p_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(Log2F32, vm_log2_f32);
-      DISPATCH_OP_EXT_F32_BINARY_F32(PowF32, vm_pow_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(RsqrtF32, vm_rsqrt_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(SqrtF32, vm_sqrt_f32);
-      DISPATCH_OP_EXT_F32_UNARY_F32(TanhF32, vm_tanh_f32);
-
-      //===----------------------------------------------------------------===//
-      // ExtF32: Casting and type conversion/emulation
-      //===----------------------------------------------------------------===//
 
       //===----------------------------------------------------------------===//
       // ExtF32: Comparison ops


### PR DESCRIPTION
This groups the f32 functions in `ops.h` as in the dispatcher and VM to
EmitC conversion pass. Further moves the f32 cast ops in the dispatcher
to the appropriate position.