### PR TITLE
Switching iree_allocator_t to a single control function ptr.

### DIFF
--- a/bindings/python/iree/runtime/hal.cc
+++ b/bindings/python/iree/runtime/hal.cc
@@ -28,7 +28,7 @@ std::vector<std::string> HalDriver::Query() {
     driver_names[i] = std::string(driver_infos[i].driver_name.data,
                                   driver_infos[i].driver_name.size);
   }
-  iree_allocator_system_free(NULL, driver_infos);
+  iree_allocator_free(iree_allocator_system(), driver_infos);
   return driver_names;
 }
 

--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -127,20 +127,22 @@ VmModule VmModule::FromFlatbufferBlob(py::object flatbuffer_blob_object) {
 
   // Bridge to the C-based deallocator API.
   auto* raw_ptr = flatbuffer_blob.ptr();
-  auto free_fn = +([](void* self, void*) {
-    PyObject* self_ptr = static_cast<PyObject*>(self);
-    Py_XDECREF(self_ptr);
+  auto ctl_fn = +([](void* self, iree_allocator_command_t command,
+                     const void* params, void** inout_ptr) {
+    assert(command == IREE_ALLOCATOR_COMMAND_FREE);
+    PyObject* object_ptr = static_cast<PyObject*>(*inout_ptr);
+    Py_XDECREF(object_ptr);
+    return iree_ok_status();
   });
   flatbuffer_blob.inc_ref();
-  iree_allocator_t deallocator{raw_ptr /* self */, nullptr /* alloc */,
-                               free_fn /* dealloc */};
+  iree_allocator_t deallocator{/*self=*/NULL, /*ctl=*/ctl_fn};
 
   auto status = iree_vm_bytecode_module_create(
       {static_cast<const uint8_t*>(buffer_info.ptr),
        static_cast<iree_host_size_t>(buffer_info.size)},
       deallocator, iree_allocator_system(), &module);
   if (!iree_status_is_ok(status)) {
-    deallocator.free(raw_ptr, nullptr);
+    iree_allocator_free(deallocator, raw_ptr);
   }
 
   CheckApiStatus(status, "Error creating vm module from flatbuffer");

--- a/iree/base/internal/file_path_test.cc
+++ b/iree/base/internal/file_path_test.cc
@@ -62,7 +62,7 @@ static std::string JoinPaths(std::string lhs, std::string rhs) {
   std::string result;
   result.resize(strlen(result_str));
   memcpy((char*)result.data(), result_str, result.size());
-  iree_allocator_system_free(NULL, result_str);
+  iree_allocator_free(iree_allocator_system(), result_str);
   return result;
 }
 

--- a/iree/base/time.h
+++ b/iree/base/time.h
@@ -35,7 +35,7 @@ typedef int64_t iree_time_t;
 typedef int64_t iree_duration_t;
 
 // A zero-length duration.
-// Like IREE_TIME_INFINITE_FUTURE this forces APIs that would wait to instead
+// Like IREE_TIME_INFINITE_PAST this forces APIs that would wait to instead
 // return IREE_STATUS_DEADLINE_EXCEEDED immediately.
 #define IREE_DURATION_ZERO 0
 

--- a/iree/hal/testing/driver_registry.h
+++ b/iree/hal/testing/driver_registry.h
@@ -37,7 +37,7 @@ static std::vector<std::string> EnumerateAvailableDrivers() {
     driver_names[i] = std::string(driver_infos[i].driver_name.data,
                                   driver_infos[i].driver_name.size);
   }
-  iree_allocator_system_free(NULL, driver_infos);
+  iree_allocator_free(iree_allocator_system(), driver_infos);
   return driver_names;
 }
 

--- a/iree/tools/iree-run-mlir-main.cc
+++ b/iree/tools/iree-run-mlir-main.cc
@@ -159,16 +159,17 @@ Status GetTargetBackends(std::vector<std::string>* out_target_backends) {
   auto target_backends =
       mlir::iree_compiler::IREE::HAL::getTargetOptionsFromFlags().targets;
   if (target_backends.empty()) {
+    iree_allocator_t host_allocator = iree_allocator_system();
     iree_hal_driver_info_t* driver_infos = NULL;
     iree_host_size_t driver_info_count = 0;
     IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
-        iree_hal_driver_registry_default(), iree_allocator_system(),
-        &driver_infos, &driver_info_count));
+        iree_hal_driver_registry_default(), host_allocator, &driver_infos,
+        &driver_info_count));
     for (iree_host_size_t i = 0; i < driver_info_count; ++i) {
       target_backends.push_back(std::string(driver_infos[i].driver_name.data,
                                             driver_infos[i].driver_name.size));
     }
-    iree_allocator_system_free(NULL, driver_infos);
+    iree_allocator_free(host_allocator, driver_infos);
   }
   *out_target_backends = std::move(target_backends);
   return OkStatus();

--- a/iree/vm/buffer.c
+++ b/iree/vm/buffer.c
@@ -162,8 +162,8 @@ IREE_API_EXPORT iree_status_t iree_vm_buffer_clone(
   // over all of it.
   uint8_t* data_ptr = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, allocator.alloc(allocator.self, /*mode=*/0, total_size,
-                          (void**)&data_ptr));
+      z0, iree_allocator_malloc_uninitialized(allocator, total_size,
+                                              (void**)&data_ptr));
 
   // Initialize the prefix buffer handle.
   iree_vm_buffer_t* buffer = (iree_vm_buffer_t*)data_ptr;

--- a/iree/vm/buffer_test.cc
+++ b/iree/vm/buffer_test.cc
@@ -27,9 +27,14 @@ TEST_F(VMBufferTest, Initialize) {
   bool did_free = false;
   iree_allocator_t test_allocator = {
       /*.self=*/&did_free,
-      /*.alloc=*/NULL,
-      /*.free=*/
-      +[](void* self, void* ptr) { *(bool*)self = true; },
+      /*.ctl=*/
+      +[](void* self, iree_allocator_command_t command, const void* params,
+          void** inout_ptr) {
+        if (command == IREE_ALLOCATOR_COMMAND_FREE) {
+          *(bool*)self = true;
+        }
+        return iree_ok_status();
+      },
   };
 
   uint32_t data[] = {0, 1, 2, 3};

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -297,7 +297,7 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_query_module_state(
 // Fails if dynamic stack growth is disabled or the allocator is OOM.
 static iree_status_t iree_vm_stack_grow(iree_vm_stack_t* stack,
                                         iree_host_size_t minimum_capacity) {
-  if (stack->allocator.alloc == NULL) {
+  if (IREE_UNLIKELY(stack->allocator.ctl == NULL)) {
     return iree_make_status(
         IREE_STATUS_RESOURCE_EXHAUSTED,
         "stack initialized on the host stack and cannot grow");


### PR DESCRIPTION
This saves 4-8 bytes of stack/heap in any place an allocator is used.
The smaller size (`2*sizeof(void*)`) aids in triggering register-passed
struct arguments in certain calling conventions. Having a generic control
function will also allow us to add new commands in the future for
import/export, queries, etc.