### PR TITLE
Make tracing compatible with sanitizers.

### DIFF
--- a/iree/base/tracing.cc
+++ b/iree/base/tracing.cc
@@ -205,7 +205,8 @@ void iree_tracing_mutex_after_unlock(uint32_t lock_id) {
 #endif  // __cplusplus
 
 #if defined(__cplusplus) && \
-    (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING)
+    (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING) && \
+    !IREE_SANITIZER_ADDRESS && !IREE_SANITIZER_MEMORY && !IREE_SANITIZER_THREAD
 
 void* operator new(size_t count) noexcept {
   auto ptr = malloc(count);

--- a/iree/base/tracing.cc
+++ b/iree/base/tracing.cc
@@ -204,9 +204,10 @@ void iree_tracing_mutex_after_unlock(uint32_t lock_id) {
 }  // extern "C"
 #endif  // __cplusplus
 
-#if defined(__cplusplus) && \
+#if defined(__cplusplus) &&                                               \
     (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING) && \
-    !IREE_SANITIZER_ADDRESS && !IREE_SANITIZER_MEMORY && !IREE_SANITIZER_THREAD
+    !IREE_SANITIZER_ADDRESS && !IREE_SANITIZER_MEMORY &&                  \
+    !IREE_SANITIZER_THREAD
 
 void* operator new(size_t count) noexcept {
   auto ptr = malloc(count);


### PR DESCRIPTION
Splitting this off from working on https://github.com/google/iree/issues/6404.

Sanitizers define these functions, so tracing needs to not define them (or wrap them somehow).