### PR TITLE
fix build failure for MSVC

### DIFF
--- a/iree/base/alignment.h
+++ b/iree/base/alignment.h
@@ -193,39 +193,6 @@ static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
 
 // clang-format off
 
-// Dereferences |ptr| and returns the value.
-// Automatically handles unaligned accesses on architectures that may not
-// support them natively (or efficiently). Memory is treated as little-endian.
-#define iree_unaligned_load_le(ptr)                                               \
-  _Generic((ptr),                                                              \
-        int8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \
-       uint8_t*: iree_unaligned_load_le_u8((const uint8_t*)(ptr)),             \
-       int16_t*: iree_unaligned_load_le_u16((const uint16_t*)(ptr)),           \
-      uint16_t*: iree_unaligned_load_le_u16((const uint16_t*)(ptr)),           \
-       int32_t*: iree_unaligned_load_le_u32((const uint32_t*)(ptr)),           \
-      uint32_t*: iree_unaligned_load_le_u32((const uint32_t*)(ptr)),           \
-       int64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
-      uint64_t*: iree_unaligned_load_le_u64((const uint64_t*)(ptr)),           \
-         float*: iree_unaligned_load_le_f32((const float*)(ptr)),              \
-        double*: iree_unaligned_load_le_f64((const double*)(ptr))              \
-  )
-
-// Dereferences |ptr| and writes the given |value|.
-// Automatically handles unaligned accesses on architectures that may not
-// support them natively (or efficiently). Memory is treated as little-endian.
-#define iree_unaligned_store(ptr, value)                                       \
-  _Generic((ptr),                                                              \
-        int8_t*: iree_unaligned_store_le_u8((uint8_t*)(ptr), value),           \
-       uint8_t*: iree_unaligned_store_le_u8((uint8_t*)(ptr), value),           \
-       int16_t*: iree_unaligned_store_le_u16((uint16_t*)(ptr), value),         \
-      uint16_t*: iree_unaligned_store_le_u16((uint16_t*)(ptr), value),         \
-       int32_t*: iree_unaligned_store_le_u32((uint32_t*)(ptr), value),         \
-      uint32_t*: iree_unaligned_store_le_u32((uint32_t*)(ptr), value),         \
-       int64_t*: iree_unaligned_store_le_u64((uint64_t*)(ptr), value),         \
-      uint64_t*: iree_unaligned_store_le_u64((uint64_t*)(ptr), value),         \
-         float*: iree_unaligned_store_le_f32((float*)(ptr), value),            \
-        double*: iree_unaligned_store_le_f64((double*)(ptr), value)            \
-  )
 
 // clang-format on
 

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -153,12 +153,12 @@ static const int kRegSize = sizeof(uint16_t);
 
 // Bytecode data access macros for reading values of a given type from a byte
 // offset within the current function.
-#define OP_I8(i) iree_unaligned_load_le((uint8_t*)&bytecode_data[pc + (i)])
-#define OP_I16(i) iree_unaligned_load_le((uint16_t*)&bytecode_data[pc + (i)])
-#define OP_I32(i) iree_unaligned_load_le((uint32_t*)&bytecode_data[pc + (i)])
-#define OP_I64(i) iree_unaligned_load_le((uint64_t*)&bytecode_data[pc + (i)])
-#define OP_F32(i) iree_unaligned_load_le((float*)&bytecode_data[pc + (i)])
-#define OP_F64(i) iree_unaligned_load_le((double*)&bytecode_data[pc + (i)])
+#define OP_I8(i) iree_unaligned_load_le_u8((uint8_t*)&bytecode_data[pc + (i)])
+#define OP_I16(i) iree_unaligned_load_le_u16((uint16_t*)&bytecode_data[pc + (i)])
+#define OP_I32(i) iree_unaligned_load_le_u32((uint32_t*)&bytecode_data[pc + (i)])
+#define OP_I64(i) iree_unaligned_load_le_u64((uint64_t*)&bytecode_data[pc + (i)])
+#define OP_F32(i) iree_unaligned_load_le_f32((float*)&bytecode_data[pc + (i)])
+#define OP_F64(i) iree_unaligned_load_le_f64((double*)&bytecode_data[pc + (i)])
 
 //===----------------------------------------------------------------------===//
 // Utilities matching the tablegen op encoding scheme


### PR DESCRIPTION
MSVC does not support _Generic (introduced in this commit: 082aacd3925385fbcba105d99edebe214b868df0) which fixed this issue: https://github.com/google/iree/issues/6566