### PR TITLE
Flatten first structure level of tensorflow args and results.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -43,6 +43,13 @@ iree_py_library(
 
 iree_py_test(
   NAME
+    function_test
+  SRCS
+    "function_test.py"
+)
+
+iree_py_test(
+  NAME
     hal_test
   SRCS
     "hal_test.py"

--- a/bindings/python/iree/runtime/function_test.py
+++ b/bindings/python/iree/runtime/function_test.py
@@ -1,0 +1,202 @@
+# Lint as: python3
+# Copyright 2019 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import json
+
+from absl.testing import absltest
+
+from iree import runtime as rt
+from iree.runtime.function import FunctionInvoker
+from iree.runtime.binding import VmVariantList
+
+
+class MockVmContext:
+
+  def __init__(self, invoke_callback):
+    self._invoke_callback = invoke_callback
+    self.invocations = []
+
+  def invoke(self, vm_function, arg_list, ret_list):
+    self._invoke_callback(arg_list, ret_list)
+    self.invocations.append((vm_function, arg_list, ret_list))
+    print(f"INVOKE: {arg_list} -> {ret_list}")
+
+  @property
+  def mock_arg_reprs(self):
+    return repr([arg_list for _, arg_list, _ in self.invocations])
+
+
+class MockVmFunction:
+
+  def __init__(self, reflection):
+    self.reflection = reflection
+
+
+class FunctionTest(absltest.TestCase):
+
+  def setUp(self):
+    # Doesn't matter what device. We just need one.
+    config = rt.Config("vmvx")
+    self.device = config.device
+
+  def testNoReflectionScalars(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+      ret_list.push_int(4)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(reflection={})
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    result = invoker(1, 2)
+    self.assertEqual("[<VmVariantList(2): [1, 2]>]", vm_context.mock_arg_reprs)
+    self.assertEqual((3, 4), result)
+
+  def testKeywordArgs(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(
+        reflection={
+            "iree.abi":
+                json.dumps({
+                    "a": [
+                        "i32",
+                        ["named", "a", "i32"],
+                        ["named", "b", "i32"],
+                    ],
+                    "r": ["i32",],
+                })
+        })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    result = invoker(-1, a=1, b=2)
+    self.assertEqual("[<VmVariantList(3): [-1, 1, 2]>]",
+                     vm_context.mock_arg_reprs)
+    self.assertEqual(3, result)
+
+  def testInlinedResults(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+      ret_list.push_int(4)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(reflection={
+        "iree.abi": json.dumps({
+            "a": [],
+            "r": [["slist", "i32", "i32"]],
+        })
+    })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    result = invoker()
+    self.assertEqual([3, 4], result)
+
+  def testNestedResults(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+      sub_list = VmVariantList(2)
+      sub_dict = VmVariantList(2)
+      sub_dict.push_int(100)
+      sub_dict.push_int(200)
+      sub_list.push_list(sub_dict)
+      sub_list.push_int(6)
+      ret_list.push_list(sub_list)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(
+        reflection={
+            "iree.abi":
+                json.dumps({
+                    "a": [],
+                    "r": [
+                        "i32",
+                        [
+                            "slist",
+                            ["sdict", ["bar", "i32"], ["foo", "i32"]],
+                            "i64",
+                        ]
+                    ],
+                })
+        })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    result = invoker()
+    self.assertEqual((3, [{'bar': 100, 'foo': 200}, 6]), result)
+
+  def testMissingPositional(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(
+        reflection={
+            "iree.abi":
+                json.dumps({
+                    "a": [
+                        "i32",
+                        ["named", "a", "i32"],
+                        ["named", "b", "i32"],
+                    ],
+                    "r": ["i32",],
+                })
+        })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    with self.assertRaisesRegexp(ValueError,
+                                 "a required argument was not specified"):
+      result = invoker(a=1, b=2)
+
+  def testMissingKeyword(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(
+        reflection={
+            "iree.abi":
+                json.dumps({
+                    "a": [
+                        "i32",
+                        ["named", "a", "i32"],
+                        ["named", "b", "i32"],
+                    ],
+                    "r": ["i32",],
+                })
+        })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    with self.assertRaisesRegexp(ValueError,
+                                 "a required argument was not specified"):
+      result = invoker(-1, a=1)
+
+  def testExtraKeyword(self):
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_int(3)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(
+        reflection={
+            "iree.abi":
+                json.dumps({
+                    "a": [
+                        "i32",
+                        ["named", "a", "i32"],
+                        ["named", "b", "i32"],
+                    ],
+                    "r": ["i32",],
+                })
+        })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    with self.assertRaisesRegexp(ValueError, "specified kwarg 'c' is unknown"):
+      result = invoker(-1, a=1, b=2, c=3)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/docs/developers/design_docs/function_abi.md
+++ b/docs/developers/design_docs/function_abi.md
@@ -168,6 +168,9 @@ Type records are one of:
 A compound type tuple has a type identifier as its first element, followed with
 type specific fields:
 
+-   `["named", "key", {slot_type}]`: Associates a name with a slot. This is
+    used with the root argument list to denote named arguments that can be
+    passed positionally or by keyword.
 -   `["ndarray", {element_type}, {rank}, {dim...}]`: For unknown rank, the
     `rank` will be `null` and there will be no dims. Any unknown dim will be
     `null`.
@@ -180,6 +183,3 @@ type specific fields:
 -   `["sdict", ["key", {slot_type}]...]`: An anonymous structure with named
     slots. Note that when passing these types, the keys are not passed to the
     function (only the slot values).
--   `["sdict_kwargs", ...]`: Same as `sdict` but signifies to languages that
-    allow keyword-argument passing that this is the keyword-argument dictionary.
-    It can only ever be present as the last entry of the root arguments `slist`.

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: module @binary_func
 // Should just be a pass through.
 // CHECK: func @binary_func
-// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22r\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22v\22:1}"
+// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22r\22:[[\22stuple\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]],\22v\22:1}"
 // CHECK: %[[ARG0_TENSOR:.*]] = hal.tensor.cast %arg0 : !hal.buffer_view -> tensor<16xf32>
 // CHECK: %[[ARG1_TENSOR:.*]] = hal.tensor.cast %arg1 : !hal.buffer_view -> tensor<16xf32>
 // CHECK: %[[R:.*]]:2 = call @__inference_binary_func_70(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
@@ -40,7 +40,7 @@ builtin.module @unary_func attributes {tf.versions = {bad_consumers = [], min_co
 // -----
 // CHECK-LABEL: module @return_list
 // CHECK: func @return_list
-// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22r\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22v\22:1}"
+// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]],\22r\22:[[\22stuple\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]],\22v\22:1}"
 // CHECK: %[[ARG0_TENSOR:.*]] = hal.tensor.cast %arg0 : !hal.buffer_view -> tensor<16xf32>
 // CHECK: %[[ARG1_TENSOR:.*]] = hal.tensor.cast %arg1 : !hal.buffer_view -> tensor<16xf32>
 // CHECK: %[[R:.+]]:2 = call @__inference_return_list_260(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
@@ -12,8 +12,8 @@
 // CHECK: return %[[R0_BV]], %[[R1_BV]] : !hal.buffer_view, !hal.buffer_view
 // CHECK: func private @__inference_binary_func_70
 // CHECK-NOT: tf_saved_model
-module @binary_func attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_binary_func_70(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<16xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = [0]}, tensor<16xf32> {tf_saved_model.index_path = [1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>], tf_saved_model.exported_names = ["binary_func"]} {
+builtin.module @binary_func attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  builtin.func @__inference_binary_func_70(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<16xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = [0]}, tensor<16xf32> {tf_saved_model.index_path = [1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>], tf_saved_model.exported_names = ["binary_func"]} {
     %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     %1 = "tf.Identity"(%arg1) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     return %0, %1 : tensor<16xf32>, tensor<16xf32>
@@ -30,8 +30,8 @@ module @binary_func attributes {tf.versions = {bad_consumers = [], min_consumer 
 // CHECK: return %[[R0_BV]] : !hal.buffer_view
 // CHECK: func private @__inference_unary_func_240
   // CHECK-NOT: tf_saved_model
-module @unary_func attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_unary_func_240(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}) -> (tensor<16xf32> {tf_saved_model.index_path = []}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>], tf_saved_model.exported_names = ["unary_func"]} {
+builtin.module @unary_func attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  builtin.func @__inference_unary_func_240(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}) -> (tensor<16xf32> {tf_saved_model.index_path = []}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>], tf_saved_model.exported_names = ["unary_func"]} {
     %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     return %0 : tensor<16xf32>
   }
@@ -49,8 +49,8 @@ module @unary_func attributes {tf.versions = {bad_consumers = [], min_consumer =
 // CHECK: return %[[R0_BV]], %[[R1_BV]] : !hal.buffer_view, !hal.buffer_view
 // CHECK: func private @__inference_return_list_260
 // CHECK-NOT: tf_saved_model
-module @return_list attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_return_list_260(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<16xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = [0]}, tensor<16xf32> {tf_saved_model.index_path = [1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>], tf_saved_model.exported_names = ["return_list"]} {
+builtin.module @return_list attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  builtin.func @__inference_return_list_260(%arg0: tensor<16xf32> {tf._user_specified_name = "a", tf_saved_model.index_path = [0]}, %arg1: tensor<16xf32> {tf._user_specified_name = "b", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = [0]}, tensor<16xf32> {tf_saved_model.index_path = [1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>], tf_saved_model.exported_names = ["return_list"]} {
     %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     %1 = "tf.Identity"(%arg1) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     return %0, %1 : tensor<16xf32>, tensor<16xf32>
@@ -100,8 +100,8 @@ module @return_list attributes {tf.versions = {bad_consumers = [], min_consumer 
 // return %[[R7]], %[[R8]] : !iree.list<?>, !iree.list<?>
 // CHECK: func private @__inference_dict_nest_190
 // CHECK-NOT: tf_saved_model
-module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_dict_nest_190(
+builtin.module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  builtin.func @__inference_dict_nest_190(
       %arg0: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "a"]},
       %arg1: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "b"]},
       %arg2: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 0]},
@@ -119,8 +119,8 @@ module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 
 // CHECK-LABEL: module @kwargs
 // CHECK: func @dict_nest(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !iree.list<?>
 // CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22named\22,\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22named\22,\22b\22,[\22ndarray\22,\22f32\22,1,16]],[\22named\22,\22scalar\22,[\22ndarray\22,\22f32\22,0]]],\22r\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]],[\22scalar\22,[\22ndarray\22,\22f32\22,0]]]]]],\22v\22:1}"
-module @kwargs attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_dict_nest_190(
+builtin.module @kwargs attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
+  builtin.func @__inference_dict_nest_190(
       %arg0: tensor<16xf32> {tf_saved_model.index_path = ["a"]},
       %arg1: tensor<16xf32> {tf_saved_model.index_path = ["b"]},
       %arg2: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = ["scalar"]}) ->

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/saved_model_to_iree_abi.mlir
@@ -59,7 +59,7 @@ module @return_list attributes {tf.versions = {bad_consumers = [], min_consumer 
 
 // -----
 // CHECK-LABEL: module @dict_nest
-// CHECK: func @dict_nest
+// CHECK: func @dict_nest(%arg0: !iree.list<?>, %arg1: !hal.buffer_view) -> (!iree.list<?>, !iree.list<?>)
 // CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],[\22list\22,[\22slist\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]],[\22ndarray\22,\22f32\22,0]],\22r\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],[\22list\22,[\22stuple\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]]],\22v\22:1}"
 // CHECK: %[[c0:.+]] = constant 0 : index
 // CHECK: %[[L0:.+]] = iree.list.get %arg0[%[[c0]]] : !iree.list<?> -> !iree.list<?>
@@ -81,31 +81,32 @@ module @return_list attributes {tf.versions = {bad_consumers = [], min_consumer 
 // CHECK: %[[RESULT:.+]]:4 = call @__inference_dict_nest_190(%[[L1_TENSOR]], %[[L2_TENSOR]], %[[L4_TENSOR]], %[[L5_TENSOR]], %[[ARG1_TENSOR]]) : (tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<f32>) -> (tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>)
 // CHECK: %[[c2:.+]] = constant 2 : index
 // CHECK: %[[R7:.+]] = iree.list.create %[[c2]] : !iree.list<?>
-// CHECK: %[[c2_4:.+]] = constant 2 : index
-// CHECK: %[[R8:.+]] = iree.list.create %[[c2_4]] : !iree.list<?>
+// CHECK: iree.list.resize %[[R7]], %[[c2]]
 // CHECK: %[[R0_BV:.+]] = hal.tensor.cast %[[RESULT]]#0 : tensor<16xf32> -> !hal.buffer_view
-// CHECK: %[[c0_5:.+]] = constant 0 : index
-// CHECK: iree.list.set %[[R8]][%[[c0_5]]], %[[R0_BV]] : !hal.buffer_view -> !iree.list<?>
+// CHECK: %[[c0_4:.+]] = constant 0 : index
+// CHECK: iree.list.set %[[R7]][%[[c0_4]]], %[[R0_BV]] : !hal.buffer_view -> !iree.list<?>
 // CHECK: %[[R1_BV:.+]] = hal.tensor.cast %[[RESULT]]#1 : tensor<16xf32> -> !hal.buffer_view
-// CHECK: %[[c1_6:.+]] = constant 1 : index
-// CHECK: iree.list.set %[[R8]][%[[c1_6]]], %[[R1_BV]] : !hal.buffer_view -> !iree.list<?>
-// CHECK: %[[c0_7:.+]] = constant 0 : index
-// CHECK: iree.list.set %[[R7]][%[[c0_7]]], %[[R8]] : !iree.list<?> -> !iree.list<?>
+// CHECK: %[[c1_5:.+]] = constant 1 : index
+// CHECK: iree.list.set %[[R7]][%[[c1_5]]], %[[R1_BV]] : !hal.buffer_view -> !iree.list<?>
 // CHECK: %[[c2_8:.+]] = constant 2 : index
 // CHECK: %[[R9:.+]] = iree.list.create %[[c2_8]] : !iree.list<?>
+// CHECK: iree.list.resize %[[R9]], %[[c2_8]]
 // CHECK: %[[R2_BV:.+]] = hal.tensor.cast %[[RESULT]]#2 : tensor<16xf32> -> !hal.buffer_view
 // CHECK: %[[c0_9:.+]] = constant 0 : index
 // CHECK: iree.list.set %[[R9]][%[[c0_9]]], %[[R2_BV]] : !hal.buffer_view -> !iree.list<?>
 // CHECK: %[[R3_BV:.+]] = hal.tensor.cast %[[RESULT]]#3 : tensor<16xf32> -> !hal.buffer_view
 // CHECK: %[[c1_10:.+]] = constant 1 : index
 // CHECK: iree.list.set %[[R9]][%[[c1_10]]], %[[R3_BV]] : !hal.buffer_view -> !iree.list<?>
-// CHECK: %[[c1_11:.+]] = constant 1 : index
-// CHECK: iree.list.set %[[R7]][%[[c1_11]]], %[[R9]] : !iree.list<?> -> !iree.list<?>
-// return %[[R7]] : !iree.list<?>
+// return %[[R7]], %[[R8]] : !iree.list<?>, !iree.list<?>
 // CHECK: func private @__inference_dict_nest_190
 // CHECK-NOT: tf_saved_model
 module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_dict_nest_190(%arg0: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "a"]}, %arg1: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "b"]}, %arg2: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 0]}, %arg3: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 1]}, %arg4: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = ["dict", "a"]}, tensor<16xf32> {tf_saved_model.index_path = ["dict", "b"]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 0]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<>], tf_saved_model.exported_names = ["dict_nest"]} {
+  func @__inference_dict_nest_190(
+      %arg0: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "a"]},
+      %arg1: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "dict", "b"]},
+      %arg2: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 0]},
+      %arg3: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 1]},
+      %arg4: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = ["dict", "a"]}, tensor<16xf32> {tf_saved_model.index_path = ["dict", "b"]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 0]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<>], tf_saved_model.exported_names = ["dict_nest"]} {
     %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     %1 = "tf.Identity"(%arg1) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     %2 = "tf.Identity"(%arg2) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
@@ -116,14 +117,20 @@ module @dict_nest attributes {tf.versions = {bad_consumers = [], min_consumer = 
 
 // -----
 // CHECK-LABEL: module @kwargs
-// CHECK: func @dict_nest
-// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22sdict\22,[\22list\22,[\22slist\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]],[\22ndarray\22,\22f32\22,0],[\22sdict_kwargs\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],\22r\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]]]],[\22list\22,[\22stuple\22,[\22ndarray\22,\22f32\22,1,16],[\22ndarray\22,\22f32\22,1,16]]]]],\22v\22:1}"
+// CHECK: func @dict_nest(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !iree.list<?>
+// CHECK-SAME{LITERAL}: iree.abi = "{\22a\22:[[\22named\22,\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22named\22,\22b\22,[\22ndarray\22,\22f32\22,1,16]],[\22named\22,\22scalar\22,[\22ndarray\22,\22f32\22,0]]],\22r\22:[[\22sdict\22,[\22dict\22,[\22sdict\22,[\22a\22,[\22ndarray\22,\22f32\22,1,16]],[\22b\22,[\22ndarray\22,\22f32\22,1,16]],[\22scalar\22,[\22ndarray\22,\22f32\22,0]]]]]],\22v\22:1}"
 module @kwargs attributes {tf.versions = {bad_consumers = [], min_consumer = 12 : i32, producer = 729 : i32}, tf_saved_model.semantics}  {
-  func @__inference_dict_nest_190(%arg0: tensor<16xf32> {tf_saved_model.index_path = ["a"]}, %arg1: tensor<16xf32> {tf_saved_model.index_path = ["b"]}, %arg2: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 0]}, %arg3: tensor<16xf32> {tf._user_specified_name = "mapping", tf_saved_model.index_path = [0, "list", 1]}, %arg4: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = [1]}) -> (tensor<16xf32> {tf_saved_model.index_path = ["dict", "a"]}, tensor<16xf32> {tf_saved_model.index_path = ["dict", "b"]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 0]}, tensor<16xf32> {tf_saved_model.index_path = ["list", 1]}) attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<>], tf_saved_model.exported_names = ["dict_nest"]} {
+  func @__inference_dict_nest_190(
+      %arg0: tensor<16xf32> {tf_saved_model.index_path = ["a"]},
+      %arg1: tensor<16xf32> {tf_saved_model.index_path = ["b"]},
+      %arg2: tensor<f32> {tf._user_specified_name = "scalar", tf_saved_model.index_path = ["scalar"]}) ->
+      (tensor<16xf32> {tf_saved_model.index_path = ["dict", "a"]},
+       tensor<16xf32> {tf_saved_model.index_path = ["dict", "b"]},
+       tensor<f32> {tf_saved_model.index_path = ["dict", "scalar"]})
+      attributes {tf._construction_context = "kEagerRuntime", tf._input_shapes = [#tf_type.shape<16>, #tf_type.shape<16>, #tf_type.shape<>], tf_saved_model.exported_names = ["dict_nest"]} {
     %0 = "tf.Identity"(%arg0) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
     %1 = "tf.Identity"(%arg1) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
-    %2 = "tf.Identity"(%arg2) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
-    %3 = "tf.Identity"(%arg3) {device = ""} : (tensor<16xf32>) -> tensor<16xf32>
-    return %0, %1, %2, %3 : tensor<16xf32>, tensor<16xf32>, tensor<16xf32>, tensor<16xf32>
+    %2 = "tf.Identity"(%arg2) {device = ""} : (tensor<f32>) -> tensor<f32>
+    return %0, %1, %2 : tensor<16xf32>, tensor<16xf32>, tensor<f32>
   }
 }


### PR DESCRIPTION
* Has the effect that V1 saved models just use regular args (vs vm.list) for their implicit keyword arguments.
* Also "inlines" the first level result (tuple/list/dict) so that simple, one level nests (i.e. dict of keyword results) is compiled as just a normal multi-result function.
* Breaking change: The python API will not be able to process structured invocations across this commit.
* Still working on unit test coverage, which is non trivial.