### PR TITLE
Add linalg detensorizing behind a flag.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -122,7 +122,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());
   passManager.addNestedPass<FuncOp>(mlir::createCSEPass());
   if (clEnableLinalgDetensorize) {
-    // NOTE: must run flow->tensor ops and canonicalization after detensorizing.
     passManager.addNestedPass<FuncOp>(mlir::createLinalgDetensorizePass());
   }
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -59,6 +59,13 @@ static llvm::cl::opt<int> clLinalgOpsPaddingSize(
                    "flow-padding-size"),
     llvm::cl::init(4));
 
+// TODO(#1159): enable by default or remove this option once it works on
+//              a broader set of programs
+static llvm::cl::opt<bool> clEnableLinalgDetensorize(
+    "iree-flow-enable-linalg-detensorize",
+    llvm::cl::desc("Enable detensorizing linalg ops to operate on primitives"),
+    llvm::cl::init(false));
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
@@ -114,10 +121,15 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createFusionOfTensorOpsPass());
   passManager.addNestedPass<FuncOp>(mlir::createCSEPass());
+  if (clEnableLinalgDetensorize) {
+    // NOTE: must run flow->tensor ops and canonicalization after detensorizing.
+    passManager.addNestedPass<FuncOp>(mlir::createLinalgDetensorizePass());
+  }
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
   passManager.addNestedPass<FuncOp>(
       IREE::Flow::createConvertToFlowTensorOpsPass(
           /*runBeforeDispatchRegionFormation=*/true));
+  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(
       IREE::Flow::createDispatchLinalgOnTensorsPass());
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());


### PR DESCRIPTION
Progress on https://github.com/google/iree/issues/1159

With this pass enabled, some programs do not yet compile fully through IREE's full mlir-to-vm pipeline. I think it would still be useful to wire up this way so others can more easily experiment.