### PR TITLE
Add support for lowering linalg_ext.scatter to loops + Linalg ops.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -83,6 +83,26 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter"> {
           .getShape()
           .back();
     }
+
+    Value updates() {
+      return getInputOperand(0)->get();
+    }
+
+    Value indices() {
+      return getInputOperand(1)->get();
+    }
+
+    Value original() {
+      return getOutputOperand(0)->get();
+    }
+
+    int64_t getUpdateSliceRank() {
+      return updates().getType().cast<ShapedType>().getRank() - 1;
+    }
+
+    bool isScalarUpdate() {
+      return getUpdateSliceRank() == 0;
+    }
   }];
 }
 

--- a/iree/compiler/Dialect/LinalgExt/Transforms/BUILD
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "//iree/compiler/Dialect/LinalgExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",

--- a/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     ::PassesIncGen
     LLVMSupport
     MLIRIR
+    MLIRLinalg
     MLIRMemRef
     MLIRPass
     MLIRSCF

--- a/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -22,6 +23,10 @@ namespace mlir {
 namespace iree_compiler {
 namespace linalg_ext {
 namespace {
+
+//===----------------------------------------------------------------------===//
+// SortOp
+//===----------------------------------------------------------------------===//
 
 struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
   using OpRewritePattern<linalg_ext::SortOp>::OpRewritePattern;
@@ -119,23 +124,166 @@ struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
   }
 };
 
+//===----------------------------------------------------------------------===//
+// ScatterOp
+//===----------------------------------------------------------------------===//
+
+struct ScatterScalarConversion
+    : public OpRewritePattern<linalg_ext::ScatterOp> {
+  using OpRewritePattern<linalg_ext::ScatterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg_ext::ScatterOp op,
+                                PatternRewriter& rewriter) const final {
+    if (!op.hasBufferSemantics()) return failure();
+
+    auto updates = op.getInputOperand(0);
+    auto indices = op.getInputOperand(1);
+    auto original = op.getOutputOperand(0);
+    if (op.getRank(updates) != 1) return failure();
+
+    Location loc = op.getLoc();
+    Value zero = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value ub = rewriter.createOrFold<memref::DimOp>(loc, updates->get(), zero);
+    auto indexDepth = op.getIndexDepth();
+    rewriter.create<scf::ForOp>(
+        loc, zero, ub, one, ValueRange{},
+        [&](OpBuilder& b, Location loc, Value iv, ValueRange iters) {
+          Value update = b.create<memref::LoadOp>(loc, updates->get(), iv);
+          SmallVector<Value> starts;
+          SmallVector<Value> ivs = {iv, Value()};
+          for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
+            ivs.back() = b.create<ConstantIndexOp>(loc, i);
+            Value idx = b.create<memref::LoadOp>(loc, indices->get(), ivs);
+            starts.push_back(
+                b.create<IndexCastOp>(loc, rewriter.getIndexType(), idx));
+          }
+          Value init = b.create<memref::LoadOp>(loc, original->get(), starts);
+
+          // TODO(hanchung): Integrate the below body into TiedOpInterface.
+          BlockAndValueMapping bvm;
+          Block& block = op.region().front();
+          bvm.map(block.getArgument(0), update);
+          bvm.map(block.getArgument(1), init);
+          Operation* res;
+          for (auto& blockOp : block.getOperations()) {
+            res = b.clone(blockOp, bvm);
+          }
+          // The last op is linalg_ext.yield op. Store the operand to
+          // destination.
+          b.create<memref::StoreOp>(loc, res->getOperand(0), original->get(),
+                                    starts);
+          rewriter.replaceOp(res, {});
+          b.create<scf::YieldOp>(loc);
+        });
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ScatterSliceConversion : public OpRewritePattern<linalg_ext::ScatterOp> {
+  using OpRewritePattern<linalg_ext::ScatterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg_ext::ScatterOp op,
+                                PatternRewriter& rewriter) const final {
+    if (!op.hasBufferSemantics()) return failure();
+
+    auto updates = op.getInputOperand(0);
+    auto indices = op.getInputOperand(1);
+    auto original = op.getOutputOperand(0);
+    if (op.getRank(updates) == 1) return failure();
+
+    Location loc = op.getLoc();
+    Value zero = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value ub = rewriter.createOrFold<memref::DimOp>(loc, updates->get(), zero);
+    auto indexDepth = op.getIndexDepth();
+    rewriter.create<scf::ForOp>(
+        loc, zero, ub, one, ValueRange{},
+        [&](OpBuilder& b, Location loc, Value iv, ValueRange iters) {
+          Value update =
+              b.create<memref::SubViewOp>(loc, updates->get(), iv, one, one);
+
+          SmallVector<Value> ivs = {iv, Value()};
+          SmallVector<Value> starts;
+          for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
+            ivs.back() = b.create<ConstantIndexOp>(loc, i);
+            Value idx = b.create<memref::LoadOp>(loc, indices->get(), ivs);
+            starts.push_back(
+                b.create<IndexCastOp>(loc, rewriter.getIndexType(), idx));
+          }
+          SmallVector<Value> ones(indexDepth, one);
+          Value subview = b.create<memref::SubViewOp>(loc, original->get(),
+                                                      starts, ones, ones);
+
+          // TODO(hanchung): Integrate the below body into TiedOpInterface.
+          auto nloops = op.getRank(updates) - 1;
+          SmallVector<AffineMap> maps;
+          {
+            SmallVector<AffineExpr> exprs;
+            exprs.push_back(b.getAffineConstantExpr(0));
+            for (int i = 0; i < nloops; ++i) {
+              exprs.push_back(b.getAffineDimExpr(i));
+            }
+            maps.push_back(AffineMap::get(nloops, 0, exprs, b.getContext()));
+          }
+          {
+            SmallVector<AffineExpr> exprs(indexDepth,
+                                          b.getAffineConstantExpr(0));
+            for (int i = 0; i < nloops; ++i) {
+              exprs.push_back(b.getAffineDimExpr(i));
+            }
+            maps.push_back(AffineMap::get(nloops, 0, exprs, b.getContext()));
+          }
+
+          SmallVector<StringRef> iterTypes(nloops,
+                                           getParallelIteratorTypeName());
+          auto genericOp =
+              b.create<linalg::GenericOp>(loc, TypeRange{}, ValueRange{update},
+                                          ValueRange{subview}, maps, iterTypes);
+          rewriter.inlineRegionBefore(op.region(), genericOp.region(),
+                                      genericOp.region().end());
+
+          // Replace linalg_ext.yield with linalg.yield.
+          auto linalgExtYieldOp = llvm::to_vector<4>(
+              genericOp.region().front().getOps<linalg_ext::YieldOp>())[0];
+          {
+            OpBuilder::InsertionGuard guard(b);
+            b.setInsertionPointToEnd(&genericOp.region().back());
+            b.create<linalg::YieldOp>(loc, linalgExtYieldOp.operands());
+          }
+          rewriter.replaceOp(linalgExtYieldOp, {});
+
+          b.create<scf::YieldOp>(loc);
+        });
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
 struct LinalgExtToLoopsPass
     : public LinalgExtToLoopsBase<LinalgExtToLoopsPass> {
   void getDependentDialects(DialectRegistry& registry) const override {
-    registry
-        .insert<StandardOpsDialect, memref::MemRefDialect, scf::SCFDialect>();
+    registry.insert<linalg::LinalgDialect, StandardOpsDialect,
+                    memref::MemRefDialect, scf::SCFDialect>();
   }
 
   void runOnOperation() override {
     MLIRContext* context = &getContext();
 
     OwningRewritePatternList patterns(context);
-    patterns.insert<BubbleSortConversion>(context);
+    patterns.insert<BubbleSortConversion, ScatterScalarConversion,
+                    ScatterSliceConversion>(context);
 
     ConversionTarget target(getContext());
-    target.addLegalDialect<memref::MemRefDialect, StandardOpsDialect,
-                           scf::SCFDialect>();
-    target.addIllegalOp<linalg_ext::SortOp>();
+    target.addLegalDialect<linalg::LinalgDialect, memref::MemRefDialect,
+                           StandardOpsDialect, scf::SCFDialect>();
+    target.addIllegalDialect<linalg_ext::LinalgExtDialect>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -11,7 +11,7 @@ include "mlir/Pass/PassBase.td"
 
 def LinalgExtToLoops :
     Pass<"iree-linalg-ext-to-loops", "FuncOp"> {
-  let summary = "";
+  let summary = "Convert LinalgExt ops to loops and Linalg ops.";
   let constructor = "mlir::iree_compiler::linalg_ext::createLinalgExtToLoopsPass()";
 }
 

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -266,3 +266,103 @@ func @scatter_add_slice_2D(
 // CHECK:           ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: i32):
 // CHECK:             %[[RES:.+]] = addi %[[ARG5]], %[[ARG4]] : i32
 // CHECK:             linalg.yield %[[RES]]
+
+// -----
+
+func @scatter_update_scalar_dynamic_1D(
+    %original: memref<?xi32>, %indices: memref<?x1xi32>,
+    %updates: memref<?xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<?xi32>, memref<?x1xi32>)
+    outs(%original : memref<?xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    linalg_ext.yield %arg0 : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scatter_update_scalar_dynamic_1D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?xi32>
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
+// CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<?xi32>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
+// CHECK:           memref.store %[[T1]], %[[ORIGINAL]][%[[IDX]]]
+
+// -----
+
+func @scatter_add_scalar_dynamic_2D(
+    %original: memref<?x?xi32>, %indices: memref<?x2xi32>,
+    %updates: memref<?xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<?xi32>, memref<?x2xi32>)
+    outs(%original : memref<?x?xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    %0 = addi %arg1, %arg0 : i32
+    linalg_ext.yield %0 : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scatter_add_scalar_dynamic_2D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?xi32>
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
+// CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<?xi32>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T2:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x2xi32>
+// CHECK:           %[[IDX1:.+]] = index_cast %[[T2]] : i32 to index
+// CHECK:           %[[C1:.+]] = constant 1 : index
+// CHECK:           %[[T3:.+]] = memref.load %[[INDICES]][%[[I]], %[[C1]]] : memref<?x2xi32>
+// CHECK:           %[[IDX2:.+]] = index_cast %[[T3]] : i32 to index
+// CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]] : memref<?x?xi32>
+// CHECK:           %[[ADD:.+]] = addi %[[ORI]], %[[T1]] : i32
+// CHECK:           memref.store %[[ADD]], %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]]
+
+// -----
+
+func @scatter_update_slice_dynamic_2D(
+    %original: memref<?x?xi32>, %indices: memref<?x1xi32>,
+    %updates: memref<?x?xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<?x?xi32>, memref<?x1xi32>)
+    outs(%original : memref<?x?xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    linalg_ext.yield %arg0 : i32
+  }
+  return
+}
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
+// CHECK:       func @scatter_update_slice_dynamic_2D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?x?xi32>
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
+// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
+// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<?x?xi32> to memref<?x?xi32, #[[MAP0]]>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
+// CHECK:           %[[SUB_ORI:.+]] = memref.subview
+// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<?x?xi32> to memref<?x?xi32, #[[MAP0]]>
+// CHECK:           linalg.generic
+// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
+// CHECK-SAME:        iterator_types = ["parallel"]
+// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x?xi32, #[[MAP0]]>)
+// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x?xi32, #[[MAP0]]>)
+// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %{{.+}}: i32):
+// CHECK:             linalg.yield %[[ARG4]]

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -94,3 +94,175 @@ func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 // CHECK:               memref.store %[[V4]], %[[BUF2]][%[[ARG2]]]
 // CHECK:               memref.store %[[V3]], %[[BUF2]][%[[T2]]]
 // CHECK:             }
+
+// -----
+
+func @scatter_update_scalar_1D(
+    %original: memref<8xi32>, %indices: memref<3x1xi32>,
+    %updates: memref<3xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
+    outs(%original : memref<8xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    linalg_ext.yield %arg0 : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scatter_update_scalar_1D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C3:.+]] = constant 3 : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
+// CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
+// CHECK:           memref.store %[[T1]], %[[ORIGINAL]][%[[IDX]]]
+
+// -----
+
+func @scatter_add_scalar_2D(
+    %original: memref<4x3xi32>, %indices: memref<3x2xi32>,
+    %updates: memref<3xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<3xi32>, memref<3x2xi32>)
+    outs(%original : memref<4x3xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    %0 = addi %arg1, %arg0 : i32
+    linalg_ext.yield %0 : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scatter_add_scalar_2D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C3:.+]] = constant 3 : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
+// CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T2:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x2xi32>
+// CHECK:           %[[IDX1:.+]] = index_cast %[[T2]] : i32 to index
+// CHECK:           %[[C1:.+]] = constant 1 : index
+// CHECK:           %[[T3:.+]] = memref.load %[[INDICES]][%[[I]], %[[C1]]] : memref<3x2xi32>
+// CHECK:           %[[IDX2:.+]] = index_cast %[[T3]] : i32 to index
+// CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]] : memref<4x3xi32>
+// CHECK:           %[[ADD:.+]] = addi %[[ORI]], %[[T1]] : i32
+// CHECK:           memref.store %[[ADD]], %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]]
+
+// -----
+
+func @scatter_update_slice_2D(
+    %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
+    %updates: memref<2x3xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
+    outs(%original : memref<4x3xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    linalg_ext.yield %arg0 : i32
+  }
+  return
+}
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
+// CHECK:       func @scatter_update_slice_2D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = constant 2 : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
+// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<2x3xi32> to memref<?x3xi32, #[[MAP0]]>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<2x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
+// CHECK:           %[[SUB_ORI:.+]] = memref.subview
+// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<4x3xi32> to memref<?x3xi32, #[[MAP0]]>
+// CHECK:           linalg.generic
+// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
+// CHECK-SAME:        iterator_types = ["parallel"]
+// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x3xi32, #[[MAP0]]>)
+// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x3xi32, #[[MAP0]]>)
+// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %{{.+}}: i32):
+// CHECK:             linalg.yield %[[ARG4]]
+
+// -----
+
+func @scatter_add_scalar_1D(
+    %original: memref<8xi32>, %indices: memref<3x1xi32>,
+    %updates: memref<3xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
+    outs(%original : memref<8xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    %0 = addi %arg1, %arg0 : i32
+    linalg_ext.yield %0 : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scatter_add_scalar_1D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C3:.+]] = constant 3 : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
+// CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
+// CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX]]] : memref<8xi32>
+// CHECK:           %[[ADD:.+]] = addi %[[ORI]], %[[T1]] : i32
+// CHECK:           memref.store %[[ADD]], %[[ORIGINAL]][%[[IDX]]]
+
+// -----
+
+func @scatter_add_slice_2D(
+    %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
+    %updates: memref<2x3xi32>) {
+  linalg_ext.scatter
+    ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
+    outs(%original : memref<4x3xi32>)  {
+  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    %0 = addi %arg1, %arg0 : i32
+    linalg_ext.yield %0 : i32
+  }
+  return
+}
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
+// CHECK:       func @scatter_add_slice_2D
+// CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = constant 2 : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
+// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<2x3xi32> to memref<?x3xi32, #[[MAP0]]>
+// CHECK:           %[[C0:.+]] = constant 0 : index
+// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<2x1xi32>
+// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
+// CHECK:           %[[SUB_ORI:.+]] = memref.subview
+// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
+// CHECK-SAME:      : memref<4x3xi32> to memref<?x3xi32, #[[MAP0]]>
+// CHECK:           linalg.generic
+// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
+// CHECK-SAME:        iterator_types = ["parallel"]
+// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x3xi32, #[[MAP0]]>)
+// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x3xi32, #[[MAP0]]>)
+// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: i32):
+// CHECK:             %[[RES:.+]] = addi %[[ARG5]], %[[ARG4]] : i32
+// CHECK:             linalg.yield %[[RES]]


### PR DESCRIPTION
This supports both scalar and slice cases. For slice cases, we will
create a linalg.generic op with parallel loops to handle slices. It also
works for cases that index_depth > 1.

This is a step towards https://github.com/google/iree/issues/6403