### PR TITLE
[CUDA] Re-enable vectorization for generic op

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -137,8 +137,7 @@ static LogicalResult setRootDefaultConfig(FuncOp entryPoint, Operation *op) {
   tileSizes.emplace_back(std::move(threadTileSizes));     // Thread level
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, tileSizes, /*nativeVectorSize=*/ArrayRef<int64_t>{},
-      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute,
-      workgroupSize);
+      IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUVectorize, workgroupSize);
 }
 
 static LogicalResult setRootConfig(FuncOp entryPointFn, Operation *computeOp) {

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -46,7 +46,7 @@ hal.executable @add_dispatch_0 attributes {sym_visibility = "private"} {
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
 //  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0) -> (d0)>
 //      CHECK: hal.executable.entry_point @add_dispatch_0
-// CHECK-SAME:     passPipeline = 2 : i32
+// CHECK-SAME:     passPipeline = 3 : i32
 // CHECK-SAME:     workloadPerWorkgroup = [128]
 // CHECK-SAME:     workgroup_size = [32 : index, 1 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index,


### PR DESCRIPTION
It got disabled by mistake during refactoring