### PR TITLE
Use clock_gettime on emscripten.

### DIFF
--- a/iree/base/time.c
+++ b/iree/base/time.c
@@ -31,7 +31,7 @@ IREE_API_EXPORT iree_time_t iree_time_now(void) {
   li.QuadPart /= kFtToMicroSec;
   return li.QuadPart;
 #elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_APPLE) || \
-    defined(IREE_PLATFORM_LINUX)
+    defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_EMSCRIPTEN)
   struct timespec clock_time;
   clock_gettime(CLOCK_REALTIME, &clock_time);
   return clock_time.tv_nsec;


### PR DESCRIPTION
This was all that was needed to build `iree_samples_simple_embedding_simple_embedding_vmvx_sync` using emscripten.