### PR TITLE
Fix cuda_backend.md

### DIFF
--- a/docs/developers/design_docs/cuda_backend.md
+++ b/docs/developers/design_docs/cuda_backend.md
@@ -80,7 +80,6 @@ $ ../iree-build/iree/tools/iree-translate \
  -iree-input-type=mhlo \
  -iree-mlir-to-vm-bytecode-module \
  -iree-hal-target-backends=cuda \
- -iree-flow-dispatch-linalg-on-tensors \
  /tmp/add.mlir \
  -o /tmp/mhlo-add.vmfb
 


### PR DESCRIPTION
`-iree-flow-dispatch-linalg-on-tensors` is not an option of `iree-translate`.  
Or should I use `-iree-flow-dispatch-linalg-on-tensors-tile-sizes=<>` instead?