### PR TITLE
Fixing VM symbol visibility.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertVariableOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertVariableOps.cpp
@@ -25,9 +25,10 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
     auto convertedType = typeConverter.convertType(op.type());
     if (convertedType.isa<IREE::VM::RefType>() ||
         IREE::VM::RefType::isCompatible(convertedType)) {
-      rewriter.replaceOpWithNewOp<IREE::VM::GlobalRefOp>(
+      auto newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalRefOp>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           op.initial_value(), llvm::to_vector<4>(op->getDialectAttrs()));
+      newOp.setVisibility(op.getVisibility());
       return success();
     } else if (convertedType.isInteger(32)) {
       auto convertedValue =
@@ -35,9 +36,10 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
               ? rewriter.getI32IntegerAttr(static_cast<int32_t>(
                     op.initial_value().getValue().cast<IntegerAttr>().getInt()))
               : Attribute{};
-      rewriter.replaceOpWithNewOp<IREE::VM::GlobalI32Op>(
+      auto newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI32Op>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           convertedValue, llvm::to_vector<4>(op->getDialectAttrs()));
+      newOp.setVisibility(op.getVisibility());
       return success();
     } else if (convertedType.isInteger(64)) {
       auto convertedValue =
@@ -45,9 +47,10 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
               ? rewriter.getI64IntegerAttr(
                     op.initial_value().getValue().cast<IntegerAttr>().getInt())
               : Attribute{};
-      rewriter.replaceOpWithNewOp<IREE::VM::GlobalI64Op>(
+      auto newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalI64Op>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           convertedValue, llvm::to_vector<4>(op->getDialectAttrs()));
+      newOp.setVisibility(op.getVisibility());
       return success();
     } else if (convertedType.isF32()) {
       auto convertedValue = op.initial_value().hasValue()
@@ -57,9 +60,10 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
                                           .cast<FloatAttr>()
                                           .getValueAsDouble()))
                                 : Attribute{};
-      rewriter.replaceOpWithNewOp<IREE::VM::GlobalF32Op>(
+      auto newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF32Op>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           convertedValue, llvm::to_vector<4>(op->getDialectAttrs()));
+      newOp.setVisibility(op.getVisibility());
       return success();
     } else if (convertedType.isF64()) {
       auto convertedValue =
@@ -69,9 +73,10 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
                                              .cast<FloatAttr>()
                                              .getValueAsDouble())
               : Attribute{};
-      rewriter.replaceOpWithNewOp<IREE::VM::GlobalF64Op>(
+      auto newOp = rewriter.replaceOpWithNewOp<IREE::VM::GlobalF64Op>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           convertedValue, llvm::to_vector<4>(op->getDialectAttrs()));
+      newOp.setVisibility(op.getVisibility());
       return success();
     }
     return op.emitOpError("unsupported variable type");

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/allocator_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -canonicalize -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK-LABEL: @allocatorComputeSizeFoldsAway
+// CHECK-LABEL: vm.func private @allocatorComputeSizeFoldsAway
 func @allocatorComputeSizeFoldsAway(%arg0 : !hal.allocator) -> index {
   // CHECK: %c4194304 = vm.const.i32 4194304 : i32
   // CHECK-NOT: hal.allocator.compute_size
@@ -12,7 +12,7 @@ func @allocatorComputeSizeFoldsAway(%arg0 : !hal.allocator) -> index {
 
 // -----
 
-// CHECK-LABEL: @allocatorAllocate
+// CHECK-LABEL: vm.func private @allocatorAllocate
 func @allocatorAllocate(%arg0 : !hal.allocator) -> !hal.buffer {
   %c1024 = constant 1024 : index
   // CHECK: %ref = vm.call @hal.allocator.allocate(%arg0, %c6, %c14, %c1024) : (!vm.ref<!hal.allocator>, i32, i32, i32) -> !vm.ref<!hal.buffer>
@@ -22,7 +22,7 @@ func @allocatorAllocate(%arg0 : !hal.allocator) -> !hal.buffer {
 
 // -----
 
-// CHECK-LABEL: func @allocatorMapByteBuffer
+// CHECK-LABEL: vm.func private @allocatorMapByteBuffer
 func @allocatorMapByteBuffer(%arg0 : !hal.allocator, %arg1 : !util.byte_buffer) -> !hal.buffer {
   %offset = constant 128 : index
   %length = constant 256 : index

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_view_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/buffer_view_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK-LABEL: func @buffer_view_dims
+// CHECK-LABEL: vm.func private @buffer_view_dims
 // CHECK-SAME: %[[VIEW:.+]]: !vm.ref<!hal.buffer_view>
 func @buffer_view_dims(%arg0 : !hal.buffer_view) -> (index, index, index) {
   // CHECK-DAG: %[[D0:.+]] = vm.call @hal.buffer_view.dim(%[[VIEW]], %zero)

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
@@ -11,7 +11,7 @@ hal.constant_pool @pool attributes {buffer_constraints = #hal.buffer_constraints
   hal.constant_storage @_storage1 = dense<[6, 7, 8, 0]> : vector<4xi8>
 }
 
-// CHECK: vm.global.ref @pool_storage0_buffer initializer(@pool_storage0_buffer_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_storage0_buffer initializer(@pool_storage0_buffer_initializer) : !vm.ref<!hal.buffer>
 hal.variable @pool_storage0_buffer init(@pool_storage0_buffer_initializer) : !hal.buffer attributes {sym_visibility = "private"}
 // CHECK: vm.func private @pool_storage0_buffer_initializer() -> !vm.ref<!hal.buffer>
 func private @pool_storage0_buffer_initializer() -> !hal.buffer {
@@ -29,11 +29,11 @@ func private @pool_storage0_buffer_initializer() -> !hal.buffer {
   return %mapped : !hal.buffer
 }
 
-// CHECK: vm.global.ref @pool_storage1_buffer initializer(@pool_storage1_buffer_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_storage1_buffer initializer(@pool_storage1_buffer_initializer) : !vm.ref<!hal.buffer>
 hal.variable @pool_storage1_buffer init(@pool_storage1_buffer_initializer) : !hal.buffer attributes {sym_visibility = "private"}
 func private @pool_storage1_buffer_initializer() -> !hal.buffer
 
-// CHECK: vm.global.ref @pool_splats initializer(@pool_splats_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_splats initializer(@pool_splats_initializer) : !vm.ref<!hal.buffer>
 hal.variable @pool_splats init(@pool_splats_initializer) : !hal.buffer attributes {sym_visibility = "private"}
 // CHECK: vm.func private @pool_splats_initializer() -> !vm.ref<!hal.buffer>
 func private @pool_splats_initializer() -> !hal.buffer {

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/control_flow_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK-LABEL: func @check_success
+// CHECK-LABEL: vm.func private @check_success
 func @check_success() {
     // CHECK: %[[CODE:.+]] =
     %statusCode = constant 1 : i32
@@ -11,7 +11,7 @@ func @check_success() {
 
 // -----
 
-// CHECK-LABEL: func @check_success_with_message
+// CHECK-LABEL: vm.func private @check_success_with_message
 func @check_success_with_message() {
     // CHECK: %[[CODE:.+]] =
     %statusCode = constant 1 : i32

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/variable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/variable_ops.mlir
@@ -1,19 +1,22 @@
 // RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
 
-// CHECK: vm.global.i32 @v_initialized_const = 4 : i32
+// CHECK: vm.global.i32 public @v_initialized_const = 4 : i32
 hal.variable @v_initialized_const = 4 : i32
+
+// CHECK: vm.global.i32 private @v_private_const = 5 : i32
+hal.variable @v_private_const attributes {sym_visibility = "private"} = 5 : i32
 
 // -----
 
-// CHECK: vm.global.ref @v_initialized initializer(@initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref public @v_initialized initializer(@initializer) : !vm.ref<!hal.buffer>
 hal.variable @v_initialized init(@initializer) : !hal.buffer
 func private @initializer() -> !hal.buffer
 
 // -----
 
-// CHECK: vm.global.ref @v_loaded : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref public @v_loaded : !vm.ref<!hal.buffer>
 hal.variable @v_loaded : !hal.buffer
-// CHECK-LABEL: func @loaded
+// CHECK-LABEL: vm.func private @loaded
 func @loaded() {
   // CHECK: %v_loaded = vm.global.load.ref @v_loaded : !vm.ref<!hal.buffer>
   %0 = hal.variable.load @v_loaded : !hal.buffer
@@ -22,9 +25,9 @@ func @loaded() {
 
 // -----
 
-// CHECK: vm.global.ref mutable @v_stored : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref public mutable @v_stored : !vm.ref<!hal.buffer>
 hal.variable @v_stored mutable : !hal.buffer
-// CHECK-LABEL: func @stored
+// CHECK-LABEL: vm.func private @stored
 func @stored(%arg0 : !hal.buffer) {
   // CHECK: vm.global.store.ref %arg0, @v_stored : !vm.ref<!hal.buffer>
   hal.variable.store %arg0, @v_stored : !hal.buffer

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -89,7 +89,7 @@ func @basic_linking() -> () {
 // CHECK-NEXT:      hal.executable.entry_point @dispatch_1 attributes {interface = @io_0, ordinal = 1 : index}
 // CHECK-NEXT:      hal.executable.entry_point @dispatch_2 attributes {interface = @io_1, ordinal = 2 : index}
 // CHECK-NEXT:      module {
-// CHECK-NEXT:        vm.module @linked_module {
+// CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.func @dispatch_0() {
 // CHECK-NEXT:            vm.return
 // CHECK-NEXT:          }
@@ -197,7 +197,7 @@ func @other_targets() -> () {
 // CHECK-NEXT:      hal.executable.entry_point @dispatch_0 attributes {interface = @io_0, ordinal = 0 : index}
 // CHECK-NEXT:      hal.executable.entry_point @dispatch_1 attributes {interface = @io_1, ordinal = 1 : index}
 // CHECK-NEXT:      module {
-// CHECK-NEXT:        vm.module @linked_module {
+// CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.func @dispatch_0() {
 // CHECK-NEXT:            vm.return
 // CHECK-NEXT:          }
@@ -361,7 +361,7 @@ hal.executable @dispatch_1 attributes {sym_visibility = "private"} {
 // CHECK:       hal.executable @vmvx_linked attributes {sym_visibility = "private"} {
 // CHECK:       hal.executable.variant @vmvx_bytecode_fb, target = #executable_target_vmvx_bytecode_fb {
 // CHECK:           module {
-// CHECK-NEXT:        vm.module @linked_module {
+// CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.rodata public @rodata_a dense<0> : tensor<1xi32>
 // CHECK-NEXT:          vm.rodata public @rodata_b dense<0> : tensor<1xi32>
 // CHECK-NEXT:          vm.rodata public @rodata_b_0 dense<0> : tensor<1xi32>

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -46,8 +46,8 @@ flow.executable @add_dispatch_0 {
 //  CHECK-SAME:       ordinal = 0 : index
 //  CHECK-SAME:     }
 //       CHECK:     module {
-//  CHECK-NEXT:       vm.module @module {
-//  CHECK-NEXT:         vm.func @entry(
+//  CHECK-NEXT:       vm.module public @module {
+//  CHECK-NEXT:         vm.func private @entry(
 //  CHECK-SAME:             %[[SCRATCHPAD:.+]]: !vm.buffer, %[[CONSTANTS:.+]]: !vm.buffer,
 //  CHECK-SAME:             %[[BINDINGS:.+]]: !vm.list<!vm.buffer>
 //   CHECK-DAG:           %c16 = vm.const.i32 16 : i32

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/byte_buffer_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/byte_buffer_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @byte_buffer_constant
 module @byte_buffer_constant {
 module {
-  // CHECK: vm.func @my_fn
+  // CHECK: vm.func private @my_fn
   func @my_fn() {
     // CHECK-NEXT: = vm.rodata.inline : !vm.buffer = dense<[1, 2, 3]> : tensor<3xi32>
     %0 = util.byte_buffer.constant : !util.byte_buffer = dense<[1, 2, 3]> : tensor<3xi32>

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/hint_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/hint_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @unreachable_block
 module @unreachable_block {
 module {
-  // CHECK: vm.func @my_fn
+  // CHECK: vm.func private @my_fn
   func @my_fn() {
     // CHECK-NEXT: %[[CODE:.+]] = vm.const.i32 2
     // CHECK-NEXT: vm.fail %[[CODE]], "nope!"

--- a/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/list_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/IREEToVM/test/list_ops.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @list_ops
 module @list_ops { module {
-  // CHECK: vm.func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: (%[[BUFFER_VIEW:.+]]: !vm.ref<!hal.buffer_view>)
   func @my_fn(%buffer_view: !hal.buffer_view) {
     // CHECK: %[[CAPACITY:.+]] = vm.const.i32 5

--- a/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -iree-vm-conversion -iree-vm-target-extension=f32 %s | IreeFileCheck %s
 
 module {
-  // CHECK-LABEL: func @arithmetic
+  // CHECK-LABEL: vm.func private @arithmetic
   func @arithmetic(%arg0: f32) -> f32 {
 
     // CHECK: vm.atan.f32

--- a/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt -split-input-file -iree-vm-conversion -iree-vm-target-extension=f32 %s | IreeFileCheck %s
 
 module {
-  // CHECK-LABEL: vm.func @load_store
+  // CHECK-LABEL: vm.func private @load_store
   // CHECK-SAME: (%[[BUFFER:.+]]: !vm.buffer, %[[IDX0:.+]]: i32, %[[IDX1:.+]]: i32) -> f32 {
   func @load_store(%buffer: memref<?xf32>, %idx0: index, %idx1: index) -> f32 {
     // CHECK-NEXT: %[[C4_0:.+]] = vm.const.i32 4 : i32
@@ -22,7 +22,7 @@ module {
 module {
   // CHECK: vm.rodata private @__constant dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
   memref.global "private" constant @__constant : memref<2xf32> = dense<[0.0287729427, 0.0297581609]>
-  // CHECK-LABEL: vm.func @load_global
+  // CHECK-LABEL: vm.func private @load_global
   // CHECK-SAME: (%[[IDX:.+]]: i32) -> f32 {
   func @load_global(%idx: index) -> f32 {
     // CHECK-NEXT: %[[BUFFER:.+]] = vm.const.ref.rodata @__constant : !vm.buffer

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -124,6 +124,9 @@ class FuncOpConversion : public OpConversionPattern<FuncOp> {
       rewriter.create<IREE::VM::ExportOp>(srcOp.getLoc(), newFuncOp,
                                           exportName);
     }
+    // VM functions are private by default and exported via the dedicated
+    // vm.export ops.
+    newFuncOp.setPrivate();
 
     rewriter.replaceOp(srcOp, llvm::None);
     return success();

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/arithmetic_ops.mlir
@@ -5,7 +5,7 @@
 module @t001_addi {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -22,7 +22,7 @@ module {
 module @t002_divis {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -39,7 +39,7 @@ module {
 module @t002_diviu {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -56,7 +56,7 @@ module {
 module @t003_muli {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -73,7 +73,7 @@ module {
 module @t004_remis {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -90,7 +90,7 @@ module {
 module @t005_remiu {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -107,7 +107,7 @@ module {
 module @t006_subi {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -124,7 +124,7 @@ module {
 module @t007_and {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -141,7 +141,7 @@ module {
 module @t008_or {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -158,7 +158,7 @@ module {
 module @t009_xor {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1: i32) -> (i32) {
@@ -175,7 +175,7 @@ module {
 module @t010_shift_left {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32) -> (i32) {
     %c3 = constant 3 : i32
@@ -192,7 +192,7 @@ module {
 module @t011_shift_right {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32) -> (i32) {
     %c3 = constant 3 : i32

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/assignment_ops.mlir
@@ -5,7 +5,7 @@
 module @t001_cmp_select {
 
 module @my_module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG2:[a-zA-Z0-9$._-]+]]
@@ -28,7 +28,7 @@ module @my_module {
 module @t002_cmp_select_index {
 
 module @my_module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG2:[a-zA-Z0-9$._-]+]]

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/comparison_ops.mlir
@@ -5,7 +5,7 @@
 module @t001_cmp_eq_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -22,7 +22,7 @@ module {
 module @t002_cmp_ne_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -39,7 +39,7 @@ module {
 module @t003_cmp_slt_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -56,7 +56,7 @@ module {
 module @t004_cmp_sle_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -73,7 +73,7 @@ module {
 module @t005_cmp_sgt_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -90,7 +90,7 @@ module {
 module @t006_cmp_sge_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -107,7 +107,7 @@ module {
 module @t007_cmp_ult_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -124,7 +124,7 @@ module {
 module @t008_cmp_ule_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -141,7 +141,7 @@ module {
 module @t009_cmp_ugt_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {
@@ -158,7 +158,7 @@ module {
 module @t010_cmp_uge_i32 {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0: i32, %arg1 : i32) -> (i1) {

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/control_flow_ops.mlir
@@ -20,7 +20,7 @@ module {
 module @t002_cond_br {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i1, %arg1 : i32, %arg2 : i32) -> (i32) {
     // CHECK: vm.cond_br %[[ARG0]], ^bb1, ^bb2
@@ -39,7 +39,7 @@ module {
 module @t003_br_args {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i32, %arg1 : i32) -> (i32) {
@@ -57,7 +57,7 @@ module {
 module @t004_cond_br_args {
 
 module {
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG1:[a-zA-Z0-9$._-]+]]
   // CHECK-SAME: %[[ARG2:[a-zA-Z0-9$._-]+]]
@@ -79,7 +79,7 @@ module @t005_call {
 
 module {
   func private @import_fn(%arg0 : i32) -> i32
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i32) -> (i32) {
     // CHECK: vm.call @import_fn(%[[ARG0]]) : (i32) -> i32
@@ -96,7 +96,7 @@ module @t005_call_int_promotion {
 
 module {
   func private @import_fn(%arg0 : i1) -> i1
-  // CHECK: func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i1) -> (i1) {
     // CHECK: vm.call @import_fn(%[[ARG0]]) : (i32) -> i32
@@ -112,7 +112,7 @@ module {
 module @t006_assert {
 
 module {
-  // CHECK: vm.func @my_fn
+  // CHECK: vm.func private @my_fn
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9$._-]+]]
   func @my_fn(%arg0 : i32) -> (i32) {
     %zero = constant 0 : i32

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/func_attrs.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/func_attrs.mlir
@@ -5,7 +5,7 @@
 module @t001_iree_reflection {
 
 module {
-  // CHECK: func @t001_iree_reflection
+  // CHECK: vm.func private @t001_iree_reflection
   // CHECK-SAME: iree.reflection = {f = "FOOBAR"}
   func @t001_iree_reflection(%arg0: i32) -> (i32) attributes {
     iree.reflection = {f = "FOOBAR"}
@@ -21,7 +21,7 @@ module {
 module @t002_iree_module_export_default {
 
 module {
-  // CHECK: func @internal_function_name
+  // CHECK: vm.func private @internal_function_name
   // CHECK: vm.export @internal_function_name
   func @internal_function_name(%arg0: i32) -> (i32) {
     return %arg0 : i32

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
@@ -6,9 +6,9 @@
 // CHECK-LABEL: @t001_module_all_options
 module @t001_module_all_options {
 
-// CHECK: module @my_module {
+// CHECK: vm.module public @my_module {
 module @my_module {
-  // CHECK: vm.func @my_fn(%[[ARG0:[a-zA-Z0-9$._-]+]]: i32) -> i32
+  // CHECK: vm.func private @my_fn(%[[ARG0:[a-zA-Z0-9$._-]+]]: i32) -> i32
   func @my_fn(%arg0: i32) -> (i32) {
     // CHECK: vm.return %[[ARG0]] : i32
     return %arg0 : i32
@@ -22,7 +22,7 @@ module @my_module {
 module @t002_no_args_results {
 
 module @my_module {
-  // CHECK: vm.func @my_fn() {
+  // CHECK: vm.func private @my_fn() {
   func @my_fn() -> () {
     // CHECK: vm.return
     return
@@ -35,7 +35,7 @@ module @my_module {
 // CHECK-LABEL: @t003_unnamed_module
 module @t003_unnamed_module {
 
-// CHECK: module @module {
+// CHECK: vm.module public @module {
 module {
 }
 
@@ -49,9 +49,9 @@ module {
   module {
     // CHECK: module
     module {
-      // CHECK-LABEL: vm.module @deeplyNested
+      // CHECK-LABEL: vm.module public @deeplyNested
       module @deeplyNested {
-        // CHECK: vm.func @foo
+        // CHECK: vm.func private @foo
         func @foo() {
           return
         }

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -46,8 +46,11 @@ static ParseResult parseSymbolVisibility(OpAsmParser &parser,
 
 static void printSymbolVisibility(OpAsmPrinter &p, Operation *op,
                                   StringAttr symVisibilityAttr) {
-  if (!symVisibilityAttr) return;
-  p << symVisibilityAttr.getValue();
+  if (!symVisibilityAttr) {
+    p << "public";
+  } else {
+    p << symVisibilityAttr.getValue();
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
@@ -4,19 +4,19 @@
 
 // CHECK-LABEL: @global_i32_folds
 vm.module @global_i32_folds {
-  // CHECK: vm.global.i32 mutable @g0 = 123 : i32
+  // CHECK: vm.global.i32 public mutable @g0 = 123 : i32
   vm.global.i32 mutable @g0 initializer(@g0init) : i32
   vm.func @g0init() -> i32 {
     %c123 = vm.const.i32 123 : i32
     vm.return %c123 : i32
   }
 
-  // CHECK: vm.global.i32 mutable @g1 : i32
+  // CHECK: vm.global.i32 public mutable @g1 : i32
   vm.global.i32 mutable @g1 = 0 : i32
-  // CHECK: vm.global.i32 @g2 : i32
+  // CHECK: vm.global.i32 public @g2 : i32
   vm.global.i32 @g2 = 0 : i32
 
-  // CHECK: vm.global.i32 mutable @g3 : i32
+  // CHECK: vm.global.i32 public mutable @g3 : i32
   vm.global.i32 mutable @g3 initializer(@g3init) : i32
   vm.func @g3init() -> i32 {
     %c0 = vm.const.i32 0 : i32
@@ -28,7 +28,7 @@ vm.module @global_i32_folds {
 
 // CHECK-LABEL: @global_ref_folds_null
 vm.module @global_ref_folds_null {
-  // CHECK: vm.global.ref mutable @g0 : !vm.ref<?>
+  // CHECK: vm.global.ref public mutable @g0 : !vm.ref<?>
   vm.global.ref mutable @g0 initializer(@g0init) : !vm.ref<?>
   vm.func @g0init() -> !vm.ref<?> {
     %null = vm.const.ref.zero : !vm.ref<?>

--- a/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
@@ -17,7 +17,7 @@ vm.module @module_attributed attributes {a} {
 
 // CHECK-LABEL: @module_structure
 vm.module @module_structure {
-  // CHECK-NEXT: vm.global.i32 @g0 : i32
+  // CHECK-NEXT: vm.global.i32 public @g0 : i32
   vm.global.i32 @g0 : i32
   // CHECK-NEXT: vm.export @fn
   vm.export @fn

--- a/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -83,11 +83,13 @@ class GlobalInitializationPass
 
     // If we didn't need to initialize anything then we can elide the functions.
     if (initFuncOp.getBlocks().front().getOperations().size() > 1) {
+      initFuncOp.setPrivate();
       moduleBuilder.create<ExportOp>(moduleBuilder.getUnknownLoc(), initFuncOp);
     } else {
       initFuncOp.erase();
     }
     if (deinitFuncOp.getBlocks().front().getOperations().size() > 1) {
+      deinitFuncOp.setPrivate();
       moduleBuilder.create<ExportOp>(moduleBuilder.getUnknownLoc(),
                                      deinitFuncOp);
     } else {

--- a/iree/compiler/Dialect/VM/Transforms/test/deduplicate_rodata.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/deduplicate_rodata.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-vm-deduplicate-rodata %s | IreeFileCheck %s
 
-// CHECK-LABEL: vm.module @basic
+// CHECK-LABEL: vm.module public @basic
 vm.module @basic {
   // CHECK: vm.rodata private @const0 dense<0>
   vm.rodata private @const0 dense<0> : vector<1xi8>
@@ -25,7 +25,7 @@ vm.module @basic {
 
 // -----
 
-// CHECK-LABEL: vm.module @unique_mime_types
+// CHECK-LABEL: vm.module public @unique_mime_types
 vm.module @unique_mime_types {
   // CHECK: vm.rodata private @const1a {mime_type = "aaa"} dense<1>
   vm.rodata private @const1a {mime_type = "aaa"} dense<1> : vector<1xi8>
@@ -44,7 +44,7 @@ vm.module @unique_mime_types {
 // -----
 
 // {alignment = 16 : i64, mime_type = "application/x-elf"}
-// CHECK-LABEL: vm.module @widen_alignment
+// CHECK-LABEL: vm.module public @widen_alignment
 vm.module @widen_alignment {
   // CHECK: vm.rodata private @const1a {alignment = 16 : i64} dense<1>
   vm.rodata private @const1a {alignment = 1 : i64} dense<1> : vector<1xi8>

--- a/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-global-initialization)' %s | IreeFileCheck %s
 
-// CHECK: vm.module @initEmpty {
+// CHECK: vm.module public @initEmpty {
 // CHECK: }
 vm.module @initEmpty {
 }
@@ -9,20 +9,20 @@ vm.module @initEmpty {
 
 // CHECK-LABEL: @initI32
 vm.module @initI32 {
-  // CHECK: vm.global.i32 mutable @g0 : i32
+  // CHECK: vm.global.i32 public mutable @g0 : i32
   vm.global.i32 mutable @g0 initializer(@g0init) : i32
   vm.func @g0init() -> i32 {
     %c123 = vm.const.i32 123 : i32
     vm.return %c123 : i32
   }
 
-  // CHECK: vm.global.i32 mutable @g1 : i32
+  // CHECK: vm.global.i32 public mutable @g1 : i32
   vm.global.i32 mutable @g1 = 123 : i32
 
-  // CHECK: vm.global.i32 mutable @g2 : i32
+  // CHECK: vm.global.i32 public mutable @g2 : i32
   vm.global.i32 @g2 = 123 : i32
 
-  // CHECK: vm.func @__init() {
+  // CHECK: vm.func private @__init() {
   // CHECK-NEXT:   %0 = vm.call @g0init()
   // CHECK-NEXT:   vm.global.store.i32 %0, @g0
   // CHECK-NEXT:   %c123 = vm.const.i32 123 : i32
@@ -37,20 +37,20 @@ vm.module @initI32 {
 
 // CHECK-LABEL: @initRef
 vm.module @initRef {
-  // CHECK: vm.global.ref mutable @g0 : !vm.ref<?>
+  // CHECK: vm.global.ref public mutable @g0 : !vm.ref<?>
   vm.global.ref mutable @g0 initializer(@g0init) : !vm.ref<?>
   vm.func @g0init() -> !vm.ref<?> {
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return %null : !vm.ref<?>
   }
 
-  // CHECK: vm.global.ref mutable @g1 : !vm.ref<?>
+  // CHECK: vm.global.ref public mutable @g1 : !vm.ref<?>
   vm.global.ref mutable @g1 : !vm.ref<?>
 
-  // CHECK: vm.global.ref @g2 : !vm.ref<?>
+  // CHECK: vm.global.ref public @g2 : !vm.ref<?>
   vm.global.ref @g2 : !vm.ref<?>
 
-  // CHECK: vm.func @__init() {
+  // CHECK: vm.func private @__init() {
   // CHECK-NEXT:   %ref = vm.call @g0init()
   // CHECK-NEXT:   vm.global.store.ref %ref, @g0
   // CHECK-NEXT:   vm.return

--- a/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
@@ -13,9 +13,9 @@
   // CHECK-SAME: rwdatas = 0
   // CHECK-SAME: >}
 vm.module @global_address_propagation {
-  // CHECK-DAG: vm.global.i32 mutable @g0 {ordinal = 0 : i32} : i32
+  // CHECK-DAG: vm.global.i32 public mutable @g0 {ordinal = 0 : i32} : i32
   vm.global.i32 mutable @g0 : i32
-  // CHECK-DAG: vm.global.i32 mutable @g1 {ordinal = 4 : i32} : i32
+  // CHECK-DAG: vm.global.i32 public mutable @g1 {ordinal = 4 : i32} : i32
   vm.global.i32 mutable @g1 : i32
 
   // CHECK-NEXT: @main

--- a/iree/samples/custom_modules/dialect/test/conversion.mlir
+++ b/iree/samples/custom_modules/dialect/test/conversion.mlir
@@ -128,7 +128,7 @@ func @reverseOp(%arg0 : !custom.message) -> !custom.message {
 // -----
 
 // CHECK: vm.import @custom.get_unique_message
-// CHECK-LABEL: func @getUniqueMessageOp
+// CHECK-LABEL: @getUniqueMessageOp
 func @getUniqueMessageOp() -> !custom.message {
   // CHECK: %ref = vm.call @custom.get_unique_message() : () -> !vm.ref<!custom.message>
   %0 = "custom.get_unique_message"() : () -> !custom.message


### PR DESCRIPTION
hal.variable -> vm.global was not preserving visibility, and vm.func was
set as public even though they are all private by default.
There was also nasty double-spaced printing happening due to the custom
assembly format so I changed it to print the default visibility of
'public' when unspecified.