### PR TITLE
[spirv] Create variables early for conversion and deduplication

### DIFF
--- a/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -87,7 +87,8 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
   SymbolTable symbolTable(module);
   InterfaceResourceMap interfaceToResourceVars;
 
-  for (FuncOp func : module.getOps<FuncOp>()) {
+  auto fns = llvm::to_vector<1>(module.getOps<FuncOp>());
+  for (FuncOp func : llvm::reverse(fns)) {
     // Collect all interface ops and their (set, binding) pairs in this
     // function. Use SmallVector here for a deterministic order.
     SmallVector<IREE::HAL::InterfaceBindingSubspanOp, 8> interfaceOps;
@@ -112,7 +113,7 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
                    spirv::GlobalVariableOp>
         resourceVars;
 
-    for (unsigned i = 0; i < interfaceOps.size(); ++i) {
+    for (int i = interfaceOps.size() - 1; i >= 0; --i) {
       auto interfaceOp = interfaceOps[i];
       const auto &setBinding = setBindings[i];
 

--- a/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -13,6 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <tuple>
+
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
@@ -51,15 +53,19 @@ namespace {
 // Resource utilities
 //===----------------------------------------------------------------------===//
 
-/// Inserts a resource evariable of the given `type` at the beginning of
+/// Map from hal.interface.binding.subspan ops to their corresponding
+/// spv.GlobalVariable ops.
+using InterfaceResourceMap =
+    llvm::DenseMap<Operation *, spirv::GlobalVariableOp>;
+
+/// Creates a resource evariable of the given `type` at the beginning of
 /// `moduleOp`'s block via `symbolTable` and bind it to `set` and `binding`.
-spirv::GlobalVariableOp insertResourceVariable(Location loc, Type type,
+spirv::GlobalVariableOp createResourceVariable(Location loc, Type type,
                                                unsigned set, unsigned binding,
                                                bool alias, ModuleOp moduleOp,
-                                               SymbolTable *symbolTable,
-                                               OpBuilder::Listener *listener) {
-  OpBuilder builder(moduleOp.getContext(), listener);
+                                               SymbolTable *symbolTable) {
   std::string name = llvm::formatv("__resource_var_{0}_{1}_", set, binding);
+  OpBuilder builder(moduleOp.getContext());
   auto variable =
       builder.create<spirv::GlobalVariableOp>(loc, type, name, set, binding);
   if (alias) variable->setAttr("aliased", builder.getUnitAttr());
@@ -74,35 +80,65 @@ std::pair<int32_t, int32_t> getInterfaceSetAndBinding(Operation *op) {
   return {bindingOp.set().getSExtValue(), bindingOp.binding().getSExtValue()};
 }
 
-/// Returns the set of resources that should be marked as aliased in SPIR-V.
-llvm::DenseSet<Operation *> getAliasedResources(ModuleOp module) {
-  llvm::DenseSet<Operation *> aliasedResources;
+/// Scans all hal.interface.binding.subspan ops in `module`, creates their
+/// corresponding spv.GlobalVariables when needed, and returns the map.
+/// The created variables need to have their types fixed later.
+InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
+  SymbolTable symbolTable(module);
+  InterfaceResourceMap interfaceToResourceVars;
 
   for (FuncOp func : module.getOps<FuncOp>()) {
     // Collect all interface ops and their (set, binding) pairs in this
-    // function.
-    SmallVector<Operation *, 4> interfaceOps;
-    SmallVector<std::pair<uint32_t, uint32_t>, 4> setBindings;
-    llvm::DenseMap<std::pair<uint32_t, uint32_t>, unsigned> setBindingCount;
+    // function. Use SmallVector here for a deterministic order.
+    SmallVector<IREE::HAL::InterfaceBindingSubspanOp, 8> interfaceOps;
+    SmallVector<std::pair<uint32_t, uint32_t>, 8> setBindings;
+
+    // Use a map to see if we have different types for one (set, binding) pair,
+    // which will require creating multiple SPIR-V global variables.
+    llvm::DenseMap<std::pair<uint32_t, uint32_t>, llvm::DenseSet<Type>>
+        setBindingTypes;
+
     func.walk([&](Operation *op) {
-      if (isa<IREE::HAL::InterfaceBindingSubspanOp>(op)) {
-        interfaceOps.emplace_back(op);
-        setBindings.emplace_back(getInterfaceSetAndBinding(op));
-        ++setBindingCount[setBindings.back()];
-      }
+      auto interfaceOp = dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(op);
+      if (!interfaceOp || interfaceOp.use_empty()) return;
+      interfaceOps.emplace_back(interfaceOp);
+      setBindings.emplace_back(getInterfaceSetAndBinding(interfaceOp));
+      setBindingTypes[setBindings.back()].insert(interfaceOp.getType());
     });
 
-    // Perform analysis to determine whether we need to mark the resource as
-    // alias. This should happen when we have multiple resources binding to the
-    // same (set, binding) pair and they are used in the same function.
+    // Keep track of created SPIR-V global variables. This allows us to
+    // deduplicate when possible to reduce generated SPIR-V blob size.
+    llvm::DenseMap<std::tuple<uint32_t, uint32_t, Type>,
+                   spirv::GlobalVariableOp>
+        resourceVars;
+
     for (unsigned i = 0; i < interfaceOps.size(); ++i) {
-      if (setBindingCount[setBindings[i]] > 1) {
-        aliasedResources.insert(interfaceOps[i]);
+      auto interfaceOp = interfaceOps[i];
+      const auto &setBinding = setBindings[i];
+
+      auto key = std::make_tuple(setBinding.first, setBinding.second,
+                                 interfaceOp.getType());
+      auto var = resourceVars.lookup(key);
+      if (!var) {
+        // If we have multiple SPIR-V global variables bound to the same (set,
+        // binding) pair and they are used in the same function, those variables
+        // need to have alias decoration.
+        bool alias = setBindingTypes[setBindings[i]].size() > 1;
+
+        // We are using the interface op's type for creating the global
+        // variable. It's fine. The correctness boundary is the pass.
+        // We will fix it up during conversion so it won't leak.
+        var = createResourceVariable(
+            interfaceOp.getLoc(), interfaceOp.getType(), setBinding.first,
+            setBinding.second, alias, module, &symbolTable);
+        resourceVars[key] = var;
       }
+
+      interfaceToResourceVars[interfaceOp] = var;
     }
   }
 
-  return aliasedResources;
+  return interfaceToResourceVars;
 }
 
 }  // namespace
@@ -169,17 +205,19 @@ struct HALInterfaceBindingSubspanConverter final
     : public OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
   HALInterfaceBindingSubspanConverter(
       TypeConverter &typeConverter, MLIRContext *context,
-      const llvm::DenseSet<Operation *> &aliasedResources,
-      SymbolTable *symbolTable, PatternBenefit benefit = 1)
+      const InterfaceResourceMap &interfaceToResourceVars,
+      PatternBenefit benefit = 1)
       : OpConversionPattern(typeConverter, context, benefit),
-        aliasedResources(aliasedResources),
-        symbolTable(symbolTable) {}
+        interfaceToResourceVars(interfaceToResourceVars) {}
 
   LogicalResult matchAndRewrite(
       IREE::HAL::InterfaceBindingSubspanOp interfaceOp,
       ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto moduleOp = interfaceOp->template getParentOfType<ModuleOp>();
+    if (interfaceOp.use_empty()) {
+      rewriter.eraseOp(interfaceOp);
+      return success();
+    }
 
     Type resultType = interfaceOp.getOperation()->getResult(0).getType();
     Type convertedType = this->getTypeConverter()->convertType(resultType);
@@ -187,22 +225,18 @@ struct HALInterfaceBindingSubspanConverter final
       return interfaceOp.emitError()
              << "failed to convert SPIR-V type: " << resultType;
     }
-    auto setAndBinding = getInterfaceSetAndBinding(interfaceOp.getOperation());
 
-    // We always create a new resource variable for the interface.
-    spirv::GlobalVariableOp varOp = insertResourceVariable(
-        interfaceOp.getLoc(), convertedType, setAndBinding.first,
-        setAndBinding.second,
-        aliasedResources.contains(interfaceOp.getOperation()), moduleOp,
-        symbolTable, rewriter.getListener());
+    auto varOp = interfaceToResourceVars.lookup(interfaceOp);
+    // Fix up the variable's type.
+    varOp.typeAttr(TypeAttr::get(convertedType));
 
     rewriter.replaceOpWithNewOp<spirv::AddressOfOp>(interfaceOp, varOp);
+
     return success();
   }
 
  private:
-  const llvm::DenseSet<Operation *> &aliasedResources;
-  SymbolTable *symbolTable;
+  const InterfaceResourceMap &interfaceToResourceVars;
 };
 
 /// Pattern to lower operations that become a no-ops at this level.
@@ -307,18 +341,12 @@ void ConvertToSPIRVPass::runOnOperation() {
           IREE::HAL::InterfaceWorkgroupCountOp, spirv::BuiltIn::NumWorkgroups>>(
       typeConverter, context);
 
-  // Create a symbol table for the current module op. This must be done before
-  // starting conversion. The conversion framework has a deferred nature.
-  // Actions like replacing/deleting ops are just recorded instead of directly
-  // applied. So for function conversion, we will see both the original function
-  // and the new replacement function during conversion process. That causes an
-  // issue for creating symbol tables, which scans all symbols and errors out
-  // when duplicates are found. We should be fine here tough becuase we only use
-  // this symbol table to insert new SPIR-V global variables.
-  SymbolTable symbolTable(moduleOp);
-  auto aliasedResources = getAliasedResources(moduleOp);
-  patterns.insert<HALInterfaceBindingSubspanConverter>(
-      typeConverter, context, aliasedResources, &symbolTable);
+  // Performs a prelimiary step to analyze all hal.interface.binding.subspan ops
+  // and create spv.GlobalVariables.
+  auto interfaceToResourceVars = createResourceVariables(moduleOp);
+  // For using use them in conversion.
+  patterns.insert<HALInterfaceBindingSubspanConverter>(typeConverter, context,
+                                                       interfaceToResourceVars);
 
   /// Fold certain operations as no-ops:
   /// - linalg.reshape becomes a no-op since all memrefs are linearized in

--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -24,10 +24,10 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
 
 module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
   // CHECK-LABEL: spv.module
-  // CHECK: spv.GlobalVariable @[[RET0:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @[[ARG1_1:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @[[ARG1_0:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
   // CHECK: spv.GlobalVariable @[[ARG0:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[ARG1_0:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[ARG1_1:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[RET0:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
   // CHECK: spv.func @resource_bindings_in_same_entry_func()
   func @resource_bindings_in_same_entry_func() {
     %c0 = constant 0 : index
@@ -69,10 +69,10 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
 
 module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
   // CHECK-LABEL: spv.module
-  // CHECK: spv.GlobalVariable @[[FUNC2_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @[[FUNC2_ARG:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @[[FUNC1_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
   // CHECK: spv.GlobalVariable @[[FUNC1_ARG:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[FUNC1_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[FUNC2_ARG:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[FUNC2_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
 
   // CHECK: spv.func @resource_bindings_in_entry_func1()
   func @resource_bindings_in_entry_func1() {
@@ -133,9 +133,9 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
 // Explicitly check the variable symbols
 
 // CHECK-LABEL: spv.module
-//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_2_ bind(0, 2)
-//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_1_ bind(0, 1)
-//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_0_ bind(0, 0)
+//       CHECK:   spv.GlobalVariable @__resource_var_0_0_ bind(0, 0)
+//       CHECK:   spv.GlobalVariable @__resource_var_0_1_ bind(0, 1)
+//       CHECK:   spv.GlobalVariable @__resource_var_0_2_ bind(0, 2)
 //       CHECK:   spv.func
 //       CHECK:   %{{.+}} = spv.mlir.addressof @__resource_var_0_0_
 //       CHECK:   %{{.+}} = spv.mlir.addressof @__resource_var_0_1_

--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -24,20 +24,43 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
 
 module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
   // CHECK-LABEL: spv.module
-  // CHECK: spv.GlobalVariable @__resource_var_3_4_ bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @__resource_var_1_2__0 bind(1, 2) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
-  // CHECK: spv.GlobalVariable @__resource_var_1_2_ bind(1, 2) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[RET0:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[ARG1_1:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[ARG1_0:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
+  // CHECK: spv.GlobalVariable @[[ARG0:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
   // CHECK: spv.func @resource_bindings_in_same_entry_func()
   func @resource_bindings_in_same_entry_func() {
     %c0 = constant 0 : index
+
+    // Same type
+    // CHECK: spv.mlir.addressof @[[ARG0]]
+    // CHECK: spv.mlir.addressof @[[ARG0]]
     %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
     %1 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
-    %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32>
+
+    // Different type
+    // CHECK: spv.mlir.addressof @[[ARG1_0]]
+    // CHECK: spv.mlir.addressof @[[ARG1_1]]
+    %2 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<4x4xf32>
+    %3 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<4xvector<4xf32>>
+
+    // CHECK: spv.mlir.addressof @[[RET0]]
+    %4 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32>
+
+    %5 = memref.load %0[%c0, %c0] : memref<4x4xf32>
+    %6 = memref.load %1[%c0, %c0] : memref<4x4xf32>
+
+    %7 = memref.load %2[%c0, %c0] : memref<4x4xf32>
+    %8 = memref.load %3[%c0] : memref<4xvector<4xf32>>
+
+    %9 = memref.load %4[%c0, %c0] : memref<4x4xf32>
+
     return
   }
 
   hal.interface @io attributes {push_constants = 5 : index, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=1, binding=3, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
   }
 }
@@ -53,11 +76,15 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
 
   // CHECK: spv.func @resource_bindings_in_entry_func1()
   func @resource_bindings_in_entry_func1() {
-    // CHECK: spv.mlir.addressof @[[FUNC1_ARG:.+]]
-    // CHECK: spv.mlir.addressof @[[FUNC1_RET:.+]]
+    // CHECK: spv.mlir.addressof @[[FUNC1_ARG]]
+    // CHECK: spv.mlir.addressof @[[FUNC1_RET]]
     %c0 = constant 0 : index
     %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
     %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4xvector<4xf32>>
+
+    %2 = memref.load %0[%c0, %c0] : memref<4x4xf32>
+    %3 = memref.load %1[%c0] : memref<4xvector<4xf32>>
+
     return
   }
 
@@ -66,8 +93,12 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
     // CHECK: spv.mlir.addressof @[[FUNC2_ARG]]
     // CHECK: spv.mlir.addressof @[[FUNC2_RET]]
     %c0 = constant 0 : index
-    %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
-    %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32>
+    %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32> // Same type as previous function
+    %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32> // Different type as previous function
+
+    %2 = memref.load %0[%c0, %c0] : memref<4x4xf32>
+    %3 = memref.load %1[%c0, %c0] : memref<4x4xf32>
+
     return
   }
 
@@ -85,6 +116,11 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
     %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<8x5xf32>
     %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<5xf32>
     %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<8x5xf32>
+
+    %3 = memref.load %0[%c0, %c0] : memref<8x5xf32>
+    %4 = memref.load %1[%c0] : memref<5xf32>
+    %5 = memref.load %2[%c0, %c0] : memref<8x5xf32>
+
     return
   }
   hal.interface @io attributes {sym_visibility = "private"} {
@@ -93,14 +129,17 @@ module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
 }
+
+// Explicitly check the variable symbols
+
 // CHECK-LABEL: spv.module
-//   CHECK-DAG:   spv.GlobalVariable @[[RET0:.+]] bind(0, 2)
-//   CHECK-DAG:   spv.GlobalVariable @[[ARG1:.+]] bind(0, 1)
-//   CHECK-DAG:   spv.GlobalVariable @[[ARG0:.+]] bind(0, 0)
+//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_2_ bind(0, 2)
+//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_1_ bind(0, 1)
+//   CHECK-DAG:   spv.GlobalVariable @__resource_var_0_0_ bind(0, 0)
 //       CHECK:   spv.func
-//   CHECK-DAG:   %{{.+}} = spv.mlir.addressof @[[RET0]]
-//   CHECK-DAG:   %{{.+}} = spv.mlir.addressof @[[ARG0]]
-//   CHECK-DAG:   %{{.+}} = spv.mlir.addressof @[[ARG1]]
+//       CHECK:   %{{.+}} = spv.mlir.addressof @__resource_var_0_0_
+//       CHECK:   %{{.+}} = spv.mlir.addressof @__resource_var_0_1_
+//       CHECK:   %{{.+}} = spv.mlir.addressof @__resource_var_0_2_
 
 // -----
 


### PR DESCRIPTION
This is a followup to https://github.com/google/iree/pull/6509. 

`hal.interface.binding.subspan` to `spv.GlobalVariable` conversion
is tricky due to their different scopes (function vs. module),
SSA values vs. symbols, and the need to attach `alias` decorations.

Previously we create `spv.GlobalVariable` in the middle of the
conversion procedure, it requires us to pass down a few data
structures to the pattern so that we can access the alias
status. Notably, it requires us to pass in a `SymbolTable` so
that we can unique symbols. The `SymbolTable` needs to be created
before the conversion; otherwise we will see errors. It's relying
on `SymbolTable` and conversion framework implementation details;
so quite opaque.

This commit changes to create the global variables earlier, at the
alias analysis step. Then during conversion, we just need to
look up the table and perform mechanical rewrite, plus type fixup.
This limits all the `SymbolTable` access to a much smaller scope.
More importantly, we can also perform some deduplication for
created global variables to generate smaller SPIR-V blobs.