### PR TITLE
[CUDA] Fix copy distribution for sizes not aligned on 4

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -54,6 +54,7 @@ cc_library(
         "@llvm-project//mlir:SCFToStandard",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
         "@llvm-project//mlir:VectorToLLVM",

--- a/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     MLIRStandard
     MLIRStandardOpsTransforms
     MLIRStandardToLLVM
+    MLIRSupport
     MLIRTransforms
     MLIRVector
     MLIRVectorToLLVM

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Support/MathExtras.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -175,7 +176,7 @@ static void populateTilingCopyToWorkgroupMemPatterns(
     for (int i = numDims - 1; i >= 0; i--) {
       std::array<int64_t, 3> &range = staticRanges[i];
       Value id = serializedId;
-      int64_t interval = (range[1] - range[0]) / range[2];
+      int64_t interval = ceilDiv(range[1] - range[0], range[2]);
       Value intervalValue = builder.create<ConstantIndexOp>(loc, interval);
       int64_t count = 0;
       if (numIds <= 1) {


### PR DESCRIPTION
The code generated will still be sub-optimal but this fix functionality.
Heuristics for this will come in future patches.