### PR TITLE
Fixing gcc/clang builds when i64/f32 VM extensions are disabled.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -317,6 +317,11 @@ endif()
   # TODO(#898): add a dedicated size-constrained configuration.
 if(${IREE_SIZE_OPTIMIZED})
   iree_select_compiler_opts(IREE_SIZE_OPTIMIZED_DEFAULT_COPTS
+    CLANG_OR_GCC
+      "-DIREE_STATUS_MODE=0"
+      "-DIREE_HAL_MODULE_STRING_UTIL_ENABLE=0"
+      "-DIREE_VM_EXT_I64_ENABLE=0"
+      "-DIREE_VM_EXT_F32_ENABLE=0"
     MSVC_OR_CLANG_CL
       "/GS-"
       "/GL"

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -1540,8 +1540,8 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Extension trampolines
     //===------------------------------------------------------------------===//
 
-    BEGIN_DISPATCH_PREFIX(PrefixExtI64, EXT_I64) {
 #if IREE_VM_EXT_I64_ENABLE
+    BEGIN_DISPATCH_PREFIX(PrefixExtI64, EXT_I64) {
       //===----------------------------------------------------------------===//
       // ExtI64: Globals
       //===----------------------------------------------------------------===//
@@ -1802,15 +1802,14 @@ iree_status_t iree_vm_bytecode_dispatch(
         IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
             &value, buffer, offset, 1, sizeof(uint64_t)));
       });
-
-#else
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
-#endif  // IREE_VM_EXT_I64_ENABLE
     }
     END_DISPATCH_PREFIX();
+#else
+    UNHANDLED_DISPATCH_PREFIX(PrefixExtI64, EXT_I64);
+#endif  // IREE_VM_EXT_I64_ENABLE
 
-    BEGIN_DISPATCH_PREFIX(PrefixExtF32, EXT_F32) {
 #if IREE_VM_EXT_F32_ENABLE
+    BEGIN_DISPATCH_PREFIX(PrefixExtF32, EXT_F32) {
       //===----------------------------------------------------------------===//
       // ExtF32: Globals
       //===----------------------------------------------------------------===//
@@ -2077,12 +2076,11 @@ iree_status_t iree_vm_bytecode_dispatch(
         IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
             &value, buffer, offset, 1, sizeof(float)));
       });
-
-#else
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
-#endif  // IREE_VM_EXT_F32_ENABLE
     }
     END_DISPATCH_PREFIX();
+#else
+    UNHANDLED_DISPATCH_PREFIX(PrefixExtF32, EXT_F32);
+#endif  // IREE_VM_EXT_F32_ENABLE
 
     DISPATCH_OP(CORE, PrefixExtF64,
                 { return iree_make_status(IREE_STATUS_UNIMPLEMENTED); });

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -329,7 +329,12 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
     VMCHECK(0);                                                             \
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "unhandled opcode"); \
   }
-#define DISPATCH_UNHANDLED_EXT()
+#define UNHANDLED_DISPATCH_PREFIX(op_name, ext)                    \
+  _dispatch_CORE_##op_name : {                                     \
+    VMCHECK(0);                                                    \
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,             \
+                            "unhandled dispatch extension " #ext); \
+  }
 
 #define DISPATCH_OP(ext, op_name, body)                             \
   _dispatch_##ext##_##op_name : IREE_DISPATCH_LOG_OPCODE(#op_name); \
@@ -359,11 +364,11 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED, \
                             "unhandled core opcode");  \
   }
-#define DISPATCH_UNHANDLED_EXT                             \
-  () default : {                                           \
-    VMCHECK(0);                                            \
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,     \
-                            "unhandled extension opcode"); \
+#define UNHANDLED_DISPATCH_PREFIX(op_name, ext)                    \
+  case IREE_VM_OP_CORE_##op_name: {                                \
+    VMCHECK(0);                                                    \
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,             \
+                            "unhandled dispatch extension " #ext); \
   }
 
 #define DISPATCH_OP(ext, op_name, body) \


### PR DESCRIPTION
Fixes #6620.