### PR TITLE
Update TensorFlow mid-level input models used for benchmarking

### DIFF
--- a/benchmarks/TensorFlow/CMakeLists.txt
+++ b/benchmarks/TensorFlow/CMakeLists.txt
@@ -21,7 +21,7 @@ set(MOBILEBERT_FP16_MODULE
   "fp16"                          # MODULE_TAGS
   # This uses the same input MLIR source as fp32 to save download time.
   # It requires users to have "--iree-flow-demote-f32-to-f16".
-  "https://storage.googleapis.com/iree-model-artifacts/MobileBertSquad-810f6fdc.tar.gz" # MLIR_SOURCE
+  "https://storage.googleapis.com/iree-model-artifacts/MobileBertSquad-9e4b02e4b.tar.gz" # MLIR_SOURCE
   "serving_default"               # ENTRY_FUNCTION
   # The conversion done by "--iree-flow-demote-f32-to-f16" won't change the
   # original input signature.
@@ -31,7 +31,7 @@ set(MOBILEBERT_FP16_MODULE
 set(MOBILEBERT_FP32_MODULE
   "MobileBertSquad"               # MODULE_NAME
   "fp32"                          # MODULE_TAGS
-  "https://storage.googleapis.com/iree-model-artifacts/MobileBertSquad-810f6fdc.tar.gz" # MLIR_SOURCE
+  "https://storage.googleapis.com/iree-model-artifacts/MobileBertSquad-9e4b02e4b.tar.gz" # MLIR_SOURCE
   "serving_default"               # ENTRY_FUNCTION
   "1x384xi32,1x384xi32,1x384xi32" # FUNCTION_INPUTS
 )
@@ -39,7 +39,7 @@ set(MOBILEBERT_FP32_MODULE
 set(MOBILENET_V2_MODULE
   "MobileNetV2"     # MODULE_NAME
   "fp32,imagenet"   # MODULE_TAGS
-  "https://storage.googleapis.com/iree-model-artifacts/MobileNetV2-b0c5c584.tar.gz" # MLIR_SOURCE
+  "https://storage.googleapis.com/iree-model-artifacts/MobileNetV2-9e4b02e4b.tar.gz" # MLIR_SOURCE
   "call"            # ENTRY_FUNCTION
   "1x224x224x3xf32" # FUNCTION_INPUTS
 )
@@ -47,7 +47,7 @@ set(MOBILENET_V2_MODULE
 set(MOBILENET_V3SMALL_MODULE
   "MobileNetV3Small" # MODULE_NAME
   "fp32,imagenet"    # MODULE_TAGS
-  "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3Small-b0c5c584.tar.gz" # MLIR_SOURCE
+  "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3Small-9e4b02e4b.tar.gz" # MLIR_SOURCE
   "call"             # ENTRY_FUNCTION
   "1x224x224x3xf32"  # FUNCTION_INPUTS
 )


### PR DESCRIPTION
This commit regenerates all TensorFlow mid-level input models
using `*-import` binaries and Python bindings built from IREE
source at commit 9e4b02e4b.