### PR TITLE
Update iree-run-module to error out with more than one positional argument.

### DIFF
--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -160,6 +160,15 @@ iree_status_t Run() {
 
 extern "C" int main(int argc, char** argv) {
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
+  if (argc > 1) {
+    // Avoid iree-run-module spinning endlessly on stdin if the user uses single
+    // dashes for flags.
+    std::cout << "Error: More than one positional argument (single dash '-') "
+                 "given for initiating stdin input. Perhaps you meant to use "
+                 "'--' instead?"
+              << std::endl;
+    return 3;  // status IREE_STATUS_INVALID_ARGUMENT
+  }
   IREE_CHECK_OK(iree_hal_register_all_available_drivers(
       iree_hal_driver_registry_default()));
   IREE_CHECK_OK(Run());

--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -163,11 +163,10 @@ extern "C" int main(int argc, char** argv) {
   if (argc > 1) {
     // Avoid iree-run-module spinning endlessly on stdin if the user uses single
     // dashes for flags.
-    std::cout << "Error: More than one positional argument (single dash '-') "
-                 "given for initiating stdin input. Perhaps you meant to use "
-                 "'--' instead?"
-              << std::endl;
-    return 3;  // status IREE_STATUS_INVALID_ARGUMENT
+    std::cout << "Error: unexpected positional argument (expected none)."
+                 " Did you use pass a flag with a single dash ('-')?"
+                 " Use '--' instead.\n";
+    return 1;
   }
   IREE_CHECK_OK(iree_hal_register_all_available_drivers(
       iree_hal_driver_registry_default()));


### PR DESCRIPTION
Running `iree-run-module` with single dash flags are silently ignored while it waits to accept a module file via `stdin`. This leads to the program spinning endlessly without warning on inputs like:

```
./iree-run-module -module_file=/path/to/module.vmfb --entry_function=my_function --function_input=some_input ...
```

 `iree-run-module` doesn't consume positional arguments but single dash arguments are treated as such. This will prevent users from hitting confusing error cases with ignored flags. 

Adresses #5931