### PR TITLE
Drop TESTONLY from sample target.

### DIFF
--- a/iree/samples/static_library/CMakeLists.txt
+++ b/iree/samples/static_library/CMakeLists.txt
@@ -63,7 +63,6 @@ iree_c_embed_data(
     simple_mul_c.h
   FLATTEN
   PUBLIC
-  TESTONLY
 )
 
 iree_cc_binary(


### PR DESCRIPTION
`static_library_demo` is not a test, so it can't depend on a `TESTONLY` target. We don't check this in CMake, outside of `-DIREE_BUILD_TESTS=OFF` builds, which will fail at configure time.