### PR TITLE
Tuning the task system slice size up to 16.

### DIFF
--- a/iree/task/tuning.h
+++ b/iree/task/tuning.h
@@ -30,7 +30,7 @@ extern "C" {
 // Increasing this number will decrease initial allocation storms in cases of
 // extremely wide concurrency regions (many dispatches running at the same time)
 // at the cost of a higher minimum memory consumption.
-#define IREE_TASK_EXECUTOR_INITIAL_SHARD_RESERVATION_PER_WORKER (4)
+#define IREE_TASK_EXECUTOR_INITIAL_SHARD_RESERVATION_PER_WORKER (16)
 
 // Maximum number of simultaneous waits an executor may perform as part of a
 // wait-any operation. A larger value may enable better wake coalescing by the
@@ -108,7 +108,7 @@ extern "C" {
 // destroying behavior where multiple workers all stomp on the same cache lines
 // (as say worker 0 and worker 1 both fight over sequential tiles adjacent in
 // memory).
-#define IREE_TASK_DISPATCH_MAX_TILES_PER_SHARD_RESERVATION (8)
+#define IREE_TASK_DISPATCH_MAX_TILES_PER_SHARD_RESERVATION (16)
 
 // Whether to enable per-tile colors for each tile tracing zone based on the
 // tile grid xyz. Not cheap and can be disabled to reduce tracing overhead.

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -419,7 +419,6 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_function_enter(
   IREE_TRACE_ZONE_BEGIN_NAMED_DYNAMIC(z0, function_name.data,
                                       function_name.size);
   callee_frame->trace_zone = z0;
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, frame_size);
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
   if (out_callee_frame) *out_callee_frame = callee_frame;


### PR DESCRIPTION
We'll need a better way to determine this in the future, but it's a 2x
win with how we are generating tiles today and that's too good to ignore.
It's also hiding the cache effects of the actual codegen.