### PR TITLE
Reduce linalg convolution variants for IREE CodeGen pipelines

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -31,6 +31,7 @@ gentbl_cc_library(
 cc_library(
     name = "Transforms",
     srcs = [
+        "ChangeConv2DLayout.cpp",
         "ConvertConv2D1x1ToMatmulPass.cpp",
         "ConvertConv2DToImg2ColPass.cpp",
         "ConvertToFlowTensorOps.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     "Passes.h.inc"
     "TypeConverter.h"
   SRCS
+    "ChangeConv2DLayout.cpp"
     "ConvertConv2D1x1ToMatmulPass.cpp"
     "ConvertConv2DToImg2ColPass.cpp"
     "ConvertToFlowTensorOps.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/ChangeConv2DLayout.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ChangeConv2DLayout.cpp
@@ -1,0 +1,103 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+
+/// Shuffles elements in a FHWC constant tensor to follow HWCF layout.
+DenseElementsAttr convertFHWCTensorToHWCF(DenseElementsAttr inputTensor) {
+  if (inputTensor.isSplat()) return inputTensor;
+  auto inputType = inputTensor.getType().cast<RankedTensorType>();
+
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  assert(inputShape.size() == 4);
+  int64_t oc = inputShape[0], h = inputShape[1];
+  int64_t w = inputShape[2], ic = inputShape[3];
+
+  SmallVector<Attribute, 4> values;
+  values.resize(inputType.getNumElements());
+  for (unsigned i = 0; i < oc; ++i) {
+    for (unsigned j = 0; j < h; ++j) {
+      for (unsigned k = 0; k < w; ++k) {
+        for (unsigned l = 0; l < ic; ++l) {
+          unsigned outputIndex = j * w * ic * oc + k * ic * oc + l * oc + i;
+          values[outputIndex] = inputTensor.getValue({i, j, k, l});
+        }
+      }
+    }
+  }
+
+  SmallVector<int64_t, 4> outputShape = {h, w, ic, oc};
+  auto outputType = RankedTensorType::get(
+      outputShape, inputType.getElementType(), inputType.getEncoding());
+  return DenseElementsAttr::get(outputType, values);
+}
+
+/// Converts linalg.conv_2d_input_nhwc_filter_ohwi_poly with constant filters
+/// into linalg.conv_2d_input_nhwc_filter_hwcf.
+struct ChangeConv2DFilterFromFHWCToHWCF
+    : public OpRewritePattern<linalg::Conv2DInputNhwcFilterOhwiPolyOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DInputNhwcFilterOhwiPolyOp convOp,
+                                PatternRewriter &rewriter) const override {
+    auto linalgOp = cast<linalg::LinalgOp>(convOp.getOperation());
+    if (linalgOp.hasBufferSemantics()) return failure();
+
+    DenseElementsAttr fhwcTensor;
+    Value input = convOp.getOperand(0), fhwcFilter = convOp.getOperand(1);
+    if (!matchPattern(fhwcFilter, m_Constant(&fhwcTensor))) return failure();
+
+    auto hwcfTensor = convertFHWCTensorToHWCF(fhwcTensor);
+    auto hwcfFilter =
+        rewriter.create<ConstantOp>(fhwcFilter.getLoc(), hwcfTensor);
+
+    rewriter.replaceOpWithNewOp<linalg::ConvInputNHWCFilterHWCFOp>(
+        convOp, convOp.getResultTypes(), ValueRange{input, hwcfFilter},
+        ValueRange{convOp.getOperand(2)}, convOp.dilationsAttr(),
+        convOp.stridesAttr());
+
+    return success();
+  }
+};
+
+struct ChangeConv2DLayoutPass
+    : public ChangeConv2DLayoutBase<ChangeConv2DLayoutPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(&getContext());
+    patterns.insert<ChangeConv2DFilterFromFHWCToHWCF>(context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createChangeConv2DLayoutPass() {
+  return std::make_unique<ChangeConv2DLayoutPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -93,6 +93,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
       Shape::createExpandFunctionDynamicDimsPass());
 
   // Special case peephole optimizations.
+  passManager.addNestedPass<FuncOp>(createChangeConv2DLayoutPass());
   if (clEnable1x1ConvToMatmul) {
     passManager.addNestedPass<FuncOp>(createConvertConv2D1x1ToMatmulPass());
   }

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -42,6 +42,10 @@ void registerFlowTransformPassPipeline();
 // Input canonicalization and legalization
 //===----------------------------------------------------------------------===//
 
+/// Creates a pass to convert linalg convolution ops to the variants with
+/// better layouts for IREE.
+std::unique_ptr<OperationPass<FuncOp>> createChangeConv2DLayoutPass();
+
 /// Creates a pass to convert linalg convolution ops with 1x1 kernels into
 /// linalg.matmul
 std::unique_ptr<OperationPass<FuncOp>> createConvertConv2D1x1ToMatmulPass();

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -9,6 +9,12 @@
 
 include "mlir/Pass/PassBase.td"
 
+def ChangeConv2DLayout :
+    Pass<"iree-flow-change-conv2d-layout", "FuncOp"> {
+  let summary = "Change linalg convolution ops to variants with better layouts";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createChangeConv2DLayoutPass()";
+}
+
 def ConvertConv2D1x1ConvToMatmul :
     Pass<"iree-flow-convert-conv2d-1x1-to-matmul", "FuncOp"> {
   let summary = "Convert linalg convolution ops with 1x1 kernels into linalg matrix multiplication ops.";

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "change_conv2d_layout.mlir",
             "conv1x1_to_matmul.mlir",
             "conv2d_to_img2col.mlir",
             "convert_to_flow_tensor_ops_after.mlir",

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "change_conv2d_layout.mlir"
     "conv1x1_to_matmul.mlir"
     "conv2d_to_img2col.mlir"
     "convert_to_flow_tensor_ops_after.mlir"

--- a/iree/compiler/Dialect/Flow/Transforms/test/change_conv2d_layout.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/change_conv2d_layout.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-opt -split-input-file -iree-flow-change-conv2d-layout %s | IreeFileCheck %s
+
+//  CHECK-LABEL: func @conv_filter_fhwc_to_hwcf
+//   CHECK-SAME: (%[[INPUT:.+]]: tensor<1x2x5x4xf32>, %[[INIT:.+]]: tensor<1x2x2x2xf32>)
+func @conv_filter_fhwc_to_hwcf(%input: tensor<1x2x5x4xf32>, %init: tensor<1x2x2x2xf32>) -> tensor<1x2x2x2xf32> {
+  //      CHECK: %[[FILTER:.+]] = constant
+  // CHECK-SAME{LITERAL}: dense<[[
+  // CHECK-SAME{LITERAL}:   [[1.000000e+00, 1.300000e+01], [2.000000e+00, 1.400000e+01], [3.000000e+00, 1.500000e+01], [4.000000e+00, 1.600000e+01]],
+  // CHECK-SAME{LITERAL}:   [[5.000000e+00, 1.700000e+01], [6.000000e+00, 1.800000e+01], [7.000000e+00, 1.900000e+01], [8.000000e+00, 2.000000e+01]],
+  // CHECK-SAME{LITERAL}:   [[9.000000e+00, 2.100000e+01], [1.000000e+01, 2.200000e+01], [1.100000e+01, 2.300000e+01], [1.200000e+01, 2.400000e+01]]
+  // CHECK-SAME{LITERAL}: ]]> : tensor<1x3x4x2xf32>
+  %filter = constant dense<[
+    [[[ 1.0,  2.0,  3.0,  4.0], [ 5.0,  6.0,  7.0,  8.0], [ 9.0, 10.0, 11.0, 12.0]]],
+    [[[13.0, 14.0, 15.0, 16.0], [17.0, 18.0, 19.0, 20.0], [21.0, 22.0, 23.0, 24.0]]]
+  ]> : tensor<2x1x3x4xf32>
+  //      CHECK: %[[CONV:.+]] = linalg.conv_2d_input_nhwc_filter_hwcf
+  // CHECK-SAME:   {dilations = dense<1> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>}
+  // CHECK-SAME: ins(%[[INPUT]], %[[FILTER]] : tensor<1x2x5x4xf32>, tensor<1x3x4x2xf32>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x2x2x2xf32>)
+  %0 = linalg.conv_2d_input_nhwc_filter_ohwi_poly
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>}
+       ins(%input, %filter : tensor<1x2x5x4xf32>, tensor<2x1x3x4xf32>)
+       outs(%init : tensor<1x2x2x2xf32>)
+       -> tensor<1x2x2x2xf32>
+  //      CHECK: return %[[CONV]]
+  return %0: tensor<1x2x2x2xf32>
+}
+
+// CHECK-LABEL: func @dont_change_conv_without_const_filter
+func @dont_change_conv_without_const_filter(%input: tensor<1x2x5x4xf32>, %filter: tensor<2x1x3x4xf32>, %init: tensor<1x2x2x2xf32>) -> tensor<1x2x2x2xf32> {
+  // CHECK: linalg.conv_2d_input_nhwc_filter_ohwi_poly
+  %0 = linalg.conv_2d_input_nhwc_filter_ohwi_poly
+         {dilations = dense<1> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>}
+       ins(%input, %filter : tensor<1x2x5x4xf32>, tensor<2x1x3x4xf32>)
+       outs(%init : tensor<1x2x2x2xf32>)
+       -> tensor<1x2x2x2xf32>
+  return %0: tensor<1x2x2x2xf32>
+}


### PR DESCRIPTION
There are quite a few linalg convolution op variants upstream.
Handling all of them is burdensome for IREE CodeGen pieplines,
let alone that not all of them have layouts that are good for
CodeGen natively. So this commit adds a pass to reduce the
variants seen by downstream CodeGen pipelines.

For now the pass just converts conv2d ops with FHWC-flavor
constant filters into  HWCF-flavor, given that right now both
the CPU (via img2col) and GPU (via direct convolution) expect
HWCF layout filters.

The immediate use is to enable compiling MobileSSD and
PoseNet from TOSA path in IREE.