### PR TITLE
Fix use of `IREE_TRACE_ZONE_APPEND_TEXT` in library loaders.

### DIFF
--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -237,7 +237,7 @@ static iree_status_t iree_hal_elf_executable_issue_call(
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {
-      IREE_TRACE_ZONE_APPEND_TEXT(tag);
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, tag);
     }
   }
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/iree/hal/local/loaders/legacy_library_loader.c
+++ b/iree/hal/local/loaders/legacy_library_loader.c
@@ -318,7 +318,7 @@ static iree_status_t iree_hal_legacy_executable_issue_call(
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {
-      IREE_TRACE_ZONE_APPEND_TEXT(tag);
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, tag);
     }
   }
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/iree/hal/local/loaders/static_library_loader.c
+++ b/iree/hal/local/loaders/static_library_loader.c
@@ -125,7 +125,7 @@ static iree_status_t iree_hal_static_executable_issue_call(
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {
-      IREE_TRACE_ZONE_APPEND_TEXT(tag);
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, tag);
     }
   }
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION


### PR DESCRIPTION
Fixes https://github.com/google/iree/issues/6302