### PR TITLE
Add support for lowering mhlo.sort to linalg_ext ops and distrubute them

### DIFF
--- a/integrations/tensorflow/build_tools/overlay/mlir-hlo/BUILD.bazel
+++ b/integrations/tensorflow/build_tools/overlay/mlir-hlo/BUILD.bazel
@@ -27,6 +27,7 @@ alias(
         "legalize_gather_to_torch_index_select",
         "legalize_to_linalg",
         "lhlo",
+        "map_lmhlo_to_scalar_op",
         "materialize_broadcasts",
         "mhlo_to_mhlo_lowering_patterns",
         "unfuse_batch_norm",

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -638,6 +638,18 @@ void DispatchTensorLoadOp::build(OpBuilder &builder, OperationState &state,
 }
 
 //===----------------------------------------------------------------------===//
+// flow.dispatch.tensor.store
+//===----------------------------------------------------------------------===//
+
+void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
+                                  Value value, Value target,
+                                  ArrayRef<NamedAttribute> attributes) {
+  build(builder, state, ArrayRef<Type>(), value, target, ArrayRef<Value>(),
+        ArrayRef<Value>(), ArrayRef<Value>(), builder.getI64ArrayAttr({}),
+        builder.getI64ArrayAttr({}), builder.getI64ArrayAttr({}));
+}
+
+//===----------------------------------------------------------------------===//
 // flow.dispatch.workgroups
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -543,6 +543,13 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     attr-dict `:` type($value) `->` type($target)
   }];
 
+  let builders = [
+    // Builder for tensor.store with empty offset, sizes and strides operands.
+    // This is used to store an entire tensor.
+    OpBuilder<(ins "Value":$value, "Value":$target,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+  ];
+
   let extraClassDeclaration = [{
     /// Return the expected rank of each of the`static_offsets`, `static_sizes`
     /// and `static_strides` attributes.

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -165,14 +165,18 @@ static void printSortOp(OpAsmPrinter &p, SortOp op) {
 }
 
 static LogicalResult verifySortOp(SortOp op) {
-  Block &block = op.region().front();
-  size_t numInputs = op.getNumInputs();
-  if (block.getNumArguments() != 2 * numInputs) {
-    return op.emitOpError("region block should have ")
-           << 2 * numInputs << " arguments";
+  if (op.getNumInputs()) {
+    return op.emitOpError("does not expect to take any inputs");
   }
 
-  int rank = op.getRank(op.getInputOperand(0));
+  Block &block = op.region().front();
+  size_t numOutputs = op.getNumOutputs();
+  if (block.getNumArguments() != 2 * numOutputs) {
+    return op.emitOpError("region block should have ")
+           << 2 * numOutputs << " arguments";
+  }
+
+  int rank = op.getRank(op.getOutputOperand(0));
   if (rank > 1 && !op.dimensionAttr()) {
     return op.emitOpError("dimension must be specified if rank > 1");
   }

--- a/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -3,7 +3,7 @@
 func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   // expected-error @+1 {{dimension must be within (0, 1]}}
   %0 = linalg_ext.sort {dimension = 1 : i64}
-    ins(%arg0 : tensor<128xi32>) {
+    outs(%arg0 : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
     %1 = cmpi sgt, %arg1, %arg2 : i32
     linalg_ext.yield %1 : i1
@@ -16,7 +16,7 @@ func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 func @sort_without_dimension(%arg0: tensor<3x4xi32>) -> tensor<3x4xi32> {
   // expected-error @+1 {{dimension must be specified if rank > 1}}
   %0 = linalg_ext.sort
-    ins(%arg0 : tensor<3x4xi32>) {
+    outs(%arg0 : tensor<3x4xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
     %1 = cmpi sgt, %arg1, %arg2 : i32
     linalg_ext.yield %1 : i1

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -2,11 +2,11 @@
 
 // CHECK-LABEL: func @sort_tensor
 // CHECK:         linalg_ext.sort
-// CHECK-SAME:      ins({{.*}})
+// CHECK-SAME:      outs({{.*}})
 // CHECK:           linalg_ext.yield
 func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   %0 = linalg_ext.sort
-    ins(%arg0 : tensor<128xi32>) {
+    outs(%arg0 : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
     %1 = cmpi sgt, %arg1, %arg2 : i32
     linalg_ext.yield %1 : i1
@@ -16,14 +16,13 @@ func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 // CHECK-LABEL: func @sort_memref
 // CHECK:         linalg_ext.sort
-// CHECK-SAME:      ins({{.*}}) outs({{.*}})
+// CHECK-SAME:      outs({{.*}})
 // CHECK:           linalg_ext.yield
-func @sort_memref(%arg0: memref<128xi32>, %arg1: memref<128xi32>) {
+func @sort_memref(%arg0: memref<128xi32>) {
   linalg_ext.sort {dimension = 0 : i64}
-    ins(%arg0 : memref<128xi32>)
-    outs(%arg1 : memref<128xi32>) {
-  ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
-    %0 = cmpi sgt, %arg2, %arg3 : i32
+    outs(%arg0 : memref<128xi32>) {
+  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
+    %0 = cmpi sgt, %arg1, %arg2 : i32
     linalg_ext.yield %0 : i1
   }
   return

--- a/iree/compiler/InputConversion/MHLO/BUILD
+++ b/iree/compiler/InputConversion/MHLO/BUILD
@@ -46,6 +46,7 @@ cc_library(
     name = "MHLO",
     srcs = [
         "BroadcastingToLinalgPatterns.cpp",
+        "ConvertAndDistributeMHLOToLinalgExt.cpp",
         "ConvertComplexToReal.cpp",
         "ConvertMHLOToFlow.cpp",
         "ConvertMHLOToFlow.h",
@@ -63,6 +64,7 @@ cc_library(
         ":PassesIncGen",
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/Flow/Transforms",
+        "//iree/compiler/Dialect/LinalgExt/IR",
         "//iree/compiler/Dialect/Shape/IR",
         "//iree/compiler/InputConversion/Common",
         "@llvm-project//llvm:Support",
@@ -86,6 +88,7 @@ cc_library(
         "@mlir-hlo//:hlo",
         "@mlir-hlo//:legalize_gather_to_torch_index_select",
         "@mlir-hlo//:legalize_to_linalg",
+        "@mlir-hlo//:map_lmhlo_to_scalar_op",
         "@mlir-hlo//:materialize_broadcasts",
         "@mlir-hlo//:mhlo_to_mhlo_lowering_patterns",
         "@mlir-hlo//:unfuse_batch_norm",

--- a/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "Passes.h"
   SRCS
     "BroadcastingToLinalgPatterns.cpp"
+    "ConvertAndDistributeMHLOToLinalgExt.cpp"
     "ConvertComplexToReal.cpp"
     "ConvertMHLOToFlow.cpp"
     "ConvertMHLOToFlow.h"
@@ -69,6 +70,7 @@ iree_cc_library(
     MLIRTransforms
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Shape::IR
     iree::compiler::InputConversion::Common
     tensorflow::mlir_hlo

--- a/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
@@ -1,0 +1,191 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/InputConversion/MHLO/PassDetail.h"
+#include "iree/compiler/InputConversion/MHLO/Passes.h"
+#include "iree/compiler/InputConversion/MHLO/Rewriters.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/map_lmhlo_to_scalar_op.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+static bool isInBodyOfLinalgExtOps(Operation *op) {
+  auto parent_op = op->getParentRegion()->getParentOp();
+  return parent_op->getDialect() ==
+         parent_op->getContext()
+             ->getLoadedDialect<linalg_ext::LinalgExtDialect>();
+}
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Base classes.
+//===----------------------------------------------------------------------===//
+
+template <typename Derived, typename OpTy>
+struct ConvertToLinalgExtPattern : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      OpTy op, ArrayRef<Value> args,
+      ConversionPatternRewriter &rewriter) const final {
+    Value one = rewriter.create<ConstantIndexOp>(op.getLoc(), 1);
+    SmallVector<Value> workload(3, one);
+    auto dispatchOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
+        op.getLoc(), workload, op->getResultTypes(),
+        /*result_dims=*/ValueRange{},
+        /*operands=*/args,
+        /*operand_dims=*/ValueRange{},
+        /*tied_operands=*/Derived::getTiedResultOperandIndices(args));
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&dispatchOp.getRegion().front());
+      if (failed(Derived::lowerMHLOOp(dispatchOp, op, args, rewriter))) {
+        return failure();
+      }
+      rewriter.create<IREE::Flow::ReturnOp>(op.getLoc());
+    }
+    rewriter.replaceOp(op, dispatchOp.getResults());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Region operations lowering.
+//===----------------------------------------------------------------------===//
+
+template <typename OpTy>
+struct LinalgExtRegionHLOOpConversion : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      OpTy op, ArrayRef<Value> args,
+      ConversionPatternRewriter &rewriter) const final {
+    if (!isInBodyOfLinalgExtOps(op)) return failure();
+    if (!op.getResult().getType().template isa<TensorType>()) return failure();
+    if (llvm::all_of(args, [](Value arg) {
+          return arg.getType().template isa<TensorType>();
+        })) {
+      return failure();
+    }
+    Value result = lmhlo::HloOpToStdScalarOp::map<OpTy>(
+        op, getElementTypeOrSelf(op.getType()), args, &rewriter);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct LinalgExtRegionReturnOpConversion
+    : public OpConversionPattern<mhlo::ReturnOp> {
+  using OpConversionPattern<mhlo::ReturnOp>::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mhlo::ReturnOp op, ArrayRef<Value> args,
+      ConversionPatternRewriter &rewriter) const final {
+    if (!isInBodyOfLinalgExtOps(op)) return failure();
+    rewriter.replaceOpWithNewOp<linalg_ext::YieldOp>(op, args);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// SortOp
+//===----------------------------------------------------------------------===//
+
+struct SortOpConversion
+    : public ConvertToLinalgExtPattern<SortOpConversion, mhlo::SortOp> {
+  using ConvertToLinalgExtPattern<SortOpConversion,
+                                  mhlo::SortOp>::ConvertToLinalgExtPattern;
+
+  static SmallVector<int64_t> getTiedResultOperandIndices(
+      ArrayRef<Value> args) {
+    return llvm::to_vector<4>(llvm::seq<int64_t>(0, args.size()));
+  }
+
+  static LogicalResult lowerMHLOOp(IREE::Flow::DispatchWorkgroupsOp dispatchOp,
+                                   mhlo::SortOp op, ArrayRef<Value> args,
+                                   ConversionPatternRewriter &rewriter) {
+    auto blockArgs = dispatchOp.getClosureBodyRegion().getArguments();
+    SmallVector<Value> initValues;
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    for (auto it : llvm::zip(args, blockArgs)) {
+      auto argTy = std::get<0>(it).getType().cast<RankedTensorType>();
+      auto blockArg = std::get<1>(it);
+      initValues.push_back(
+          b.create<IREE::Flow::DispatchTensorLoadOp>(argTy, blockArg));
+    }
+
+    auto sortOp = b.create<linalg_ext::SortOp>(op.getResultTypes(),
+                                               /*inputs=*/ValueRange{},
+                                               initValues, op.dimensionAttr());
+    rewriter.inlineRegionBefore(op.comparator(), sortOp.region(),
+                                sortOp.region().begin());
+    Region &region = sortOp.region();
+    Block &block = region.front();
+    TypeConverter::SignatureConversion signature_converter(
+        block.getNumArguments());
+    for (auto en : llvm::enumerate(block.getArguments())) {
+      signature_converter.addInputs(en.index(),
+                                    getElementTypeOrSelf(en.value().getType()));
+    }
+    rewriter.applySignatureConversion(&region, signature_converter);
+
+    for (auto it : llvm::zip(sortOp.getResults(), blockArgs)) {
+      auto value = std::get<0>(it);
+      auto target = std::get<1>(it);
+      b.create<IREE::Flow::DispatchTensorStoreOp>(value, target);
+    }
+
+    return success();
+  }
+};
+
+struct ConvertAndDistributeMHLOToLinalgExtPass
+    : public ConvertAndDistributeMHLOToLinalgExtBase<
+          ConvertAndDistributeMHLOToLinalgExtPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg_ext::LinalgExtDialect, IREE::Flow::FlowDialect,
+                    StandardOpsDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    OwningRewritePatternList patterns(&getContext());
+    MLIRContext *context = &getContext();
+
+    patterns.insert<SortOpConversion>(context);
+    patterns.insert<LinalgExtRegionHLOOpConversion<mhlo::CompareOp>,
+                    LinalgExtRegionReturnOpConversion>(context,
+                                                       PatternBenefit(1000));
+
+    ConversionTarget target(getContext());
+    target
+        .addLegalDialect<linalg_ext::LinalgExtDialect, IREE::Flow::FlowDialect,
+                         StandardOpsDialect, tensor::TensorDialect>();
+    target.addIllegalOp<mhlo::SortOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+createConvertAndDistributeMHLOToLinalgExtPass() {
+  return std::make_unique<ConvertAndDistributeMHLOToLinalgExtPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/InputConversion/MHLO/Passes.h
+++ b/iree/compiler/InputConversion/MHLO/Passes.h
@@ -34,6 +34,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createLegalizeInputTypesPass();
 /// Creates XLA-HLO to Linalg on tensors transformation pass.
 std::unique_ptr<OperationPass<FuncOp>> createMHLOToLinalgOnTensorsPass();
 
+/// Creates XLA-HLO to LinalgExt and Flow transformation pass.
+std::unique_ptr<OperationPass<FuncOp>>
+createConvertAndDistributeMHLOToLinalgExtPass();
+
 /// Creates XLA-HLO preprocessing transformation pass. In this pass we should
 /// have all mhlo -> mhlo transformations that are shared between all
 /// backends.

--- a/iree/compiler/InputConversion/MHLO/Passes.td
+++ b/iree/compiler/InputConversion/MHLO/Passes.td
@@ -15,6 +15,14 @@ def ConvertMHLOToLinalgOnTensors :
   let constructor = "mlir::iree_compiler::createMHLOToLinalgOnTensorsPass()";
 }
 
+def ConvertAndDistributeMHLOToLinalgExt
+    : Pass<"iree-mhlo-to-linalg-ext", "FuncOp"> {
+  let summary =
+      "Convert from XLA-HLO ops to LinalgExt ops and distribute to Flow ops";
+  let constructor =
+      "mlir::iree_compiler::createConvertAndDistributeMHLOToLinalgExtPass()";
+}
+
 def LegalizeInputTypes :
     Pass<"iree-mhlo-legalize-input-types", "ModuleOp"> {
   let summary = "Legalizes input types to ones supported by the IREE flow dialect";

--- a/iree/compiler/InputConversion/MHLO/test/BUILD
+++ b/iree/compiler/InputConversion/MHLO/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "broadcasting.mlir",
+            "convert_and_distribute_mhlo_to_linalg_ext.mlir",
             "convert_complex_to_real.mlir",
             "dynamic_shape.mlir",
             "fft.mlir",

--- a/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "broadcasting.mlir"
+    "convert_and_distribute_mhlo_to_linalg_ext.mlir"
     "convert_complex_to_real.mlir"
     "dynamic_shape.mlir"
     "fft.mlir"

--- a/iree/compiler/InputConversion/MHLO/test/convert_and_distribute_mhlo_to_linalg_ext.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/convert_and_distribute_mhlo_to_linalg_ext.mlir
@@ -1,0 +1,82 @@
+// RUN: iree-opt -split-input-file -iree-mhlo-to-linalg-ext %s | IreeFileCheck %s
+
+func @sort_1d(%arg0: tensor<128xi32>) -> (tensor<128xi32>) {
+  %0 = "mhlo.sort"(%arg0) ( {
+  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):  // no predecessors
+    %1 = "mhlo.compare"(%arg2, %arg3) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "mhlo.return"(%1) : (tensor<i1>) -> ()
+  }) {dimension = 0 : i64, is_stable = false} : (tensor<128xi32>) -> (tensor<128xi32>)
+  return %0 : tensor<128xi32>
+}
+// CHECK-LABEL: func @sort_1d
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]]) : (tensor<128xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG1:.+]]: !flow.dispatch.tensor<readwrite:128xi32>
+// CHECK:           %[[IN:.+]] = flow.dispatch.tensor.load %[[ARG1]]
+// CHECK:           %[[SORT:.+]] = linalg_ext.sort
+// CHECK-SAME:        dimension = 0 : i64
+// CHECK-SAME:        outs(%[[IN]] : tensor<128xi32>)
+// CHECK:          ^bb0(%[[ARG2:.+]]: i32, %[[ARG3:.+]]: i32)
+// CHECK:            %[[CMP:.+]] = cmpi sgt, %[[ARG2]], %[[ARG3]]
+// CHECK:            linalg_ext.yield %[[CMP]]
+// CHECK:          flow.dispatch.tensor.store %[[SORT]], %[[ARG1]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @sort_2d(%arg0: tensor<16x32xi32>) -> (tensor<16x32xi32>) {
+  %0 = "mhlo.sort"(%arg0) ( {
+  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):  // no predecessors
+    %1 = "mhlo.compare"(%arg2, %arg3) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "mhlo.return"(%1) : (tensor<i1>) -> ()
+  }) {dimension = 0 : i64, is_stable = false} : (tensor<16x32xi32>) -> (tensor<16x32xi32>)
+  return %0 : tensor<16x32xi32>
+}
+// CHECK-LABEL: func @sort_2d
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]]) : (tensor<16x32xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG1:.+]]: !flow.dispatch.tensor<readwrite:16x32xi32>
+// CHECK:           %[[IN:.+]] = flow.dispatch.tensor.load %[[ARG1]]
+// CHECK:           %[[SORT:.+]] = linalg_ext.sort
+// CHECK-SAME:        dimension = 0 : i64
+// CHECK-SAME:        outs(%[[IN]] : tensor<16x32xi32>)
+// CHECK:          ^bb0(%[[ARG2:.+]]: i32, %[[ARG3:.+]]: i32)
+// CHECK:            %[[CMP:.+]] = cmpi sgt, %[[ARG2]], %[[ARG3]]
+// CHECK:            linalg_ext.yield %[[CMP]]
+// CHECK:          flow.dispatch.tensor.store %[[SORT]], %[[ARG1]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @topk(%arg0: tensor<128xi32>, %arg1: tensor<128xi32>) -> (tensor<128xi32>) {
+  %0:2 = "mhlo.sort"(%arg0, %arg1) ( {
+  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>):  // no predecessors
+    %1 = "mhlo.compare"(%arg2, %arg3) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "mhlo.return"(%1) : (tensor<i1>) -> ()
+  }) {dimension = 0 : i64, is_stable = false} : (tensor<128xi32>, tensor<128xi32>) -> (tensor<128xi32>, tensor<128xi32>)
+  return %0#0 : tensor<128xi32>
+}
+// CHECK-LABEL: func @topk
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]]:2 = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]])
+// CHECK-SAME:    : (tensor<128xi32>, tensor<128xi32>) -> (%[[ARG0]], %[[ARG1]])
+// CHECK:           %[[ARG2:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:128xi32>
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:128xi32>
+// CHECK:           %[[IN1:.+]] = flow.dispatch.tensor.load %[[ARG2]]
+// CHECK:           %[[IN2:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[SORT:.+]]:2 = linalg_ext.sort
+// CHECK-SAME:        dimension = 0 : i64
+// CHECK-SAME:        outs(%[[IN1]], %[[IN2]] : tensor<128xi32>, tensor<128xi32>)
+// CHECK:          ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: i32, %{{.*}}: i32, %{{.*}}: i32)
+// CHECK:            %[[CMP:.+]] = cmpi sgt, %[[ARG4]], %[[ARG5]]
+// CHECK:            linalg_ext.yield %[[CMP]]
+// CHECK:          flow.dispatch.tensor.store %[[SORT]]#0, %[[ARG2]]
+// CHECK:          flow.dispatch.tensor.store %[[SORT]]#1, %[[ARG3]]
+// CHECK:        return %[[RES]]#0


### PR DESCRIPTION
The pass creates flow.dispatch.workgroups ops and pull the lowered sort op into the body. The workgroup counts are all set to one. Also adds a build method to flow.dispatch.tensor.store.

This is a step towards https://github.com/google/iree/issues/6154