### PR TITLE
Fixing task system off-by-one that was preventing proper distribution.

### DIFF
--- a/iree/task/task.c
+++ b/iree/task/task.c
@@ -824,10 +824,6 @@ iree_status_t iree_task_dispatch_shard_execute(
                                                    tiles_per_reservation,
                                                    iree_memory_order_relaxed);
   while (tile_base < tile_count) {
-    const uint32_t next_tile_base = iree_atomic_fetch_add_int32(
-        &shared_state->tile_index, tiles_per_reservation,
-        iree_memory_order_relaxed);
-
     const uint32_t tile_range =
         iree_min(tile_base + tiles_per_reservation, tile_count);
     for (uint32_t tile_index = tile_base; tile_index < tile_range;
@@ -865,7 +861,9 @@ iree_status_t iree_task_dispatch_shard_execute(
       }
     }
 
-    tile_base = next_tile_base;
+    tile_base = iree_atomic_fetch_add_int32(&shared_state->tile_index,
+                                            tiles_per_reservation,
+                                            iree_memory_order_relaxed);
   }
 
   // Push aggregate statistics up to the dispatch.


### PR DESCRIPTION
This would lead to a single shard executing more tiles than it should in
a single iteration leading to unbalanced distribution when the tile count
was low.
Fixes #5568.

before (~410ms total for bert):
![image](https://user-images.githubusercontent.com/75337/126229339-ca0432c7-96a7-40b6-b48e-74c2e467c2d0.png)

after (~376ms total for bert):
![image](https://user-images.githubusercontent.com/75337/126229183-5d93c379-4e42-4bae-9fee-52e4e32b6bc5.png)
