### PR TITLE
Generate API functions in VMToEmitC conversion pass

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -50,6 +50,10 @@ Optional<std::string> getCType(Type type) {
     return std::string(oType.getValue());
   }
 
+  if (type.isa<IREE::VM::RefType>()) {
+    return std::string("iree_vm_ref_t*");
+  }
+
   return None;
 }
 
@@ -68,9 +72,9 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   std::string moduleTypeName = (moduleOp.getName() + "_t*").str();
   std::string moduleStateTypeName = (moduleOp.getName() + "_state_t*").str();
 
-  Type stackType = mlir::emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
-  Type moduleType = mlir::emitc::OpaqueType::get(ctx, moduleTypeName);
-  Type moduleStateType = mlir::emitc::OpaqueType::get(ctx, moduleStateTypeName);
+  Type stackType = emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
+  Type moduleType = emitc::OpaqueType::get(ctx, moduleTypeName);
+  Type moduleStateType = emitc::OpaqueType::get(ctx, moduleStateTypeName);
 
   SmallVector<Type, 3> inputTypes = {stackType, moduleType, moduleStateType};
   SmallVector<Type, 1> outputTypes;
@@ -85,13 +89,13 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
       return funcOp.emitError() << "unable to emit C type";
     }
     std::string cPtrType = cType.getValue() + std::string("*");
-    Type type = mlir::emitc::OpaqueType::get(ctx, cPtrType);
+    Type type = emitc::OpaqueType::get(ctx, cPtrType);
     inputTypes.push_back(type);
     outputTypes.push_back(type);
   }
 
   auto newFuncType = mlir::FunctionType::get(
-      ctx, {inputTypes}, {mlir::emitc::OpaqueType::get(ctx, "iree_status_t")});
+      ctx, {inputTypes}, {emitc::OpaqueType::get(ctx, "iree_status_t")});
 
   auto newFuncOp = builder.create<mlir::FuncOp>(loc, name, newFuncType);
   newFuncOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
@@ -101,7 +105,8 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   // Annotate new function with calling convention string which gets used in
   // the CModuleTarget.
   newFuncOp.getOperation()->setAttr(
-      "calling_convention", StringAttr::get(ctx, callingConvention.getValue()));
+      "vm.calling_convention",
+      StringAttr::get(ctx, callingConvention.getValue()));
 
   // This call shold be equivalent to rewriter.inlineRegionBefore()
   newFuncOp.getBody().getBlocks().splice(newFuncOp.end(),
@@ -120,9 +125,13 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
     return funcOp.emitError() << "parent func op not found in cache.";
   }
 
-  // Add constant ops for refs
+  // Add constant ops for local refs
+  const int numRefArgs = llvm::count_if(inputTypes, [](Type inputType) {
+    return inputType.isa<IREE::VM::RefType>();
+  });
   const int numRefs =
-      ptr->second.registerAllocation.getMaxRefRegisterOrdinal() + 1;
+      ptr->second.registerAllocation.getMaxRefRegisterOrdinal() + 1 -
+      numRefArgs;
 
   builder.setInsertionPointToStart(&entryBlock);
 
@@ -130,10 +139,39 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
     auto refOp = builder.create<emitc::ConstantOp>(
         /*location=*/loc,
         /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t"),
-        /*value=*/emitc::OpaqueAttr::get(ctx, "{0}"));
+        /*value=*/emitc::OpaqueAttr::get(ctx, ""));
 
-    // Mark local refs so that we can release them before a return operation
-    refOp.getOperation()->setAttr("ref_ordinal", builder.getIndexAttr(i));
+    // Mark local refs so that we can release them before a return operation.
+    // Here we rely on the fact that the register allocation maps arguments in
+    // the first slots.
+    refOp.getOperation()->setAttr("ref_ordinal",
+                                  builder.getIndexAttr(i + numRefArgs));
+
+    auto refPtrOp = builder.create<emitc::ApplyOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
+        /*applicableOperator=*/StringAttr::get(ctx, "&"),
+        /*operand=*/refOp.getResult());
+
+    auto refSizeOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/builder.getI32Type(),
+        /*callee=*/StringAttr::get(ctx, "sizeof"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{refOp.getResult()});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "memset"),
+        /*args=*/
+        ArrayAttr::get(ctx,
+                       {builder.getIndexAttr(0), builder.getUI32IntegerAttr(0),
+                        builder.getIndexAttr(1)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{refPtrOp.getResult(), refSizeOp.getResult(0)});
   }
 
   vmAnalysisCache.insert(
@@ -209,7 +247,34 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
   return elementTypePtrOp;
 }
 
-void releaseLocalRefs(ConversionPatternRewriter &rewriter, Location location,
+Optional<Value> findRef(mlir::FuncOp &parentFuncOp,
+                        VMAnalysisCache &vmAnalysisCache, Value refResult) {
+  assert(refResult.getType().isa<IREE::VM::RefType>());
+
+  auto ptr = vmAnalysisCache.find(parentFuncOp.getOperation());
+  if (ptr == vmAnalysisCache.end()) {
+    parentFuncOp.emitError() << "parent func op not found in cache.";
+    return None;
+  }
+  RegisterAllocation &registerAllocation = ptr->second.registerAllocation;
+
+  int32_t ordinal = registerAllocation.mapToRegister(refResult).ordinal();
+
+  for (auto constantOp : parentFuncOp.getOps<emitc::ConstantOp>()) {
+    Operation *op = constantOp.getOperation();
+    if (!op->hasAttr("ref_ordinal")) continue;
+    if (op->getAttr("ref_ordinal")
+            .cast<IntegerAttr>()
+            .getValue()
+            .getZExtValue() == ordinal) {
+      return constantOp.getResult();
+    }
+  }
+
+  return None;
+}
+
+void releaseLocalRefs(OpBuilder &builder, Location location,
                       mlir::FuncOp funcOp) {
   auto ctx = funcOp.getContext();
 
@@ -218,13 +283,13 @@ void releaseLocalRefs(ConversionPatternRewriter &rewriter, Location location,
     Operation *op = constantOp.getOperation();
     if (!op->hasAttr("ref_ordinal")) continue;
 
-    auto refPtrOp = rewriter.create<emitc::ApplyOp>(
+    auto refPtrOp = builder.create<emitc::ApplyOp>(
         /*location=*/location,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/constantOp.getResult());
 
-    rewriter.create<emitc::CallOp>(
+    builder.create<emitc::CallOp>(
         /*location=*/location,
         /*type=*/TypeRange{},
         /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
@@ -234,18 +299,18 @@ void releaseLocalRefs(ConversionPatternRewriter &rewriter, Location location,
   }
 }
 
-/// Generate a call op with one result and split the current block into a
+/// Generate an emitc.call op with one result and split the current block into a
 /// continuation and failure block based on the truthiness of the result
-/// value, i.e. a truthy value branches to the continuation block.
+/// value, i.e. a truthy value branches to the continuation block when
+/// `negateCondition` is false.
 emitc::CallOp failableCall(
-    ConversionPatternRewriter &rewriter, Location location, Type type,
-    StringAttr callee, ArrayAttr args, ArrayAttr templateArgs,
-    ArrayRef<Value> operands,
+    OpBuilder &builder, Location location, Type type, StringAttr callee,
+    ArrayAttr args, ArrayAttr templateArgs, ArrayRef<Value> operands,
     const std::function<void(emitc::CallOp &)> &failureBlockBuilder,
-    bool negateResult = false) {
-  auto ctx = rewriter.getContext();
+    bool negateCondition = false) {
+  auto ctx = builder.getContext();
 
-  auto callOp = rewriter.create<emitc::CallOp>(
+  auto callOp = builder.create<emitc::CallOp>(
       /*location=*/location,
       /*type=*/type,
       /*callee=*/callee,
@@ -253,174 +318,723 @@ emitc::CallOp failableCall(
       /*templateArgs=*/templateArgs,
       /*operands=*/operands);
 
-  Type boolType = rewriter.getIntegerType(1);
+  Type boolType = builder.getIntegerType(1);
 
-  auto conditionI1 = rewriter.create<emitc::CallOp>(
+  auto conditionI1 = builder.create<emitc::CallOp>(
       /*location=*/location,
       /*type=*/boolType,
       /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
       /*args=*/
-      ArrayAttr::get(ctx, {rewriter.getIndexAttr(0), TypeAttr::get(boolType)}),
+      ArrayAttr::get(ctx, {builder.getIndexAttr(0), TypeAttr::get(boolType)}),
       /*templateArgs=*/ArrayAttr{},
       /*operands=*/ArrayRef<Value>{callOp.getResult(0)});
 
-  if (negateResult)
-    conditionI1 = rewriter.create<emitc::CallOp>(
-        /*location=*/location,
-        /*type=*/boolType,
-        /*callee=*/StringAttr::get(ctx, "EMITC_NOT"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ArrayRef<Value>{conditionI1.getResult(0)});
-
   // Start by splitting the block into two. The part before will contain the
   // condition, and the part after will contain the continuation point.
-  Block *condBlock = rewriter.getInsertionBlock();
-  Block::iterator opPosition = rewriter.getInsertionPoint();
-  Block *continuationBlock = rewriter.splitBlock(condBlock, opPosition);
+  Block *condBlock = builder.getInsertionBlock();
+  Block::iterator opPosition = builder.getInsertionPoint();
+  Block *continuationBlock = condBlock->splitBlock(opPosition);
 
   // Create a new block for the target of the failure.
   Block *failureBlock;
   {
-    OpBuilder::InsertionGuard guard(rewriter);
+    OpBuilder::InsertionGuard guard(builder);
     Region *parentRegion = condBlock->getParent();
-    failureBlock = rewriter.createBlock(parentRegion, parentRegion->end());
+    failureBlock = builder.createBlock(parentRegion, parentRegion->end());
 
     failureBlockBuilder(callOp);
   }
 
-  rewriter.setInsertionPointToEnd(condBlock);
-  auto branchOp = rewriter.create<CondBranchOp>(
-      location, conditionI1.getResult(0), continuationBlock, failureBlock);
+  builder.setInsertionPointToEnd(condBlock);
+  auto branchOp = builder.create<CondBranchOp>(
+      location, conditionI1.getResult(0),
+      negateCondition ? failureBlock : continuationBlock,
+      negateCondition ? continuationBlock : failureBlock);
 
-  rewriter.setInsertionPoint(continuationBlock, opPosition);
+  builder.setInsertionPointToStart(continuationBlock);
 
   return callOp;
 }
 
-emitc::CallOp returnIfError(ConversionPatternRewriter &rewriter,
-                            Location location, StringAttr callee,
-                            ArrayAttr args, ArrayAttr templateArgs,
-                            ArrayRef<Value> operands) {
-  auto blockBuilder = [&rewriter, &location](emitc::CallOp &callOp) {
-    auto ctx = rewriter.getContext();
+emitc::CallOp returnIfError(OpBuilder &builder, Location location,
+                            StringAttr callee, ArrayAttr args,
+                            ArrayAttr templateArgs, ArrayRef<Value> operands) {
+  auto blockBuilder = [&builder, &location](emitc::CallOp &callOp) {
+    auto ctx = builder.getContext();
 
-    Block *block = rewriter.getBlock();
+    Block *block = builder.getBlock();
     mlir::FuncOp funcOp = cast<mlir::FuncOp>(block->getParentOp());
 
-    releaseLocalRefs(rewriter, location, funcOp);
+    releaseLocalRefs(builder, location, funcOp);
 
-    rewriter.create<mlir::ReturnOp>(location, callOp.getResult(0));
+    builder.create<mlir::ReturnOp>(location, callOp.getResult(0));
   };
 
-  auto ctx = rewriter.getContext();
+  auto ctx = builder.getContext();
   Type type = emitc::OpaqueType::get(ctx, "iree_status_t");
-  return failableCall(rewriter, location, type, callee, args, templateArgs,
+  return failableCall(builder, location, type, callee, args, templateArgs,
                       operands, blockBuilder, /*negateResult=*/true);
 }
 
-emitc::CallOp failListNull(ConversionPatternRewriter &rewriter,
-                           Location location, Type type, StringAttr callee,
-                           ArrayAttr args, ArrayAttr templateArgs,
-                           ArrayRef<Value> operands) {
-  auto blockBuilder = [&rewriter, &location](emitc::CallOp &callOp) {
-    auto ctx = rewriter.getContext();
+emitc::CallOp failListNull(OpBuilder &builder, Location location, Type type,
+                           StringAttr callee, ArrayAttr args,
+                           ArrayAttr templateArgs, ArrayRef<Value> operands) {
+  auto blockBuilder = [&builder, &location](emitc::CallOp &callOp) {
+    auto ctx = builder.getContext();
 
-    Block *block = rewriter.getBlock();
+    Block *block = builder.getBlock();
     mlir::FuncOp funcOp = cast<mlir::FuncOp>(block->getParentOp());
 
-    releaseLocalRefs(rewriter, location, funcOp);
+    releaseLocalRefs(builder, location, funcOp);
 
-    auto statusOp = rewriter.create<emitc::CallOp>(
+    auto statusOp = builder.create<emitc::CallOp>(
         /*location=*/location,
-        /*type=*/mlir::emitc::OpaqueType::get(ctx, "iree_status_t"),
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
         /*callee=*/StringAttr::get(ctx, "iree_make_status"),
         /*args=*/
-        ArrayAttr::get(ctx, {mlir::emitc::OpaqueAttr::get(
-                                ctx, "IREE_STATUS_INVALID_ARGUMENT")}),
+        ArrayAttr::get(
+            ctx, {emitc::OpaqueAttr::get(ctx, "IREE_STATUS_INVALID_ARGUMENT")}),
         /*templateArgs=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{});
 
-    rewriter.create<mlir::ReturnOp>(location, statusOp.getResult(0));
+    builder.create<mlir::ReturnOp>(location, statusOp.getResult(0));
   };
 
-  return failableCall(rewriter, location, type, callee, args, templateArgs,
+  return failableCall(builder, location, type, callee, args, templateArgs,
                       operands, blockBuilder);
 }
 
+/// Generate a mlir.call op with one result and split the current block into a
+/// continuation and failure block based on the truthiness of the result
+/// value, i.e. a truthy value branches to the continuation block when
+/// `negateCondition` is false.
 mlir::CallOp failableCall(
-    ConversionPatternRewriter &rewriter, Location location,
-    mlir::FuncOp &callee, ArrayRef<Value> operands,
+    OpBuilder &builder, Location location, mlir::FuncOp &callee,
+    ArrayRef<Value> operands,
     const std::function<void(mlir::CallOp &)> &failureBlockBuilder,
-    bool negateResult = false) {
-  auto ctx = rewriter.getContext();
+    bool negateCondition = false) {
+  auto ctx = builder.getContext();
 
-  auto callOp = rewriter.create<mlir::CallOp>(
+  auto callOp = builder.create<mlir::CallOp>(
       /*location=*/location,
       /*callee=*/callee,
       /*operands=*/operands);
 
-  Type boolType = rewriter.getIntegerType(1);
+  Type boolType = builder.getIntegerType(1);
 
-  auto conditionI1 = rewriter.create<emitc::CallOp>(
+  auto conditionI1 = builder.create<emitc::CallOp>(
       /*location=*/location,
       /*type=*/boolType,
       /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
       /*args=*/
-      ArrayAttr::get(ctx, {rewriter.getIndexAttr(0), TypeAttr::get(boolType)}),
+      ArrayAttr::get(ctx, {builder.getIndexAttr(0), TypeAttr::get(boolType)}),
       /*templateArgs=*/ArrayAttr{},
       /*operands=*/ArrayRef<Value>{callOp.getResult(0)});
 
-  if (negateResult)
-    conditionI1 = rewriter.create<emitc::CallOp>(
-        /*location=*/location,
-        /*type=*/boolType,
-        /*callee=*/StringAttr::get(ctx, "EMITC_NOT"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ArrayRef<Value>{conditionI1.getResult(0)});
-
   // Start by splitting the block into two. The part before will contain the
   // condition, and the part after will contain the continuation point.
-  Block *condBlock = rewriter.getInsertionBlock();
-  Block::iterator opPosition = rewriter.getInsertionPoint();
-  Block *continuationBlock = rewriter.splitBlock(condBlock, opPosition);
+  Block *condBlock = builder.getInsertionBlock();
+  Block::iterator opPosition = builder.getInsertionPoint();
+  Block *continuationBlock = condBlock->splitBlock(opPosition);
 
   // Create a new block for the target of the failure.
   Block *failureBlock;
   {
-    OpBuilder::InsertionGuard guard(rewriter);
+    OpBuilder::InsertionGuard guard(builder);
     Region *parentRegion = condBlock->getParent();
-    failureBlock = rewriter.createBlock(parentRegion, parentRegion->end());
+    failureBlock = builder.createBlock(parentRegion, parentRegion->end());
 
     failureBlockBuilder(callOp);
   }
 
-  rewriter.setInsertionPointToEnd(condBlock);
-  auto branchOp = rewriter.create<CondBranchOp>(
-      location, conditionI1.getResult(0), continuationBlock, failureBlock);
+  builder.setInsertionPointToEnd(condBlock);
+  auto branchOp = builder.create<CondBranchOp>(
+      location, conditionI1.getResult(0),
+      negateCondition ? failureBlock : continuationBlock,
+      negateCondition ? continuationBlock : failureBlock);
 
-  rewriter.setInsertionPoint(continuationBlock, opPosition);
+  builder.setInsertionPoint(continuationBlock, opPosition);
 
   return callOp;
 }
 
-mlir::CallOp returnIfError(ConversionPatternRewriter &rewriter,
-                           Location location, mlir::FuncOp &callee,
-                           ArrayRef<Value> operands) {
-  auto blockBuilder = [&rewriter, &location](mlir::CallOp &callOp) {
-    auto ctx = rewriter.getContext();
+mlir::CallOp returnIfError(OpBuilder &builder, Location location,
+                           mlir::FuncOp &callee, ArrayRef<Value> operands) {
+  auto blockBuilder = [&builder, &location](mlir::CallOp &callOp) {
+    auto ctx = builder.getContext();
 
-    Block *block = rewriter.getBlock();
+    Block *block = builder.getBlock();
     mlir::FuncOp funcOp = cast<mlir::FuncOp>(block->getParentOp());
 
-    releaseLocalRefs(rewriter, location, funcOp);
+    releaseLocalRefs(builder, location, funcOp);
 
-    rewriter.create<mlir::ReturnOp>(location, callOp.getResult(0));
+    builder.create<mlir::ReturnOp>(location, callOp.getResult(0));
   };
 
-  return failableCall(rewriter, location, callee, operands, blockBuilder,
+  return failableCall(builder, location, callee, operands, blockBuilder,
                       /*negateResult=*/true);
+}
+
+LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp) {
+  auto ctx = moduleOp.getContext();
+  auto loc = moduleOp.getLoc();
+
+  OpBuilder builder(moduleOp);
+  builder.setInsertionPoint(moduleOp.getBody()->getTerminator());
+
+  std::string moduleName{moduleOp.getName()};
+
+  // destroy
+  {
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto funcType = mlir::FunctionType::get(
+        ctx, {emitc::OpaqueType::get(ctx, "void*")}, {});
+
+    auto funcOp =
+        builder.create<mlir::FuncOp>(loc, moduleName + "_destroy", funcType);
+
+    funcOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
+
+    Block *entryBlock = funcOp.addEntryBlock();
+
+    builder.setInsertionPointToStart(entryBlock);
+
+    std::string moduleTypeName = moduleName + "_t*";
+
+    auto castedModuleOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, moduleTypeName),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, moduleTypeName)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{funcOp.getArgument(0)});
+
+    auto allocatorOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_allocator_t"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "allocator")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{castedModuleOp.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{allocatorOp.getResult(0), castedModuleOp.getResult(0)});
+
+    builder.create<mlir::ReturnOp>(loc);
+  }
+
+  // alloc_state
+  {
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto funcType = mlir::FunctionType::get(
+        ctx,
+        {emitc::OpaqueType::get(ctx, "void*"),
+         emitc::OpaqueType::get(ctx, "iree_allocator_t"),
+         emitc::OpaqueType::get(ctx, "iree_vm_module_state_t**")},
+        {emitc::OpaqueType::get(ctx, "iree_status_t")});
+
+    auto funcOp = builder.create<mlir::FuncOp>(loc, moduleName + "_alloc_state",
+                                               funcType);
+
+    funcOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
+
+    Block *entryBlock = funcOp.addEntryBlock();
+
+    builder.setInsertionPointToStart(entryBlock);
+
+    std::string moduleStateTypeName = moduleName + "_state_t*";
+
+    auto stateOp = builder.create<emitc::ConstantOp>(
+        /*location=*/loc,
+        /*resultType=*/emitc::OpaqueType::get(ctx, moduleStateTypeName),
+        /*value=*/emitc::OpaqueAttr::get(ctx, "NULL"));
+
+    auto stateSize = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
+        /*callee=*/StringAttr::get(ctx, "sizeof"),
+        /*args=*/
+        ArrayAttr::get(ctx,
+                       {emitc::OpaqueAttr::get(ctx, moduleName + "_state_t")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{});
+
+    auto statePtr = builder.template create<emitc::ApplyOp>(
+        /*location=*/loc,
+        /*result=*/emitc::OpaqueType::get(ctx, moduleStateTypeName + "*"),
+        /*applicableOperator=*/StringAttr::get(ctx, "&"),
+        /*operand=*/stateOp.getResult());
+
+    auto voidPtr = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "void**"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "void**")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{statePtr.getResult()});
+
+    returnIfError(
+        builder, loc, StringAttr::get(ctx, "iree_allocator_malloc"), {}, {},
+        {funcOp.getArgument(1), stateSize.getResult(0), voidPtr.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "memset"),
+        /*args=*/
+        ArrayAttr::get(ctx,
+                       {builder.getIndexAttr(0), builder.getUI32IntegerAttr(0),
+                        builder.getIndexAttr(1)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{stateOp.getResult(), stateSize.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ASSIGN"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "allocator"),
+                             builder.getIndexAttr(1)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{stateOp.getResult(), funcOp.getArgument(1)});
+
+    // Initialize buffers
+    for (auto rodataOp : moduleOp.getOps<IREE::VM::RodataOp>()) {
+      auto ordinal = rodataOp.ordinal().getValue().getZExtValue();
+
+      std::string bufferName = moduleName + "_" + rodataOp.getName().str();
+
+      auto bufferVoid = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "void*"),
+          /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+          /*args=*/
+          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, bufferName),
+                               emitc::OpaqueAttr::get(ctx, "void*")}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ArrayRef<Value>{});
+
+      auto bufferSize = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
+          /*callee=*/StringAttr::get(ctx, "sizeof"),
+          /*args=*/
+          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, bufferName)}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ArrayRef<Value>{});
+
+      auto byteSpan = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "iree_byte_span_t"),
+          /*callee=*/StringAttr::get(ctx, "iree_make_byte_span"),
+          /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/
+          ArrayRef<Value>{bufferVoid.getResult(0), bufferSize.getResult(0)});
+
+      auto allocator = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "iree_allocator_t"),
+          /*callee=*/StringAttr::get(ctx, "iree_allocator_null"),
+          /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/
+          ArrayRef<Value>{});
+
+      auto buffers = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
+          /*args=*/
+          ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                               emitc::OpaqueAttr::get(ctx, "rodata_buffers")}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ArrayRef<Value>{stateOp.getResult()});
+
+      auto buffer = builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+          /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
+          /*args=*/
+          ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                               builder.getUI32IntegerAttr(ordinal)}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ArrayRef<Value>{buffers.getResult(0)});
+
+      builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/TypeRange{},
+          /*callee=*/StringAttr::get(ctx, "iree_vm_buffer_initialize"),
+          /*args=*/
+          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(
+                                   ctx, "IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE"),
+                               builder.getIndexAttr(0), builder.getIndexAttr(1),
+                               builder.getIndexAttr(2)}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/
+          ArrayRef<Value>{byteSpan.getResult(0), allocator.getResult(0),
+                          buffer.getResult(0)});
+    }
+
+    auto baseStateOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(
+            ctx, {builder.getIndexAttr(0),
+                  emitc::OpaqueAttr::get(ctx, "iree_vm_module_state_t*")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{stateOp.getResult()});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_VALUE"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{funcOp.getArgument(2), baseStateOp.getResult(0)});
+
+    auto status = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
+        /*callee=*/StringAttr::get(ctx, "iree_ok_status"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{});
+
+    builder.create<mlir::ReturnOp>(loc, status.getResult(0));
+  }
+
+  // free_state
+  {
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto funcType = mlir::FunctionType::get(
+        ctx,
+        {emitc::OpaqueType::get(ctx, "void*"),
+         emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*")},
+        {});
+
+    auto funcOp =
+        builder.create<mlir::FuncOp>(loc, moduleName + "_free_state", funcType);
+
+    funcOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
+
+    Block *entryBlock = funcOp.addEntryBlock();
+
+    builder.setInsertionPointToStart(entryBlock);
+
+    std::string moduleStateTypeName = moduleName + "_state_t*";
+
+    auto stateOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, moduleStateTypeName),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, moduleStateTypeName)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{funcOp.getArgument(1)});
+
+    auto allocatorOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_allocator_t"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "allocator")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{stateOp.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{allocatorOp.getResult(0), stateOp.getResult(0)});
+
+    builder.create<mlir::ReturnOp>(loc);
+  }
+
+  // resolve_import
+  {
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto funcType = mlir::FunctionType::get(
+        ctx,
+        {
+            emitc::OpaqueType::get(ctx, "void*"),
+            emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
+            emitc::OpaqueType::get(ctx, "iree_host_size_t"),
+            emitc::OpaqueType::get(ctx, "const iree_vm_function_t*"),
+            emitc::OpaqueType::get(ctx, "const iree_vm_function_signature_t*"),
+        },
+        {emitc::OpaqueType::get(ctx, "iree_status_t")});
+
+    auto funcOp = builder.create<mlir::FuncOp>(
+        loc, moduleName + "_resolve_import", funcType);
+
+    funcOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
+
+    Block *entryBlock = funcOp.addEntryBlock();
+
+    builder.setInsertionPointToStart(entryBlock);
+
+    std::string moduleStateTypeName = moduleName + "_state_t*";
+
+    auto stateOp = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, moduleStateTypeName),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, moduleStateTypeName)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{funcOp.getArgument(1)});
+
+    auto imports = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "imports")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{stateOp.getResult(0)});
+
+    auto import = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{imports.getResult(0), funcOp.getArgument(2)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_PTR"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{import.getResult(0), funcOp.getArgument(3)});
+
+    auto status = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
+        /*callee=*/StringAttr::get(ctx, "iree_ok_status"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{});
+
+    builder.create<mlir::ReturnOp>(loc, status.getResult(0));
+  }
+
+  // create
+  {
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto funcType = mlir::FunctionType::get(
+        ctx,
+        {emitc::OpaqueType::get(ctx, "iree_allocator_t"),
+         emitc::OpaqueType::get(ctx, "iree_vm_module_t**")},
+        {emitc::OpaqueType::get(ctx, "iree_status_t")});
+
+    auto funcOp =
+        builder.create<mlir::FuncOp>(loc, moduleName + "_create", funcType);
+
+    funcOp.getOperation()->setAttr("emitc.static", UnitAttr::get(ctx));
+
+    // This function needs an iree_vm_native_module_descriptor_t that is emitted
+    // by the CModuleTarget at the moment. So we add a marker to this function
+    // and delay the printing of it.
+    funcOp.getOperation()->setAttr("vm.emit_at_end", UnitAttr::get(ctx));
+
+    Block *entryBlock = funcOp.addEntryBlock();
+
+    builder.setInsertionPointToStart(entryBlock);
+
+    std::string moduleTypeName = moduleName + "_t*";
+
+    auto module = builder.create<emitc::ConstantOp>(
+        /*location=*/loc,
+        /*resultType=*/emitc::OpaqueType::get(ctx, moduleTypeName),
+        /*value=*/emitc::OpaqueAttr::get(ctx, "NULL"));
+
+    auto moduleSize = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
+        /*callee=*/StringAttr::get(ctx, "sizeof"),
+        /*args=*/
+        ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, moduleName + "_t")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{});
+
+    auto modulePtr = builder.template create<emitc::ApplyOp>(
+        /*location=*/loc,
+        /*result=*/emitc::OpaqueType::get(ctx, moduleTypeName + "*"),
+        /*applicableOperator=*/StringAttr::get(ctx, "&"),
+        /*operand=*/module.getResult());
+
+    auto voidPtr = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "void**"),
+        /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "void**")}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ArrayRef<Value>{modulePtr.getResult()});
+
+    returnIfError(
+        builder, loc, StringAttr::get(ctx, "iree_allocator_malloc"), {}, {},
+        {funcOp.getArgument(0), moduleSize.getResult(0), voidPtr.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "memset"),
+        /*args=*/
+        ArrayAttr::get(ctx,
+                       {builder.getIndexAttr(0), builder.getUI32IntegerAttr(0),
+                        builder.getIndexAttr(1)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{module.getResult(), moduleSize.getResult(0)});
+
+    builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/TypeRange{},
+        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ASSIGN"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, "allocator"),
+                             builder.getIndexAttr(1)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{module.getResult(), funcOp.getArgument(0)});
+
+    auto vmModule = builder.create<emitc::ConstantOp>(
+        /*location=*/loc,
+        /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_module_t"),
+        /*value=*/emitc::OpaqueAttr::get(ctx, ""));
+
+    auto vmModulePtr = builder.template create<emitc::ApplyOp>(
+        /*location=*/loc,
+        /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_module_t*"),
+        /*applicableOperator=*/StringAttr::get(ctx, "&"),
+        /*operand=*/vmModule.getResult());
+
+    auto vmInitializeStatus = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
+        /*callee=*/StringAttr::get(ctx, "iree_vm_module_initialize"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{vmModulePtr.getResult(), module.getResult()});
+
+    Type boolType = builder.getIntegerType(1);
+
+    auto vmInitializeIsOk = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/boolType,
+        /*callee=*/StringAttr::get(ctx, "iree_status_is_ok"),
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{vmInitializeStatus.getResult(0)});
+
+    // Start by splitting the block into two. The part before will contain the
+    // condition, and the part after will contain the continuation point.
+    Block *condBlock = builder.getInsertionBlock();
+    Block::iterator opPosition = builder.getInsertionPoint();
+    Block *continuationBlock = condBlock->splitBlock(opPosition);
+
+    // Create a new block for the target of the failure.
+    Block *failureBlock;
+    {
+      OpBuilder::InsertionGuard guard(builder);
+      Region *parentRegion = condBlock->getParent();
+      failureBlock = builder.createBlock(parentRegion, parentRegion->end());
+
+      builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/TypeRange{},
+          /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
+          /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/
+          ArrayRef<Value>{funcOp.getArgument(0), module.getResult()});
+
+      builder.create<mlir::ReturnOp>(loc, vmInitializeStatus.getResult(0));
+    }
+
+    builder.setInsertionPointToEnd(condBlock);
+
+    builder.create<CondBranchOp>(loc, vmInitializeIsOk.getResult(0),
+                                 continuationBlock, failureBlock);
+
+    builder.setInsertionPointToStart(continuationBlock);
+
+    // Set function pointers
+    for (std::string funcName :
+         {"destroy", "alloc_state", "free_state", "resolve_import"}) {
+      builder.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/TypeRange{},
+          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ASSIGN"),
+          /*args=*/
+          ArrayAttr::get(
+              ctx,
+              {builder.getIndexAttr(0), emitc::OpaqueAttr::get(ctx, funcName),
+               emitc::OpaqueAttr::get(ctx, moduleName + "_" + funcName)}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/
+          ArrayRef<Value>{vmModule.getResult()});
+    }
+
+    std::string descriptoPtr = "&" + moduleName + "_descriptor_";
+
+    auto status = builder.create<emitc::CallOp>(
+        /*location=*/loc,
+        /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
+        /*callee=*/StringAttr::get(ctx, "iree_vm_native_module_create"),
+        /*args=*/
+        ArrayAttr::get(ctx, {builder.getIndexAttr(0),
+                             emitc::OpaqueAttr::get(ctx, descriptoPtr),
+                             builder.getIndexAttr(1), builder.getIndexAttr(2)}),
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/
+        ArrayRef<Value>{vmModulePtr.getResult(), funcOp.getArgument(0),
+                        funcOp.getArgument(1)});
+
+    builder.create<mlir::ReturnOp>(loc, status.getResult(0));
+  }
+
+  return success();
 }
 
 SmallVector<Attribute, 4> indexSequence(int64_t n, MLIRContext *ctx) {
@@ -489,8 +1103,49 @@ class GenericOpConversion : public OpConversionPattern<SrcOpTy> {
   StringRef funcName;
 };
 
+class FuncOpConversion : public OpConversionPattern<mlir::FuncOp> {
+ public:
+  using OpConversionPattern<mlir::FuncOp>::OpConversionPattern;
+
+  FuncOpConversion(TypeConverter &typeConverter, MLIRContext *context,
+                   VMAnalysisCache &vmAnalysisCache)
+      : OpConversionPattern<mlir::FuncOp>(typeConverter, context),
+        vmAnalysisCache(vmAnalysisCache) {}
+
+ private:
+  LogicalResult matchAndRewrite(
+      mlir::FuncOp funcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    TypeConverter::SignatureConversion signatureConverter(
+        funcOp.getType().getNumInputs());
+    TypeConverter typeConverter;
+    for (const auto &arg : llvm::enumerate(funcOp.getArgumentTypes())) {
+      Type convertedType = getTypeConverter()->convertType(arg.value());
+      signatureConverter.addInputs(arg.index(), convertedType);
+    }
+
+    rewriter.applySignatureConversion(&funcOp.getBody(), signatureConverter);
+
+    // Creates a new function with the updated signature.
+    rewriter.updateRootInPlace(funcOp, [&] {
+      funcOp.setType(
+          rewriter.getFunctionType(signatureConverter.getConvertedTypes(),
+                                   funcOp.getType().getResults()));
+    });
+    return success();
+  }
+
+  VMAnalysisCache &vmAnalysisCache;
+};
+
 class CallOpConversion : public OpConversionPattern<IREE::VM::CallOp> {
+ public:
   using OpConversionPattern<IREE::VM::CallOp>::OpConversionPattern;
+
+  CallOpConversion(TypeConverter &typeConverter, MLIRContext *context,
+                   VMAnalysisCache &vmAnalysisCache)
+      : OpConversionPattern<IREE::VM::CallOp>(typeConverter, context),
+        vmAnalysisCache(vmAnalysisCache) {}
 
  private:
   LogicalResult matchAndRewrite(
@@ -536,23 +1191,27 @@ class CallOpConversion : public OpConversionPattern<IREE::VM::CallOp> {
     // Create a variable for every result and a pointer to it as output
     // parameter to the call.
     for (OpResult result : op.getResults()) {
-      auto resultOp = rewriter.create<emitc::ConstantOp>(
-          /*location=*/loc,
-          /*resultType=*/result.getType(),
-          /*value=*/emitc::OpaqueAttr::get(ctx, ""));
+      if (result.getType().isa<IREE::VM::RefType>()) {
+        return op.emitError() << "Ref results not supported yet";
+      } else {
+        auto resultOp = rewriter.create<emitc::ConstantOp>(
+            /*location=*/loc,
+            /*resultType=*/result.getType(),
+            /*value=*/emitc::OpaqueAttr::get(ctx, ""));
 
-      Optional<std::string> cType = getCType(result.getType());
-      if (!cType.hasValue()) return op.emitError() << "unable to emit C type";
+        Optional<std::string> cType = getCType(result.getType());
+        if (!cType.hasValue()) return op.emitError() << "unable to emit C type";
 
-      std::string cPtrType = cType.getValue() + std::string("*");
-      auto resultPtrOp = rewriter.create<emitc::ApplyOp>(
-          /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, cPtrType),
-          /*applicableOperator=*/StringAttr::get(ctx, "&"),
-          /*operand=*/resultOp);
+        std::string cPtrType = cType.getValue() + std::string("*");
+        auto resultPtrOp = rewriter.create<emitc::ApplyOp>(
+            /*location=*/loc,
+            /*type=*/emitc::OpaqueType::get(ctx, cPtrType),
+            /*applicableOperator=*/StringAttr::get(ctx, "&"),
+            /*operand=*/resultOp);
 
-      resultOperands.push_back(resultOp.getResult());
-      updatedOperands.push_back(resultPtrOp.getResult());
+        resultOperands.push_back(resultOp.getResult());
+        updatedOperands.push_back(resultPtrOp.getResult());
+      }
     }
 
     auto callOp = returnIfError(
@@ -662,6 +1321,8 @@ class CallOpConversion : public OpConversionPattern<IREE::VM::CallOp> {
 
     return op.emitError() << "calls to imported function not supported yet";
   }
+
+  VMAnalysisCache &vmAnalysisCache;
 };
 
 template <typename CmpOpTy>
@@ -713,7 +1374,8 @@ class CompareRefOpConversion : public OpConversionPattern<CmpOpTy> {
           /*operands=*/ArrayRef<Value>{operands[0]});
     }
 
-    // NOTE: If lhs and rhs alias we call release twice on the same argument.
+    // NOTE: If lhs and rhs alias we call release twice on the same
+    // argument.
     if (moveRhs) {
       rewriter.create<emitc::CallOp>(
           /*location=*/loc,
@@ -836,37 +1498,17 @@ class ConstRefZeroOpConversion
     auto funcOp =
         constRefZeroOp.getOperation()->getParentOfType<mlir::FuncOp>();
 
-    auto ptr = vmAnalysisCache.find(funcOp.getOperation());
-    if (ptr == vmAnalysisCache.end()) {
-      return constRefZeroOp.emitError() << "parent func op not found in cache.";
+    auto ref = findRef(funcOp, vmAnalysisCache, constRefZeroOp.getResult());
+
+    if (!ref.hasValue()) {
+      return failure();
     }
-    RegisterAllocation &registerAllocation = ptr->second.registerAllocation;
-
-    int32_t ordinal =
-        registerAllocation.mapToRegister(constRefZeroOp.getResult()).ordinal();
-
-    emitc::ConstantOp refOp = nullptr;
-    for (auto constantOp : funcOp.getOps<emitc::ConstantOp>()) {
-      Operation *op = constantOp.getOperation();
-      if (!op->hasAttr("ref_ordinal")) continue;
-      if (op->getAttr("ref_ordinal")
-              .cast<IntegerAttr>()
-              .getValue()
-              .getZExtValue() == ordinal) {
-        refOp = constantOp;
-        break;
-      }
-    }
-
-    if (!refOp)
-      return constRefZeroOp.emitError()
-             << "Corresponding ref for ordinal '" << ordinal << "' not found";
 
     auto refPtrOp = rewriter.replaceOpWithNewOp<emitc::ApplyOp>(
         /*op=*/constRefZeroOp,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
-        /*operand=*/refOp);
+        /*operand=*/ref.getValue());
 
     rewriter.create<emitc::CallOp>(
         /*location=*/loc,
@@ -874,7 +1516,7 @@ class ConstRefZeroOpConversion
         /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ArrayRef<Value>{constRefZeroOp.result()});
+        /*operands=*/ArrayRef<Value>{refPtrOp.result()});
     return success();
   }
 
@@ -938,39 +1580,15 @@ class ConstRefRodataOpConversion
         /*templateArgs=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{});
 
-    auto ptr = vmAnalysisCache.find(funcOp.getOperation());
-    if (ptr == vmAnalysisCache.end()) {
-      return constRefRodataOp.emitError()
-             << "parent func op not found in cache.";
-    }
-    RegisterAllocation &registerAllocation = ptr->second.registerAllocation;
+    auto ref = findRef(funcOp, vmAnalysisCache, constRefRodataOp.getResult());
 
-    int32_t ordinal =
-        registerAllocation.mapToRegister(constRefRodataOp.getResult())
-            .ordinal();
-
-    emitc::ConstantOp refOp = nullptr;
-    for (auto constantOp : funcOp.getOps<emitc::ConstantOp>()) {
-      Operation *op = constantOp.getOperation();
-      if (!op->hasAttr("ref_ordinal")) continue;
-      if (op->getAttr("ref_ordinal")
-              .cast<IntegerAttr>()
-              .getValue()
-              .getZExtValue() == ordinal) {
-        refOp = constantOp;
-        break;
-      }
-    }
-
-    if (!refOp)
-      return constRefRodataOp.emitError()
-             << "Corresponding ref for ordinal '" << ordinal << "' not found";
+    if (!ref.hasValue()) return failure();
 
     auto refPtrOp = rewriter.replaceOpWithNewOp<emitc::ApplyOp>(
         /*op=*/constRefRodataOp,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
-        /*operand=*/refOp);
+        /*operand=*/ref.getValue());
 
     returnIfError(
         /*rewriter=*/rewriter,
@@ -998,8 +1616,6 @@ class BranchOpConversion : public OpConversionPattern<IREE::VM::BranchOp> {
     auto ctx = op.getContext();
     auto loc = op.getLoc();
 
-    Type boolType = rewriter.getIntegerType(1);
-
     rewriter.replaceOpWithNewOp<mlir::BranchOp>(op, op.dest(),
                                                 op.destOperands());
 
@@ -1018,7 +1634,7 @@ class CondBranchOpConversion
     auto ctx = op.getContext();
     auto loc = op.getLoc();
 
-    Type boolType = rewriter.getIntegerType(1);
+    Type boolType = rewriter.getI1Type();
 
     auto condition = rewriter.create<IREE::VM::CmpNZI32Op>(
         loc, rewriter.getI32Type(), op.condition());
@@ -1069,7 +1685,7 @@ class ReturnOpConversion : public OpConversionPattern<IREE::VM::ReturnOp> {
       rewriter.create<emitc::CallOp>(
           /*location=*/loc,
           /*type=*/TypeRange{},
-          /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN"),
+          /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_VALUE"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
           /*operands=*/ArrayRef<Value>{resultArgument, operand.value()});
@@ -1139,7 +1755,7 @@ class FailOpConversion : public OpConversionPattern<IREE::VM::FailOp> {
           /*type=*/emitc::OpaqueType::get(ctx, "iree_string_view_t"),
           /*callee=*/StringAttr::get(ctx, "iree_make_cstring_view"),
           /*args=*/
-          ArrayAttr::get(ctx, {mlir::emitc::OpaqueAttr::get(ctx, message)}),
+          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, message)}),
           /*templateArgs=*/ArrayAttr{},
           /*operands=*/ArrayRef<Value>{});
 
@@ -1178,13 +1794,13 @@ class FailOpConversion : public OpConversionPattern<IREE::VM::FailOp> {
           /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
           /*callee=*/StringAttr::get(ctx, "iree_status_allocate_f"),
           /*args=*/
-          ArrayAttr::get(ctx,
-                         {mlir::emitc::OpaqueAttr::get(
-                              ctx, "IREE_STATUS_FAILED_PRECONDITION"),
-                          mlir::emitc::OpaqueAttr::get(ctx, "\"<vm>\""),
-                          rewriter.getI32IntegerAttr(0),
-                          mlir::emitc::OpaqueAttr::get(ctx, "\"%.*s\""),
-                          rewriter.getIndexAttr(0), rewriter.getIndexAttr(1)}),
+          ArrayAttr::get(
+              ctx,
+              {emitc::OpaqueAttr::get(ctx, "IREE_STATUS_FAILED_PRECONDITION"),
+               emitc::OpaqueAttr::get(ctx, "\"<vm>\""),
+               rewriter.getI32IntegerAttr(0),
+               emitc::OpaqueAttr::get(ctx, "\"%.*s\""),
+               rewriter.getIndexAttr(0), rewriter.getIndexAttr(1)}),
           /*templateArgs=*/ArrayAttr{},
           /*operands=*/
           ArrayRef<Value>{messageSizeIntOp.getResult(0),
@@ -1307,9 +1923,9 @@ class GlobalStoreOpConversion : public OpConversionPattern<StoreOpTy> {
   StringRef funcName;
 };
 
-// Convert vm list operations to two emitc calls. The wrapping ref pointer is
-// first dereferenced and the result is used as the argument of the specified
-// function name.
+// Convert vm list operations to two emitc calls. The wrapping ref pointer
+// is first dereferenced and the result is used as the argument of the
+// specified function name.
 template <typename SrcOpTy>
 class ListOpConversion : public OpConversionPattern<SrcOpTy> {
   using OpConversionPattern<SrcOpTy>::OpConversionPattern;
@@ -1465,37 +2081,15 @@ class ListAllocOpConversion
         ArrayRef<Value>{elementTypePtrOp.getValue().getResult(), operands[0],
                         allocatorOp.getResult(0), listPtrOp.getResult()});
 
-    auto ptr = vmAnalysisCache.find(funcOp.getOperation());
-    if (ptr == vmAnalysisCache.end()) {
-      return allocOp.emitError() << "parent func op not found in cache.";
-    }
-    RegisterAllocation &registerAllocation = ptr->second.registerAllocation;
+    auto ref = findRef(funcOp, vmAnalysisCache, allocOp.getResult());
 
-    int32_t ordinal =
-        registerAllocation.mapToRegister(allocOp.getResult()).ordinal();
-
-    emitc::ConstantOp refOp = nullptr;
-    for (auto constantOp : funcOp.getOps<emitc::ConstantOp>()) {
-      Operation *op = constantOp.getOperation();
-      if (!op->hasAttr("ref_ordinal")) continue;
-      if (op->getAttr("ref_ordinal")
-              .cast<IntegerAttr>()
-              .getValue()
-              .getZExtValue() == ordinal) {
-        refOp = constantOp;
-        break;
-      }
-    }
-
-    if (!refOp)
-      return allocOp.emitError()
-             << "Corresponding ref for ordinal '" << ordinal << "' not found";
+    if (!ref.hasValue()) return failure();
 
     auto refPtrOp = rewriter.replaceOpWithNewOp<emitc::ApplyOp>(
         /*op=*/allocOp,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
-        /*operand=*/refOp);
+        /*operand=*/ref.getValue());
 
     auto refTypeOp = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
@@ -1638,37 +2232,15 @@ class ListGetRefOpConversion
 
     auto funcOp = getOp.getOperation()->getParentOfType<mlir::FuncOp>();
 
-    auto ptr = vmAnalysisCache.find(funcOp.getOperation());
-    if (ptr == vmAnalysisCache.end()) {
-      return getOp.emitError() << "parent func op not found in cache.";
-    }
-    RegisterAllocation &registerAllocation = ptr->second.registerAllocation;
+    auto ref = findRef(funcOp, vmAnalysisCache, getOp.getResult());
 
-    int32_t ordinal =
-        registerAllocation.mapToRegister(getOp.getResult()).ordinal();
-
-    emitc::ConstantOp refOp = nullptr;
-    for (auto constantOp : funcOp.getOps<emitc::ConstantOp>()) {
-      Operation *op = constantOp.getOperation();
-      if (!op->hasAttr("ref_ordinal")) continue;
-      if (op->getAttr("ref_ordinal")
-              .cast<IntegerAttr>()
-              .getValue()
-              .getZExtValue() == ordinal) {
-        refOp = constantOp;
-        break;
-      }
-    }
-
-    if (!refOp)
-      return getOp.emitError()
-             << "Corresponding ref for ordinal '" << ordinal << "' not found";
+    if (!ref.hasValue()) return failure();
 
     auto refPtrOp = rewriter.replaceOpWithNewOp<emitc::ApplyOp>(
         /*op=*/getOp,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_t*"),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
-        /*operand=*/refOp);
+        /*operand=*/ref.getValue());
 
     returnIfError(
         /*rewriter=*/rewriter,
@@ -1690,7 +2262,8 @@ class ListGetRefOpConversion
 
     // Build the following expression:
     // (ref->type != IREE_VM_REF_TYPE_NULL &&
-    // (iree_vm_type_def_is_value(type_def) || ref->type != type_def->ref_type))
+    // (iree_vm_type_def_is_value(type_def) || ref->type !=
+    // type_def->ref_type))
     emitc::CallOp invalidType;
     {
       auto refType = rewriter.create<emitc::CallOp>(
@@ -1712,7 +2285,7 @@ class ListGetRefOpConversion
 
       auto typedefIsValue = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/rewriter.getIntegerType(1),
+          /*type=*/rewriter.getI1Type(),
           /*callee=*/StringAttr::get(ctx, "iree_vm_type_def_is_value"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -1733,7 +2306,7 @@ class ListGetRefOpConversion
 
       auto refTypeIsNotNull = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/rewriter.getIntegerType(1),
+          /*type=*/rewriter.getI1Type(),
           /*callee=*/StringAttr::get(ctx, "EMITC_NE"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -1742,7 +2315,7 @@ class ListGetRefOpConversion
 
       auto refTypesDontMatch = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/rewriter.getIntegerType(1),
+          /*type=*/rewriter.getI1Type(),
           /*callee=*/StringAttr::get(ctx, "EMITC_NE"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -1751,7 +2324,7 @@ class ListGetRefOpConversion
 
       auto invalidRefType = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/rewriter.getIntegerType(1),
+          /*type=*/rewriter.getI1Type(),
           /*callee=*/StringAttr::get(ctx, "EMITC_OR"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -1761,7 +2334,7 @@ class ListGetRefOpConversion
 
       invalidType = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/rewriter.getIntegerType(1),
+          /*type=*/rewriter.getI1Type(),
           /*callee=*/StringAttr::get(ctx, "EMITC_AND"),
           /*args=*/ArrayAttr{},
           /*templateArgs=*/ArrayAttr{},
@@ -1770,11 +2343,12 @@ class ListGetRefOpConversion
                           invalidRefType.getResult(0)});
     }
 
-    // Start by splitting the block into two. The part before will contain the
-    // condition, and the part after will contain the continuation point.
+    // Start by splitting the block into two. The part before will contain
+    // the condition, and the part after will contain the continuation
+    // point.
     Block *condBlock = rewriter.getInsertionBlock();
     Block::iterator opPosition = rewriter.getInsertionPoint();
-    Block *continuationBlock = rewriter.splitBlock(condBlock, opPosition);
+    Block *continuationBlock = condBlock->splitBlock(opPosition);
 
     // Create a new block for the target of the failure.
     Block *failureBlock;
@@ -1939,9 +2513,10 @@ void populateVMToEmitCPatterns(MLIRContext *context,
 
   // CFG
   patterns.insert<BranchOpConversion>(context);
-  patterns.insert<CallOpConversion>(context);
+  patterns.insert<CallOpConversion>(typeConverter, context, vmAnalysisCache);
   patterns.insert<CondBranchOpConversion>(context);
   patterns.insert<FailOpConversion>(context);
+  patterns.insert<FuncOpConversion>(typeConverter, context, vmAnalysisCache);
   patterns.insert<ReturnOpConversion>(context);
 
   // Globals
@@ -2245,9 +2820,10 @@ class ConvertVMToEmitCPass
     // Run analysis passes
     VMAnalysisCache vmAnalysisCache;
 
-    // Convert vm.func ops to std.func with the calling convntion used by EmitC.
-    // We convert these upfront to make sure vm.call ops always reference
-    // std.func ops with the correct calling convention during the conversion.
+    // Convert vm.func ops to std.func with the calling convntion used by
+    // EmitC. We convert these upfront to make sure vm.call ops always
+    // reference std.func ops with the correct calling convention during the
+    // conversion.
     SmallVector<IREE::VM::FuncOp, 4> funcsToRemove;
     for (auto funcOp : module.getOps<IREE::VM::FuncOp>()) {
       Operation *op = funcOp.getOperation();
@@ -2261,12 +2837,19 @@ class ConvertVMToEmitCPass
 
     for (auto &funcOp : funcsToRemove) funcOp.erase();
 
+    // Generate func ops that implement the C API.
+    if (failed(createAPIFunctions(module))) return signalPassFailure();
+
     OwningRewritePatternList patterns(&getContext());
     populateVMToEmitCPatterns(&getContext(), typeConverter, patterns,
                               vmAnalysisCache);
 
-    target.addLegalDialect<mlir::emitc::EmitCDialect, mlir::BuiltinDialect,
+    target.addLegalDialect<emitc::EmitCDialect, mlir::BuiltinDialect,
                            mlir::StandardOpsDialect>();
+
+    target.addDynamicallyLegalOp<mlir::FuncOp>([&](mlir::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getType());
+    });
 
     target.addDynamicallyLegalOp<IREE::Util::DoNotOptimizeOp>(
         [&](IREE::Util::DoNotOptimizeOp op) {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
@@ -17,13 +17,43 @@ namespace mlir {
 namespace iree_compiler {
 
 struct VMAnalysis {
-  RegisterAllocation registerAllocation;
-  ValueLiveness valueLiveness;
+ public:
+  VMAnalysis(RegisterAllocation &&registerAllocation,
+             ValueLiveness &&valueLiveness)
+      : registerAllocation(std::move(registerAllocation)),
+        valueLiveness(std::move(valueLiveness)) {}
 
   VMAnalysis(VMAnalysis &&) = default;
   VMAnalysis &operator=(VMAnalysis &&) = default;
   VMAnalysis(const VMAnalysis &) = delete;
   VMAnalysis &operator=(const VMAnalysis &) = delete;
+
+  int getNumRefRegisters() {
+    return registerAllocation.getMaxRefRegisterOrdinal() + 1;
+  }
+
+  int getRefRegisterOrdinal(Value ref) {
+    return registerAllocation.mapToRegister(originalValue(ref)).ordinal();
+  }
+
+  bool isLastValueUse(Value ref, Operation *op) {
+    return valueLiveness.isLastValueUse(originalValue(ref), op);
+  }
+
+  void remapValue(Value original, Value replacement) {
+    mapping[replacement] = original;
+    return;
+  }
+
+ private:
+  RegisterAllocation registerAllocation;
+  ValueLiveness valueLiveness;
+  DenseMap<Value, Value> mapping;
+
+  Value originalValue(Value ref) {
+    auto ptr = mapping.find(ref);
+    return ptr == mapping.end() ? ref : ptr->second;
+  }
 };
 
 using VMAnalysisCache = DenseMap<Operation *, VMAnalysis>;

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_TYPECONVERTER_H_
-#define IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_TYPECONVERTER_H_
+#ifndef IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_
+#define IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_
 
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
@@ -35,4 +35,4 @@ class EmitCTypeConverter : public mlir::TypeConverter {
 }  // namespace iree_compiler
 }  // namespace mlir
 
-#endif  // IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_TYPECONVERTER_H_
+#endif  // IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -30,9 +30,12 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @my_module_const_ref_zero
   vm.func @const_ref_zero() {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"{0}">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
-    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.opaque<"iree_vm_ref_t*">) -> ()
+    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> i32
+    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.opaque<"iree_vm_ref_t*">, i32) -> ()
+    // CHECK-NEXT: %[[REFPTR2:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR2]]) : (!emitc.opaque<"iree_vm_ref_t*">) -> ()
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -3,7 +3,9 @@
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"{0}">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // The first pointer is used in a call to memset
+    // CHECK: emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
     // CHECK: %[[LISTREF:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     %list_dno = util.do_not_optimize(%list) : !vm.list<i32>
@@ -14,7 +16,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_size
   vm.func @list_size(%arg0: i32) {
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"{0}">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK: %[[LISTREF:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
     // CHECK: %[[SIZE:.+]] = emitc.call "iree_vm_list_size"(%{{.+}})
@@ -31,7 +33,9 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_ref
   vm.export @ref
   vm.func @ref(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"{0}">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK: %[[REF:.+]] = "emitc.constant"() {ref_ordinal = 0 : index, value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
+    // The first pointer is used in a call to memset
+    // CHECK: emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
     // CHECK: %[[BUFFERREF:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
     %buffer = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %buffer_dno = util.do_not_optimize(%buffer) : !vm.buffer

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -77,11 +77,11 @@ static LogicalResult printRodataBuffers(IREE::VM::ModuleOp &moduleOp,
       return rodataOp.emitError() << "error during serialization";
     }
 
-    std::string buffer_name =
+    std::string bufferName =
         moduleOp.getName().str() + "_" + rodataOp.getName().str();
 
     output << "iree_alignas(" << alignment << ") static const uint8_t "
-           << buffer_name << "[] = {";
+           << bufferName << "[] = {";
     llvm::interleaveComma(byteBuffer, output, [&](uint8_t value) {
       output << static_cast<unsigned int>(value);
     });
@@ -98,7 +98,10 @@ static LogicalResult printStructDefinitions(IREE::VM::ModuleOp &moduleOp,
   llvm::raw_ostream &output = emitter.ostream();
   std::string moduleName = moduleOp.getName().str();
 
-  output << "struct " << moduleName << "_t {};\n";
+  output << "struct " << moduleName << "_t {\n";
+  output << "iree_allocator_t allocator;\n";
+  output << "};\n ";
+
   output << "struct " << moduleName << "_state_t {\n";
 
   // Returns |count| or 1 if |count| == 0.
@@ -129,31 +132,13 @@ static LogicalResult printStructDefinitions(IREE::VM::ModuleOp &moduleOp,
 
 static LogicalResult printShim(mlir::FuncOp &funcOp,
                                llvm::raw_ostream &output) {
-  StringAttr callingConvention =
-      funcOp.getOperation()->getAttr("calling_convention").cast<StringAttr>();
+  StringAttr callingConvention = funcOp.getOperation()
+                                     ->getAttr("vm.calling_convention")
+                                     .cast<StringAttr>();
   if (!callingConvention) {
-    return funcOp.emitError("Couldn't create calling convention string");
+    return funcOp.emitError("Couldn't find calling convention attribute");
   }
   output << "call_" << callingConvention.getValue() << "_shim";
-  return success();
-}
-
-static LogicalResult initializeState(IREE::VM::ModuleOp moduleOp,
-                                     mlir::emitc::CppEmitter &emitter) {
-  llvm::raw_ostream &output = emitter.ostream();
-
-  for (auto rodataOp : moduleOp.getOps<IREE::VM::RodataOp>()) {
-    std::string buffer_name =
-        moduleOp.getName().str() + "_" + rodataOp.getName().str();
-    output << "iree_vm_buffer_initialize("
-           << "IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, "
-           << "iree_make_byte_span("
-           << "(void*)" << buffer_name << ", sizeof(" << buffer_name << ")), "
-           << "iree_allocator_null(), "
-           << "&state->rodata_buffers[" << rodataOp.ordinal() << "]"
-           << ");\n";
-  }
-
   return success();
 }
 
@@ -190,11 +175,10 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
         return exportOp.emitError("Couldn't find referenced FuncOp");
       }
       StringAttr callingConvention = funcOp.getOperation()
-                                         ->getAttr("calling_convention")
+                                         ->getAttr("vm.calling_convention")
                                          .cast<StringAttr>();
       if (!callingConvention) {
-        return exportOp.emitError(
-            "Couldn't create calling convention string for referenced FuncOp");
+        return exportOp.emitError("Couldn't find calling convention attribute");
       }
 
       // TODO(simon-camp): support function-level reflection attributes
@@ -252,7 +236,7 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
              << "(iree_vm_native_function_shim_t)";
 
       if (failed(printShim(funcOp, output))) {
-        return funcOp.emitError("Couldn't create calling convention string");
+        return funcOp.emitError("Error generatiing shim");
       }
       output << ", "
              << "(iree_vm_native_function_target_t)" << funcName << "},\n";
@@ -276,65 +260,6 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
          << "0,\n"
          << "NULL,\n"
          << "};\n";
-
-  // destroy
-  // TODO(simon-camp):
-
-  // alloc_state
-  output << "static iree_status_t " << moduleName
-         << "_alloc_state(void* self, iree_allocator_t allocator, "
-            "iree_vm_module_state_t** out_module_state) {\n"
-         << moduleName << "_state_t* state = NULL;\n"
-         << "IREE_RETURN_IF_ERROR(iree_allocator_malloc(allocator, "
-            "sizeof(*state), (void**)&state));\n "
-         << "memset(state, 0, sizeof(*state));\n"
-         << "state->allocator = allocator;\n";
-
-  // initialize globals
-  if (failed(initializeState(moduleOp, emitter))) {
-    return moduleOp.emitError() << "Failed to emit state members";
-  }
-
-  output << "*out_module_state = (iree_vm_module_state_t*)state;\n"
-         << "return iree_ok_status();\n"
-         << "}\n";
-
-  // free_state
-  output << "static void " << moduleName
-         << "_free_state(void* self, iree_vm_module_state_t* "
-            "module_state) {\n"
-         << moduleName << "_state_t* state = (" << moduleName
-         << "_state_t*)module_state;\n"
-         << "iree_allocator_free(state->allocator, state);\n"
-         << "}\n";
-
-  // resolve_imports
-  output << "static iree_status_t " << moduleName << "_resolve_import("
-         << "void* self, iree_vm_module_state_t* module_state, "
-            "iree_host_size_t ordinal, const iree_vm_function_t* function, "
-            "const iree_vm_function_signature_t* signature) {\n"
-         << moduleName << "_state_t* state = (" << moduleName
-         << "_state_t*)module_state;\n"
-         << "state->imports[ordinal] = *function;\n"
-         << "return iree_ok_status();\n}";
-
-  output << "\n";
-
-  // create
-  output << "static iree_status_t " << moduleName << "_create("
-         << "iree_allocator_t allocator, iree_vm_module_t** "
-            "out_module) {\n"
-         << "iree_vm_module_t interface;\n"
-         << "IREE_RETURN_IF_ERROR(iree_vm_module_initialize(&interface, "
-            "NULL));\n"
-         << "interface.destroy = NULL;\n"
-         << "interface.alloc_state = " << moduleName << "_alloc_state;\n"
-         << "interface.free_state = " << moduleName << "_free_state;\n"
-         << "interface.resolve_import = " << moduleName << "_resolve_import;\n"
-         << "return iree_vm_native_module_create(&interface, "
-            "&"
-         << descriptorName << ", allocator, out_module);\n"
-         << "}\n";
 
   output << "\n";
   return success();
@@ -440,7 +365,6 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
   printInclude("iree/vm/ops.h");
   printInclude("iree/vm/ops_emitc.h");
   printInclude("iree/vm/shims_emitc.h");
-  printInclude("iree/vm/value.h");
   output << "\n";
 
   printCompilerConfigurationBlock(output);
@@ -487,23 +411,31 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
 
   output << "// DEFINE FUNCTIONS\n";
 
+  // Emit code for functions skipping those marked with `vm.emit_at_end`.
   for (auto funcOp : moduleOp.getOps<mlir::FuncOp>()) {
     Operation *op = funcOp.getOperation();
+    if (op->hasAttr("vm.emit_at_end")) continue;
     if (op->hasAttr("emitc.static")) output << "static ";
     if (failed(emitter.emitOperation(*funcOp.getOperation(),
-                                     /*trailingSemicolon=*/
-                                     false)))
+                                     /*trailingSemicolon=*/false)))
       return failure();
   }
 
-  printSeparatingComment(output);
-
-  printModuleComment(moduleOp, output);
   output << "\n";
 
   // generate module descriptors
   if (failed(buildModuleDescriptors(moduleOp, emitter))) {
     return failure();
+  }
+
+  // Emit code for functions marked with `vm.emit_at_end`.
+  for (auto funcOp : moduleOp.getOps<mlir::FuncOp>()) {
+    Operation *op = funcOp.getOperation();
+    if (!op->hasAttr("vm.emit_at_end")) continue;
+    if (op->hasAttr("emitc.static")) output << "static ";
+    if (failed(emitter.emitOperation(*funcOp.getOperation(),
+                                     /*trailingSemicolon=*/false)))
+      return failure();
   }
 
   return success();

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -100,7 +100,7 @@ static LogicalResult printStructDefinitions(IREE::VM::ModuleOp &moduleOp,
 
   output << "struct " << moduleName << "_t {\n";
   output << "iree_allocator_t allocator;\n";
-  output << "};\n ";
+  output << "};\n";
 
   output << "struct " << moduleName << "_state_t {\n";
 
@@ -236,7 +236,7 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
              << "(iree_vm_native_function_shim_t)";
 
       if (failed(printShim(funcOp, output))) {
-        return funcOp.emitError("Error generatiing shim");
+        return funcOp.emitError("Error generating shim");
       }
       output << ", "
              << "(iree_vm_native_function_target_t)" << funcName << "},\n";

--- a/iree/compiler/Dialect/VM/Target/C/test/add.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/add.mlir
@@ -11,8 +11,8 @@ vm.module @add_module {
     %0 = vm.add.i32 %arg0, %arg1 : i32
     // CHECK-NEXT: v9 = vm_add_i32(v8, v8);
     %1 = vm.add.i32 %0, %0 : i32
-    // CHECK-NEXT: EMITC_DEREF_ASSIGN(v6, v8);
-    // CHECK-NEXT: EMITC_DEREF_ASSIGN(v7, v9);
+    // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v6, v8);
+    // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v7, v9);
     // CHECK-NEXT: v10 = iree_ok_status();
     // CHECK-NEXT: return v10;
     vm.return %0, %1 : i32, i32

--- a/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
@@ -24,7 +24,7 @@ vm.module @calling_convention_test {
     // CHECK-NEXT: iree_status_t v6;
     // CHECK-NEXT: v5 = 32;
     %0 = vm.const.i32 32 : i32
-    // CHECK-NEXT: EMITC_DEREF_ASSIGN(v4, v5);
+    // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v4, v5);
     // CHECK-NEXT: v6 = iree_ok_status();
     // CHECK-NEXT: return v6;
     vm.return %0 : i32
@@ -36,7 +36,7 @@ vm.module @calling_convention_test {
     // CHECK-NEXT: iree_status_t v7;
     // CHECK-NEXT: v6 = 32;
     %0 = vm.const.i32 32 : i32
-    // CHECK-NEXT: EMITC_DEREF_ASSIGN(v5, v6);
+    // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v5, v6);
     // CHECK-NEXT: v7 = iree_ok_status();
     // CHECK-NEXT: return v7;
     vm.return %0 : i32

--- a/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
@@ -22,6 +22,21 @@ vm.module @constant_ops {
 
   // check state initialization inside the alloc_state function
   // CHECK-LABEL: static iree_status_t constant_ops_alloc_state(
-  // CHECK: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, iree_make_byte_span((void*)constant_ops_buffer_1, sizeof(constant_ops_buffer_1)), iree_allocator_null(), &state->rodata_buffers[0]);
-  // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, iree_make_byte_span((void*)constant_ops_buffer_2, sizeof(constant_ops_buffer_2)), iree_allocator_null(), &state->rodata_buffers[1]);
+  // CHECK: [[STATE:[^ ]*]] = NULL;
+  
+  // CHECK: [[VOID_PTR_1:[^ ]*]] = EMITC_CAST(constant_ops_buffer_1, void*);
+  // CHECK-NEXT: [[SIZE_1:[^ ]*]] = sizeof(constant_ops_buffer_1);
+  // CHECK-NEXT: [[BYTE_SPAN_1:[^ ]*]] = iree_make_byte_span([[VOID_PTR_1]], [[SIZE_1]]);
+  // CHECK-NEXT: [[ALLOCATOR_1:[^ ]*]] = iree_allocator_null();
+  // CHECK-NEXT: [[BUFFERS_1:[^ ]*]] = EMITC_STRUCT_PTR_MEMBER([[STATE]], rodata_buffers);
+  // CHECK-NEXT: [[BUFFER_1:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_1]], 0);
+  // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_1]], [[ALLOCATOR_1]], [[BUFFER_1]]);
+
+  // CHECK: [[VOID_PTR_2:[^ ]*]] = EMITC_CAST(constant_ops_buffer_2, void*);
+  // CHECK-NEXT: [[SIZE_2:[^ ]*]] = sizeof(constant_ops_buffer_2);
+  // CHECK-NEXT: [[BYTE_SPAN_2:[^ ]*]] = iree_make_byte_span([[VOID_PTR_2]], [[SIZE_2]]);
+  // CHECK-NEXT: [[ALLOCATOR_2:[^ ]*]] = iree_allocator_null();
+  // CHECK-NEXT: [[BUFFERS_2:[^ ]*]] = EMITC_STRUCT_PTR_MEMBER([[STATE]], rodata_buffers);
+  // CHECK-NEXT: [[BUFFER_2:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_2]], 1);
+  // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_2]], [[ALLOCATOR_2]], [[BUFFER_2]]);
 }

--- a/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
@@ -45,6 +45,6 @@ vm.module @control_flow_module {
   // CHECK-NEXT: goto [[BB4:[^ ]*]];
   // CHECK-NEXT: [[BB4]]:
   // CHECK-NEXT: [[V0]] = vm_add_i32([[D]], [[E]]);
-  // CHECK-NEXT: EMITC_DEREF_ASSIGN([[RESULT]], [[V0]]);
+  // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE([[RESULT]], [[V0]]);
   // CHECK-NEXT: [[STATUS]] = iree_ok_status();
   // CHECK-NEXT: return [[STATUS]];

--- a/iree/vm/ops_emitc.h
+++ b/iree/vm/ops_emitc.h
@@ -7,17 +7,28 @@
 #ifndef IREE_VM_OPS_EMITC_H_
 #define IREE_VM_OPS_EMITC_H_
 
-// This file contains utility functions and macros used for things that EmitC
-// can't handle directly.
+// This file contains utility macros used for things that EmitC  can't handle
+// directly.
 
 // Assign a value through a pointer variable
-#define EMITC_DEREF_ASSIGN(ptr, value) *(ptr) = (value)
+#define EMITC_DEREF_ASSIGN_VALUE(ptr, value) *(ptr) = (value)
+
+// Assign a value pointed to by `ptr` through a pointer variable
+#define EMITC_DEREF_ASSIGN_PTR(ptr, value) *(ptr) = *(value)
 
 // Access a member of a struct
 #define EMITC_STRUCT_MEMBER(struct, member) (struct).member
 
+// Assign a value to a member of a struct
+#define EMITC_STRUCT_MEMBER_ASSIGN(struct, member, value) \
+  (struct).member = (value)
+
 // Access a member of a pointer to a struct
 #define EMITC_STRUCT_PTR_MEMBER(struct, member) (struct)->member
+
+// Assign a value to a member of a pointer to a struct
+#define EMITC_STRUCT_PTR_MEMBER_ASSIGN(struct, member, value) \
+  (struct)->member = (value)
 
 // Get the address of an array element
 #define EMITC_ARRAY_ELEMENT_ADDRESS(array, index) &(array)[index]

--- a/iree/vm/ops_emitc.h
+++ b/iree/vm/ops_emitc.h
@@ -10,6 +10,9 @@
 // This file contains utility macros used for things that EmitC  can't handle
 // directly.
 
+// Assign a value to a variable
+#define EMITC_ASSIGN_VALUE(var, value) (var) = (value)
+
 // Assign a value through a pointer variable
 #define EMITC_DEREF_ASSIGN_VALUE(ptr, value) *(ptr) = (value)
 

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -13,9 +13,8 @@ vm.module @call_ops {
     vm.return
   }
 
-  // TODO(simon-camp): The EmitC conversion doesn't support ref types on function boundaries.
-  vm.export @test_call_r_v attributes {emitc.exclude}
-  vm.func private @test_call_r_v() {
+  vm.export @test_call_r_v
+  vm.func @test_call_r_v() {
     %ref = vm.const.ref.zero : !vm.ref<?>
     vm.call @_r_v(%ref) : (!vm.ref<?>) -> ()
     vm.return
@@ -55,10 +54,15 @@ vm.module @call_ops {
   }
 
   vm.func @_i_v(%arg : i32) attributes {noinline} {
+    %c1 = vm.const.i32 1 : i32
+    vm.check.eq %arg, %c1, "_i_v(1)" : i32
     vm.return
   }
 
-  vm.func private @_r_v(%arg : !vm.ref<?>) attributes {noinline} {
+  vm.func @_r_v(%arg : !vm.ref<?>) attributes {noinline} {
+    %ref = vm.const.ref.zero : !vm.ref<?>
+    %ref_dno = util.do_not_optimize(%ref) : !vm.ref<?>
+    vm.check.eq %arg, %ref_dno, "_r_v(NULL)" : !vm.ref<?>
     vm.return
   }
 

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -28,12 +28,12 @@ vm.module @call_ops {
     vm.return
   }
 
-  // TODO(simon-camp): The EmitC conversion doesn't support ref types on function boundaries.
-  vm.export @test_call_v_r attributes {emitc.exclude}
-  vm.func private @test_call_v_r() {
+  vm.export @test_call_v_r
+  vm.func @test_call_v_r() {
     %ref = vm.const.ref.zero : !vm.ref<?>
+    %ref_dno = util.do_not_optimize(%ref) : !vm.ref<?>
     %res = vm.call @_v_r() : () -> (!vm.ref<?>)
-    vm.check.eq %ref, %res, "_v_r()=NULL" : !vm.ref<?>
+    vm.check.eq %ref_dno, %res, "_v_r()=NULL" : !vm.ref<?>
     vm.return
   }
 

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -55,14 +55,14 @@ vm.module @call_ops {
 
   vm.func @_i_v(%arg : i32) attributes {noinline} {
     %c1 = vm.const.i32 1 : i32
-    vm.check.eq %arg, %c1, "_i_v(1)" : i32
+    vm.check.eq %arg, %c1, "Expected %arg to be 1" : i32
     vm.return
   }
 
   vm.func @_r_v(%arg : !vm.ref<?>) attributes {noinline} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     %ref_dno = util.do_not_optimize(%ref) : !vm.ref<?>
-    vm.check.eq %arg, %ref_dno, "_r_v(NULL)" : !vm.ref<?>
+    vm.check.eq %arg, %ref_dno, "Expected %arg to be NULL" : !vm.ref<?>
     vm.return
   }
 


### PR DESCRIPTION
This moves more logic from the printer into the conversion pass.

Additionally fix initialization of `iree_vm_ref_t` variables and add basic support for function calls with arguments of ref type.