### PR TITLE
Adding iree-run-trace binary.

### DIFF
--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -336,7 +336,7 @@ py::object VmVariantList::GetAsSerializedTraceValue(int index) {
     // Convert reference type.
     if (iree_vm_list_isa(v.ref)) {
       py::dict record;
-      record["type"] = "list";
+      record["type"] = "vm.list";
       py::list items;
       iree_vm_list_t* sub_list = NULL;
       CheckApiStatus(iree_vm_list_check_deref(v.ref, &sub_list),
@@ -350,7 +350,7 @@ py::object VmVariantList::GetAsSerializedTraceValue(int index) {
       return std::move(record);
     } else if (iree_hal_buffer_view_isa(v.ref)) {
       py::dict record;
-      record["type"] = "buffer_view";
+      record["type"] = "hal.buffer_view";
       iree_hal_buffer_view_t* buffer_view = iree_hal_buffer_view_deref(v.ref);
       if (!buffer_view) {
         throw RaiseValueError(

--- a/build_tools/third_party/libyaml/CMakeLists.txt
+++ b/build_tools/third_party/libyaml/CMakeLists.txt
@@ -14,7 +14,7 @@ external_cc_library(
   ROOT
     ${LIBYAML_ROOT}
   INCLUDES
-    "${FLATCC_ROOT}/include"
+    "${LIBYAML_ROOT}/include"
   SRCS
     "src/api.c"
     "src/dumper.c"

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -153,7 +153,7 @@ static iree_status_t iree_hal_cuda_device_query_i32(
   // iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   *out_value = 0;
   return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "unknown device configuration key value '%*.s'",
+                          "unknown device configuration key value '%.*s'",
                           (int)key.size, key.data);
 }
 

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -142,7 +142,7 @@ static iree_status_t iree_hal_sync_device_query_i32(
   // iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   *out_value = 0;
   return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "unknown device configuration key value '%*.s'",
+                          "unknown device configuration key value '%.*s'",
                           (int)key.size, key.data);
 }
 

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -198,7 +198,7 @@ static iree_status_t iree_hal_task_device_query_i32(
   // iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
   *out_value = 0;
   return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "unknown device configuration key value '%*.s'",
+                          "unknown device configuration key value '%.*s'",
                           (int)key.size, key.data);
 }
 

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -910,7 +910,7 @@ static iree_status_t iree_hal_vulkan_device_query_i32(
   //     iree_hal_vulkan_device_cast(base_device);
   *out_value = 0;
   return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "unknown device configuration key value '%*.s'",
+                          "unknown device configuration key value '%.*s'",
                           (int)key.size, key.data);
 }
 

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -285,10 +285,28 @@ cc_binary(
         "//iree/hal/drivers",
         "//iree/modules/hal",
         "//iree/tools/utils:vm_util",
-        "//iree/tools/utils:yaml_util",
         "//iree/vm",
         "//iree/vm:bytecode_module",
         "//iree/vm:cc",
+    ],
+)
+
+cc_binary(
+    name = "iree-run-trace",
+    srcs = ["iree-run-trace-main.c"],
+    deps = [
+        "//iree/base",
+        "//iree/base:tracing",
+        "//iree/base/internal:file_io",
+        "//iree/base/internal:file_path",
+        "//iree/base/internal:flags",
+        "//iree/hal",
+        "//iree/hal/drivers",
+        "//iree/modules/hal",
+        "//iree/tools/utils:yaml_util",
+        "//iree/vm",
+        "//iree/vm:bytecode_module",
+        "@com_github_yaml_libyaml//:yaml",
     ],
 )
 

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -121,6 +121,7 @@ iree_cc_binary(
   SRCS
     "iree-run-module-main.cc"
   DEPS
+    iree::base
     iree::base::cc
     iree::base::internal::file_io
     iree::base::internal::flags
@@ -128,9 +129,28 @@ iree_cc_binary(
     iree::hal::drivers
     iree::modules::hal
     iree::tools::utils::vm_util
+    iree::vm
+    iree::vm::bytecode_module
+    iree::vm::cc
+)
+
+iree_cc_binary(
+  NAME
+    iree-run-trace
+  SRCS
+    "iree-run-trace-main.c"
+  DEPS
+    iree::base
+    iree::base::internal::file_io
+    iree::base::internal::file_path
+    iree::base::internal::flags
+    iree::base::tracing
+    iree::hal::drivers
+    iree::modules::hal
     iree::tools::utils::yaml_util
     iree::vm
     iree::vm::bytecode_module
+    yaml
 )
 
 if(${IREE_BUILD_COMPILER})

--- a/iree/tools/iree-run-module-main.cc
+++ b/iree/tools/iree-run-module-main.cc
@@ -21,7 +21,6 @@
 #include "iree/hal/drivers/init.h"
 #include "iree/modules/hal/module.h"
 #include "iree/tools/utils/vm_util.h"
-#include "iree/tools/utils/yaml_util.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"
 #include "iree/vm/ref_cc.h"

--- a/iree/tools/iree-run-trace-main.c
+++ b/iree/tools/iree-run-trace-main.c
@@ -1,0 +1,750 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/file_io.h"
+#include "iree/base/internal/file_path.h"
+#include "iree/base/internal/flags.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/init.h"
+#include "iree/modules/hal/module.h"
+#include "iree/tools/utils/yaml_util.h"
+#include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
+
+IREE_FLAG(string, driver, "vmvx", "Backend driver to use.");
+
+typedef struct iree_trace_replay_t {
+  iree_allocator_t host_allocator;
+  iree_string_view_t root_path;
+  iree_vm_instance_t* instance;
+  iree_vm_context_t* context;
+
+  iree_hal_device_t* device;
+} iree_trace_replay_t;
+
+static void iree_trace_replay_deinitialize(iree_trace_replay_t* replay);
+
+static iree_status_t iree_trace_replay_initialize(
+    iree_string_view_t root_path, iree_vm_instance_t* instance,
+    iree_allocator_t host_allocator, iree_trace_replay_t* out_replay) {
+  memset(out_replay, 0, sizeof(*out_replay));
+  out_replay->root_path = root_path;
+  out_replay->instance = instance;
+  out_replay->host_allocator = host_allocator;
+  iree_vm_instance_retain(out_replay->instance);
+  return iree_ok_status();
+}
+
+static void iree_trace_replay_deinitialize(iree_trace_replay_t* replay) {
+  iree_hal_device_release(replay->device);
+  iree_vm_context_release(replay->context);
+  iree_vm_instance_release(replay->instance);
+  memset(replay, 0, sizeof(*replay));
+}
+
+static iree_status_t iree_trace_replay_event_context_load(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* event_node) {
+  // Cleanup previous state.
+  iree_hal_device_release(replay->device);
+  replay->device = NULL;
+  iree_vm_context_release(replay->context);
+  replay->context = NULL;
+
+  // Create new context.
+  return iree_vm_context_create(replay->instance, replay->host_allocator,
+                                &replay->context);
+}
+
+static iree_status_t iree_trace_replay_create_device(
+    yaml_node_t* driver_node, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  // Use the provided driver name or override with the --driver= flag.
+  iree_string_view_t driver_name = iree_yaml_node_as_string(driver_node);
+  if (iree_string_view_is_empty(driver_name)) {
+    driver_name = iree_make_cstring_view(FLAG_driver);
+  }
+
+  // Try to create a device from the driver.
+  iree_hal_driver_t* driver = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_try_create_by_name(
+      iree_hal_driver_registry_default(), driver_name, host_allocator,
+      &driver));
+  iree_status_t status =
+      iree_hal_driver_create_default_device(driver, host_allocator, out_device);
+  iree_hal_driver_release(driver);
+
+  return status;
+}
+
+static iree_status_t iree_trace_replay_load_builtin_module(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* module_node) {
+  iree_vm_module_t* module = NULL;
+
+  yaml_node_t* name_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, module_node, iree_make_cstring_view("name"), &name_node));
+  if (iree_yaml_string_equal(name_node, iree_make_cstring_view("hal"))) {
+    yaml_node_t* driver_node = NULL;
+    IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+        document, module_node, iree_make_cstring_view("driver"), &driver_node));
+    IREE_RETURN_IF_ERROR(iree_trace_replay_create_device(
+        driver_node, replay->host_allocator, &replay->device));
+    IREE_RETURN_IF_ERROR(iree_hal_module_create(
+        replay->device, replay->host_allocator, &module));
+  }
+  if (!module) {
+    return iree_make_status(
+        IREE_STATUS_NOT_FOUND, "builtin module '%.*s' not registered",
+        (int)name_node->data.scalar.length, name_node->data.scalar.value);
+  }
+
+  iree_status_t status =
+      iree_vm_context_register_modules(replay->context, &module, 1);
+  iree_vm_module_release(module);
+  return status;
+}
+
+static iree_status_t iree_trace_replay_load_bytecode_module(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* module_node) {
+  yaml_node_t* path_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, module_node, iree_make_cstring_view("path"), &path_node));
+
+  // Load bytecode file contents into memory.
+  char* full_path = NULL;
+  IREE_RETURN_IF_ERROR(iree_file_path_join(replay->root_path,
+                                           iree_yaml_node_as_string(path_node),
+                                           replay->host_allocator, &full_path));
+  iree_byte_span_t flatbuffer_data;
+  iree_status_t status = iree_file_read_contents(
+      full_path, replay->host_allocator, &flatbuffer_data);
+  iree_allocator_free(replay->host_allocator, full_path);
+
+  // Load and verify the bytecode module.
+  iree_vm_module_t* module = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_bytecode_module_create(
+        iree_make_const_byte_span(flatbuffer_data.data,
+                                  flatbuffer_data.data_length),
+        replay->host_allocator, replay->host_allocator, &module);
+    if (!iree_status_is_ok(status)) {
+      iree_allocator_free(replay->host_allocator, flatbuffer_data.data);
+    }
+  }
+
+  // Register the bytecode module with the context.
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_context_register_modules(replay->context, &module, 1);
+  }
+
+  iree_vm_module_release(module);
+  return status;
+}
+
+static iree_status_t iree_trace_replay_event_module_load(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* event_node) {
+  yaml_node_t* module_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, event_node, iree_make_cstring_view("module"), &module_node));
+
+  yaml_node_t* type_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, module_node, iree_make_cstring_view("type"), &type_node));
+  iree_string_view_t type = iree_yaml_node_as_string(type_node);
+
+  if (iree_string_view_equal(type, iree_make_cstring_view("builtin"))) {
+    return iree_trace_replay_load_builtin_module(replay, document, module_node);
+  } else if (iree_string_view_equal(type, iree_make_cstring_view("bytecode"))) {
+    return iree_trace_replay_load_bytecode_module(replay, document,
+                                                  module_node);
+  }
+
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "module type '%.*s' not recognized", (int)type.size,
+                          type.data);
+}
+
+static iree_status_t iree_trace_replay_parse_item(iree_trace_replay_t* replay,
+                                                  yaml_document_t* document,
+                                                  yaml_node_t* value_node,
+                                                  iree_vm_list_t* target_list);
+static iree_status_t iree_trace_replay_parse_item_sequence(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* sequence_node, iree_vm_list_t* target_list);
+
+// Parses a scalar value and appends it to |target_list|.
+//
+// ```yaml
+// i8: 7
+// ```
+static iree_status_t iree_trace_replay_parse_scalar(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* value_node, iree_vm_list_t* target_list) {
+  yaml_node_t* data_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("i8"), &data_node));
+  if (data_node) {
+    int32_t value = 0;
+    if (!iree_string_view_atoi_int32(iree_yaml_node_as_string(data_node),
+                                     &value)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse i8 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_I8;
+    variant.i8 = (int8_t)value;
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("i16"), &data_node));
+  if (data_node) {
+    int32_t value = 0;
+    if (!iree_string_view_atoi_int32(iree_yaml_node_as_string(data_node),
+                                     &value)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse i16 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_I16;
+    variant.i16 = (int16_t)value;
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("i32"), &data_node));
+  if (data_node) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_I32;
+    if (!iree_string_view_atoi_int32(iree_yaml_node_as_string(data_node),
+                                     &variant.i32)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse i32 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("i64"), &data_node));
+  if (data_node) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_I64;
+    if (!iree_string_view_atoi_int64(iree_yaml_node_as_string(data_node),
+                                     &variant.i64)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse i64 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("f32"), &data_node));
+  if (data_node) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_F32;
+    if (!iree_string_view_atof(iree_yaml_node_as_string(data_node),
+                               &variant.f32)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse f32 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("f64"), &data_node));
+  if (data_node) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    variant.type.value_type = IREE_VM_VALUE_TYPE_F64;
+    if (!iree_string_view_atod(iree_yaml_node_as_string(data_node),
+                               &variant.f64)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "failed to parse f64 value: '%.*s'",
+          (int)data_node->data.scalar.length, data_node->data.scalar.value);
+    }
+    return iree_vm_list_push_variant(target_list, &variant);
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "(%zu): unimplemented scalar type parser",
+                          value_node->start_mark.line);
+}
+
+// Parses a !vm.list and appends it to |target_list|.
+//
+// ```yaml
+// items:
+// - type: value
+//   i8: 7
+// - type: vm.list
+//   items: ...
+// ```
+static iree_status_t iree_trace_replay_parse_vm_list(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* value_node, iree_vm_list_t* target_list) {
+  if (value_node->type != YAML_SEQUENCE_NODE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "(%zu): expected sequence node for type",
+                            value_node->start_mark.line);
+  }
+  yaml_node_t* items_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("items"), &items_node));
+
+  iree_vm_list_t* list = NULL;
+  IREE_RETURN_IF_ERROR(iree_vm_list_create(/*element_type=*/NULL,
+                                           /*initial_capacity=*/8,
+                                           replay->host_allocator, &list));
+
+  iree_status_t status = iree_ok_status();
+  if (items_node) {
+    status = iree_trace_replay_parse_item_sequence(replay, document, items_node,
+                                                   list);
+  }
+
+  if (iree_status_is_ok(status)) {
+    iree_vm_ref_t list_ref = iree_vm_list_move_ref(list);
+    status = iree_vm_list_push_ref_move(target_list, &list_ref);
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_vm_list_release(list);
+  }
+  return status;
+}
+
+// Parses a shape sequence.
+//
+// ```yaml
+// shape:
+// - 1
+// - 2
+// - 3
+// ```
+static iree_status_t iree_trace_replay_parse_hal_shape(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* shape_node, size_t shape_capacity, iree_hal_dim_t* shape,
+    size_t* out_shape_rank) {
+  size_t shape_rank = 0;
+  *out_shape_rank = shape_rank;
+  if (!shape_node) return iree_ok_status();
+  if (shape_node->type != YAML_SEQUENCE_NODE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "(%zu): expected sequence node for shape",
+                            shape_node->start_mark.line);
+  }
+  for (yaml_node_item_t* item = shape_node->data.sequence.items.start;
+       item != shape_node->data.sequence.items.top; ++item) {
+    yaml_node_t* dim_node = yaml_document_get_node(document, *item);
+    if (dim_node->type != YAML_SCALAR_NODE) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "(%zu): expected integer shape dimension",
+                              dim_node->start_mark.line);
+    }
+    int64_t dim = 0;
+    if (!iree_string_view_atoi_int64(iree_yaml_node_as_string(dim_node),
+                                     &dim)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT, "(%zu): invalid shape dimension '%.*s'",
+          dim_node->start_mark.line, (int)dim_node->data.scalar.length,
+          dim_node->data.scalar.value);
+    }
+    if (shape_rank >= shape_capacity) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "(%zu): shape rank overflow (>%zu)",
+                              shape_node->start_mark.line, shape_capacity);
+    }
+    shape[shape_rank++] = (iree_hal_dim_t)dim;
+  }
+  *out_shape_rank = shape_rank;
+  return iree_ok_status();
+}
+
+// Parses a serialized !hal.buffer into |buffer|.
+//
+// ```yaml
+// contents: !!binary |
+//   AACAPwAAAEAAAEBAAACAQA==
+// ```
+static iree_status_t iree_trace_replay_parse_hal_buffer(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* contents_node, iree_hal_buffer_t* buffer) {
+  if (!contents_node) {
+    // Empty contents = zero fill.
+    return iree_ok_status();
+  } else if (contents_node->type != YAML_SCALAR_NODE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "(%zu): expected scalar node for buffer contents",
+                            contents_node->start_mark.line);
+  }
+  iree_string_view_t value = iree_make_string_view(
+      contents_node->data.scalar.value, contents_node->data.scalar.length);
+  value = iree_string_view_trim(value);
+
+  if (strcmp(contents_node->tag, "tag:yaml.org,2002:binary") == 0) {
+    iree_hal_buffer_mapping_t mapping;
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_map_range(buffer, IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE,
+                                  0, IREE_WHOLE_BUFFER, &mapping));
+    iree_status_t status = iree_yaml_base64_decode(value, mapping.contents);
+    iree_hal_buffer_unmap_range(&mapping);
+    return status;
+  }
+
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "(%zu): unimplemented buffer encoding '%s'",
+                          contents_node->start_mark.line, contents_node->tag);
+}
+
+// Parses a !hal.buffer_view and appends it to |target_list|.
+//
+// ```yaml
+// shape:
+// - 4
+// element_type: 50331680
+// contents: !!binary |
+//   AACAPwAAAEAAAEBAAACAQA==
+// ```
+static iree_status_t iree_trace_replay_parse_hal_buffer_view(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* value_node, iree_vm_list_t* target_list) {
+  yaml_node_t* element_type_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, value_node, iree_make_cstring_view("element_type"),
+      &element_type_node));
+  iree_hal_element_type_t element_type = IREE_HAL_ELEMENT_TYPE_NONE;
+  static_assert(sizeof(element_type) == sizeof(uint32_t), "4 bytes");
+  if (!iree_string_view_atoi_uint32(iree_yaml_node_as_string(element_type_node),
+                                    &element_type)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "(%zu): invalid element type",
+                            element_type_node->start_mark.line);
+  }
+
+  yaml_node_t* shape_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("shape"), &shape_node));
+  iree_hal_dim_t shape[16];
+  size_t shape_rank = 0;
+  IREE_RETURN_IF_ERROR(iree_trace_replay_parse_hal_shape(
+      replay, document, shape_node, IREE_ARRAYSIZE(shape), shape, &shape_rank));
+
+  yaml_node_t* contents_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, value_node, iree_make_cstring_view("contents"),
+      &contents_node));
+
+  iree_device_size_t allocation_size = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_compute_view_size(
+      shape, shape_rank, element_type, &allocation_size));
+
+  iree_hal_buffer_t* buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(replay->device),
+      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+      IREE_HAL_BUFFER_USAGE_ALL, allocation_size, &buffer));
+  iree_status_t status = iree_trace_replay_parse_hal_buffer(
+      replay, document, contents_node, buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_buffer_release(buffer);
+    return status;
+  }
+
+  iree_hal_buffer_view_t* buffer_view = NULL;
+  status = iree_hal_buffer_view_create(buffer, shape, shape_rank, element_type,
+                                       &buffer_view);
+  iree_hal_buffer_release(buffer);
+  IREE_RETURN_IF_ERROR(status);
+
+  iree_vm_ref_t buffer_view_ref = iree_hal_buffer_view_move_ref(buffer_view);
+  status = iree_vm_list_push_ref_move(target_list, &buffer_view_ref);
+  iree_vm_ref_release(&buffer_view_ref);
+  return status;
+}
+
+// Parses a typed item from |value_node| and appends it to |target_list|.
+//
+// ```yaml
+// type: vm.list
+// items:
+// - type: value
+//   i8: 7
+// ```
+static iree_status_t iree_trace_replay_parse_item(iree_trace_replay_t* replay,
+                                                  yaml_document_t* document,
+                                                  yaml_node_t* value_node,
+                                                  iree_vm_list_t* target_list) {
+  yaml_node_t* type_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, value_node, iree_make_cstring_view("type"), &type_node));
+  iree_string_view_t type = iree_yaml_node_as_string(type_node);
+  if (iree_string_view_equal(type, iree_make_cstring_view("null"))) {
+    iree_vm_variant_t null_value = iree_vm_variant_empty();
+    return iree_vm_list_push_variant(target_list, &null_value);
+  } else if (iree_string_view_equal(type, iree_make_cstring_view("value"))) {
+    return iree_trace_replay_parse_scalar(replay, document, value_node,
+                                          target_list);
+  } else if (iree_string_view_equal(type, iree_make_cstring_view("vm.list"))) {
+    return iree_trace_replay_parse_vm_list(replay, document, value_node,
+                                           target_list);
+  } else if (iree_string_view_equal(
+                 type, iree_make_cstring_view("hal.buffer_view"))) {
+    return iree_trace_replay_parse_hal_buffer_view(replay, document, value_node,
+                                                   target_list);
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplemented type parser: '%.*s'", (int)type.size,
+                          type.data);
+}
+
+// Parses a sequence of items appending each to |target_list|.
+static iree_status_t iree_trace_replay_parse_item_sequence(
+    iree_trace_replay_t* replay, yaml_document_t* document,
+    yaml_node_t* sequence_node, iree_vm_list_t* target_list) {
+  for (yaml_node_item_t* item = sequence_node->data.sequence.items.start;
+       item != sequence_node->data.sequence.items.top; ++item) {
+    yaml_node_t* item_node = yaml_document_get_node(document, *item);
+    IREE_RETURN_IF_ERROR(
+        iree_trace_replay_parse_item(replay, document, item_node, target_list));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_trace_replay_print_item(iree_vm_variant_t* value);
+
+static iree_status_t iree_trace_replay_print_scalar(iree_vm_variant_t* value) {
+  switch (value->type.value_type) {
+    case IREE_VM_VALUE_TYPE_I8:
+      fprintf(stdout, "i8=%" PRIi8, value->i8);
+      break;
+    case IREE_VM_VALUE_TYPE_I16:
+      fprintf(stdout, "i16=%" PRIi16, value->i16);
+      break;
+    case IREE_VM_VALUE_TYPE_I32:
+      fprintf(stdout, "i32=%" PRIi32, value->i32);
+      break;
+    case IREE_VM_VALUE_TYPE_I64:
+      fprintf(stdout, "i64=%" PRIi64, value->i64);
+      break;
+    case IREE_VM_VALUE_TYPE_F32:
+      fprintf(stdout, "f32=%G", value->f32);
+      break;
+    case IREE_VM_VALUE_TYPE_F64:
+      fprintf(stdout, "f64=%G", value->f64);
+      break;
+    default:
+      fprintf(stdout, "?");
+      break;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_trace_replay_print_vm_list(iree_vm_list_t* list) {
+  for (iree_host_size_t i = 0; i < iree_vm_list_size(list); ++i) {
+    iree_vm_variant_t variant = iree_vm_variant_empty();
+    IREE_RETURN_IF_ERROR(iree_vm_list_get_variant(list, i, &variant),
+                         "variant %zu not present", i);
+    IREE_RETURN_IF_ERROR(iree_trace_replay_print_item(&variant));
+    fprintf(stdout, "\n");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_trace_replay_print_hal_buffer_view(
+    iree_hal_buffer_view_t* buffer_view) {
+  return iree_hal_buffer_view_fprint(stdout, buffer_view,
+                                     /*max_element_count=*/1024);
+}
+
+static iree_status_t iree_trace_replay_print_item(iree_vm_variant_t* value) {
+  if (iree_vm_variant_is_value(*value)) {
+    IREE_RETURN_IF_ERROR(iree_trace_replay_print_scalar(value));
+  } else if (iree_vm_variant_is_ref(*value)) {
+    if (iree_hal_buffer_view_isa(value->ref)) {
+      iree_hal_buffer_view_t* buffer_view =
+          iree_hal_buffer_view_deref(value->ref);
+      IREE_RETURN_IF_ERROR(
+          iree_trace_replay_print_hal_buffer_view(buffer_view));
+    } else if (iree_vm_list_isa(value->ref)) {
+      iree_vm_list_t* list = iree_vm_list_deref(value->ref);
+      IREE_RETURN_IF_ERROR(iree_trace_replay_print_vm_list(list));
+    } else {
+      // TODO(benvanik): a way for ref types to describe themselves.
+      fprintf(stdout, "(no printer)");
+    }
+  } else {
+    fprintf(stdout, "(null)");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_trace_replay_event_call(iree_trace_replay_t* replay,
+                                                  yaml_document_t* document,
+                                                  yaml_node_t* event_node) {
+  // Resolve the function ('module.function') within the context.
+  yaml_node_t* function_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, event_node, iree_make_cstring_view("function"),
+      &function_node));
+  iree_string_view_t function_name = iree_yaml_node_as_string(function_node);
+  iree_vm_function_t function;
+  IREE_RETURN_IF_ERROR(iree_vm_context_resolve_function(
+      replay->context, function_name, &function));
+
+  fprintf(stdout, "--- CALL[%.*s] ---\n", (int)function_name.size,
+          function_name.data);
+
+  // Parse function inputs.
+  yaml_node_t* args_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_try_find(
+      document, event_node, iree_make_cstring_view("args"), &args_node));
+  iree_vm_list_t* input_list = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_list_create(/*element_type=*/NULL, /*initial_capacity=*/8,
+                          replay->host_allocator, &input_list));
+  iree_status_t status = iree_trace_replay_parse_item_sequence(
+      replay, document, args_node, input_list);
+
+  // Invoke the function to produce outputs.
+  iree_vm_list_t* output_list = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_list_create(/*element_type=*/NULL, /*initial_capacity=*/8,
+                                 replay->host_allocator, &output_list);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_invoke(replay->context, function, /*policy=*/NULL,
+                            input_list, output_list, replay->host_allocator);
+  }
+  iree_vm_list_release(input_list);
+
+  // TODO(benvanik): flag for yaml emitter output.
+  if (iree_status_is_ok(status)) {
+    status = iree_trace_replay_print_vm_list(output_list);
+  }
+  iree_vm_list_release(output_list);
+
+  return status;
+}
+
+static iree_status_t iree_trace_replay_event(iree_trace_replay_t* replay,
+                                             yaml_document_t* document,
+                                             yaml_node_t* event_node) {
+  if (event_node->type != YAML_MAPPING_NODE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "(%zu): expected mapping node",
+                            event_node->start_mark.line);
+  }
+  yaml_node_t* type_node = NULL;
+  IREE_RETURN_IF_ERROR(iree_yaml_mapping_find(
+      document, event_node, iree_make_cstring_view("type"), &type_node));
+  if (iree_yaml_string_equal(type_node,
+                             iree_make_cstring_view("context_load"))) {
+    return iree_trace_replay_event_context_load(replay, document, event_node);
+  } else if (iree_yaml_string_equal(type_node,
+                                    iree_make_cstring_view("module_load"))) {
+    return iree_trace_replay_event_module_load(replay, document, event_node);
+  } else if (iree_yaml_string_equal(type_node,
+                                    iree_make_cstring_view("call"))) {
+    return iree_trace_replay_event_call(replay, document, event_node);
+  }
+  return iree_make_status(
+      IREE_STATUS_UNIMPLEMENTED, "(%zu): unhandled type '%.*s'",
+      event_node->start_mark.line, (int)type_node->data.scalar.length,
+      type_node->data.scalar.value);
+}
+
+// Runs the trace in |file| using |root_path| as the base for any path lookups
+// required for external files referenced in |file|.
+static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
+                                         FILE* file,
+                                         iree_vm_instance_t* instance) {
+  iree_trace_replay_t replay;
+  IREE_RETURN_IF_ERROR(iree_trace_replay_initialize(
+      root_path, instance, iree_allocator_system(), &replay));
+
+  yaml_parser_t parser;
+  if (!yaml_parser_initialize(&parser)) {
+    iree_trace_replay_deinitialize(&replay);
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "yaml_parser_initialize failed");
+  }
+  yaml_parser_set_input_file(&parser, file);
+
+  iree_status_t status = iree_ok_status();
+  for (bool document_eof = false; !document_eof;) {
+    yaml_document_t document;
+    if (!yaml_parser_load(&parser, &document)) {
+      status = iree_status_from_yaml_parser_error(&parser);
+      break;
+    }
+    yaml_node_t* event_node = yaml_document_get_root_node(&document);
+    if (event_node) {
+      status = iree_trace_replay_event(&replay, &document, event_node);
+    } else {
+      document_eof = true;
+    }
+    yaml_document_delete(&document);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  yaml_parser_delete(&parser);
+  iree_trace_replay_deinitialize(&replay);
+  return status;
+}
+
+// Runs each of the given traces files sequentially in isolated contexts.
+static iree_status_t iree_run_trace_files(int file_count, char** file_paths,
+                                          iree_vm_instance_t* instance) {
+  for (int i = 0; i < file_count; ++i) {
+    iree_string_view_t file_path = iree_make_cstring_view(file_paths[i]);
+    iree_string_view_t root_path = iree_file_path_dirname(file_path);
+    FILE* file = fopen(file_paths[i], "rb");
+    if (!file) {
+      return iree_make_status(iree_status_code_from_errno(errno),
+                              "failed to open trace file '%.*s'",
+                              (int)file_path.size, file_path.data);
+    }
+    iree_status_t status = iree_run_trace_file(root_path, file, instance);
+    fclose(file);
+    IREE_RETURN_IF_ERROR(status, "replaying trace file '%.*s'",
+                         (int)file_path.size, file_path.data);
+  }
+  return iree_ok_status();
+}
+
+int main(int argc, char** argv) {
+  iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
+  if (argc <= 1) {
+    fprintf(stderr,
+            "no trace files provided; pass one or more yaml file paths");
+    return 1;
+  }
+
+  iree_vm_instance_t* instance = NULL;
+  iree_status_t status =
+      iree_vm_instance_create(iree_allocator_system(), &instance);
+  if (iree_status_is_ok(status)) {
+    IREE_CHECK_OK(iree_hal_register_all_available_drivers(
+        iree_hal_driver_registry_default()));
+    IREE_CHECK_OK(iree_hal_module_register_types());
+    status = iree_run_trace_files(argc - 1, argv + 1, instance);
+  }
+  iree_vm_instance_release(instance);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+    return 1;
+  }
+  return 0;
+}

--- a/iree/tools/utils/BUILD
+++ b/iree/tools/utils/BUILD
@@ -52,8 +52,6 @@ cc_library(
     hdrs = ["yaml_util.h"],
     deps = [
         "//iree/base",
-        "//iree/hal",
-        "//iree/vm",
         "@com_github_yaml_libyaml//:yaml",
     ],
 )

--- a/iree/tools/utils/CMakeLists.txt
+++ b/iree/tools/utils/CMakeLists.txt
@@ -58,8 +58,6 @@ iree_cc_library(
     "yaml_util.c"
   DEPS
     iree::base
-    iree::hal
-    iree::vm
     yaml
   PUBLIC
 )

--- a/iree/tools/utils/yaml_util.c
+++ b/iree/tools/utils/yaml_util.c
@@ -6,11 +6,184 @@
 
 #include "iree/tools/utils/yaml_util.h"
 
-#include <yaml.h>
+iree_status_t iree_status_from_yaml_parser_error(yaml_parser_t* parser) {
+  // TODO(benvanik): copy parser.error to status.
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "yaml_parser_load failed");
+}
 
-// TODO(benvanik): yaml parsing/printing to vm types.
+iree_string_view_t iree_yaml_node_as_string(yaml_node_t* node) {
+  if (!node || node->type != YAML_SCALAR_NODE) return iree_string_view_empty();
+  return iree_make_string_view(node->data.scalar.value,
+                               node->data.scalar.length);
+}
 
-void yaml_util_dummy() {
-  // Just here to make linking issues visible.
-  yaml_get_version_string();
+bool iree_yaml_string_equal(yaml_node_t* node, iree_string_view_t value) {
+  return iree_string_view_equal(iree_yaml_node_as_string(node), value);
+}
+
+iree_status_t iree_yaml_mapping_try_find(yaml_document_t* document,
+                                         yaml_node_t* node,
+                                         iree_string_view_t key,
+                                         yaml_node_t** out_value) {
+  *out_value = NULL;
+  if (!node) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION, "invalid node");
+  }
+  if (node->type != YAML_MAPPING_NODE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "(%zu): expected mapping node",
+                            node->start_mark.line);
+  }
+  for (yaml_node_pair_t* pair = node->data.mapping.pairs.start;
+       pair != node->data.mapping.pairs.top; ++pair) {
+    yaml_node_t* key_node = yaml_document_get_node(document, pair->key);
+    if (iree_yaml_string_equal(key_node, key)) {
+      *out_value = yaml_document_get_node(document, pair->value);
+      if (!*out_value) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "(%zu): mapping entry has no value",
+                                key_node->start_mark.line);
+      }
+      return iree_ok_status();
+    }
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_yaml_mapping_find(yaml_document_t* document,
+                                     yaml_node_t* node, iree_string_view_t key,
+                                     yaml_node_t** out_value) {
+  IREE_RETURN_IF_ERROR(
+      iree_yaml_mapping_try_find(document, node, key, out_value));
+  if (!*out_value) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "no mapping found for key '%.*s'", (int)key.size,
+                            key.data);
+  }
+  return iree_ok_status();
+}
+
+// base64 incremental decoding with support for interior whitespace (as required
+// by the general YAML encoding convention).
+//
+// YAML !binary encoding:
+// https://yaml.org/type/binary.html
+//
+// Source:
+// https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64#C_2
+static const uint8_t iree_yaml_base64_decode_table[] = {
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 64, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 62, 66, 66, 66, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 66, 66, 66, 65, 66, 66, 66, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 66, 66, 66, 66,
+    66, 66, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+    66, 66, 66, 66, 66, 66, 66, 66, 66,
+};
+
+#define IREE_YAML_BASE64_WHITESPACE 64
+#define IREE_YAML_BASE64_EQUALS 65
+#define IREE_YAML_BASE64_INVALID 66
+
+size_t iree_yaml_base64_calculate_size(iree_string_view_t source) {
+  uint32_t block = 0;
+  size_t block_length = 0;
+  size_t decoded_length = 0;
+  size_t i = 0;
+  while (i < source.size) {
+    uint8_t c = iree_yaml_base64_decode_table[source.data[i++]];
+    if (c == IREE_YAML_BASE64_WHITESPACE) {
+      // Skip whitespace.
+      continue;
+    } else if (c == IREE_YAML_BASE64_INVALID) {
+      // Invalid base64 character.
+      return SIZE_MAX;
+    } else if (c == IREE_YAML_BASE64_EQUALS) {
+      // End-of-data padding ('=').
+      break;
+    }
+    // Additional byte for the current 4-byte block.
+    block = block << 6 | c;
+    ++block_length;
+    if (block_length == 4) {
+      // Flush 4-byte block.
+      decoded_length += 3;
+      block = 0;
+      block_length = 0;
+    }
+  }
+  if (block_length == 3) {
+    // 2 bytes leftover.
+    decoded_length += 2;
+  } else if (block_length == 2) {
+    // 1 byte leftover.
+    ++decoded_length;
+  }
+  return decoded_length;
+}
+
+iree_status_t iree_yaml_base64_decode(iree_string_view_t source,
+                                      iree_byte_span_t target) {
+  uint32_t block = 0;
+  size_t block_length = 0;
+  size_t decoded_length = 0;
+  size_t i = 0;
+  uint8_t* p = target.data;
+  while (i < source.size) {
+    uint8_t c = iree_yaml_base64_decode_table[source.data[i++]];
+    if (c == IREE_YAML_BASE64_WHITESPACE) {
+      // Skip whitespace.
+      continue;
+    } else if (c == IREE_YAML_BASE64_INVALID) {
+      // Invalid base64 character.
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "invalid base64 character");
+    } else if (c == IREE_YAML_BASE64_EQUALS) {
+      // End-of-data padding ('=').
+      break;
+    }
+    // Additional byte for the current 4-byte block.
+    block = block << 6 | c;
+    ++block_length;
+    if (block_length == 4) {
+      // Flush 4-byte block.
+      decoded_length += 3;
+      if (decoded_length > target.data_length) {
+        return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "base64 target buffer overflow");
+      }
+      *(p++) = (block >> 16) & 0xFF;
+      *(p++) = (block >> 8) & 0xFF;
+      *(p++) = block & 0xFF;
+      block = 0;
+      block_length = 0;
+    }
+  }
+  if (block_length == 3) {
+    // 2 bytes leftover.
+    decoded_length += 2;
+    if (decoded_length > target.data_length) {
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "base64 target buffer overflow");
+    }
+    *(p++) = (block >> 10) & 0xFF;
+    *(p++) = (block >> 2) & 0xFF;
+  } else if (block_length == 2) {
+    // 1 byte leftover.
+    ++decoded_length;
+    if (decoded_length > target.data_length) {
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "base64 target buffer overflow");
+    }
+    *(p++) = (block >> 4) & 0xFF;
+  }
+  return iree_ok_status();
 }

--- a/iree/tools/utils/yaml_util.h
+++ b/iree/tools/utils/yaml_util.h
@@ -8,9 +8,39 @@
 #define IREE_TOOLS_UTILS_YAML_UTIL_H_
 
 #include "iree/base/api.h"
-#include "iree/hal/api.h"
-#include "iree/vm/api.h"
 
-// TODO(benvanik): yaml parsing/printing to vm types.
+#define YAML_DECLARE_STATIC
+#include <yaml.h>  // IWYU pragma: export
+
+// Wraps a YAML parser error in an iree_status_t.
+iree_status_t iree_status_from_yaml_parser_error(yaml_parser_t* parser);
+
+// Returns the given scalar |node| as an iree_string_view_t or empty string if
+// the node is not scalar.
+iree_string_view_t iree_yaml_node_as_string(yaml_node_t* node);
+
+// Returns true if the scalar |node| is equal to |value|.
+bool iree_yaml_string_equal(yaml_node_t* node, iree_string_view_t value);
+
+// Finds the mapping pair with |key|, returning OK and *|out_value| == NULL if
+// it does not exist within |node|.
+iree_status_t iree_yaml_mapping_try_find(yaml_document_t* document,
+                                         yaml_node_t* node,
+                                         iree_string_view_t key,
+                                         yaml_node_t** out_value);
+
+// Finds the mapping pair with |key|, returning NOT_FOUND if it does not exist
+// within |node|.
+iree_status_t iree_yaml_mapping_find(yaml_document_t* document,
+                                     yaml_node_t* node, iree_string_view_t key,
+                                     yaml_node_t** out_value);
+
+// Calculates the size, in bytes, of |source| once decoded as a base64 value.
+size_t iree_yaml_base64_calculate_size(iree_string_view_t source);
+
+// Decodes |source| as a base64 value into |target| which must be at least the
+// size returned by iree_yaml_base64_calculate_size.
+iree_status_t iree_yaml_base64_decode(iree_string_view_t source,
+                                      iree_byte_span_t target);
 
 #endif  // IREE_TOOLS_UTILS_YAML_UTIL_H_


### PR DESCRIPTION
This processes yaml trace files from the python tracing mechanism.

There's limited support for binary data encoding that we can extend as needed (for example, allowing string-form tensors instead of base64-encoded values). Things like `element_type` would also be good to make more user-friendly (supporting the same types available on `iree_hal_parse_element_type`).

Outputs are in iree-run-module format today but we could use libyaml's emitter to output in the same format as the trace inputs. This could allow for easy in-place updates of files. Future improvements could add `--verify-results` to read the results from the input yaml and ensure the outputs are equal.

Would be nice to get an end-to-end test in place for this somehow. For now this is still just a first-pass at a dev tool and will undergo more changes as we figure out what we want to do with it. Once we have a good e2e example adding the documentation for `--help` with `iree_flags_set_usage` would be nice.

Example input:
```yaml
type: context_load
---
type: module_load
module:
  name: hal
  type: builtin
---
type: module_load
module:
  name: module
  type: bytecode
  path: ../../../../iree-tmp/simple_mul.vmfb
---
type: call
function: module.simple_mul
args:
- type: hal.buffer_view
  shape:
  - 4
  element_type: 50331680
  contents: !!binary |
    AACAPwAAAEAAAEBAAACAQA==
- type: hal.buffer_view
  shape:
  - 4
  element_type: 50331680
  contents: !!binary |
    AACAQAAAoEAAAMBAAADgQA==
results:
- type: hal.buffer_view
  shape:
  - 4
  element_type: 50331680
  contents: !!binary |
    AACAQAAAIEEAAJBBAADgQQ==
```

Example output:
```
--- CALL[module.simple_mul] ---
4xf32=4 10 18 28
```