### PR TITLE
Remove redundant variable to enable CUDA test

### DIFF
--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -44,7 +44,6 @@ declare -a default_test_tag_filters=("-nokokoro" "-driver=metal")
 # We test on SwiftShader, which does not support this extension.
 default_test_tag_filters+=("-vulkan_uses_vk_khr_shader_float16_int8")
 # CUDA CI testing disabled until we setup a target for it.
-default_test_tag_filters+=("-uses_cuda_runtime")
 default_test_tag_filters+=("-driver=cuda")
 
 if [[ "${IREE_VULKAN_DISABLE?}" == 1 ]]; then

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -24,7 +24,6 @@ export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
-export IREE_CUDA_RUNTIME_DISABLE=${IREE_CUDA_RUNTIME_DISABLE:-1}
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
 # We test on SwiftShader, which does not support this extension.
 export IREE_VULKAN_F16_DISABLE=${IREE_VULKAN_F16_DISABLE:-1}
@@ -59,8 +58,6 @@ if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then
 fi
 if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^driver=cuda$")
-fi
-if [[ "${IREE_CUDA_RUNTIME_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^uses_cuda_runtime$")
 fi
 if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -58,7 +58,6 @@ if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then
 fi
 if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^driver=cuda$")
-  label_exclude_args+=("^uses_cuda_runtime$")
 fi
 if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^vulkan_uses_vk_khr_shader_float16_int8$")

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -54,7 +54,6 @@ export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-1}
 export IREE_LLVMAOT_DISABLE=${IREE_LLVMAOT_DISABLE:-0}
 # CUDA is off by default.
 export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
-export IREE_CUDA_RUNTIME_DISABLE=${IREE_CUDA_RUNTIME_DISABLE:-1}
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
 # We test on SwiftShader, which does not support this extension.
 export IREE_VULKAN_F16_DISABLE=${IREE_VULKAN_F16_DISABLE:-1}
@@ -89,8 +88,6 @@ if [[ "${IREE_LLVMAOT_DISABLE?}" == 1 ]]; then
 fi
 if [[ "${IREE_CUDA_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^driver=cuda$")
-fi
-if [[ "${IREE_CUDA_RUNTIME_DISABLE?}" == 1 ]]; then
   label_exclude_args+=("^uses_cuda_runtime$")
 fi
 if [[ "${IREE_VULKAN_F16_DISABLE?}" == 1 ]]; then

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
@@ -38,6 +38,5 @@ echo "Building with cmake"
 
 export IREE_VULKAN_F16_DISABLE=0
 export IREE_CUDA_DISABLE=0
-export IREE_CUDA_RUNTIME_DISABLE=0
 echo "Testing with ctest"
 ./build_tools/cmake/test.sh

--- a/iree/samples/simple_embedding/BUILD
+++ b/iree/samples/simple_embedding/BUILD
@@ -303,7 +303,7 @@ iree_bytecode_module(
 run_binary_test(
     name = "simple_embedding_cuda_test",
     tags = [
-        "uses_cuda_runtime",
+        "driver=cuda",
     ],
     test_binary = ":simple_embedding_cuda",
 )

--- a/iree/samples/simple_embedding/CMakeLists.txt
+++ b/iree/samples/simple_embedding/CMakeLists.txt
@@ -282,7 +282,7 @@ iree_run_binary_test(
   NAME
     "simple_embedding_cuda_test"
   LABELS
-    "uses_cuda_runtime"
+    "driver=cuda"
   TEST_BINARY
     ::simple_embedding_cuda
 )


### PR DESCRIPTION
We only need one variable to disable CUDA execution tests.