### PR TITLE
Introduce linalg_ext.fft to LinalgExt dialect.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
@@ -40,18 +40,9 @@ LogicalResult verifyLinalgExtOpInterface(Operation *op) {
       }
     }
   } else {
-    for (auto en : llvm::enumerate(linalgExtOp.getInputOperands())) {
-      if (!linalgExtOp.isScalar(en.value()) &&
-          !en.value()->get().getType().isa<MemRefType>()) {
-        return linalgExtOp.emitOpError("expected `ins` operand #")
-               << en.index() << " to be of MemRefType or scalar";
-      }
-    }
-    for (auto en : llvm::enumerate(linalgExtOp.outputs())) {
-      if (!en.value().getType().isa<MemRefType>()) {
-        return linalgExtOp.emitOpError("expected `outs` operand #")
-               << en.index() << " to be of MemRefType";
-      }
+    if (!linalgExtOp.hasBufferSemantics()) {
+      return linalgExtOp.emitOpError(
+          "expected inputs and outputs to be MemRefType or scalar");
     }
   }
   return success();

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -558,6 +558,9 @@ SmallVector<StringRef> FftOp::getLoopIteratorTypes() {
   // the stage, and another is merge step. Thus, there are `rank+1` in total.
   SmallVector<StringRef> iteratorTypes(getOperandRank() + 1,
                                        getParallelIteratorTypeName());
+  // TODO(hanchung): Mark the loop type as "parallel" after tiling is
+  // implemented.
+  iteratorTypes[0] = getReductionIteratorTypeName();
   return iteratorTypes;
 }
 

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -556,9 +556,6 @@ SmallVector<Range> FftOp::getLoopBounds(OpBuilder &builder) {
   Value size = builder.create<ConstantIndexOp>(loc, getFftLength());
   Value stride = builder.create<ShiftLeftOp>(loc, one, getStage());
   res.emplace_back(Range{/*offset=*/zero, size, /*stride=*/stride});
-
-  Value halfStride = builder.create<SignedShiftRightOp>(loc, stride, one);
-  res.emplace_back(Range{/*offset=*/zero, halfStride, /*stride=*/one});
   return res;
 }
 

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -201,7 +201,7 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft",
     `outs` `(` $outputs `:` type($outputs) `)`
     (`:` type($results)^)?
   }];
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
     Value operand() {
       return outputs()[0];
     }

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -178,6 +178,49 @@ def LinalgExt_SortOp : LinalgExt_Op<"sort",
   }];
 }
 
+def LinalgExt_FftOp : LinalgExt_Op<"fft",
+    [DeclareOpInterfaceMethods<TiledOpInterface, []>]> {
+  let summary = "Fft operator";
+  let description = [{
+    Apply 1D FFT to innermost dim. This is an iterative FFT, not recurrsive.
+    Thus, the bit reversal is assumed applied on the input. The op carries an
+    input -- stage, which indicates the level of reduction loop in the
+    algorithm. It represents the computation body. For more details, see
+    "Data reordering, bit reversal, and in-place algorithms" section in
+    https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
+
+    The size of innermost dim is expected to be a power of 2.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs,
+                       Variadic<AnyShaped>:$outputs
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let assemblyFormat = [{
+    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`:` type($results)^)?
+  }];
+  let extraClassDeclaration = [{
+    Value operand() {
+      return outputs()[0];
+    }
+    ShapedType getOperandType() {
+      return operand().getType().cast<ShapedType>();
+    }
+    int64_t getOperandRank() {
+      return getOperandType().getRank();
+    }
+    ArrayRef<int64_t> getOperandShape() {
+      return getOperandType().getShape();
+    }
+    int64_t getFftLength() {
+      return getOperandShape().back();
+    }
+    Value getStage() { return inputs()[0]; }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Pure ops
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -57,7 +57,7 @@ func @sort_mismatch_shape(%arg0: tensor<?xi32>, %arg1: tensor<42xf32>)
 func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{expected `ins` operand #0 to be of RankedTensorType}}
+  // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
   %0 = linalg_ext.scatter
       ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
@@ -73,7 +73,7 @@ func @scatter_mixed_tensor_memref(
 func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{expected `ins` operand #1 to be of RankedTensorType}}
+  // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
   %0 = linalg_ext.scatter
       ins(%update, %indices : tensor<?x?xf32>, memref<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
@@ -105,7 +105,7 @@ func @scatter_extra_outputs(
 func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{expected type of `outs` operand #0 'memref<?x?xf32>' to be same as result type 'tensor<?x?xf32>'}}
+  // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
   %0 = linalg_ext.scatter
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : memref<?x?xf32>) {
@@ -121,7 +121,7 @@ func @scatter_mixed_tensor_memref(
 func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> memref<?x?xf32> {
-  // expected-error @+1 {{expected result #0 to be of RankedTensorType}}
+  // expected-error @+1 {{expected type of `outs` operand #0 'tensor<?x?xf32>' to be same as result type 'memref<?x?xf32>'}}
   %0 = linalg_ext.scatter
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {

--- a/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -137,7 +137,7 @@ func @scatter_mixed_tensor_memref(
 func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) {
-  // expected-error @+1 {{expected `ins` operand #1 to be of MemRefType}}
+  // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
   linalg_ext.scatter
     ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
@@ -153,7 +153,7 @@ func @scatter_mixed_tensor_memref(
 func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) {
-  // expected-error @+1 {{expected `outs` operand #0 to be of MemRefType}}
+  // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
   linalg_ext.scatter
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -280,3 +280,42 @@ func @scatter_update_slice_2D(
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     linalg_ext.yield %{{.+}} : i32
 //       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
+    -> (tensor<1024xf32>, tensor<1024xf32>) {
+  %cst0 = constant 0 : index
+  %0:2 = linalg_ext.fft
+    ins(%cst0: index)
+    outs(%arg0, %arg1: tensor<1024xf32>, tensor<1024xf32>)
+  : tensor<1024xf32>, tensor<1024xf32>
+  return %0#0, %0#1 : tensor<1024xf32>, tensor<1024xf32>
+}
+// CHECK-LABEL: func @fft_tensor(
+//  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[CST:.+]] = constant 0 : index
+//       CHECK:   %[[RES:.+]]:2 = linalg_ext.fft
+//  CHECK-SAME:     ins(%[[CST]] : index)
+//  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : tensor<1024xf32>, tensor<1024xf32>)
+//  CHECK-SAME:   : tensor<1024xf32>, tensor<1024xf32>
+//       CHECK:   return %[[RES]]#0, %[[RES]]#1
+
+// -----
+
+func @fft_memref(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>) {
+  %cst0 = constant 0 : index
+  linalg_ext.fft
+    ins(%cst0: index)
+    outs(%arg0, %arg1: memref<1024xf32>, memref<1024xf32>)
+  return
+}
+// CHECK-LABEL: func @fft_memref(
+//  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[CST:.+]] = constant 0 : index
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     ins(%[[CST]] : index)
+//  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : memref<1024xf32>, memref<1024xf32>)
+//       CHECK:   return


### PR DESCRIPTION
The linalg_ext.fft ops take `stage` as input where is an index type.
Like other Linalg ops, we relax the limitation to make LinalgExt ops
allow scalar operand.

A step toward https://github.com/google/iree/issues/6477