### PR TITLE
Don't fold flow.tensor.splat with dynamic shape

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -740,8 +740,7 @@ OpFoldResult TensorStoreOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult TensorSplatOp::fold(ArrayRef<Attribute> operands) {
-  // TODO(benvanik): only fold when shape is constant.
-  if (operands[0]) {
+  if (operands.size() == 1 && operands.front()) {
     // Splat value is constant and we can fold the operation.
     return SplatElementsAttr::get(result().getType().cast<ShapedType>(),
                                   operands[0]);

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -143,6 +143,19 @@ func @splatConstScalar() -> tensor<i32> {
 
 // -----
 
+// CHECK-LABEL: @splatDynamicShape
+//  CHECK-SAME: (%[[DIM0:.+]]: index, %[[DIM1:.+]]: index)
+func @splatDynamicShape(%dim0: index, %dim1: index) -> tensor<?x?xi32> {
+  // CHECK: %[[FOUR:.+]] = constant 4 : i32
+  %four = constant 4 : i32
+  // CHECK: %[[SPLAT:.+]] = flow.tensor.splat %[[FOUR]] : tensor<?x?xi32>{%[[DIM0]], %[[DIM1]]}
+  %1 = flow.tensor.splat %four : tensor<?x?xi32>{%dim0, %dim1}
+  // CHECK: return %[[SPLAT]]
+  return %1 : tensor<?x?xi32>
+}
+
+// -----
+
 // CHECK-LABEL: @cloneConst
 func @cloneConst() -> tensor<4xi32> {
   %0 = constant dense<[0, 1, 2, 3]> : tensor<4xi32>


### PR DESCRIPTION
DenseElementsAttr requires static shape; we will hit assertions
when trying to fold dynamic shaped flow.tensor.splat.