### PR TITLE
Fixing build break in MSVC from wrong type used.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -88,7 +88,7 @@ struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
 
           b.setInsertionPointToEnd(&region.front());
           b.create<scf::IfOp>(
-              loc, ValueRange{}, cond,
+              loc, TypeRange{}, cond,
               [&](OpBuilder& b, Location loc) {
                 // Swap the pairs if true.
                 SmallVector<Value> indices(ivs.begin(), ivs.end());


### PR DESCRIPTION
Still annoys me that clang accepts this no problem.