### PR TITLE
Update RISC-V docs

### DIFF
--- a/docs/developers/get_started/getting_started_riscv_cmake.md
+++ b/docs/developers/get_started/getting_started_riscv_cmake.md
@@ -17,7 +17,22 @@ executables that can be run on the target platform.
 
 ## Prerequisites
 
-### Install RISC-V Tools
+You'll need a RISC-V LLVM compilation toolchain and a RISC-V enabled QEMU
+emulator.
+
+* RISC-V toolchain is built from https://github.com/llvm/llvm-project (main branch).<br>
+  * Currently, the LLVM compiler is built on GNU toolchain, including libgcc,
+    GNU linker, and C libraries. You need to build GNU toolchain first.<br>
+  * Clone GNU toolchain from: https://github.com/riscv/riscv-gnu-toolchain
+    (master branch). Switch the "riscv-binutils" submodule to `rvv-1.0.x-zfh`
+    branch manually.
+* RISC-V QEMU is built from https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh
+
+An environment variable `RISCV_TOOLCHAIN_ROOT` needs
+to be set to the root directory of the installed GNU toolchain. The variable can
+be used in building the RISCV target and a LLVM AOT module.
+
+### Install Prebuilt RISC-V Tools (RISC-V 64-bit Linux toolchain)
 
 Execute the following script to download the prebuilt RISC-V toolchain and QEMU:
 
@@ -25,21 +40,9 @@ Execute the following script to download the prebuilt RISC-V toolchain and QEMU:
 # In IREE source root
 $ ./build_tools/riscv/riscv_bootstrap.sh
 ```
-After running the script, an environment variable `RISCV_TOOLCHAIN_ROOT` needs
-to be set to the root directory of the installed GNU toolchain
+**NOTE**:
+* You also need to set `RISCV_TOOLCHAIN_ROOT`
 (default at ${HOME}/riscv/toolchain/clang/linux/RISCV).
-The variable can be used in building the RISCV target and a LLVM AOT module.
-
-
-NOTE: If you want to build the tools by yourself:
-* RISC-V toolchain is built from https://github.com/llvm/llvm-project (main branch).<br>
-  * Currently, our LLVM compiler is built on GNU toolchain, including libgcc,
-    GNU linker, and C libraries. You need to build GNU toolchain first.<br>
-  * Clone GNU toolchain from: https://github.com/riscv/riscv-gnu-toolchain
-    (master branch). Switch the "riscv-binutils" submodule to `rvv-1.0.x-zfh`
-    branch manually.
-* RISC-V QEMU is built from https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh
-* You also need to set `RISCV_TOOLCHAIN_ROOT`.
 
 ## Configure and build
 
@@ -62,6 +65,18 @@ the build above will fail, and you should run `unset IREE_LLVMAOT_LINKER_PATH`.
 
 ### Target configuration
 
+Currently IREE verifies (and tests in CI) two RISC-V targets:
+* RISC-V 64-bit CPU with Linux OS
+* RISC-V 32-bit CPU with "bare-metal" config -- a limited subset of IREE runtime
+libraries that _can_ run on the bare-metal machine mode (with the machine BSP
+linker script), but can also run on larger machines without the system library
+support.
+
+For other RISC-V targets, please refer to
+[riscv.toolchain.cmake](https://github.com/google/iree/blob/main/build_tools/cmake/riscv.toolchain.cmake)
+as a reference of how to set up the cmake configuration.
+
+#### RISC-V 64-bit Linux target
 ```shell
 $ cmake -G Ninja -B ../iree-build-riscv/ \
   -DCMAKE_TOOLCHAIN_FILE="./build_tools/cmake/riscv.toolchain.cmake" \
@@ -69,16 +84,19 @@ $ cmake -G Ninja -B ../iree-build-riscv/ \
   -DRISCV_CPU=rv64 \
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_ENABLE_MLIR=OFF \
-  -DIREE_BUILD_SAMPLES=OFF \
+  -DIREE_BUILD_SAMPLES=ON \
+  -DRISCV_TOOLCHAIN_ROOT=${RISCV_TOOLCHAIN_ROOT}
   .
 ```
+#### RISC-V 32-bit bare-metal target
 
-* The above configures IREE to cross-compile towards `rv64` cpu platform.
-* If user specify different download path (default in `${HOME}/riscv`) in
-  `riscv_bootscrap.sh`, please append
-  `-DRISCV_TOOLCHAIN_ROOT="${RISCV_TOOLCHAIN_ROOT}"` in cmake command.
+For the RISC-V 32-bit bare-metal config, append the following CMake options
+```shell
+-DRISCV_CPU=rv32-baremetal \
+-DIREE_BUILD_TESTS=OFF
+```
 
-Build target:
+#### Build target
 
 ```shell
 $ cmake --build ../iree-build-riscv/
@@ -86,7 +104,18 @@ $ cmake --build ../iree-build-riscv/
 
 ## Test on RISC-V QEMU
 
-### VMLA HAL backend
+**NOTE**:The following instructions are meant for the RISC-V 64-bit Linux
+target. For the bare-metal target, please refer to
+[simple_embedding](https://github.com/google/iree/blob/main/iree/samples/simple_embedding)
+to see how to build a ML workload for a bare-metal machine.
+
+Set the environment variable `RISCV_TOOLCHAIN_ROOT` if it is not set yet:
+
+```shell
+$ export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
+```
+
+### VMVX HAL backend
 
 Translate a source MLIR into IREE module:
 
@@ -94,16 +123,24 @@ Translate a source MLIR into IREE module:
 $ ../iree-build-host/install/bin/iree-translate \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=vmvx \
-  $PWD/iree/samples/models/simple_abs.mlir \
+  ${PWD}/iree/samples/models/simple_abs.mlir \
   -o /tmp/simple_abs_vmvx.vmfb
 ```
 
 Then run on the RISC-V QEMU:
 
+Set the path to qemu-riscv64 emulator binary in the `QEMU_BIN` environment
+variable. If it is installed with `riscv_bootstrap.sh`, the path is default at
+${HOME}/riscv/qemu/linux/RISCV/bin/qemu-riscv64.
+
 ```shell
-$ $HOME/riscv/qemu/linux/RISCV/bin/qemu-riscv64 \
+$ export QEMU_BIN=<path to qemu-riscv64 binary>
+```
+
+```shell
+$ ${QEMU_BIN} \
   -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
-  -L $HOME/riscv/toolchain/clang/linux/RISCV/sysroot/ \
+  -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/iree/tools/iree-run-module \
   --driver=vmvx \
   --module_file=/tmp/simple_abs_vmvx.vmfb \
@@ -122,11 +159,6 @@ f32=5
 ### Dylib LLVM AOT backend
 To compile an IREE module using the Dylib LLVM ahead-of-time (AOT) backend for
 a RISC-V target we need to use the corresponding cross-compile toolchain.
-Set the environment variable `RISCV_TOOLCHAIN_ROOT` if it is not set yet:
-
-```shell
-$ export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
-```
 
 Translate a source MLIR into an IREE module:
 
@@ -137,16 +169,16 @@ $ ../iree-build-host/install/bin/iree-translate \
   -iree-llvm-target-triple=riscv64 \
   -iree-llvm-target-cpu=sifive-u74 \
   -iree-llvm-target-abi=lp64d \
-  $PWD/iree/samples/models/simple_abs.mlir \
+  ${PWD}/iree/samples/models/simple_abs.mlir \
   -o /tmp/simple_abs_dylib.vmfb
 ```
 
 Then run on the RISC-V QEMU:
 
 ```shell
-$ $HOME/riscv/qemu/linux/RISCV/bin/qemu-riscv64 \
-  -cpu rv64 \
-  -L $HOME/riscv/toolchain/clang/linux/RISCV/sysroot/ \
+$ ${QEMU_BIN} \
+  -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+  -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/iree/tools/iree-run-module \
   --driver=dylib \
   --module_file=/tmp/simple_abs_dylib.vmfb \
@@ -167,7 +199,7 @@ Through IREE's vectorization pass and LLVM backend, we can generate RVV
 VLS(Vector Length Specific) style codes.
 
 ```shell
-../iree-build-host/install/bin/iree-translate \
+$ ../iree-build-host/install/bin/iree-translate \
 -iree-mlir-to-vm-bytecode-module \
 -iree-hal-target-backends=dylib-llvm-aot \
 -iree-llvm-target-triple=riscv64 \
@@ -181,9 +213,9 @@ VLS(Vector Length Specific) style codes.
 Then run on the RISC-V QEMU:
 
 ```shell
-$ $HOME/riscv/qemu/linux/RISCV/bin/qemu-riscv64 \
+$ ${QEMU_BIN}} \
   -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
-  -L $HOME/riscv/toolchain/clang/linux/RISCV/sysroot/ \
-  ../iree-build-riscv/iree/tools/iree-run-module -driver=dylib \
-  -flagfile=/path/to/flagfile
+  -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
+  ../iree-build-riscv/iree/tools/iree-run-module --driver=dylib \
+  --flagfile=/path/to/flagfile
 ```

--- a/docs/developers/get_started/getting_started_riscv_cmake.md
+++ b/docs/developers/get_started/getting_started_riscv_cmake.md
@@ -65,14 +65,8 @@ the build above will fail, and you should run `unset IREE_LLVMAOT_LINKER_PATH`.
 
 ### Target configuration
 
-Currently IREE verifies (and tests in CI) two RISC-V targets:
-* RISC-V 64-bit CPU with Linux OS
-* RISC-V 32-bit CPU with "bare-metal" config -- a limited subset of IREE runtime
-libraries that _can_ run on the bare-metal machine mode (with the machine BSP
-linker script), but can also run on larger machines without the system library
-support.
-
-For other RISC-V targets, please refer to
+The following instruction shows how to build for the RISC-V 64-bit Linux machine
+and 32-bit bare-metal machine. For other RISC-V targets, please refer to
 [riscv.toolchain.cmake](https://github.com/google/iree/blob/main/build_tools/cmake/riscv.toolchain.cmake)
 as a reference of how to set up the cmake configuration.
 

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -107,7 +107,7 @@ run the tests, then report the status back to your host machine.
 
 ## Running tools directly
 
-Invoke the host compiler tools produce input files:
+Invoke the host compiler tools to produce a bytecode module flatbuffer:
 
 ``` shell
 ../iree-build/install/bin/iree-translate \
@@ -117,7 +117,7 @@ Invoke the host compiler tools produce input files:
   -o /tmp/simple_abs_vmvx.vmfb
 ```
 
-Push the Android runtime tools to the device, along with any input files:
+Push the Android runtime tools to the device, along with any flatbuffer files:
 
 ``` shell
 adb push ../iree-build-android/iree/tools/iree-run-module /data/local/tmp/

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -22,29 +22,29 @@ steps.
 You'll need a RISC-V LLVM compilation toolchain and a RISC-V enabled QEMU
 emulator.
 
-* RISC-V toolchain is built from https://github.com/llvm/llvm-project (main branch).<br>
-  * Currently, the LLVM compiler is built on GNU toolchain, including libgcc,
-    GNU linker, and C libraries. You need to build GNU toolchain first.<br>
-  * Clone GNU toolchain from: https://github.com/riscv/riscv-gnu-toolchain
-    (master branch). Switch the "riscv-binutils" submodule to `rvv-1.0.x-zfh`
-    branch manually.
-* RISC-V QEMU is built from https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh
+See instructions in the following links
 
-An environment variable `RISCV_TOOLCHAIN_ROOT` needs
-to be set to the root directory of the installed GNU toolchain. The variable can
-be used in building the RISCV target and a LLVM AOT module.
+* [Clang getting started](https://clang.llvm.org/get_started.html)
+* [RISC-V GNU toolchain](https://github.com/riscv/riscv-gnu-toolchain)
+* [QEMU](https://github.com/qemu/qemu)
+* [RISC-V Linux QEMU](https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html)
+
+!!! note
+    An environment variable `RISCV_TOOLCHAIN_ROOT` needs
+    to be set to the root directory of the installed GNU toolchain. The variable
+    can be used in building the RISCV target and a LLVM AOT module.
 
 ### Install Prebuilt RISC-V Tools (RISC-V 64-bit Linux toolchain)
 
-Execute the following script to download the prebuilt RISC-V toolchain and QEMU:
+Execute the following script to download the prebuilt RISC-V toolchain and QEMU
+from the IREE root directory:
 
 ```shell
-# In IREE source root
-$ ./build_tools/riscv/riscv_bootstrap.sh
+./build_tools/riscv/riscv_bootstrap.sh
 ```
-**NOTE**:
-* You also need to set `RISCV_TOOLCHAIN_ROOT`
-(default at ${HOME}/riscv/toolchain/clang/linux/RISCV).
+!!! note
+    You also need to set `RISCV_TOOLCHAIN_ROOT`
+    (default at ${HOME}/riscv/toolchain/clang/linux/RISCV).
 
 ## Configure and build
 
@@ -62,47 +62,35 @@ cmake --build ../iree-build/ --target install
 
 ### Target configuration
 
-Currently IREE verifies (and tests in CI) two RISC-V targets:
-* RISC-V 64-bit CPU with Linux OS
-* RISC-V 32-bit CPU with "bare-metal" config -- a limited subset of IREE runtime
-libraries that _can_ run on the bare-metal machine mode (with the machine BSP
-linker script), but can also run on larger machines without the system library
-support.
-
+The following instruction shows how to build for a RISC-V 64-bit Linux machine.
 For other RISC-V targets, please refer to
 [riscv.toolchain.cmake](https://github.com/google/iree/blob/main/build_tools/cmake/riscv.toolchain.cmake)
 as a reference of how to set up the cmake configuration.
 
 #### RISC-V 64-bit Linux target
 ```shell
-$ cmake -G Ninja -B ../iree-build-riscv/ \
+cmake -B ../iree-build-riscv/ \
   -DCMAKE_TOOLCHAIN_FILE="./build_tools/cmake/riscv.toolchain.cmake" \
   -DIREE_HOST_BINARY_ROOT=$(realpath ../iree-build-host/install) \
   -DRISCV_CPU=rv64 \
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_ENABLE_MLIR=OFF \
-  -DIREE_BUILD_SAMPLES=ON \
   -DRISCV_TOOLCHAIN_ROOT=${RISCV_TOOLCHAIN_ROOT}
   .
 ```
 
-For the RISC-V 32-bit bare-metal config, append the following CMake options
-```shell
--DRISCV_CPU=rv32-baremetal \
--DIREE_BUILD_TESTS=OFF
-```
-
 ## Running IREE bytecode modules on the RISC-V system
 
-**NOTE**:The following instructions are meant for the RISC-V 64-bit Linux
-target. For the bare-metal target, please refer to
-[simple_embedding](https://github.com/google/iree/blob/main/iree/samples/simple_embedding)
-to see how to build a ML workload for a bare-metal machine.
+!!! note
+    The following instructions are meant for the RISC-V 64-bit Linux
+    target. For the bare-metal target, please refer to
+    [simple_embedding](https://github.com/google/iree/blob/main/iree/samples/simple_embedding)
+    to see how to build a ML workload for a bare-metal machine.
 
 Set the environment variable `RISCV_TOOLCHAIN_ROOT` if it is not set yet:
 
 ```shell
-$ export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
+export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
 ```
 
 Set the path to qemu-riscv64 Linux emulator binary in the `QEMU_BIN` environment
@@ -110,13 +98,13 @@ variable. If it is installed with `riscv_bootstrap.sh`, the path is default at
 ${HOME}/riscv/qemu/linux/RISCV/bin/qemu-riscv64.
 
 ```shell
-$ export QEMU_BIN=<path to qemu-riscv64 binary>
+export QEMU_BIN=<path to qemu-riscv64 binary>
 ```
 
 Invoke the host compiler tools produce input files:
 
 ``` shell
-$ ../iree-build/install/bin/iree-translate \
+../iree-build/install/bin/iree-translate \
   -iree-mlir-to-vm-bytecode-module \
   -iree-hal-target-backends=vmvx \
   iree/samples/models/simple_abs.mlir \
@@ -126,8 +114,8 @@ $ ../iree-build/install/bin/iree-translate \
 Run the RISC-V emulation:
 
 ```shell
-$ ${QEMU_BIN} \
-  -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+${QEMU_BIN} \
+  -cpu rv64 \
   -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/iree/tools/iree-run-module \
   --driver=vmvx \

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -30,11 +30,11 @@ See instructions in the following links
 * [RISC-V Linux QEMU](https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html)
 
 !!! note
-    An environment variable `RISCV_TOOLCHAIN_ROOT` needs
-    to be set to the root directory of the installed GNU toolchain. The variable
-    can be used in building the RISCV target and a LLVM AOT module.
+    The `RISCV_TOOLCHAIN_ROOT` environment variable needs
+    to be set to the root directory of the installed GNU toolchain when building
+    the RISC-V compiler target and the runtime library.
 
-### Install Prebuilt RISC-V Tools (RISC-V 64-bit Linux toolchain)
+#### Install prebuilt RISC-V tools (RISC-V 64-bit Linux toolchain)
 
 Execute the following script to download the prebuilt RISC-V toolchain and QEMU
 from the IREE root directory:
@@ -42,9 +42,11 @@ from the IREE root directory:
 ```shell
 ./build_tools/riscv/riscv_bootstrap.sh
 ```
-!!! note
-    You also need to set `RISCV_TOOLCHAIN_ROOT`
-    (default at ${HOME}/riscv/toolchain/clang/linux/RISCV).
+
+#### Support vector extension
+
+For RISC-V vector extensions support, see
+[additional instructions](#optional-configuration)
 
 ## Configure and build
 
@@ -68,6 +70,7 @@ For other RISC-V targets, please refer to
 as a reference of how to set up the cmake configuration.
 
 #### RISC-V 64-bit Linux target
+
 ```shell
 cmake -B ../iree-build-riscv/ \
   -DCMAKE_TOOLCHAIN_FILE="./build_tools/cmake/riscv.toolchain.cmake" \
@@ -87,12 +90,6 @@ cmake -B ../iree-build-riscv/ \
     [simple_embedding](https://github.com/google/iree/blob/main/iree/samples/simple_embedding)
     to see how to build a ML workload for a bare-metal machine.
 
-Set the environment variable `RISCV_TOOLCHAIN_ROOT` if it is not set yet:
-
-```shell
-export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
-```
-
 Set the path to qemu-riscv64 Linux emulator binary in the `QEMU_BIN` environment
 variable. If it is installed with `riscv_bootstrap.sh`, the path is default at
 ${HOME}/riscv/qemu/linux/RISCV/bin/qemu-riscv64.
@@ -101,7 +98,7 @@ ${HOME}/riscv/qemu/linux/RISCV/bin/qemu-riscv64.
 export QEMU_BIN=<path to qemu-riscv64 binary>
 ```
 
-Invoke the host compiler tools produce input files:
+Invoke the host compiler tools to produce a bytecode module flatbuffer:
 
 ``` shell
 ../iree-build/install/bin/iree-translate \
@@ -122,4 +119,50 @@ ${QEMU_BIN} \
   --module_file=/tmp/simple_abs_vmvx.vmfb \
   --entry_function=abs \
   --function_input=f32=-5
+```
+
+## Optional configuration
+
+[RISC-V Vector extensions](https://github.com/riscv/riscv-v-spec) allows SIMD
+ code to run more efficiently. To enable the vector extension for the compiler
+ toolchain and the emulator, build the tools from the following sources:
+
+* RISC-V toolchain is built from
+[https://github.com/llvm/llvm-project](https://github.com/llvm/llvm-project) (main branch).
+  * Currently, the LLVM compiler is built on GNU toolchain, including libgcc,
+    GNU linker, and C libraries. You need to build GNU toolchain first.
+  * Clone GNU toolchain from:
+  [https://github.com/riscv/riscv-gnu-toolchain](https://github.com/riscv/riscv-gnu-toolchain)
+    (master branch). Switch the "riscv-binutils" submodule to `rvv-1.0.x-zfh`
+    branch manually.
+* RISC-V QEMU is built from
+[https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh](https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh).
+
+The SIMD code can be generated following the
+[IREE dynamic library CPU HAL driver flow](https://google.github.io/iree/deployment-configurations/cpu-dylib)
+with the additional command-line flags
+
+```shell hl_lines="3 4 5 6 7 8"
+iree/tools/iree-translate \
+  -iree-mlir-to-vm-bytecode-module \
+  -iree-hal-target-backends=dylib-llvm-aot \
+  -iree-llvm-target-triple=riscv64 \
+  -iree-llvm-target-cpu=generic-rv64 \
+  -iree-llvm-target-abi=lp64d \
+  -iree-llvm-target-cpu-features="+m,+a,+f,+experimental-v" \
+  -riscv-v-vector-bits-min=128 -riscv-v-fixed-length-vector-lmul-max=8 \
+  iree_input.mlir -o mobilenet-dylib.vmfb
+```
+
+Then run on the RISC-V QEMU:
+
+```shell hl_lines="2 5"
+${QEMU_BIN}} \
+  -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+  -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
+  ../iree-build-riscv/iree/tools/iree-run-module \
+  --driver=dylib \
+  --module_file=mobilenet-dylib.vmfb \
+  --entry_function=predict \
+  --function_input="1x224x224x3xf32=0"
 ```

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -139,7 +139,7 @@ ${QEMU_BIN} \
 [https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh](https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh).
 
 The SIMD code can be generated following the
-[IREE dynamic library CPU HAL driver flow](https://google.github.io/iree/deployment-configurations/cpu-dylib)
+[IREE dynamic library CPU HAL driver flow](../deployment-configurations/cpu-dylib.md)
 with the additional command-line flags
 
 ```shell hl_lines="3 4 5 6 7 8"

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -1,0 +1,137 @@
+# RISC-V cross-compilation
+
+Running on a platform like RISC-V involves cross-compiling from a _host_
+platform (e.g. Linux) to a _target_ platform (a specific RISC-V CPU architecture
+and operating system):
+
+* IREE's _compiler_ is built on the host and is used there to generate modules
+  for the target
+* IREE's _runtime_ is built on the host for the target. The runtime is then
+  pushed to the target to run natively.
+
+## Prerequisites
+
+### Host environment setup
+
+You should already be able to build IREE from source on your host platform.
+Please make sure you have followed the [getting started](./getting-started.md)
+steps.
+
+### Install RISC-V cross-compile toolchain and emulator
+
+You'll need a RISC-V LLVM compilation toolchain and a RISC-V enabled QEMU
+emulator.
+
+* RISC-V toolchain is built from https://github.com/llvm/llvm-project (main branch).<br>
+  * Currently, the LLVM compiler is built on GNU toolchain, including libgcc,
+    GNU linker, and C libraries. You need to build GNU toolchain first.<br>
+  * Clone GNU toolchain from: https://github.com/riscv/riscv-gnu-toolchain
+    (master branch). Switch the "riscv-binutils" submodule to `rvv-1.0.x-zfh`
+    branch manually.
+* RISC-V QEMU is built from https://github.com/sifive/qemu/tree/v5.2.0-rvv-rvb-zfh
+
+An environment variable `RISCV_TOOLCHAIN_ROOT` needs
+to be set to the root directory of the installed GNU toolchain. The variable can
+be used in building the RISCV target and a LLVM AOT module.
+
+### Install Prebuilt RISC-V Tools (RISC-V 64-bit Linux toolchain)
+
+Execute the following script to download the prebuilt RISC-V toolchain and QEMU:
+
+```shell
+# In IREE source root
+$ ./build_tools/riscv/riscv_bootstrap.sh
+```
+**NOTE**:
+* You also need to set `RISCV_TOOLCHAIN_ROOT`
+(default at ${HOME}/riscv/toolchain/clang/linux/RISCV).
+
+## Configure and build
+
+### Host configuration
+
+Build and install on your host machine:
+
+``` shell
+cmake -B ../iree-build/ \
+  -DCMAKE_INSTALL_PREFIX=../iree-build/install \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  .
+cmake --build ../iree-build/ --target install
+```
+
+### Target configuration
+
+Currently IREE verifies (and tests in CI) two RISC-V targets:
+* RISC-V 64-bit CPU with Linux OS
+* RISC-V 32-bit CPU with "bare-metal" config -- a limited subset of IREE runtime
+libraries that _can_ run on the bare-metal machine mode (with the machine BSP
+linker script), but can also run on larger machines without the system library
+support.
+
+For other RISC-V targets, please refer to
+[riscv.toolchain.cmake](https://github.com/google/iree/blob/main/build_tools/cmake/riscv.toolchain.cmake)
+as a reference of how to set up the cmake configuration.
+
+#### RISC-V 64-bit Linux target
+```shell
+$ cmake -G Ninja -B ../iree-build-riscv/ \
+  -DCMAKE_TOOLCHAIN_FILE="./build_tools/cmake/riscv.toolchain.cmake" \
+  -DIREE_HOST_BINARY_ROOT=$(realpath ../iree-build-host/install) \
+  -DRISCV_CPU=rv64 \
+  -DIREE_BUILD_COMPILER=OFF \
+  -DIREE_ENABLE_MLIR=OFF \
+  -DIREE_BUILD_SAMPLES=ON \
+  -DRISCV_TOOLCHAIN_ROOT=${RISCV_TOOLCHAIN_ROOT}
+  .
+```
+
+For the RISC-V 32-bit bare-metal config, append the following CMake options
+```shell
+-DRISCV_CPU=rv32-baremetal \
+-DIREE_BUILD_TESTS=OFF
+```
+
+## Running IREE bytecode modules on the RISC-V system
+
+**NOTE**:The following instructions are meant for the RISC-V 64-bit Linux
+target. For the bare-metal target, please refer to
+[simple_embedding](https://github.com/google/iree/blob/main/iree/samples/simple_embedding)
+to see how to build a ML workload for a bare-metal machine.
+
+Set the environment variable `RISCV_TOOLCHAIN_ROOT` if it is not set yet:
+
+```shell
+$ export RISCV_TOOLCHAIN_ROOT=<root directory of the RISC-V GNU toolchain>
+```
+
+Set the path to qemu-riscv64 Linux emulator binary in the `QEMU_BIN` environment
+variable. If it is installed with `riscv_bootstrap.sh`, the path is default at
+${HOME}/riscv/qemu/linux/RISCV/bin/qemu-riscv64.
+
+```shell
+$ export QEMU_BIN=<path to qemu-riscv64 binary>
+```
+
+Invoke the host compiler tools produce input files:
+
+``` shell
+$ ../iree-build/install/bin/iree-translate \
+  -iree-mlir-to-vm-bytecode-module \
+  -iree-hal-target-backends=vmvx \
+  iree/samples/models/simple_abs.mlir \
+  -o /tmp/simple_abs_vmvx.vmfb
+```
+
+Run the RISC-V emulation:
+
+```shell
+$ ${QEMU_BIN} \
+  -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+  -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
+  ../iree-build-riscv/iree/tools/iree-run-module \
+  --driver=vmvx \
+  --module_file=/tmp/simple_abs_vmvx.vmfb \
+  --entry_function=abs \
+  --function_input=f32=-5
+```

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - 'building-from-source/getting-started.md'
       - Optional features: 'building-from-source/optional-features.md'
       - Android cross-compilation: 'building-from-source/android.md'
+      - RISC-V cross-compilation: 'building-from-source/riscv.md'
   - 'Bindings':
       - C API: 'bindings/c-api.md'
       - Python: 'bindings/python.md'


### PR DESCRIPTION
Update the RISC-V getting started doc to add the rv32-baremetal config.
Add a user-facing doc of RISC-V cross-compile flow.

Part of https://github.com/google/iree/issues/6327