### PR TITLE
Fixing/eliminating/clarifying some runtime struct alignment issues.

### DIFF
--- a/iree/base/alignment.h
+++ b/iree/base/alignment.h
@@ -55,6 +55,20 @@ static inline iree_device_size_t iree_device_align(
   return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
+// Returns the size of a struct padded out to iree_max_align_t.
+// This must be used when performing manual trailing allocation packing to
+// ensure the alignment requirements of the trailing data are satisified.
+//
+// NOTE: do not use this if using VLAs (`struct { int trailing[]; }`) - those
+// must precisely follow the normal sizeof(t) as the compiler does the padding
+// for you.
+//
+// Example:
+//  some_buffer_ptr_t* p = NULL;
+//  iree_host_size_t total_size = iree_sizeof_struct(*buffer) + extra_data_size;
+//  IREE_CHECK_OK(iree_allocator_malloc(allocator, total_size, (void**)&p));
+#define iree_sizeof_struct(t) iree_host_align(sizeof(t), iree_max_align_t)
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/iree/base/internal/threading_darwin.c
+++ b/iree/base/internal/threading_darwin.c
@@ -82,7 +82,7 @@ iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
   // (including the user-specified entry_arg).
   iree_thread_t* thread = NULL;
   iree_status_t status =
-      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+      iree_allocator_malloc(allocator, sizeof(*thread), (void**)&thread);
   if (!iree_status_is_ok(status)) {
     IREE_TRACE_ZONE_END(z0);
     return status;

--- a/iree/base/internal/threading_pthreads.c
+++ b/iree/base/internal/threading_pthreads.c
@@ -124,7 +124,7 @@ iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
   // (including the user-specified entry_arg).
   iree_thread_t* thread = NULL;
   iree_status_t status =
-      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+      iree_allocator_malloc(allocator, sizeof(*thread), (void**)&thread);
   if (!iree_status_is_ok(status)) {
     IREE_TRACE_ZONE_END(z0);
     return status;

--- a/iree/base/internal/threading_win32.c
+++ b/iree/base/internal/threading_win32.c
@@ -139,7 +139,7 @@ iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
   // (including the user-specified entry_arg).
   iree_thread_t* thread = NULL;
   iree_status_t status =
-      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+      iree_allocator_malloc(allocator, sizeof(*thread), (void**)&thread);
   if (!iree_status_is_ok(status)) {
     IREE_TRACE_ZONE_END(z0);
     return status;

--- a/iree/base/internal/wait_handle_poll.c
+++ b/iree/base/internal/wait_handle_poll.c
@@ -148,10 +148,10 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   }
 
   iree_host_size_t user_handle_list_size =
-      capacity * sizeof(iree_wait_handle_t);
+      capacity * iree_sizeof_struct(iree_wait_handle_t);
   iree_host_size_t poll_fd_list_size = capacity * sizeof(struct pollfd);
-  iree_host_size_t total_size =
-      sizeof(iree_wait_set_t) + user_handle_list_size + poll_fd_list_size;
+  iree_host_size_t total_size = iree_sizeof_struct(iree_wait_set_t) +
+                                user_handle_list_size + poll_fd_list_size;
 
   iree_wait_set_t* set = NULL;
   IREE_RETURN_IF_ERROR(
@@ -161,7 +161,8 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   iree_wait_set_clear(set);
 
   set->user_handles =
-      (iree_wait_handle_t*)((uint8_t*)set + sizeof(iree_wait_set_t));
+      (iree_wait_handle_t*)((uint8_t*)set +
+                            iree_sizeof_struct(iree_wait_set_t));
   set->poll_fds =
       (struct pollfd*)((uint8_t*)set->user_handles + user_handle_list_size);
 

--- a/iree/base/internal/wait_handle_win32.c
+++ b/iree/base/internal/wait_handle_win32.c
@@ -147,8 +147,8 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   iree_host_size_t user_handle_list_size =
       capacity * sizeof(iree_wait_handle_t);
   iree_host_size_t native_handle_list_size = capacity * sizeof(HANDLE);
-  iree_host_size_t total_size =
-      sizeof(iree_wait_set_t) + user_handle_list_size + native_handle_list_size;
+  iree_host_size_t total_size = iree_sizeof_struct(iree_wait_set_t) +
+                                user_handle_list_size + native_handle_list_size;
 
   iree_wait_set_t* set = NULL;
   IREE_RETURN_IF_ERROR(
@@ -158,7 +158,8 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
   iree_wait_set_clear(set);
 
   set->user_handles =
-      (iree_wait_handle_t*)((uint8_t*)set + sizeof(iree_wait_set_t));
+      (iree_wait_handle_t*)((uint8_t*)set +
+                            iree_sizeof_struct(iree_wait_set_t));
   set->native_handles =
       (HANDLE*)((uint8_t*)set->user_handles + user_handle_list_size);
 

--- a/iree/hal/allocator_heap.c
+++ b/iree/hal/allocator_heap.c
@@ -28,7 +28,8 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_heap_allocator_t* allocator = NULL;
-  iree_host_size_t total_size = sizeof(*allocator) + identifier.size;
+  iree_host_size_t total_size =
+      iree_sizeof_struct(*allocator) + identifier.size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&allocator);
   if (iree_status_is_ok(status)) {
@@ -37,7 +38,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
     allocator->host_allocator = host_allocator;
     iree_string_view_append_to_buffer(
         identifier, &allocator->identifier,
-        (char*)allocator + total_size - identifier.size);
+        (char*)allocator + iree_sizeof_struct(*allocator));
     *out_allocator = (iree_hal_allocator_t*)allocator;
   }
 

--- a/iree/hal/buffer_heap.c
+++ b/iree/hal/buffer_heap.c
@@ -32,8 +32,10 @@ iree_status_t iree_hal_heap_buffer_create(
   IREE_ASSERT_ARGUMENT(out_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // NOTE: we want the buffer data to always be 16-byte aligned.
   iree_hal_heap_buffer_t* buffer = NULL;
-  iree_host_size_t header_size = iree_host_align(sizeof(*buffer), 16);
+  iree_host_size_t header_size =
+      iree_host_align(iree_sizeof_struct(*buffer), 16);
   iree_host_size_t total_size = header_size + allocation_size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&buffer);

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -105,16 +105,16 @@ static iree_status_t iree_hal_cuda_device_create_internal(
     CUstream stream, CUcontext context, iree_hal_cuda_dynamic_symbols_t* syms,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
   iree_hal_cuda_device_t* device = NULL;
-  iree_host_size_t total_size = sizeof(*device) + identifier.size;
+  iree_host_size_t total_size = iree_sizeof_struct(*device) + identifier.size;
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(host_allocator, total_size, (void**)&device));
   memset(device, 0, total_size);
   iree_hal_resource_initialize(&iree_hal_cuda_device_vtable, &device->resource);
   device->driver = driver;
   iree_hal_driver_retain(device->driver);
-  uint8_t* buffer_ptr = (uint8_t*)device + sizeof(*device);
-  buffer_ptr += iree_string_view_append_to_buffer(
-      identifier, &device->identifier, (char*)buffer_ptr);
+  iree_string_view_append_to_buffer(
+      identifier, &device->identifier,
+      (char*)device + iree_sizeof_struct(*device));
   device->device = cu_device;
   device->stream = stream;
   device->context_wrapper.cu_context = context;

--- a/iree/hal/cuda/cuda_driver.c
+++ b/iree/hal/cuda/cuda_driver.c
@@ -51,17 +51,19 @@ static iree_status_t iree_hal_cuda_driver_create_internal(
     const iree_hal_cuda_driver_options_t* options,
     iree_allocator_t host_allocator, iree_hal_driver_t** out_driver) {
   iree_hal_cuda_driver_t* driver = NULL;
-  iree_host_size_t total_size = sizeof(*driver) + identifier.size;
+  iree_host_size_t total_size = iree_sizeof_struct(*driver) + identifier.size;
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(host_allocator, total_size, (void**)&driver));
+
   iree_hal_resource_initialize(&iree_hal_cuda_driver_vtable, &driver->resource);
   driver->host_allocator = host_allocator;
   iree_string_view_append_to_buffer(
       identifier, &driver->identifier,
-      (char*)driver + total_size - identifier.size);
+      (char*)driver + iree_sizeof_struct(*driver));
   memcpy(&driver->default_params, default_params,
          sizeof(driver->default_params));
   driver->default_device_index = options->default_device_index;
+
   iree_status_t status =
       iree_hal_cuda_dynamic_symbols_initialize(host_allocator, &driver->syms);
   if (iree_status_is_ok(status)) {

--- a/iree/hal/driver_registry.c
+++ b/iree/hal/driver_registry.c
@@ -188,8 +188,8 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
 
   // Allocate the required memory for both the driver infos and the string
   // storage in a single block.
-  iree_host_size_t total_driver_infos_size = iree_host_align(
-      total_driver_info_count * sizeof(iree_hal_driver_info_t), 8);
+  iree_host_size_t total_driver_infos_size =
+      total_driver_info_count * sizeof(iree_hal_driver_info_t);
   if (iree_status_is_ok(status)) {
     status = iree_allocator_malloc(allocator,
                                    total_driver_infos_size + total_storage_size,

--- a/iree/hal/local/loaders/embedded_library_loader.c
+++ b/iree/hal/local/loaders/embedded_library_loader.c
@@ -35,6 +35,8 @@ typedef struct iree_hal_elf_executable_t {
     const iree_hal_executable_library_header_t** header;
     const iree_hal_executable_library_v0_t* v0;
   } library;
+
+  iree_hal_local_executable_layout_t* layouts[];
 } iree_hal_elf_executable_t;
 
 extern const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable;
@@ -140,16 +142,13 @@ static iree_status_t iree_hal_elf_executable_create(
   iree_hal_elf_executable_t* executable = NULL;
   iree_host_size_t total_size =
       sizeof(*executable) +
-      executable_layout_count * sizeof(iree_hal_local_executable_layout_t);
+      executable_layout_count * sizeof(*executable->layouts);
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&executable);
   if (iree_status_is_ok(status)) {
-    iree_hal_local_executable_layout_t** executable_layouts_ptr =
-        (iree_hal_local_executable_layout_t**)(((uint8_t*)executable) +
-                                               sizeof(*executable));
     iree_hal_local_executable_initialize(
         &iree_hal_elf_executable_vtable, executable_layout_count,
-        executable_layouts, executable_layouts_ptr, host_allocator,
+        executable_layouts, &executable->layouts[0], host_allocator,
         &executable->base);
   }
   if (iree_status_is_ok(status)) {

--- a/iree/hal/local/loaders/legacy_library_loader.c
+++ b/iree/hal/local/loaders/legacy_library_loader.c
@@ -81,6 +81,8 @@ typedef struct iree_hal_legacy_executable_t {
     const iree_hal_executable_library_header_t** header;
     const iree_hal_executable_library_v0_t* v0;
   } library;
+
+  iree_hal_local_executable_layout_t* layouts[];
 } iree_hal_legacy_executable_t;
 
 extern const iree_hal_local_executable_vtable_t
@@ -224,16 +226,13 @@ static iree_status_t iree_hal_legacy_executable_create(
   iree_hal_legacy_executable_t* executable = NULL;
   iree_host_size_t total_size =
       sizeof(*executable) +
-      executable_layout_count * sizeof(iree_hal_local_executable_layout_t);
+      executable_layout_count * sizeof(*executable->layouts);
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&executable);
   if (iree_status_is_ok(status)) {
-    iree_hal_local_executable_layout_t** executable_layouts_ptr =
-        (iree_hal_local_executable_layout_t**)(((uint8_t*)executable) +
-                                               sizeof(*executable));
     iree_hal_local_executable_initialize(
         &iree_hal_legacy_executable_vtable, executable_layout_count,
-        executable_layouts, executable_layouts_ptr, host_allocator,
+        executable_layouts, &executable->layouts[0], host_allocator,
         &executable->base);
     executable->def = executable_def;
   }

--- a/iree/hal/local/loaders/static_library_loader.c
+++ b/iree/hal/local/loaders/static_library_loader.c
@@ -30,6 +30,8 @@ typedef struct iree_hal_static_executable_t {
     const iree_hal_executable_library_header_t** header;
     const iree_hal_executable_library_v0_t* v0;
   } library;
+
+  iree_hal_local_executable_layout_t* layouts[];
 } iree_hal_static_executable_t;
 
 static const iree_hal_local_executable_vtable_t
@@ -50,16 +52,13 @@ static iree_status_t iree_hal_static_executable_create(
   iree_hal_static_executable_t* executable = NULL;
   iree_host_size_t total_size =
       sizeof(*executable) +
-      executable_layout_count * sizeof(iree_hal_local_executable_layout_t);
+      executable_layout_count * sizeof(*executable->layouts);
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&executable);
   if (iree_status_is_ok(status)) {
-    iree_hal_local_executable_layout_t** executable_layouts_ptr =
-        (iree_hal_local_executable_layout_t**)(((uint8_t*)executable) +
-                                               sizeof(*executable));
     iree_hal_local_executable_initialize(
         &iree_hal_static_executable_vtable, executable_layout_count,
-        executable_layouts, executable_layouts_ptr, host_allocator,
+        executable_layouts, &executable->layouts[0], host_allocator,
         &executable->base);
     executable->library.header = library_header;
     executable->identifier = iree_make_cstring_view((*library_header)->name);

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -23,13 +23,13 @@ typedef struct iree_hal_sync_device_t {
   iree_hal_resource_t resource;
   iree_string_view_t identifier;
 
-  iree_host_size_t loader_count;
-  iree_hal_executable_loader_t** loaders;
-
   iree_allocator_t host_allocator;
   iree_hal_allocator_t* device_allocator;
 
   iree_hal_sync_semaphore_state_t semaphore_state;
+
+  iree_host_size_t loader_count;
+  iree_hal_executable_loader_t* loaders[];
 } iree_hal_sync_device_t;
 
 static const iree_hal_device_vtable_t iree_hal_sync_device_vtable;
@@ -64,8 +64,9 @@ iree_status_t iree_hal_sync_device_create(
                                     iree_hal_sync_device_check_params(params));
 
   iree_hal_sync_device_t* device = NULL;
-  iree_host_size_t total_size = sizeof(*device) + identifier.size +
-                                loader_count * sizeof(*device->loaders);
+  iree_host_size_t struct_size =
+      sizeof(*device) + loader_count * sizeof(*device->loaders);
+  iree_host_size_t total_size = struct_size + identifier.size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&device);
   if (iree_status_is_ok(status)) {
@@ -73,13 +74,10 @@ iree_status_t iree_hal_sync_device_create(
     iree_hal_resource_initialize(&iree_hal_sync_device_vtable,
                                  &device->resource);
     iree_string_view_append_to_buffer(identifier, &device->identifier,
-                                      (char*)device + sizeof(*device));
+                                      (char*)device + struct_size);
     device->host_allocator = host_allocator;
 
     device->loader_count = loader_count;
-    device->loaders =
-        (iree_hal_executable_loader_t**)((uint8_t*)device->identifier.data +
-                                         identifier.size);
     for (iree_host_size_t i = 0; i < device->loader_count; ++i) {
       device->loaders[i] = loaders[i];
       iree_hal_executable_loader_retain(device->loaders[i]);

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -92,19 +92,18 @@ iree_status_t iree_hal_task_device_create(
                                     iree_hal_task_device_check_params(params));
 
   iree_hal_task_device_t* device = NULL;
-  iree_host_size_t total_size =
-      sizeof(*device) + params->queue_count * sizeof(*device->queues) +
-      identifier.size + loader_count * sizeof(*device->loaders);
+  iree_host_size_t struct_size = sizeof(*device) +
+                                 params->queue_count * sizeof(*device->queues) +
+                                 loader_count * sizeof(*device->loaders);
+  iree_host_size_t total_size = struct_size + identifier.size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&device);
   if (iree_status_is_ok(status)) {
     memset(device, 0, total_size);
     iree_hal_resource_initialize(&iree_hal_task_device_vtable,
                                  &device->resource);
-    iree_string_view_append_to_buffer(
-        identifier, &device->identifier,
-        (char*)device + sizeof(*device) +
-            params->queue_count * sizeof(*device->queues));
+    iree_string_view_append_to_buffer(identifier, &device->identifier,
+                                      (char*)device + struct_size);
     device->host_allocator = host_allocator;
     iree_arena_block_pool_initialize(4096, host_allocator,
                                      &device->small_block_pool);
@@ -117,8 +116,9 @@ iree_status_t iree_hal_task_device_create(
 
     device->loader_count = loader_count;
     device->loaders =
-        (iree_hal_executable_loader_t**)((uint8_t*)device->identifier.data +
-                                         identifier.size);
+        (iree_hal_executable_loader_t**)((uint8_t*)device + sizeof(*device) +
+                                         params->queue_count *
+                                             sizeof(*device->queues));
     for (iree_host_size_t i = 0; i < device->loader_count; ++i) {
       device->loaders[i] = loaders[i];
       iree_hal_executable_loader_retain(device->loaders[i]);

--- a/iree/hal/local/task_driver.c
+++ b/iree/hal/local/task_driver.c
@@ -47,9 +47,9 @@ iree_status_t iree_hal_task_driver_create(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_task_driver_t* driver = NULL;
-  iree_host_size_t total_size = sizeof(*driver) +
-                                loader_count * sizeof(*driver->loaders) +
-                                identifier.size;
+  iree_host_size_t struct_size =
+      sizeof(*driver) + loader_count * sizeof(*driver->loaders);
+  iree_host_size_t total_size = struct_size + identifier.size;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, total_size, (void**)&driver);
   if (iree_status_is_ok(status)) {
@@ -57,9 +57,8 @@ iree_status_t iree_hal_task_driver_create(
                                  &driver->resource);
     driver->host_allocator = host_allocator;
 
-    iree_string_view_append_to_buffer(
-        identifier, &driver->identifier,
-        (char*)driver + total_size - identifier.size);
+    iree_string_view_append_to_buffer(identifier, &driver->identifier,
+                                      (char*)driver + struct_size);
     memcpy(&driver->default_params, default_params,
            sizeof(driver->default_params));
 

--- a/iree/hal/vulkan/native_descriptor_set_layout.cc
+++ b/iree/hal/vulkan/native_descriptor_set_layout.cc
@@ -56,6 +56,7 @@ static iree_status_t iree_hal_vulkan_create_descriptor_set_layout(
 
   VkDescriptorSetLayoutBinding* native_bindings = NULL;
   if (binding_count > 0) {
+    // TODO(benvanik): avoid this allocation if possible (inline_array).
     IREE_RETURN_IF_ERROR(iree_allocator_malloc(
         logical_device->host_allocator(),
         binding_count * sizeof(VkDescriptorSetLayoutBinding),

--- a/iree/samples/custom_modules/module.cc
+++ b/iree/samples/custom_modules/module.cc
@@ -56,7 +56,7 @@ iree_status_t iree_custom_message_create(iree_string_view_t value,
   // Note that we allocate the message and the string value together.
   iree_custom_message_t* message = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      allocator, sizeof(iree_custom_message_t) + value.size, (void**)&message));
+      allocator, sizeof(*message) + value.size, (void**)&message));
   message->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
   message->allocator = allocator;
   message->value.data = ((const char*)message) + sizeof(iree_custom_message_t);
@@ -71,8 +71,8 @@ iree_status_t iree_custom_message_wrap(iree_string_view_t value,
                                        iree_custom_message_t** out_message) {
   IREE_ASSERT_ARGUMENT(out_message);
   iree_custom_message_t* message = NULL;
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      allocator, sizeof(iree_custom_message_t), (void**)&message));
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, sizeof(*message), (void**)&message));
   message->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
   message->allocator = allocator;
   message->value = value;  // Unowned.

--- a/iree/vm/buffer.c
+++ b/iree/vm/buffer.c
@@ -95,8 +95,7 @@ IREE_API_EXPORT iree_status_t iree_vm_buffer_create(
 
   // The actual buffer payload is prefixed with the buffer type so we need only
   // a single allocation.
-  iree_host_size_t prefix_size =
-      iree_host_align(sizeof(iree_vm_buffer_t), iree_max_align_t);
+  iree_host_size_t prefix_size = iree_sizeof_struct(**out_buffer);
   iree_host_size_t total_size = prefix_size + length;
 
   // Allocate combined [prefix | buffer] memory.

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -761,9 +761,8 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
 
   iree_vm_bytecode_module_t* module = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(
-              allocator, sizeof(iree_vm_bytecode_module_t) + type_table_size,
-              (void**)&module));
+      z0, iree_allocator_malloc(allocator, sizeof(*module) + type_table_size,
+                                (void**)&module));
   module->allocator = allocator;
 
   iree_vm_FunctionDescriptor_vec_t function_descriptors =
@@ -782,8 +781,6 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
   module->def = module_def;
 
   module->type_count = iree_vm_TypeDef_vec_len(type_defs);
-  module->type_table = (iree_vm_type_def_t*)((uint8_t*)module +
-                                             sizeof(iree_vm_bytecode_module_t));
   iree_status_t resolve_status =
       iree_vm_bytecode_module_resolve_types(type_defs, module->type_table);
   if (!iree_status_is_ok(resolve_status)) {

--- a/iree/vm/bytecode_module_impl.h
+++ b/iree/vm/bytecode_module_impl.h
@@ -67,7 +67,7 @@ typedef struct iree_vm_bytecode_module_t {
 
   // Type table mapping module type IDs to registered VM types.
   iree_host_size_t type_count;
-  iree_vm_type_def_t* type_table;
+  iree_vm_type_def_t type_table[];
 } iree_vm_bytecode_module_t;
 
 // A resolved and split import in the module state table.

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -321,12 +321,12 @@ IREE_API_EXPORT iree_status_t iree_vm_context_register_modules(
       // TODO(benvanik): tune list growth for module count >> 4.
       new_capacity = context->list.capacity * 2;
     }
-    iree_vm_module_t** new_module_list;
+    iree_vm_module_t** new_module_list = NULL;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_allocator_malloc(context->allocator,
                                   sizeof(iree_vm_module_t*) * new_capacity,
                                   (void**)&new_module_list));
-    iree_vm_module_state_t** new_module_state_list;
+    iree_vm_module_state_t** new_module_state_list = NULL;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0,
         iree_allocator_malloc(context->allocator,

--- a/iree/vm/instance.c
+++ b/iree/vm/instance.c
@@ -27,8 +27,8 @@ IREE_API_EXPORT iree_status_t iree_vm_instance_create(
 
   iree_vm_instance_t* instance = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(allocator, sizeof(iree_vm_instance_t),
-                                (void**)&instance));
+      z0,
+      iree_allocator_malloc(allocator, sizeof(*instance), (void**)&instance));
   instance->allocator = allocator;
   iree_atomic_ref_count_init(&instance->ref_count);
 

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -166,7 +166,7 @@ IREE_API_EXPORT iree_status_t iree_vm_list_create(
     iree_allocator_t allocator, iree_vm_list_t** out_list) {
   iree_vm_list_t* list = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc(allocator, sizeof(iree_vm_list_t), (void**)&list));
+      iree_allocator_malloc(allocator, sizeof(*list), (void**)&list));
   memset(list, 0, sizeof(*list));
   iree_atomic_ref_count_init(&list->ref_object.counter);
   list->allocator = allocator;

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -360,8 +360,8 @@ IREE_API_EXPORT iree_status_t iree_vm_native_module_create(
   // to expose this via a query_size function so that we could adjust the size
   // of our storage independent of the definition of the user module.
   iree_vm_native_module_t* module = NULL;
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      allocator, sizeof(iree_vm_native_module_t), (void**)&module));
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, sizeof(*module), (void**)&module));
 
   iree_status_t status = iree_vm_native_module_initialize(
       interface, module_descriptor, allocator, (iree_vm_module_t*)module);


### PR DESCRIPTION
Several places where we were doing trailing struct allocations were
not padding to ensure the trailing structs would be properly aligned.
Some could have been VLAs and were switched (woo less pointer math).

Partial fix for #6566.