### PR TITLE
Add a separate option for enabling compiler tracing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 #-------------------------------------------------------------------------------
 
 option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
+option(IREE_ENABLE_COMPILER_TRACING "Enables instrumented compiler tracing." OFF)
 option(IREE_ENABLE_MLIR "Enables MLIR/LLVM dependencies." ON)
 option(IREE_ENABLE_EMITC "Enables MLIR EmitC dependencies." OFF)
 

--- a/build_tools/cmake/build_tracing.sh
+++ b/build_tools/cmake/build_tracing.sh
@@ -28,9 +28,13 @@ else
 fi
 cd build-tracing
 
+# Note: https://github.com/google/iree/issues/6404 prevents us from building
+# tests with these other settings. Many tests invoke the compiler tools with
+# MLIR threading enabled, which crashes with compiler tracing enabled.
 "${CMAKE_BIN?}" -G Ninja .. \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_ENABLE_RUNTIME_TRACING=ON \
+  -DIREE_ENABLE_COMPILER_TRACING=ON \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
 "${CMAKE_BIN?}" --build .

--- a/docs/developers/developing_iree/profiling_with_tracy.md
+++ b/docs/developers/developing_iree/profiling_with_tracy.md
@@ -66,6 +66,11 @@ $ cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   ... # other cmake arguments as usual
 ```
+
+For tracing the compiler, additionally set `IREE_ENABLE_COMPILER_TRACING` to
+`ON`. Compiler tracing is less stable, particularly on Linux with MLIR
+threading enabled (https://github.com/google/iree/issues/6404).
+
 ## Permissions issues
 
 The profiled application (i.e. the Tracy client) needs to have appropriate

--- a/docs/developers/get_started/cmake_options_and_variables.md
+++ b/docs/developers/get_started/cmake_options_and_variables.md
@@ -21,6 +21,11 @@ This gives a brief explanation of IREE specific CMake options and variables.
 
 Enables instrumented runtime tracing. Defaults to `OFF`.
 
+#### `IREE_ENABLE_COMPILER_TRACING`:BOOL
+
+Enables instrumented compiler tracing. This requires that
+`IREE_ENABLE_RUNTIME_TRACING` also be set. Defaults to `OFF`.
+
 #### `IREE_ENABLE_MLIR`:BOOL
 
 Enables MLIR/LLVM dependencies. Defaults to `ON`. MLIR/LLVM dependencies are

--- a/iree/compiler/Utils/CMakeLists.txt
+++ b/iree/compiler/Utils/CMakeLists.txt
@@ -37,3 +37,10 @@ iree_cc_library(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+if(${IREE_ENABLE_COMPILER_TRACING})
+  target_compile_definitions(iree_compiler_Utils_Utils
+  PUBLIC
+    "IREE_ENABLE_COMPILER_TRACING=1"
+  )
+endif()

--- a/iree/compiler/Utils/TracingUtils.cpp
+++ b/iree/compiler/Utils/TracingUtils.cpp
@@ -9,7 +9,8 @@
 namespace mlir {
 namespace iree_compiler {
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if IREE_ENABLE_COMPILER_TRACING && \
+    IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
 namespace {
 thread_local llvm::SmallVector<iree_zone_id_t, 8> passTraceZonesStack;

--- a/iree/compiler/Utils/TracingUtils.h
+++ b/iree/compiler/Utils/TracingUtils.h
@@ -22,7 +22,8 @@ struct PassTracing : public PassInstrumentation {
   PassTracing() {}
   ~PassTracing() override = default;
 
-#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+#if IREE_ENABLE_COMPILER_TRACING && \
+    IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
   void runBeforePass(Pass *pass, Operation *op) override;
   void runAfterPass(Pass *pass, Operation *op) override;
   void runAfterPassFailed(Pass *pass, Operation *op) override;


### PR DESCRIPTION
General improvement and workaround for issues like https://github.com/google/iree/issues/6404.

I opted to keep this change pretty localized by making `IREE_ENABLE_COMPILER_TRACING` simply extend `IREE_ENABLE_RUNTIME_TRACING`. If we wanted to support _just_ tracing the compiler without also tracing the runtime, that would require some deeper changes to C defines and checks.