### PR TITLE
Fix bugs in sort op lowering.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -90,7 +90,11 @@ struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
           b.create<scf::IfOp>(
               loc, TypeRange{}, cond,
               [&](OpBuilder& b, Location loc) {
-                // Swap the pairs if true.
+                // Do not swap the pairs if true.
+                b.create<scf::YieldOp>(loc);
+              },
+              [&](OpBuilder& b, Location loc) {
+                // Swap the pairs if false.
                 SmallVector<Value> indices(ivs.begin(), ivs.end());
                 Value ivPlusOne =
                     b.create<AddIOp>(loc, scfFor.getInductionVar(), one);
@@ -104,10 +108,6 @@ struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
                   b.create<memref::StoreOp>(
                       loc, v1, op.getOutputOperand(i)->get(), indices);
                 }
-                b.create<scf::YieldOp>(loc);
-              },
-              [&](OpBuilder& b, Location loc) {
-                // Do not swap the pairs if false.
                 b.create<scf::YieldOp>(loc);
               });
 

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -22,6 +22,7 @@ func @sort_1d(%arg0: memref<128xi32>) {
 // CHECK:             %[[V2:.+]] = memref.load %[[BUF]][%[[T1]]]
 // CHECK:             %[[COND:.+]] = cmpi sgt, %[[V1]], %[[V2]] : i32
 // CHECK:             scf.if %[[COND]] {
+// CHECK:             } else {
 // CHECK:               %[[T2:.+]] = addi %[[ARG2]], %[[C1]] : index
 // CHECK:               memref.store %[[V2]], %[[BUF]][%[[ARG2]]]
 // CHECK:               memref.store %[[V1]], %[[BUF]][%[[T2]]]
@@ -53,6 +54,7 @@ func @sort_2d(%arg0: memref<16x32xi32>) {
 // CHECK:               %[[V2:.+]] = memref.load %[[BUF]][%[[T1]], %[[ARG2]]]
 // CHECK:               %[[COND:.+]] = cmpi sgt, %[[V1]], %[[V2]] : i32
 // CHECK:               scf.if %[[COND]] {
+// CHECK:               } else {
 // CHECK:                 %[[T2:.+]] = addi %[[ARG3]], %[[C1]] : index
 // CHECK:                 memref.store %[[V2]], %[[BUF]][%[[ARG3]], %[[ARG2]]]
 // CHECK:                 memref.store %[[V1]], %[[BUF]][%[[T2]], %[[ARG2]]]
@@ -85,6 +87,7 @@ func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 // CHECK:             %[[V4:.+]] = memref.load %[[BUF2]][%[[T1]]]
 // CHECK:             %[[COND:.+]] = cmpf ogt, %[[V1]], %[[V2]] : f32
 // CHECK:             scf.if %[[COND]] {
+// CHECK:             } else {
 // CHECK:               %[[T2:.+]] = addi %[[ARG2]], %[[C1]] : index
 // CHECK:               memref.store %[[V2]], %[[BUF1]][%[[ARG2]]]
 // CHECK:               memref.store %[[V1]], %[[BUF1]][%[[T2]]]

--- a/iree/test/e2e/xla_ops/sort.mlir
+++ b/iree/test/e2e/xla_ops/sort.mlir
@@ -3,7 +3,7 @@ func @sort1D() {
 
   %sort = "mhlo.sort"(%input) ( {
   ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
-    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "mhlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 0 : i64, is_stable = false} : (tensor<4xi32>) -> tensor<4xi32>
 
@@ -17,7 +17,7 @@ func @sort2D() {
 
   %sort = "mhlo.sort"(%input) ( {
   ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
-    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "mhlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 1 : i64, is_stable = false} : (tensor<2x4xi32>) -> tensor<2x4xi32>
 
@@ -31,7 +31,7 @@ func @sort3D() {
 
   %sort = "mhlo.sort"(%input) ( {
   ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
-    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "LT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "mhlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 2 : i64, is_stable = false} : (tensor<1x2x4xi32>) -> tensor<1x2x4xi32>
 

--- a/iree/test/e2e/xla_ops/sort.mlir
+++ b/iree/test/e2e/xla_ops/sort.mlir
@@ -38,3 +38,16 @@ func @sort3D() {
   check.expect_eq_const(%sort, dense<[[[1, 2, 3, 4], [1, 2, 3, 4]]]> : tensor<1x2x4xi32>) : tensor<1x2x4xi32>
   return
 }
+
+func @sort_to_decreasing_seq() {
+  %input = iree.unfoldable_constant dense<[3, 2, 1, 4]> : tensor<4xi32>
+
+  %sort = "mhlo.sort"(%input) ( {
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
+    %compare = "mhlo.compare"(%arg1, %arg2) {comparison_direction = "GT"} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "mhlo.return"(%compare) : (tensor<i1>) -> ()
+  }) {dimension = 0 : i64, is_stable = false} : (tensor<4xi32>) -> tensor<4xi32>
+
+  check.expect_eq_const(%sort, dense<[4, 3, 2, 1]> : tensor<4xi32>) : tensor<4xi32>
+  return
+}


### PR DESCRIPTION
According to XLA operation semantics:

> Formally, after the array is sorted, it holds for all index positions
> i, j with i < j that either
>   comparator(v[i], v[j]) = comparator(v[j], v[i]) = false
> or
>   comparator(v[i], v[j]) = true

In this context, the pairs should swap only if the comparison result is
false.

The PR also fixes tests to match the semantics -- replacing `GT` with
`LT`.