### PR TITLE
Run a check_submodule_init script during CMake configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ endif()
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_FOUND)
   execute_process(
-    COMMAND python scripts/git/check_submodule_init.py
+    COMMAND python3 scripts/git/check_submodule_init.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE ret
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,20 @@ if(${IREE_BUILD_COMPILER} OR
 endif()
 
 #-------------------------------------------------------------------------------
+# Check if git submodules have been initialized.
+# This will only run if python/python3 is available
+#-------------------------------------------------------------------------------
+
+execute_process(
+  COMMAND python --version && python scripts/git/check_submodule_init.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RESULT_VARIABLE ret
+)
+if(NOT ret EQUAL "0")
+  message(FATAL_ERROR "check_submodule_init.py failed with code: ${ret}")
+endif()
+
+#-------------------------------------------------------------------------------
 # MLIR/LLVM Dependency
 # We treat the LLVM dependency specially because we support several different
 # ways to use it:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,7 @@ endif()
 #-------------------------------------------------------------------------------
 
 execute_process(
-  COMMAND python --version && python scripts/git/check_submodule_init.py
+  COMMAND !(python --version) || python scripts/git/check_submodule_init.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   RESULT_VARIABLE ret
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ endif()
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_FOUND)
   execute_process(
-    COMMAND python3 scripts/git/check_submodule_init.py
+    COMMAND ${Python3_EXECUTABLE} scripts/git/check_submodule_init.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE ret
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,16 +323,19 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Check if git submodules have been initialized.
-# This will only run if python/python3 is available
+# This will only run if python3 is available.
 #-------------------------------------------------------------------------------
 
-execute_process(
-  COMMAND !(python --version) || python scripts/git/check_submodule_init.py
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RESULT_VARIABLE ret
-)
-if(NOT ret EQUAL "0")
-  message(FATAL_ERROR "check_submodule_init.py failed with code: ${ret}")
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_FOUND)
+  execute_process(
+    COMMAND python scripts/git/check_submodule_init.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE ret
+  )
+  if(NOT ret EQUAL "0")
+    message(FATAL_ERROR "check_submodule_init.py failed, see the logs above")
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/scripts/git/check_submodule_init.py
+++ b/scripts/git/check_submodule_init.py
@@ -5,27 +5,28 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
+import subprocess
 import sys
 
 
 def run():
-  # Checking the "git status"
-  git_check = os.popen("git status")
-  git_status = git_check.readline()
+  # No-op if we're not in a git repository.
+  try:
+    subprocess.check_call(['git', 'rev-parse', '--is-inside-work-tree'],
+                          stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL)
+  except:
+    return
 
-  # no-op if not a git repository
-  if not git_status.startswith("On"):
-    sys.exit(1)
-  else:
-    output = os.popen("git submodule status")
-    submodules = output.readlines()
+  output = os.popen("git submodule status")
+  submodules = output.readlines()
 
-    for submodule in submodules:
-      if (submodule.strip()[0] == "-"):
-        print(
-            f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`"
-        )
-        sys.exit(1)
+  for submodule in submodules:
+    if (submodule.strip()[0] == "-"):
+      print(
+          f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`"
+      )
+      sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/git/check_submodule_init.py
+++ b/scripts/git/check_submodule_init.py
@@ -9,22 +9,24 @@ import sys
 
 
 def run():
-    # Checking the "git status"
-    git_check = os.popen("git status")
-    git_status = git_check.readline()
+  # Checking the "git status"
+  git_check = os.popen("git status")
+  git_status = git_check.readline()
 
-    # no-op if not a git repository
-    if (git_status.startswith("On")):
-        output = os.popen("git submodule status")
-        submodules = output.readlines()
+  # no-op if not a git repository
+  if not git_status.startswith("On"):
+    sys.exit(1)
+  else:
+    output = os.popen("git submodule status")
+    submodules = output.readlines()
 
-        for submodule in submodules:
-            if (submodule.strip()[0] == "-"):
-                print(
-                    f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`")
-
-            sys.exit(1)
+    for submodule in submodules:
+      if (submodule.strip()[0] == "-"):
+        print(
+            f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`"
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    run()
+  run()

--- a/scripts/git/check_submodule_init.py
+++ b/scripts/git/check_submodule_init.py
@@ -1,0 +1,30 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import sys
+
+
+def run():
+    # Checking the "git status"
+    git_check = os.popen("git status")
+    git_status = git_check.readline()
+
+    # no-op if not a git repository
+    if (git_status.startswith("On")):
+        output = os.popen("git submodule status")
+        submodules = output.readlines()
+
+        for submodule in submodules:
+            if (submodule.strip()[0] == "-"):
+                print(
+                    f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`")
+
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/git/check_submodule_init.py
+++ b/scripts/git/check_submodule_init.py
@@ -24,8 +24,8 @@ def run():
   for submodule in submodules:
     if (submodule.strip()[0] == "-"):
       print(
-          f"The git submodule '{submodule.split()[1]}' is not initialized. Please run `git submodule update --init`"
-      )
+          "The git submodule '%s' is not initialized. Please run `git submodule update --init`"
+          % (submodule.split()[1]))
       sys.exit(1)
 
 


### PR DESCRIPTION
Checking if git submodules have been initialized and printing warning messages.
Added a python script in `scripts/git/check_submodule_init.py` which will run inside the CMake: `CMakeLists.txt `

- The script won't check for the status of the submodules if not a git repository
- This will only run if python/python3 is available

Fixes #6434 