### PR TITLE
Add riscv-32 baremetal kokoro scripts

### DIFF
--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -18,6 +18,7 @@ set -e
 
 ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel)}"
 CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
+RISCV_CONFIG="${RISCV_CONFIG:-rv64}"
 
 "${CMAKE_BIN?}" --version
 ninja --version
@@ -46,7 +47,7 @@ fi
 
 
 # --------------------------------------------------------------------------- #
-# Build for the target (riscv64).
+# Build for the target (riscv).
 BUILD_RISCV_DIR="${BUILD_RISCV_DIR:-$ROOT_DIR/build-riscv}"
 if [[ -d "${BUILD_RISCV_DIR?}" ]]; then
   echo "build-riscv directory already exists. Will use cached results there."
@@ -55,15 +56,34 @@ else
   mkdir -p "${BUILD_RISCV_DIR?}"
 fi
 
-# Configure riscv for 64-bit linux config, then build.
-"${CMAKE_BIN?}" -G Ninja -B "${BUILD_RISCV_DIR?}" \
-  -DCMAKE_TOOLCHAIN_FILE="$(realpath ${ROOT_DIR?}/build_tools/cmake/riscv.toolchain.cmake)" \
-  -DIREE_HOST_BINARY_ROOT="$(realpath ${BUILD_HOST_DIR?}/install)" \
-  -DRISCV_CPU=rv64 \
-  -DIREE_BUILD_COMPILER=OFF \
-  -DIREE_ENABLE_MLIR=OFF \
-  -DIREE_BUILD_TESTS=ON \
-  -DIREE_BUILD_SAMPLES=ON \
-  -DRISCV_TOOLCHAIN_ROOT="${RISCV_TOOLCHAIN_ROOT?}" \
-  "${ROOT_DIR?}"
+echo "Build riscv target with the config of ${RISCV_CONFIG?}"
+declare -a args
+args=(
+  "-G" "Ninja"
+  "-B" "${BUILD_RISCV_DIR?}"
+  -DCMAKE_TOOLCHAIN_FILE="$(realpath ${ROOT_DIR?}/build_tools/cmake/riscv.toolchain.cmake)"
+  -DIREE_HOST_BINARY_ROOT="$(realpath ${BUILD_HOST_DIR?}/install)"
+  -DRISCV_CPU="${RISCV_CONFIG?}"
+  -DIREE_BUILD_COMPILER=OFF
+  -DIREE_ENABLE_MLIR=OFF
+  -DIREE_BUILD_SAMPLES=ON
+)
+
+if [[ "${RISCV_CONFIG?}" == "rv64" ]]; then
+  args+=(
+    -DRISCV_TOOLCHAIN_ROOT="${RISCV_TOOLCHAIN_ROOT?}"
+  )
+elif [[ "${RISCV_CONFIG?}" == "rv32-baremetal" ]]; then
+  args+=(
+    # TODO(#6353): Off until iree/tools are refactored to support threadless config.
+    -DIREE_BUILD_TESTS=OFF
+    -DRISCV_TOOLCHAIN_ROOT="${RISCV_RV32_NEWLIB_TOOLCHAIN_ROOT?}"
+  )
+else
+  echo "riscv config not supported yet"
+  return -1
+fi
+
+args_str=$(IFS=' ' ; echo "${args[*]}")
+"${CMAKE_BIN?}" ${args_str} "${ROOT_DIR?}"
 "${CMAKE_BIN?}" --build "${BUILD_RISCV_DIR?}"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Cross-compile the project towards RISCV with CMake using Kokoro.
+
+set -e
+set -x
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+# Check these exist and print the versions for later debugging
+export CMAKE_BIN="$(which cmake)"
+"${CMAKE_BIN?}" --version
+"${CC?}" --version
+"${CXX?}" --version
+python3 --version
+
+echo "Initializing submodules"
+./scripts/git/submodule_versions.py init
+
+export ROOT_DIR="$(git rev-parse --show-toplevel)"
+export BUILD_HOST_DIR="${ROOT_DIR?}/build-host"
+export BUILD_RISCV_DIR="${ROOT_DIR?}/build-riscv-rv32-baremetal"
+export RISCV_CONFIG="rv32-baremetal"
+
+echo "Cross-compiling with cmake"
+./build_tools/cmake/build_riscv.sh
+
+echo "Run sanity tests"
+./build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/test.sh

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build_kokoro.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Cross-compile the project towards riscv with the
+# gcr.io/iree-oss/cmake-riscv image using Kokoro.
+# Requires the environment variables KOKORO_ROOT and KOKORO_ARTIFACTS_DIR, which
+# are set by Kokoro.
+
+set -x
+set -e
+set -o pipefail
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docker_common.sh"
+
+# Sets DOCKER_RUN_ARGS
+docker_setup
+
+docker run "${DOCKER_RUN_ARGS[@]?}" \
+  gcr.io/iree-oss/cmake-riscv@sha256:2ec67bdb5094323e1df45b88c088aeda435655a6543b6ee42db4a41adde3048d \
+  build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build.sh
+
+# Kokoro will rsync this entire directory back to the executor orchestrating the
+# build which takes forever and is totally useless.
+rm -rf "${KOKORO_ARTIFACTS_DIR?}"/*
+
+# Print out artifacts dir contents after deleting them as a coherence check.
+ls -1a "${KOKORO_ARTIFACTS_DIR?}/"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/common.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/common.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Common configuration for Kokoro builds that run cmake on linux.
+
+build_file: "iree/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build_kokoro.sh"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/google.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/google.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/main.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/main.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/presubmit.cfg
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/presubmit.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Deliberately blank as everything necessary is configured in common files, but
+# file must still exist to match corresponding (Google internal) job
+# configurations that trigger the builds.

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Test the cross-compiled RISCV targets using Kokoro.
+
+set -e
+set -x
+
+# Print the UTC time when set -x is on
+export PS4='[$(date -u "+%T %Z")] '
+
+# Docker image has the QEMU installed at /usr/src/qemu-riscv.
+# Run the embedded_library module loader and simple_embedding under QEMU.
+
+echo "Test elf_module_test_binary"
+pushd "${BUILD_RISCV_DIR?}/iree/hal/local/elf" > /dev/null
+/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+elf_module_test_binary
+popd > /dev/null
+
+echo "Test simple_embedding binaries"
+pushd "${BUILD_RISCV_DIR?}/iree/samples/simple_embedding" > /dev/null
+
+/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+simple_embedding_embedded_sync
+
+/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+simple_embedding_vmvx_sync
+
+popd > /dev/null


### PR DESCRIPTION
Test IREE build with riscv 32-bit for the bare-metal configuration. It tests
* 32-bit code-gen flow.
* build with the bare-metal config without threading and system library
    support.
* Execute the 32-bit codegen workload with 32-bit linux user-space QEMU
    emulator.

The CI setup for https://github.com/google/iree/issues/6322