### PR TITLE
Redefine iree_ext.scatter for having index depth information.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -122,14 +122,19 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
   auto checkDimensionsMatch = [&](ShapedType t1, ShapedType t2, unsigned dim) {
     return t1.getShape()[dim] == t2.getShape()[dim];
   };
+
   auto indicesType = op.inputs()[1].getType().cast<ShapedType>();
-  if (indicesType.getRank() != 1 ||
+  if (indicesType.getRank() != 2 ||
       !indicesType.getElementType().isInteger(32)) {
     return op.emitOpError(
-        "expected indices to be of rank 1 of i32 element type");
+        "expected indices to be of rank 2 of i32 element type");
   }
+  if (indicesType.isDynamicDim(1)) {
+    return op.emitOpError("expected index depth is static");
+  }
+
   // The first dimension of the indices should match the first dimension of the
-  // output.
+  // output. They indicate to the number of updates.
   auto updateType = op.inputs()[0].getType().cast<ShapedType>();
   if (updateType.getRank() < 1) {
     return op.emitOpError("expected update value to be at least rank 1");
@@ -139,15 +144,19 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "mismatch in shape of indices and update value at dim#0");
   }
   auto originalType = op.outputs()[0].getType().cast<ShapedType>();
-  if (originalType.getRank() != updateType.getRank()) {
+  auto indexDepth = indicesType.getDimSize(1);
+  // indexDepth + update dims should match to original dims. The first dim of
+  // update is the number of updates.
+  if (originalType.getRank() != indexDepth + updateType.getRank() - 1) {
     return op.emitOpError(
-        "mismatch in rank of update value and original value");
+        "mismatch in rank of update value, index depth and original value");
   }
-  for (auto dim : llvm::seq<unsigned>(1, originalType.getRank())) {
-    if (!checkDimensionsMatch(updateType, originalType, dim)) {
-      return op.emitOpError(
-                 "mismatch in shape of update value and original value at dim#")
-             << dim;
+  for (auto dim : llvm::seq<unsigned>(indexDepth, originalType.getRank())) {
+    // Offset one because the first dim is the number of updates.
+    if (updateType.getDimSize(1 + dim - indexDepth) !=
+        originalType.getDimSize(dim)) {
+      return op.emitOpError("mismatch in shape of update value dim#")
+             << (1 + dim - indexDepth) << " and original value at dim#" << dim;
     }
   }
   Region &region = op.region();

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -129,7 +129,8 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
     return op.emitOpError(
         "expected indices to be of rank 2 of i32 element type");
   }
-  if (indicesType.isDynamicDim(1)) {
+  auto indexDepth = op.getIndexDepth();
+  if (indexDepth == ShapedType::kDynamicSize) {
     return op.emitOpError("expected index depth is static");
   }
 
@@ -144,7 +145,6 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "mismatch in shape of indices and update value at dim#0");
   }
   auto originalType = op.outputs()[0].getType().cast<ShapedType>();
-  auto indexDepth = indicesType.getDimSize(1);
   // indexDepth + update dims should match to original dims. The first dim of
   // update is the number of updates.
   if (originalType.getRank() != indexDepth + updateType.getRank() - 1) {

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -73,6 +73,17 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter"> {
     custom<LinalgExtOutsList>($outputs, type($outputs))
     $region (`->` type($results)^)?
   }];
+
+  let extraClassDeclaration = [{
+    int64_t getIndexDepth() {
+      return getInputOperand(1)
+          ->get()
+          .getType()
+          .cast<ShapedType>()
+          .getShape()
+          .back();
+    }
+  }];
 }
 
 def LinalgExt_SortOp : LinalgExt_Op<"sort"> {

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -46,6 +46,21 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter"> {
     `updates` (and `original`). The first argument correspond the
     value to be updated (i.e. from `updates`), and the second the
     current value (i.e. value from `original`).
+
+    The `indices` is a 2D tensor/memref type. The first dim is the number of
+    updates, and the second dim is index depth. The index depth should always be
+    static.
+
+    The first dim of `updates` and `indices` is identical, since they represent
+    the number of updates.
+
+    The rank of the `original`/`result` is `index_depth + rank(%updates) - 1`.
+    The first `index_depth` indices are derived from `indices` and the shape of
+    update value must match the rest shape of `original`.
+
+    The shapes definition follows tensorflow operations execept that it force
+    batch dims to be 1D. See more information in
+      https://www.tensorflow.org/api_docs/python/tf/tensor_scatter_nd_update
   }];
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,

--- a/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -27,11 +27,11 @@ func @sort_without_dimension(%arg0: tensor<3x4xi32>) -> tensor<3x4xi32> {
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : memref<?x?xf32>, %indices : tensor<?xi32>,
+    %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected `ins` operand #0 to be of RankedTensorType}}
   %0 = linalg_ext.scatter
-      ins(%update, %indices : memref<?x?xf32>, tensor<?xi32>)
+      ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
         %1 = addf %arg1, %arg2 : f32
@@ -43,11 +43,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : tensor<?x?xf32>, %indices : memref<?xi32>,
+    %update : tensor<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected `ins` operand #1 to be of RankedTensorType}}
   %0 = linalg_ext.scatter
-      ins(%update, %indices : tensor<?x?xf32>, memref<?xi32>)
+      ins(%update, %indices : tensor<?x?xf32>, memref<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
         %1 = addf %arg1, %arg2 : f32
@@ -59,11 +59,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_extra_outputs(
-    %update : tensor<?x?xf32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
   // expected-error @+1 {{expected number of outputs to be same as the number of results}}
   %0, %1 = linalg_ext.scatter
-      ins(%update, %indices : tensor<?x?xf32>, tensor<?xi32>)
+      ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
         %1 = addf %arg1, %arg2 : f32
@@ -75,11 +75,11 @@ func @scatter_extra_outputs(
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : tensor<?x?xf32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected type of `outs` operand #0 'memref<?x?xf32>' to be same as result type 'tensor<?x?xf32>'}}
   %0 = linalg_ext.scatter
-      ins(%update, %indices : tensor<?x?xf32>, tensor<?xi32>)
+      ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : memref<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
         %1 = addf %arg1, %arg2 : f32
@@ -91,11 +91,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : tensor<?x?xf32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> memref<?x?xf32> {
   // expected-error @+1 {{expected result #0 to be of RankedTensorType}}
   %0 = linalg_ext.scatter
-      ins(%update, %indices : tensor<?x?xf32>, tensor<?xi32>)
+      ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
         %1 = addf %arg1, %arg2 : f32
@@ -107,11 +107,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : memref<?x?xf32>, %indices : tensor<?xi32>,
+    %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) {
   // expected-error @+1 {{expected `ins` operand #1 to be of MemRefType}}
   linalg_ext.scatter
-    ins(%update, %indices : memref<?x?xf32>, tensor<?xi32>)
+    ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -123,11 +123,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_mixed_tensor_memref(
-    %update : memref<?x?xf32>, %indices : memref<?xi32>,
+    %update : memref<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) {
   // expected-error @+1 {{expected `outs` operand #0 to be of MemRefType}}
   linalg_ext.scatter
-    ins(%update, %indices : memref<?x?xf32>, memref<?xi32>)
+    ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -139,11 +139,11 @@ func @scatter_mixed_tensor_memref(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<?x?xf32>, %indices : tensor<48xi32>,
+    %update : tensor<?x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xf32>, tensor<48xi32>)
+    ins(%update, %indices : tensor<?x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -155,11 +155,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<64x?xf32>, %indices : tensor<48xi32>,
+    %update : tensor<64x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<64x?xf32>, tensor<48xi32>)
+    ins(%update, %indices : tensor<64x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -171,11 +171,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<?x?x?xf32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in rank of update value and original value}}
+  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?x?xf32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -187,11 +187,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<?x4xf32>, %indices : tensor<?xi32>,
+    %update : tensor<?x4xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in shape of update value and original value at dim#1}}
+  // expected-error @+1 {{mismatch in shape of update value dim#1 and original value at dim#1}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x4xf32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x4xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -203,11 +203,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_region_type_mismatch(
-    %update : tensor<?x?xi32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{expected region to have scalar argument of integer or float types}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: index, %arg2: index):
       %1 = addi %arg1, %arg2 : index
@@ -220,11 +220,11 @@ func @scatter_region_type_mismatch(
 // -----
 
 func @scatter_region_type_mismatch(
-    %update : tensor<?x?xi32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 0 of region 'i64' and element type of update value 'i32'}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i64, %arg2: i32):
       %1 = trunci %arg1 : i64 to i32
@@ -237,11 +237,11 @@ func @scatter_region_type_mismatch(
 // -----
 
 func @scatter_region_type_mismatch(
-    %update : tensor<?x?xi32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 1 of region 'i64' and element type of original value 'i32'}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i32, %arg2: i64):
       %1 = trunci %arg2 : i64 to i32
@@ -254,11 +254,11 @@ func @scatter_region_type_mismatch(
 // -----
 
 func @scatter_region_type_mismatch(
-    %update : tensor<?x?xi32>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{mismatch in region argument types 'i32' and 'i64'}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i32, %arg2: i64):
       %1 = sexti %arg1 : i32 to i64
@@ -271,11 +271,11 @@ func @scatter_region_type_mismatch(
 // -----
 
 func @scatter_region_type_mismatch(
-    %update : tensor<?x?xi64>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{expected region to have two arguments}}
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64, %arg3 : i64):
       %1 = addi %arg1, %arg2 : i64
@@ -288,10 +288,10 @@ func @scatter_region_type_mismatch(
 // -----
 
 func @scatter_yield_mismatch(
-    %update : tensor<?x?xi64>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = addi %arg1, %arg2 : i64
@@ -305,15 +305,49 @@ func @scatter_yield_mismatch(
 // -----
 
 func @scatter_yield_mismatch(
-    %update : tensor<?x?xi64>, %indices : tensor<?xi32>,
+    %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = addi %arg1, %arg2 : i64
       %2 = trunci %1 : i64 to i32
       // expected-error @+1 {{expected region to yield a single value}}
+      linalg_ext.yield %1, %2 : i64, i32
+    } -> tensor<?x?xi64>
+  return %0 : tensor<?x?xi64>
+}
+
+// -----
+
+func @scatter_index_depth_dynamic(
+    %update : tensor<?x?xi64>, %indices : tensor<?x?xi32>,
+    %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
+  // expected-error @+1 {{expected index depth is static}}
+  %0 = linalg_ext.scatter
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x?xi32>)
+    outs(%original : tensor<?x?xi64>) {
+    ^bb0(%arg1: i64, %arg2: i64):
+      %1 = addi %arg1, %arg2 : i64
+      %2 = trunci %1 : i64 to i32
+      linalg_ext.yield %1, %2 : i64, i32
+    } -> tensor<?x?xi64>
+  return %0 : tensor<?x?xi64>
+}
+
+// -----
+
+func @scatter_original_rank_mismatch(
+    %update : tensor<?x?xi64>, %indices : tensor<?x2xi32>,
+    %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
+  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
+  %0 = linalg_ext.scatter
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
+    outs(%original : tensor<?x?xi64>) {
+    ^bb0(%arg1: i64, %arg2: i64):
+      %1 = addi %arg1, %arg2 : i64
+      %2 = trunci %1 : i64 to i32
       linalg_ext.yield %1, %2 : i64, i32
     } -> tensor<?x?xi64>
   return %0 : tensor<?x?xi64>

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -33,10 +33,10 @@ func @sort_memref(%arg0: memref<128xi32>) {
 // -----
 
 func @scatter_tensor_dynamic(
-    %original: tensor<?x?xf32>, %indices: tensor<?xi32>,
+    %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xf32>, tensor<?xi32>)
+    ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original: tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -46,7 +46,7 @@ func @scatter_tensor_dynamic(
 }
 // CHECK-LABEL: func @scatter_tensor_dynamic(
 //  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
-//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?xi32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
@@ -57,10 +57,10 @@ func @scatter_tensor_dynamic(
 // -----
 
 func @scatter_tensor_static(
-    %original: tensor<128x3xf32>, %indices: tensor<48xi32>,
+    %original: tensor<128x3xf32>, %indices: tensor<48x1xi32>,
     %update: tensor<48x3xf32>) -> tensor<128x3xf32> {
   %0 = linalg_ext.scatter
-    ins(%update, %indices : tensor<48x3xf32>, tensor<48xi32>)
+    ins(%update, %indices : tensor<48x3xf32>, tensor<48x1xi32>)
     outs(%original: tensor<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -70,7 +70,31 @@ func @scatter_tensor_static(
 }
 // CHECK-LABEL: func @scatter_tensor_static(
 //  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: tensor<128x3xf32>
-//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48xi32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x1xi32>
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     linalg_ext.yield %{{.+}} : f32
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scatter_tensor_multi_index_depth(
+    %original: tensor<1x128x3xf32>, %indices: tensor<48x2xi32>,
+    %update: tensor<48x3xf32>) -> tensor<1x128x3xf32> {
+  %0 = linalg_ext.scatter
+    ins(%update, %indices : tensor<48x3xf32>, tensor<48x2xi32>)
+    outs(%original: tensor<1x128x3xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = addf %arg1, %arg2 : f32
+      linalg_ext.yield %1 : f32
+    } -> tensor<1x128x3xf32>
+  return %0 : tensor<1x128x3xf32>
+}
+// CHECK-LABEL: func @scatter_tensor_multi_index_depth(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: tensor<1x128x3xf32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
 //       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
@@ -81,10 +105,10 @@ func @scatter_tensor_static(
 // -----
 
 func @scatter_memref_dynamic(
-    %original: memref<?x?xf32>, %indices: memref<?xi32>,
+    %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update: memref<?x?xf32>) {
   linalg_ext.scatter
-    ins(%update, %indices : memref<?x?xf32>, memref<?xi32>)
+    ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original: memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -94,7 +118,7 @@ func @scatter_memref_dynamic(
 }
 // CHECK-LABEL: func @scatter_memref_dynamic(
 //  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: memref<?x?xf32>
-//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<?xi32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<?x?xf32>
 //       CHECK:   linalg_ext.scatter
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
@@ -105,10 +129,10 @@ func @scatter_memref_dynamic(
 // -----
 
 func @scatter_memref_static(
-    %original: memref<128x3xf32>, %indices: memref<48xi32>,
+    %original: memref<128x3xf32>, %indices: memref<48x1xi32>,
     %update: memref<48x3xf32>) {
   linalg_ext.scatter
-    ins(%update, %indices : memref<48x3xf32>, memref<48xi32>)
+    ins(%update, %indices : memref<48x3xf32>, memref<48x1xi32>)
     outs(%original: memref<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = addf %arg1, %arg2 : f32
@@ -118,7 +142,31 @@ func @scatter_memref_static(
 }
 // CHECK-LABEL: func @scatter_memref_static(
 //  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: memref<128x3xf32>
-//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48xi32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x1xi32>
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
+//       CHECK:   linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     linalg_ext.yield %{{.+}} : f32
+//       CHECK:   return
+
+// -----
+
+func @scatter_memref_multi_index_depth(
+    %original: memref<1x128x3xf32>, %indices: memref<48x2xi32>,
+    %update: memref<48x3xf32>) {
+  linalg_ext.scatter
+    ins(%update, %indices : memref<48x3xf32>, memref<48x2xi32>)
+    outs(%original: memref<1x128x3xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = addf %arg1, %arg2 : f32
+      linalg_ext.yield %1 : f32
+    }
+  return
+}
+// CHECK-LABEL: func @scatter_memref_multi_index_depth(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: memref<1x128x3xf32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
 //       CHECK:   linalg_ext.scatter
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -173,3 +173,72 @@ func @scatter_memref_multi_index_depth(
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     linalg_ext.yield %{{.+}} : f32
 //       CHECK:   return
+
+// -----
+
+func @scatter_update_scalar_1D(
+    %original: tensor<8xi32>, %indices: tensor<3x1xi32>,
+    %updates: tensor<3xi32>) -> tensor<8xi32> {
+  %0 = linalg_ext.scatter
+    ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi32>)
+    outs(%original : tensor<8xi32>)  {
+    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+      linalg_ext.yield %arg0 : i32
+    } -> tensor<8xi32>
+  return %0 : tensor<8xi32>
+}
+// CHECK-LABEL: func @scatter_update_scalar_1D(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     linalg_ext.yield %{{.+}} : i32
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scatter_update_scalar_2D(
+    %original: tensor<4x3xi32>, %indices: tensor<3x2xi32>,
+    %updates: tensor<3xi32>) -> tensor<4x3xi32> {
+  %0 = linalg_ext.scatter
+    ins(%updates, %indices : tensor<3xi32>, tensor<3x2xi32>)
+    outs(%original : tensor<4x3xi32>)  {
+    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+      linalg_ext.yield %arg0 : i32
+    } -> tensor<4x3xi32>
+  return %0 : tensor<4x3xi32>
+}
+// CHECK-LABEL: func @scatter_update_scalar_2D(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     linalg_ext.yield %{{.+}} : i32
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scatter_update_slice_2D(
+    %original: tensor<4x3xi32>, %indices: tensor<1x1xi32>,
+    %updates: tensor<1x3xi32>) -> tensor<4x3xi32> {
+  %0 = linalg_ext.scatter
+    ins(%updates, %indices : tensor<1x3xi32>, tensor<1x1xi32>)
+    outs(%original : tensor<4x3xi32>)  {
+    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+      linalg_ext.yield %arg0 : i32
+    } -> tensor<4x3xi32>
+  return %0 : tensor<4x3xi32>
+}
+// CHECK-LABEL: func @scatter_update_slice_2D(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     linalg_ext.yield %{{.+}} : i32
+//       CHECK:   return %[[RESULT]]


### PR DESCRIPTION
The index depth could be others than one. E.g.,

```
%0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):  // no predecessors
  "mhlo.return"(%arg4) : (tensor<f32>) -> ()
}) {indices_are_sorted = false,
    scatter_dimension_numbers = {
      ...
    },
    unique_indices = false
} : (tensor<1x24x512xf32>, tensor<1x2xi32>, tensor<1x512xf32>)
  -> tensor<1x24x512xf32>
}
```

This is a step toward https://github.com/google/iree/issues/6403