### PR TITLE
Relax LegalizeInputTypesPass to work on non-structured Linalg ops.

### DIFF
--- a/iree/compiler/InputConversion/MHLO/LegalizeInputTypes.cpp
+++ b/iree/compiler/InputConversion/MHLO/LegalizeInputTypes.cpp
@@ -76,8 +76,10 @@ LogicalResult convertOperation(Operation *oldOp,
                                FlowTypeConverter &typeConverter,
                                BlockAndValueMapping &mapping,
                                OpBuilder &builder) {
-  if (isa<linalg::LinalgDialect>(oldOp->getDialect())) {
-    // Currently we assume all Linalg ops only contain valid types.
+  if (llvm::isa<linalg::LinalgOp>(oldOp)) {
+    // Currently we assume all Linalg structured ops only contain valid types.
+    // We allow to convert non-structured operation like
+    // linalg.tensor_expand_shape.
     // TODO: Support converting Linalg types when unsupported.
     builder.clone(*oldOp, mapping);
     return success();

--- a/iree/compiler/InputConversion/MHLO/test/legalize_input_types.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/legalize_input_types.mlir
@@ -143,3 +143,14 @@ func @linalg(%A: tensor<2xf32>)  -> tensor<2xf32> {
 
   return %init : tensor<2xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func @linalg_non_structured_op
+// CHECK-SAME:    (%arg0: tensor<9xi32>) -> tensor<1x9xi32>
+func @linalg_non_structured_op(%arg0: tensor<9xi64>) -> tensor<1x9xi64> {
+  // CHECK:       %[[RES:.+]] = linalg.tensor_expand_shape %arg0 {{\[}}[0, 1]] : tensor<9xi32> into tensor<1x9xi32>
+  // CHECK:       return %[[RES:.+]] : tensor<1x9xi32>
+  %0 = linalg.tensor_expand_shape %arg0 [[0, 1]] : tensor<9xi64> into tensor<1x9xi64>
+  return %0 : tensor<1x9xi64>
+}


### PR DESCRIPTION
Ideally we can apply it to all the Linalg ops including structure ops. However, it could break some poly ops like linalg.matmul. The region could be different from native poly ops, since the pass does not know exactly how to handle the body of Linalg structured ops. For now only apply it on non-structured ops which could be created by some direct lowering pass.

This is a step toward https://github.com/google/iree/issues/6399