### PR TITLE
Adding bytecode debug databases.

### DIFF
--- a/iree/compiler/Dialect/VM/Target/Bytecode/BUILD
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BUILD
@@ -12,6 +12,8 @@ cc_library(
         "BytecodeModuleTarget.cpp",
         "ConstantEncoder.cpp",
         "ConstantEncoder.h",
+        "DebugDatabaseBuilder.cpp",
+        "DebugDatabaseBuilder.h",
         "TranslationFlags.cpp",
         "TranslationRegistration.cpp",
     ],

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Dialect/VM/IR/VMFuncEncoder.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.h"
 #include "mlir/IR/SymbolTable.h"
 
 namespace mlir {
@@ -17,8 +18,13 @@ namespace IREE {
 namespace VM {
 
 struct EncodedBytecodeFunction {
+  // Encoded bytecode data for the function body.
   std::vector<uint8_t> bytecodeData;
+
+  // Total i32 register slots required for execution.
+  // Note that larger types also use these slots (i64=2xi32).
   uint16_t i32RegisterCount = 0;
+  // Total vm.ref register slots required for execution.
   uint16_t refRegisterCount = 0;
 };
 
@@ -29,7 +35,7 @@ class BytecodeEncoder : public VMFuncEncoder {
   // Returns None on failure.
   static Optional<EncodedBytecodeFunction> encodeFunction(
       IREE::VM::FuncOp funcOp, llvm::DenseMap<Type, int> &typeTable,
-      SymbolTable &symbolTable);
+      SymbolTable &symbolTable, DebugDatabaseBuilder &debugDatabase);
 
   BytecodeEncoder() = default;
   ~BytecodeEncoder() = default;

--- a/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/CMakeLists.txt
@@ -22,6 +22,8 @@ iree_cc_library(
     "BytecodeModuleTarget.cpp"
     "ConstantEncoder.cpp"
     "ConstantEncoder.h"
+    "DebugDatabaseBuilder.cpp"
+    "DebugDatabaseBuilder.h"
     "TranslationFlags.cpp"
     "TranslationRegistration.cpp"
   DEPS

--- a/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.cpp
@@ -1,0 +1,142 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VM {
+
+void DebugDatabaseBuilder::addFunctionSourceMap(IREE::VM::FuncOp funcOp,
+                                                FunctionSourceMap sourceMap) {
+  uint64_t ordinal = funcOp.ordinal().getValueOr(APInt(64, 0)).getZExtValue();
+  if (functionSourceMaps.size() <= ordinal) {
+    functionSourceMaps.resize(ordinal + 1);
+  }
+  functionSourceMaps[ordinal] = std::move(sourceMap);
+}
+
+struct LocationTable {
+  explicit LocationTable(FlatbufferBuilder &fbb) : fbb(fbb) {}
+
+  FlatbufferBuilder &fbb;
+
+  // String table.
+  DenseMap<StringRef, flatbuffers_string_ref_t> strings;
+  // All serialized location entries.
+  SmallVector<iree_vm_LocationTypeDef_union_ref_t> entries;
+  // Map of uniqued location to the entry in the table.
+  DenseMap<Location, int32_t> map;
+
+  // Inserts a string into the location table string subtable if needed.
+  flatbuffers_string_ref_t insert(StringRef value) {
+    auto it = strings.find(value);
+    if (it != strings.end()) return it->second;
+    auto stringRef = fbb.createString(value);
+    strings[value] = stringRef;
+    return stringRef;
+  }
+
+  // Inserts a location into the location table if it does not already exist.
+  // Returns the ordinal of the location in the table.
+  int32_t insert(Location baseLoc) {
+    auto it = map.find(baseLoc);
+    if (it != map.end()) return it->second;
+    auto locationRef =
+        llvm::TypeSwitch<Location, iree_vm_LocationTypeDef_union_ref_t>(baseLoc)
+            .Case([&](CallSiteLoc loc) {
+              auto callee = insert(loc.getCallee());
+              auto caller = insert(loc.getCaller());
+              return iree_vm_LocationTypeDef_as_CallSiteLocDef(
+                  iree_vm_CallSiteLocDef_create(fbb, callee, caller));
+            })
+            .Case([&](FileLineColLoc loc) {
+              return iree_vm_LocationTypeDef_as_FileLineColLocDef(
+                  iree_vm_FileLineColLocDef_create(
+                      fbb, insert(loc.getFilename()), loc.getLine(),
+                      loc.getColumn()));
+            })
+            .Case([&](FusedLoc loc) {
+              flatbuffers_string_ref_t metadataRef = 0;
+              if (loc.getMetadata()) {
+                std::string str;
+                llvm::raw_string_ostream os(str);
+                loc.getMetadata().print(os);
+                metadataRef = insert(os.str());
+              }
+              SmallVector<int32_t> childLocs;
+              childLocs.reserve(loc.getLocations().size());
+              for (auto childLoc : loc.getLocations()) {
+                childLocs.push_back(insert(childLoc));
+              }
+              auto childLocsRef = flatbuffers_int32_vec_create(
+                  fbb, childLocs.data(), childLocs.size());
+              iree_vm_FusedLocDef_start(fbb);
+              iree_vm_FusedLocDef_metadata_add(fbb, metadataRef);
+              iree_vm_FusedLocDef_locations_add(fbb, childLocsRef);
+              return iree_vm_LocationTypeDef_as_FusedLocDef(
+                  iree_vm_FusedLocDef_end(fbb));
+            })
+            .Case([&](NameLoc loc) {
+              return iree_vm_LocationTypeDef_as_NameLocDef(
+                  iree_vm_NameLocDef_create(fbb, insert(loc.getName()),
+                                            insert(loc.getChildLoc())));
+            })
+            .Default(
+                [](Location loc) { return iree_vm_LocationTypeDef_as_NONE(); });
+    int32_t ordinal = static_cast<int32_t>(entries.size());
+    map[baseLoc] = ordinal;
+    entries.push_back(locationRef);
+    return ordinal;
+  }
+
+  iree_vm_LocationTypeDef_union_vec_ref_t finish() {
+    return iree_vm_LocationTypeDef_vec_create(fbb, entries.data(),
+                                              entries.size());
+  }
+};
+
+iree_vm_DebugDatabaseDef_ref_t DebugDatabaseBuilder::build(
+    FlatbufferBuilder &fbb) {
+  if (functionSourceMaps.empty()) return 0;
+
+  LocationTable locationTable(fbb);
+
+  // functions:[FunctionSourceMapDef]
+  SmallVector<iree_vm_FunctionSourceMapDef_ref_t> functionRefs;
+  for (auto &sourceMap : functionSourceMaps) {
+    SmallVector<iree_vm_BytecodeLocationDef_t> locationDefs;
+    locationDefs.resize(sourceMap.locations.size());
+    for (size_t i = 0; i < sourceMap.locations.size(); ++i) {
+      locationDefs[i].bytecode_offset = sourceMap.locations[i].bytecodeOffset;
+      locationDefs[i].location =
+          locationTable.insert(sourceMap.locations[i].location);
+    }
+    auto locationsRef = iree_vm_BytecodeLocationDef_vec_create(
+        fbb, locationDefs.data(), locationDefs.size());
+    functionRefs.push_back(
+        iree_vm_FunctionSourceMapDef_create(fbb, locationsRef));
+  }
+  auto functionsRef = iree_vm_FunctionSourceMapDef_vec_create(
+      fbb, functionRefs.data(), functionRefs.size());
+
+  // location_table:[LocationTypeDef]
+  auto locationTableRef = locationTable.finish();
+
+  // DebugDatabaseDef
+  iree_vm_DebugDatabaseDef_start(fbb);
+  iree_vm_DebugDatabaseDef_location_table_add(fbb, locationTableRef);
+  iree_vm_DebugDatabaseDef_functions_add(fbb, functionsRef);
+  return iree_vm_DebugDatabaseDef_end(fbb);
+}
+
+}  // namespace VM
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/DebugDatabaseBuilder.h
@@ -1,0 +1,49 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_VM_TARGET_BYTECODE_DEBUGDATABASEBUILDER_H_
+#define IREE_COMPILER_DIALECT_VM_TARGET_BYTECODE_DEBUGDATABASEBUILDER_H_
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Utils/FlatbufferUtils.h"
+#include "iree/schemas/bytecode_module_def_builder.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Location.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VM {
+
+struct BytecodeLocation {
+  int32_t bytecodeOffset;
+  Location location;
+};
+
+struct FunctionSourceMap {
+  SmallVector<BytecodeLocation> locations;
+};
+
+class DebugDatabaseBuilder {
+ public:
+  // Appends a function source map entry to the debug database.
+  void addFunctionSourceMap(IREE::VM::FuncOp funcOp,
+                            FunctionSourceMap sourceMap);
+
+  // Finishes construction of the debug database and emits it to the flatbuffer.
+  iree_vm_DebugDatabaseDef_ref_t build(FlatbufferBuilder &fbb);
+
+ private:
+  // Function source maps ordered by function ordinal.
+  SmallVector<FunctionSourceMap> functionSourceMaps;
+};
+
+}  // namespace VM
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_VM_TARGET_BYTECODE_DEBUGDATABASEBUILDER_H_

--- a/iree/schemas/bytecode_module_def.fbs
+++ b/iree/schemas/bytecode_module_def.fbs
@@ -116,11 +116,68 @@ struct FunctionDescriptor {
   // Offset and length within the larger bytecode data block.
   bytecode_offset:int32;
   bytecode_length:int32;
+
   // TODO(benvanik): remove counts and embed directly in bytecode.
   // Total number of i32 registers used by the function.
   i32_register_count:int16;
   // Total number of ref registers used by the function.
   ref_register_count:int16;
+}
+
+// mlir/IR/BuiltinLocationAttributes.td : CallSiteLoc
+table CallSiteLocDef {
+  callee:int32;
+  caller:int32;
+}
+
+// mlir/IR/BuiltinLocationAttributes.td : FileLineColLoc
+table FileLineColLocDef {
+  filename:string;
+  line:int32;
+  column:int32;
+}
+
+// mlir/IR/BuiltinLocationAttributes.td : FusedLoc
+table FusedLocDef {
+  metadata:string;
+  locations:[int32];
+}
+
+// mlir/IR/BuiltinLocationAttributes.td : FusedLoc
+table NameLocDef {
+  name:string;
+  child_location:int32;
+}
+
+// A location - possibly nested.
+union LocationTypeDef {
+  CallSiteLocDef,
+  FileLineColLocDef,
+  FusedLocDef,
+  NameLocDef,
+}
+
+// Maps a relative bytecode offset within a function to a source location.
+struct BytecodeLocationDef {
+  // Bytecode offset of the start of the operation.
+  bytecode_offset:int32;
+  // Index into the debug database location_table.
+  location:int32;
+}
+
+// Debug data for a single function mapping back into source IR.
+table FunctionSourceMapDef {
+  // Operation locations for all ops within the function.
+  locations:[BytecodeLocationDef];
+}
+
+// VM debug information database.
+table DebugDatabaseDef {
+  // Location table. Source maps reference this table.
+  location_table:[LocationTypeDef];
+
+  // Internal function source maps; 1:1 with the module function_descriptors.
+  functions:[FunctionSourceMapDef];
 }
 
 // Defines a bytecode module containing the information required to serve the
@@ -176,6 +233,9 @@ table BytecodeModuleDef {
 
   // Bytecode contents. One large buffer containing all of the function op data.
   bytecode_data:[uint8];
+
+  // Optional module debug database.
+  debug_database:DebugDatabaseDef;
 }
 
 root_type BytecodeModuleDef;


### PR DESCRIPTION
These - when not stripping - will embed function bytecode locations.
These faithfully mirror the Location types in MLIR. It's up to the runtime
tooling to interpret them for presentation.

This is not a great format: it does do basic string and location deduping
but this really calls for delta-coded bytecode offsets and inlining of
file line/col values. But there's zero reason to deploy this and 95% of
the IR in our modules is folded into rodata executable blobs so this is
fine for now.

Future changes will introduce the runtime wrappers. TBD is register
mappings (simulating "locals") and type information.

Fixes #1199. (enough to call it done for now)
Progress on #55.