### PR TITLE
NFC: Cleanups to TiledOpInterface and LinalgExtOps.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -496,6 +496,7 @@ static void tryToTieOperandsAndResults(
     if (!storeOp) return nullptr;
 
     Operation *tieOp = storeOp.value().getDefiningOp();
+    if (!tieOp) return nullptr;
 
     // TODO(antiagainst): use TiedOpInterface here instead of hardcoding ops
     // when it's available in MLIR core in some form.
@@ -507,7 +508,7 @@ static void tryToTieOperandsAndResults(
                                     .template getDefiningOp<
                                         IREE::Flow::DispatchTensorLoadOp>();
                   if (!loadOp) return nullptr;
-                  return loadOp.source().cast<BlockArgument>();
+                  return loadOp.source().dyn_cast<BlockArgument>();
                 })
             .Case<linalg::LinalgOp, linalg_ext::LinalgExtOp>(
                 [&](auto linalgLikeOp) -> BlockArgument {
@@ -519,7 +520,7 @@ static void tryToTieOperandsAndResults(
                           .template getDefiningOp<
                               IREE::Flow::DispatchTensorLoadOp>();
                   if (!loadOp) return nullptr;
-                  return loadOp.source().template cast<BlockArgument>();
+                  return loadOp.source().template dyn_cast<BlockArgument>();
                 })
             .Default([&](Operation *) -> BlockArgument { return nullptr; });
 
@@ -1296,6 +1297,12 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
 
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
+    llvm::dbgs() << "\n--- After dispatch region creation ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+
   // After outlining in dispatch region we can rewrite the dispatch ops with
   // proper captures.
   if (funcOp
@@ -1320,6 +1327,12 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
 
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
+    llvm::dbgs() << "\n--- After dispatch op legalization ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+
   // Rewrite destructive updates and ensure no remaining store remains to the
   // full output.
   if (funcOp
@@ -1334,6 +1347,12 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
           .wasInterrupted()) {
     signalPassFailure();
   }
+
+  DEBUG_WITH_TYPE(DEBUG_TYPE, {
+    llvm::dbgs() << "\n--- After rewriting destructive updates ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
 
   // Now try to see if we can tie certain results to operands in order to
   // indicate sharing storage. This need to happen here because it needs to

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -501,6 +501,21 @@ SmallVector<Range> SortOp::getLoopBounds(OpBuilder &builder) {
   return loopBounds;
 }
 
+SmallVector<unsigned> SortOp::getPartitionableLoops(
+    unsigned maxNumParallelDims) {
+  auto range = llvm::seq<unsigned>(0, getOperandRank());
+  SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
+  partitionableLoops.erase(
+      std::next(partitionableLoops.begin(), getSortedDimension()));
+  if (partitionableLoops.size() > maxNumParallelDims) {
+    partitionableLoops.erase(
+        partitionableLoops.begin(),
+        std::next(partitionableLoops.begin(),
+                  partitionableLoops.size() - maxNumParallelDims));
+  }
+  return partitionableLoops;
+}
+
 Operation *SortOp::getTiledImplementation(
     OpBuilder &builder, ValueRange outputs, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes,

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -95,56 +95,6 @@ OpFoldResult getDim(OpBuilder &builder, Location loc, Value v, int64_t dim) {
 }
 
 //===----------------------------------------------------------------------===//
-// Common methods from Linalg dialect.
-//===----------------------------------------------------------------------===//
-
-static ParseResult parseLinalgExtOperandList(
-    OpAsmParser &parser, StringRef keyword,
-    SmallVectorImpl<OpAsmParser::OperandType> &values,
-    SmallVectorImpl<Type> &types) {
-  StringRef parsedKeyword;
-  if (succeeded(parser.parseOptionalKeyword(&parsedKeyword, {keyword}))) {
-    if (parser.parseLParen() || parser.parseOperandList(values) ||
-        parser.parseColonTypeList(types) || parser.parseRParen()) {
-      return failure();
-    }
-  }
-  return success();
-}
-
-static ParseResult parseLinalgExtInsList(
-    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::OperandType> &values,
-    SmallVectorImpl<Type> &types) {
-  return parseLinalgExtOperandList(parser, "ins", values, types);
-}
-
-static ParseResult parseLinalgExtOutsList(
-    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::OperandType> &values,
-    SmallVectorImpl<Type> &types) {
-  return parseLinalgExtOperandList(parser, "outs", values, types);
-}
-
-static void printLinalgExtOperandList(OpAsmPrinter &printer, Operation *op,
-                                      StringRef keyword, OperandRange values,
-                                      TypeRange types) {
-  if (!values.empty()) {
-    printer << keyword << "(";
-    printer.printOperands(values);
-    printer << " : " << types << ")";
-  }
-}
-
-static void printLinalgExtInsList(OpAsmPrinter &printer, Operation *op,
-                                  OperandRange values, TypeRange types) {
-  return printLinalgExtOperandList(printer, op, "ins", values, types);
-}
-
-static void printLinalgExtOutsList(OpAsmPrinter &printer, Operation *op,
-                                   OperandRange values, TypeRange types) {
-  return printLinalgExtOperandList(printer, op, "outs", values, types);
-}
-
-//===----------------------------------------------------------------------===//
 // ScatterOp
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -29,6 +29,11 @@ class LinalgExt_Op<string mnemonic, list<OpTrait> traits = []> :
   let verifier = [{ return verify$cppClass(*this); }];
   let printer = [{ return print$cppClass(p, *this); }];
   let parser = [{ return parse$cppClass(parser, result); }];
+  code extraLinalgExtOpClassDeclaration = [{
+    ValueRange getDestinationOperands() {
+      return outputs();
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -76,8 +81,8 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter",
     custom<LinalgExtOutsList>($outputs, type($outputs))
     $region (`->` type($results)^)?
   }];
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 
-  let extraClassDeclaration = [{
     int64_t getIndexDepth() {
       return getInputOperand(1)
           ->get()
@@ -128,7 +133,8 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter",
 
 def LinalgExt_SortOp : LinalgExt_Op<"sort",
     [DeclareOpInterfaceMethods<TiledOpInterface,
-        ["getTiledImplementation", "generateScalarImplementation"]>]> {
+        ["getPartitionableLoops", "generateScalarImplementation",
+         "getTiledImplementation"]>]> {
   let summary = "Sort operator";
   let description = [{
     Based on XLA operation semantics, sorts the given `operands` at the given
@@ -153,7 +159,7 @@ def LinalgExt_SortOp : LinalgExt_Op<"sort",
     custom<LinalgExtOutsList>($outputs, type($outputs))
     $region (`->` type($results)^)?
   }];
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
     Value operand(int index) {
       return outputs()[index];
     }

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -30,8 +30,9 @@ class LinalgExt_Op<string mnemonic, list<OpTrait> traits = []> :
   let printer = [{ return print$cppClass(p, *this); }];
   let parser = [{ return parse$cppClass(parser, result); }];
   code extraLinalgExtOpClassDeclaration = [{
-    ValueRange getDestinationOperands() {
-      return outputs();
+    SmallVector<Value> getDestinationOperands() {
+      SmallVector<Value> dest(outputs().begin(), outputs().end());
+      return dest;
     }
   }];
 }
@@ -77,8 +78,8 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter",
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    attr-dict custom<LinalgExtInsList>($inputs, type($inputs))
-    custom<LinalgExtOutsList>($outputs, type($outputs))
+    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
@@ -155,8 +156,8 @@ def LinalgExt_SortOp : LinalgExt_Op<"sort",
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
     (`dimension` `(` $dimension^ `)`)?
-    attr-dict custom<LinalgExtInsList>($inputs, type($inputs))
-    custom<LinalgExtOutsList>($outputs, type($outputs))
+    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.h
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_IR_TILEDOPINTERFACE_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_IR_TILEDOPINTERFACE_H_
 
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.td
@@ -19,6 +19,22 @@ def TiledOpInterface : OpInterface<"TiledOpInterface"> {
   let methods = [
       InterfaceMethod<
         /*desc=*/[{
+          Returns the destination operands. For op with `memref`
+          operands, this is the result buffers. For op with `tensor`
+          operands, this is the operands that contain the initial
+          value for the result. These are "tied" to the result
+          buffers. For example, for a `LinalgOp`/`LinalgExt` ops, it
+          is the `outs` parameters. For `tensor.insert_slice`, it is
+          the `dest` parameter.
+        }],
+        /*retType=*/"ValueRange",
+        /*methodName=*/"getDestinationOperands",
+        /*args=*/(ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/"return ValueRange{};"
+      >,
+      InterfaceMethod<
+        /*desc=*/[{
           Returns a list of `StringRef`s that describe the number of
           loops and the iterator types of the operation. The list is
           expected to use
@@ -36,6 +52,34 @@ def TiledOpInterface : OpInterface<"TiledOpInterface"> {
         /*retTy=*/"SmallVector<Range>",
         /*methodName=*/"getLoopBounds",
         /*args=*/(ins "OpBuilder &":$b)
+      >,
+      InterfaceMethod<
+        /*desc=*/[{
+          Return the loops that are to be distributed given the
+          maximum amount of logical processor dimensions available.
+        }],
+        /*retTy=*/"SmallVector<unsigned>",
+        /*methodName=*/"getPartitionableLoops",
+        /*args=*/(ins "unsigned ":$maxNumParallelDims),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+           SmallVector<unsigned> partitionableLoops;
+           auto interfaceOp = cast<TiledOpInterface>($_op.getOperation());
+           for (auto iteratorType :
+               llvm::enumerate(interfaceOp.getLoopIteratorTypes())) {
+             if (iteratorType.value() != getParallelIteratorTypeName()) {
+               break;
+             }
+             partitionableLoops.push_back(iteratorType.index());
+           }
+           if (partitionableLoops.size() > maxNumParallelDims) {
+             partitionableLoops.erase(
+               partitionableLoops.begin(),
+               std::next(partitionableLoops.begin(),
+                   partitionableLoops.size() - maxNumParallelDims));
+           }
+           return partitionableLoops;
+        }]
       >,
       InterfaceMethod<
         /*desc=*/[{

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.td
@@ -27,7 +27,7 @@ def TiledOpInterface : OpInterface<"TiledOpInterface"> {
           is the `outs` parameters. For `tensor.insert_slice`, it is
           the `dest` parameter.
         }],
-        /*retType=*/"ValueRange",
+        /*retType=*/"SmallVector<Value>",
         /*methodName=*/"getDestinationOperands",
         /*args=*/(ins),
         /*methodBody=*/"",

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -230,7 +230,7 @@ static FailureOr<TiledOp> tileInterfaceOpImpl(
 
 FailureOr<TiledOp> tileInterfaceOp(OpBuilder &b, TiledOpInterface tilableOp,
                                    const linalg::LinalgTilingOptions &options) {
-  ValueRange dest = tilableOp.getDestinationOperands();
+  SmallVector<Value> dest = tilableOp.getDestinationOperands();
   if (dest.empty()) {
     return static_cast<LogicalResult>(tilableOp.emitOpError(
         "cannot tile operation without destination operands"));
@@ -291,7 +291,9 @@ struct InsertSliceTiledOpInterface
     : public TiledOpInterface::ExternalModel<InsertSliceTiledOpInterface,
                                              tensor::InsertSliceOp> {
   SmallVector<Value> getDestinationOperands(Operation *op) const {
-    return {cast<tensor::InsertSliceOp>(op).dest()};
+    SmallVector<Value> dest;
+    dest.push_back(cast<tensor::InsertSliceOp>(op).dest());
+    return dest;
   }
 
   SmallVector<StringRef> getLoopIteratorTypes(Operation *op) const {

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -25,9 +25,8 @@ struct TiledOp {
   SmallVector<Value> results;
 };
 
-/// Main entry point for tiling LinalgExtOps using TiledOpInterface.  If the
-/// `op` does not implement the `TiledOpInterface` returns a `TiledOp{}` value.
-FailureOr<TiledOp> tileLinalgExtOp(OpBuilder &b, Operation *op, ValueRange dest,
+/// Main entry point for tiling LinalgExtOps using TiledOpInterface.
+FailureOr<TiledOp> tileLinalgExtOp(OpBuilder &b, TiledOpInterface tilableOp,
                                    const linalg::LinalgTilingOptions &options);
 
 /// Base rewrite pattern to tile and distribute operations that implement the
@@ -43,7 +42,7 @@ struct TiledOpInterfaceBaseTilingPattern : public RewritePattern {
         filter(filter),
         options(options) {}
 
-  LogicalResult matchAndRewriteBase(Operation *op, ValueRange dest,
+  LogicalResult matchAndRewriteBase(TiledOpInterface tilableOp,
                                     PatternRewriter &rewriter,
                                     TiledOp &result) const;
 


### PR DESCRIPTION
- Adds an interface method to get the operands that can be used as
  destination for the operation. This allows better structuring of the
  patterns for tiling and unifies the way they are applied for both
  operations and external models that implement the interface.
- Add an interface to get the loops to be partitioned, along with
  default implementation of this.
- Remove duplicate registration.