### PR TITLE
Add a tf-to-tosa option for the tensorflow importer

### DIFF
--- a/bindings/python/iree/compiler/tf.py
+++ b/bindings/python/iree/compiler/tf.py
@@ -84,6 +84,7 @@ class ImportOptions(CompilerOptions):
                save_temp_tf_input: Optional[str] = None,
                save_temp_mid_level_input: Optional[str] = None,
                save_temp_iree_input: Optional[str] = None,
+               use_tosa: bool = False,
                **kwargs):
     """Initialize options from keywords.
 
@@ -116,6 +117,7 @@ class ImportOptions(CompilerOptions):
     self.save_temp_tf_input = save_temp_tf_input
     self.save_temp_mid_level_input = save_temp_mid_level_input
     self.save_temp_iree_input = save_temp_iree_input
+    self.use_tosa = use_tosa
 
 
 def build_import_command_line(input_path: str, tfs: TempFileSaver,
@@ -163,6 +165,9 @@ def build_import_command_line(input_path: str, tfs: TempFileSaver,
                                        export_as=options.save_temp_iree_input)
   if save_iree_input:
     cl.append(f"--save-temp-iree-input={save_iree_input}")
+
+  if options.use_tosa:
+    cl.append(f"--use-tosa")
 
   # Crash reproducer (locally qualified).
   requested_crash_reproducer_path = options.crash_reproducer_path

--- a/integrations/tensorflow/iree_tf_compiler/TF/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/BUILD
@@ -58,6 +58,7 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:lower_tf_lib",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
+        "@org_tensorflow//tensorflow/compiler/mlir/tosa:tf_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
     ],
 )

--- a/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
+++ b/integrations/tensorflow/iree_tf_compiler/TF/Passes.h
@@ -19,7 +19,7 @@ namespace TF {
 
 // Create a single pipeline that will run all the needed IREE-specific TF import
 // passes in the right order.
-void buildTFImportPassPipeline(OpPassManager &pm);
+void buildTFImportPassPipeline(OpPassManager &pm, bool useTosa);
 void registerTFImportPassPipeline();
 
 //===----------------------------------------------------------------------===//

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -163,6 +163,9 @@ int main(int argc, char **argv) {
       llvm::cl::desc("Prettifies TF debug information to make it easier "
                      "to look at"),
       llvm::cl::init(true));
+  static llvm::cl::opt<bool> useTosa(
+      "use-tosa", llvm::cl::desc("Use tosa as the intermediate IR"),
+      llvm::cl::init(false));
 
   // Register any command line options.
   registerAsmPrinterCLOptions();
@@ -222,7 +225,7 @@ int main(int argc, char **argv) {
       pm.addPass(iree_integrations::TF::createPrettifyDebugInfoPass());
     }
 
-    iree_integrations::TF::buildTFImportPassPipeline(pm);
+    iree_integrations::TF::buildTFImportPassPipeline(pm, useTosa);
     if (failed(pm.run(*module))) {
       llvm::errs() << "Running iree-import-tf TF import pass pipeline failed "
                       "(see diagnostics)\n";


### PR DESCRIPTION
Tosa can import more than TFLite models, being able to import directly from
Tensorflow itself. Support this path as an option instead of importing via HLO.