### PR TITLE
[ROCM] bindings with kernels and device local host

### DIFF
--- a/experimental/rocm/descriptor_set_layout.c
+++ b/experimental/rocm/descriptor_set_layout.c
@@ -14,6 +14,7 @@
 typedef struct iree_hal_rocm_descriptor_set_layout_t {
   iree_hal_resource_t resource;
   iree_hal_rocm_context_wrapper_t *context;
+  iree_host_size_t binding_count;
 } iree_hal_rocm_descriptor_set_layout_t;
 
 extern const iree_hal_descriptor_set_layout_vtable_t
@@ -46,11 +47,19 @@ iree_status_t iree_hal_rocm_descriptor_set_layout_create(
     iree_hal_resource_initialize(&iree_hal_rocm_descriptor_set_layout_vtable,
                                  &descriptor_set_layout->resource);
     descriptor_set_layout->context = context;
+    descriptor_set_layout->binding_count = binding_count;
     *out_descriptor_set_layout =
         (iree_hal_descriptor_set_layout_t *)descriptor_set_layout;
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
+}
+
+iree_host_size_t iree_hal_rocm_descriptor_set_layout_binding_count(
+    iree_hal_descriptor_set_layout_t *base_descriptor_set_layout) {
+  iree_hal_rocm_descriptor_set_layout_t *descriptor_set_layout =
+      iree_hal_rocm_descriptor_set_layout_cast(base_descriptor_set_layout);
+  return descriptor_set_layout->binding_count;
 }
 
 static void iree_hal_rocm_descriptor_set_layout_destroy(

--- a/experimental/rocm/descriptor_set_layout.h
+++ b/experimental/rocm/descriptor_set_layout.h
@@ -22,6 +22,10 @@ iree_status_t iree_hal_rocm_descriptor_set_layout_create(
     const iree_hal_descriptor_set_layout_binding_t *bindings,
     iree_hal_descriptor_set_layout_t **out_descriptor_set_layout);
 
+// Return the binding count for the given descriptor set layout.
+iree_host_size_t iree_hal_rocm_descriptor_set_layout_binding_count(
+    iree_hal_descriptor_set_layout_t *descriptor_set_layout);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/experimental/rocm/direct_command_buffer.c
+++ b/experimental/rocm/direct_command_buffer.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "experimental/rocm/dynamic_symbols.h"
+#include "experimental/rocm/executable_layout.h"
 #include "experimental/rocm/native_executable.h"
 #include "experimental/rocm/rocm_buffer.h"
 #include "experimental/rocm/status_util.h"
@@ -283,6 +284,8 @@ static iree_status_t iree_hal_rocm_direct_command_buffer_push_descriptor_set(
     const iree_hal_descriptor_set_binding_t* bindings) {
   iree_hal_rocm_direct_command_buffer_t* command_buffer =
       iree_hal_rocm_direct_command_buffer_cast(base_command_buffer);
+  iree_host_size_t base_binding =
+      iree_hal_rocm_base_binding_index(executable_layout, set);
   // Convention with the compiler side. We map bindings to kernel argument.
   // We compact the bindings to get a dense set of arguments and keep them order
   // based on the binding index.
@@ -303,7 +306,8 @@ static iree_status_t iree_hal_rocm_direct_command_buffer_push_descriptor_set(
         iree_hal_rocm_buffer_device_pointer(
             iree_hal_buffer_allocated_buffer(binding.buffer)) +
         iree_hal_buffer_byte_offset(binding.buffer) + binding.offset;
-    *((hipDeviceptr_t*)command_buffer->current_descriptor[i]) = device_ptr;
+    *((hipDeviceptr_t*)command_buffer->current_descriptor[i + base_binding]) =
+        device_ptr;
   }
   return iree_ok_status();
 }

--- a/experimental/rocm/dynamic_symbol_tables.h
+++ b/experimental/rocm/dynamic_symbol_tables.h
@@ -30,6 +30,7 @@ RC_PFN_DECL(hipMemcpy, void *, const void *, size_t, hipMemcpyKind)
 RC_PFN_DECL(hipMemcpyAsync, void *, const void *, size_t, hipMemcpyKind,
             hipStream_t)
 RC_PFN_DECL(hipMalloc, void **, size_t)
+RC_PFN_DECL(hipMallocManaged, hipDeviceptr_t *, size_t, unsigned int)
 RC_PFN_DECL(hipFree, void *)
 RC_PFN_DECL(hipHostFree, void *)
 RC_PFN_DECL(hipMemAllocHost, void **, size_t, unsigned int)

--- a/experimental/rocm/executable_layout.c
+++ b/experimental/rocm/executable_layout.c
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 
+#include "experimental/rocm/descriptor_set_layout.h"
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
 
@@ -74,6 +75,20 @@ static void iree_hal_rocm_executable_layout_destroy(
   iree_allocator_free(host_allocator, executable_layout);
 
   IREE_TRACE_ZONE_END(z0);
+}
+
+iree_host_size_t iree_hal_rocm_base_binding_index(
+    iree_hal_executable_layout_t *base_executable_layout, uint32_t set) {
+  iree_hal_rocm_executable_layout_t *executable_layout =
+      iree_hal_rocm_executable_layout_cast(base_executable_layout);
+  iree_host_size_t base_binding = 0;
+  for (iree_host_size_t i = 0; i < set; ++i) {
+    iree_host_size_t binding_count =
+        iree_hal_rocm_descriptor_set_layout_binding_count(
+            executable_layout->set_layouts[i]);
+    base_binding += binding_count;
+  }
+  return base_binding;
 }
 
 const iree_hal_executable_layout_vtable_t

--- a/experimental/rocm/executable_layout.h
+++ b/experimental/rocm/executable_layout.h
@@ -22,6 +22,10 @@ iree_status_t iree_hal_rocm_executable_layout_create(
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t **out_executable_layout);
 
+// Return the base binding index for the given set.
+iree_host_size_t iree_hal_rocm_base_binding_index(
+    iree_hal_executable_layout_t *executable_layout, uint32_t set);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Following CUDA backend updates:
-Fix mapping of bindings to kernel argument with multiple sets.
-Fix allocation for device local hoist visible case.