### PR TITLE
C flags were being passed to assembler (masm)

### DIFF
--- a/iree/hal/local/elf/CMakeLists.txt
+++ b/iree/hal/local/elf/CMakeLists.txt
@@ -89,5 +89,8 @@ iree_cc_library(
 if(${MSVC})
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
     target_sources(iree_hal_local_elf_arch PRIVATE "arch/x86_64_msvc.asm")
+    set_source_files_properties(
+        arch/x86_64_msvc.asm
+        PROPERTIES LANGUAGE ASM_MASM)
   endif()
 endif()


### PR DESCRIPTION
Avoids sending C flags to MASM resulting in issues while building with MSVC/MASM.