### PR TITLE
Improving tracing of vulkan command buffers/dispatches.

### DIFF
--- a/iree/hal/vulkan/direct_command_buffer.cc
+++ b/iree/hal/vulkan/direct_command_buffer.cc
@@ -184,6 +184,13 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_begin(
                          command_buffer->handle, &begin_info),
                      "vkBeginCommandBuffer");
 
+  IREE_VULKAN_TRACE_ZONE_BEGIN_EXTERNAL(
+      command_buffer->tracing_context, command_buffer->handle,
+      /*file_name=*/NULL, 0,
+      /*line=*/0, /*func_name=*/NULL, 0,
+      "iree_hal_vulkan_direct_command_buffer",
+      strlen("iree_hal_vulkan_direct_command_buffer"));
+
   return iree_ok_status();
 }
 
@@ -191,6 +198,9 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_end(
     iree_hal_command_buffer_t* base_command_buffer) {
   iree_hal_vulkan_direct_command_buffer_t* command_buffer =
       iree_hal_vulkan_direct_command_buffer_cast(base_command_buffer);
+
+  IREE_VULKAN_TRACE_ZONE_END(command_buffer->tracing_context,
+                             command_buffer->handle);
 
   VK_RETURN_IF_ERROR(
       command_buffer->syms->vkEndCommandBuffer(command_buffer->handle),
@@ -602,8 +612,8 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_dispatch(
     IREE_VULKAN_TRACE_ZONE_BEGIN_EXTERNAL(
         command_buffer->tracing_context, command_buffer->handle,
         source_location.file_name.data, source_location.file_name.size,
-        source_location.line, source_location.func_name.data,
-        source_location.func_name.size, NULL, 0);
+        source_location.line, /*func_name=*/NULL, 0,
+        source_location.func_name.data, source_location.func_name.size);
   });
 
   // Get the compiled and linked pipeline for the specified entry point and
@@ -638,8 +648,8 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_dispatch_indirect(
   IREE_VULKAN_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->handle,
       source_location.file_name.data, source_location.file_name.size,
-      source_location.line, source_location.func_name.data,
-      source_location.func_name.size, NULL, 0);
+      source_location.line, /*func_name=*/NULL, 0,
+      source_location.func_name.data, source_location.func_name.size);
 
   // Get the compiled and linked pipeline for the specified entry point and
   // bind it to the command buffer.


### PR DESCRIPTION
This adds a command buffer wrapping scope to allow for measuring the total time spent executing commands:
![image](https://user-images.githubusercontent.com/75337/126043945-2c5dff5b-ab70-4a45-a1be-da5ab61dbc87.png)

A cool somewhat hidden feature of Tracy is that then if you click on that command buffer zone and check the "group" box you can see a nice summary of which dispatches are taking time within that command buffer:
![image](https://user-images.githubusercontent.com/75337/126044445-6a90a400-bcf3-4bcb-a11b-6c395a20b917.png)
