### PR TITLE
Add VM to EmitC support for f32/i64 global ops

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1326,6 +1326,14 @@ void populateVMToEmitCPatterns(MLIRContext *context,
       context, "vm_cmp_ne_ref", vmAnalysisCache);
   patterns.insert<CompareRefNotZeroOpConversion>(context, vmAnalysisCache);
 
+  // ExtF32: Globals
+  patterns.insert<
+      GlobalLoadOpConversion<IREE::VM::GlobalLoadF32Op, IREE::VM::GlobalF32Op>>(
+      context, "vm_global_load_f32");
+  patterns.insert<GlobalStoreOpConversion<IREE::VM::GlobalStoreF32Op,
+                                          IREE::VM::GlobalF32Op>>(
+      context, "vm_global_store_f32");
+
   // ExtF32: Native floating-point constants
   patterns.insert<ConstOpConversion<IREE::VM::ConstF32Op>>(context);
   patterns.insert<ConstZeroOpConversion<IREE::VM::ConstF32ZeroOp>>(context);
@@ -1403,6 +1411,14 @@ void populateVMToEmitCPatterns(MLIRContext *context,
                                                             "vm_cmp_lte_f32u");
   patterns.insert<CallOpConversion<IREE::VM::CmpNaNF32Op>>(context,
                                                            "vm_cmp_nan_f32");
+
+  // ExtI64: Globals
+  patterns.insert<
+      GlobalLoadOpConversion<IREE::VM::GlobalLoadI64Op, IREE::VM::GlobalI64Op>>(
+      context, "vm_global_load_i64");
+  patterns.insert<GlobalStoreOpConversion<IREE::VM::GlobalStoreI64Op,
+                                          IREE::VM::GlobalI64Op>>(
+      context, "vm_global_store_i64");
 
   // ExtI64: Constants
   patterns.insert<ConstOpConversion<IREE::VM::ConstI64Op>>(context);
@@ -1505,6 +1521,8 @@ class ConvertVMToEmitCPass
 
     // Global ops
     target.addLegalOp<IREE::VM::GlobalI32Op>();
+    target.addLegalOp<IREE::VM::GlobalI64Op>();
+    target.addLegalOp<IREE::VM::GlobalF32Op>();
     target.addLegalOp<IREE::VM::RodataOp>();
 
     // Control flow ops

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -160,26 +160,6 @@ static LogicalResult initializeState(IREE::VM::ModuleOp moduleOp,
                                      mlir::emitc::CppEmitter &emitter) {
   llvm::raw_ostream &output = emitter.ostream();
 
-  for (auto globalOp : moduleOp.getOps<IREE::VM::GlobalI32Op>()) {
-    Optional<Attribute> initialValue = globalOp.initial_value();
-    Optional<StringRef> initializer = globalOp.initializer();
-    if (initialValue.hasValue()) {
-      // TODO(simon-camp): We can't represent structs in emitc (yet maybe), so
-      // the struct argument name here must not be changed.
-      emitter.ostream() << "vm_global_store_i32(state->rwdata, "
-                        << globalOp.ordinal() << ", ";
-      if (failed(emitter.emitAttribute(*globalOp.getOperation(),
-                                       initialValue.getValue()))) {
-        return globalOp.emitError() << "Unable to emit initial_value";
-      }
-      emitter.ostream() << ");\n";
-    } else if (initializer.hasValue()) {
-      return globalOp.emitError()
-             << "Initializers for globals not supported yet";
-    }
-  }
-  // TODO(simon-camp): Support globals with different element type
-
   for (auto rodataOp : moduleOp.getOps<IREE::VM::RodataOp>()) {
     std::string buffer_name =
         moduleOp.getName().str() + "_" + rodataOp.getName().str();

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1555,9 +1555,9 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         int64_t* value = VM_DecResultRegI64("value");
-        const int64_t* global_ptr =
-            (const int64_t*)(module_state->rwdata_storage.data + byte_offset);
-        *value = *global_ptr;
+        const int64_t global_value =
+            vm_global_load_i64(module_state->rwdata_storage.data, byte_offset);
+        *value = global_value;
       });
 
       DISPATCH_OP(EXT_I64, GlobalStoreI64, {
@@ -1570,9 +1570,8 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         int64_t value = VM_DecOperandRegI64("value");
-        int64_t* global_ptr =
-            (int64_t*)(module_state->rwdata_storage.data + byte_offset);
-        *global_ptr = value;
+        vm_global_store_i64(module_state->rwdata_storage.data, byte_offset,
+                            value);
       });
 
       DISPATCH_OP(EXT_I64, GlobalLoadIndirectI64, {
@@ -1585,9 +1584,9 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         int64_t* value = VM_DecResultRegI64("value");
-        const int64_t* global_ptr =
-            (const int64_t*)(module_state->rwdata_storage.data + byte_offset);
-        *value = *global_ptr;
+        const int64_t global_value =
+            vm_global_load_i64(module_state->rwdata_storage.data, byte_offset);
+        *value = global_value;
       });
 
       DISPATCH_OP(EXT_I64, GlobalStoreIndirectI64, {
@@ -1600,9 +1599,8 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         int64_t value = VM_DecOperandRegI64("value");
-        int64_t* global_ptr =
-            (int64_t*)(module_state->rwdata_storage.data + byte_offset);
-        *global_ptr = value;
+        vm_global_store_i64(module_state->rwdata_storage.data, byte_offset,
+                            value);
       });
 
       //===----------------------------------------------------------------===//
@@ -1826,9 +1824,10 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         float* value = VM_DecResultRegF32("value");
-        const float* global_ptr =
-            (const float*)(module_state->rwdata_storage.data + byte_offset);
-        *value = *global_ptr;
+        const float global_value =
+            vm_global_load_f32(module_state->rwdata_storage.data, byte_offset);
+        *value = global_value;
+        
       });
 
       DISPATCH_OP(EXT_F32, GlobalStoreF32, {
@@ -1841,9 +1840,8 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         float value = VM_DecOperandRegF32("value");
-        float* global_ptr =
-            (float*)(module_state->rwdata_storage.data + byte_offset);
-        *global_ptr = value;
+        vm_global_store_f32(module_state->rwdata_storage.data, byte_offset,
+                            value);
       });
 
       DISPATCH_OP(EXT_F32, GlobalLoadIndirectF32, {
@@ -1856,9 +1854,9 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         float* value = VM_DecResultRegF32("value");
-        const float* global_ptr =
-            (const float*)(module_state->rwdata_storage.data + byte_offset);
-        *value = *global_ptr;
+        const float global_value =
+            vm_global_load_f32(module_state->rwdata_storage.data, byte_offset);
+        *value = global_value;
       });
 
       DISPATCH_OP(EXT_F32, GlobalStoreIndirectF32, {
@@ -1871,9 +1869,8 @@ iree_status_t iree_vm_bytecode_dispatch(
               module_state->rwdata_storage.data_length);
         }
         float value = VM_DecOperandRegF32("value");
-        float* global_ptr =
-            (float*)(module_state->rwdata_storage.data + byte_offset);
-        *global_ptr = value;
+        vm_global_store_f32(module_state->rwdata_storage.data, byte_offset,
+                            value);
       });
 
       //===----------------------------------------------------------------===//

--- a/iree/vm/ops.h
+++ b/iree/vm/ops.h
@@ -149,6 +149,21 @@ static inline iree_status_t vm_fail_or_ok(int32_t status_code,
 }
 
 //===------------------------------------------------------------------===//
+// ExtI64: Globals
+//===------------------------------------------------------------------===//
+
+static inline int64_t vm_global_load_i64(uint8_t* base, uint32_t byte_offset) {
+  const int64_t* global_ptr = (const int64_t*)(base + byte_offset);
+  return *global_ptr;
+}
+
+static inline void vm_global_store_i64(uint8_t* base, uint32_t byte_offset,
+                                       int64_t value) {
+  int64_t* global_ptr = (int64_t*)(base + byte_offset);
+  *global_ptr = value;
+}
+
+//===------------------------------------------------------------------===//
 // ExtI64: Conditional assignment
 //===------------------------------------------------------------------===//
 
@@ -235,6 +250,21 @@ static inline int32_t vm_cmp_lt_i64u(int64_t lhs, int64_t rhs) {
 }
 static inline int32_t vm_cmp_nz_i64(int64_t operand) {
   return (operand != 0) ? 1 : 0;
+}
+
+//===------------------------------------------------------------------===//
+// ExtF32: Globals
+//===------------------------------------------------------------------===//
+
+static inline float vm_global_load_f32(uint8_t* base, uint32_t byte_offset) {
+  const float* global_ptr = (const float*)(base + byte_offset);
+  return *global_ptr;
+}
+
+static inline void vm_global_store_f32(uint8_t* base, uint32_t byte_offset,
+                                       float value) {
+  float* global_ptr = (float*)(base + byte_offset);
+  *global_ptr = value;
 }
 
 //===------------------------------------------------------------------===//

--- a/iree/vm/test/global_ops_f32.mlir
+++ b/iree/vm/test/global_ops_f32.mlir
@@ -8,16 +8,16 @@ vm.module @global_ops_f32 {
   vm.global.f32 @c107_mut mutable 107.5 : f32 attributes {sym_visibility = "private"}
   // TODO(simon-camp): Add test for initializer
 
-  vm.export @test_global_load_f32 attributes {emitc.exclude}
-  vm.func private @test_global_load_f32() {
+  vm.export @test_global_load_f32
+  vm.func @test_global_load_f32() {
     %actual = vm.global.load.f32 @c42 : f32
     %expected = vm.const.f32 42.5 : f32
     vm.check.eq %actual, %expected, "@c42 != 42.5" : f32
     vm.return
   }
 
-  vm.export @test_global_store_f32 attributes {emitc.exclude}
-  vm.func private @test_global_store_f32() {
+  vm.export @test_global_store_f32
+  vm.func @test_global_store_f32() {
     %c17 = vm.const.f32 17.5 : f32
     vm.global.store.f32 %c17, @c107_mut : f32
     %actual = vm.global.load.f32 @c107_mut : f32

--- a/iree/vm/test/global_ops_i64.mlir
+++ b/iree/vm/test/global_ops_i64.mlir
@@ -8,16 +8,16 @@ vm.module @global_ops_i64 {
   vm.global.i64 @c107_mut mutable 107 : i64 attributes {sym_visibility = "private"}
   // TODO(simon-camp): Add test for initializer
 
-  vm.export @test_global_load_i64 attributes {emitc.exclude}
-  vm.func private @test_global_load_i64() {
+  vm.export @test_global_load_i64
+  vm.func @test_global_load_i64() {
     %actual = vm.global.load.i64 @c42 : i64
     %expected = vm.const.i64 42 : i64
     vm.check.eq %actual, %expected, "@c42 != 42" : i64
     vm.return
   }
 
-  vm.export @test_global_store_i64 attributes {emitc.exclude}
-  vm.func private @test_global_store_i64() {
+  vm.export @test_global_store_i64
+  vm.func @test_global_store_i64() {
     %c17 = vm.const.i64 17 : i64
     vm.global.store.i64 %c17, @c107_mut : i64
     %actual = vm.global.load.i64 @c107_mut : i64


### PR DESCRIPTION
Implements global load and store ops for f32 and i64 types in `ops.h`
and changes the dispatcher to use them. Fruther adds the corresponding
VM to EmitC conversions.