### PR TITLE
Interchange linalg generic op to move reduction loops to inner loops

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "FusionOfTensorOps.cpp",
         "HoistUnstreamableOps.cpp",
         "InjectDispatchTracing.cpp",
+        "InterchangeGenericOp.cpp",
         "OutlineDispatchRegions.cpp",
         "OutlineLargeConstants.cpp",
         "PadLinalgOps.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "FusionOfTensorOps.cpp"
     "HoistUnstreamableOps.cpp"
     "InjectDispatchTracing.cpp"
+    "InterchangeGenericOp.cpp"
     "OutlineDispatchRegions.cpp"
     "OutlineLargeConstants.cpp"
     "PadLinalgOps.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/InterchangeGenericOp.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/InterchangeGenericOp.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===--------------- InterchangeGenericOp.cpp -----------------------------===//
+//
+// Interchange loops in generic ops to force the reduction loops to be the most
+// inner loops.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+
+struct GenericOpInterchangePattern
+    : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<unsigned> interchange;
+    bool needInterchange = false;
+    unsigned numParallelLoop = genericOp.getNumParallelLoops();
+    if (numParallelLoop == 0) return failure();
+    for (auto iter : llvm::enumerate(genericOp.iterator_types())) {
+      if (isParallelIterator(iter.value())) {
+        interchange.push_back(iter.index());
+        if (iter.index() >= numParallelLoop) needInterchange = true;
+      }
+    }
+    // If all the parallel loops are outter loops skip the pattern.
+    if (!needInterchange) return failure();
+    for (auto iter : llvm::enumerate(genericOp.iterator_types())) {
+      if (isReductionIterator(iter.value()))
+        interchange.push_back(iter.index());
+    }
+    rewriter.updateRootInPlace(genericOp, [&]() {
+      interchangeGenericOp(rewriter, genericOp, interchange);
+    });
+    return success();
+  }
+};
+
+struct InterchangeGenericOpsPass
+    : public InterchangeGenericBase<InterchangeGenericOpsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+
+  void runOnOperation() override {
+    OwningRewritePatternList patterns(&getContext());
+    patterns.add<GenericOpInterchangePattern>(&getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createInterchangeLinalgGenericPass() {
+  return std::make_unique<InterchangeGenericOpsPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -105,6 +105,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(
       mlir::createConvertElementwiseToLinalgPass());
   passManager.addNestedPass<FuncOp>(mlir::createLinalgFoldUnitExtentDimsPass());
+  passManager.addNestedPass<FuncOp>(createInterchangeLinalgGenericPass());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());
   passManager.addNestedPass<FuncOp>(

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -57,6 +57,10 @@ std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
 /// Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();
 
+/// Create a pass to interchange generic ops to force the reduction loop to be
+/// the most inner loops.
+std::unique_ptr<OperationPass<FuncOp>> createInterchangeLinalgGenericPass();
+
 // Convert operations to equivalent flow.tensor.* ops. This is run after
 // dispatch region creation to catch operations that were left outside of
 // dispatch regions and could be represented as flow.tensor.* ops.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -120,7 +120,7 @@ def StripAndSplatConstantVariables :
 }
 
 def InterchangeGeneric :
-    Pass<"iree-interchange-generic-op", "FuncOp"> {
+    Pass<"iree-flow-interchange-generic-op", "FuncOp"> {
   let summary = "Interchange generic op loops to have all the reduction loops to be inner loops.";
   let constructor = "mlir::iree_compiler::IREE::Flow::createInterchangeLinalgGenericPass()";
 }

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -119,4 +119,10 @@ def StripAndSplatConstantVariables :
   let constructor = "mlir::iree_compiler::IREE::Flow::createStripAndSplatConstantVariablesPass()";
 }
 
+def InterchangeGeneric :
+    Pass<"iree-interchange-generic-op", "FuncOp"> {
+  let summary = "Interchange generic op loops to have all the reduction loops to be inner loops.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createInterchangeLinalgGenericPass()";
+}
+
 #endif  // IREE_DIALECT_FLOW_PASSES

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "form_streams.mlir",
             "hoist_unstreamable_ops.mlir",
             "inject_dispatch_tracing.mlir",
+            "interchange.mlir",
             "outline_dispatch_regions.mlir",
             "outline_large_constants.mlir",
             "pad_linalg_ops.mlir",

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     "form_streams.mlir"
     "hoist_unstreamable_ops.mlir"
     "inject_dispatch_tracing.mlir"
+    "interchange.mlir"
     "outline_dispatch_regions.mlir"
     "outline_large_constants.mlir"
     "pad_linalg_ops.mlir"

--- a/iree/compiler/Dialect/Flow/Transforms/test/interchange.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/interchange.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -iree-interchange-generic-op %s | IreeFileCheck %s
+// RUN: iree-opt -iree-flow-interchange-generic-op %s | IreeFileCheck %s
 
 // CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 // CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d0, d1)>

--- a/iree/compiler/Dialect/Flow/Transforms/test/interchange.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/interchange.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt -iree-interchange-generic-op %s | IreeFileCheck %s
+
+// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d0, d1)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d0, d1)>
+//      CHECK: func @interchange
+//      CHECK:   linalg.generic {indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+func @interchange(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>, %arg2: tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>) {
+  %0 = linalg.generic {indexing_maps = [
+    affine_map<(d0, d1, d2, d3) -> (d1, d0, d3)>,
+    affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>,
+    affine_map<(d0, d1, d2, d3) -> (d3, d1, d2)>],
+    iterator_types = ["reduction", "parallel", "parallel", "parallel"]}
+  ins(%arg0, %arg1 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+  outs(%arg2 : tensor<?x?x?xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+    %m = mulf %arg3, %arg4 : f32
+    %a = addf %arg5, %m : f32
+    linalg.yield %a : f32
+  } -> tensor<?x?x?xf32>
+  return %0 : tensor<?x?x?xf32>
+}


### PR DESCRIPTION
During dispatchLinalgOnTensor we only tile outer parallel loops so if
the parallel loops are not outer loop we may skip tiling some ops which
will prevent them from being distributed onto several workgroups.