### PR TITLE
Inserting a workaround for constant tensors escaping blocks.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "FusionOfTensorOps.cpp",
         "HoistUnstreamableOps.cpp",
         "InjectDispatchTracing.cpp",
+        "InsertConstantClones.cpp",
         "InterchangeGenericOps.cpp",
         "OutlineDispatchRegions.cpp",
         "OutlineLargeConstants.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "FusionOfTensorOps.cpp"
     "HoistUnstreamableOps.cpp"
     "InjectDispatchTracing.cpp"
+    "InsertConstantClones.cpp"
     "InterchangeGenericOps.cpp"
     "OutlineDispatchRegions.cpp"
     "OutlineLargeConstants.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/InsertConstantClones.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/InsertConstantClones.cpp
@@ -1,0 +1,124 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/IREE/IR/IREEDialect.h"
+#include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+// Inserts tensor clones of constant values that escape a block either via
+// function returns or branches. This is a workaround for not having a full
+// DFA pass that attributes tensors with their usage information.
+//
+// TODO(#5492): related to DFA for HAL buffer attributes but we want this at the
+// flow level so that we can schedule the commands appropriately but we may be
+// able to push this down into the HAL stream work when that arrives.
+class InsertConstantClonesPass
+    : public InsertConstantClonesBase<InsertConstantClonesPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREEDialect, IREE::Flow::FlowDialect>();
+  }
+
+  void runOnOperation() override {
+    for (auto &block : getOperation()) {
+      if (auto op = dyn_cast<mlir::ReturnOp>(block.getTerminator())) {
+        tryCloneConstantValues(op);
+      } else if (auto op = dyn_cast<mlir::BranchOp>(block.getTerminator())) {
+        tryCloneConstantValues(op);
+      } else if (auto op =
+                     dyn_cast<mlir::CondBranchOp>(block.getTerminator())) {
+        tryCloneConstantValues(op);
+      }
+    }
+  }
+
+ private:
+  // Heuristics to try to determine if a tensor will be sourced from a constant.
+  // This really is just a guess and a real solution requires proper DFA.
+  bool isLikelyConstant(Value value) {
+    auto op = value.getDefiningOp();
+    if (!op) return false;
+    if (op->hasTrait<OpTrait::ConstantLike>() ||
+        isa<IREE::UnfoldableConstantOp>(op)) {
+      return true;
+    } else if (auto loadOp = dyn_cast<IREE::Flow::VariableLoadOp>(op)) {
+      return !loadOp.getLoadedVariable().is_mutable();
+    } else if (auto loadOp = dyn_cast<IREE::Flow::VariableLoadIndirectOp>(op)) {
+      return true;  // can't know indirect variable behavior (without DFA)
+    } else if (auto sliceOp = dyn_cast<IREE::Flow::TensorSliceOp>(op)) {
+      return isLikelyConstant(sliceOp.source());
+    } else if (auto reshapeOp = dyn_cast<IREE::Flow::TensorReshapeOp>(op)) {
+      return isLikelyConstant(reshapeOp.source());
+    }
+    return false;
+  }
+
+  void replaceWithClone(Value value, Operation *useOp, OpBuilder &builder) {
+    auto cloneOp =
+        builder.create<IREE::Flow::TensorCloneOp>(value.getLoc(), value);
+    value.replaceUsesWithIf(cloneOp.result(), [&](OpOperand &operand) {
+      return operand.getOwner() == useOp;
+    });
+  }
+
+  void tryCloneConstantValues(mlir::ReturnOp op) {
+    OpBuilder builder(op);
+    for (auto value : op.getOperands()) {
+      if (value.getType().isa<TensorType>() && isLikelyConstant(value)) {
+        replaceWithClone(value, op, builder);
+      }
+    }
+  }
+
+  void tryCloneConstantValues(mlir::BranchOp op) {
+    OpBuilder builder(op);
+    for (auto value : op.getOperands()) {
+      if (value.getType().isa<TensorType>() && isLikelyConstant(value)) {
+        replaceWithClone(value, op, builder);
+      }
+    }
+  }
+
+  void tryCloneConstantValues(mlir::CondBranchOp op) {
+    OpBuilder builder(op);
+    for (unsigned i = 0; i < op.getNumSuccessors(); ++i) {
+      auto operands = op.getSuccessorOperands(i);
+      if (!operands.hasValue()) continue;
+      for (auto value : operands.getValue()) {
+        if (value.getType().isa<TensorType>() && isLikelyConstant(value)) {
+          replaceWithClone(value, op, builder);
+        }
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<FuncOp>> createInsertConstantClonesPass() {
+  return std::make_unique<InsertConstantClonesPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -169,6 +169,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // arbitrary ordering.
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
 
+  // Clone constants that escape basic blocks until we have better analysis.
+  passManager.addNestedPass<FuncOp>(
+      IREE::Flow::createInsertConstantClonesPass());
+
+  // Group streamable ops into streams.
   passManager.addNestedPass<FuncOp>(IREE::Flow::createFormStreamsPass());
 
   // Prior to leaving the pipeline we need to clean things up for following

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -131,6 +131,9 @@ std::unique_ptr<OperationPass<FuncOp>> createHoistUnstreamableOpsPass();
 
 // TODO(benvanik): cross-function stream flows.
 
+// Inserts clones of constant values where they may be required.
+std::unique_ptr<OperationPass<FuncOp>> createInsertConstantClonesPass();
+
 //===----------------------------------------------------------------------===//
 // Module Analysis and Finalization
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -75,6 +75,12 @@ def InjectDispatchTracing :
   let constructor = "mlir::iree_compiler::IREE::Flow::createInjectDispatchTracingPass()";
 }
 
+def InsertConstantClones :
+    Pass<"iree-flow-insert-constant-clones", "FuncOp"> {
+  let summary = "Inserts clones of constant values where they may be required";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createInsertConstantClonesPass()";
+}
+
 def InterchangeGenericOps :
     Pass<"iree-flow-interchange-generic-ops", "FuncOp"> {
   let summary = "Interchange generic op loops to have all the reduction loops to be inner loops.";

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "form_streams.mlir",
             "hoist_unstreamable_ops.mlir",
             "inject_dispatch_tracing.mlir",
+            "insert_constant_clones.mlir",
             "interchange_generic_ops.mlir",
             "outline_dispatch_regions.mlir",
             "outline_large_constants.mlir",

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     "form_streams.mlir"
     "hoist_unstreamable_ops.mlir"
     "inject_dispatch_tracing.mlir"
+    "insert_constant_clones.mlir"
     "interchange_generic_ops.mlir"
     "outline_dispatch_regions.mlir"
     "outline_large_constants.mlir"

--- a/iree/compiler/Dialect/Flow/Transforms/test/insert_constant_clones.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/insert_constant_clones.mlir
@@ -1,0 +1,62 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='func(iree-flow-insert-constant-clones)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @function_return
+func @function_return() -> (tensor<8xf32>, i32) {
+  // CHECK-DAG: %[[SCALAR:.+]] = constant 5
+  %1 = constant 5 : i32
+  // CHECK-DAG: %[[CST:.+]] = constant dense
+  %cst = constant dense<1.200000e+00> : tensor<8xf32>
+  // CHECK-NEXT: %[[RESHAPE:.+]] = flow.tensor.reshape %[[CST]]
+  %0 = flow.tensor.reshape %cst : tensor<8xf32> -> tensor<8xf32>
+  // CHECK-NEXT: %[[CLONE:.+]] = flow.tensor.clone %[[RESHAPE]] : tensor<8xf32>
+  // CHECK-NEXT: return %[[CLONE]], %[[SCALAR]]
+  return %0, %1 : tensor<8xf32>, i32
+}
+
+// -----
+
+// CHECK-LABEL: @branch_argument
+func @branch_argument() -> tensor<8xf32> {
+  // CHECK: %[[CST:.+]] = constant dense
+  %cst = constant dense<1.200000e+00> : tensor<8xf32>
+  // CHECK-NEXT: %[[CLONE:.+]] = flow.tensor.clone %[[CST]] : tensor<8xf32>
+  // CHECK-NEXT: br ^[[EXIT:.+]](%[[CLONE]] : tensor<8xf32>
+  br ^exit(%cst : tensor<8xf32>)
+  // CHECK-NEXT: ^[[EXIT]](%[[BBARG:.+]]: tensor<8xf32>)
+^exit(%0 : tensor<8xf32>):
+  // CHECK-NEXT: = flow.tensor.reshape %[[CST]]
+  %other_use = flow.tensor.reshape %cst : tensor<8xf32> -> tensor<8xf32>
+  // CHECK-NEXT: return %[[BBARG]]
+  return %0 : tensor<8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @branch_argument_reuse
+func @branch_argument_reuse(%cond : i1) -> tensor<8xf32> {
+  // CHECK: %[[CST:.+]] = constant dense
+  %cst = constant dense<1.200000e+00> : tensor<8xf32>
+  // CHECK-NEXT: %[[CLONE:.+]] = flow.tensor.clone %[[CST]] : tensor<8xf32>
+  // CHECK-NEXT: cond_br %{{.+}}, ^[[BBT:.+]](%[[CLONE]] : tensor<8xf32>), ^[[BBF:.+]](%[[CLONE]] : tensor<8xf32>)
+  cond_br %cond, ^exit_t(%cst : tensor<8xf32>), ^exit_f(%cst : tensor<8xf32>)
+  // CHECK: ^[[BBT]](%[[BBARGT:.+]]: tensor<8xf32>)
+^exit_t(%0 : tensor<8xf32>):
+  // CHECK-NEXT: return %[[BBARGT]]
+  return %0 : tensor<8xf32>
+  // CHECK-NEXT: ^[[BBF]](%[[BBARGF:.+]]: tensor<8xf32>)
+^exit_f(%1 : tensor<8xf32>):
+  // CHECK-NEXT: return %[[BBARGF]]
+  return %1 : tensor<8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @constant_variable
+flow.variable @constant_variable dense<1.200000e+00> : tensor<8xf32>
+func @constant_load() -> (tensor<8xf32>) {
+  // CHECK: %[[VAR:.+]] = flow.variable.load @constant_variable
+  %0 = flow.variable.load @constant_variable : tensor<8xf32>
+  // CHECK-NEXT: %[[CLONE:.+]] = flow.tensor.clone %[[VAR]] : tensor<8xf32>
+  // CHECK-NEXT: return %[[CLONE]]
+  return %0 : tensor<8xf32>
+}


### PR DESCRIPTION
This is required for correctness until #5492 properly implements this with
a DFA and hal.stream exists to allow for insertions of efficient clones.