### PR TITLE
linalg.depthwise_conv2d -> img2col with batch_matvec

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/ConvertConv2DToImg2ColPass.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertConv2DToImg2ColPass.cpp
@@ -164,6 +164,184 @@ class Conv2DImg2ColMatmulConversion
   }
 };
 
+// Similar to the conv pattern above except there is no reduction among the
+// input channles so each convolution can be a matrix-vector product and
+// by transposing both input filter so channles are outer most the computation
+// is a batched matrix-vector product.
+class DepthwiseConv2DNHWCHWCImg2ColMatmulConversion
+    : public OpRewritePattern<linalg::DepthwiseConvInputNHWCFilterHWCOp> {
+ public:
+  using OpRewritePattern<
+      linalg::DepthwiseConvInputNHWCFilterHWCOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      linalg::DepthwiseConvInputNHWCFilterHWCOp convOp,
+      PatternRewriter &rewriter) const override {
+    RankedTensorType inputTensorType =
+        convOp.getInputOperand(0)->get().getType().dyn_cast<RankedTensorType>();
+    RankedTensorType filterTensorType =
+        convOp.getInputOperand(1)->get().getType().dyn_cast<RankedTensorType>();
+    RankedTensorType outputTensorType = convOp.getOutputOperand(0)
+                                            ->get()
+                                            .getType()
+                                            .dyn_cast<RankedTensorType>();
+
+    if (!filterTensorType || !inputTensorType) return failure();
+    if (!filterTensorType.hasStaticShape() || !inputTensorType.hasStaticShape())
+      return failure();
+
+    // TODO(ataei) : Support padding & dilation.
+    if (!llvm::all_of(convOp.dilations(), [](APInt element) {
+          return element.getSExtValue() == 1;
+        }))
+      return failure();
+
+    auto loc = convOp.getLoc();
+
+    auto transposeOperand = [&](Value operand,
+                                ArrayRef<int64_t> indices) -> Value {
+      RankedTensorType operandTensorType =
+          operand.getType().cast<RankedTensorType>();
+      auto nloops = indices.size();
+      auto inputShape = operandTensorType.getShape();
+
+      SmallVector<AffineExpr, 4> exprs = llvm::to_vector<4>(
+          llvm::map_range(indices, [&](int64_t index) -> AffineExpr {
+            return rewriter.getAffineDimExpr(index);
+          }));
+
+      SmallVector<int64_t> targetShape = llvm::to_vector<4>(llvm::map_range(
+          indices,
+          [&](int64_t index) -> int64_t { return inputShape[index]; }));
+
+      Value outputTensor = rewriter.create<linalg::InitTensorOp>(
+          loc, targetShape, operandTensorType.getElementType());
+
+      SmallVector<StringRef> loopAttributeTypes(nloops, "parallel");
+
+      SmallVector<AffineMap> indexingMaps = {
+          inversePermutation(
+              AffineMap::get(nloops, 0, exprs, rewriter.getContext())),
+          AffineMap::getMultiDimIdentityMap(nloops, rewriter.getContext())};
+
+      auto transposedOp = rewriter.create<linalg::GenericOp>(
+          loc, outputTensor.getType(),
+          /*inputs=*/operand, /*outputs=*/outputTensor, indexingMaps,
+          loopAttributeTypes,
+          [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+            nestedBuilder.create<linalg::YieldOp>(nestedLoc, args[0]);
+          });
+
+      return transposedOp.getResult(0);
+    };
+
+    Value input = convOp.getInputOperand(0)->get();
+    Value filter = convOp.getInputOperand(1)->get();
+    Value output = convOp.getOutputOperand(0)->get();
+
+    // Transpose input, filter so channels are outermost
+    auto transposedInput = transposeOperand(input, {0, 3, 1, 2});
+    auto transposedFilter = transposeOperand(filter, {2, 0, 1});
+    auto transposedFilterShape =
+        transposedFilter.getType().cast<RankedTensorType>().getShape();
+    auto outputShape = output.getType().cast<RankedTensorType>().getShape();
+
+    // Transposed output tensor shape (n, ci, d1, d2)
+    SmallVector<int64_t, 4> transposedOutputTensorShape = {
+        outputShape[0], transposedFilterShape[0], outputShape[1],
+        outputShape[2]};
+
+    // col tensor shape (n, ci, d1, d2, k1, k2)
+    SmallVector<int64_t, 4> colTensorShape = {
+        outputShape[0], transposedFilterShape[0], outputShape[1],
+        outputShape[2], transposedFilterShape[1], transposedFilterShape[2]};
+    Value transposedOutputTensor = transposeOperand(output, {0, 3, 1, 2});
+
+    auto n = rewriter.getAffineDimExpr(0);
+    auto ci = rewriter.getAffineDimExpr(1);
+    auto d = [&](int i) { return rewriter.getAffineDimExpr(i + 1); };
+    auto k = [&](int i) { return rewriter.getAffineDimExpr(i + 3); };
+
+    auto s = [&](unsigned i) {
+      return rewriter.getAffineConstantExpr(
+          convOp.strides().getValue<int64_t>({i}));
+    };
+
+    SmallVector<AffineExpr> inputExprs = {n, ci, d(1) * s(0) + k(1),
+                                          d(2) * s(1) + k(2)};
+
+    auto nloops = colTensorShape.size();
+
+    SmallVector<StringRef> loopAttributeTypes(nloops, "parallel");
+
+    SmallVector<AffineMap> indexingMaps = {
+        AffineMap::get(nloops, 0, inputExprs, rewriter.getContext()),
+        AffineMap::getMultiDimIdentityMap(nloops, rewriter.getContext())};
+
+    Value colTensor = rewriter.create<linalg::InitTensorOp>(
+        loc, colTensorShape, inputTensorType.getElementType());
+
+    auto img2ColTensor = rewriter.create<linalg::GenericOp>(
+        loc, colTensor.getType(),
+        /*inputs=*/transposedInput, /*outputs=*/colTensor, indexingMaps,
+        loopAttributeTypes,
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+          nestedBuilder.create<linalg::YieldOp>(nestedLoc, args[0]);
+        });
+
+    SmallVector<linalg::ReassociationIndices>
+        img2ColTensorReassociationIndices = {{0, 1}, {2, 3}, {4, 5}};
+    SmallVector<linalg::ReassociationIndices> filterReassociationIndice = {
+        {0}, {1, 2}};
+    SmallVector<linalg::ReassociationIndices> outputReassociationIndice = {
+        {0, 1}, {2, 3}};
+
+    auto reshapedImg2ColTensorType = RankedTensorType::get(
+        {outputShape[0] * transposedFilterShape[0],
+         outputShape[1] * outputShape[2],
+         transposedFilterShape[1] * transposedFilterShape[2]},
+        inputTensorType.getElementType());
+    auto reshapedFilterTensorType = RankedTensorType::get(
+        {transposedFilterShape[0],
+         transposedFilterShape[1] * transposedFilterShape[2]},
+        filterTensorType.getElementType());
+    auto reshapedOutputTensorType = RankedTensorType::get(
+        {transposedOutputTensorShape[0] * transposedOutputTensorShape[1],
+         transposedOutputTensorShape[2] * transposedOutputTensorShape[3]},
+        outputTensorType.getElementType());
+
+    Value reshapedImg2ColTensor =
+        rewriter.create<linalg::TensorCollapseShapeOp>(
+            loc, reshapedImg2ColTensorType, img2ColTensor.getResult(0),
+            img2ColTensorReassociationIndices);
+    Value reshapedFilterTensor = rewriter.create<linalg::TensorCollapseShapeOp>(
+        loc, reshapedFilterTensorType, transposedFilter,
+        filterReassociationIndice);
+    Value reshapedoutputTensor = rewriter.create<linalg::TensorCollapseShapeOp>(
+        loc, reshapedOutputTensorType, transposedOutputTensor,
+        outputReassociationIndice);
+
+    auto batchMatVecResult = rewriter.create<linalg::BatchMatvecOp>(
+        loc, TypeRange{reshapedoutputTensor.getType()},
+        ValueRange{reshapedImg2ColTensor, reshapedFilterTensor},
+        ValueRange{reshapedoutputTensor});
+
+    SmallVector<linalg::ReassociationIndices> batchMatVecReassociationIndice = {
+        {0, 1}, {2, 3}};
+
+    Value batchMatVecResultReshaped =
+        rewriter.create<linalg::TensorExpandShapeOp>(
+            loc, transposedOutputTensor.getType(),
+            batchMatVecResult.getResult(0), batchMatVecReassociationIndice);
+
+    auto transposedResult =
+        transposeOperand(batchMatVecResultReshaped, {0, 2, 3, 1});
+
+    rewriter.replaceOp(convOp, ArrayRef<Value>{transposedResult});
+    return success();
+  }
+};
+
 struct ConvertConv2DToImg2ColPass
     : ConvertConv2DToImg2ColBase<ConvertConv2DToImg2ColPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -172,7 +350,8 @@ struct ConvertConv2DToImg2ColPass
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     OwningRewritePatternList patterns(&getContext());
-    patterns.insert<Conv2DImg2ColMatmulConversion>(context);
+    patterns.insert<Conv2DImg2ColMatmulConversion,
+                    DepthwiseConv2DNHWCHWCImg2ColMatmulConversion>(context);
     (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
   }
 };

--- a/iree/compiler/Dialect/Flow/Transforms/test/conv2d_to_img2col.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/conv2d_to_img2col.mlir
@@ -1,6 +1,5 @@
 // RUN: iree-opt -split-input-file -iree-flow-convert-conv2d-to-img2col %s | IreeFileCheck %s
 
-
 func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
     %0 = linalg.conv_2d_input_nhwc_filter_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
@@ -31,3 +30,75 @@ func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %
 //      CHECK: %[[MATMUL_RESULT:.+]] = linalg.matmul ins(%[[RESHAPED_INIT_COL_TENSOR]], %[[RESHAPED_FILTER]] : tensor<196x36xf32>, tensor<36x16xf32>) outs(%[[RESHAPED_OUTPUT]] : tensor<196x16xf32>)
 //      CHECK: %[[RESULT:.+]] = linalg.tensor_expand_shape %[[MATMUL_RESULT]] {{\[}}[0, 1, 2], [3]] : tensor<196x16xf32> into tensor<1x14x14x16xf32>
 //      CHECK: return %[[RESULT]]
+
+// -----
+
+func @depthwise_conv_hwc_114x16x3(%input: tensor<1x114x114x16xf32>, %filter: tensor<3x3x16xf32>, %output: tensor<1x112x112x16xf32>) -> tensor<1x112x112x16xf32> {
+    %0 = linalg.depthwise_conv_2d_input_nhwc_filter_hwc {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    } ins(%input, %filter : tensor<1x114x114x16xf32>, tensor<3x3x16xf32>) outs(%output : tensor<1x112x112x16xf32>) -> tensor<1x112x112x16xf32>
+    return %0 : tensor<1x112x112x16xf32>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d1, d2, d0)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 + d4, d3 + d5)>
+// CHECK-DAG: #[[MAP5:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
+// CHECK-DAG: #[[MAP6:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>
+// CHECK: @depthwise_conv_hwc_114x16x3
+// CHECK-SAME: %[[INPUT:.+]]: tensor<1x114x114x16xf32>
+// CHECK-SAME: %[[FILTER:.+]]: tensor<3x3x16xf32>
+// CHECK-SAME: %[[OUTPUT:.+]]: tensor<1x112x112x16xf32>
+//      CHECK: %[[INPUT_T_INIT:.+]] = linalg.init_tensor [1, 16, 114, 114] : tensor<1x16x114x114xf32>
+//      CHECK: %[[INPUT_T:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP0]], #[[MAP1]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME: ins(%[[INPUT]] : tensor<1x114x114x16xf32>) outs(%[[INPUT_T_INIT]] : tensor<1x16x114x114xf32>) {
+// CHECK-NEXT: ^bb0(%arg3: f32, %arg4: f32):
+// CHECK-NEXT:     linalg.yield %arg3 : f32
+// CHECK-NEXT:  } -> tensor<1x16x114x114xf32>
+//      CHECK: %[[FILTER_T_INIT:.+]] = linalg.init_tensor [16, 3, 3] : tensor<16x3x3xf32>
+//      CHECK: %[[FILTER_T:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP2]], #[[MAP3]]
+// CHECK-SMAE: iterator_types = ["parallel", "parallel", "parallel"]
+// CHECK-SAME: ins(%[[FILTER]] : tensor<3x3x16xf32>) outs(%[[FILTER_T_INIT]] : tensor<16x3x3xf32>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: f32, %{{.*}}: f32):
+//      CHECK:      linalg.yield
+//      CHECK:    } -> tensor<16x3x3xf32>
+//      CHECK: %[[INIT_OUTPUT_TENSOR:.+]] = linalg.init_tensor [1, 16, 112, 112] : tensor<1x16x112x112xf32>
+//      CHECK: %[[OUTPUT_T:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP0]], #[[MAP1]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME: ins(%[[OUTPUT]] : tensor<1x112x112x16xf32>) outs(%[[INIT_OUTPUT_TENSOR]] : tensor<1x16x112x112xf32>) {
+// CHECK-NEXT:  ^bb0(%{{.*}}: f32, %{{.*}}: f32):
+// CHECK-NEXT:     linalg.yield
+// CHECK-NEXT:  } -> tensor<1x16x112x112xf32>
+//      CHECK:  %[[INIT_COL_TENSOR:.+]] = linalg.init_tensor [1, 16, 112, 112, 3, 3] : tensor<1x16x112x112x3x3xf32>
+//      CHECK: %[[COL_TENSOR:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP4]], #[[MAP5]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME:   ins(%[[INPUT_T]] : tensor<1x16x114x114xf32>) outs(%[[INIT_COL_TENSOR]] : tensor<1x16x112x112x3x3xf32>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: f32, %{{.*}}: f32):
+// CHECK-NEXT:         linalg.yield
+// CHECK-NEXT:    } -> tensor<1x16x112x112x3x3xf32>
+//      CHECK: %[[COL_TENSOR_R:.+]] = linalg.tensor_collapse_shape %[[COL_TENSOR]]
+// CHECK-SAME:    tensor<1x16x112x112x3x3xf32> into tensor<16x12544x9xf32>
+//      CHECK: %[[FILTER_T_R:.+]] = linalg.tensor_collapse_shape %[[FILTER_T]]
+// CHECK-SAME:    tensor<16x3x3xf32> into tensor<16x9xf32>
+//      CHECK: %[[OUTPUT_T_R:.+]] = linalg.tensor_collapse_shape %[[OUTPUT_T]]
+// CHECK-SAME:    tensor<1x16x112x112xf32> into tensor<16x12544xf32>
+//      CHECK: %[[BMV_RESULT:.+]] = linalg.batch_matvec ins(%[[COL_TENSOR_R]], %[[FILTER_T_R]] : tensor<16x12544x9xf32>, tensor<16x9xf32>) outs(%[[OUTPUT_T_R]] : tensor<16x12544xf32>) -> tensor<16x12544xf32>
+//      CHECK: %[[RESULT_R:.+]] = linalg.tensor_expand_shape %[[BMV_RESULT]]
+// CHECK-SAME:    tensor<16x12544xf32> into tensor<1x16x112x112xf32>
+//      CHECK: %[[RESULT_INIT:.+]] = linalg.init_tensor [1, 112, 112, 16] : tensor<1x112x112x16xf32>
+//      CHECK: %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP6]], #[[MAP1]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME: ins(%[[RESULT_R]] : tensor<1x16x112x112xf32>) outs(%[[RESULT_INIT]] : tensor<1x112x112x16xf32>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: f32, %{{.*}}: f32):
+// CHECK-NEXT:      linalg.yield
+// CHECK-NEXT:    } -> tensor<1x112x112x16xf32>
+//      CHECK: return %[[RESULT]] : tensor<1x112x112x16xf32>


### PR DESCRIPTION
A pattern to rewrite depthwise convolution with `depth_multiplier = 1` into a `linalg.batch_matvec`. The pattern transposes the input and the filter so channels are outer most dimension . After the transpose inner most dims are separable convolutions where each is a matrix-vector product.