### PR TITLE
Forcing 2-byte alignment on VM register lists.

### DIFF
--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/module_encoding_smoke.mlir
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/module_encoding_smoke.mlir
@@ -18,13 +18,16 @@ vm.module @simple_module {
   // CHECK: "function_descriptors":
   // CHECK-NEXT: {
   // CHECK-NEXT:   "bytecode_offset": 0
-  // CHECK-NEXT:   "bytecode_length": 5
+  // CHECK-NEXT:   "bytecode_length": 8
   // CHECK-NEXT:   "i32_register_count": 1
   // CHECK-NEXT:   "ref_register_count": 0
   // CHECK-NEXT: }
   //      CHECK: "bytecode_data": [
   // CHECK-NEXT:   84,
+  // CHECK-NEXT:   0,
   // CHECK-NEXT:   1,
+  // CHECK-NEXT:   0,
+  // CHECK-NEXT:   0,
   // CHECK-NEXT:   0,
   // CHECK-NEXT:   0,
   // CHECK-NEXT:   0

--- a/iree/compiler/Translation/test/smoketest.mlir
+++ b/iree/compiler/Translation/test/smoketest.mlir
@@ -14,12 +14,13 @@ func @func(%arg0 : i32) -> i32 {
 // CHECK: "function_descriptors":
 // CHECK-NEXT: {
 // CHECK-NEXT:   "bytecode_offset": 0
-// CHECK-NEXT:   "bytecode_length": 5
+// CHECK-NEXT:   "bytecode_length": 8
 // CHECK-NEXT:   "i32_register_count": 1
 // CHECK-NEXT:   "ref_register_count": 0
 // CHECK-NEXT: }
 // CHECK: "bytecode_data": [
 // CHECK-NEXT:   84,
+// CHECK-NEXT:   0,
 // CHECK-NEXT:   1,
 // CHECK-NEXT:   0,
 // CHECK-NEXT:   0,

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -191,6 +191,9 @@ static const int kRegSize = sizeof(uint16_t);
 // Each macro will increment the pc by the number of bytes read and as such must
 // be called in the same order the values are encoded.
 
+#define VM_AlignPC(pc, alignment) \
+  (pc) = ((pc) + ((alignment)-1)) & ~((alignment)-1)
+
 #define VM_DecConstI8(name) \
   OP_I8(0);                 \
   ++pc;
@@ -223,11 +226,16 @@ static const int kRegSize = sizeof(uint16_t);
   (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
   pc += 2 + (out_str)->size;
 #define VM_DecBranchTarget(block_name) VM_DecConstI32(name)
-#define VM_DecBranchOperands(operands_name)                                   \
-  (const iree_vm_register_remap_list_t*)&bytecode_data[pc];                   \
-  pc +=                                                                       \
-      kRegSize + ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * \
-                     2 * kRegSize;
+#define VM_DecBranchOperands(operands_name) \
+  VM_DecBranchOperandsImpl(bytecode_data, &pc)
+static inline const iree_vm_register_remap_list_t* VM_DecBranchOperandsImpl(
+    const uint8_t* IREE_RESTRICT bytecode_data, iree_vm_source_offset_t* pc) {
+  VM_AlignPC(*pc, kRegSize);
+  const iree_vm_register_remap_list_t* list =
+      (const iree_vm_register_remap_list_t*)&bytecode_data[*pc];
+  *pc = *pc + kRegSize + list->size * 2 * kRegSize;
+  return list;
+}
 #define VM_DecOperandRegI32(name)      \
   regs.i32[OP_I16(0) & regs.i32_mask]; \
   pc += kRegSize;
@@ -244,10 +252,16 @@ static const int kRegSize = sizeof(uint16_t);
   &regs.ref[OP_I16(0) & regs.ref_mask];                    \
   *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
   pc += kRegSize;
-#define VM_DecVariadicOperands(name)                  \
-  (const iree_vm_register_list_t*)&bytecode_data[pc]; \
-  pc += kRegSize +                                    \
-        ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * kRegSize;
+#define VM_DecVariadicOperands(name) \
+  VM_DecVariadicOperandsImpl(bytecode_data, &pc)
+static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
+    const uint8_t* IREE_RESTRICT bytecode_data, iree_vm_source_offset_t* pc) {
+  VM_AlignPC(*pc, kRegSize);
+  const iree_vm_register_list_t* list =
+      (const iree_vm_register_list_t*)&bytecode_data[*pc];
+  *pc = *pc + kRegSize + list->size * kRegSize;
+  return list;
+}
 #define VM_DecResultRegI32(name)        \
   &regs.i32[OP_I16(0) & regs.i32_mask]; \
   pc += kRegSize;


### PR DESCRIPTION
This is a hack for #6566 but not a bad idea in general. Future revisions
of the bytecode format will take this into account natively such that
we don't need any unaligned loads at runtime.