### PR TITLE
End-to-end CPUexecution of ops implementing `TiledOpInterface`.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
         "//iree/compiler/Dialect/IREE/IR",
+        "//iree/compiler/Dialect/LinalgExt/IR",
         "//iree/compiler/Dialect/LinalgExt/Transforms",
         "//iree/compiler/Dialect/Shape/IR",
         "//iree/compiler/Dialect/Shape/Transforms",

--- a/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::IREE::IR
+    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::Shape::IR
     iree::compiler::Dialect::Shape::Transforms

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
@@ -180,9 +180,7 @@ void LLVMCPUVectorizationPass::runOnOperation() {
                             context),
             Identifier::get(getWorkgroupL1TileMarker(), context)));
 
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(l1patterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(l1patterns));
   }
 
   // Second level of tiling. (workgroups memory -> vectors)
@@ -201,9 +199,7 @@ void LLVMCPUVectorizationPass::runOnOperation() {
             Identifier::get(getWorkgroupL1TileMarker(), context),
             Identifier::get(getVectorizeMarker(), context)));
 
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(l2patterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(l2patterns));
   }
 
   // Apply canonicalization.
@@ -229,10 +225,8 @@ void LLVMCPUVectorizationPass::runOnOperation() {
         vectorizationPatterns, linalg::LinalgVectorizationOptions(),
         linalg::LinalgTransformationFilter(
             Identifier::get(getVectorizeMarker(), context)));
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(vectorizationPatterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(funcOp,
+                                       std::move(vectorizationPatterns));
   }
 
   // TODO: This should be a folding of Add into Contract in core but while they
@@ -247,10 +241,8 @@ void LLVMCPUVectorizationPass::runOnOperation() {
     RewritePatternSet vectorToAArch64AsmPatterns(context);
     populateVectorContractToAArch64InlineAsm(vectorToAArch64AsmPatterns,
                                              context);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(vectorToAArch64AsmPatterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(funcOp,
+                                       std::move(vectorToAArch64AsmPatterns));
   }
 
   // Apply vector specific operation lowering.
@@ -265,10 +257,8 @@ void LLVMCPUVectorizationPass::runOnOperation() {
             vectorTransformsOptions, context);
     vector::populateVectorTransferPermutationMapLoweringPatterns(
         vectorContractLoweringPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(vectorContractLoweringPatterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(
+        funcOp, std::move(vectorContractLoweringPatterns));
   }
 
   // Hosit hierarchical tiling indexing and other loop invariant transfer
@@ -286,10 +276,8 @@ void LLVMCPUVectorizationPass::runOnOperation() {
     linalg::hoistRedundantVectorTransfers(funcOp);
 
     memref::populateFoldSubViewOpPatterns(vectorToLoopsPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(vectorToLoopsPatterns)))) {
-      return signalPassFailure();
-    }
+    (void)applyPatternsAndFoldGreedily(funcOp,
+                                       std::move(vectorToLoopsPatterns));
   }
 }
 

--- a/iree/compiler/Codegen/Utils/BUILD
+++ b/iree/compiler/Codegen/Utils/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/HAL/IR",
+        "//iree/compiler/Dialect/LinalgExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",

--- a/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     MLIRSupport
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::LinalgExt::IR
   PUBLIC
 )
 

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -46,24 +46,40 @@ ArrayRef<int64_t> getUntiledShape(Value tiledView);
 ///   ...
 ///   scf.for ... {
 ///     ...
-///     linalg.
+///     filtered_op.
 ///     ...
-///     linalg.
+///     filtered_op.
 ///     ...
 ///   }
 /// }
 ///
-/// Returns the list of linalg operations in the functions. If there are no
+/// Returns the list of filtered operations in the functions. If there are no
 /// `scf.for` operations in the function return the linalg operations in the
 /// body of the function if it has a single basic block. Return failure in all
 /// other cases.
-///
+using RootOpFilteringFn = std::function<bool(Operation *)>;
+LogicalResult getFilteredOps(FuncOp funcOp, RootOpFilteringFn filteringFn,
+                             SmallVectorImpl<Operation *> &filteredOps,
+                             SmallVectorImpl<Operation *> &tiledLoops);
+
+/// Specialization of `getFilteredOps` for filtering `LinalgOp`s and
+/// `LinagExtOp`s.
+/// TODO(ravishankarm) This methods also adds the "workgroup" marker to all ops
+/// within the loop. The marker is the way to tie into rest of the
+/// codegen. Refactor the downstream passes and get rid of the markers once and
+/// for all.
+LogicalResult getComputeOps(FuncOp funcOp,
+                            SmallVectorImpl<Operation *> &computeOps,
+                            SmallVectorImpl<Operation *> &tiledLoops);
+
+/// ***Legacy method to be deprecated***
+/// Specialization of `getFilteredOps` for filtering `LinalgOp`s
 /// TODO(ravishankarm) This methods also adds the "workgroup" marker to all ops
 /// within the loop. The marker is the way to tie into rest of the
 /// codegen. Refactor the downstream passes and get rid of the markers once and
 /// for all.
 LogicalResult getLinalgOps(FuncOp funcOp,
-                           SmallVectorImpl<linalg::LinalgOp> &linalgOps,
+                           SmallVectorImpl<linalg::LinalgOp> &computeOps,
                            SmallVectorImpl<Operation *> &tiledLoops);
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -192,15 +192,21 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
 }
 
 SmallVector<StringRef> ScatterOp::getLoopIteratorTypes() {
-  return {getParallelIteratorTypeName()};
+  SmallVector<StringRef> iteratorTypes(getUpdateType().getRank(),
+                                       getParallelIteratorTypeName());
+  return iteratorTypes;
 }
 
 SmallVector<Range> ScatterOp::getLoopBounds(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<ConstantIndexOp>(loc, 0);
   Value one = builder.create<ConstantIndexOp>(loc, 1);
-  Value ub = getDimValue(builder, loc, updates(), 0);
-  return {Range{zero, ub, one}};
+  SmallVector<Range> ranges;
+  for (auto dim : llvm::seq<int64_t>(0, getUpdateType().getRank())) {
+    Value ub = getDimValue(builder, loc, updates(), dim);
+    ranges.emplace_back(Range{zero, ub, one});
+  }
+  return ranges;
 }
 
 Operation *ScatterOp::getTiledImplementation(OpBuilder &builder,
@@ -215,22 +221,15 @@ Operation *ScatterOp::getTiledImplementation(OpBuilder &builder,
 
   // Slice of the updates.
   auto updateRank = getUpdateType().getRank();
-  SmallVector<OpFoldResult> updateOffsets(updateRank, zeroAttr);
-  SmallVector<OpFoldResult> updateSizes(updateRank, zeroAttr);
-  updateOffsets[0] = offsets[0];
-  updateSizes[0] = sizes[0];
-  for (auto dim : llvm::seq<int64_t>(1, updateRank)) {
-    updateSizes[dim] = getDim(builder, loc, updates(), dim);
-  }
   SmallVector<OpFoldResult> updateStrides(updateRank, oneAttr);
-  Value tiledUpdate = getSlice(builder, loc, updates(), updateOffsets,
-                               updateSizes, updateStrides);
+  Value tiledUpdate =
+      getSlice(builder, loc, updates(), offsets, sizes, updateStrides);
   assert(tiledUpdate && "failed to get slice of update");
 
   // Slice of indices.
   auto indicesRank = getIndicesType().getRank();
   SmallVector<OpFoldResult> indicesOffsets(indicesRank, zeroAttr);
-  SmallVector<OpFoldResult> indicesSizes(indicesRank, zeroAttr);
+  SmallVector<OpFoldResult> indicesSizes(indicesRank);
   indicesOffsets[0] = offsets[0];
   indicesSizes[0] = sizes[0];
   for (auto dim : llvm::seq<int64_t>(1, indicesRank)) {
@@ -241,32 +240,55 @@ Operation *ScatterOp::getTiledImplementation(OpBuilder &builder,
                                 indicesSizes, indicesStrides);
   assert(tiledIndices && "failed to get slice of indices");
 
+  // Slice of the original.
+  auto originalRank = getOriginalType().getRank();
+  SmallVector<OpFoldResult> originalOffsets(originalRank, zeroAttr);
+  SmallVector<OpFoldResult> originalSizes(originalRank);
+  for (auto dim : llvm::seq<int64_t>(0, originalRank - updateRank + 1)) {
+    originalSizes[dim] = getDim(builder, loc, original(), dim);
+  }
+  for (auto dim :
+       llvm::seq<int64_t>(originalRank - updateRank + 1, originalRank)) {
+    originalOffsets[dim] = offsets[dim - (originalRank - updateRank)];
+    originalSizes[dim] = sizes[dim - (originalRank - updateRank)];
+  }
+  SmallVector<OpFoldResult> originalStrides(originalRank, oneAttr);
+  Value tiledOriginal = getSlice(builder, loc, outputs[0], originalOffsets,
+                                 originalSizes, originalStrides);
+  assert(tiledOriginal && "failed to get slice of original tensor");
+
   SmallVector<Type> resultTypes;
   if (getNumResults()) {
-    resultTypes.push_back(getResultTypes()[0]);
+    resultTypes.push_back(tiledOriginal.getType());
   }
   Operation *tiledScatterOp =
       cast<LinalgExtOp>(getOperation())
           .clone(builder, loc, resultTypes,
-                 ValueRange{tiledUpdate, tiledIndices, outputs[0]});
-  if (getNumResults()) {
-    results.push_back(tiledScatterOp->getResult(0));
+                 ValueRange{tiledUpdate, tiledIndices, tiledOriginal});
+  for (auto result : llvm::enumerate(tiledScatterOp->getResults())) {
+    auto insertSliceOp = builder.create<tensor::InsertSliceOp>(
+        loc, result.value(), outputs[0], originalOffsets, originalSizes,
+        originalStrides);
+    results.push_back(insertSliceOp.getResult());
   }
   return tiledScatterOp;
 }
 
-void ScatterOp::generateScalarUpdateLoopBody(OpBuilder &b, Location loc,
-                                             ValueRange ivs) {
+LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
+                                                      Location loc,
+                                                      ValueRange ivs) {
   auto indexDepth = getIndexDepth();
   Value update = b.create<memref::LoadOp>(loc, updates(), ivs);
   SmallVector<Value> starts;
-  SmallVector<Value> loadIndices(ivs.begin(), ivs.end());
+  SmallVector<Value> loadIndices;
+  loadIndices.push_back(ivs.front());
   loadIndices.push_back(Value());
   for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
     loadIndices.back() = b.create<ConstantIndexOp>(loc, i);
     Value idx = b.create<memref::LoadOp>(loc, indices(), loadIndices);
     starts.push_back(b.create<IndexCastOp>(loc, b.getIndexType(), idx));
   }
+  starts.append(std::next(ivs.begin()), ivs.end());
   Value init = b.create<memref::LoadOp>(loc, original(), starts);
 
   BlockAndValueMapping bvm;
@@ -281,73 +303,6 @@ void ScatterOp::generateScalarUpdateLoopBody(OpBuilder &b, Location loc,
   b.create<memref::StoreOp>(
       loc, bvm.lookupOrDefault(block.getTerminator()->getOperand(0)),
       original(), starts);
-}
-
-void ScatterOp::generateSliceUpdateLoopBody(OpBuilder &b, Location loc,
-                                            ValueRange ivs) {
-  auto indexDepth = getIndexDepth();
-  Value one = b.create<ConstantIndexOp>(loc, 1);
-  Value update = b.create<memref::SubViewOp>(loc, updates(), ivs, one, one);
-  SmallVector<Value> starts;
-  SmallVector<Value> loadIndices(ivs.begin(), ivs.end());
-  loadIndices.push_back(Value());
-  for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
-    loadIndices.back() = b.create<ConstantIndexOp>(loc, i);
-    Value idx = b.create<memref::LoadOp>(loc, indices(), loadIndices);
-    starts.push_back(b.create<IndexCastOp>(loc, b.getIndexType(), idx));
-  }
-  SmallVector<Value> ones(indexDepth, one);
-  Value subview =
-      b.create<memref::SubViewOp>(loc, original(), starts, ones, ones);
-
-  auto nloops = getUpdateSliceRank();
-  SmallVector<AffineMap> maps;
-  {
-    SmallVector<AffineExpr> exprs(1, b.getAffineConstantExpr(0));
-    for (int i = 0; i < nloops; ++i) {
-      exprs.push_back(b.getAffineDimExpr(i));
-    }
-    maps.push_back(AffineMap::get(nloops, 0, exprs, b.getContext()));
-  }
-  {
-    SmallVector<AffineExpr> exprs(indexDepth, b.getAffineConstantExpr(0));
-    for (int i = 0; i < nloops; ++i) {
-      exprs.push_back(b.getAffineDimExpr(i));
-    }
-    maps.push_back(AffineMap::get(nloops, 0, exprs, b.getContext()));
-  }
-
-  SmallVector<StringRef> iterTypes(nloops, getParallelIteratorTypeName());
-  auto genericOp =
-      b.create<linalg::GenericOp>(loc, TypeRange{}, ValueRange{update},
-                                  ValueRange{subview}, maps, iterTypes);
-  {
-    OpBuilder::InsertionGuard guard(b);
-    auto *block = b.createBlock(&genericOp.region(), genericOp.region().end());
-    b.setInsertionPointToEnd(block);
-    BlockAndValueMapping bvm;
-    auto &srcBlock = region().front();
-    for (auto blockArg : srcBlock.getArguments()) {
-      bvm.map(blockArg, block->addArgument(blockArg.getType()));
-    }
-    for (auto &blockOp : srcBlock.without_terminator()) {
-      b.clone(blockOp, bvm);
-    }
-    b.create<linalg::YieldOp>(
-        loc, bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0)));
-  }
-}
-
-LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
-                                                      Location loc,
-                                                      ValueRange ivs) {
-  assert(ivs.size() == 1);
-
-  if (isScalarUpdate()) {
-    generateScalarUpdateLoopBody(b, loc, ivs);
-  } else {
-    generateSliceUpdateLoopBody(b, loc, ivs);
-  }
   return success();
 }
 
@@ -543,6 +498,7 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
   }
   Value cond = bvm.lookupOrDefault(srcBlock.getTerminator()->getOperand(0));
 
+  OpBuilder::InsertionGuard g(b);
   b.setInsertionPointToEnd(&region.front());
   b.create<scf::IfOp>(
       loc, TypeRange{}, cond,
@@ -566,6 +522,7 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
         }
         b.create<scf::YieldOp>(loc);
       });
+  b.create<scf::YieldOp>(loc);
   return success();
 }
 

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -214,7 +214,7 @@ Operation *ScatterOp::getTiledImplementation(OpBuilder &builder,
                                              ArrayRef<OpFoldResult> offsets,
                                              ArrayRef<OpFoldResult> sizes,
                                              SmallVectorImpl<Value> &results) {
-  assert(outputs.size() == 1 && offsets.size() == 1 && sizes.size() == 1);
+  assert(outputs.size() >= 1 && offsets.size() >= 1 && sizes.size() >= 1);
   Location loc = getLoc();
   auto zeroAttr = builder.getI64IntegerAttr(0);
   auto oneAttr = builder.getI64IntegerAttr(1);

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -124,11 +124,6 @@ def LinalgExt_ScatterOp : LinalgExt_Op<"scatter",
     bool isScalarUpdate() {
       return getUpdateSliceRank() == 0;
     }
-
-    void generateScalarUpdateLoopBody(OpBuilder & b, Location loc,
-                                      ValueRange ivs);
-    void generateSliceUpdateLoopBody(OpBuilder & b, Location loc,
-                                      ValueRange ivs);
   }];
 }
 

--- a/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -35,7 +35,7 @@ static LogicalResult lowerToLoopsImpl(OpBuilder &builder,
   if (loopDepth == loopRanges.size()) {
     return tilableOp.generateScalarImplementation(builder, loc, ivs);
   }
-  LogicalResult status = success(true);
+  LogicalResult status = success();
   builder.create<scf::ForOp>(
       loc, loopRanges[loopDepth].offset, loopRanges[loopDepth].size,
       loopRanges[loopDepth].stride, ValueRange{},
@@ -68,9 +68,8 @@ struct TiledOpInterfaceLowerToLoopsPattern : public RewritePattern {
     if (!tilableOp) {
       return failure();
     }
-    if (llvm::any_of(tilableOp->getOperands(), [&](Value v) {
-          return v.getType().isa<RankedTensorType>();
-        })) {
+    if (llvm::any_of(tilableOp->getResults(),
+                     [&](Value v) { return v.getType().isa<ShapedType>(); })) {
       return rewriter.notifyMatchFailure(
           tilableOp, "lower to loops needs to have tensor semantics");
     }

--- a/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -16,112 +16,93 @@
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace linalg_ext {
+
+/// Recursive method that lowers one dimension of the `TiledOpInterface` to
+/// scalar loops at a time.
+static LogicalResult lowerToLoopsImpl(OpBuilder &builder,
+                                      TiledOpInterface tilableOp,
+                                      ArrayRef<Range> loopRanges,
+                                      unsigned loopDepth,
+                                      SmallVectorImpl<Value> &ivs) {
+  Location loc = tilableOp.getLoc();
+  if (loopDepth == loopRanges.size()) {
+    return tilableOp.generateScalarImplementation(builder, loc, ivs);
+  }
+  LogicalResult status = success(true);
+  builder.create<scf::ForOp>(
+      loc, loopRanges[loopDepth].offset, loopRanges[loopDepth].size,
+      loopRanges[loopDepth].stride, ValueRange{},
+      [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
+        ivs.push_back(iv);
+        status = lowerToLoopsImpl(b, tilableOp, loopRanges, loopDepth + 1, ivs);
+        b.create<scf::YieldOp>(loc);
+      });
+  return status;
+}
+
+/// Main entry point for lowering `TiledOpInterface` op to loops.
+static LogicalResult lowerToLoops(OpBuilder &builder,
+                                  TiledOpInterface tilableOp) {
+  SmallVector<Range> loopBounds = tilableOp.getLoopBounds(builder);
+  SmallVector<Value> ivs;
+  return lowerToLoopsImpl(builder, tilableOp, loopBounds, 0, ivs);
+}
+
+/// Pattern rewriter hook to lower a `TiledOpInterface` to loops.
 namespace {
+struct TiledOpInterfaceLowerToLoopsPattern : public RewritePattern {
+  TiledOpInterfaceLowerToLoopsPattern(MLIRContext *context,
+                                      PatternBenefit benefit = 1)
+      : RewritePattern(MatchAnyOpTypeTag(), benefit, context) {}
 
-//===----------------------------------------------------------------------===//
-// SortOp
-//===----------------------------------------------------------------------===//
-
-struct BubbleSortConversion : public OpRewritePattern<linalg_ext::SortOp> {
-  using OpRewritePattern<linalg_ext::SortOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg_ext::SortOp op,
-                                PatternRewriter& rewriter) const final {
-    if (!op.hasBufferSemantics()) return failure();
-
-    auto arg0 = op.getOutputOperand(0);
-    Location loc = op.getLoc();
-    SmallVector<Value, 4> lbs, ubs, steps;
-    for (auto en : llvm::enumerate(op.getShape(arg0))) {
-      if (ShapedType::isDynamic(en.value())) {
-        ubs.push_back(
-            rewriter.create<memref::DimOp>(loc, arg0->get(), en.index()));
-      } else {
-        ubs.push_back(rewriter.create<ConstantIndexOp>(loc, en.value()));
-      }
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto tilableOp = dyn_cast<TiledOpInterface>(op);
+    if (!tilableOp) {
+      return failure();
     }
-    Value zero = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value one = rewriter.create<ConstantIndexOp>(loc, 1);
-    lbs.append(op.getRank(arg0), zero);
-    steps.append(op.getRank(arg0), one);
-
-    bool fail = false;
-    mlir::scf::buildLoopNest(
-        rewriter, loc, lbs, ubs, steps, ValueRange{},
-        [&](OpBuilder& b, Location loc, ValueRange ivs, ValueRange iters) {
-          if (failed(op.generateScalarImplementation(b, loc, ivs))) {
-            fail = true;
-          }
-          b.create<scf::YieldOp>(loc);
-          return scf::ValueVector();
-        });
-    if (fail) return failure();
+    if (llvm::any_of(tilableOp->getOperands(), [&](Value v) {
+          return v.getType().isa<RankedTensorType>();
+        })) {
+      return rewriter.notifyMatchFailure(
+          tilableOp, "lower to loops needs to have tensor semantics");
+    }
+    if (failed(lowerToLoops(rewriter, tilableOp))) {
+      return failure();
+    }
     rewriter.eraseOp(op);
     return success();
   }
 };
-
-//===----------------------------------------------------------------------===//
-// ScatterOp
-//===----------------------------------------------------------------------===//
-
-struct ScatterConversion : public OpRewritePattern<linalg_ext::ScatterOp> {
-  using OpRewritePattern<linalg_ext::ScatterOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg_ext::ScatterOp op,
-                                PatternRewriter& rewriter) const final {
-    if (!op.hasBufferSemantics()) return failure();
-    auto updates = op.updates();
-    Location loc = op.getLoc();
-    Value zero = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value one = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value ub = rewriter.createOrFold<memref::DimOp>(loc, updates, zero);
-    bool fail = false;
-    rewriter.create<scf::ForOp>(
-        loc, zero, ub, one, ValueRange{},
-        [&](OpBuilder& b, Location loc, Value iv, ValueRange iters) {
-          if (failed(op.generateScalarImplementation(b, loc, iv))) {
-            fail = true;
-          }
-          b.create<scf::YieldOp>(loc);
-        });
-    if (fail) return failure();
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
+}  // namespace
 
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
 
+namespace {
 struct LinalgExtToLoopsPass
     : public LinalgExtToLoopsBase<LinalgExtToLoopsPass> {
-  void getDependentDialects(DialectRegistry& registry) const override {
+  void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, StandardOpsDialect,
                     memref::MemRefDialect, scf::SCFDialect>();
   }
 
   void runOnOperation() override {
-    MLIRContext* context = &getContext();
+    MLIRContext *context = &getContext();
 
     OwningRewritePatternList patterns(context);
-    patterns.insert<BubbleSortConversion, ScatterConversion>(context);
-
-    ConversionTarget target(getContext());
-    target.addLegalDialect<linalg::LinalgDialect, memref::MemRefDialect,
-                           StandardOpsDialect, scf::SCFDialect>();
-    target.addIllegalDialect<linalg_ext::LinalgExtDialect>();
-
-    if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns)))) {
-      signalPassFailure();
+    patterns.insert<TiledOpInterfaceLowerToLoopsPattern>(context);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
     }
   }
 };

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -14,12 +14,9 @@ func @sort_1d(%arg0: memref<128xi32>) {
 // CHECK-DAG:     %[[C128:.+]] = constant 128 : index
 // CHECK-DAG:     %[[C0:.+]] = constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C127:.+]] = constant 127 : index
 // CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C128]] step %[[C1]]
-// CHECK-DAG:       %[[C128:.+]] = constant 128 : index
-// CHECK-DAG:       %[[C0:.+]] = constant 0 : index
-// CHECK-DAG:       %[[C1:.+]] = constant 1 : index
-// CHECK-DAG:       %[[UB:.+]] = subi %[[C128]], %[[C1]] : index
-// CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[UB]] step %[[C1]]
+// CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[C127]] step %[[C1]]
 // CHECK:             %[[T1:.+]] = addi %[[ARG2]], %[[C1]] : index
 // CHECK:             %[[V1:.+]] = memref.load %[[BUF]][%[[ARG2]]]
 // CHECK:             %[[V2:.+]] = memref.load %[[BUF]][%[[T1]]]
@@ -48,13 +45,10 @@ func @sort_2d(%arg0: memref<16x32xi32>) {
 // CHECK-DAG:     %[[C32:.+]] = constant 32 : index
 // CHECK-DAG:     %[[C0:.+]] = constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C15:.+]] = constant 15 : index
 // CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C16]] step %[[C1]]
 // CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
-// CHECK-DAG:         %[[C16:.+]] = constant 16 : index
-// CHECK-DAG:         %[[C0:.+]] = constant 0 : index
-// CHECK-DAG:         %[[C1:.+]] = constant 1 : index
-// CHECK-DAG:         %[[UB:.+]] = subi %[[C16]], %[[C1]] : index
-// CHECK:             scf.for %[[ARG3:.+]] = %[[C0]] to %[[UB]] step %[[C1]]
+// CHECK:             scf.for %[[ARG3:.+]] = %[[C0]] to %[[C15]] step %[[C1]]
 // CHECK:               %[[T1:.+]] = addi %[[ARG3]], %[[C1]] : index
 // CHECK:               %[[V1:.+]] = memref.load %[[BUF]][%[[ARG3]], %[[ARG2]]]
 // CHECK:               %[[V2:.+]] = memref.load %[[BUF]][%[[T1]], %[[ARG2]]]
@@ -83,12 +77,9 @@ func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 // CHECK-DAG:     %[[C128:.+]] = constant 128 : index
 // CHECK-DAG:     %[[C0:.+]] = constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C127:.+]] = constant 127 : index
 // CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C128]] step %[[C1]]
-// CHECK-DAG:       %[[C128:.+]] = constant 128 : index
-// CHECK-DAG:       %[[C0:.+]] = constant 0 : index
-// CHECK-DAG:       %[[C1:.+]] = constant 1 : index
-// CHECK-DAG:       %[[UB:.+]] = subi %[[C128]], %[[C1]] : index
-// CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[UB]] step %[[C1]]
+// CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[C127]] step %[[C1]]
 // CHECK:             %[[T1:.+]] = addi %[[ARG2]], %[[C1]] : index
 // CHECK:             %[[V1:.+]] = memref.load %[[BUF1]][%[[ARG2]]]
 // CHECK:             %[[V2:.+]] = memref.load %[[BUF1]][%[[T1]]]
@@ -126,7 +117,6 @@ func @scatter_update_scalar_1D(
 // CHECK-DAG:     %[[C3:.+]] = constant 3 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
 // CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
-// CHECK:           %[[C0:.+]] = constant 0 : index
 // CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x1xi32>
 // CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
 // CHECK:           memref.store %[[T1]], %[[ORIGINAL]][%[[IDX]]]
@@ -154,10 +144,8 @@ func @scatter_add_scalar_2D(
 // CHECK-DAG:     %[[C3:.+]] = constant 3 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
 // CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
-// CHECK:           %[[C0:.+]] = constant 0 : index
 // CHECK:           %[[T2:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x2xi32>
 // CHECK:           %[[IDX1:.+]] = index_cast %[[T2]] : i32 to index
-// CHECK:           %[[C1:.+]] = constant 1 : index
 // CHECK:           %[[T3:.+]] = memref.load %[[INDICES]][%[[I]], %[[C1]]] : memref<3x2xi32>
 // CHECK:           %[[IDX2:.+]] = index_cast %[[T3]] : i32 to index
 // CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]] : memref<4x3xi32>
@@ -177,8 +165,6 @@ func @scatter_update_slice_2D(
   }
   return
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
 // CHECK:       func @scatter_update_slice_2D
 // CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
@@ -186,24 +172,15 @@ func @scatter_update_slice_2D(
 // CHECK-DAG:     %[[C0:.+]] = constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
 // CHECK-DAG:     %[[C2:.+]] = constant 2 : index
+// CHECK-DAG:     %[[C3:.+]] = constant 3 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK-DAG:       %[[C1:.+]] = constant 1 : index
-// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
-// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<2x3xi32> to memref<?x3xi32, #[[MAP0]]>
-// CHECK:           %[[C0:.+]] = constant 0 : index
-// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<2x1xi32>
-// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
-// CHECK:           %[[SUB_ORI:.+]] = memref.subview
-// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<4x3xi32> to memref<?x3xi32, #[[MAP0]]>
-// CHECK:           linalg.generic
-// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
-// CHECK-SAME:        iterator_types = ["parallel"]
-// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x3xi32, #[[MAP0]]>)
-// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x3xi32, #[[MAP0]]>)
-// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %{{.+}}: i32):
-// CHECK:             linalg.yield %[[ARG4]]
+// CHECK:           scf.for %[[J:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
+// CHECK:             %[[UPDATE:.+]] = memref.load %[[UPDATES]][%[[I]], %[[J]]]
+// CHECK:             %[[INDEX:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]]
+// CHECK:             %[[LOC:.+]] = index_cast %[[INDEX]] : i32 to index
+// CHECK:             memref.store %[[UPDATE]], %[[ORIGINAL]][%[[LOC]], %[[J]]]
+// CHECK:           }
+// CHECK:         }
 
 // -----
 
@@ -228,7 +205,6 @@ func @scatter_add_scalar_1D(
 // CHECK-DAG:     %[[C3:.+]] = constant 3 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
 // CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<3xi32>
-// CHECK:           %[[C0:.+]] = constant 0 : index
 // CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<3x1xi32>
 // CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
 // CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX]]] : memref<8xi32>
@@ -249,8 +225,6 @@ func @scatter_add_slice_2D(
   }
   return
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
 // CHECK:       func @scatter_add_slice_2D
 // CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
@@ -259,24 +233,13 @@ func @scatter_add_slice_2D(
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
 // CHECK-DAG:     %[[C2:.+]] = constant 2 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK-DAG:       %[[C1:.+]] = constant 1 : index
-// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
-// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<2x3xi32> to memref<?x3xi32, #[[MAP0]]>
-// CHECK:           %[[C0:.+]] = constant 0 : index
-// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<2x1xi32>
-// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
-// CHECK:           %[[SUB_ORI:.+]] = memref.subview
-// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<4x3xi32> to memref<?x3xi32, #[[MAP0]]>
-// CHECK:           linalg.generic
-// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
-// CHECK-SAME:        iterator_types = ["parallel"]
-// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x3xi32, #[[MAP0]]>)
-// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x3xi32, #[[MAP0]]>)
-// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %[[ARG5:.+]]: i32):
-// CHECK:             %[[RES:.+]] = addi %[[ARG5]], %[[ARG4]] : i32
-// CHECK:             linalg.yield %[[RES]]
+// CHECK:           scf.for %[[J:.+]] = %[[C0]] to %[[C3]] step %[[C1]] {
+// CHECK:             %[[UPDATEVAL:.+]] = memref.load %[[UPDATES]][%[[I]], %[[J]]]
+// CHECK:             %[[INDEXVAL:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]]
+// CHECK:             %[[INDEX:.+]] = index_cast %[[INDEXVAL]] : i32 to index
+// CHECK:             %[[ORIGINALVAL:.+]] = memref.load %[[ORIGINAL]][%[[INDEX]], %[[J]]]
+// CHECK:             %[[STOREVAL:.+]] = addi %[[ORIGINALVAL]], %[[UPDATEVAL]]
+// CHECK:             memref.store %[[STOREVAL]], %[[ORIGINAL]][%[[INDEX]], %[[J]]]
 
 // -----
 
@@ -300,7 +263,6 @@ func @scatter_update_scalar_dynamic_1D(
 // CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?xi32>
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
 // CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<?xi32>
-// CHECK:           %[[C0:.+]] = constant 0 : index
 // CHECK:           %[[T2:.+]] =  memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x1xi32>
 // CHECK:           %[[IDX:.+]] = index_cast %[[T2]] : i32 to index
 // CHECK:           memref.store %[[T1]], %[[ORIGINAL]][%[[IDX]]]
@@ -328,10 +290,8 @@ func @scatter_add_scalar_dynamic_2D(
 // CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?xi32>
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
 // CHECK:           %[[T1:.+]] = memref.load %[[UPDATES]][%[[I]]] : memref<?xi32>
-// CHECK:           %[[C0:.+]] = constant 0 : index
 // CHECK:           %[[T2:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x2xi32>
 // CHECK:           %[[IDX1:.+]] = index_cast %[[T2]] : i32 to index
-// CHECK:           %[[C1:.+]] = constant 1 : index
 // CHECK:           %[[T3:.+]] = memref.load %[[INDICES]][%[[I]], %[[C1]]] : memref<?x2xi32>
 // CHECK:           %[[IDX2:.+]] = index_cast %[[T3]] : i32 to index
 // CHECK:           %[[ORI:.+]] = memref.load %[[ORIGINAL]][%[[IDX1]], %[[IDX2]]] : memref<?x?xi32>
@@ -351,30 +311,17 @@ func @scatter_update_slice_dynamic_2D(
   }
   return
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0) -> (0, d0)>
 // CHECK:       func @scatter_update_slice_dynamic_2D
 // CHECK-SAME:    %[[ORIGINAL:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[UPDATES:[a-zA-Z0-9]+]]
 // CHECK-DAG:     %[[C0:.+]] = constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = constant 1 : index
-// CHECK-DAG:     %[[UB:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?x?xi32>
-// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB]] step %[[C1]] {
-// CHECK-DAG:       %[[C1:.+]] = constant 1 : index
-// CHECK:           %[[SUB_UPDATE:.+]] = memref.subview
-// CHECK-SAME:        %[[UPDATES]][%[[I]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<?x?xi32> to memref<?x?xi32, #[[MAP0]]>
-// CHECK:           %[[C0:.+]] = constant 0 : index
-// CHECK:           %[[T1:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]] : memref<?x1xi32>
-// CHECK:           %[[IDX:.+]] = index_cast %[[T1]] : i32 to index
-// CHECK:           %[[SUB_ORI:.+]] = memref.subview
-// CHECK-SAME:        %[[ORIGINAL]][%[[IDX]]] [%[[C1]]] [%[[C1]]]
-// CHECK-SAME:      : memref<?x?xi32> to memref<?x?xi32, #[[MAP0]]>
-// CHECK:           linalg.generic
-// CHECK-SAME:        indexing_maps = [#[[MAP1]], #[[MAP1]]]
-// CHECK-SAME:        iterator_types = ["parallel"]
-// CHECK-SAME:        ins(%[[SUB_UPDATE]] : memref<?x?xi32, #[[MAP0]]>)
-// CHECK-SAME:        outs(%[[SUB_ORI]] : memref<?x?xi32, #[[MAP0]]>)
-// CHECK:           ^bb0(%[[ARG4:.+]]: i32, %{{.+}}: i32):
-// CHECK:             linalg.yield %[[ARG4]]
+// CHECK-DAG:     %[[UB1:.+]] = memref.dim %[[UPDATES]], %[[C0]] : memref<?x?xi32>
+// CHECK-DAG:     %[[UB2:.+]] = memref.dim %[[UPDATES]], %[[C1]] : memref<?x?xi32>
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[UB1]] step %[[C1]] {
+// CHECK:           scf.for %[[J:.+]] = %[[C0]] to %[[UB2]] step %[[C1]] {
+// CHECK:             %[[UPDATEVAL:.+]] = memref.load %[[UPDATES]][%[[I]], %[[J]]]
+// CHECK:             %[[INDEXVAL:.+]] = memref.load %[[INDICES]][%[[I]], %[[C0]]]
+// CHECK:             %[[INDEX:.+]] = index_cast %[[INDEXVAL]] : i32 to index
+// CHECK:             memref.store %[[UPDATEVAL]], %[[ORIGINAL]][%[[INDEX]], %[[J]]]

--- a/iree/test/e2e/xla_ops/scatter.mlir
+++ b/iree/test/e2e/xla_ops/scatter.mlir
@@ -124,3 +124,67 @@ func @scatter_add_slice_2D_dynamic_num_updates() {
                                    [1, 1, 1]]> : tensor<6x3xi32>) : tensor<6x3xi32>
   return
 }
+
+func @scatter_1D_large() {
+  %original = iree.unfoldable_constant dense<1> : tensor<1400xi32>
+  %update = iree.unfoldable_constant dense<2> : tensor<1400xi32>
+  %init = linalg.init_tensor [1400] : tensor<1400xi32>
+  %indices = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%init : tensor<1400xi32>) {
+      ^bb0(%arg0: i32):
+        %0 = linalg.index 0 : index
+     %1 = index_cast %0 : index to i32
+     linalg.yield %1 : i32
+      } -> tensor<1400xi32>
+  %indices_reshaped = linalg.tensor_expand_shape %indices [[0, 1]] :
+      tensor<1400xi32> into tensor<1400x1xi32>
+  %result = "mhlo.scatter"(%original, %indices_reshaped, %update)({
+    ^bb0(%arg3 : tensor<i32>, %arg4 : tensor<i32>):
+      "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+    }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1: i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<> : tensor<0xi64>
+    },
+    unique_indices = false
+  } : (tensor<1400xi32>, tensor<1400x1xi32>, tensor<1400xi32>) -> tensor<1400xi32>
+  check.expect_eq_const(%result, dense<2> : tensor<1400xi32>) : tensor<1400xi32>
+  return
+}
+
+func @scatter_2D_large() {
+  %original = iree.unfoldable_constant dense<1> : tensor<200x300xi32>
+  %update = iree.unfoldable_constant dense<2> : tensor<200x300xi32>
+  %init = linalg.init_tensor [200] : tensor<200xi32>
+  %indices = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%init : tensor<200xi32>) {
+      ^bb0(%arg0: i32):
+        %0 = linalg.index 0 : index
+        %1 = index_cast %0 : index to i32
+        linalg.yield %1 : i32
+      } -> tensor<200xi32>
+  %indices_reshaped = linalg.tensor_expand_shape %indices [[0, 1]] :
+      tensor<200xi32> into tensor<200x1xi32>
+  %result = "mhlo.scatter"(%original, %indices_reshaped, %update)({
+    ^bb0(%arg3 : tensor<i32>, %arg4 : tensor<i32>):
+      "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+    }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = {
+      index_vector_dim = 1: i64,
+      inserted_window_dims = dense<0> : tensor<1xi64>,
+      scatter_dims_to_operand_dims = dense<0> : tensor<1xi64>,
+      update_window_dims = dense<1> : tensor<0xi64>
+    },
+    unique_indices = false
+  } : (tensor<200x300xi32>, tensor<200x1xi32>, tensor<200x300xi32>) -> tensor<200x300xi32>
+  check.expect_eq_const(%result, dense<2> : tensor<200x300xi32>) : tensor<200x300xi32>
+  return
+}


### PR DESCRIPTION
This change enables the end-to-end execution of ops that implement the
`TiledOpInterface` on CPU. To enable this
- Change the CPU lowering configuration to treat `LinalgExtOp`s as
  "compute" ops as well (in additional to `LinalgOp`). Use a default
  for all ops that are not explicitly set.
- Change the `TiledOpInterface` implementation of `linalg_ext.scatter`
  by specifying number of loops to be same as the number of dimensions
  of the `update`. This allows tile + distribution of dimensions that
  are not scattered as well. This is needed for effective
  parallelization (especially on GPU that is to come)
- The above necessitated changes to `ConvertToLoops` pass to not have
  patterns per op, but rather use the interface to lower all ops that
  implement the `generateScalarImplementation` method.
Also add large e2e tests of `scatter` to check the distribution of
work.