### PR TITLE
Avoid trying to check py.in files with pytype

### DIFF
--- a/build_tools/pytype/check_diff.sh
+++ b/build_tools/pytype/check_diff.sh
@@ -20,7 +20,7 @@ echo "Running pycheck against '${DIFF_TARGET?}'"
 if [[ "${DIFF_TARGET?}" = "all" ]]; then
   FILES=$(find -name "*\.py" -not -path "./third_party/*")
 else
-  FILES=$(git diff --diff-filter=d --name-only "${DIFF_TARGET?}" | grep '.*\.py')
+  FILES=$(git diff --diff-filter=d --name-only "${DIFF_TARGET?}" | grep '.*\.py\$')
 fi
 
 
@@ -43,6 +43,8 @@ function check_files() {
     echo
     return "${1?}"
   fi
+
+  echo "This is the list: '${@:2}'"
 
   # We disable import-error because pytype doesn't have access to bazel.
   # We disable pyi-error because of the way the bindings imports work.


### PR DESCRIPTION
This is giving me errors on https://github.com/google/iree/pull/6611
because it touches .py.in files (and maybe only triggered because it
touches no .py files)