### PR TITLE
Adding -iree-flow-simplify-variable-accesses pass.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -85,7 +85,7 @@ def FLOW_VariableLoadOp : FLOW_Op<"variable.load", [
   }];
 
   let arguments = (ins
-    FLOW_VariableRefAttr:$variable
+    Arg<FLOW_VariableRefAttr, "", [MemRead]>:$variable
   );
   let results = (outs
     AnyType:$result
@@ -135,7 +135,7 @@ def FLOW_VariableStoreOp : FLOW_Op<"variable.store"> {
 
   let arguments = (ins
     AnyType:$value,
-    FLOW_VariableRefAttr:$variable
+    Arg<FLOW_VariableRefAttr, "", [MemWrite]>:$variable
   );
 
   let assemblyFormat = "$value `,` $variable attr-dict `:` type($value)";

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "Passes.cpp",
         "PromoteI1ToI8Pass.cpp",
         "PromoteTensorLoads.cpp",
+        "SimplifyVariableAccesses.cpp",
         "StripAndSplatConstantVariables.cpp",
         "TypeConverter.cpp",
     ],

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_library(
     "Passes.cpp"
     "PromoteI1ToI8Pass.cpp"
     "PromoteTensorLoads.cpp"
+    "SimplifyVariableAccesses.cpp"
     "StripAndSplatConstantVariables.cpp"
     "TypeConverter.cpp"
   DEPS

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -131,6 +131,10 @@ std::unique_ptr<OperationPass<FuncOp>> createFormStreamsPass();
 // Reorders blocks to hoist ops that cannot be put into streams.
 std::unique_ptr<OperationPass<FuncOp>> createHoistUnstreamableOpsPass();
 
+// Hoists loads and sinks stores to variables to decrease data dependency
+// regions.
+std::unique_ptr<OperationPass<FuncOp>> createSimplifyVariableAccessesPass();
+
 // TODO(benvanik): cross-function stream flows.
 
 // Inserts clones of constant values where they may be required.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -57,7 +57,7 @@ def ExportBenchmarkFuncs :
 
 def FormStreams :
     Pass<"iree-flow-form-streams", "FuncOp"> {
-  let summary = "Identifies dispatches that can be grouped into streams within functions";
+  let summary = "Identifies dispatches that can be grouped into streams within functions.";
   let constructor = "mlir::iree_compiler::IREE::Flow::createFormStreamsPass()";
 }
 
@@ -75,7 +75,7 @@ def HoistUnstreamableOps :
 
 def InjectDispatchTracing :
     Pass<"iree-flow-inject-dispatch-tracing", "FuncOp"> {
-  let summary = "Injects dispatch region tracing";
+  let summary = "Injects dispatch region tracing.";
   let constructor = "mlir::iree_compiler::IREE::Flow::createInjectDispatchTracingPass()";
 }
 
@@ -126,6 +126,12 @@ def PromoteTensorLoads :
     Pass<"iree-flow-promote-tensor-loads", "FuncOp"> {
   let summary = "Converts standard ops which match to flow.tensor.load (typically causing a read-back)";
   let constructor = "mlir::iree_compiler::IREE::Flow::createPromoteTensorLoadsPass()";
+}
+
+def SimplifyVariableAccesses :
+    Pass<"iree-flow-simplify-variable-accesses", "FuncOp"> {
+  let summary = "Hoist loads and sinks stores to variables to decrease data dependency regions.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createSimplifyVariableAccessesPass()";
 }
 
 def StripAndSplatConstantVariables :

--- a/iree/compiler/Dialect/Flow/Transforms/SimplifyVariableAccesses.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/SimplifyVariableAccesses.cpp
@@ -1,0 +1,279 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <iterator>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+#define DEBUG_TYPE "iree-flow-simplify-variable-accesses"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+// Builds symbol ref set for all immutable variables in |moduleOp|.
+static DenseSet<StringRef> gatherImmutableVariables(ModuleOp moduleOp) {
+  DenseSet<StringRef> set;
+  for (auto variableOp : moduleOp.getOps<IREE::Flow::VariableOp>()) {
+    if (!variableOp.is_mutable()) {
+      set.insert(variableOp.sym_name());
+    }
+  }
+  return set;
+}
+
+// Hoists all loads of immutable variables in |funcOp| to the entry block.
+// |immutableVariables| is used for lookups of which variables are immutable.
+static void hoistImmutableLoads(FuncOp funcOp,
+                                DenseSet<StringRef> &immutableVariables) {
+  // Since CSE of loads isn't a thing yet we perform a basic deduping here by
+  // folding all subsequent loads into the first one found. This works only for
+  // immutable variables as otherwise we'd have to ensure stores and
+  // side-effects were properly observed.
+  DenseMap<Attribute, Operation *> loadOps;
+  auto *entryBlock = &funcOp.getBlocks().front();
+  Operation *lastEntryOp = nullptr;
+  SmallVector<std::pair<Operation *, Operation *>> opReplacements;
+  for (auto &block : funcOp) {
+    auto ops = llvm::to_vector<8>(block.getOps<IREE::Flow::VariableLoadOp>());
+    for (auto &op : ops) {
+      if (!immutableVariables.contains(op.variable())) continue;
+      auto variableRef = op.variableAttr().cast<Attribute>();
+      auto it = loadOps.find(variableRef);
+      if (it == loadOps.end()) {
+        // Move to entry block; even if it's already there (so loads are
+        // hoisted at the same time).
+        LLVM_DEBUG(llvm::dbgs() << "moving immutable variable " << op.variable()
+                                << " load to the entry block\n");
+        if (lastEntryOp) {
+          op->moveAfter(lastEntryOp);
+        } else {
+          op->moveBefore(entryBlock, entryBlock->begin());
+        }
+        loadOps[variableRef] = op;
+        lastEntryOp = op;
+      } else {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "CSE'ing immutable variable " << op.variable() << "\n");
+        opReplacements.push_back({op, it->getSecond()});
+      }
+    }
+  }
+  for (auto &replacement : opReplacements) {
+    replacement.first->replaceAllUsesWith(replacement.second);
+    replacement.first->erase();
+  }
+}
+
+static bool doesOpBlockMotion(Operation *op) {
+  return isa<mlir::CallOpInterface>(op) ||
+         op->hasTrait<OpTrait::IREE::YieldPoint>();
+}
+
+static void moveOpUpInBlock(Block &block, Operation *op) {
+  while (op->getPrevNode()) {
+    if (doesOpBlockMotion(op->getPrevNode())) break;
+    op->moveBefore(op->getPrevNode());
+  }
+}
+
+static void moveOpDownInBlock(Block &block, Operation *op) {
+  while (op->getNextNode() != block.getTerminator()) {
+    if (doesOpBlockMotion(op->getNextNode())) break;
+    op->moveAfter(op->getNextNode());
+  }
+}
+
+// Optimizes the load/store ops for each given bucket.
+// Returns true if any op was removed.
+static bool optimizeBuckets(
+    Block &block, std::map<StringRef, SmallVector<Operation *>> &buckets) {
+  bool didRemoveAny = false;
+  for (auto &bucket : buckets) {
+    // First perform basic load-store forwarding and such.
+    auto &ops = bucket.second;
+    for (int i = ops.size() - 1; i >= 1; --i) {
+      auto previous = ops[i - 1];
+      auto current = ops[i];
+      if (isa<IREE::Flow::VariableStoreOp>(previous) &&
+          isa<IREE::Flow::VariableLoadOp>(current)) {
+        // RAW - forward the stored variable to the following use.
+        auto storedValue = previous->getOperand(0);
+        LLVM_DEBUG({
+          llvm::dbgs() << "RAW: replacing load with previous store value:\n";
+          current->dump();
+          llvm::dbgs() << "->\n";
+          storedValue.dump();
+        });
+        current->replaceAllUsesWith(ValueRange{storedValue});
+        ops.erase(ops.begin() + i);
+        current->erase();
+        didRemoveAny = true;
+      } else if (isa<IREE::Flow::VariableLoadOp>(previous) &&
+                 isa<IREE::Flow::VariableLoadOp>(current)) {
+        // RAR - forward the loaded variable to the following use.
+        LLVM_DEBUG({
+          llvm::dbgs() << "RAR: replacing subsequent load with op:\n";
+          current->dump();
+          llvm::dbgs() << "->\n";
+          previous->dump();
+        });
+        current->replaceAllUsesWith(previous);
+        ops.erase(ops.begin() + i);
+        current->erase();
+        didRemoveAny = true;
+      } else if (isa<IREE::Flow::VariableStoreOp>(previous) &&
+                 isa<IREE::Flow::VariableStoreOp>(current)) {
+        // WAW - remove the first store.
+        LLVM_DEBUG({
+          llvm::dbgs() << "WAW: erasing source op:\n";
+          previous->dump();
+          llvm::dbgs() << "\nand keeping subsequent op:\n";
+          current->dump();
+        });
+        ops.erase(ops.begin() + i - 1);
+        previous->erase();
+        didRemoveAny = true;
+      }
+    }
+    if (ops.empty()) continue;
+
+    if (auto loadOp = dyn_cast<IREE::Flow::VariableLoadOp>(ops.front())) {
+      // If the head op is a load we can move that to the top of the block.
+      LLVM_DEBUG(llvm::dbgs() << "moving mutable variable " << loadOp.variable()
+                              << " load upward\n");
+      moveOpUpInBlock(block, ops.front());
+    }
+    if (auto storeOp = dyn_cast<IREE::Flow::VariableStoreOp>(ops.back())) {
+      // If the tail op is a store we can move that to the bottom of the block.
+      LLVM_DEBUG(llvm::dbgs() << "moving mutable variable "
+                              << storeOp.variable() << " store downward\n");
+      moveOpDownInBlock(block, ops.back());
+    }
+  }
+  return didRemoveAny;
+}
+
+// Hoists loads and sinks stores to the boundary of |block| when safe.
+// |immutableVariables| is used for lookups of which variables are immutable.
+//
+// Basic algorithm (repeat until no op removals):
+//   for each op:
+//     if immutable: skip
+//     add to load/store buckets (sorted vector)
+//   for each bucket (symbol):
+//     walk ops in reverse:
+//       if (prev == store && this == load)  // RAW
+//         replace load with store source
+//       if (prev == load && this == load)  // RAR
+//         replace with first load
+//       if (prev == store && this == store) // WAW
+//         remove first store
+//     if (head == load) move load to front
+//     if (tail == store) move store to back
+//
+// Returns true if there were any removals and the block should be reprocessed.
+static bool rearrangeBlockVariableAccesses(
+    Block &block, DenseSet<StringRef> &immutableVariables) {
+  // Gather sequences of operations that are safe to reorder.
+  // Certain ops - like calls/do_not_optimize/etc - prevent us from moving any
+  // variable operations across them.
+  //
+  // From each sequence we produce [symbol_name, [op, op, op, ...]] buckets.
+  // NOTE: we use a map here so that we are deterministically ordered. This may
+  // not be needed but the variable count is low and it's nice to not care about
+  // op order issues.
+  SmallVector<std::map<StringRef, SmallVector<Operation *>>> sequencedBuckets;
+  sequencedBuckets.push_back({});  // Start in a sequence.
+  block.walk([&](Operation *op) {
+    auto &buckets = sequencedBuckets.back();
+    if (auto loadOp = dyn_cast<IREE::Flow::VariableLoadOp>(op)) {
+      if (!immutableVariables.contains(loadOp.variable())) {
+        buckets[loadOp.variable()].push_back(op);
+      }
+    } else if (auto storeOp = dyn_cast<IREE::Flow::VariableStoreOp>(op)) {
+      buckets[storeOp.variable()].push_back(op);
+    } else if (doesOpBlockMotion(op)) {
+      // Split point - all accesses after this point must not assume anything
+      // about accesses before it.
+      if (!buckets.empty()) {
+        sequencedBuckets.push_back({});
+      }
+    }
+  });
+  bool didRemoveAny = false;
+  for (auto &buckets : sequencedBuckets) {
+    didRemoveAny = optimizeBuckets(block, buckets) || didRemoveAny;
+  }
+  return didRemoveAny;
+}
+
+namespace {
+
+class SimplifyVariableAccessesPass
+    : public SimplifyVariableAccessesBase<SimplifyVariableAccessesPass> {
+ public:
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    if (funcOp.empty()) return;
+
+    auto moduleOp = funcOp->getParentOfType<mlir::ModuleOp>();
+    assert(moduleOp && "func not in a module");
+
+    // Build a set of all immutable variables for fast lookup.
+    auto immutableVariables = gatherImmutableVariables(moduleOp);
+
+    // Hoist immutable variables first. These have no hazards and don't care
+    // about control flow - like `constant` - so getting them handled first
+    // avoids the need for us to do the full analysis.
+    hoistImmutableLoads(funcOp, immutableVariables);
+
+    // We can't optimize the function if there are indirect loads/stores.
+    // Note that constant loads are still ok above.
+    for (auto &block : funcOp) {
+      for (auto &op : block) {
+        if (isa<IREE::Flow::VariableLoadIndirectOp>(op) ||
+            isa<IREE::Flow::VariableStoreIndirectOp>(op)) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "bailing on variable access simplification: indirect "
+                        "accesses present in function\n");
+          return;
+        }
+      }
+    }
+
+    // For each block in the function hoist loads and sink stores.
+    // This does no cross-block movement, though it really should. Maybe when a
+    // real compiler engineer sees this they'll be inspired to do this properly.
+    for (auto &block : funcOp) {
+      LLVM_DEBUG(llvm::dbgs() << "==== REARRANGING BLOCK ACCESSES ====\n");
+      while (rearrangeBlockVariableAccesses(block, immutableVariables)) {
+        // NOTE: block is processed until no more ops are removed. Will always
+        // end in a fixed amount of time as ops are only removed from the block.
+      }
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createSimplifyVariableAccessesPass() {
+  return std::make_unique<SimplifyVariableAccessesPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "pad_tensor_to_tensor.mlir",
             "promote_i1_to_i8.mlir",
             "promote_tensor_loads.mlir",
+            "simplify_variable_accesses.mlir",
             "strip_and_splat_constant_variables.mlir",
             "transformation.mlir",
         ],

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "pad_tensor_to_tensor.mlir"
     "promote_i1_to_i8.mlir"
     "promote_tensor_loads.mlir"
+    "simplify_variable_accesses.mlir"
     "strip_and_splat_constant_variables.mlir"
     "transformation.mlir"
   DATA

--- a/iree/compiler/Dialect/Flow/Transforms/test/simplify_variable_accesses.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/simplify_variable_accesses.mlir
@@ -1,0 +1,136 @@
+// RUN: iree-opt -split-input-file -iree-flow-simplify-variable-accesses %s | IreeFileCheck %s
+
+flow.variable @varA dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+flow.variable @varB dense<3> : tensor<2x4xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @constants()
+func @constants() {
+  // CHECK-NEXT: %[[VAR_A:.+]] = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-NEXT: %[[VAR_B:.+]] = flow.variable.load @varB : tensor<2x4xi32>
+  // CHECK-NEXT: constant 10
+  %w = constant 10 : index
+  %varA = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-NEXT: %[[T:.+]] = flow.dispatch @ex::@dispatch0{{.+}}(%[[VAR_A]])
+  %d0 = flow.dispatch @ex::@dispatch0[%w](%varA) : (tensor<2xi32>) -> tensor<2xi32>
+  %varB = flow.variable.load @varB : tensor<2x4xi32>
+  // CHECK-NEXT: flow.dispatch @ex::@dispatch1{{.+}}(%[[T]], %[[VAR_B]])
+  %d1 = flow.dispatch @ex::@dispatch1[%w](%d0, %varB) : (tensor<2xi32>, tensor<2x4xi32>) -> tensor<2xi32>
+  return
+}
+
+// -----
+
+flow.variable @varA 1 : i32 attributes {sym_visibility = "private"}
+flow.variable @varB 2 : i32 attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @constants_in_cfg
+func @constants_in_cfg(%start: i32, %bound: i32) -> i32 {
+  // CHECK-NEXT: %[[VAR_A:.+]] = flow.variable.load @varA : i32
+  // CHECK-NEXT: %[[VAR_B:.+]] = flow.variable.load @varB : i32
+  // CHECK-NEXT: br ^bb1
+  br ^bb1(%start : i32)
+// CHECK: ^bb1(%[[BB1_ARG:.+]]: i32):
+^bb1(%2: i32):
+  %cmp = cmpi slt, %2, %bound : i32
+  cond_br %cmp, ^bb2(%2 : i32), ^bb3(%2 : i32)
+// CHECK: ^bb2(%[[BB2_ARG:.+]]: i32):
+^bb2(%5: i32):
+  %6 = flow.variable.load @varA : i32
+  // CHECK-NEXT: = addi %[[BB2_ARG]], %[[VAR_A]] : i32
+  %7 = addi %5, %6 : i32
+  br ^bb1(%7 : i32)
+// CHECK: ^bb3(%[[BB3_ARG:.+]]: i32):
+^bb3(%8: i32):
+  %9 = flow.variable.load @varA : i32
+  // CHECK-NEXT: %[[T0:.+]] = muli %[[BB3_ARG]], %[[VAR_A]] : i32
+  %10 = muli %8, %9 : i32
+  %11 = flow.variable.load @varB : i32
+  // CHECK-NEXT: %[[T1:.+]] = subi %[[T0]], %[[VAR_B]]
+  %12 = subi %10, %11 : i32
+  // CHECK-NEXT: return %[[T1]]
+  return %12 : i32
+}
+
+// -----
+
+flow.variable @varA mutable dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+flow.variable @varB dense<3> : tensor<2x4xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @mixed_mutability
+func @mixed_mutability() {
+  // CHECK-DAG: %[[VAR_A:.+]] = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-DAG: %[[VAR_B:.+]] = flow.variable.load @varB : tensor<2x4xi32>
+  // CHECK-NEXT: constant 10
+  %w = constant 10 : index
+  %varA = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-NEXT: %[[T0:.+]] = flow.dispatch @ex::@dispatch0{{.+}}(%[[VAR_A]])
+  %d0 = flow.dispatch @ex::@dispatch0[%w](%varA) : (tensor<2xi32>) -> tensor<2xi32>
+  %varB = flow.variable.load @varB : tensor<2x4xi32>
+  // CHECK-NEXT: %[[T1:.+]] = flow.dispatch @ex::@dispatch1{{.+}}(%[[T0]], %[[VAR_B]])
+  %d1 = flow.dispatch @ex::@dispatch1[%w](%d0, %varB) : (tensor<2xi32>, tensor<2x4xi32>) -> tensor<2xi32>
+  // CHECK-NEXT: flow.variable.store %[[T1]], @varA : tensor<2xi32>
+  flow.variable.store %d1, @varA : tensor<2xi32>
+  return
+}
+
+// -----
+
+flow.variable @varA mutable dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @raw
+func @raw() {
+  // CHECK: %[[T:.+]] = flow.variable.load @varA {id = 0
+  %varA_0 = flow.variable.load @varA {id = 0} : tensor<2xi32>
+  flow.variable.store %varA_0, @varA {id = 0} : tensor<2xi32>
+  %varA_1 = flow.variable.load @varA {id = 1} : tensor<2xi32>
+  // CHECK-NEXT: flow.variable.store %[[T]], @varA {id = 1
+  flow.variable.store %varA_1, @varA {id = 1} : tensor<2xi32>
+  return
+}
+
+// -----
+
+flow.variable @varA mutable dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @rar
+func @rar() -> (tensor<2xi32>, tensor<2xi32>) {
+  // CHECK: %[[T:.+]] = flow.variable.load @varA {id = 0
+  %varA_0 = flow.variable.load @varA {id = 0} : tensor<2xi32>
+  %varA_1 = flow.variable.load @varA {id = 1} : tensor<2xi32>
+  // CHECK-NEXT: return %[[T]], %[[T]]
+  return %varA_0, %varA_1 : tensor<2xi32>, tensor<2xi32>
+}
+
+// -----
+
+flow.variable @varA mutable dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @waw
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<2xi32>, %[[ARG1:.+]]: tensor<2xi32>)
+func @waw(%varA_0: tensor<2xi32>, %varA_1: tensor<2xi32>) {
+  flow.variable.store %varA_0, @varA : tensor<2xi32>
+  // CHECK-NEXT: flow.variable.store %[[ARG1]], @varA
+  flow.variable.store %varA_1, @varA : tensor<2xi32>
+  return
+}
+
+// -----
+
+flow.variable @varA mutable dense<1> : tensor<2xi32> attributes {sym_visibility = "private"}
+
+// CHECK-LABEL: @side_effects(
+func @side_effects() {
+  // CHECK-NEXT: %[[T0:.+]] = flow.variable.load @varA
+  %varA_0 = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-NEXT: flow.variable.store %[[T0]], @varA
+  flow.variable.store %varA_0, @varA : tensor<2xi32>
+  // CHECK-NEXT: call @other_fn()
+  call @other_fn() : () -> ()
+  // CHECK-NEXT: %[[T1:.+]] = flow.variable.load @varA
+  %varA_1 = flow.variable.load @varA : tensor<2xi32>
+  // CHECK-NEXT: flow.variable.store %[[T1]], @varA
+  flow.variable.store %varA_1, @varA : tensor<2xi32>
+  return
+}
+
+func private @other_fn()


### PR DESCRIPTION
Relanding #6565 (reverted in #6581 due to segfaults from an invalidated
iterator).

Since there's nothing like this upstream (I know about) this is a naive
result of an afternoon of hacking to solve our immediate problem (variable
accesses interleaved with logic we want to dispatch). This only operates
within basic blocks and does no fancy dataflow analysis leaving a lot of
potential optimizations on the table.

Programs are still correct if this pass is not used but for any model
with a lot of variable updates it's a big win.

This reverts commit 009e782d52a5594f1a80ab4e10e968ff5c812467.