### PR TITLE
[CUDA] Fix mapping of binding to kernel argument with multiple sets.

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -22,7 +22,7 @@ func @abs_ex_dispatch_0() {
 hal.interface @io attributes {sym_visibility = "private"} {
   hal.interface.binding @arg0, set=0, binding=4, type="StorageBuffer", access="Read"
   hal.interface.binding @arg1, set=0, binding=0, type="StorageBuffer", access="Read"
-  hal.interface.binding @ret0, set=0, binding=7, type="StorageBuffer", access="Write|Discard"
+  hal.interface.binding @ret0, set=1, binding=2, type="StorageBuffer", access="Write|Discard"
 }
 
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0

--- a/iree/hal/cuda/descriptor_set_layout.c
+++ b/iree/hal/cuda/descriptor_set_layout.c
@@ -14,6 +14,7 @@
 typedef struct iree_hal_cuda_descriptor_set_layout_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
+  iree_host_size_t binding_count;
 } iree_hal_cuda_descriptor_set_layout_t;
 
 extern const iree_hal_descriptor_set_layout_vtable_t
@@ -46,11 +47,19 @@ iree_status_t iree_hal_cuda_descriptor_set_layout_create(
     iree_hal_resource_initialize(&iree_hal_cuda_descriptor_set_layout_vtable,
                                  &descriptor_set_layout->resource);
     descriptor_set_layout->context = context;
+    descriptor_set_layout->binding_count = binding_count;
     *out_descriptor_set_layout =
         (iree_hal_descriptor_set_layout_t*)descriptor_set_layout;
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
+}
+
+iree_host_size_t iree_hal_cuda_descriptor_set_layout_binding_count(
+    iree_hal_descriptor_set_layout_t* base_descriptor_set_layout) {
+  iree_hal_cuda_descriptor_set_layout_t* descriptor_set_layout =
+      iree_hal_cuda_descriptor_set_layout_cast(base_descriptor_set_layout);
+  return descriptor_set_layout->binding_count;
 }
 
 static void iree_hal_cuda_descriptor_set_layout_destroy(

--- a/iree/hal/cuda/descriptor_set_layout.h
+++ b/iree/hal/cuda/descriptor_set_layout.h
@@ -22,6 +22,10 @@ iree_status_t iree_hal_cuda_descriptor_set_layout_create(
     const iree_hal_descriptor_set_layout_binding_t* bindings,
     iree_hal_descriptor_set_layout_t** out_descriptor_set_layout);
 
+// Return the binding count for the given descriptor set layout.
+iree_host_size_t iree_hal_cuda_descriptor_set_layout_binding_count(
+    iree_hal_descriptor_set_layout_t* descriptor_set_layout);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/cuda/executable_layout.c
+++ b/iree/hal/cuda/executable_layout.c
@@ -10,6 +10,7 @@
 
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
+#include "iree/hal/cuda/descriptor_set_layout.h"
 
 typedef struct iree_hal_cuda_executable_layout_t {
   iree_hal_resource_t resource;
@@ -74,6 +75,20 @@ static void iree_hal_cuda_executable_layout_destroy(
   iree_allocator_free(host_allocator, executable_layout);
 
   IREE_TRACE_ZONE_END(z0);
+}
+
+iree_host_size_t iree_hal_cuda_base_binding_index(
+    iree_hal_executable_layout_t* base_executable_layout, uint32_t set) {
+  iree_hal_cuda_executable_layout_t* executable_layout =
+      iree_hal_cuda_executable_layout_cast(base_executable_layout);
+  iree_host_size_t base_binding = 0;
+  for (iree_host_size_t i = 0; i < set; ++i) {
+    iree_host_size_t binding_count =
+        iree_hal_cuda_descriptor_set_layout_binding_count(
+            executable_layout->set_layouts[i]);
+    base_binding += binding_count;
+  }
+  return base_binding;
 }
 
 const iree_hal_executable_layout_vtable_t

--- a/iree/hal/cuda/executable_layout.h
+++ b/iree/hal/cuda/executable_layout.h
@@ -22,6 +22,10 @@ iree_status_t iree_hal_cuda_executable_layout_create(
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout);
 
+// Return the base binding index for the given set.
+iree_host_size_t iree_hal_cuda_base_binding_index(
+    iree_hal_executable_layout_t* executable_layout, uint32_t set);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/cuda/graph_command_buffer.c
+++ b/iree/hal/cuda/graph_command_buffer.c
@@ -14,6 +14,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/cuda_buffer.h"
 #include "iree/hal/cuda/dynamic_symbols.h"
+#include "iree/hal/cuda/executable_layout.h"
 #include "iree/hal/cuda/native_executable.h"
 #include "iree/hal/cuda/status_util.h"
 
@@ -355,6 +356,8 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_push_descriptor_set(
     const iree_hal_descriptor_set_binding_t* bindings) {
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
+  iree_host_size_t base_binding =
+      iree_hal_cuda_base_binding_index(executable_layout, set);
   // Convention with the compiler side. We map bindings to kernel argument.
   // We compact the bindings to get a dense set of arguments and keep them order
   // based on the binding index.
@@ -375,7 +378,8 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_push_descriptor_set(
         iree_hal_cuda_buffer_device_pointer(
             iree_hal_buffer_allocated_buffer(binding.buffer)) +
         iree_hal_buffer_byte_offset(binding.buffer) + binding.offset;
-    *((CUdeviceptr*)command_buffer->current_descriptor[i]) = device_ptr;
+    *((CUdeviceptr*)command_buffer->current_descriptor[i + base_binding]) =
+        device_ptr;
   }
   return iree_ok_status();
 }


### PR DESCRIPTION
If multiple sets are used by a kernel the arguments needs to be first
ordered based on the set index.