### PR TITLE
Fix cuda hal for `-Wunused-but-set-parameter`

### DIFF
--- a/iree/hal/cuda/stream_command_buffer.c
+++ b/iree/hal/cuda/stream_command_buffer.c
@@ -216,10 +216,10 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_copy_buffer(
 
   CUdeviceptr target_device_buffer = iree_hal_cuda_buffer_device_pointer(
       iree_hal_buffer_allocated_buffer(target_buffer));
-  iree_hal_buffer_byte_offset(target_buffer);
+  /* target_offset += */ iree_hal_buffer_byte_offset(target_buffer);
   CUdeviceptr source_device_buffer = iree_hal_cuda_buffer_device_pointer(
       iree_hal_buffer_allocated_buffer(source_buffer));
-  iree_hal_buffer_byte_offset(source_buffer);
+  /* source_offset += */ iree_hal_buffer_byte_offset(source_buffer);
   CUDA_RETURN_IF_ERROR(command_buffer->context->syms,
                        cuMemcpyAsync(target_device_buffer, source_device_buffer,
                                      length, command_buffer->stream),

--- a/iree/hal/cuda/stream_command_buffer.c
+++ b/iree/hal/cuda/stream_command_buffer.c
@@ -216,10 +216,10 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_copy_buffer(
 
   CUdeviceptr target_device_buffer = iree_hal_cuda_buffer_device_pointer(
       iree_hal_buffer_allocated_buffer(target_buffer));
-  target_offset += iree_hal_buffer_byte_offset(target_buffer);
+  iree_hal_buffer_byte_offset(target_buffer);
   CUdeviceptr source_device_buffer = iree_hal_cuda_buffer_device_pointer(
       iree_hal_buffer_allocated_buffer(source_buffer));
-  source_offset += iree_hal_buffer_byte_offset(source_buffer);
+  iree_hal_buffer_byte_offset(source_buffer);
   CUDA_RETURN_IF_ERROR(command_buffer->context->syms,
                        cuMemcpyAsync(target_device_buffer, source_device_buffer,
                                      length, command_buffer->stream),


### PR DESCRIPTION
This is a new check in clang that is going to be enabled globally
internally soon. It's not yet available in a released clang. If it ends
up being annoying, we could disable it for all of IREE internally. We
could also do that now.

Regardless, I think this fix is probably good, since we've identified
the issue. This is currently the only failure in IREE core.
