### PR TITLE
Add a pattern to convert tensor.from_elements to flow.tensor.splat.

### DIFF
--- a/iree/compiler/InputConversion/Common/test/convert_upstream_to_iree.mlir
+++ b/iree/compiler/InputConversion/Common/test/convert_upstream_to_iree.mlir
@@ -28,3 +28,25 @@ func @dynamic_tensor_cast_to_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x3xf32> 
   %0 = tensor.cast %arg0 : tensor<?x?xf32> to tensor<?x3xf32>
   return %0 : tensor<?x3xf32>
 }
+
+// -----
+// CHECK: func @tensor.from_elements__to__flow.tensor.splat(%[[arg0:.*]]: i8)
+func @tensor.from_elements__to__flow.tensor.splat(%arg0: i8) -> (i8) {
+  // CHECK: %[[splat_res:.*]] = flow.tensor.splat %[[arg0]]
+  %0 = tensor.from_elements %arg0 : tensor<1xi8>
+  // CHECK: flow.tensor.load %[[splat_res]]
+  %1 = flow.tensor.load %0 : tensor<1xi8>
+  return %1 : i8
+}
+
+// -----
+// CHECK: func @tensor.from_elements__not_convertible(%[[arg0:.*]]: i8)
+func @tensor.from_elements__not_convertible(%arg0: i8) -> (i8) {
+  // CHECK: %[[c0:.*]] = constant 0
+  %c0 = constant 0 : index
+  // CHECK: %[[res:.*]] = tensor.from_elements %[[arg0]], %[[arg0]] : tensor<2xi8>
+  %0 = tensor.from_elements %arg0, %arg0 : tensor<2xi8>
+  // CHECK: flow.tensor.load %[[res]][%[[c0]]]
+  %1 = flow.tensor.load %0[%c0] : tensor<2xi8>
+  return %1 : i8
+}


### PR DESCRIPTION
- Adds a conversion pattern to convert single-element tensors that
result from a `tensor.from_elements` op to a `flow.tensor.splat` op.
- This is a step towards cleaning-up the IR after running it through the
detensoring pass.
- In particular, it sets the stage for a canonicalization pattern within
the `flow` dialect that can fold `flow.tensor.splat`, `flow.tensor.load`
pairs of ops into the underlying primitive value (TODO).

See: https://github.com/google/iree/issues/1159.