### PR TITLE
Adding -iree-vm-bytecode-source-listing= flag.

### DIFF
--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
@@ -39,6 +39,11 @@ struct BytecodeTargetOptions {
   // Run basic CSE/inlining/etc passes prior to serialization.
   bool optimize = true;
 
+  // Dump a VM MLIR file and annotate source locations with it.
+  // This allows for the runtime to serve stack traces referencing both the
+  // original source locations and the VM IR.
+  std::string sourceListing;
+
   // Strips all internal symbol names. Import and export names will remain.
   bool stripSymbols = false;
   // Strips source map information.

--- a/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
@@ -40,6 +40,12 @@ static llvm::cl::opt<bool> optimizeFlag{
     llvm::cl::init(true),
 };
 
+static llvm::cl::opt<std::string> sourceListingFlag{
+    "iree-vm-bytecode-source-listing",
+    llvm::cl::desc("Dump a VM MLIR file and annotate source locations with it"),
+    llvm::cl::init(""),
+};
+
 static llvm::cl::opt<bool> stripSymbolsFlag{
     "iree-vm-bytecode-module-strip-symbols",
     llvm::cl::desc("Strips all internal symbol names from the module"),
@@ -69,6 +75,7 @@ BytecodeTargetOptions getBytecodeTargetOptionsFromFlags() {
   BytecodeTargetOptions targetOptions;
   targetOptions.outputFormat = outputFormatFlag;
   targetOptions.optimize = optimizeFlag;
+  targetOptions.sourceListing = sourceListingFlag;
   targetOptions.stripSymbols = stripSymbolsFlag;
   targetOptions.stripSourceMap = stripSourceMapFlag;
   targetOptions.stripDebugOps = stripDebugOpsFlag;


### PR DESCRIPTION
This allows for a vm dialect dump immediately prior to serialization.
Source locations in the IR are tagged with the locations in the file.