### PR TITLE
 Fix a couple of bugs in PadLinalgOps

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/test/pad_linalg_ops.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/pad_linalg_ops.mlir
@@ -33,3 +33,23 @@ func @matmul_f32_12x12x17(%lhs: tensor<12x17xf32>, %rhs: tensor<17x12xf32>, %ini
 //  CHECK-SAME:         ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<12x20xf32>, tensor<20x12xf32>)
 //  CHECK-SAME:         outs(%[[DST]] : tensor<12x12xf32>)
 //       CHECK:      return %[[RESULT]] : tensor<12x12xf32>
+
+
+// -----
+
+func @matmul_i8_i8_i32_2x2x4(%lhs: tensor<2x4xi8>, %rhs: tensor<4x2xi8>, %dst: tensor<2x2xi32>) -> tensor<2x2xi32> {
+    %result = linalg.matmul ins(%lhs, %rhs : tensor<2x4xi8>, tensor<4x2xi8>) outs(%dst: tensor<2x2xi32>) -> tensor<2x2xi32>
+    return %result : tensor<2x2xi32>
+}
+// CHECK-LABEL: @matmul_i8_i8_i32_2x2x4
+//  CHECK-SAME:   %[[LHS:.+]]: tensor<2x4xi8>
+//  CHECK-SAME:   %[[RHS:.+]]: tensor<4x2xi8>
+//  CHECK-SAME:   %[[DST:.+]]: tensor<2x2xi32>
+//   CHECK-DAG:      %[[PADDED_LHS:.+]] = linalg.pad_tensor %[[LHS]]
+//   CHECK-DAG:      %[[PADDED_RHS:.+]] = linalg.pad_tensor %[[RHS]]
+//   CHECK-DAG:      %[[PADDED_DST:.+]] = linalg.pad_tensor %[[DST]]
+//       CHECK:      %[[PADDED_RESULT:.+]] = linalg.matmul
+//  CHECK-SAME:         ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<4x4xi8>, tensor<4x4xi8>)
+//  CHECK-SAME:         outs(%[[PADDED_DST]] : tensor<4x4xi32>)
+//       CHECK:      %[[RESULT:.+]] = tensor.extract_slice %[[PADDED_RESULT]]
+//       CHECK:      return %[[RESULT]] : tensor<2x2xi32>


### PR DESCRIPTION
    - Use correct result element type and padding value type.
    - Allow padding of padded operands if the size isn't an integer
    multiple of the padding size.