### PR TITLE
Precompute coefficients for FFT kernels at compile time.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -626,8 +626,8 @@ void FftOp::generateScalarImplWithCoeffBuf(OpBuilder &b, Location loc,
                                            ArrayRef<Value> operands) {
   auto rank = getOperandRank();
   SmallVector<AffineMap> maps;
-  // The size of coefficent buffer is epxected to match `2^(stage-1)`, where is
-  // exacatlly the last dim of operands.
+  // The size of coefficent buffer is epxected to match `2^(stage-1)`, which
+  // equals to the last dim of operands.
   maps.append(
       2, AffineMap::get(rank, 0, b.getAffineDimExpr(rank - 1), b.getContext()));
   maps.append(operands.size(), b.getMultiDimIdentityMap(rank));

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -626,6 +626,8 @@ void FftOp::generateScalarImplWithCoeffBuf(OpBuilder &b, Location loc,
                                            ArrayRef<Value> operands) {
   auto rank = getOperandRank();
   SmallVector<AffineMap> maps;
+  // The size of coefficent buffer is epxected to match `2^(stage-1)`, where is
+  // exacatlly the last dim of operands.
   maps.append(
       2, AffineMap::get(rank, 0, b.getAffineDimExpr(rank - 1), b.getContext()));
   maps.append(operands.size(), b.getMultiDimIdentityMap(rank));

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -521,6 +521,12 @@ static LogicalResult verifyFftOp(FftOp op) {
   if (!op.getNumInputs() || !op.isScalar(op.getInputOperand(0))) {
     return op.emitOpError("expected to carry `stage` input");
   }
+  if (op.getNumInputs() != 1) {
+    if (op.getNumInputs() != 3 || op.isScalar(op.getInputOperand(1)) ||
+        op.isScalar(op.getInputOperand(2))) {
+      return op.emitOpError("expected to carry real and imag coeff inputs");
+    }
+  }
   if (op.getNumOutputs() != 2) {
     return op.emitOpError("expected outputs to be real and imag tensor/memref");
   }
@@ -547,7 +553,7 @@ SmallVector<Range> FftOp::getLoopBounds(OpBuilder &builder) {
   for (auto en : llvm::enumerate(getOperandShape().drop_back())) {
     Value size;
     if (en.value() == ShapedType::kDynamicSize) {
-      size = getDimValue(builder, loc, operand(), en.index());
+      size = getDimValue(builder, loc, getReal(), en.index());
     } else {
       size = builder.create<ConstantIndexOp>(loc, en.value());
     }
@@ -560,47 +566,10 @@ SmallVector<Range> FftOp::getLoopBounds(OpBuilder &builder) {
   return res;
 }
 
-// Generates FFT stage scalar implementation. This follows Cooley–Tukey FFT
-// algorithm. The pseudo reference code is:
-//   let s <- stage of linalg_ext.fft
-//   int m = 1 << s;
-//   int mh = m >> 1;
-//   for (int k = 0; k < n; k += m) {
-//     for (int j = 0; j < mh; ++j) {
-//       cplx w = exp(-2 * PI * j / m * I);
-//       cplx t = w * a[k + j + mh];
-//       cplx u = a[k + j];
-//       a[k + j] = u + t;
-//       a[k + j + mh] = u - t;
-//     }
-//   }
-LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
-                                                  ValueRange ivs) {
-  Value real = getReal();
-  Value imag = getImag();
-  Value stage = getStage();
-  Value one = b.create<ConstantIndexOp>(loc, 1);
-  Value wholeSize = b.create<ShiftLeftOp>(loc, one, stage);
-  Value halfSize = b.create<SignedShiftRightOp>(loc, wholeSize, one);
-
+void FftOp::generateScalarImplWithoutCoeffBuf(OpBuilder &b, Location loc,
+                                              ArrayRef<Value> operands,
+                                              Value wholeSize) {
   auto rank = getOperandRank();
-  SmallVector<Value> operands;
-  SmallVector<OpFoldResult> lhsIvs(ivs.begin(), ivs.end());
-  SmallVector<OpFoldResult> ones(rank, b.getIndexAttr(1));
-  SmallVector<OpFoldResult> sizes(rank, b.getIndexAttr(1));
-  sizes.back() = halfSize;
-  operands.push_back(
-      b.create<memref::SubViewOp>(loc, real, lhsIvs, sizes, ones));
-  operands.push_back(
-      b.create<memref::SubViewOp>(loc, imag, lhsIvs, sizes, ones));
-
-  SmallVector<OpFoldResult> rhsIvs(ivs.begin(), ivs.end());
-  rhsIvs.back() = b.create<AddIOp>(loc, ivs.back(), halfSize).getResult();
-  operands.push_back(
-      b.create<memref::SubViewOp>(loc, real, rhsIvs, sizes, ones));
-  operands.push_back(
-      b.create<memref::SubViewOp>(loc, imag, rhsIvs, sizes, ones));
-
   SmallVector<AffineMap> maps(operands.size(), b.getMultiDimIdentityMap(rank));
   // TODO(hanchung): Use getLoopIteratorTypes(), once tiling method is
   // implemented.
@@ -651,6 +620,96 @@ LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
         Value r4 = b.create<SubFOp>(loc, lhsImag, tImag);
         b.create<linalg::YieldOp>(loc, ValueRange{r1, r2, r3, r4});
       });
+}
+
+void FftOp::generateScalarImplWithCoeffBuf(OpBuilder &b, Location loc,
+                                           ArrayRef<Value> operands) {
+  auto rank = getOperandRank();
+  SmallVector<AffineMap> maps;
+  maps.append(
+      2, AffineMap::get(rank, 0, b.getAffineDimExpr(rank - 1), b.getContext()));
+  maps.append(operands.size(), b.getMultiDimIdentityMap(rank));
+  // TODO(hanchung): Use getLoopIteratorTypes(), once tiling method is
+  // implemented.
+  SmallVector<StringRef> iterTypes(rank, getParallelIteratorTypeName());
+
+  b.create<linalg::GenericOp>(
+      loc, TypeRange{}, ValueRange{getRealCoeff(), getImagCoeff()}, operands,
+      maps, iterTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value wReal = args[0];
+        Value wImag = args[1];
+        Value lhsReal = args[2];
+        Value lhsImag = args[3];
+        Value rhsReal = args[4];
+        Value rhsImag = args[5];
+
+        // t = w * a[k + j + mh];
+        // ->  (x + yi)(u + vi) = (xu - yv) + (xv + yu)i
+        Value xu = b.create<MulFOp>(loc, wReal, rhsReal);
+        Value yv = b.create<MulFOp>(loc, wImag, rhsImag);
+        Value xv = b.create<MulFOp>(loc, wReal, rhsImag);
+        Value yu = b.create<MulFOp>(loc, wImag, rhsReal);
+        Value tReal = b.create<SubFOp>(loc, xu, yv);
+        Value tImag = b.create<AddFOp>(loc, xv, yu);
+
+        // cplx u = a[k + j];
+        // a[k + j] = u + t;
+        // a[k + j + mh] = u - t;
+        Value r1 = b.create<AddFOp>(loc, lhsReal, tReal);
+        Value r2 = b.create<AddFOp>(loc, lhsImag, tImag);
+        Value r3 = b.create<SubFOp>(loc, lhsReal, tReal);
+        Value r4 = b.create<SubFOp>(loc, lhsImag, tImag);
+        b.create<linalg::YieldOp>(loc, ValueRange{r1, r2, r3, r4});
+      });
+}
+
+// Generates FFT stage scalar implementation. This follows Cooley–Tukey FFT
+// algorithm. The pseudo reference code is:
+//   let s <- stage of linalg_ext.fft
+//   int m = 1 << s;
+//   int mh = m >> 1;
+//   for (int k = 0; k < n; k += m) {
+//     for (int j = 0; j < mh; ++j) {
+//       cplx w = exp(-2 * PI * j / m * I);
+//       cplx t = w * a[k + j + mh];
+//       cplx u = a[k + j];
+//       a[k + j] = u + t;
+//       a[k + j + mh] = u - t;
+//     }
+//   }
+LogicalResult FftOp::generateScalarImplementation(OpBuilder &b, Location loc,
+                                                  ValueRange ivs) {
+  Value real = getReal();
+  Value imag = getImag();
+  Value stage = getStage();
+  Value one = b.create<ConstantIndexOp>(loc, 1);
+  Value wholeSize = b.create<ShiftLeftOp>(loc, one, stage);
+  Value halfSize = b.create<SignedShiftRightOp>(loc, wholeSize, one);
+
+  auto rank = getOperandRank();
+  SmallVector<Value> operands;
+  SmallVector<OpFoldResult> lhsIvs(ivs.begin(), ivs.end());
+  SmallVector<OpFoldResult> ones(rank, b.getIndexAttr(1));
+  SmallVector<OpFoldResult> sizes(rank, b.getIndexAttr(1));
+  sizes.back() = halfSize;
+  operands.push_back(
+      b.create<memref::SubViewOp>(loc, real, lhsIvs, sizes, ones));
+  operands.push_back(
+      b.create<memref::SubViewOp>(loc, imag, lhsIvs, sizes, ones));
+
+  SmallVector<OpFoldResult> rhsIvs(ivs.begin(), ivs.end());
+  rhsIvs.back() = b.create<AddIOp>(loc, ivs.back(), halfSize).getResult();
+  operands.push_back(
+      b.create<memref::SubViewOp>(loc, real, rhsIvs, sizes, ones));
+  operands.push_back(
+      b.create<memref::SubViewOp>(loc, imag, rhsIvs, sizes, ones));
+
+  if (hasCoeff()) {
+    generateScalarImplWithCoeffBuf(b, loc, operands);
+  } else {
+    generateScalarImplWithoutCoeffBuf(b, loc, operands, wholeSize);
+  }
+
   return success();
 }
 

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -191,6 +191,9 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft",
     https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
 
     The size of innermost dim is expected to be a power of 2.
+
+    It is optional to carry coefficient tensors/buffers as inputs. In this
+    context, they will be the second and third inputs.
   }];
 
   let arguments = (ins Variadic<AnyType>:$inputs,
@@ -203,11 +206,24 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft",
     (`:` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value operand() {
-      return outputs()[0];
+    Value getStage() { return inputs()[0]; }
+    Value getReal() { return outputs()[0]; }
+    Value getImag() { return outputs()[1]; }
+    bool hasCoeff() { return getNumInputs() > 1; }
+    void generateScalarImplWithoutCoeffBuf(
+        OpBuilder & b, Location loc, ArrayRef<Value> operands, Value wholeSize);
+    void generateScalarImplWithCoeffBuf(OpBuilder & b, Location loc,
+                                        ArrayRef<Value> operands);
+    Value getRealCoeff() {
+      if (!hasCoeff()) return Value();
+      return inputs()[1];
+    }
+    Value getImagCoeff() {
+      if (!hasCoeff()) return Value();
+      return inputs()[2];
     }
     ShapedType getOperandType() {
-      return operand().getType().cast<ShapedType>();
+      return getReal().getType().cast<ShapedType>();
     }
     int64_t getOperandRank() {
       return getOperandType().getRank();
@@ -218,9 +234,6 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft",
     int64_t getFftLength() {
       return getOperandShape().back();
     }
-    Value getStage() { return inputs()[0]; }
-    Value getReal() { return outputs()[0]; }
-    Value getImag() { return outputs()[1]; }
   }];
 }
 

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -371,12 +371,12 @@ func @fft_tensor_coef_stage_5(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>,
     %arg2: tensor<16xf32>, %arg3: tensor<16xf32>) -> (tensor<1024xf32>, tensor<1024xf32>) {
   %cst1 = constant 5 : index
   %0:2 = linalg_ext.fft
-    ins(%cst1, %arg2, %arg3: index, tensor<1xf32>, tensor<1xf32>)
+    ins(%cst1, %arg2, %arg3: index, tensor<16xf32>, tensor<16xf32>)
     outs(%arg0, %arg1: tensor<1024xf32>, tensor<1024xf32>)
   : tensor<1024xf32>, tensor<1024xf32>
   return %0#0, %0#1 : tensor<1024xf32>, tensor<1024xf32>
 }
-// CHECK-LABEL: func @fft_tensor_coef_stage_two(
+// CHECK-LABEL: func @fft_tensor_coef_stage_5(
 //  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[COEF_REAL:[a-zA-Z0-9_]+]]

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -363,3 +363,27 @@ func @fft_memref_coef(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>,
 //  CHECK-SAME:     ins(%[[CST]], %[[COEF_REAL]], %[[COEF_IMAG]] : index, memref<1xf32>, memref<1xf32>)
 //  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : memref<1024xf32>, memref<1024xf32>)
 //       CHECK:   return
+
+// -----
+
+// The size of coefficient tensor is 2^(stage-1).
+func @fft_tensor_coef_stage_5(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>,
+    %arg2: tensor<16xf32>, %arg3: tensor<16xf32>) -> (tensor<1024xf32>, tensor<1024xf32>) {
+  %cst1 = constant 5 : index
+  %0:2 = linalg_ext.fft
+    ins(%cst1, %arg2, %arg3: index, tensor<1xf32>, tensor<1xf32>)
+    outs(%arg0, %arg1: tensor<1024xf32>, tensor<1024xf32>)
+  : tensor<1024xf32>, tensor<1024xf32>
+  return %0#0, %0#1 : tensor<1024xf32>, tensor<1024xf32>
+}
+// CHECK-LABEL: func @fft_tensor_coef_stage_two(
+//  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_IMAG:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[CST:.+]] = constant 5 : index
+//       CHECK:   %[[RES:.+]]:2 = linalg_ext.fft
+//  CHECK-SAME:     ins(%[[CST]], %[[COEF_REAL]], %[[COEF_IMAG]] : index, tensor<16xf32>, tensor<16xf32>)
+//  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : tensor<1024xf32>, tensor<1024xf32>)
+//  CHECK-SAME:   : tensor<1024xf32>, tensor<1024xf32>
+//       CHECK:   return %[[RES]]#0, %[[RES]]#1

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -285,9 +285,9 @@ func @scatter_update_slice_2D(
 
 func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
     -> (tensor<1024xf32>, tensor<1024xf32>) {
-  %cst0 = constant 0 : index
+  %cst1 = constant 1 : index
   %0:2 = linalg_ext.fft
-    ins(%cst0: index)
+    ins(%cst1: index)
     outs(%arg0, %arg1: tensor<1024xf32>, tensor<1024xf32>)
   : tensor<1024xf32>, tensor<1024xf32>
   return %0#0, %0#1 : tensor<1024xf32>, tensor<1024xf32>
@@ -295,7 +295,7 @@ func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
 // CHECK-LABEL: func @fft_tensor(
 //  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[CST:.+]] = constant 0 : index
+//       CHECK:   %[[CST:.+]] = constant 1 : index
 //       CHECK:   %[[RES:.+]]:2 = linalg_ext.fft
 //  CHECK-SAME:     ins(%[[CST]] : index)
 //  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : tensor<1024xf32>, tensor<1024xf32>)
@@ -305,17 +305,61 @@ func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
 // -----
 
 func @fft_memref(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>) {
-  %cst0 = constant 0 : index
+  %cst1 = constant 1 : index
   linalg_ext.fft
-    ins(%cst0: index)
+    ins(%cst1: index)
     outs(%arg0, %arg1: memref<1024xf32>, memref<1024xf32>)
   return
 }
 // CHECK-LABEL: func @fft_memref(
 //  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
-//       CHECK:   %[[CST:.+]] = constant 0 : index
+//       CHECK:   %[[CST:.+]] = constant 1 : index
 //       CHECK:   linalg_ext.fft
 //  CHECK-SAME:     ins(%[[CST]] : index)
+//  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : memref<1024xf32>, memref<1024xf32>)
+//       CHECK:   return
+
+// -----
+
+func @fft_tensor_coef(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>,
+    %arg2: tensor<1xf32>, %arg3: tensor<1xf32>) -> (tensor<1024xf32>, tensor<1024xf32>) {
+  %cst1 = constant 1 : index
+  %0:2 = linalg_ext.fft
+    ins(%cst1, %arg2, %arg3: index, tensor<1xf32>, tensor<1xf32>)
+    outs(%arg0, %arg1: tensor<1024xf32>, tensor<1024xf32>)
+  : tensor<1024xf32>, tensor<1024xf32>
+  return %0#0, %0#1 : tensor<1024xf32>, tensor<1024xf32>
+}
+// CHECK-LABEL: func @fft_tensor_coef(
+//  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_IMAG:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[CST:.+]] = constant 1 : index
+//       CHECK:   %[[RES:.+]]:2 = linalg_ext.fft
+//  CHECK-SAME:     ins(%[[CST]], %[[COEF_REAL]], %[[COEF_IMAG]] : index, tensor<1xf32>, tensor<1xf32>)
+//  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : tensor<1024xf32>, tensor<1024xf32>)
+//  CHECK-SAME:   : tensor<1024xf32>, tensor<1024xf32>
+//       CHECK:   return %[[RES]]#0, %[[RES]]#1
+
+// -----
+
+func @fft_memref_coef(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>,
+                 %arg2: memref<1xf32>, %arg3: memref<1xf32>) {
+  %cst1 = constant 1 : index
+  linalg_ext.fft
+    ins(%cst1, %arg2, %arg3: index, memref<1xf32>, memref<1xf32>)
+    outs(%arg0, %arg1: memref<1024xf32>, memref<1024xf32>)
+  return
+}
+// CHECK-LABEL: func @fft_memref_coef(
+//  CHECK-SAME:   %[[REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[IMAG:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_REAL:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[COEF_IMAG:[a-zA-Z0-9_]+]]
+//       CHECK:   %[[CST:.+]] = constant 1 : index
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     ins(%[[CST]], %[[COEF_REAL]], %[[COEF_IMAG]] : index, memref<1xf32>, memref<1xf32>)
 //  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : memref<1024xf32>, memref<1024xf32>)
 //       CHECK:   return

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -305,7 +305,8 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
                           realType, b.getF32FloatAttr(0.0).cast<Attribute>()))};
   }
 
-  static SmallVector<Value> getCoeffConstants(ImplicitLocOpBuilder &b, int stage) {
+  static SmallVector<Value> getCoeffConstants(ImplicitLocOpBuilder &b,
+                                              int stage) {
     constexpr std::complex<double> kI(0, 1);
     int m = 1 << stage;
     int mh = m >> 1;

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cmath>
+#include <complex>
+
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
@@ -302,6 +305,21 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
                           realType, b.getF32FloatAttr(0.0).cast<Attribute>()))};
   }
 
+  static SmallVector<Value> getCoeffConstants(ImplicitLocOpBuilder &b, int stage) {
+    constexpr std::complex<double> kI(0, 1);
+    int m = 1 << stage;
+    int mh = m >> 1;
+    SmallVector<Attribute> real, imag;
+    for (auto i : llvm::seq<unsigned>(0, mh)) {
+      auto v = std::exp(-2 * M_PI * i / m * kI);
+      real.push_back(b.getF32FloatAttr(v.real()));
+      imag.push_back(b.getF32FloatAttr(v.imag()));
+    }
+    auto type = RankedTensorType::get({mh}, b.getF32Type());
+    return {b.create<ConstantOp>(type, DenseFPElementsAttr::get(type, real)),
+            b.create<ConstantOp>(type, DenseFPElementsAttr::get(type, imag))};
+  }
+
   LogicalResult matchAndRewrite(
       mhlo::FftOp op, ArrayRef<Value> args,
       ConversionPatternRewriter &rewriter) const final {
@@ -323,9 +341,12 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
         getBitReversalOrder(b, adaptor.operand(), fftLength);
     int lognPlus1 = std::log(fftLength) / std::log(2) + 1;
     for (auto s : llvm::seq<unsigned>(1, lognPlus1)) {
+      SmallVector<Value> inputs;
+      inputs.push_back(b.create<ConstantIndexOp>(s));
+      inputs.append(getCoeffConstants(b, s));
       auto fft = b.create<linalg_ext::FftOp>(
-          TypeRange{results[0].getType(), results[1].getType()},
-          ValueRange{b.create<ConstantIndexOp>(s)}, results);
+          TypeRange{results[0].getType(), results[1].getType()}, inputs,
+          results);
       results = fft.getResults();
     }
 

--- a/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -275,16 +275,22 @@ func @rfft_1d(%input: tensor<8xf32>) -> (tensor<5xf32>, tensor<5xf32>) {
 // CHECK:          linalg.yield %[[LOAD]] : f32
 // CHECK:        %[[IMAG:.+]] = constant dense<0.000000e+00> : tensor<8xf32>
 // CHECK:        %[[C1:.+]] = constant 1 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<1xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<1xf32>
 // CHECK:        %[[R1:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C1]]
+// CHECK-SAME:     ins(%[[C1]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[REORDERED]], %[[IMAG]]
 // CHECK:        %[[C2:.+]] = constant 2 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<2xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<2xf32>
 // CHECK:        %[[R2:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C2]]
+// CHECK-SAME:     ins(%[[C2]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[R1]]#0, %[[R1]]#1
 // CHECK:        %[[C3:.+]] = constant 3 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<4xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<4xf32>
 // CHECK:        %[[R3:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C3]]
+// CHECK-SAME:     ins(%[[C3]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[R2]]#0, %[[R2]]#1
 // CHECK:        %[[RES_REAL:.+]] = tensor.extract_slice %[[R3]]#0[0] [5] [1] : tensor<8xf32> to tensor<5xf32>
 // CHECK:        %[[RES_IMAG:.+]] = tensor.extract_slice %[[R3]]#1[0] [5] [1] : tensor<8xf32> to tensor<5xf32>
@@ -318,16 +324,22 @@ func @rfft_2d(%input: tensor<4x8xf32>) -> (tensor<4x5xf32>, tensor<4x5xf32>) {
 // CHECK:          linalg.yield %[[LOAD]] : f32
 // CHECK:        %[[IMAG:.+]] = constant dense<0.000000e+00> : tensor<4x8xf32>
 // CHECK:        %[[C1:.+]] = constant 1 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<1xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<1xf32>
 // CHECK:        %[[R1:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C1]]
+// CHECK-SAME:     ins(%[[C1]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[REORDERED]], %[[IMAG]]
 // CHECK:        %[[C2:.+]] = constant 2 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<2xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<2xf32>
 // CHECK:        %[[R2:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C2]]
+// CHECK-SAME:     ins(%[[C2]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[R1]]#0, %[[R1]]#1
 // CHECK:        %[[C3:.+]] = constant 3 : index
+// CHECK:        %[[COEF_REAL:.+]] = constant dense<{{.+}}> : tensor<4xf32>
+// CHECK:        %[[COEF_IMAG:.+]] = constant dense<{{.+}}> : tensor<4xf32>
 // CHECK:        %[[R3:.+]]:2 = linalg_ext.fft
-// CHECK-SAME:     ins(%[[C3]]
+// CHECK-SAME:     ins(%[[C3]], %[[COEF_REAL]], %[[COEF_IMAG]]
 // CHECK-SAME:     outs(%[[R2]]#0, %[[R2]]#1
 // CHECK:        %[[RES_REAL:.+]] = tensor.extract_slice %[[R3]]#0[0, 0] [4, 5] [1, 1] : tensor<4x8xf32> to tensor<4x5xf32>
 // CHECK:        %[[RES_IMAG:.+]] = tensor.extract_slice %[[R3]]#1[0, 0] [4, 5] [1, 1] : tensor<4x8xf32> to tensor<4x5xf32>


### PR DESCRIPTION
- Allow linalg_ext.fft takes optional coefficients inputs. If
  coefficients are given, it will load the value from them when lowering
  to loops.
- Since the fft length is static most of time, we create constant
  coefficients tensors when lowering from MHLO to LinalgExt.

This improves RFFT kernels from 14.5 ms to 5 ms on tensor<325x1024xf32>
inputs.

This is a step toward https://github.com/google/iree/issues/6477