### PR TITLE
Add a pattern to convert tensor<->tensor static information casts to …

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -630,7 +630,7 @@ static uint64_t getFlattenedIndex(ShapedType type, ArrayRef<uint64_t> index) {
 
 static bool compareShapesEqual(ShapedType lhsType, ValueRange lhsDynamicDims,
                                ShapedType rhsType, ValueRange rhsDynamicDims) {
-  if (lhsType.hasStaticShape() &&
+  if (lhsType.hasStaticShape() && rhsType.hasStaticShape() &&
       lhsType.getNumElements() == rhsType.getNumElements()) {
     // Static shape equivalence means we can fast-path the check.
     return true;

--- a/iree/compiler/InputConversion/Common/BUILD
+++ b/iree/compiler/InputConversion/Common/BUILD
@@ -44,6 +44,7 @@ cc_library(
 cc_library(
     name = "Common",
     srcs = [
+        "ConvertUpstreamToIREE.cpp",
         "Passes.cpp",
         "TopLevelSCFToCFG.cpp",
     ],
@@ -53,10 +54,13 @@ cc_library(
     deps = [
         ":PassHeaders",
         ":PassesIncGen",
+        "//iree/compiler/Dialect/Flow/IR",
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFToStandard",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "ConvertUpstreamToIREE.cpp"
     "Passes.cpp"
     "TopLevelSCFToCFG.cpp"
   DEPS
@@ -48,7 +49,10 @@ iree_cc_library(
     MLIRPass
     MLIRSCF
     MLIRSCFToStandard
+    MLIRStandard
+    MLIRTensor
     MLIRTransforms
+    iree::compiler::Dialect::Flow::IR
   PUBLIC
 )
 

--- a/iree/compiler/InputConversion/Common/ConvertUpstreamToIREE.cpp
+++ b/iree/compiler/InputConversion/Common/ConvertUpstreamToIREE.cpp
@@ -1,0 +1,133 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct ConvertTensorCastPattern : public OpConversionPattern<tensor::CastOp> {
+  using OpConversionPattern<tensor::CastOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor::CastOp op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    Value input = operands.front();
+    ShapedType inputType = input.getType().dyn_cast<ShapedType>();
+    ShapedType resultType =
+        typeConverter->convertType(op.getType()).dyn_cast_or_null<ShapedType>();
+    if (!inputType || !resultType || !inputType.hasRank() ||
+        !resultType.hasRank()) {
+      return rewriter.notifyMatchFailure(op, "not ranked shaped types");
+    }
+    // This should not happen, except in the context of type conversion.
+    if (inputType.getRank() != resultType.getRank()) {
+      return rewriter.notifyMatchFailure(op, "mismatched rank");
+    }
+
+    // Resolve dims to the most specific value.
+    int rank = inputType.getRank();
+    SmallVector<Value> dimSizes(rank);
+    auto resolveDimSize = [&](int position) -> Value {
+      if (!dimSizes[position]) {
+        // Find the most specific.
+        if (!inputType.isDynamicDim(position) ||
+            !resultType.isDynamicDim(position)) {
+          // Static dim.
+          int64_t dimSize = !inputType.isDynamicDim(position)
+                                ? inputType.getDimSize(position)
+                                : resultType.getDimSize(position);
+          dimSizes[position] = rewriter.create<ConstantIndexOp>(loc, dimSize);
+        } else {
+          // Dynamic dim.
+          dimSizes[position] =
+              rewriter.create<tensor::DimOp>(loc, input, position);
+        }
+      }
+
+      return dimSizes[position];
+    };
+
+    SmallVector<Value> sourceDynamicDims;
+    SmallVector<Value> targetDynamicDims;
+    for (int i = 0; i < rank; i++) {
+      if (inputType.isDynamicDim(i)) {
+        sourceDynamicDims.push_back(resolveDimSize(i));
+      }
+      if (resultType.isDynamicDim(i)) {
+        targetDynamicDims.push_back(resolveDimSize(i));
+      }
+    }
+
+    // TODO: Decide if this needs to be replaced with a flow.tensor.cast
+    // See https://github.com/google/iree/issues/6418
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
+        op, resultType, input, sourceDynamicDims, targetDynamicDims);
+
+    return success();
+  }
+};
+
+}  // namespace
+
+void populateConvertUpstreamToIREEPatterns(MLIRContext *context,
+                                           TypeConverter &typeConverter,
+                                           OwningRewritePatternList &patterns) {
+  patterns.add<ConvertTensorCastPattern>(typeConverter, context);
+}
+
+namespace {
+
+struct ConvertUpstreamToIREEPass
+    : public ConvertUpstreamToIREEBase<ConvertUpstreamToIREEPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<StandardOpsDialect, tensor::TensorDialect,
+                    IREE::Flow::FlowDialect>();
+  }
+
+  void runOnOperation() override;
+};
+
+}  // namespace
+
+void ConvertUpstreamToIREEPass::runOnOperation() {
+  OwningRewritePatternList patterns(&getContext());
+  MLIRContext *context = &getContext();
+  TypeConverter typeConverter;
+  typeConverter.addConversion([](Type t) { return t; });
+  populateConvertUpstreamToIREEPatterns(&getContext(), typeConverter, patterns);
+
+  ConversionTarget target(*context);
+  target.addIllegalOp<tensor::CastOp>();
+
+  target.addLegalDialect<StandardOpsDialect>();
+  target.addLegalDialect<tensor::TensorDialect>();
+  target.addLegalDialect<IREE::Flow::FlowDialect>();
+
+  if (failed(applyPartialConversion(getOperation(), target,
+                                    std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<FuncOp>> createConvertUpstreamToIREE() {
+  return std::make_unique<ConvertUpstreamToIREEPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/iree/compiler/InputConversion/Common/Passes.cpp
@@ -6,12 +6,27 @@
 
 #include "iree/compiler/InputConversion/Common/Passes.h"
 
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
 namespace iree_compiler {
+
+void registerCommonConversionPassPipelines() {
+  PassPipelineRegistration<> common(
+      "iree-common-input-transformation-pipeline",
+      "Runs the common input transformation pipeline",
+      [](OpPassManager &passManager) {
+        buildCommonInputConversionPassPipeline(passManager);
+      });
+}
+
+// Common transformations to prepare input dialects for IREE.
+void buildCommonInputConversionPassPipeline(OpPassManager &passManager) {
+  passManager.addNestedPass<FuncOp>(createConvertUpstreamToIREE());
+}
 
 namespace {
 #define GEN_PASS_REGISTRATION
@@ -21,6 +36,9 @@ namespace {
 void registerCommonInputConversionPasses() {
   // Generated.
   registerPasses();
+
+  // Pipelines.
+  registerCommonConversionPassPipelines();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/InputConversion/Common/Passes.h
+++ b/iree/compiler/InputConversion/Common/Passes.h
@@ -8,15 +8,34 @@
 #define IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES_H_
 
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 namespace iree_compiler {
 
-//------------------------------------------------------------------------------
-// Conversions into Linalg
-//------------------------------------------------------------------------------
+//===----------------------------------------------------------------------===//
+// Pipelines
+//===----------------------------------------------------------------------===//
+
+// Performs input legalization for specific combination of input dialects.
+void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
+
+void registerCommonConversionPassPipelines();
+
+//===----------------------------------------------------------------------===//
+// Passes
+//===----------------------------------------------------------------------===//
 
 std::unique_ptr<OperationPass<FuncOp>> createTopLevelSCFToCFGPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertUpstreamToIREE();
+
+//===----------------------------------------------------------------------===//
+// Patterns
+//===----------------------------------------------------------------------===//
+
+void populateConvertUpstreamToIREEPatterns(MLIRContext *context,
+                                           TypeConverter &typeConverter,
+                                           OwningRewritePatternList &patterns);
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/iree/compiler/InputConversion/Common/Passes.td
+++ b/iree/compiler/InputConversion/Common/Passes.td
@@ -15,4 +15,10 @@ def TopLevelSCFToCFG :
   let constructor = "mlir::iree_compiler::createTopLevelSCFToCFGPass()";
 }
 
+def ConvertUpstreamToIREE :
+    Pass<"iree-convert-upstream-to-iree", "FuncOp"> {
+  let summary = "Catch-all pass to convert upstream MLIR ops that (for whatever reason) we prefer to be represented differently in IREE";
+  let constructor = "mlir::iree_compiler::createConvertUpstreamToIREE()";
+}
+
 #endif // IREE_COMPILER_INPUTCONVERSION_TOSA_PASSES

--- a/iree/compiler/InputConversion/Common/test/BUILD
+++ b/iree/compiler/InputConversion/Common/test/BUILD
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "convert_upstream_to_iree.mlir",
             "top_level_scf_to_cfg.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "convert_upstream_to_iree.mlir"
     "top_level_scf_to_cfg.mlir"
   DATA
     iree::tools::IreeFileCheck

--- a/iree/compiler/InputConversion/Common/test/convert_upstream_to_iree.mlir
+++ b/iree/compiler/InputConversion/Common/test/convert_upstream_to_iree.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt -split-input-file -iree-convert-upstream-to-iree %s | IreeFileCheck %s
+
+func @static_tensor_cast_to_dynamic(%arg0: tensor<4x4xf32>) -> tensor<?x?xf32> {
+  // CHECK-DAG: %[[C4_0:.*]] = constant 4 : index
+  // CHECK-DAG: %[[C4_1:.*]] = constant 4 : index
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x4xf32> -> tensor<?x?xf32>{%[[C4_0]], %[[C4_1]]}
+  // CHECK: return %[[RESULT]]
+  %0 = tensor.cast %arg0 : tensor<4x4xf32> to tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+func @dynamic_tensor_cast_to_static(%arg0: tensor<?xf32>) -> tensor<4xf32> {
+  // CHECK: %[[C4_0:.*]] = constant 4 : index
+  // CHECK: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<?xf32>{%[[C4_0]]} -> tensor<4xf32>
+  // CHECK: return %[[RESULT]]
+  %0 = tensor.cast %arg0 : tensor<?xf32> to tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+func @dynamic_tensor_cast_to_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x3xf32> {
+  // CHECK-DAG: %[[C0:.*]] = constant 0 : index
+  // CHECK-DAG: %[[D0:.*]] = tensor.dim %arg0, %[[C0]] : tensor<?x?xf32>
+  // CHECK-DAG: %[[C3:.*]] = constant 3 : index
+  // CHECK: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<?x?xf32>{%[[D0]], %[[C3]]} -> tensor<?x3xf32>{%[[D0]]}
+  // CHECK: return %[[RESULT]]
+  %0 = tensor.cast %arg0 : tensor<?x?xf32> to tensor<?x3xf32>
+  return %0 : tensor<?x3xf32>
+}

--- a/iree/compiler/Translation/BUILD
+++ b/iree/compiler/Translation/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//iree/compiler/Dialect/VM/Conversion/StandardToVM",
         "//iree/compiler/Dialect/VM/Target/Bytecode",
         "//iree/compiler/Dialect/VM/Transforms",
+        "//iree/compiler/InputConversion/Common",
         "//iree/compiler/InputConversion/MHLO",
         "//iree/compiler/InputConversion/TOSA",
         "//iree/compiler/Utils",

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/IREE/Transforms/Passes.h"
 #include "iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.h"
 #include "iree/compiler/Dialect/VM/Transforms/Passes.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
 #include "iree/compiler/InputConversion/MHLO/Passes.h"
 #include "iree/compiler/InputConversion/TOSA/Passes.h"
 #include "iree/compiler/Utils/TracingUtils.h"
@@ -179,6 +180,7 @@ static void buildIREEVMTransformPassPipeline(
       break;
   }
 
+  buildCommonInputConversionPassPipeline(passManager);
   IREE::Flow::buildFlowTransformPassPipeline(passManager);
   IREE::HAL::buildHALTransformPassPipeline(passManager, executableOptions);
   IREE::VM::buildVMTransformPassPipeline(passManager, targetOptions);


### PR DESCRIPTION
…flow.tensor.reshape.

* Adds a common input conversion pipeline for this sort of thing (previously, the default was to do no input legalization, and I suspect there will be other odds and ends to be done).
* Fixes #6368 (verified on both the loopback and full MLP pastes).