### PR TITLE
Don't exclude gen targets in bazel->cmake

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -126,29 +126,7 @@ def _convert_target(target):
   """Returns a list of targets that correspond to the specified Bazel target.
   Note that this must be a list because some targets have a one to many mapping.
   """
-  if target.startswith(":") and target.endswith(("_gen", "Gen")):
-    # Files created by gentbl have to be included as source and header files
-    # and not as a dependency. Adding these targets to the dependencies list,
-    # results in linkage failures if the library including the gentbl dep is
-    # marked as ALWAYSLINK.
-    # This drops deps in the local namespace ending with '_gen' and 'Gen'
-    target = [""]
-  elif not target.startswith(("//bindings", "//experimental", "//iree", ":")):
-    # External target, call helper method for special case handling.
-    target = bazel_to_cmake_targets.convert_external_target(target)
-  else:
-    # Bazel `:api`            -> CMake `::api`
-    # Bazel `//iree/base`     -> CMake `iree::base`
-    # Bazel `//iree/base:foo` -> CMake `iree::base::foo`
-    target = target.replace("//bindings", "bindings")  # bindings:api
-    # Support for experimental targets is best effort with no guarantees.
-    target = target.replace("//experimental",
-                            "experimental")  # experimental:api
-    target = target.replace("//iree", "iree")  # iree/base:foo
-    target = target.replace(":", "::")  # iree/base::foo or ::foo
-    target = target.replace("/", "::")  # iree::base
-    target = [target]
-  return target
+  return bazel_to_cmake_targets.convert_target(target)
 
 
 def _convert_single_target(target):

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -101,11 +101,8 @@ def convert_target(target):
     # Bazel `:api`            -> CMake `::api`
     # Bazel `//iree/base`     -> CMake `iree::base`
     # Bazel `//iree/base:foo` -> CMake `iree::base::foo`
-    target = target.replace("//bindings", "bindings")  # bindings:api
-    # Support for experimental targets is best effort with no guarantees.
-    target = target.replace("//experimental",
-                            "experimental")  # experimental:api
-    target = target.replace("//iree", "iree")  # iree/base:foo
+    if target.startswith("//"):
+      target = target[len("//"):]
     target = target.replace(":", "::")  # iree/base::foo or ::foo
     target = target.replace("/", "::")  # iree::base
     return [target]

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -79,8 +79,8 @@ def _convert_llvm_target(target):
   return ["LLVM" + target.rsplit(":")[-1]]
 
 
-def convert_external_target(target):
-  """Converts an external (non-IREE) Bazel target to a list of CMake targets.
+def convert_target(target):
+  """Converts a Bazel target to a list of CMake targets.
 
   IREE targets are expected to follow a standard form between Bazel and CMake
   that facilitates conversion. External targets *may* have their own patterns,
@@ -97,6 +97,18 @@ def convert_external_target(target):
   """
   if target in EXPLICIT_TARGET_MAPPING:
     return EXPLICIT_TARGET_MAPPING[target]
+  if not target.startswith("@"):
+    # Bazel `:api`            -> CMake `::api`
+    # Bazel `//iree/base`     -> CMake `iree::base`
+    # Bazel `//iree/base:foo` -> CMake `iree::base::foo`
+    target = target.replace("//bindings", "bindings")  # bindings:api
+    # Support for experimental targets is best effort with no guarantees.
+    target = target.replace("//experimental",
+                            "experimental")  # experimental:api
+    target = target.replace("//iree", "iree")  # iree/base:foo
+    target = target.replace(":", "::")  # iree/base::foo or ::foo
+    target = target.replace("/", "::")  # iree::base
+    return [target]
   if target.startswith("@llvm-project//llvm"):
     return _convert_llvm_target(target)
   if target.startswith("@llvm-project//mlir"):

--- a/iree/compiler/Codegen/CMakeLists.txt
+++ b/iree/compiler/Codegen/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.h"
     "Passes.h.inc"
   DEPS
+    ::PassesIncGen
     MLIRLinalgTransforms
     MLIRPass
     MLIRTransforms
@@ -41,6 +42,7 @@ iree_cc_library(
     "Passes.cpp"
   DEPS
     ::PassHeaders
+    ::PassesIncGen
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::LLVMGPU

--- a/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -31,6 +31,9 @@ iree_cc_library(
     "FlowOps.cpp.inc"
     "FlowTypes.cpp"
   DEPS
+    ::FlowEnumsGen
+    ::FlowInterfacesGen
+    ::FlowOpsGen
     LLVMSupport
     MLIRIR
     MLIRInferTypeOpInterface

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     "StripAndSplatConstantVariables.cpp"
     "TypeConverter.cpp"
   DEPS
+    ::PassesIncGen
     LLVMSupport
     MLIRAffine
     MLIRIR
@@ -80,8 +81,3 @@ set_property(SOURCE
   PROPERTY COMPILE_FLAGS $<$<CXX_COMPILER_ID:GNU>:-fno-devirtualize>)
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
-# TODO: For some reason, these dependencies are not being added automatically.
-add_dependencies(
-  iree_compiler_Dialect_Flow_Transforms_Transforms
-  iree_compiler_Dialect_Flow_Transforms_PassesIncGen
-)

--- a/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -39,6 +39,12 @@ iree_cc_library(
     "HALTypes.cpp"
     "LoweringConfig.cpp"
   DEPS
+    ::HALInterfacesGen
+    ::HALOpsGen
+    ::HALStructsGen
+    ::HALTypesGen
+    ::LoweringConfigEnumGen
+    ::LoweringConfigGen
     LLVMSupport
     MLIRIR
     MLIRMemRef

--- a/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/IREE/IR/CMakeLists.txt
@@ -27,6 +27,8 @@ iree_cc_library(
     "IREEOps.cpp.inc"
     "IREETypes.cpp"
   DEPS
+    ::IREEInterfacesGen
+    ::IREEOpsGen
     LLVMSupport
     MLIRIR
     MLIRParser

--- a/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -26,6 +26,8 @@ iree_cc_library(
     "LinalgExtOps.cpp"
     "LinalgExtOps.cpp.inc"
   DEPS
+    ::LinalgExtInterfacesGen
+    ::LinalgExtOpsGen
     LLVMSupport
     MLIRControlFlowInterfaces
     MLIRIR

--- a/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "PassDetail.h"
     "Passes.cpp"
   DEPS
+    ::PassesIncGen
     LLVMSupport
     MLIRIR
     MLIRMemRef

--- a/iree/compiler/Dialect/Modules/Check/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/Check/IR/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     "CheckOps.cpp"
     "CheckOps.cpp.inc"
   DEPS
+    ::check_ops_gen
     MLIRIR
     MLIRStandard
     iree::compiler::Dialect::HAL::IR
@@ -35,6 +36,7 @@ iree_cc_library(
     "CheckDialect.cpp"
   DEPS
     ::IR
+    ::check_ops_gen
     MLIRIR
     MLIRParser
     MLIRTransforms

--- a/iree/compiler/Dialect/Modules/VMVX/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Modules/VMVX/IR/CMakeLists.txt
@@ -27,6 +27,9 @@ iree_cc_library(
     "VMVXOps.cpp"
     "VMVXTypes.cpp"
   DEPS
+    ::VMVXEnumsGen
+    ::VMVXOpInterfaceGen
+    ::VMVXOpsGen
     LLVMSupport
     MLIRIR
     MLIRSideEffectInterfaces

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -31,6 +31,8 @@ iree_cc_library(
     "ShapeOps.cpp.inc"
     "ShapeTypes.cpp"
   DEPS
+    ::ShapeInterfacesGen
+    ::ShapeOpsGen
     LLVMSupport
     MLIRControlFlowInterfaces
     MLIRIR

--- a/iree/compiler/Dialect/VM/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/CMakeLists.txt
@@ -34,6 +34,11 @@ iree_cc_library(
     "VMStructs.cpp.inc"
     "VMTypes.cpp"
   DEPS
+    ::VMEnumsGen
+    ::VMOpEncoderGen
+    ::VMOpInterfaceGen
+    ::VMOpsGen
+    ::VMStructsGen
     LLVMSupport
     MLIRControlFlowInterfaces
     MLIRIR

--- a/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Vulkan/IR/CMakeLists.txt
@@ -26,6 +26,8 @@ iree_cc_library(
     "VulkanEnums.cpp.inc"
     "VulkanTypes.cpp"
   DEPS
+    ::VulkanAttrsGen
+    ::VulkanEnumsGen
     LLVMSupport
     MLIRIR
     MLIRSPIRV

--- a/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.h"
     "Passes.h.inc"
   DEPS
+    ::PassesIncGen
     MLIRPass
     MLIRTransforms
   PUBLIC
@@ -42,6 +43,7 @@ iree_cc_library(
     "TopLevelSCFToCFG.cpp"
   DEPS
     ::PassHeaders
+    ::PassesIncGen
     MLIRLinalg
     MLIRPass
     MLIRSCF
@@ -51,8 +53,3 @@ iree_cc_library(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
-# TODO: For some reason, these dependencies are not being added automatically.
-add_dependencies(
-  iree_compiler_InputConversion_Common_PassHeaders
-  iree_compiler_InputConversion_Common_PassesIncGen
-)

--- a/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     "Passes.h.inc"
     "Rewriters.h"
   DEPS
+    ::PassesIncGen
     MLIRPass
     MLIRTransforms
   PUBLIC
@@ -51,6 +52,7 @@ iree_cc_library(
     "VerifyCompilerMHLOInputLegality.cpp"
   DEPS
     ::PassHeaders
+    ::PassesIncGen
     LLVMSupport
     MLIRAffine
     MLIRComplex

--- a/iree/compiler/InputConversion/TOSA/CMakeLists.txt
+++ b/iree/compiler/InputConversion/TOSA/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.h"
     "Passes.h.inc"
   DEPS
+    ::PassesIncGen
     MLIRPass
     MLIRTransforms
   PUBLIC
@@ -42,6 +43,7 @@ iree_cc_library(
     "VerifyCompilerTOSAInputLegality.cpp"
   DEPS
     ::PassHeaders
+    ::PassesIncGen
     MLIRPass
     MLIRSCFToStandard
     MLIRTosa

--- a/iree/samples/custom_modules/dialect/CMakeLists.txt
+++ b/iree/samples/custom_modules/dialect/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     "custom_ops.cc.inc"
   DEPS
     ::custom_imports
+    ::custom_ops_gen
     LLVMSupport
     MLIRIR
     MLIRParser


### PR DESCRIPTION
This was a special carveout in service of ALWAYSLINK, which we've gotten
rid of.

While I was here I cleaned up and moved the target conversion logic for
internal targets to bazel_to_cmake_targets.py and removed the hardcoded
subdirectory names.

Fixes https://github.com/google/iree/issues/6363