### PR TITLE
Add support for lowering mhlo.scatter to LinalgExt ops.

### DIFF
--- a/iree/compiler/InputConversion/MHLO/BUILD
+++ b/iree/compiler/InputConversion/MHLO/BUILD
@@ -64,6 +64,7 @@ cc_library(
         ":PassesIncGen",
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/Flow/Transforms",
+        "//iree/compiler/Dialect/IREE/IR",
         "//iree/compiler/Dialect/LinalgExt/IR",
         "//iree/compiler/Dialect/Shape/IR",
         "//iree/compiler/InputConversion/Common",

--- a/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_cc_library(
     MLIRTransforms
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::Dialect::IREE::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Shape::IR
     iree::compiler::InputConversion::Common

--- a/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
@@ -195,6 +195,9 @@ struct ScatterOpConversion
   /// * Scatter dims to operand dims order: (0, ... , n)
   /// * Inserted window dims order: (0, ... , d)
   /// * Update window dims order: (d + 1, ... , m)
+  ///
+  /// TODO(hanchung): Add a pattern for legalizing mhlo.scatter to canonical
+  /// form to MHLOToMHLOPreprocessingPass.
   static bool hasCanonicalDimensionNumbers(mhlo::ScatterOp op) {
     auto dimNumbers = op.scatter_dimension_numbers();
     auto indicesType = op.scatter_indices().getType().cast<ShapedType>();

--- a/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertAndDistributeMHLOToLinalgExt.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/InputConversion/MHLO/PassDetail.h"
@@ -13,6 +14,7 @@
 #include "iree/compiler/InputConversion/MHLO/Rewriters.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/map_lmhlo_to_scalar_op.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
@@ -22,11 +24,23 @@
 namespace mlir {
 namespace iree_compiler {
 
+//===----------------------------------------------------------------------===//
+// Utils
+//===----------------------------------------------------------------------===//
+
 static bool isInBodyOfLinalgExtOps(Operation *op) {
   auto parent_op = op->getParentRegion()->getParentOp();
   return parent_op->getDialect() ==
          parent_op->getContext()
              ->getLoadedDialect<linalg_ext::LinalgExtDialect>();
+}
+
+static SmallVector<int64_t> extract1DVector(DenseIntElementsAttr elements) {
+  SmallVector<int64_t> ret;
+  for (const APInt &element : elements) {
+    ret.push_back(element.getLimitedValue());
+  }
+  return ret;
 }
 
 namespace {
@@ -44,11 +58,24 @@ struct ConvertToLinalgExtPattern : public OpConversionPattern<OpTy> {
       ConversionPatternRewriter &rewriter) const final {
     Value one = rewriter.create<ConstantIndexOp>(op.getLoc(), 1);
     SmallVector<Value> workload(3, one);
+
+    // Gather the dynamic dimensions for all operands.
+    SmallVector<Value> operandDynamicDims;
+    for (Value arg : args) {
+      if (auto rt = arg.getType().dyn_cast<RankedTensorType>()) {
+        for (unsigned i = 0; i < rt.getRank(); ++i) {
+          if (!rt.isDynamicDim(i)) continue;
+          auto dim = rewriter.createOrFold<tensor::DimOp>(op.getLoc(), arg, i);
+          operandDynamicDims.push_back(dim);
+        }
+      }
+    }
+
     auto dispatchOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
         op.getLoc(), workload, op->getResultTypes(),
         /*result_dims=*/ValueRange{},
         /*operands=*/args,
-        /*operand_dims=*/ValueRange{},
+        /*operand_dims=*/operandDynamicDims,
         /*tied_operands=*/Derived::getTiedResultOperandIndices(args));
     {
       OpBuilder::InsertionGuard guard(rewriter);
@@ -151,28 +178,169 @@ struct SortOpConversion
   }
 };
 
+//===----------------------------------------------------------------------===//
+// ScatterOp
+//===----------------------------------------------------------------------===//
+
+struct ScatterOpConversion
+    : public ConvertToLinalgExtPattern<ScatterOpConversion, mhlo::ScatterOp> {
+  using ConvertToLinalgExtPattern<ScatterOpConversion,
+                                  mhlo::ScatterOp>::ConvertToLinalgExtPattern;
+
+  /// Returns true if the `dimensionNumbers` from the mhlo.scatter op follows a
+  /// canonical form:
+  ///
+  /// * The rank of indices is greater than or equal to two.
+  /// * The index_vector_dim is the last dim of indices.
+  /// * Scatter dims to operand dims order: (0, ... , n)
+  /// * Inserted window dims order: (0, ... , d)
+  /// * Update window dims order: (d + 1, ... , m)
+  static bool hasCanonicalDimensionNumbers(mhlo::ScatterOp op) {
+    auto dimNumbers = op.scatter_dimension_numbers();
+    auto indicesType = op.scatter_indices().getType().cast<ShapedType>();
+    auto indicesRank = indicesType.getRank();
+
+    if (indicesRank < 2) return false;
+    if (dimNumbers.index_vector_dim().getInt() != indicesRank - 1) return false;
+
+    auto indexDepth = indicesType.getShape().back();
+    auto scatterDimsToOperandDims =
+        extract1DVector(dimNumbers.scatter_dims_to_operand_dims());
+    if (scatterDimsToOperandDims.size() != indexDepth) return false;
+    for (auto en : llvm::enumerate(scatterDimsToOperandDims)) {
+      if (en.index() != en.value()) return false;
+    }
+
+    auto insertedWindowDims =
+        extract1DVector(dimNumbers.inserted_window_dims());
+    for (auto en : llvm::enumerate(insertedWindowDims)) {
+      if (en.index() != en.value()) return false;
+    }
+
+    auto updateWindowDims = extract1DVector(dimNumbers.update_window_dims());
+    for (auto en : llvm::enumerate(updateWindowDims)) {
+      if (en.index() + insertedWindowDims.size() != en.value()) return false;
+    }
+
+    return true;
+  }
+
+  static SmallVector<int64_t> getTiedResultOperandIndices(
+      ArrayRef<Value> args) {
+    // Mark linalg_ext.scatter::orinigal as readwrite tensor.
+    return {0};
+  }
+
+  static LogicalResult collapseBatchDimsIfNeeded(Value &indices, Value &updates,
+                                                 ImplicitLocOpBuilder &b) {
+    auto indicesType = indices.getType().cast<ShapedType>();
+    auto updatesType = updates.getType().cast<ShapedType>();
+    if (indicesType.getRank() == 2) return success();
+
+    int64_t batchSize = 1;
+    auto indicesRank = indicesType.getRank();
+    auto shape = indicesType.getShape();
+    for (auto i : shape.drop_back(1)) {  // drop index_detph_dim
+      if (i == ShapedType::kDynamicSize) {
+        batchSize = ShapedType::kDynamicSize;
+      } else if (batchSize != ShapedType::kDynamicSize) {
+        batchSize *= i;
+      }
+    }
+
+    SmallVector<linalg::ReassociationIndices> map;
+    map.emplace_back(
+        llvm::to_vector<4>(llvm::seq<int64_t>(0, indicesRank - 1)));
+    map.emplace_back(1, indicesRank - 1);
+    auto resultType = RankedTensorType::get({batchSize, shape.back()},
+                                            indicesType.getElementType());
+    indices = b.create<linalg::TensorCollapseShapeOp>(resultType, indices, map);
+
+    auto updateShape = updatesType.getShape().drop_front(shape.size() - 1);
+    SmallVector<int64_t> collapsedUpdateShape = {batchSize};
+    collapsedUpdateShape.append(updateShape.begin(), updateShape.end());
+    resultType = RankedTensorType::get(collapsedUpdateShape,
+                                       updatesType.getElementType());
+    // The batching dims are identical.
+    map.pop_back();
+    for (auto i : llvm::seq<int64_t>(indicesRank - 1, updatesType.getRank())) {
+      map.emplace_back(1, i);
+    }
+    updates = b.create<linalg::TensorCollapseShapeOp>(resultType, updates, map);
+
+    return success();
+  }
+
+  static LogicalResult lowerMHLOOp(IREE::Flow::DispatchWorkgroupsOp dispatchOp,
+                                   mhlo::ScatterOp op, ArrayRef<Value> args,
+                                   ConversionPatternRewriter &rewriter) {
+    if (!hasCanonicalDimensionNumbers(op)) return failure();
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    mhlo::ScatterOpAdaptor adaptor(args);
+
+    auto blockArgs = dispatchOp.getClosureBodyRegion().getArguments();
+    Value original = b.create<IREE::Flow::DispatchTensorLoadOp>(
+        adaptor.operand().getType().cast<RankedTensorType>(), blockArgs[0]);
+    Value indices = b.create<IREE::Flow::DispatchTensorLoadOp>(
+        adaptor.scatter_indices().getType().cast<RankedTensorType>(),
+        blockArgs[1]);
+    Value updates = b.create<IREE::Flow::DispatchTensorLoadOp>(
+        adaptor.updates().getType().cast<RankedTensorType>(), blockArgs[2]);
+
+    if (failed(collapseBatchDimsIfNeeded(indices, updates, b))) {
+      return failure();
+    }
+    auto scatterOp = b.create<linalg_ext::ScatterOp>(
+        op->getResultTypes(), ValueRange{updates, indices},
+        ValueRange{original});
+
+    rewriter.inlineRegionBefore(op.update_computation(), scatterOp.region(),
+                                scatterOp.region().begin());
+    Region &region = scatterOp.region();
+    TypeConverter::SignatureConversion signatureConverter(2);
+    Type argType = getElementTypeOrSelf(original.getType());
+    // mhlo.scatter ops takes:
+    //   output[O] = update_computation(output[O], updates[U])
+    // where output[O] maps to block args #1 in linalg_ext.scatter ops.
+    signatureConverter.addInputs(1, argType);
+    signatureConverter.addInputs(0, argType);
+    rewriter.applySignatureConversion(&region, signatureConverter);
+
+    b.create<IREE::Flow::DispatchTensorStoreOp>(scatterOp.getResult(0),
+                                                blockArgs[0]);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
 struct ConvertAndDistributeMHLOToLinalgExtPass
     : public ConvertAndDistributeMHLOToLinalgExtBase<
           ConvertAndDistributeMHLOToLinalgExtPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg_ext::LinalgExtDialect, IREE::Flow::FlowDialect,
-                    StandardOpsDialect, tensor::TensorDialect>();
+    registry.insert<linalg_ext::LinalgExtDialect, linalg::LinalgDialect,
+                    IREE::Flow::FlowDialect, StandardOpsDialect,
+                    tensor::TensorDialect>();
   }
 
   void runOnOperation() override {
     OwningRewritePatternList patterns(&getContext());
     MLIRContext *context = &getContext();
 
-    patterns.insert<SortOpConversion>(context);
+    patterns.insert<SortOpConversion, ScatterOpConversion>(context);
     patterns.insert<LinalgExtRegionHLOOpConversion<mhlo::CompareOp>,
+                    LinalgExtRegionHLOOpConversion<mhlo::AddOp>,
                     LinalgExtRegionReturnOpConversion>(context,
                                                        PatternBenefit(1000));
 
     ConversionTarget target(getContext());
-    target
-        .addLegalDialect<linalg_ext::LinalgExtDialect, IREE::Flow::FlowDialect,
-                         StandardOpsDialect, tensor::TensorDialect>();
-    target.addIllegalOp<mhlo::SortOp>();
+    target.addLegalDialect<linalg_ext::LinalgExtDialect, linalg::LinalgDialect,
+                           IREE::Flow::FlowDialect, StandardOpsDialect,
+                           tensor::TensorDialect>();
+    target.addIllegalOp<mhlo::SortOp, mhlo::ScatterOp>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/iree/compiler/InputConversion/MHLO/test/convert_and_distribute_mhlo_to_linalg_ext.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/convert_and_distribute_mhlo_to_linalg_ext.mlir
@@ -80,3 +80,263 @@ func @topk(%arg0: tensor<128xi32>, %arg1: tensor<128xi32>) -> (tensor<128xi32>) 
 // CHECK:          flow.dispatch.tensor.store %[[SORT]]#0, %[[ARG2]]
 // CHECK:          flow.dispatch.tensor.store %[[SORT]]#1, %[[ARG3]]
 // CHECK:        return %[[RES]]#0
+
+// -----
+
+func @scatter_update_scalar_1D(%arg0: tensor<8xi32>, %arg1: tensor<4x1xi32>,
+    %arg2: tensor<4xi32>) -> tensor<8xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1 : i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<> : tensor<0xi64>
+    },
+    unique_indices = false
+  } : (tensor<8xi32>, tensor<4x1xi32>, tensor<4xi32>) -> tensor<8xi32>
+  return %0 : tensor<8xi32>
+}
+// CHECK-LABEL: func @scatter_update_scalar_1D
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<8xi32>, tensor<4x1xi32>, tensor<4xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:8xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:4x1xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:4xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[UPDATES]], %[[INDICES]] : tensor<4xi32>, tensor<4x1xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<8xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+// CEECK:             linalg.yield %[[V1]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @scatter_update_scalar_2D(%arg0: tensor<4x3xi32>, %arg1: tensor<3x2xi32>,
+    %arg2: tensor<3xi32>) -> tensor<4x3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {indices_are_sorted = false,
+      scatter_dimension_numbers = {
+        index_vector_dim = 1 : i64,
+        inserted_window_dims = dense<[0, 1]> : tensor<2xi64>,
+        scatter_dims_to_operand_dims = dense<[0, 1]> : tensor<2xi64>,
+        update_window_dims = dense<> : tensor<0xi64>
+      },
+      unique_indices = false
+  } : (tensor<4x3xi32>, tensor<3x2xi32>, tensor<3xi32>) -> tensor<4x3xi32>
+  return %0 : tensor<4x3xi32>
+}
+// CHECK-LABEL: func @scatter_update_scalar_2D
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<4x3xi32>, tensor<3x2xi32>, tensor<3xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:4x3xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:3x2xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:3xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[UPDATES]], %[[INDICES]] : tensor<3xi32>, tensor<3x2xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<4x3xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+// CEECK:             linalg.yield %[[V1]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @scatter_update_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
+    %arg2: tensor<2x3xi32>) -> tensor<6x3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1 : i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<1> : tensor<1xi64>
+    },
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
+  return %0 : tensor<6x3xi32>
+}
+// CHECK-LABEL: func @scatter_update_slice_2D
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:6x3xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:2x1xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:2x3xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[UPDATES]], %[[INDICES]] : tensor<2x3xi32>, tensor<2x1xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<6x3xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+// CEECK:             linalg.yield %[[V1]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @scatter_add_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
+    %arg2: tensor<2x3xi32>) -> tensor<6x3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    %1 = mhlo.add %arg3, %arg4 : tensor<i32>
+    "mhlo.return"(%1) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1 : i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<1> : tensor<1xi64>
+    },
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
+  return %0 : tensor<6x3xi32>
+}
+// CHECK-LABEL: func @scatter_add_slice_2D
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:6x3xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:2x1xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:2x3xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[UPDATES]], %[[INDICES]] : tensor<2x3xi32>, tensor<2x1xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<6x3xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+//
+//                   The order is reverse.
+// CHECK:             %[[V3:.+]] = addi %[[V2]], %[[V1]]
+// CEECK:             linalg.yield %[[V3]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @scatter_update_batch_scalar_1D(%arg0: tensor<8xi32>,
+    %arg1: tensor<3x4x1xi32>, %arg2: tensor<3x4xi32>) -> tensor<8xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 2 : i64,
+      inserted_window_dims = dense<0> : tensor<i64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<> : tensor<0xi64>
+    },
+    unique_indices = false
+  } : (tensor<8xi32>, tensor<3x4x1xi32>, tensor<3x4xi32>) -> tensor<8xi32>
+  return %0 : tensor<8xi32>
+}
+// CHECK-LABEL: func @scatter_update_batch_scalar_1D
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<8xi32>, tensor<3x4x1xi32>, tensor<3x4xi32>) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:8xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:3x4x1xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:3x4xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[COLLAPSED_INDICES:.+]] = linalg.tensor_collapse_shape
+// CHECK-SAME:        %[[INDICES]] {{\[}}[0, 1], [2]] : tensor<3x4x1xi32> into tensor<12x1xi32>
+// CHECK:           %[[COLLAPSED_UPDATES:.+]] = linalg.tensor_collapse_shape
+// CHECK-SAME:        %[[UPDATES]] {{\[}}[0, 1]] : tensor<3x4xi32> into tensor<12xi32>
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[COLLAPSED_UPDATES]], %[[COLLAPSED_INDICES]] : tensor<12xi32>, tensor<12x1xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<8xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+// CEECK:             linalg.yield %[[V1]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]
+
+// -----
+
+func @scatter_update_batch_slice_3D_dynamic(%arg0: tensor<1x24x512xi32>,
+    %arg1: tensor<?x3x2xi32>, %arg2: tensor<?x3x512xi32>) -> tensor<1x24x512xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {indices_are_sorted = false,
+      scatter_dimension_numbers = {
+        index_vector_dim = 2 : i64,
+        inserted_window_dims = dense<[0, 1]> : tensor<2xi64>,
+        scatter_dims_to_operand_dims = dense<[0, 1]> : tensor<2xi64>,
+        update_window_dims = dense<2> : tensor<1xi64>
+      },
+      unique_indices = false
+  } : (tensor<1x24x512xi32>, tensor<?x3x2xi32>, tensor<?x3x512xi32>) -> tensor<1x24x512xi32>
+  return %0 : tensor<1x24x512xi32>
+}
+// CHECK-LABEL: func @scatter_update_batch_slice_3D_dynamic
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[DIM1:.+]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?x3x2xi32>
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[DIM2:.+]] = tensor.dim %[[ARG2]], %[[C0]] : tensor<?x3x512xi32>
+// CHECK:         %[[RES:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:      [%[[C1]], %[[C1]], %[[C1]]](%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-SAME:    : (tensor<1x24x512xi32>, tensor<?x3x2xi32>{%[[DIM1]]}, tensor<?x3x512xi32>{%[[DIM2]]}) -> %[[ARG0]]
+// CHECK:           %[[ARG3:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:1x24x512xi32>
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:?x3x2xi32>
+// CHECK-SAME:      %[[ARG5:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:?x3x512xi32>
+// CHECK:           %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG3]]
+// CHECK:           %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG4]]
+// CHECK:           %[[UPDATES:.+]] = flow.dispatch.tensor.load %[[ARG5]]
+// CHECK:           %[[COLLAPSED_INDICES:.+]] = linalg.tensor_collapse_shape
+// CHECK-SAME:        %[[INDICES]] {{\[}}[0, 1], [2]] : tensor<?x3x2xi32> into tensor<?x2xi32>
+// CHECK:           %[[COLLAPSED_UPDATES:.+]] = linalg.tensor_collapse_shape
+// CHECK-SAME:        %[[UPDATES]] {{\[}}[0, 1], [2]] : tensor<?x3x512xi32> into tensor<?x512xi32>
+// CHECK:           %[[SCATTER:.+]] = linalg_ext.scatter
+// CHECK-SAME:        ins(%[[COLLAPSED_UPDATES]], %[[COLLAPSED_INDICES]] : tensor<?x512xi32>, tensor<?x2xi32>)
+// CHECK-SAME:       outs(%[[ORIGINAL]] : tensor<1x24x512xi32>)
+// CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):  // no predecessors
+// CEECK:             linalg.yield %[[V1]]
+// CHECK:           flow.dispatch.tensor.store %[[SCATTER]], %[[ARG3]]
+// CHECK:        return %[[RES]]

--- a/iree/test/e2e/xla_ops/scatter.mlir
+++ b/iree/test/e2e/xla_ops/scatter.mlir
@@ -1,4 +1,4 @@
-func @scatter_scalar() {
+func @scatter_update_scalar_1D() {
   %arg0 = iree.unfoldable_constant dense<0> : tensor<8xi32>
   %arg1 = iree.unfoldable_constant dense<[[1], [3], [4], [7]]> : tensor<4x1xi32>
   %arg2 = iree.unfoldable_constant dense<[9, 10, 11, 12]> : tensor<4xi32>
@@ -19,7 +19,30 @@ func @scatter_scalar() {
   return
 }
 
-func @scatter_slice() {
+func @scatter_update_scalar_2D() {
+  %arg0 = iree.unfoldable_constant dense<0> : tensor<4x3xi32>
+  %arg1 = iree.unfoldable_constant dense<[[0, 0], [1, 1], [2, 2]]> : tensor<3x2xi32>
+  %arg2 = iree.unfoldable_constant dense<[1, 2, 3]> : tensor<3xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {indices_are_sorted = false,
+      scatter_dimension_numbers = {
+        index_vector_dim = 1 : i64,
+        inserted_window_dims = dense<[0, 1]> : tensor<2xi64>,
+        scatter_dims_to_operand_dims = dense<[0, 1]> : tensor<2xi64>,
+        update_window_dims = dense<> : tensor<0xi64>
+      },
+      unique_indices = false
+  } : (tensor<4x3xi32>, tensor<3x2xi32>, tensor<3xi32>) -> tensor<4x3xi32>
+  check.expect_eq_const(%0, dense<[[1, 0, 0],
+                                   [0, 2, 0],
+                                   [0, 0, 3],
+                                   [0, 0, 0]]> : tensor<4x3xi32>) : tensor<4x3xi32>
+  return
+}
+
+func @scatter_update_slice_2D() {
   %arg0 = iree.unfoldable_constant dense<0> : tensor<6x3xi32>
   %arg1 = iree.unfoldable_constant dense<[[2], [4]]> : tensor<2x1xi32>
   %arg2 = iree.unfoldable_constant dense<[[1, 2, 3],
@@ -43,5 +66,61 @@ func @scatter_slice() {
                                    [0, 0, 0],
                                    [4, 5, 6],
                                    [0, 0, 0]]> : tensor<6x3xi32>) : tensor<6x3xi32>
+  return
+}
+
+func @scatter_add_slice_2D() {
+  %arg0 = iree.unfoldable_constant dense<1> : tensor<6x3xi32>
+  %arg1 = iree.unfoldable_constant dense<[[2], [4]]> : tensor<2x1xi32>
+  %arg2 = iree.unfoldable_constant dense<[[1, 2, 3],
+                                          [4, 5, 6]]> : tensor<2x3xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    %1 = mhlo.add %arg3, %arg4 : tensor<i32>
+    "mhlo.return"(%1) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1 : i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<1> : tensor<1xi64>
+    },
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
+  check.expect_eq_const(%0, dense<[[1, 1, 1],
+                                   [1, 1, 1],
+                                   [2, 3, 4],
+                                   [1, 1, 1],
+                                   [5, 6, 7],
+                                   [1, 1, 1]]> : tensor<6x3xi32>) : tensor<6x3xi32>
+  return
+}
+
+func @scatter_add_slice_2D_dynamic_num_updates() {
+  %arg0 = iree.unfoldable_constant dense<1> : tensor<6x3xi32>
+  %arg1 = iree.dynamic_shape_constant dense<[[2], [4]]> : tensor<2x1xi32> -> tensor<?x1xi32>
+  %arg2 = iree.dynamic_shape_constant dense<[[1, 2, 3],
+                                             [4, 5, 6]]> : tensor<2x3xi32> -> tensor<?x3xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    %1 = mhlo.add %arg3, %arg4 : tensor<i32>
+    "mhlo.return"(%1) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1 : i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<1> : tensor<1xi64>
+    },
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<?x1xi32>, tensor<?x3xi32>) -> tensor<6x3xi32>
+  check.expect_eq_const(%0, dense<[[1, 1, 1],
+                                   [1, 1, 1],
+                                   [2, 3, 4],
+                                   [1, 1, 1],
+                                   [5, 6, 7],
+                                   [1, 1, 1]]> : tensor<6x3xi32>) : tensor<6x3xi32>
   return
 }


### PR DESCRIPTION
This will make IREE use linalg_ext path instead of mhlo patterns. It
adds more end-to-end tests and also supports dynamic shapes.

Fixes https://github.com/google/iree/issues/6403