### PR TITLE
Avoid nesting modules in modules for VM conversion if not needed.

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/ConversionTarget.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/ConversionTarget.cpp
@@ -12,6 +12,10 @@ namespace iree_compiler {
 // static
 std::pair<mlir::ModuleOp, mlir::ModuleOp>
 VMConversionTarget::nestModuleForConversion(mlir::ModuleOp outerModuleOp) {
+  if (isa<IREE::VM::ModuleOp>(outerModuleOp.getBody()->front())) {
+    // Already have a VM module; no need for the nesting.
+    return std::make_pair(outerModuleOp, outerModuleOp);
+  }
   auto innerModuleOp = dyn_cast<ModuleOp>(outerModuleOp.getBody()->front());
   if (!innerModuleOp) {
     innerModuleOp =


### PR DESCRIPTION
The implicit outer MLIR module cannot have conversion patterns applied so
prior to conversion we create _another_ module and nest it for the
module->vm.module conversion to work. If trying to run VM conversion on
an already converted module with both the implicit outer module and
vm.module nested within this would cause module>module>vm.module to be
converted to module>vm.module>vm.module.

Fixes #6307.