### PR TITLE
Simplifying the hal.device.switch and match attribute infra.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/ConversionTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/ConversionTarget.cpp
@@ -40,7 +40,8 @@ HALConversionTarget::HALConversionTarget(MLIRContext *context,
   // There are a variety of patterns which convert std.dim and std.rank ops
   // to corresponding HAL ops. All should be eliminated.
   addIllegalOp<memref::DimOp>();
-  addIllegalOp<RankOp>();
+  addIllegalOp<mlir::RankOp>();
+  addIllegalOp<tensor::DimOp>();
 
   // Metadata ops are dynamically legal if their types are legal.
   addDynamicallyLegalOp<Shape::TieShapeOp>([&](Shape::TieShapeOp op) {

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -455,9 +455,7 @@ def HAL_DescriptorSetLayoutBindingArrayAttr : TypedArrayAttrBase<
     "HAL descriptor set layout binding array attribute">;
 
 def HAL_ExecutableTargetAttr :
-    AttrDef<HAL_Dialect, "ExecutableTarget", [
-      DeclareAttrInterfaceMethods<HAL_ExecutableTargetAttrInterface>,
-    ]> {
+    AttrDef<HAL_Dialect, "ExecutableTarget", []> {
   let mnemonic = "executable.target";
   let summary = [{Generic executable target specification.}];
   let description = [{
@@ -519,54 +517,153 @@ def HAL_ExResultBufferAttr :
 def HAL_DeviceQuery : NativeOpTrait<"IREE::HAL::DeviceQuery">;
 
 def HAL_MatchAlwaysAttr :
-  IREE_StructAttr<"match.always", "MatchAlwaysAttr", HAL_Dialect, []> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "MatchAlways", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "match.always";
+  let summary = [{always matches}];
+  let description = [{
+    Returns true (constant true).
+  }];
 }
 
 def HAL_MatchAnyAttr :
-  IREE_StructAttr<"match.any", "MatchAnyAttr", HAL_Dialect, [
-    IREE_StructFieldAttr<"conditions", AnyAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "MatchAny", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "match.any";
+  let summary = [{matches if any subexpression matches}];
+  let description = [{
+    Returns true if any subexpression matches (logical OR) and not empty.
+  }];
+  let parameters = (ins
+    AttrParameter<"ArrayAttr", "">:$conditions
+  );
+  let builders = [
+    AttrBuilder<(ins "ArrayRef<Attribute>":$conditions), [{
+      return $_get(context, ArrayAttr::get(context, conditions));
+    }]>,
+  ];
 }
 
 def HAL_MatchAllAttr :
-  IREE_StructAttr<"match.all", "MatchAllAttr", HAL_Dialect, [
-    IREE_StructFieldAttr<"conditions", AnyAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "MatchAll", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "match.all";
+  let summary = [{matches if all subexpressions match}];
+  let description = [{
+    Returns true only if all subexpressions return true (logical AND) or empty.
+  }];
+  let parameters = (ins
+    AttrParameter<"ArrayAttr", "">:$conditions
+  );
+  let builders = [
+    AttrBuilder<(ins "ArrayRef<Attribute>":$conditions), [{
+      return $_get(context, ArrayAttr::get(context, conditions));
+    }]>,
+  ];
 }
 
 def HAL_DeviceMatchIDAttr :
-  IREE_StructAttr<"device.match.id", "DeviceMatchIDAttr", HAL_Dialect, [
-    IREE_StructFieldAttr<"pattern", StrAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
-}
-
-def HAL_DeviceMatchMemoryModelAttr : IREE_StructAttr<
-    "device.match.memory_model", "DeviceMatchMemoryModelAttr", HAL_Dialect, [
-    IREE_StructFieldAttr<"memory_model", HAL_MemoryModelAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "DeviceMatchID", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "device.match.id";
+  let summary = [{matches against a device ID pattern}];
+  let description = [{
+    Matches a device by its canonical compiler/runtime ID.
+  }];
+  let parameters = (ins
+    AttrParameter<"StringAttr", "">:$pattern
+  );
+  let builders = [
+    AttrBuilder<(ins "StringRef":$pattern), [{
+      return $_get(context, StringAttr::get(context, pattern));
+    }]>,
+    AttrBuilderWithInferredContext<(ins "StringAttr":$pattern), [{
+      return $_get(pattern.getContext(), pattern);
+    }]>,
+  ];
 }
 
 def HAL_DeviceMatchFeatureAttr :
-  IREE_StructAttr<"device.match.feature",
-                  "DeviceMatchFeatureAttr",
-                  HAL_Dialect, [
-    IREE_StructFieldAttr<"pattern", StrAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "DeviceMatchFeature", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "device.match.feature";
+  let summary = [{matches against a supported device feature pattern}];
+  let description = [{
+    Matches a device that supports the given feature. The format of the feature
+    pattern is device-dependent.
+  }];
+  let parameters = (ins
+    AttrParameter<"StringAttr", "">:$pattern
+  );
+  let builders = [
+    AttrBuilder<(ins "StringRef":$pattern), [{
+      return $_get(context, StringAttr::get(context, pattern));
+    }]>,
+    AttrBuilderWithInferredContext<(ins "StringAttr":$pattern), [{
+      return $_get(pattern.getContext(), pattern);
+    }]>,
+  ];
 }
 
 def HAL_DeviceMatchArchitectureAttr :
-  IREE_StructAttr<"device.match.architecture",
-                  "DeviceMatchArchitectureAttr",
-                  HAL_Dialect, [
-    IREE_StructFieldAttr<"pattern", StrAttr>,
-  ]> {
-  let cppNamespace = "mlir::iree_compiler::IREE::HAL";
+    AttrDef<HAL_Dialect, "DeviceMatchArchitecture", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "device.match.architecture";
+  let summary = [{matches against a device architecture pattern}];
+  let description = [{
+    Matches a device by its runtime architecture. The format of the architecture
+    pattern is device-dependent.
+  }];
+  let parameters = (ins
+    AttrParameter<"StringAttr", "">:$pattern
+  );
+  let builders = [
+    AttrBuilder<(ins "StringRef":$pattern), [{
+      return $_get(context, StringAttr::get(context, pattern));
+    }]>,
+    AttrBuilderWithInferredContext<(ins "StringAttr":$pattern), [{
+      return $_get(pattern.getContext(), pattern);
+    }]>,
+  ];
+}
+
+def HAL_DeviceMatchExecutableFormatAttr :
+    AttrDef<HAL_Dialect, "DeviceMatchExecutableFormat", [
+      DeclareAttrInterfaceMethods<HAL_MatchAttrInterface>,
+    ]> {
+  let mnemonic = "device.match.executable.format";
+  let summary = [{matches when a device supports the given executable format}];
+  let description = [{
+    Matches a device only if it claims to support the given executable format
+    pattern. It's still possible that the executable cannot be loaded such as if
+    it uses unavailable device features. This is used for queries such as
+    "can you load ELF libraries?" to quickly get to a set of executables to
+    attempt without needing to try dozens that definitely cannot be loaded.
+
+    Note that different devices may share the same executable formats: for
+    example a local synchronous CPU executor and a remote asynchronous CPU
+    executor can both load ELF libraries. It's also possible for the same device
+    to support multiple formats such as being able to load both
+    platform-agnostic ELF libraries and platform-specific DLL/MachO/etc
+    libraries.
+  }];
+  let parameters = (ins
+    AttrParameter<"StringAttr", "">:$pattern
+  );
+  let builders = [
+    AttrBuilder<(ins "StringRef":$pattern), [{
+      return $_get(context, StringAttr::get(context, pattern));
+    }]>,
+    AttrBuilderWithInferredContext<(ins "StringAttr":$pattern), [{
+      return $_get(pattern.getContext(), pattern);
+    }]>,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/IR/HALInterfaces.td
+++ b/iree/compiler/Dialect/HAL/IR/HALInterfaces.td
@@ -71,19 +71,23 @@ def HAL_SizeAwareOp : OpInterface<"SizeAwareOpInterface"> {
   ];
 }
 
-def HAL_ExecutableTargetAttrInterface :
-    AttrInterface<"ExecutableTargetAttrInterface"> {
+def HAL_MatchAttrInterface :
+    AttrInterface<"MatchAttrInterface"> {
   let description = [{
-    An attribute that specifies a compilation target for device executables.
-    Attributes conforming to this interface are queried throughout the HAL
-    transformation pipeline for their target capabilities and to provide
-    translation, linking, and serialization pipelines.
+    An attribute that can be used in `hal.*.match.*` expressions.
+    Each attribute defines some subexpression that can be expanded to one or
+    more operations that performs the actual query and matching logic.
   }];
 
   let methods = [
     InterfaceMethod<
-      [{TODO}],
-      "bool", "someMethod", (ins "unsigned":$idx)
+      [{
+        Builds a set of operations that evaluate to a boolean (i1) value
+        indicating whether the expression tree represented by the match
+        attribute is true for the given value.
+      }],
+      "Value", "buildConditionExpression",
+      (ins "Location":$loc, "Value":$value, "OpBuilder":$builder)
     >,
   ];
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1769,7 +1769,10 @@ def HAL_DeviceAllocatorOp : HAL_PureOp<"device.allocator", [
   ];
 }
 
-def HAL_DeviceSwitchOp : HAL_Op<"device.switch", [IsolatedFromAbove]> {
+def HAL_DeviceSwitchOp : HAL_Op<"device.switch", [
+    NoRegionArguments,
+    RecursiveSideEffects,
+  ]> {
   let summary = [{runtime device switch pseudo op}];
   let description = [{
     Switches between multiple regions based on the runtime device type.
@@ -1824,8 +1827,7 @@ def HAL_DeviceSwitchOp : HAL_Op<"device.switch", [IsolatedFromAbove]> {
 
   let arguments = (ins
     HAL_Device:$device,
-    ArrayAttr:$conditions,
-    Variadic<AnyType>:$args
+    ArrayAttr:$conditions
   );
   let results = (outs
     Variadic<AnyType>:$results
@@ -1839,15 +1841,9 @@ def HAL_DeviceSwitchOp : HAL_Op<"device.switch", [IsolatedFromAbove]> {
       "TypeRange":$resultTypes,
       "Value":$device,
       "ArrayRef<Attribute>":$conditions,
-      "ArrayRef<SmallVector<Value, 4>>":$conditionArgs,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes
     )>,
   ];
-
-  let extraClassDeclaration = [{
-    /// Returns the index of the args() operand in the Operation operands list.
-    unsigned mapArgOperandToOpOperand(unsigned i) { return i + 1; }
-  }];
 
 
   let verifier = [{ return verifyDeviceSwitchOp(*this); }];
@@ -1873,130 +1869,6 @@ def HAL_ReturnOp : HAL_Op<"return", [Terminator]> {
       build($_builder, $_state, llvm::None);
     }]>,
   ];
-}
-
-def HAL_DeviceMatchIDOp :
-    HAL_PureOp<"device.match.id", [HAL_DeviceQuery]> {
-  let summary = [{returns true if the device ID matches the pattern}];
-  let description = [{
-    Pattern matches the device ID with the given wildcard pattern.
-    This can be used to conditionally evaluate device-specific code when the
-    device is not known at compile-time.
-
-    ```mlir
-    %is_match = hal.device.match.id<%device : !hal.device>
-                            pattern("vulkan-*") : i1
-    ```
-  }];
-
-  let arguments = (ins
-    HAL_Device:$device,
-    StrAttr:$pattern
-  );
-  let results = (outs
-    I1:$result
-  );
-
-  let assemblyFormat = [{
-    `<` $device `:` type($device) `>`
-    `pattern` `(` $pattern `)`
-    `:` type($result)
-    attr-dict-with-keyword
-  }];
-}
-
-def HAL_DeviceMatchMemoryModelOp :
-    HAL_PureOp<"device.match.memory_model", [HAL_DeviceQuery]> {
-  let summary = [{returns true if the device memory model matches the value}];
-  let description = [{
-    Compares the device's memory model against the specified model.
-    This can be used to conditionally evaluate device-specific code when the
-    device is not known at compile-time.
-
-    ```mlir
-    %is_match = hal.device.match.memory_model<%device : !hal.device>
-                                        value("Unified") : i1
-    ```
-  }];
-
-  let arguments = (ins
-    HAL_Device:$device,
-    HAL_MemoryModelAttr:$model
-  );
-  let results = (outs
-    I1:$result
-  );
-
-  let assemblyFormat = [{
-    `<` $device `:` type($device) `>`
-    `value` `(` $model `)`
-    `:` type($result)
-    attr-dict-with-keyword
-  }];
-}
-
-def HAL_DeviceMatchFeatureOp :
-    HAL_PureOp<"device.match.feature", [HAL_DeviceQuery]> {
-  let summary = [{returns true if the device supports the provided feature}];
-  let description = [{
-    Matches a feature pattern against the given device, returning true if the
-    feature is reported as supported. This can be used to conditionally evaluate
-    device-specific code when the device is not known at compile-time.
-
-    The feature patterns supported are device backend dependent.
-
-    ```mlir
-    %is_match = hal.device.match.feature<%device : !hal.device>
-                                 pattern("some-feature-v*") : i1
-    ```
-  }];
-
-  let arguments = (ins
-    HAL_Device:$device,
-    StrAttr:$pattern
-  );
-  let results = (outs
-    I1:$result
-  );
-
-  let assemblyFormat = [{
-    `<` $device `:` type($device) `>`
-    `pattern` `(` $pattern `)`
-    `:` type($result)
-    attr-dict-with-keyword
-  }];
-}
-
-def HAL_DeviceMatchArchitectureOp :
-    HAL_PureOp<"device.match.architecture", [HAL_DeviceQuery]> {
-  let summary = [{returns true if the device matches the given architecture}];
-  let description = [{
-    Matches an architecture pattern against the given device, returning true if
-    the architecture is compatible. This can be used to conditionally evaluate
-    device-specific code when the device is not known at compile-time.
-
-    The architecture patterns supported are device backend dependent.
-
-    ```mlir
-    %is_match = hal.device.match.architecture<%device : !hal.device>
-                                      pattern("aarch64-*") : i1
-    ```
-  }];
-
-  let arguments = (ins
-    HAL_Device:$device,
-    StrAttr:$pattern
-  );
-  let results = (outs
-    I1:$result
-  );
-
-  let assemblyFormat = [{
-    `<` $device `:` type($device) `>`
-    `pattern` `(` $pattern `)`
-    `:` type($result)
-    attr-dict-with-keyword
-  }];
 }
 
 def HAL_DeviceQueryOp :

--- a/iree/compiler/Dialect/HAL/IR/HALTypes.h
+++ b/iree/compiler/Dialect/HAL/IR/HALTypes.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/TypeSupport.h"

--- a/iree/compiler/Dialect/HAL/IR/test/device_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/device_ops.mlir
@@ -21,35 +21,25 @@ func @device_switch(%device: !hal.device) -> i32 {
   %c2 = constant 2 : i32
   // CHECK: = hal.device.switch<%[[DEVICE]] : !hal.device> -> i32
   %0 = hal.device.switch<%device : !hal.device> -> i32
-    // CHECK-NEXT: #hal.device.match.id<"vulkan-v1.?-*">(%[[C1A:.+]] = %[[C1]] : i32) {
-    #hal.device.match.id<"vulkan-v1.?-*">(%c1a = %c1 : i32) {
-      // CHECK-NEXT: hal.return %[[C1A]] : i32
-      hal.return %c1a : i32
+    // CHECK-NEXT: #hal.device.match.id<"vulkan-v1.?-*"> {
+    #hal.device.match.id<"vulkan-v1.?-*"> {
+      // CHECK-NEXT: hal.return %[[C1]] : i32
+      hal.return %c1 : i32
       // CHECK-NEXT: },
     },
-    // CHECK-NEXT: #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]>(%[[C2A:.+]] = %[[C2]] : i32) {
-    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]>(%c2a = %c2 : i32) {
-      // CHECK-NEXT: hal.return %[[C2A]] : i32
-      hal.return %c2a : i32
+    // CHECK-NEXT: #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]> {
+    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]> {
+      // CHECK-NEXT: hal.return %[[C2]] : i32
+      hal.return %c2 : i32
       // CHECK-NEXT: },
     },
-    // CHECK-NEXT: #hal.match.always(%[[C0A:.+]] = %[[C0]] : i32) {
-    #hal.match.always(%c0a = %c0 : i32) {
-      // CHECK-NEXT: hal.return %[[C0A]] : i32
-      hal.return %c0a : i32
+    // CHECK-NEXT: #hal.match.always {
+    #hal.match.always {
+      // CHECK-NEXT: hal.return %[[C0]] : i32
+      hal.return %c0 : i32
       // CHECK-NEXT: }
     }
   return %0 : i32
-}
-
-// -----
-
-// CHECK-LABEL: @device_matchers
-// CHECK-SAME: (%[[DEVICE:.+]]: !hal.device)
-func @device_matchers(%device : !hal.device) -> i1 {
-  // CHECK: = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vulkan-*") : i1
-  %0 = hal.device.match.id<%device : !hal.device> pattern("vulkan-*") : i1
-  return %0 : i1
 }
 
 // -----

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -163,16 +163,16 @@ module {
     %device = hal.ex.shared_device : !hal.device
     %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot") categories("Transfer|Dispatch") : !hal.command_buffer
     hal.device.switch<%device : !hal.device>
-    #hal.device.match.id<"vmvx">(%arg1 = %cmd : !hal.command_buffer) {
+    #hal.device.match.id<"vmvx"> {
       %c1 = constant 1 : index
-      hal.command_buffer.dispatch.symbol<%arg1 : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
-      hal.command_buffer.dispatch.symbol<%arg1 : !hal.command_buffer> target(@dispatch_1::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
+      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
+      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
       hal.return
     },
-    #hal.device.match.id<"othertarget">(%arg1 = %cmd : !hal.command_buffer) {
+    #hal.device.match.id<"othertarget"> {
       %c1 = constant 1 : index
-      hal.command_buffer.dispatch.symbol<%arg1 : !hal.command_buffer> target(@dispatch_0::@otherdispatch::@dispatch_0) workgroups([%c1, %c1, %c1])
-      hal.command_buffer.dispatch.symbol<%arg1 : !hal.command_buffer> target(@dispatch_1::@otherdispatch::@dispatch_1) workgroups([%c1, %c1, %c1])
+      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@otherdispatch::@dispatch_0) workgroups([%c1, %c1, %c1])
+      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@otherdispatch::@dispatch_1) workgroups([%c1, %c1, %c1])
       hal.return
     }
     return
@@ -218,16 +218,16 @@ module {
 //
 // CHECK:       func @main() {
 // CHECK:         hal.device.switch<%device : !hal.device>
-// CHECK-NEXT:    #hal.device.match.id<"vmvx">(%arg0 = %cmd : !hal.command_buffer) {
+// CHECK-NEXT:    #hal.device.match.id<"vmvx"> {
 // CHECK-NEXT:      %c1 = constant 1 : index
-// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%arg0 : !hal.command_buffer> target(@vmvx_linked::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%arg0 : !hal.command_buffer> target(@vmvx_linked::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@vmvx_linked::@vmvx::@dispatch_0) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@vmvx_linked::@vmvx::@dispatch_1) workgroups([%c1, %c1, %c1])
 // CHECK-NEXT:      hal.return
 // CHECK-NEXT:    },
-// CHECK-NEXT:    #hal.device.match.id<"othertarget">(%arg0 = %cmd : !hal.command_buffer) {
+// CHECK-NEXT:    #hal.device.match.id<"othertarget"> {
 // CHECK-NEXT:      %c1 = constant 1 : index
-// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%arg0 : !hal.command_buffer> target(@dispatch_0::@otherdispatch::@dispatch_0) workgroups([%c1, %c1, %c1])
-// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%arg0 : !hal.command_buffer> target(@dispatch_1::@otherdispatch::@dispatch_1) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_0::@otherdispatch::@dispatch_0) workgroups([%c1, %c1, %c1])
+// CHECK-NEXT:      hal.command_buffer.dispatch.symbol<%cmd : !hal.command_buffer> target(@dispatch_1::@otherdispatch::@dispatch_1) workgroups([%c1, %c1, %c1])
 // CHECK-NEXT:      hal.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return

--- a/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
@@ -24,92 +24,14 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
-// Given a #hal.match.* expression tree returns a boolean value indicating
-// whether the expression evaluates to true.
-static Value buildConditionExpression(Location loc, Value device,
-                                      Attribute conditionAttr,
-                                      OpBuilder funcBuilder) {
-  if (auto matchAttr = conditionAttr.dyn_cast<IREE::HAL::MatchAlwaysAttr>()) {
-    // #hal.match.always -> true
-    return funcBuilder.createOrFold<ConstantIntOp>(loc, 1, 1);
-  } else if (auto matchAttr =
-                 conditionAttr.dyn_cast<IREE::HAL::MatchAnyAttr>()) {
-    // #hal.match.any<[a, b, c]> -> or(or(a, b), c)
-    auto conditionAttrs = matchAttr.conditions().cast<ArrayAttr>();
-    auto conditionValues =
-        llvm::to_vector<4>(llvm::map_range(conditionAttrs, [&](Attribute attr) {
-          return buildConditionExpression(loc, device, attr, funcBuilder);
-        }));
-    Value resultValue = conditionValues[0];
-    for (int i = 1; i < conditionValues.size(); ++i) {
-      resultValue =
-          funcBuilder.createOrFold<OrOp>(loc, resultValue, conditionValues[i]);
-    }
-    return resultValue;
-  } else if (auto matchAttr =
-                 conditionAttr.dyn_cast<IREE::HAL::MatchAllAttr>()) {
-    // #hal.match.all<[a, b, c]> -> and(and(a, b), c)
-    auto conditionAttrs = matchAttr.conditions().cast<ArrayAttr>();
-    auto conditionValues =
-        llvm::to_vector<4>(llvm::map_range(conditionAttrs, [&](Attribute attr) {
-          return buildConditionExpression(loc, device, attr, funcBuilder);
-        }));
-    Value resultValue = conditionValues[0];
-    for (int i = 1; i < conditionValues.size(); ++i) {
-      resultValue =
-          funcBuilder.createOrFold<AndOp>(loc, resultValue, conditionValues[i]);
-    }
-    return resultValue;
-  } else if (auto matchAttr =
-                 conditionAttr.dyn_cast<IREE::HAL::DeviceMatchIDAttr>()) {
-    // #hal.device.match.id<"pattern"> -> hal.device.match.id
-    return funcBuilder.createOrFold<IREE::HAL::DeviceMatchIDOp>(
-        loc, funcBuilder.getI1Type(), device, matchAttr.patternAttr());
-  } else if (auto matchAttr =
-                 conditionAttr
-                     .dyn_cast<IREE::HAL::DeviceMatchMemoryModelAttr>()) {
-    // #hal.device.match.memory_model<"Unified"> ->
-    //     hal.device.match.memory_model
-    return funcBuilder.createOrFold<IREE::HAL::DeviceMatchMemoryModelOp>(
-        loc, funcBuilder.getI1Type(), device, matchAttr.memory_modelAttr());
-  } else if (auto matchAttr =
-                 conditionAttr.dyn_cast<IREE::HAL::DeviceMatchFeatureAttr>()) {
-    // #hal.device.match.feature<"pattern"> ->
-    //     hal.device.match.feature
-    return funcBuilder.createOrFold<IREE::HAL::DeviceMatchFeatureOp>(
-        loc, funcBuilder.getI1Type(), device, matchAttr.patternAttr());
-  } else if (auto matchAttr =
-                 conditionAttr
-                     .dyn_cast<IREE::HAL::DeviceMatchArchitectureAttr>()) {
-    // #hal.device.match.architecture<"pattern"> ->
-    //     hal.device.match.architecture
-    return funcBuilder.createOrFold<IREE::HAL::DeviceMatchArchitectureOp>(
-        loc, funcBuilder.getI1Type(), device, matchAttr.patternAttr());
-  }
-  llvm_unreachable("unhandled condition expression attribute");
-  return {};
-}
-
 // Inlines a condition region from a switch op into the function at the given
 // point. This assumes that the insertion point will only be reached if the
 // condition the region is predicated on is true.
-static void inlineConditionRegion(OperandRange regionArgs,
-                                  Region &conditionRegion, Block *exitBlock,
+static void inlineConditionRegion(Region &conditionRegion, Block *exitBlock,
                                   OpBuilder funcBuilder) {
   assert(!conditionRegion.empty() && "source regions must not be empty");
-
-  // Remap arguments from the function values captured by the switch into the
-  // entry block arguments for the region.
   auto &entryBlock = conditionRegion.front();
-  assert(regionArgs.size() == entryBlock.getNumArguments() &&
-         "switch capture args must match region args");
-  for (auto argPair : llvm::zip(regionArgs, entryBlock.getArguments())) {
-    auto outerValue = std::get<0>(argPair);
-    auto innerValue = std::get<1>(argPair);
-    assert(outerValue.getType() == innerValue.getType() &&
-           "capture arg types must match");
-    innerValue.replaceAllUsesWith(outerValue);
-  }
+  assert(entryBlock.getNumArguments() == 0 && "switch does not capture");
 
   // Splice in the region blocks.
   auto *insertBlock = funcBuilder.getBlock();
@@ -172,23 +94,17 @@ static void buildConditionDispatchTable(IREE::HAL::DeviceSwitchOp switchOp,
   }
 
   funcBuilder.setInsertionPoint(beforeBlock, beforeBlock->end());
-  int argOffset = 0;
   for (auto condition : llvm::enumerate(llvm::zip(
            switchOp.conditions().getValue(), switchOp.condition_regions()))) {
-    auto conditionAttr = std::get<0>(condition.value());
+    auto conditionAttr =
+        std::get<0>(condition.value()).cast<IREE::HAL::MatchAttrInterface>();
     auto &conditionRegion = std::get<1>(condition.value());
-
-    // Get the arguments from the switch that we want to carry along in the
-    // block arguments.
-    auto regionOperands = conditionRegion.getArguments();
-    auto regionArgs = switchOp.args().slice(argOffset, regionOperands.size());
-    argOffset += regionOperands.size();
 
     // Insert the branch based on the match. We either match and jump to a
     // block that will contain the inlined region or don't match and need to
     // fall through.
-    auto isMatch = buildConditionExpression(
-        switchOp.getLoc(), switchOp.device(), conditionAttr, funcBuilder);
+    auto isMatch = conditionAttr.buildConditionExpression(
+        switchOp.getLoc(), switchOp.device(), funcBuilder);
     auto *matchBlock = conditionMatchBlocks[condition.index()];
     auto *fallthroughBlock = conditionFallthroughBlocks[condition.index()];
     funcBuilder.create<CondBranchOp>(switchOp.getLoc(), isMatch, matchBlock,
@@ -196,7 +112,7 @@ static void buildConditionDispatchTable(IREE::HAL::DeviceSwitchOp switchOp,
 
     // Block that contains the inlined region and then jumps out of the chain.
     funcBuilder.setInsertionPointToStart(matchBlock);
-    inlineConditionRegion(regionArgs, conditionRegion, afterBlock, funcBuilder);
+    inlineConditionRegion(conditionRegion, afterBlock, funcBuilder);
 
     // Block that we enter to check the next condition.
     funcBuilder.setInsertionPointToStart(fallthroughBlock);

--- a/iree/compiler/Dialect/HAL/Transforms/test/inline_device_switches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/inline_device_switches.mlir
@@ -13,21 +13,21 @@ func @simple_constants(%device : !hal.device, %arg : i32) -> i32 {
   // CHECK-DAG: %[[C3:.+]] = constant 3
   // CHECK-DAG: %[[C4:.+]] = constant 4
   %0 = hal.device.switch<%device : !hal.device> -> i32
-    // CHECK-NEXT: %[[IS0:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vulkan-v1.?-*") : i1
+    // CHECK-NEXT: %{{.+}}, %[[IS0:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vulkan-v1.?-*") : i1, i1 = false
     // CHECK-NEXT: cond_br %[[IS0]], ^bb3(%[[C1]] : i32), ^bb1
-    #hal.device.match.id<"vulkan-v1.?-*">(%c1a = %c1 : i32) {
-      hal.return %c1a : i32
+    #hal.device.match.id<"vulkan-v1.?-*"> {
+      hal.return %c1 : i32
     },
     // CHECK-NEXT: ^bb1:
-    // CHECK-NEXT:  %[[IS1L:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vmvx") : i1
-    // CHECK-NEXT:  %[[IS1R:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vulkan-*") : i1
+    // CHECK-NEXT:  %{{.+}}, %[[IS1L:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vmvx") : i1, i1 = false
+    // CHECK-NEXT:  %{{.+}}, %[[IS1R:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vulkan-*") : i1, i1 = false
     // CHECK-NEXT:  %[[IS1:.+]] = or %[[IS1L]], %[[IS1R]] : i1
     // CHECK-NEXT:  cond_br %[[IS1]], ^bb2, ^bb3(%[[C0]] : i32)
     // CHECK-NEXT: ^bb2:
     // CHECK-NEXT:  %[[EQZ:.+]] = cmpi eq, %[[ARG]], %[[C2]] : i32
     // CHECK-NEXT:  cond_br %[[EQZ]], ^bb3(%[[C3]] : i32), ^bb3(%[[C4]] : i32)
-    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]>(%arga = %arg : i32, %c2a = %c2 : i32) {
-      %eqz = cmpi eq, %arga, %c2a : i32
+    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]> {
+      %eqz = cmpi eq, %arg, %c2 : i32
       cond_br %eqz, ^bb_true, ^bb_false
     ^bb_true:
       %c3 = constant 3 : i32
@@ -36,8 +36,8 @@ func @simple_constants(%device : !hal.device, %arg : i32) -> i32 {
       %c4 = constant 4 : i32
       hal.return %c4 : i32
     },
-    #hal.match.always(%c0b = %c0 : i32) {
-      hal.return %c0b : i32
+    #hal.match.always {
+      hal.return %c0 : i32
     }
   // CHECK-NEXT: ^bb3(%[[RES:.+]]: i32):
   // CHECK-NEXT: return %[[RES]] : i32
@@ -50,31 +50,31 @@ func @simple_constants(%device : !hal.device, %arg : i32) -> i32 {
 // CHECK-SAME: %[[DEVICE:.+]]: !hal.device
 func @no_results(%device : !hal.device) {
   hal.device.switch<%device : !hal.device>
-    // CHECK-NEXT: %[[IS0:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vulkan-v1.?-*") : i1
-    // CHECK-NEXT: cond_br %[[IS0]], ^bb1, ^bb2
+    // CHECK-NEXT:  %{{.+}}, %[[IS0:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vulkan-v1.?-*") : i1, i1 = false
+    // CHECK-NEXT:  cond_br %[[IS0]], ^bb1, ^bb2
     // CHECK-NEXT: ^bb1:
     // CHECK-NEXT:  "some.op_a"()
     // CHECK-NEXT:  br ^bb5
-    #hal.device.match.id<"vulkan-v1.?-*">() {
+    #hal.device.match.id<"vulkan-v1.?-*"> {
       "some.op_a"() : () -> ()
       hal.return
     },
     // CHECK-NEXT: ^bb2:
-    // CHECK-NEXT:  %[[IS1L:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vmvx") : i1
-    // CHECK-NEXT:  %[[IS1R:.+]] = hal.device.match.id<%[[DEVICE]] : !hal.device> pattern("vulkan-*") : i1
+    // CHECK-NEXT:  %{{.+}}, %[[IS1L:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vmvx") : i1, i1 = false
+    // CHECK-NEXT:  %{{.+}}, %[[IS1R:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "vulkan-*") : i1, i1 = false
     // CHECK-NEXT:  %[[IS1:.+]] = or %[[IS1L]], %[[IS1R]] : i1
     // CHECK-NEXT:  cond_br %[[IS1]], ^bb3, ^bb4
     // CHECK-NEXT: ^bb3:
     // CHECK-NEXT:  "some.op_b"()
     // CHECK-NEXT:  br ^bb5
-    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]>() {
+    #hal.match.any<[#hal.device.match.id<"vmvx">, #hal.device.match.id<"vulkan-*">]> {
       "some.op_b"() : () -> ()
       hal.return
     },
     // CHECK-NEXT: ^bb4:
     // CHECK-NEXT:  "some.op_c"()
     // CHECK-NEXT:  br ^bb5
-    #hal.match.always() {
+    #hal.match.always {
       "some.op_c"() : () -> ()
       hal.return
     }

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -143,9 +143,9 @@ hal.executable @exe {
 
 // CHECK: hal.variable @_executable_exe init(@_executable_exe_initializer) : !hal.executable
 // CHECK: func private @_executable_exe_initializer() -> !hal.executable {
-// CHECK:   %[[IN_DEV:.+]] = hal.ex.shared_device : !hal.device
-// CHECK:   %[[RET:.+]] = hal.device.switch<%[[IN_DEV]] : !hal.device> -> !hal.executable
-// CHECK:   #hal.device.match.id<"vmvx">(%[[DEV:.+]] = %[[IN_DEV]] : !hal.device) {
+// CHECK:   %[[DEV:.+]] = hal.ex.shared_device : !hal.device
+// CHECK:   %[[RET:.+]] = hal.device.switch<%[[DEV]] : !hal.device> -> !hal.executable
+// CHECK:   #hal.device.match.id<"vmvx"> {
 // CHECK:     %[[LAYOUT0:.+]] = hal.variable.load @_executable_layout_0 : !hal.executable_layout
 // CHECK:     %[[LAYOUT0_2:.+]] = hal.variable.load @_executable_layout_0 : !hal.executable_layout
 // CHECK:     %[[LAYOUT1:.+]] = hal.variable.load @_executable_layout_1 : !hal.executable_layout
@@ -156,7 +156,7 @@ hal.executable @exe {
 // CHECK-SAME:  : !hal.executable
 // CHECK:     hal.return %[[EXE]] : !hal.executable
 // CHECK:   },
-// CHECK:   #hal.match.always() {
+// CHECK:   #hal.match.always {
 // CHECK:     %[[NULL:.+]] = iree.null : !hal.executable
 // CHECK:     hal.return %[[NULL]] : !hal.executable
 // CHECK:   }

--- a/iree/compiler/Dialect/HAL/Transforms/test/memoize_device_queries.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/memoize_device_queries.mlir
@@ -3,20 +3,24 @@
 //      CHECK: hal.variable @_device_query_0 init(@_device_query_0_initializer) : i1
 //      CHECK: func private @_device_query_0_initializer() -> i1
 // CHECK-NEXT:   %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
-// CHECK-NEXT:   %[[OK:.+]], %[[VALUE:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "id0*") : i1, i1 = false
-// CHECK-NEXT:   return %[[VALUE]] : i1
+// CHECK-NEXT:   %[[OK0:.+]], %[[VALUE0:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "id0*") : i1, i1 = false
+// CHECK-NEXT:   return %[[VALUE0]] : i1
 
-// CHECK: hal.variable @_device_query_1
+//      CHECK: hal.variable @_device_query_1 init(@_device_query_1_initializer) : i1
+//      CHECK: func private @_device_query_1_initializer() -> i1
+// CHECK-NEXT:   %[[DEVICE:.+]] = hal.ex.shared_device : !hal.device
+// CHECK-NEXT:   %[[OK1:.+]], %[[VALUE1:.+]] = hal.device.query<%[[DEVICE]] : !hal.device> key("hal.device.id" :: "id1") : i1, i1 = false
+// CHECK-NEXT:   return %[[VALUE1]] : i1
+
 // CHECK: hal.variable @_device_query_2
-// CHECK: hal.variable @_device_query_3
 
 // CHECK-LABEL: func @device_matchers
-func @device_matchers(%device : !hal.device) -> (i1, i1, i1, i1, i1, i1) {
+func @device_matchers(%device : !hal.device) -> (i1, i1, i1, i1) {
   // Same queries (same variables):
   // CHECK-NEXT: = hal.variable.load @_device_query_0 : i1
-  %id0_a = hal.device.match.id<%device : !hal.device> pattern("id0*") : i1
+  %id0_a_ok, %id0_a = hal.device.query<%device : !hal.device> key("hal.device.id" :: "id0*") : i1, i1 = false
   // CHECK-NEXT: = hal.variable.load @_device_query_0 : i1
-  %id0_b = hal.device.match.id<%device : !hal.device> pattern("id0*") : i1
+  %id0_b_ok, %id0_b = hal.device.query<%device : !hal.device> key("hal.device.id" :: "id0*") : i1, i1 = false
 
   // Same query but with different defaults (different variables):
   // CHECK-NEXT: = hal.variable.load @_device_query_1 : i1
@@ -24,11 +28,5 @@ func @device_matchers(%device : !hal.device) -> (i1, i1, i1, i1, i1, i1) {
   // CHECK-NEXT: = hal.variable.load @_device_query_2 : i1
   %id1_b_ok, %id1_b = hal.device.query<%device : !hal.device> key("hal.device.id" :: "id1") : i1, i1 = true
 
-  // Same query via both unexpanded and expanded forms (same variables):
-  // CHECK-NEXT: = hal.variable.load @_device_query_3 : i1
-  %id2_a = hal.device.match.id<%device : !hal.device> pattern("id2*") : i1
-  // CHECK-NEXT: = hal.variable.load @_device_query_3 : i1
-  %id2_ok, %id2_b = hal.device.query<%device : !hal.device> key("hal.device.id" :: "id2*") : i1, i1 = false
-
-  return %id0_a, %id0_b, %id1_a, %id1_b, %id2_a, %id2_b : i1, i1, i1, i1, i1, i1
+  return %id0_a, %id0_b, %id1_a, %id1_b : i1, i1, i1, i1
 }


### PR DESCRIPTION
This makes each switch case implicitly capture dominating values and
switches to tablegen-defined match attributes and an attribute interface.
This removes the boilerplate that was associated with queries as now adding
a query is just adding an attribute.

Progress on #6452.