### PR TITLE
[CUDA] Improve shared memory copy lowering

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",
         "KernelConfig.cpp",
+        "LLVMGPUDistributeSharedMemoryCopy.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPURemoveTrivialLoops.cpp",
         "LLVMGPUTileAndDistribute.cpp",
@@ -27,6 +28,7 @@ cc_library(
     hdrs = [
         "ConvertToLLVM.h",
         "KernelConfig.h",
+        "LLVMGPUUtils.h",
     ],
     deps = [
         "//iree/compiler/Codegen:PassHeaders",

--- a/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -16,11 +16,13 @@ iree_cc_library(
   HDRS
     "ConvertToLLVM.h"
     "KernelConfig.h"
+    "LLVMGPUUtils.h"
   SRCS
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"
     "KernelConfig.cpp"
+    "LLVMGPUDistributeSharedMemoryCopy.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPURemoveTrivialLoops.cpp"
     "LLVMGPUTileAndDistribute.cpp"

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
@@ -1,0 +1,278 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <numeric>
+
+#include "iree/compiler/Codegen/LLVMGPU/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "mlir/Dialect/GPU/Passes.h"
+#include "mlir/Dialect/Vector/VectorTransforms.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/MathExtras.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+//====---------------------------------------------------------------------===//
+// Pass to lower workgroup memory copy to distibuted
+// transfer_read/transfer_write ops.
+//====---------------------------------------------------------------------===//
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Patterns for copy to shared memory mapping. Copy to shared memory are not
+/// part of the launch config but needs to be distributed on the workgroup
+/// picked by the root op.
+static void populateTilingCopyToWorkgroupMemPatterns(
+    OwningRewritePatternList &patterns, ArrayRef<int64_t> workgroupSize) {
+  // Tile and distribute copy to workgroup memory.
+  linalg::TileSizeComputationFunction wgCopyTileSizeFn =
+      [](OpBuilder &builder, Operation *operation) {
+        const int64_t copyTileSize = 4;
+        // We tile to 4 as we want each thread to load 4 element in a cyclic
+        // distribution.
+        SmallVector<Value, 4> tileSizesVal;
+        unsigned rank =
+            cast<linalg::CopyOp>(operation).getOutputBufferTypes()[0].getRank();
+        for (unsigned i = 0; i < rank - 1; i++) {
+          int64_t t = (rank - i) <= kNumGPUDims ? 1 : 0;
+          tileSizesVal.push_back(
+              builder.create<ConstantIndexOp>(operation->getLoc(), t));
+        }
+        tileSizesVal.push_back(
+            builder.create<ConstantIndexOp>(operation->getLoc(), copyTileSize));
+        return tileSizesVal;
+      };
+  auto getCopyThreadProcInfoFn = [workgroupSize](
+                                     OpBuilder &builder, Location loc,
+                                     ArrayRef<Range> parallelLoopRanges) {
+    return getGPUThreadIdsAndCounts(builder, loc, parallelLoopRanges.size(),
+                                    workgroupSize);
+  };
+  linalg::LinalgLoopDistributionOptions copyInvocationDistributionOptions;
+  copyInvocationDistributionOptions.procInfo = getCopyThreadProcInfoFn;
+  copyInvocationDistributionOptions.distributionMethod = {
+      {linalg::DistributionMethod::Cyclic, linalg::DistributionMethod::Cyclic,
+       linalg::DistributionMethod::Cyclic}};
+
+  auto tilingOptions =
+      linalg::LinalgTilingOptions()
+          .setLoopType(linalg::LinalgTilingLoopType::Loops)
+          .setTileSizeComputationFunction(wgCopyTileSizeFn)
+          .setDistributionOptions(copyInvocationDistributionOptions);
+  patterns.insert<linalg::LinalgTilingPattern<linalg::CopyOp>>(
+      patterns.getContext(), tilingOptions,
+      linalg::LinalgTransformationFilter(
+          {Identifier::get(getCopyToWorkgroupMemoryMarker(),
+                           patterns.getContext())},
+          Identifier::get(getVectorizeMarker(), patterns.getContext())));
+}
+
+static void populateVectorizationPatterns(RewritePatternSet &patterns) {
+  linalg::insertVectorizationPatterns<linalg::CopyOp>(
+      patterns, linalg::LinalgVectorizationOptions(),
+      linalg::LinalgTransformationFilter(Identifier::get(
+          getCopyToWorkgroupMemoryMarker(), patterns.getContext())));
+}
+
+// TODO(thomasraoux): Extend this to support smaller vector size as well.
+static constexpr int targetVectorSize = 4;
+
+/// Compute a vector size so that the numer of elements is equal to the flat
+/// workgroup size.
+static Optional<SmallVector<int64_t, 4>> getGPUNativeVectorSize(
+    Operation *op, int64_t flatWorkgroupSize) {
+  auto vt = dyn_cast<VectorTransferOpInterface>(op);
+  if (!vt) return llvm::None;
+  if (!vt.permutation_map().isMinorIdentity()) return llvm::None;
+  ArrayRef<int64_t> shape = vt.getVectorType().getShape();
+  SmallVector<int64_t, 4> unroll;
+  assert(shape.back() % targetVectorSize == 0);
+  int64_t threadsAvailable = flatWorkgroupSize;
+  for (auto &dim : llvm::enumerate(llvm::reverse(shape))) {
+    int64_t numElementPerThread = dim.index() == 0 ? targetVectorSize : 1;
+    int64_t numThreads = dim.value() / numElementPerThread;
+    numThreads = std::min(numThreads, threadsAvailable);
+    unroll.push_back(numThreads * numElementPerThread);
+    assert(threadsAvailable % numThreads == 0);
+    threadsAvailable = threadsAvailable / numThreads;
+    if (threadsAvailable == 1) break;
+  }
+  assert(threadsAvailable == 1);
+  unroll.resize(shape.size(), 1);
+  std::reverse(unroll.begin(), unroll.end());
+  if (unroll == shape) return llvm::None;
+  return unroll;
+}
+
+static void populateVectorUnrollPatterns(RewritePatternSet &patterns,
+                                         int64_t flatWorkgroupSize) {
+  auto getShape = [flatWorkgroupSize](Operation *op) {
+    return getGPUNativeVectorSize(op, flatWorkgroupSize);
+  };
+  vector::populateVectorUnrollPatterns(
+      patterns, vector::UnrollVectorOptions().setNativeShapeFn(getShape));
+}
+
+/// Return a flattened Id Value by combining the 3D gpu thread IDs.
+static Value createFlatId(FuncOp funcOp, std::array<int64_t, 3> workgroupSize) {
+  OpBuilder b(funcOp.getBody());
+  Type indexType = b.getIndexType();
+  AffineExpr d0 = getAffineDimExpr(0, b.getContext());
+  AffineExpr d1 = getAffineDimExpr(1, b.getContext());
+  AffineExpr d2 = getAffineDimExpr(2, b.getContext());
+  Value threadX = b.create<gpu::ThreadIdOp>(funcOp.getLoc(), indexType,
+                                            b.getStringAttr("x"));
+  Value threadY = b.create<gpu::ThreadIdOp>(funcOp.getLoc(), indexType,
+                                            b.getStringAttr("y"));
+  Value threadZ = b.create<gpu::ThreadIdOp>(funcOp.getLoc(), indexType,
+                                            b.getStringAttr("z"));
+  Value flatThreadId = makeComposedAffineApply(
+      b, funcOp.getLoc(),
+      d0 + workgroupSize[0] * d1 + (workgroupSize[0] * workgroupSize[1]) * d2,
+      {threadX, threadY, threadZ});
+  return flatThreadId;
+}
+
+/// Distribute a transfer read operations on the given thread ids.
+static void distributeTransferRead(FuncOp funcOp, Value flatThreadId,
+                                   int64_t flatWorkgroupSize) {
+  funcOp.walk([&](vector::TransferReadOp readOp) {
+    OpBuilder b(readOp);
+    Value id = flatThreadId;
+    SmallVector<int64_t, 2> multiplier;
+    auto shape = readOp.getVectorType().getShape();
+    SmallVector<Value> ids;
+    SmallVector<AffineExpr> exprs;
+    AffineExpr d0 = getAffineDimExpr(0, b.getContext());
+    int64_t numThreads = flatWorkgroupSize;
+    for (auto &dim : llvm::enumerate(llvm::reverse(shape))) {
+      int64_t threads =
+          dim.index() == 0 ? (dim.value() / targetVectorSize) : dim.value();
+      // If we don't need to distribute the dimension, skip it.
+      if (threads == 1) continue;
+      exprs.push_back(getAffineDimExpr(shape.size() - dim.index() - 1,
+                                       funcOp->getContext()));
+      multiplier.push_back(threads);
+      Value dimId = id;
+      assert(numThreads % threads == 0);
+      if (numThreads / threads > 1)
+        dimId =
+            makeComposedAffineApply(b, funcOp.getLoc(), d0 % threads, {dimId});
+      ids.push_back(dimId);
+      numThreads = numThreads / threads;
+      id = makeComposedAffineApply(b, funcOp.getLoc(), d0.floorDiv(threads),
+                                   {id});
+      if (numThreads <= 1) break;
+    }
+    std::reverse(ids.begin(), ids.end());
+    Optional<mlir::vector::DistributeOps> ops =
+        vector::distributPointwiseVectorOp(
+            b, readOp, ids, multiplier,
+            AffineMap::get(shape.size(), 0, exprs, funcOp.getContext()));
+    if (ops.hasValue()) {
+      SmallPtrSet<Operation *, 1> extractOp({ops->extract, ops->insert});
+      readOp.getResult().replaceAllUsesExcept(ops->insert.getResult(),
+                                              extractOp);
+    }
+  });
+}
+
+namespace {
+
+class LLVMGPUDistributeSharedMemoryCopyPass
+    : public LLVMGPUDistributeSharedMemoryCopyBase<
+          LLVMGPUDistributeSharedMemoryCopyPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+  void runOnOperation() override {
+    FuncOp funcOp = getOperation();
+    std::array<int64_t, 3> workgroupSize = getWorkgroupSize(funcOp);
+    MLIRContext *context = &getContext();
+    SmallVector<linalg::CopyOp> copiesToWorkgroupMem;
+    funcOp.walk([&](linalg::CopyOp copyOp) {
+      if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker()))
+        copiesToWorkgroupMem.push_back(copyOp);
+    });
+    if (copiesToWorkgroupMem.empty()) return;
+    int64_t flatWorkgroupSize =
+        workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
+    bool isAligned = llvm::all_of(
+        copiesToWorkgroupMem, [flatWorkgroupSize](linalg::CopyOp copyOp) {
+          auto shape = copyOp.output().getType().cast<MemRefType>().getShape();
+          // Verify that each dimension of the shape can be distributed on the
+          // threads
+          int64_t threadsAvailable = flatWorkgroupSize;
+          for (auto &dim : llvm::enumerate(llvm::reverse(shape))) {
+            int64_t numElementPerThread =
+                dim.index() == 0 ? targetVectorSize : 1;
+            int64_t numThreads = dim.value() / numElementPerThread;
+            if (numThreads == 0) return false;
+            numThreads = std::min(numThreads, threadsAvailable);
+            if (threadsAvailable % numThreads != 0) return false;
+            threadsAvailable = threadsAvailable / numThreads;
+            if (threadsAvailable == 1) break;
+          }
+          return threadsAvailable == 1;
+        });
+    if (isAligned) {
+      // Step 1. Vectorize the shared memory copy.
+      RewritePatternSet vectorizationPatterns(context);
+      populateVectorizationPatterns(vectorizationPatterns);
+      (void)applyPatternsAndFoldGreedily(funcOp,
+                                         std::move(vectorizationPatterns));
+
+      // Step 2. Unroll transfer_read/transfer_write to a vector with the number
+      // of element equal to `targetVectorSize * targetVectorSize`. The.
+      // transfer op generated can. then be distributed to a single op of target
+      // size.
+      RewritePatternSet vectorUnrollPatterns(context);
+      populateVectorUnrollPatterns(vectorUnrollPatterns, flatWorkgroupSize);
+      (void)applyPatternsAndFoldGreedily(funcOp,
+                                         std::move(vectorUnrollPatterns));
+      // Step 3. Distribute the transfer ops onto the flat ids.
+      Value flatId = createFlatId(funcOp, workgroupSize);
+      distributeTransferRead(funcOp, flatId, flatWorkgroupSize);
+      // Propagate vector distribution to the chain of ops.
+      RewritePatternSet distributePatterns(context);
+      vector::populatePropagateVectorDistributionPatterns(distributePatterns);
+      (void)applyPatternsAndFoldGreedily(funcOp, std::move(distributePatterns));
+    } else {
+      // Fall back to basic tiling for cases where workgroup memory size is not
+      // well aligned on the number of threads.
+      // TODO(thomasraoux): Handle this case with padding instead so that we get
+      // good performance for more complex shapes.
+      OwningRewritePatternList threadLevelTilingPatterns(context);
+      populateTilingCopyToWorkgroupMemPatterns(threadLevelTilingPatterns,
+                                               workgroupSize);
+      (void)applyPatternsAndFoldGreedily(funcOp,
+                                         std::move(threadLevelTilingPatterns));
+      // Apply canonicalization patterns.
+      RewritePatternSet threadTilingCanonicalizationPatterns =
+          linalg::getLinalgTilingCanonicalizationPatterns(context);
+      populateAffineMinSCFCanonicalizationPattern(
+          threadTilingCanonicalizationPatterns);
+      (void)applyPatternsAndFoldGreedily(
+          funcOp, std::move(threadTilingCanonicalizationPatterns));
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+createLLVMGPUDistributeSharedMemoryCopy() {
+  return std::make_unique<LLVMGPUDistributeSharedMemoryCopyPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -103,6 +103,9 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
       case IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize:
         addGPUVectorizationPassPipeline(nestedModulePM);
         break;
+      case IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt:
+        addGPUMatmulSimtPassPipeline(nestedModulePM);
+        break;
       default:
         llvm_unreachable("Unsupported pipeline on GPU target.");
     }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUUtils.h
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUUtils.h
@@ -1,0 +1,46 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_LLVMGPU_LLVMGPUUTILS_H_
+#define IREE_COMPILER_CODEGEN_LLVMGPU_LLVMGPUUTILS_H_
+
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/GPU/Passes.h"
+
+static constexpr int32_t kNumGPUDims = 3;
+
+static llvm::SmallVector<mlir::linalg::ProcInfo, 2> getGPUThreadIdsAndCounts(
+    mlir::OpBuilder &builder, mlir::Location loc, unsigned numDims,
+    llvm::ArrayRef<int64_t> workgroupSize) {
+  assert(numDims <= kNumGPUDims);
+  llvm::SmallVector<mlir::linalg::ProcInfo, 2> procInfo(numDims);
+  std::array<llvm::StringRef, kNumGPUDims> dimAttr{"x", "y", "z"};
+  mlir::Type indexType = builder.getIndexType();
+  for (unsigned i = 0; i < numDims; ++i) {
+    mlir::StringAttr attr = builder.getStringAttr(dimAttr[i]);
+    procInfo[numDims - 1 - i] = {
+        builder.create<mlir::gpu::ThreadIdOp>(loc, indexType, attr),
+        builder.create<mlir::ConstantOp>(
+            loc, builder.getIndexAttr(workgroupSize[i]))};
+  }
+  return procInfo;
+}
+
+static std::array<int64_t, 3> getWorkgroupSize(mlir::FuncOp funcOp) {
+  std::array<int64_t, 3> workgroupSize;
+  auto entryPointOp = mlir::iree_compiler::getEntryPoint(funcOp);
+  llvm::Optional<mlir::ArrayAttr> workgroupSizeAttr =
+      entryPointOp.workgroup_size();
+  assert(workgroupSizeAttr.hasValue());
+  for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
+    workgroupSize[it.index()] =
+        it.value().cast<mlir::IntegerAttr>().getValue().getZExtValue();
+  }
+  return workgroupSize;
+}
+
+#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_LLVMGPUUTILS_H_

--- a/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
             "distribute_to_thread.mlir",
+            "distribute_wg_copy.mlir",
             "gpu_set_num_workgroups.mlir",
             "nvvm_pipeline_test.mlir",
             "remove_loops.mlir",

--- a/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
     "distribute_to_thread.mlir"
+    "distribute_wg_copy.mlir"
     "gpu_set_num_workgroups.mlir"
     "legalize.mlir"
     "nvvm_pipeline_test.mlir"

--- a/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -64,27 +64,14 @@ hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
 //         CHECK:  memref.global "private" @{{.*}} : memref<4x256xf32, 3>
 //         CHECK:  memref.global "private" @{{.*}} : memref<2x4xf32, 3>
 //     CHECK-DAG:  %[[C0:.+]] = constant 0 : index
-//     CHECK-DAG:  %[[C1:.+]] = constant 1 : index
 //     CHECK-DAG:  %[[C2:.+]] = constant 2 : index
 //     CHECK-DAG:  %[[C4:.+]] = constant 4 : index
 //     CHECK-DAG:  %[[C256:.+]] = constant 256 : index
 //     CHECK-DAG:  %[[C1024:.+]] = constant 1024 : index
 //         CHECK:  scf.for %[[K:.+]] = %[[C0]] to %[[C1024]] step %[[C4]] {
 //         CHECK:    gpu.barrier
-//         CHECK:    %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"} : () -> index
-//         CHECK:    scf.for %[[IND:.+]] = %[[TIDX]] to %[[C2]] step %[[C2]] {
-//     CHECK-DAG:      %[[SRC:.+]] = memref.subview %{{.*}}[%[[IND]], 0] [1, 4] [1, 1] : memref<2x4xf32, #{{.*}}> to memref<1x4xf32, #{{.*}}>
-//     CHECK-DAG:      %[[DST:.+]] = memref.subview %{{.*}}[%[[IND]], 0] [1, 4] [1, 1] : memref<2x4xf32, #{{.*}}, 3> to memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:      linalg.copy(%[[SRC]], %[[DST]]) {__internal_linalg_transform__ = "vectorize"} : memref<1x4xf32, #{{.*}}>, memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:    }
-//         CHECK:    %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"} : () -> index
-//         CHECK:    scf.for %[[IND0:.+]] = %[[C0]] to %[[C4]] step %[[C1]] {
-//         CHECK:      scf.for %[[IND1:.+]] = %{{.*}} to %[[C256]] step %[[C256]] {
-//     CHECK-DAG:        %[[SRC:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [1, 4] [1, 1] : memref<4x256xf32, #{{.*}}> to memref<1x4xf32, #{{.*}}>
-//     CHECK-DAG:        %[[DST:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [1, 4] [1, 1] : memref<4x256xf32, #{{.*}}, 3> to memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:        linalg.copy(%[[SRC]], %[[DST]]) {__internal_linalg_transform__ = "vectorize"} : memref<1x4xf32, #{{.*}}>, memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:      }
-//         CHECK:    }
+//         CHECK:    linalg.copy(%{{.*}}, %{{.*}}) {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<2x4xf32, #{{.*}}>, memref<2x4xf32, #{{.*}}, 3>
+//         CHECK:    linalg.copy(%{{.*}}, %{{.*}}) {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<4x256xf32, #{{.*}}>, memref<4x256xf32, #{{.*}}, 3>
 //         CHECK:    gpu.barrier
 //         CHECK:    scf.for %[[IND0:.+]] = %{{.*}} to %[[C2]] step %[[C2]] {
 //         CHECK:      scf.for %[[IND1:.+]] = %{{.*}} to %[[C256]] step %[[C256]] {
@@ -95,89 +82,6 @@ hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
 //         CHECK:    }
 //         CHECK:  }
 
-// -----
-
-// Test that non aligned sizes compile correctly.
-#config = {tileSizes = [[2, 256, 4], [], [2, 4]]}
-#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
-#map0 = affine_map<()[s0] -> (s0 * 2)>
-#map1 = affine_map<()[s0] -> (s0 * 256)>
-#map3 = affine_map<(d0) -> (256, -d0 + 4)>
-#map4 = affine_map<(d0, d1)[s0] -> (d0 * 3 + s0 + d1)>
-#map5 = affine_map<(d0, d1)[s0] -> (d0 * 4 + s0 + d1)>
-hal.executable @dot_dispatch_1 attributes {sym_visibility = "private"} {
-  hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.entry_point @dot_dispatch_1 attributes {
-      interface = @legacy_io,
-      ordinal = 0 : index,
-      translation.info = {
-        passPipeline = 3 : i32,
-        workloadPerWorkgroup = [256, 2]},
-      workgroup_size = [64: index, 1: index, 1: index]}
-    builtin.module  {
-      builtin.func @dot_dispatch_1() {
-        %c0 = constant 0 : index
-        %c4 = constant 4 : index
-        %c2 = constant 2 : index
-        %cst = constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : memref<2x3xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : memref<3x4xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : memref<2x4xf32>
-        %workgroup_size_x = hal.interface.workgroup.size[0] : index
-        %workgroup_size_y = hal.interface.workgroup.size[1] : index
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_count_x = hal.interface.workgroup.count[0] : index
-        %workgroup_id_y = hal.interface.workgroup.id[1] : index
-        %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %3 = affine.apply #map0()[%workgroup_id_y]
-        %4 = affine.apply #map0()[%workgroup_count_y]
-        scf.for %arg0 = %3 to %c2 step %4 {
-          %5 = affine.apply #map1()[%workgroup_id_x]
-          %6 = affine.apply #map1()[%workgroup_count_x]
-          scf.for %arg1 = %5 to %c4 step %6 {
-            %8 = memref.subview %0[%arg0, 0] [2, 3] [1, 1] : memref<2x3xf32> to memref<2x3xf32, #map4>
-            %9 = affine.min #map3(%arg1)[]
-            %10 = memref.subview %1[0, %arg1] [3, %9] [1, 1] : memref<3x4xf32> to memref<3x?xf32, #map5>
-            %11 = memref.subview %2[%arg0, %arg1] [2, %9] [1, 1] : memref<2x4xf32> to memref<2x?xf32, #map5>
-            linalg.fill(%cst, %11) {
-              __internal_linalg_transform__ = "workgroup",
-              lowering.config = #config} : f32, memref<2x?xf32, #map5>
-            linalg.matmul {
-              __internal_linalg_transform__ = "workgroup",
-              lowering.config = #config}
-              ins(%8, %10 : memref<2x3xf32, #map4>, memref<3x?xf32, #map5>)
-              outs(%11 : memref<2x?xf32, #map5>)
-          }
-        }
-        return
-      }
-      hal.interface @legacy_io attributes {sym_visibility = "private"} {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer", access="Read"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer", access="Read"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
-      }
-    }
-  }
-}
-//   CHECK-LABEL: hal.executable @dot_dispatch_1
-//     CHECK-DAG:  %[[C0:.+]] = constant 0 : index
-//     CHECK-DAG:  %[[C1:.+]] = constant 1 : index
-//     CHECK-DAG:  %[[C2:.+]] = constant 2 : index
-//     CHECK-DAG:  %[[C3:.+]] = constant 3 : index
-//     CHECK-DAG:  %[[C256:.+]] = constant 256 : index
-//         CHECK:  gpu.barrier
-//         CHECK:  scf.for %[[IND:.+]] = %{{.*}} to %[[C2]] step %[[C2]] {
-//     CHECK-DAG:    %[[SRC:.+]] = memref.subview %{{.*}}[%[[IND]], 0] [1, 3] [1, 1] : memref<2x3xf32, #{{.*}}> to memref<1x3xf32, #{{.*}}>
-//     CHECK-DAG:    %[[DST:.+]] = memref.subview %{{.*}}[%[[IND]], 0] [1, 3] [1, 1] : memref<2x3xf32, #{{.*}}, 3> to memref<1x3xf32, #{{.*}}, 3>
-//         CHECK:    linalg.copy(%[[SRC]], %[[DST]]) {__internal_linalg_transform__ = "vectorize"} : memref<1x3xf32, #{{.*}}>, memref<1x3xf32, #{{.*}}, 3>
-//         CHECK:    }
-//         CHECK:  scf.for %[[IND0:.+]] = %{{.*}} to %[[C3]] step %[[C1]] {
-//         CHECK:    scf.for %[[IND1:.+]] = %{{.*}} to %{{.*}} step %[[C256]] {
-//     CHECK-DAG:      %[[SRC:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [1, 4] [1, 1] : memref<{{.*}}> to memref<1x4xf32, #{{.*}}>
-//     CHECK-DAG:      %[[DST:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [1, 4] [1, 1] : memref<{{.*}}, 3> to memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:      linalg.copy(%[[SRC]], %[[DST]]) {__internal_linalg_transform__ = "vectorize"} : memref<1x4xf32, #{{.*}}>, memref<1x4xf32, #{{.*}}, 3>
-//         CHECK:    }
-//         CHECK:  }
 // -----
 
 #config = {tileSizes = [[]]}

--- a/iree/compiler/Codegen/LLVMGPU/test/distribute_wg_copy.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/distribute_wg_copy.mlir
@@ -1,0 +1,67 @@
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-llvmgpu-distribute-shared-memory-copy))))' -cse %s | IreeFileCheck %s
+
+// CHECK-DAG: #[[$MAP0:.*]] = affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 32 + s0 floordiv 4)>
+// CHECK-DAG: #[[$MAP1:.*]] = affine_map<()[s0] -> (s0 * 4 - (s0 floordiv 4) * 16)>
+// CHECK-DAG: #[[$MAP2:.*]] = affine_map<()[s0, s1, s2] -> (s1 * 8 + s2 * 32 + s0 floordiv 4 + 32)>
+// CHECK-DAG: #[[$MAP3:.*]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * 32 + s2 * 128)>
+// CHECK-DAG: #[[$MAP4:.*]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * 32 + s2 * 128 + 128)>
+// CHECK-DAG: #[[$MAP5:.*]] = affine_map<()[s0, s1, s2] -> (s0 * 4 + s1 * 128 + s2 * 512)>
+
+hal.executable @shared_mem_cpy attributes {sym_visibility = "private"} {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @shared_mem_cpy attributes {
+      interface = @io,
+      ordinal = 0 : index,
+      workgroup_size = [32: index, 4: index, 1:index]}
+    builtin.module  {
+      memref.global "private" @__shared_memory___1 : memref<3x512xf32, 3>
+      memref.global "private" @__shared_memory___0 : memref<256x4xf32, 3>
+      memref.global "private" @__shared_memory__ : memref<64x16xf32, 3>
+    // CHECK-LABEL: builtin.func @shared_mem_cpy(
+      builtin.func @shared_mem_cpy(
+        %m0 : memref<64x16xf32>, %m1 : memref<256x4xf32>, %m2 : memref<3x512xf32>) {
+        %sm0 = memref.get_global @__shared_memory__ : memref<64x16xf32, 3>
+        %sm1 = memref.get_global @__shared_memory___0 : memref<256x4xf32, 3>
+        %sm2 = memref.get_global @__shared_memory___1 : memref<3x512xf32, 3>
+        gpu.barrier
+    // CHECK-DAG: %[[C2:.*]] = constant 2 : index
+    // CHECK-DAG: %[[C1:.*]] = constant 1 : index
+    // CHECK-DAG: %[[C0:.*]] = constant 0 : index
+    // CHECK-DAG: %[[TX:.*]] = "gpu.thread_id"() {dimension = "x"} : () -> index
+    // CHECK-DAG: %[[TY:.*]] = "gpu.thread_id"() {dimension = "y"} : () -> index
+    // CHECK-DAG: %[[TZ:.*]] = "gpu.thread_id"() {dimension = "z"} : () -> index
+
+    // CHECK-DAG: %[[Y0:.*]] = affine.apply #[[$MAP0]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    // CHECK-DAG: %[[X0:.*]] = affine.apply #[[$MAP1]]()[%[[TX]]]
+    //     CHECK: %[[R0:.*]] = vector.transfer_read %{{.*}}[%[[Y0]], %[[X0]]], %{{.*}} {in_bounds = [true, true]} : memref<64x16xf32>, vector<1x4xf32>
+    // CHECK-DAG: %[[Y1:.*]] = affine.apply #[[$MAP2]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    //     CHECK: %[[R1:.*]] = vector.transfer_read %{{.*}}[%[[Y1]], %[[X0]]], %{{.*}} {in_bounds = [true, true]} : memref<64x16xf32>, vector<1x4xf32>
+    //     CHECK: vector.transfer_write %[[R0]], %{{.*}}[%[[Y0]], %[[X0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<64x16xf32, 3>
+    //     CHECK: vector.transfer_write %[[R1]], %{{.*}}[%[[Y1]], %[[X0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<64x16xf32, 3>
+
+        linalg.copy(%m0, %sm0) {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<64x16xf32>, memref<64x16xf32, 3>
+
+    //     CHECK: %[[Y1:.*]] = affine.apply #[[$MAP3]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    //     CHECK: %[[R2:.*]] = vector.transfer_read %{{.*}}[%[[Y1]], %[[C0]]], %{{.*}} {in_bounds = [true, true]} : memref<256x4xf32>, vector<1x4xf32>
+    //     CHECK: %[[Y2:.*]] = affine.apply #[[$MAP4]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    //     CHECK: %[[R3:.*]] = vector.transfer_read %{{.*}}[%[[Y2]], %[[C0]]], %{{.*}} {in_bounds = [true, true]} : memref<256x4xf32>, vector<1x4xf32>
+    //     CHECK: vector.transfer_write %[[R2]], %{{.*}}[%[[Y1]], %[[C0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<256x4xf32, 3>
+    //     CHECK: vector.transfer_write %[[R3]], %{{.*}}[%[[Y2]], %[[C0]]] {in_bounds = [true, true]} : vector<1x4xf32>, memref<256x4xf32, 3>
+
+        linalg.copy(%m1, %sm1) {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<256x4xf32>, memref<256x4xf32, 3>
+
+    //     CHECK: %[[X1:.*]] = affine.apply #[[$MAP5]]()[%[[TX]], %[[TY]], %[[TZ]]]
+    //     CHECK: %[[R4:.*]] = vector.transfer_read %{{.*}}[%[[C0]], %[[X1]]], %{{.*}} {in_bounds = [true, true]} : memref<3x512xf32>, vector<1x4xf32>
+    //     CHECK: %[[R5:.*]] = vector.transfer_read %{{.*}}[%[[C1]], %[[X1]]], %{{.*}} {in_bounds = [true, true]} : memref<3x512xf32>, vector<1x4xf32>
+    //     CHECK: %[[R6:.*]] = vector.transfer_read %{{.*}}[%[[C2]], %[[X1]]], %{{.*}} {in_bounds = [true, true]} : memref<3x512xf32>, vector<1x4xf32>
+    //     CHECK: vector.transfer_write %[[R4]], %{{.*}}[%c0, %15] {in_bounds = [true, true]} : vector<1x4xf32>, memref<3x512xf32, 3>
+    //     CHECK: vector.transfer_write %[[R5]], %{{.*}}[%c1, %15] {in_bounds = [true, true]} : vector<1x4xf32>, memref<3x512xf32, 3>
+    //     CHECK: vector.transfer_write %[[R6]], %{{.*}}[%c2, %15] {in_bounds = [true, true]} : vector<1x4xf32>, memref<3x512xf32, 3>
+
+        linalg.copy(%m2, %sm2) {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<3x512xf32>, memref<3x512xf32, 3>
+        gpu.barrier
+        return
+      }
+    }
+  }
+}

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -106,7 +106,7 @@ hal.executable @dot_dispatch_1 attributes {sym_visibility = "private"} {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 256)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
 //      CHECK: hal.executable.entry_point @dot_dispatch_1
-// CHECK-SAME:     passPipeline = 3 : i32
+// CHECK-SAME:     passPipeline = 4 : i32
 // CHECK-SAME:     workloadPerWorkgroup = [256, 2]
 // CHECK-SAME:     workgroup_size = [64 : index, 1 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index,

--- a/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -99,15 +99,15 @@ hal.executable @dot_dispatch_0 attributes {sym_visibility = "private"} {
   }
 }
 
-//   CHECK-LABEL: hal.executable @dot_dispatch_0
-//         CHECK:   hal.executable.variant @cuda
-//     CHECK-NOT:   llvm.store
-// CHECK-COUNT-2:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
-//         CHECK:   llvm.br
-// CHECK-COUNT-6:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-// CHECK-COUNT-8:   "llvm.intr.fmuladd"({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//         CHECK:   llvm.br
-// CHECK-COUNT-2:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//     CHECK-LABEL: hal.executable @dot_dispatch_0
+//           CHECK:   hal.executable.variant @cuda
+//       CHECK-NOT:   llvm.store
+//           CHECK:   llvm.br
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
+//  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+// CHECK-COUNT-128:   "llvm.intr.fmuladd"({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+//           CHECK:   llvm.br
+//  CHECK-COUNT-16:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 
 // -----
 

--- a/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -101,9 +101,10 @@ hal.executable @dot_dispatch_0 attributes {sym_visibility = "private"} {
 
 //   CHECK-LABEL: hal.executable @dot_dispatch_0
 //         CHECK:   hal.executable.variant @rocm
-// CHECK-COUNT-2:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
-//         CHECK:   llvm.br
-// CHECK-COUNT-6:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-// CHECK-COUNT-8:   "llvm.intr.fmuladd"({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
-//         CHECK:   llvm.br
-// CHECK-COUNT-2:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//       CHECK-NOT:   llvm.store
+//           CHECK:   llvm.br
+//   CHECK-COUNT-3:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>>
+//  CHECK-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+// CHECK-COUNT-128:   "llvm.intr.fmuladd"({{.*}}) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+//           CHECK:   llvm.br
+//  CHECK-COUNT-16:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -201,12 +201,15 @@ void buildLLVMCPUCodegenPassPipeline(
 
 /// Lowering calling vectorization patterns. Expects pass manager to be a
 /// module-level pass manager.
-void addGPUVectorizationPassPipeline(OpPassManager &passManager);
+void addGPUVectorizationPassPipeline(OpPassManager &pm);
+
+/// Lowering calling vectorization patterns.
+void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 
 /// Simple lowering only distributute linalg ops on blocks and threads. This
 /// will result in scalar operations. Expects pass manager to be a module-level
 /// pass manager.
-void addGPUSimpleDistributePassPipeline(OpPassManager &passManager);
+void addGPUSimpleDistributePassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the
@@ -235,6 +238,10 @@ std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorizationPass();
 
 /// Lower vector ops before convertion to LLVM.
 std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUVectorLoweringPass();
+
+/// Convert shared memory copies to distributed transfer_read/transfer_write.
+std::unique_ptr<OperationPass<FuncOp>>
+createLLVMGPUDistributeSharedMemoryCopy();
 
 //------------------------------------------------------------------------------
 // SPIRV Passes

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -193,6 +193,12 @@ def LLVMGPUVectorLowering :
   let constructor = "mlir::iree_compiler::createLLVMGPUVectorLoweringPass()";
 }
 
+def LLVMGPUDistributeSharedMemoryCopy :
+    Pass<"iree-llvmgpu-distribute-shared-memory-copy", "FuncOp"> {
+  let summary = "Pass to distribute shared memory copies to threads.";
+  let constructor = "mlir::iree_compiler::createLLVMGPUDistributeSharedMemoryCopy()";
+}
+
 //------------------------------------------------------------------------------
 // SPIRV
 //------------------------------------------------------------------------------

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -18,6 +18,8 @@ def LLVMGPU_SimpleDistribute
     : I32EnumAttrCase<"LLVMGPUDistribute", 2>;
 def LLVMGPU_Vectorize
     : I32EnumAttrCase<"LLVMGPUVectorize", 3>;
+def LLVMGPU_MatmulSimt
+    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 4>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
@@ -25,7 +27,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_Vectorization, LLVMGPU_SimpleDistribute,
-     LLVMGPU_Vectorize]> {
+     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }
 


### PR DESCRIPTION
Move lowering of shared memory copy into a separate pass and start using
vector distribution for the cases well aligned.
Add a new pipeline for simt matmul, we will later add another one for
tensorcore one.