### PR TITLE
Update cmake-riscv docker image

### DIFF
--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -71,7 +71,7 @@ args=(
 
 if [[ "${RISCV_CONFIG?}" == "rv64" ]]; then
   args+=(
-    -DRISCV_TOOLCHAIN_ROOT="${RISCV_TOOLCHAIN_ROOT?}"
+    -DRISCV_TOOLCHAIN_ROOT="${RISCV_RV64_LINUX_TOOLCHAIN_ROOT?}"
   )
 elif [[ "${RISCV_CONFIG?}" == "rv32-baremetal" ]]; then
   args+=(

--- a/build_tools/docker/cmake-riscv/Dockerfile
+++ b/build_tools/docker/cmake-riscv/Dockerfile
@@ -19,5 +19,7 @@ FROM gcr.io/iree-oss/cmake@sha256:9d9953acf5ca0cf1ff3e8de32f10f24dfab1c4e8ec5d1f
 COPY --from=install-riscv "/usr/src/toolchain_iree" "/usr/src/toolchain_iree"
 COPY --from=install-riscv "/usr/src/toolchain_iree_rv32imf" "/usr/src/toolchain_iree_rv32imf"
 COPY --from=install-riscv "/usr/src/qemu-riscv" "/usr/src/qemu-riscv"
-ENV RISCV_TOOLCHAIN_ROOT="/usr/src/toolchain_iree"
+ENV RISCV_RV64_LINUX_TOOLCHAIN_ROOT="/usr/src/toolchain_iree"
 ENV RISCV_RV32_NEWLIB_TOOLCHAIN_ROOT="/usr/src/toolchain_iree_rv32imf"
+ENV QEMU_RV64_BIN="/usr/src/qemu-riscv/qemu-riscv64"
+ENV QEMU_RV32_BIN="/usr/src/qemu-riscv/qemu-riscv32"

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -14,6 +14,6 @@ gcr.io/iree-oss/cmake-bazel-frontends@sha256:8974ee20d855ecfc8b9e511f4fb4a25d678
 gcr.io/iree-oss/cmake-bazel-frontends-vulkan@sha256:e99fd07a48e2b1a00200b3b600ff00878d413045cb7809fe73dac4c36fa4825a
 gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:71eeb44ba014ee043ae2adeeb6458bc281444ee6f295b5ba7e4337a69a95f7df
 gcr.io/iree-oss/cmake-bazel-frontends-swiftshader@sha256:4e018bd74c630f89f86b700a47b6a6792c8f97e337870af69a000e578a3ca688
-gcr.io/iree-oss/cmake-riscv@sha256:2ec67bdb5094323e1df45b88c088aeda435655a6543b6ee42db4a41adde3048d
+gcr.io/iree-oss/cmake-riscv@sha256:95489593bc9b0cd325ce9c1a32b47389c01b174a5b8190a16d937d2e8828d384
 gcr.io/iree-oss/cmake-bazel-frontends-android@sha256:1392e3a27cddbdc597817168fb61e125bbdcbfd9076eff9d70bd8012b0a0c5ba
 gcr.io/iree-oss/samples@sha256:be5465585706b620d6c722caa6237eafdfaa8dd11ce20db0981b979f2d3387b3

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build_kokoro.sh
@@ -24,7 +24,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docke
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/cmake-riscv@sha256:2ec67bdb5094323e1df45b88c088aeda435655a6543b6ee42db4a41adde3048d \
+  gcr.io/iree-oss/cmake-riscv@sha256:95489593bc9b0cd325ce9c1a32b47389c01b174a5b8190a16d937d2e8828d384 \
   build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/baremetal/riscv32/test.sh
@@ -14,22 +14,20 @@ set -x
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Docker image has the QEMU installed at /usr/src/qemu-riscv.
 # Run the embedded_library module loader and simple_embedding under QEMU.
-
 echo "Test elf_module_test_binary"
 pushd "${BUILD_RISCV_DIR?}/iree/hal/local/elf" > /dev/null
-/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV32_BIN?}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 elf_module_test_binary
 popd > /dev/null
 
 echo "Test simple_embedding binaries"
 pushd "${BUILD_RISCV_DIR?}/iree/samples/simple_embedding" > /dev/null
 
-/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV32_BIN?}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 simple_embedding_embedded_sync
 
-/usr/src/qemu-riscv/qemu-riscv32 -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV32_BIN?}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 simple_embedding_vmvx_sync
 
 popd > /dev/null

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/build_kokoro.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/build_kokoro.sh
@@ -24,7 +24,7 @@ source "${KOKORO_ARTIFACTS_DIR?}/github/iree/build_tools/kokoro/gcp_ubuntu/docke
 docker_setup
 
 docker run "${DOCKER_RUN_ARGS[@]?}" \
-  gcr.io/iree-oss/cmake-riscv@sha256:2ec67bdb5094323e1df45b88c088aeda435655a6543b6ee42db4a41adde3048d \
+  gcr.io/iree-oss/cmake-riscv@sha256:95489593bc9b0cd325ce9c1a32b47389c01b174a5b8190a16d937d2e8828d384 \
   build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/build.sh
 
 # Kokoro will rsync this entire directory back to the executor orchestrating the

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/riscv64/test.sh
@@ -14,19 +14,21 @@ set -x
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-# Docker image has the QEMU installed at /usr/src/qemu-riscv.
-# Run the simple_embedding binaries under QEMU.
+# Environment variable used by the emulator and iree-translate for the
+# dylib-llvm-aot bytecode codegen.
+export RISCV_TOOLCHAIN_ROOT=${RISCV_RV64_LINUX_TOOLCHAIN_ROOT?}
 
+# Run the binaries under QEMU.
 echo "Test simple_embedding binaries"
 pushd "${BUILD_RISCV_DIR?}/iree/samples/simple_embedding" > /dev/null
 
-/usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV64_BIN?}" -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 -L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_dylib
 
-/usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV64_BIN?}" -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 -L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_embedded_sync
 
-/usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+"${QEMU_RV64_BIN?}" -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
 -L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" simple_embedding_vmvx_sync
 
 popd > /dev/null
@@ -43,7 +45,7 @@ echo "Test e2e mlir --> bytecode module --> iree-run-module"
   "${ROOT_DIR?}/iree/tools/test/iree-run-module.mlir" \
   -o "${BUILD_RISCV_DIR?}/iree-run-module-llvm_aot.vmfb"
 
-IREE_RUN_OUT=$(/usr/src/qemu-riscv/qemu-riscv64 -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+IREE_RUN_OUT=$(${QEMU_RV64_BIN?} -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
     -L "${RISCV_TOOLCHAIN_ROOT?}/sysroot" \
     "${BUILD_RISCV_DIR?}/iree/tools/iree-run-module" --driver=dylib \
     --module_file="${BUILD_RISCV_DIR?}/iree-run-module-llvm_aot.vmfb" \


### PR DESCRIPTION
Update the environment variables to distinguish the toolchains in
`RISCV_<arch>_<platform>_TOOLCHAIN_ROOT` naming style.

Also setup the `QEMU_<arch>_BIN` environment variables in the docker image
instead of hard-coded them in the kokoro testing scripts.