### PR TITLE
NFC: Convert away from deprecated pass static registration with explicit args/desc.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/MHLO/EmitDefaultIREEABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/MHLO/EmitDefaultIREEABI.cpp
@@ -22,6 +22,14 @@ namespace MHLO {
 class EmitDefaultIREEABIPass
     : public PassWrapper<EmitDefaultIREEABIPass, OperationPass<FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-mhlo-emit-default-iree-abi";
+  }
+
+  StringRef getDescription() const override {
+    return "Emits simple default ABI metadata";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     if (SymbolTable::getSymbolVisibility(funcOp) !=
@@ -108,8 +116,7 @@ std::unique_ptr<OperationPass<FuncOp>> createEmitDefaultIREEABIPass() {
   return std::make_unique<EmitDefaultIREEABIPass>();
 }
 
-static PassRegistration<EmitDefaultIREEABIPass> funcPass(
-    "iree-mhlo-emit-default-iree-abi", "Emits simple default ABI metadata");
+static PassRegistration<EmitDefaultIREEABIPass> funcPass;
 
 }  // namespace MHLO
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/MHLO/FlattenTuplesInCFG.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/MHLO/FlattenTuplesInCFG.cpp
@@ -276,6 +276,15 @@ bool convertFunction(FuncOp oldFunction, FuncOp newFunction) {
 class FlattenTuplesInCFGPass
     : public PassWrapper<FlattenTuplesInCFGPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-mhlo-flatten-tuples-in-cfg";
+  }
+
+  StringRef getDescription() const override {
+    return "Convert functions to remove tuples from method signatures and "
+           "blocks";
+  }
+
   void runOnOperation() override {
     auto module = getOperation();
     Builder builder(module.getContext());
@@ -320,9 +329,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createFlattenTuplesInCFGPass() {
   return std::make_unique<FlattenTuplesInCFGPass>();
 }
 
-static PassRegistration<FlattenTuplesInCFGPass> pass(
-    "iree-mhlo-flatten-tuples-in-cfg",
-    "Convert functions to remove tuples from method signatures and blocks");
+static PassRegistration<FlattenTuplesInCFGPass> pass;
 
 }  // namespace MHLO
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/ConvertToMHLO.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/ConvertToMHLO.cpp
@@ -42,6 +42,12 @@ class ConvertToMHLOPass : public PassWrapper<ConvertToMHLOPass, FunctionPass> {
                     shape::ShapeDialect, StandardOpsDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-tf-convert-to-mhlo"; }
+
+  StringRef getDescription() const override {
+    return "Converts from TensorFlow to the XLA MHLO dialect";
+  }
+
  public:
   ConvertToMHLOPass() = default;
   ConvertToMHLOPass(const ConvertToMHLOPass &) {}
@@ -146,9 +152,7 @@ std::unique_ptr<FunctionPass> createConvertToMHLOPass() {
   return std::make_unique<ConvertToMHLOPass>();
 }
 
-static PassRegistration<ConvertToMHLOPass> pass(
-    "iree-tf-convert-to-mhlo",
-    "Converts from TensorFlow to the XLA MHLO dialect");
+static PassRegistration<ConvertToMHLOPass> pass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/LowerGlobalTensors.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/LowerGlobalTensors.cpp
@@ -169,6 +169,15 @@ class LowerGlobalTensors
                     iree_compiler::IREEDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tf-saved-model-lower-global-tensors";
+  }
+
+  StringRef getDescription() const override {
+    return "Lowers tf_saved_model global tensors to IREE flow dialect "
+           "variables";
+  }
+
   void runOnOperation() override {
     if (failed(convertTFGlobalTensorsToFlowVariables(getOperation()))) {
       signalPassFailure();
@@ -180,9 +189,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createLowerGlobalTensorsPass() {
   return std::make_unique<LowerGlobalTensors>();
 }
 
-static PassRegistration<LowerGlobalTensors> pass(
-    "iree-tf-saved-model-lower-global-tensors",
-    "Lowers tf_saved_model global tensors to IREE flow dialect variables");
+static PassRegistration<LowerGlobalTensors> pass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/PrettifyDebugInfo.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/PrettifyDebugInfo.cpp
@@ -14,6 +14,14 @@ namespace TF {
 class PrettifyDebugInfoPass
     : public PassWrapper<PrettifyDebugInfoPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tf-prettify-debug-info";
+  }
+
+  StringRef getDescription() const override {
+    return "Simplifies TF debug info to make it easier to look at";
+  }
+
   void runOnOperation() override {
     // TODO: Finish algorithm for simplifying TF debug info.
     // auto moduleOp = getOperation();
@@ -30,9 +38,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createPrettifyDebugInfoPass() {
   return std::make_unique<PrettifyDebugInfoPass>();
 }
 
-static PassRegistration<PrettifyDebugInfoPass> modulePass(
-    "iree-tf-prettify-debug-info",
-    "Simplifies TF debug info to make it easier to look at");
+static PassRegistration<PrettifyDebugInfoPass> modulePass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/PropagateResourceCasts.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/PropagateResourceCasts.cpp
@@ -58,6 +58,14 @@ class PropagateResourceCastsPass
     registry.insert<mlir::TF::TensorFlowDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tf-propagate-resource-casts";
+  }
+
+  StringRef getDescription() const override {
+    return "Propagates tf.resource type casts";
+  }
+
   void runOnOperation() override {
     auto operation = getOperation();
     for (auto func : operation.getOps<FuncOp>()) {
@@ -105,8 +113,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createPropagateResourceCastsPass() {
   return std::make_unique<PropagateResourceCastsPass>();
 }
 
-static PassRegistration<PropagateResourceCastsPass> pass(
-    "iree-tf-propagate-resource-casts", "Propagates tf.resource type casts");
+static PassRegistration<PropagateResourceCastsPass> pass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
@@ -568,6 +568,14 @@ class SavedModelToIREEABIPass
                     mlir::tf_saved_model::TensorFlowSavedModelDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "tf-saved-model-to-iree-abi";
+  }
+
+  StringRef getDescription() const override {
+    return "Creates IREE ABI entrypoints for saved model exports";
+  }
+
   void runOnOperation() override {
     if (failed(run())) {
       signalPassFailure();
@@ -619,9 +627,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createSavedModelToIREEABIPass() {
   return std::make_unique<SavedModelToIREEABIPass>();
 }
 
-static PassRegistration<SavedModelToIREEABIPass> pass(
-    "tf-saved-model-to-iree-abi",
-    "Creates IREE ABI entrypoints for saved model exports");
+static PassRegistration<SavedModelToIREEABIPass> pass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/StripAsserts.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/StripAsserts.cpp
@@ -14,6 +14,10 @@ namespace TF {
 class StripAssertsPass
     : public PassWrapper<StripAssertsPass, OperationPass<FuncOp>> {
  public:
+  StringRef getArgument() const override { return "iree-tf-strip-asserts"; }
+
+  StringRef getDescription() const override { return "Remove tf.Assert ops"; }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     DenseSet<Operation *> assertOps;
@@ -33,8 +37,7 @@ std::unique_ptr<OperationPass<FuncOp>> createStripAssertsPass() {
   return std::make_unique<StripAssertsPass>();
 }
 
-static PassRegistration<StripAssertsPass> funcPass("iree-tf-strip-asserts",
-                                                   "Remove tf.Assert ops");
+static PassRegistration<StripAssertsPass> funcPass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/StripMetadata.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/StripMetadata.cpp
@@ -34,6 +34,14 @@ static bool isTFAttr(NamedAttribute &namedAttr) {
 class StripModuleMetadataPass
     : public PassWrapper<StripModuleMetadataPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tf-strip-module-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Remove unneeded TensorFlow attributes from module ops";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     auto stripAttrs = llvm::to_vector<4>(llvm::make_filter_range(
@@ -48,6 +56,14 @@ class StripModuleMetadataPass
 class StripFunctionMetadataPass
     : public PassWrapper<StripFunctionMetadataPass, OperationPass<FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tf-strip-function-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Remove unneeded TensorFlow attributes from func ops";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     auto stripAttrs = llvm::to_vector<4>(llvm::make_filter_range(
@@ -85,13 +101,9 @@ std::unique_ptr<OperationPass<FuncOp>> createStripFunctionMetadataPass() {
   return std::make_unique<StripFunctionMetadataPass>();
 }
 
-static PassRegistration<StripModuleMetadataPass> modulePass(
-    "iree-tf-strip-module-metadata",
-    "Remove unneeded TensorFlow attributes from module ops");
+static PassRegistration<StripModuleMetadataPass> modulePass;
 
-static PassRegistration<StripFunctionMetadataPass> funcPass(
-    "iree-tf-strip-function-metadata",
-    "Remove unneeded TensorFlow attributes from func ops");
+static PassRegistration<StripFunctionMetadataPass> funcPass;
 
 }  // namespace TF
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TF/VerifyFullyConverted.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/VerifyFullyConverted.cpp
@@ -40,6 +40,15 @@ class VerifyFullyConvertedPass
                     mlir::tf_saved_model::TensorFlowSavedModelDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tf-verify-fully-converted";
+  }
+
+  StringRef getDescription() const override {
+    return "Verifies that all TensorFlow frontend ops were converted and none "
+           "remain";
+  }
+
   // Validates that no TensorFlow frontends ops are in the function.
   void runOnFunction() override {
     DenseSet<Operation *> illegalOps;
@@ -76,9 +85,7 @@ class VerifyFullyConvertedPass
   }
 };
 
-static PassRegistration<VerifyFullyConvertedPass> pass(
-    "iree-tf-verify-fully-converted",
-    "Verifies that all TensorFlow frontend ops were converted and none remain");
+static PassRegistration<VerifyFullyConvertedPass> pass;
 
 std::unique_ptr<OperationPass<FuncOp>> createVerifyFullyConvertedPass() {
   return std::make_unique<VerifyFullyConvertedPass>();

--- a/integrations/tensorflow/iree_tf_compiler/TFL/ConvertMetadata.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/ConvertMetadata.cpp
@@ -28,6 +28,14 @@ static void splitFunctionIONames(StringAttr namesAttr,
 class ConvertModuleMetadataPass
     : public PassWrapper<ConvertModuleMetadataPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tflite-convert-module-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Converts TFLite attributes to IREE attributes on modules";
+  }
+
   void runOnOperation() override {
     // None currently handled.
   }
@@ -36,6 +44,14 @@ class ConvertModuleMetadataPass
 class ConvertFunctionMetadataPass
     : public PassWrapper<ConvertFunctionMetadataPass, OperationPass<FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tflite-convert-function-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Converts TFLite attributes to IREE attributes on functions";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
 
@@ -97,13 +113,8 @@ std::unique_ptr<OperationPass<FuncOp>> createConvertFunctionMetadataPass() {
   return std::make_unique<ConvertFunctionMetadataPass>();
 }
 
-static PassRegistration<ConvertModuleMetadataPass> modulePass(
-    "iree-tflite-convert-module-metadata",
-    "Converts TFLite attributes to IREE attributes on modules");
-
-static PassRegistration<ConvertFunctionMetadataPass> funcPass(
-    "iree-tflite-convert-function-metadata",
-    "Converts TFLite attributes to IREE attributes on functions");
+static PassRegistration<ConvertModuleMetadataPass> modulePass;
+static PassRegistration<ConvertFunctionMetadataPass> funcPass;
 
 }  // namespace TFL
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TFL/StripMetadata.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/StripMetadata.cpp
@@ -26,6 +26,14 @@ static bool isTFLAttr(NamedAttribute &namedAttr) {
 class StripModuleMetadataPass
     : public PassWrapper<StripModuleMetadataPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tflite-strip-module-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Remove unneeded TFLite attributes from module ops";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     auto stripAttrs = llvm::to_vector<4>(llvm::make_filter_range(
@@ -40,6 +48,14 @@ class StripModuleMetadataPass
 class StripFunctionMetadataPass
     : public PassWrapper<StripFunctionMetadataPass, OperationPass<FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-tflite-strip-function-metadata";
+  }
+
+  StringRef getDescription() const override {
+    return "Remove unneeded TFLite attributes from func ops";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     auto stripAttrs = llvm::to_vector<4>(llvm::make_filter_range(
@@ -77,13 +93,8 @@ std::unique_ptr<OperationPass<FuncOp>> createStripFunctionMetadataPass() {
   return std::make_unique<StripFunctionMetadataPass>();
 }
 
-static PassRegistration<StripModuleMetadataPass> modulePass(
-    "iree-tflite-strip-module-metadata",
-    "Remove unneeded TFLite attributes from module ops");
-
-static PassRegistration<StripFunctionMetadataPass> funcPass(
-    "iree-tflite-strip-function-metadata",
-    "Remove unneeded TFLite attributes from func ops");
+static PassRegistration<StripModuleMetadataPass> modulePass;
+static PassRegistration<StripFunctionMetadataPass> funcPass;
 
 }  // namespace TFL
 }  // namespace iree_integrations

--- a/integrations/tensorflow/iree_tf_compiler/TFL/VerifyFullyConverted.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/VerifyFullyConverted.cpp
@@ -28,6 +28,15 @@ class VerifyFullyConvertedPass
     registry.insert<mlir::TFL::TensorFlowLiteDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tflite-verify-fully-converted";
+  }
+
+  StringRef getDescription() const override {
+    return "Verifies that all TFLite frontend ops were converted and none "
+           "remain";
+  }
+
   // Validates that no TFLite frontends ops are in the function.
   void runOnFunction() override {
     DenseSet<Operation *> illegalOps;
@@ -63,9 +72,7 @@ class VerifyFullyConvertedPass
   }
 };
 
-static PassRegistration<VerifyFullyConvertedPass> pass(
-    "iree-tflite-verify-fully-converted",
-    "Verifies that all TFLite frontend ops were converted and none remain");
+static PassRegistration<VerifyFullyConvertedPass> pass;
 
 std::unique_ptr<OperationPass<FuncOp>> createVerifyFullyConvertedPass() {
   return std::make_unique<VerifyFullyConvertedPass>();

--- a/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -36,6 +36,16 @@ class WrapEntryPointsPass
                     memref::MemRefDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-abi-wrap-entry-points";
+  }
+
+  StringRef getDescription() const override {
+    return " Wraps all entry points in a function that is compatible with the "
+           "expected invocation semantics of bindings following the native "
+           "IREE ABI.";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
@@ -167,10 +177,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createWrapEntryPointsPass() {
   return std::make_unique<WrapEntryPointsPass>();
 }
 
-static PassRegistration<WrapEntryPointsPass> pass(
-    "iree-abi-wrap-entry-points",
-    " Wraps all entry points in a function that is compatible with the "
-    "expected invocation semantics of bindings following the native IREE ABI.");
+static PassRegistration<WrapEntryPointsPass> pass;
 
 }  // namespace ABI
 }  // namespace IREE

--- a/iree/compiler/Bindings/TFLite/Transforms/MaterializeShapeSupport.cpp
+++ b/iree/compiler/Bindings/TFLite/Transforms/MaterializeShapeSupport.cpp
@@ -45,6 +45,14 @@ class MaterializeShapeSupportPass
     registry.insert<StandardOpsDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tflite-materialize-shape-support";
+  }
+
+  StringRef getDescription() const override {
+    return "Materializes support functions for the tflite runtime bindings";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
@@ -440,9 +448,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeShapeSupportPass() {
   return std::make_unique<MaterializeShapeSupportPass>();
 }
 
-static PassRegistration<MaterializeShapeSupportPass> pass(
-    "iree-tflite-materialize-shape-support",
-    "Materializes support functions for the tflite runtime bindings");
+static PassRegistration<MaterializeShapeSupportPass> pass;
 
 }  // namespace TFLite
 }  // namespace IREE

--- a/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -30,6 +30,15 @@ class WrapEntryPointsPass
     registry.insert<StandardOpsDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-tflite-wrap-entry-points";
+  }
+
+  StringRef getDescription() const override {
+    return "Wraps model entry points in functions compatible with the tflite "
+           "bindings";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
@@ -158,10 +167,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createWrapEntryPointsPass() {
   return std::make_unique<WrapEntryPointsPass>();
 }
 
-static PassRegistration<WrapEntryPointsPass> pass(
-    "iree-tflite-wrap-entry-points",
-    "Wraps model entry points in functions compatible with the tflite "
-    "bindings");
+static PassRegistration<WrapEntryPointsPass> pass;
 
 }  // namespace TFLite
 }  // namespace IREE

--- a/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -163,6 +163,15 @@ struct AffineMinDistributedSCFCanonicalizationPattern
 struct AffineMinDistributedSCFCanonicalizationPass
     : public PassWrapper<AffineMinDistributedSCFCanonicalizationPass,
                          FunctionPass> {
+  StringRef getArgument() const override {
+    return "iree-codegen-affinemin-scf-canonicalization";
+  }
+
+  StringRef getDescription() const override {
+    return "Pass to run pass cleaning up affineMinOp after tiling and "
+           "distribute.";
+  }
+
   void runOnFunction() override {
     FuncOp funcOp = getFunction();
     RewritePatternSet foldPattern(&getContext());
@@ -183,12 +192,9 @@ void populateAffineMinSCFCanonicalizationPattern(RewritePatternSet &patterns) {
       patterns.getContext());
 }
 
-static PassRegistration<AffineMinDistributedSCFCanonicalizationPass> pass(
-    "iree-codegen-affinemin-scf-canonicalization",
-    "Pass to run pass cleaning up affineMinOp after tiling and distribute.",
-    [] {
-      return std::make_unique<AffineMinDistributedSCFCanonicalizationPass>();
-    });
+static PassRegistration<AffineMinDistributedSCFCanonicalizationPass> pass([] {
+  return std::make_unique<AffineMinDistributedSCFCanonicalizationPass>();
+});
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertHALToVM.cpp
@@ -106,6 +106,12 @@ class ConvertHALToVMPass
     registry.insert<IREEDialect, IREE::VM::VMDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-convert-hal-to-vm"; }
+
+  StringRef getDescription() const override {
+    return "Convert the IREE HAL dialect to the IREE VM dialect";
+  }
+
   void runOnOperation() override {
     auto *context = &getContext();
 
@@ -146,12 +152,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertHALToVMPass(
   return std::make_unique<ConvertHALToVMPass>(targetOptions);
 }
 
-static PassRegistration<ConvertHALToVMPass> pass(
-    "iree-convert-hal-to-vm",
-    "Convert the IREE HAL dialect to the IREE VM dialect", [] {
-      auto options = IREE::VM::getTargetOptionsFromFlags();
-      return std::make_unique<ConvertHALToVMPass>(options);
-    });
+static PassRegistration<ConvertHALToVMPass> pass([] {
+  auto options = IREE::VM::getTargetOptionsFromFlags();
+  return std::make_unique<ConvertHALToVMPass>(options);
+});
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/BenchmarkBatchDispatches.cpp
@@ -27,6 +27,14 @@ class BenchmarkBatchDispatchesPass
     registry.insert<HALDialect, StandardOpsDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "test-iree-hal-benchmark-batch-dispatches-2-times";
+  }
+
+  StringRef getDescription() const override {
+    return "Test pass used for benchmarking batch dispatches analysis";
+  }
+
   void runOnOperation() override {
     FuncOp f = getOperation();
     SmallVector<HAL::CommandBufferDispatchOp> ops;
@@ -64,10 +72,9 @@ std::unique_ptr<OperationPass<FuncOp>> createBenchmarkBatchDispatchesPass(
   return std::make_unique<BenchmarkBatchDispatchesPass>(repeatCount);
 }
 
-static PassRegistration<BenchmarkBatchDispatchesPass> pass(
-    "test-iree-hal-benchmark-batch-dispatches-2-times",
-    "Test pass used for benchmarking batch dispatches analysis",
-    [] { return std::make_unique<BenchmarkBatchDispatchesPass>(2); });
+static PassRegistration<BenchmarkBatchDispatchesPass> pass([] {
+  return std::make_unique<BenchmarkBatchDispatchesPass>(2);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/CSEVariableLoads.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/CSEVariableLoads.cpp
@@ -22,6 +22,15 @@ class CSEVariableLoadsPass
     registry.insert<HALDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-cse-variable-loads";
+  }
+
+  StringRef getDescription() const override {
+    return "Eliminates redundant 'hal.variable.load' ops within functions with "
+           "no 'hal.variable.store' ops";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
 
@@ -78,10 +87,7 @@ std::unique_ptr<OperationPass<FuncOp>> createCSEVariableLoadsPass() {
   return std::make_unique<CSEVariableLoadsPass>();
 }
 
-static PassRegistration<CSEVariableLoadsPass> pass(
-    "iree-hal-cse-variable-loads",
-    "Eliminates redundant 'hal.variable.load' ops within functions with no "
-    "'hal.variable.store' ops");
+static PassRegistration<CSEVariableLoadsPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
@@ -46,6 +46,12 @@ class ConvertToHALPass
     registry.insert<StandardOpsDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-convert-to-hal"; }
+
+  StringRef getDescription() const override {
+    return "Convert input flow/std/etc dialects to the IREE HAL dialect.";
+  }
+
   void runOnOperation() override {
     auto *context = &getContext();
 
@@ -103,9 +109,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertToHALPass() {
   return std::make_unique<ConvertToHALPass>();
 }
 
-static PassRegistration<ConvertToHALPass> pass(
-    "iree-convert-to-hal",
-    "Convert input flow/std/etc dialects to the IREE HAL dialect.");
+static PassRegistration<ConvertToHALPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/IdentifyConstantPools.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/IdentifyConstantPools.cpp
@@ -38,6 +38,15 @@ class IdentifyConstantPoolsPass
     registry.insert<IREE::HAL::HALDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-identify-constant-pools";
+  }
+
+  StringRef getDescription() const override {
+    return "Combines constant variables into one or more hal.constant_pools "
+           "based on usage semantics.";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
@@ -297,14 +306,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createIdentifyConstantPoolsPass(
   return std::make_unique<IdentifyConstantPoolsPass>(targetOptions);
 }
 
-static PassRegistration<IdentifyConstantPoolsPass> pass(
-    "iree-hal-identify-constant-pools",
-    "Combines constant variables into one or more hal.constant_pools based on "
-    "usage semantics.",
-    [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<IdentifyConstantPoolsPass>(options);
-    });
+static PassRegistration<IdentifyConstantPoolsPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<IdentifyConstantPoolsPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
@@ -210,6 +210,14 @@ class InlineDeviceSwitchesPass
     registry.insert<IREEDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-inline-device-switches";
+  }
+
+  StringRef getDescription() const override {
+    return "Inlines hal.device.switch condition regions";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     SmallVector<IREE::HAL::DeviceSwitchOp, 4> switchOps;
@@ -228,9 +236,7 @@ std::unique_ptr<OperationPass<FuncOp>> createInlineDeviceSwitchesPass() {
   return std::make_unique<InlineDeviceSwitchesPass>();
 }
 
-static PassRegistration<InlineDeviceSwitchesPass> pass(
-    "iree-hal-inline-device-switches",
-    "Inlines hal.device.switch condition regions");
+static PassRegistration<InlineDeviceSwitchesPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
@@ -28,6 +28,12 @@ class LinkExecutablesPass
   explicit LinkExecutablesPass(TargetOptions executableOptions)
       : executableOptions_(executableOptions) {}
 
+  StringRef getArgument() const override { return "iree-hal-link-executables"; }
+
+  StringRef getDescription() const override {
+    return "Links together hal.executables depending on target backend rules";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     for (auto &targetBackend :
@@ -61,12 +67,10 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createLinkExecutablesPass(
   return std::make_unique<LinkExecutablesPass>(executableOptions);
 }
 
-static PassRegistration<LinkExecutablesPass> pass(
-    "iree-hal-link-executables",
-    "Links together hal.executables depending on target backend rules", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<LinkExecutablesPass>(options);
-    });
+static PassRegistration<LinkExecutablesPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<LinkExecutablesPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeConstantPoolBuffers.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeConstantPoolBuffers.cpp
@@ -33,6 +33,14 @@ class MaterializeConstantPoolBuffersPass
     registry.insert<IREE::HAL::HALDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-materialize-constant-pool-buffers";
+  }
+
+  StringRef getDescription() const override {
+    return "Materializes runtime buffers for constant pools.";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
@@ -308,9 +316,7 @@ createMaterializeConstantPoolBuffersPass() {
   return std::make_unique<MaterializeConstantPoolBuffersPass>();
 }
 
-static PassRegistration<MaterializeConstantPoolBuffersPass> pass(
-    "iree-hal-materialize-constant-pool-buffers",
-    "Materializes runtime buffers for constant pools.");
+static PassRegistration<MaterializeConstantPoolBuffersPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -1122,6 +1122,14 @@ class MaterializeInterfacesPass
     }
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-materialize-interfaces2";
+  }
+
+  StringRef getDescription() const override {
+    return "Materializes hal.executable ops from flow.executable ops";
+  }
+
   void runOnOperation() override {
     SymbolTable symbolTable(getOperation());
 
@@ -1189,12 +1197,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeInterfacesPass(
   return std::make_unique<MaterializeInterfacesPass>(executableOptions);
 }
 
-static PassRegistration<MaterializeInterfacesPass> pass(
-    "iree-hal-materialize-interfaces2",
-    "Materializes hal.executable ops from flow.executable ops", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<MaterializeInterfacesPass>(options);
-    });
+static PassRegistration<MaterializeInterfacesPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<MaterializeInterfacesPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeResourceCaches.cpp
@@ -32,6 +32,14 @@ class MaterializeResourceCachesPass
   explicit MaterializeResourceCachesPass(TargetOptions targetOptions)
       : targetOptions_(targetOptions) {}
 
+  StringRef getArgument() const override {
+    return "iree-hal-materialize-resource-caches";
+  }
+
+  StringRef getDescription() const override {
+    return "Materializes hal.executable resource caches and rewrites lookups.";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     if (moduleOp.getBody()->empty()) return;
@@ -326,12 +334,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeResourceCachesPass(
   return std::make_unique<MaterializeResourceCachesPass>(targetOptions);
 }
 
-static PassRegistration<MaterializeResourceCachesPass> pass(
-    "iree-hal-materialize-resource-caches",
-    "Materializes hal.executable resource caches and rewrites lookups.", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<MaterializeResourceCachesPass>(options);
-    });
+static PassRegistration<MaterializeResourceCachesPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<MaterializeResourceCachesPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -26,6 +26,14 @@ namespace HAL {
 class MemoizeDeviceQueriesPass
     : public PassWrapper<MemoizeDeviceQueriesPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-hal-memoize-device-queries";
+  }
+
+  StringRef getDescription() const override {
+    return "Caches hal.device.query results for use across the entire module";
+  }
+
   void runOnOperation() override {
     // Find all match ops we want to memoize and group them together.
     // This lets us easily replace all usages of a match with a single variable.
@@ -94,9 +102,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createMemoizeDeviceQueriesPass() {
   return std::make_unique<MemoizeDeviceQueriesPass>();
 }
 
-static PassRegistration<MemoizeDeviceQueriesPass> pass(
-    "iree-hal-memoize-device-queries",
-    "Caches hal.device.query results for use across the entire module");
+static PassRegistration<MemoizeDeviceQueriesPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/PackAllocations.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PackAllocations.cpp
@@ -40,6 +40,13 @@ class PackAllocationsPass
     registry.insert<IREE::HAL::HALDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-hal-pack-allocations"; }
+
+  StringRef getDescription() const override {
+    return "Packs allocations and materializes runtime packing code as "
+           "required.";
+  }
+
   void runOnOperation() override {
     auto funcOp = getOperation();
 
@@ -346,12 +353,10 @@ std::unique_ptr<OperationPass<FuncOp>> createPackAllocationsPass(
   return std::make_unique<PackAllocationsPass>(targetOptions);
 }
 
-static PassRegistration<PackAllocationsPass> pass(
-    "iree-hal-pack-allocations",
-    "Packs allocations and materializes runtime packing code as required.", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<PackAllocationsPass>(options);
-    });
+static PassRegistration<PackAllocationsPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<PackAllocationsPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/PackConstantPoolStorage.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PackConstantPoolStorage.cpp
@@ -30,6 +30,15 @@ class PackConstantPoolStoragePass
     registry.insert<IREE::HAL::HALDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-pack-constant-pool-storage";
+  }
+
+  StringRef getDescription() const override {
+    return "Packs all constants in a hal.constant_pool into their possibly "
+           "target-dependent storage formats.";
+  }
+
   void runOnOperation() override {
     auto poolOp = getOperation();
     auto bufferConstraints = poolOp.buffer_constraints();
@@ -271,10 +280,7 @@ createPackConstantPoolStoragePass() {
   return std::make_unique<PackConstantPoolStoragePass>();
 }
 
-static PassRegistration<PackConstantPoolStoragePass> pass(
-    "iree-hal-pack-constant-pool-storage",
-    "Packs all constants in a hal.constant_pool into their possibly "
-    "target-dependent storage formats.");
+static PassRegistration<PackConstantPoolStoragePass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/PropagateConstantWorkgroupInfo.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PropagateConstantWorkgroupInfo.cpp
@@ -18,6 +18,14 @@ class PropagateConstantWorkgroupInfoPass
     : public PassWrapper<PropagateConstantWorkgroupInfoPass,
                          OperationPass<IREE::HAL::ExecutableTargetOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-hal-propagate-constant-workgroup-info";
+  }
+
+  StringRef getDescription() const override {
+    return "Propagates constant hal.interface.workgroup.* queries when known";
+  }
+
   void runOnOperation() override {
     auto targetOp = getOperation();
 
@@ -50,9 +58,7 @@ createPropagateConstantWorkgroupInfoPass() {
   return std::make_unique<PropagateConstantWorkgroupInfoPass>();
 }
 
-static PassRegistration<PropagateConstantWorkgroupInfoPass> pass(
-    "iree-hal-propagate-constant-workgroup-info",
-    "Propagates constant hal.interface.workgroup.* queries when known");
+static PassRegistration<PropagateConstantWorkgroupInfoPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/ResolveEntryPointOrdinals.cpp
@@ -74,6 +74,14 @@ class ResolveEntryPointOrdinalsPass
     : public PassWrapper<ResolveEntryPointOrdinalsPass,
                          OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-hal-resolve-entry-point-ordinals";
+  }
+
+  StringRef getDescription() const override {
+    return "Resolves hal.executable.entry_point references to ordinals";
+  }
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     OwningRewritePatternList patterns(&getContext());
@@ -87,9 +95,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createResolveEntryPointOrdinalsPass() {
   return std::make_unique<ResolveEntryPointOrdinalsPass>();
 }
 
-static PassRegistration<ResolveEntryPointOrdinalsPass> pass(
-    "iree-hal-resolve-entry-point-ordinals",
-    "Resolves hal.executable.entry_point references to ordinals");
+static PassRegistration<ResolveEntryPointOrdinalsPass> pass;
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
@@ -29,6 +29,14 @@ class SerializeExecutablesPass
   explicit SerializeExecutablesPass(TargetOptions executableOptions)
       : executableOptions_(executableOptions) {}
 
+  StringRef getArgument() const override {
+    return "iree-hal-serialize-executables";
+  }
+
+  StringRef getDescription() const override {
+    return "Serializes hal.executable.target ops to hal.executable.binary ops";
+  }
+
   void runOnOperation() override {
     auto executableOp = getOperation();
     auto targetOps = llvm::to_vector<4>(
@@ -60,12 +68,10 @@ createSerializeExecutablesPass(TargetOptions executableOptions) {
   return std::make_unique<SerializeExecutablesPass>(executableOptions);
 }
 
-static PassRegistration<SerializeExecutablesPass> pass(
-    "iree-hal-serialize-executables",
-    "Serializes hal.executable.target ops to hal.executable.binary ops", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<SerializeExecutablesPass>(options);
-    });
+static PassRegistration<SerializeExecutablesPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<SerializeExecutablesPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -50,6 +50,14 @@ class TranslateExecutablesPass
     }
   }
 
+  StringRef getArgument() const override {
+    return "iree-hal-translate-executables";
+  }
+
+  StringRef getDescription() const override {
+    return "Translates hal.executable.target via the target backend pipelines";
+  }
+
   void runOnOperation() override {
     auto targetOp = getOperation();
     for (auto &pipeline : pipelines_) {
@@ -82,12 +90,10 @@ createTranslateExecutablesPass(TargetOptions executableOptions) {
   return std::make_unique<TranslateExecutablesPass>(executableOptions);
 }
 
-static PassRegistration<TranslateExecutablesPass> pass(
-    "iree-hal-translate-executables",
-    "Translates hal.executable.target via the target backend pipelines", [] {
-      auto options = getTargetOptionsFromFlags();
-      return std::make_unique<TranslateExecutablesPass>(options);
-    });
+static PassRegistration<TranslateExecutablesPass> pass([] {
+  auto options = getTargetOptionsFromFlags();
+  return std::make_unique<TranslateExecutablesPass>(options);
+});
 
 }  // namespace HAL
 }  // namespace IREE

--- a/iree/compiler/Dialect/IREE/Transforms/DropCompilerHints.cpp
+++ b/iree/compiler/Dialect/IREE/Transforms/DropCompilerHints.cpp
@@ -17,6 +17,14 @@ namespace IREE {
 class DropCompilerHintsPass
     : public PassWrapper<DropCompilerHintsPass, OperationPass<void>> {
  public:
+  StringRef getArgument() const override { return "iree-drop-compiler-hints"; }
+
+  StringRef getDescription() const override {
+    return "Deletes operations that have no runtime equivalent and are only "
+           "used in the compiler. This should be performed after all other "
+           "compiler passes.";
+  }
+
   void runOnOperation() override {
     // We can't use patterns and applyPatternsAndFoldGreedily because that
     // automatically does canonicalization.
@@ -31,10 +39,7 @@ std::unique_ptr<OperationPass<void>> createDropCompilerHintsPass() {
   return std::make_unique<DropCompilerHintsPass>();
 }
 
-static PassRegistration<DropCompilerHintsPass> pass(
-    "iree-drop-compiler-hints",
-    "Deletes operations that have no runtime equivalent and are only used in "
-    "the compiler. This should be performed after all other compiler passes.");
+static PassRegistration<DropCompilerHintsPass> pass;
 
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
@@ -38,6 +38,12 @@ class ConversionPass
                     IREE::VMVX::VMVXDialect, memref::MemRefDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-vmvx-conversion"; }
+
+  StringRef getDescription() const override {
+    return "Converts from various dialects to the VMVX dialect";
+  }
+
   void runOnOperation() override {
     auto *context = &getContext();
 
@@ -91,9 +97,7 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass() {
   return std::make_unique<ConversionPass>();
 }
 
-static PassRegistration<ConversionPass> pass(
-    "iree-vmvx-conversion",
-    "Converts from various dialects to the VMVX dialect");
+static PassRegistration<ConversionPass> pass;
 
 }  // namespace VMVX
 }  // namespace IREE

--- a/iree/compiler/Dialect/Shape/Transforms/CleanupPlaceholdersPass.cpp
+++ b/iree/compiler/Dialect/Shape/Transforms/CleanupPlaceholdersPass.cpp
@@ -29,6 +29,14 @@ class CleanupTieShapePattern : public OpRewritePattern<Shape::TieShapeOp> {
 
 class CleanupShapePlaceholdersPass
     : public PassWrapper<CleanupShapePlaceholdersPass, FunctionPass> {
+  StringRef getArgument() const override {
+    return "iree-shape-cleanup-placeholders";
+  }
+
+  StringRef getDescription() const override {
+    return "Cleans up unnecessary shape placeholders.";
+  }
+
   void runOnFunction() override {
     OwningRewritePatternList patterns(&getContext());
     patterns.insert<CleanupTieShapePattern>(&getContext());
@@ -44,9 +52,7 @@ std::unique_ptr<OperationPass<FuncOp>> createCleanupShapePlaceholdersPass() {
   return std::make_unique<Shape::CleanupShapePlaceholdersPass>();
 }
 
-static PassRegistration<Shape::CleanupShapePlaceholdersPass> pass(
-    "iree-shape-cleanup-placeholders",
-    "Cleans up unnecessary shape placeholders.");
+static PassRegistration<Shape::CleanupShapePlaceholdersPass> pass;
 
 }  // namespace Shape
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Shape/Transforms/FunctionSignatureExpansionPass.cpp
+++ b/iree/compiler/Dialect/Shape/Transforms/FunctionSignatureExpansionPass.cpp
@@ -29,6 +29,14 @@ class ExpandFunctionDynamicDimsPass
     registry.insert<ShapeDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-shape-expand-function-dynamic-dims";
+  }
+
+  StringRef getDescription() const override {
+    return "Expands dynamic dimensions in function signatures.";
+  }
+
   void runOnFunction() override {
     auto funcOp = getFunction();
     auto &typeExpander = getDynamicShapeTypeExpander();
@@ -45,6 +53,14 @@ class ExpandFunctionRankedShapeDimsPass
     : public PassWrapper<ExpandFunctionRankedShapeDimsPass, FunctionPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<ShapeDialect>();
+  }
+
+  StringRef getArgument() const override {
+    return "iree-shape-expand-function-ranked-shape-dims";
+  }
+
+  StringRef getDescription() const override {
+    return "Expands ranked_shape types at function boundaries to loose dims.";
   }
 
   void runOnFunction() override {
@@ -75,13 +91,8 @@ createExpandFunctionRankedShapeDimsPass() {
   return std::make_unique<Shape::ExpandFunctionRankedShapeDimsPass>();
 }
 
-static PassRegistration<Shape::ExpandFunctionDynamicDimsPass> pass_dynamic(
-    "iree-shape-expand-function-dynamic-dims",
-    "Expands dynamic dimensions in function signatures.");
-
-static PassRegistration<Shape::ExpandFunctionRankedShapeDimsPass> pass_rs(
-    "iree-shape-expand-function-ranked-shape-dims",
-    "Expands ranked_shape types at function boundaries to loose dims.");
+static PassRegistration<Shape::ExpandFunctionDynamicDimsPass> pass_dynamic;
+static PassRegistration<Shape::ExpandFunctionRankedShapeDimsPass> pass_rs;
 
 }  // namespace Shape
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/VM/Analysis/RegisterAllocationTest.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/RegisterAllocationTest.cpp
@@ -16,6 +16,14 @@ class RegisterAllocationTestPass
     : public PassWrapper<RegisterAllocationTestPass,
                          OperationPass<IREE::VM::FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "test-iree-vm-register-allocation";
+  }
+
+  StringRef getDescription() const override {
+    return "Test pass used for register allocation";
+  }
+
   void runOnOperation() override {
     if (failed(RegisterAllocation::annotateIR(getOperation()))) {
       signalPassFailure();
@@ -32,9 +40,7 @@ createRegisterAllocationTestPass() {
 }  // namespace VM
 }  // namespace IREE
 
-static PassRegistration<RegisterAllocationTestPass> pass(
-    "test-iree-vm-register-allocation",
-    "Test pass used for register allocation");
+static PassRegistration<RegisterAllocationTestPass> pass;
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/VM/Analysis/ValueLivenessTest.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/ValueLivenessTest.cpp
@@ -16,6 +16,14 @@ class ValueLivenessTestPass
     : public PassWrapper<ValueLivenessTestPass,
                          OperationPass<IREE::VM::FuncOp>> {
  public:
+  StringRef getArgument() const override {
+    return "test-iree-vm-value-liveness";
+  }
+
+  StringRef getDescription() const override {
+    return "Test pass used for liveness analysis";
+  }
+
   void runOnOperation() override {
     if (failed(ValueLiveness::annotateIR(getOperation()))) {
       signalPassFailure();
@@ -31,8 +39,7 @@ std::unique_ptr<OperationPass<IREE::VM::FuncOp>> createValueLivenessTestPass() {
 }  // namespace VM
 }  // namespace IREE
 
-static PassRegistration<ValueLivenessTestPass> pass(
-    "test-iree-vm-value-liveness", "Test pass used for liveness analysis");
+static PassRegistration<ValueLivenessTestPass> pass;
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVMTest.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVMTest.cpp
@@ -25,6 +25,14 @@ class ConvertStandardToVMTestPass
     registry.insert<IREE::VM::VMDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "test-iree-convert-std-to-vm";
+  }
+
+  StringRef getDescription() const override {
+    return "Convert Standard Ops to the IREE VM dialect";
+  }
+
   void runOnOperation() override {
     ConversionTarget target(getContext());
     target.addLegalDialect<IREE::VM::VMDialect>();
@@ -57,9 +65,7 @@ createConvertStandardToVMTestPass() {
 }  // namespace VM
 }  // namespace IREE
 
-static PassRegistration<ConvertStandardToVMTestPass> pass(
-    "test-iree-convert-std-to-vm",
-    "Convert Standard Ops to the IREE VM dialect");
+static PassRegistration<ConvertStandardToVMTestPass> pass;
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1490,6 +1490,12 @@ class ConvertVMToEmitCPass
     registry.insert<mlir::emitc::EmitCDialect, IREEDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-convert-vm-to-emitc"; }
+
+  StringRef getDescription() const override {
+    return "Convert VM Ops to the EmitC dialect";
+  }
+
   void runOnOperation() override {
     ConversionTarget target(getContext());
     EmitCTypeConverter typeConverter;
@@ -1551,8 +1557,7 @@ createConvertVMToEmitCPass() {
 }  // namespace VM
 }  // namespace IREE
 
-static PassRegistration<IREE::VM::ConvertVMToEmitCPass> pass(
-    "iree-convert-vm-to-emitc", "Convert VM Ops to the EmitC dialect");
+static PassRegistration<IREE::VM::ConvertVMToEmitCPass> pass;
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/DropExcludedExports.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/DropExcludedExports.cpp
@@ -17,6 +17,14 @@ class DropExcludedExportsPass
     : public PassWrapper<DropExcludedExportsPass,
                          OperationPass<IREE::VM::ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-vm-drop-excluded-exports";
+  }
+
+  StringRef getDescription() const override {
+    return "Deletes exports if annotated with emitc.exclude.";
+  }
+
   void runOnOperation() override {
     // Remove exports annotated with emitc.exclude.
     SmallVector<Operation *, 4> opsToRemove;
@@ -39,9 +47,7 @@ createDropExcludedExportsPass() {
   return std::make_unique<DropExcludedExportsPass>();
 }
 
-static PassRegistration<DropExcludedExportsPass> pass(
-    "iree-vm-drop-excluded-exports",
-    "Deletes exports if annotated with emitc.exclude.");
+static PassRegistration<DropExcludedExportsPass> pass;
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/Conversion.cpp
@@ -86,6 +86,12 @@ class ConversionPass
                     math::MathDialect, AffineDialect, memref::MemRefDialect>();
   }
 
+  StringRef getArgument() const override { return "iree-vm-conversion"; }
+
+  StringRef getDescription() const override {
+    return "Converts from various dialects to the VM dialect";
+  }
+
   void runOnOperation() override {
     if (getOperation().getBody()->empty()) return;
 
@@ -162,7 +168,7 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass(
 }
 
 static PassRegistration<ConversionPass> pass(
-    "iree-vm-conversion", "Converts from various dialects to the VM dialect",
+
     [] {
       auto options = getTargetOptionsFromFlags();
       return std::make_unique<ConversionPass>(options);

--- a/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -36,6 +36,14 @@ namespace VM {
 class GlobalInitializationPass
     : public PassWrapper<GlobalInitializationPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-vm-global-initialization";
+  }
+
+  StringRef getDescription() const override {
+    return "Creates module-level global init/deinit functions";
+  }
+
   void runOnOperation() override {
     // Create the __init and __deinit functions. They may be empty if there are
     // no globals but that's fine.
@@ -203,9 +211,7 @@ createGlobalInitializationPass() {
   return std::make_unique<GlobalInitializationPass>();
 }
 
-static PassRegistration<GlobalInitializationPass> pass(
-    "iree-vm-global-initialization",
-    "Creates module-level global init/deinit functions");
+static PassRegistration<GlobalInitializationPass> pass;
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/HoistInlinedRodata.cpp
@@ -32,6 +32,15 @@ class HoistInlinedRodataPass
     registry.insert<IREE::VM::VMDialect>();
   }
 
+  StringRef getArgument() const override {
+    return "iree-vm-hoist-inlined-rodata";
+  }
+
+  StringRef getDescription() const override {
+    return "Hoists inline iree.byte_buffer values to module-level constant "
+           "storage.";
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
     SymbolTable moduleSymbolTable(moduleOp);
@@ -80,9 +89,7 @@ createHoistInlinedRodataPass() {
   return std::make_unique<HoistInlinedRodataPass>();
 }
 
-static PassRegistration<HoistInlinedRodataPass> pass(
-    "iree-vm-hoist-inlined-rodata",
-    "Hoists inline iree.byte_buffer values to module-level constant storage.");
+static PassRegistration<HoistInlinedRodataPass> pass;
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/OrdinalAllocation.cpp
@@ -34,6 +34,14 @@ namespace VM {
 class OrdinalAllocationPass
     : public PassWrapper<OrdinalAllocationPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override {
+    return "iree-vm-ordinal-allocation";
+  }
+
+  StringRef getDescription() const override {
+    return "Assigns ordinals to function and global symbols";
+  }
+
   void runOnOperation() override {
     Builder builder(&getContext());
 
@@ -117,9 +125,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createOrdinalAllocationPass() {
   return std::make_unique<OrdinalAllocationPass>();
 }
 
-static PassRegistration<OrdinalAllocationPass> pass(
-    "iree-vm-ordinal-allocation",
-    "Assigns ordinals to function and global symbols");
+static PassRegistration<OrdinalAllocationPass> pass;
 
 }  // namespace VM
 }  // namespace IREE

--- a/iree/compiler/Dialect/VM/Transforms/SinkDefiningOps.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/SinkDefiningOps.cpp
@@ -26,6 +26,12 @@ namespace VM {
 class SinkDefiningOpsPass
     : public PassWrapper<SinkDefiningOpsPass, OperationPass<ModuleOp>> {
  public:
+  StringRef getArgument() const override { return "iree-vm-sink-defining-ops"; }
+
+  StringRef getDescription() const override {
+    return "Sinks defining ops with few uses to their use-sites.";
+  }
+
   void runOnOperation() override {
     for (auto funcOp : getOperation().getOps<FuncOp>()) {
       DominanceInfo domInfo(funcOp);
@@ -83,9 +89,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createSinkDefiningOpsPass() {
   return std::make_unique<SinkDefiningOpsPass>();
 }
 
-static PassRegistration<SinkDefiningOpsPass> pass(
-    "iree-vm-sink-defining-ops",
-    "Sinks defining ops with few uses to their use-sites.");
+static PassRegistration<SinkDefiningOpsPass> pass;
 
 }  // namespace VM
 }  // namespace IREE


### PR DESCRIPTION
* Does not convert these to tablegen - just hoists arg/desc to the class as recommended in the PSA upstream.