### PR TITLE
Add canonicalizer for flow.tensor.splat+reshape -> splat.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -712,6 +712,26 @@ struct FoldSplatLoadIntoPrimitive : public OpRewritePattern<TensorLoadOp> {
   }
 };
 
+struct FoldSplatReshapeIntoSplat : public OpRewritePattern<TensorSplatOp> {
+  using OpRewritePattern<TensorSplatOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TensorSplatOp splatOp,
+                                PatternRewriter &rewriter) const override {
+    if (!splatOp.result().hasOneUse()) return failure();
+
+    auto reshapeOp = dyn_cast_or_null<TensorReshapeOp>(
+        splatOp.result().use_begin()->getOwner());
+    if (!reshapeOp) return failure();
+
+    rewriter.replaceOpWithNewOp<TensorSplatOp>(
+        reshapeOp, reshapeOp.result().getType(), splatOp.getOperands().front(),
+        reshapeOp.result_dims());
+    rewriter.eraseOp(splatOp);
+
+    return success();
+  }
+};
+
 }  // namespace
 
 void TensorReshapeOp::getCanonicalizationPatterns(
@@ -759,6 +779,12 @@ OpFoldResult TensorStoreOp::fold(ArrayRef<Attribute> operands) {
     }
   }
   return {};
+}
+
+void TensorSplatOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  // TODO(benvanik): canonicalize splat+slice to smaller splat.
+  results.insert<FoldSplatReshapeIntoSplat>(context);
 }
 
 OpFoldResult TensorSplatOp::fold(ArrayRef<Attribute> operands) {

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -724,7 +724,7 @@ struct FoldSplatReshapeIntoSplat : public OpRewritePattern<TensorSplatOp> {
     if (!reshapeOp) return failure();
 
     rewriter.replaceOpWithNewOp<TensorSplatOp>(
-        reshapeOp, reshapeOp.result().getType(), splatOp.getOperands().front(),
+        reshapeOp, reshapeOp.result().getType(), splatOp.value(),
         reshapeOp.result_dims());
     rewriter.eraseOp(splatOp);
 

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -900,7 +900,7 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
     bool isTransfer() { return true; }
   }];
 
-  // TODO(benvanik): canonicalize splat+slice to smaller splat.
+  let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -422,3 +422,14 @@ func @foldSplatLoadIntoPrimitive(%arg0 : f32, %arg1 : index, %arg2 : index) -> f
   %1 = flow.tensor.load %0[%arg1, %arg2] : tensor<4x4xf32>
   return %1 : f32
 }
+
+// -----
+
+// CHECK-LABEL: @foldSplatReshapeIntoSplat
+func @foldSplatReshapeIntoSplat(%arg0 : f32) -> tensor<16xf32> {
+  // CHECK-NEXT: %0 = flow.tensor.splat %arg0 : tensor<16xf32>
+  // CHECK-NEXT: return %0 : tensor<16xf32>
+  %0 = flow.tensor.splat %arg0 : tensor<4x4xf32>
+  %1 = flow.tensor.reshape %0 : tensor<4x4xf32> -> tensor<16xf32>
+  return %1 : tensor<16xf32>
+}

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -433,3 +433,12 @@ func @foldSplatReshapeIntoSplat(%arg0 : f32) -> tensor<16xf32> {
   %1 = flow.tensor.reshape %0 : tensor<4x4xf32> -> tensor<16xf32>
   return %1 : tensor<16xf32>
 }
+
+// CHECK-LABEL: @foldSplatReshapeIntoSplatDynamic
+func @foldSplatReshapeIntoSplatDynamic(%arg0 : f32, %arg1 : index, %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
+  // CHECK-NEXT: %0 = flow.tensor.splat %arg0 : tensor<?x?xf32>{%arg2, %arg3}
+  // CHECK-NEXT: return %0 : tensor<?x?xf32>
+  %0 = flow.tensor.splat %arg0 : tensor<?x4xf32>{%arg1}
+  %1 = flow.tensor.reshape %0 : tensor<?x4xf32>{%arg1} -> tensor<?x?xf32>{%arg2, %arg3}
+  return %1 : tensor<?x?xf32>
+}


### PR DESCRIPTION
Another step towards https://github.com/google/iree/issues/1159 (cc @KareemErgawy-TomTom)

I can fully translate xla_while using this + some pass applications:
```cpp
 passManager.addNestedPass<FuncOp>(mlir::createLinalgDetensorizePass());
 passManager.addNestedPass<FuncOp>(createConvertUpstreamToIREE());
 passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
```
(and `createConvertToFlowTensorOpsPass`)

collatz and tosa_if are failing and I'm not sure why yet (needs more investigation)