### PR TITLE
Add a pattern to fold flow.tensor.splat-.load pairs into primitives.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -822,6 +822,7 @@ def FLOW_TensorLoadOp : FLOW_PureOp<"tensor.load", [
 
   // TODO(benvanik): canonicalize to slice+load if dims are known.
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def FLOW_TensorStoreOp : FLOW_PureOp<"tensor.store", [

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -411,3 +411,14 @@ func @propogateStaticShapeOfUpdate(%arg0 : tensor<?x?xf32>, %arg1 : f32) -> tens
   // CHECK: return %[[RESULT]]
   return %1 : tensor<?x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @foldSplatLoadIntoPrimitive
+//  CHECK-SAME: (%[[arg0:.+]]: f32, %[[arg1:.+]]: index, %[[arg2:.+]]: index)
+func @foldSplatLoadIntoPrimitive(%arg0 : f32, %arg1 : index, %arg2 : index) -> f32 {
+  // CHECK-NEXT: return %[[arg0]] : f32
+  %0 = flow.tensor.splat %arg0 : tensor<4x4xf32>
+  %1 = flow.tensor.load %0[%arg1, %arg2] : tensor<4x4xf32>
+  return %1 : f32
+}


### PR DESCRIPTION
- Adds a canonicalization pattern the fold pairs of such ops into the
primitive value used in the splat op.
- Motivation for adding this is cleaning up after detensoring pass.

See: https://github.com/google/iree/issues/1159.