### PR TITLE
Create a first-class IREE compiler C and Python API.

### DIFF
--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -28,19 +28,6 @@
 namespace mlir {
 namespace iree_compiler {
 
-// TODO(#3817): move all of this code to the iree-compile driver/API.
-// Breaking this up such that for development iree-opt runs all passes/pipelines
-// and iree-translate strictly does the VM dialect to bytecode/emitc files will
-// match upstream better, and then our own iree-compile C API/binary will do the
-// whole end-to-end with options for bindings/targets/etc.
-struct BindingOptions {
-  // Whether to include runtime support functions for the IREE native ABI.
-  bool native = true;
-  // Whether to include runtime support functions required for the IREE TFLite
-  // API compatibility bindings.
-  bool tflite = false;
-};
-
 static BindingOptions getBindingOptionsFromFlags() {
   static llvm::cl::OptionCategory bindingOptionsCategory(
       "IREE translation binding support options");
@@ -62,27 +49,6 @@ static BindingOptions getBindingOptionsFromFlags() {
   bindingOptions.tflite = *bindingsTFLiteFlag;
   return bindingOptions;
 }
-
-// The transformation to apply to the input prior to main compiler execution.
-// These input pipelines are purposefully primitive and mainly focused on
-// test case/reproducers as opposed to anything that should be coming from
-// a user. For user/framework level interfacing, a dedicated importer likely
-// needs to be created in order to represent whole-module level framework
-// quirks. These are just about the ops in the functions.
-struct InputDialectOptions {
-  enum class Type {
-    // Applies no input transformation. Only supported core and extension ops
-    // are supported.
-    none,
-
-    // Legalizes input defined over TOSA ops.
-    tosa,
-
-    // Legalizes input defined over MHLO ops.
-    mhlo,
-  };
-  Type type;
-};
 
 static InputDialectOptions getInputDialectOptionsFromFlags() {
   static llvm::cl::OptionCategory inputDialectOptions(
@@ -157,7 +123,7 @@ static LogicalResult convertToVMModule(ModuleOp moduleOp,
   return success();
 }
 
-static void buildIREEVMTransformPassPipeline(
+void buildIREEVMTransformPassPipeline(
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions, OpPassManager &passManager) {

--- a/iree/compiler/Translation/IREEVM.h
+++ b/iree/compiler/Translation/IREEVM.h
@@ -18,11 +18,53 @@
 namespace mlir {
 namespace iree_compiler {
 
+// TODO(#3817): move all of this code to the iree-compile driver/API.
+// Breaking this up such that for development iree-opt runs all passes/pipelines
+// and iree-translate strictly does the VM dialect to bytecode/emitc files will
+// match upstream better, and then our own iree-compile C API/binary will do the
+// whole end-to-end with options for bindings/targets/etc.
+struct BindingOptions {
+  // Whether to include runtime support functions for the IREE native ABI.
+  bool native = true;
+  // Whether to include runtime support functions required for the IREE TFLite
+  // API compatibility bindings.
+  bool tflite = false;
+};
+
+// The transformation to apply to the input prior to main compiler execution.
+// These input pipelines are purposefully primitive and mainly focused on
+// test case/reproducers as opposed to anything that should be coming from
+// a user. For user/framework level interfacing, a dedicated importer likely
+// needs to be created in order to represent whole-module level framework
+// quirks. These are just about the ops in the functions.
+struct InputDialectOptions {
+  enum class Type {
+    // Applies no input transformation. Only supported core and extension ops
+    // are supported.
+    none,
+
+    // Legalizes input defined over TOSA ops.
+    tosa,
+
+    // Legalizes input defined over MHLO ops.
+    mhlo,
+  };
+  Type type = Type::none;
+};
+
+// Builds the translation pipeline with defaults.
+void buildDefaultIREEVMTransformPassPipeline(OpPassManager &passManager);
+
+// Builds the translation pipeline with explicit options.
+void buildIREEVMTransformPassPipeline(
+    BindingOptions bindingOptions, InputDialectOptions inputOptions,
+    IREE::HAL::TargetOptions executableOptions,
+    IREE::VM::TargetOptions targetOptions, OpPassManager &passManager);
+
+// Registration hooks.
 void registerIREEVMTransformPassPipeline();
 void registerIREEVMTranslation();
 void registerIREEVMTranslationFlags();
-
-void buildDefaultIREEVMTransformPassPipeline(OpPassManager &passManager);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/llvm-projects/iree-compiler-api/CMakeLists.txt
+++ b/llvm-projects/iree-compiler-api/CMakeLists.txt
@@ -100,10 +100,18 @@ add_system_include_hack(${LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR}/include)
 add_system_include_hack(${LLVM_MAIN_BINARY_DIR}/tools/iree-dialects/include)
 add_system_include_hack(${LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR}/include)
 add_system_include_hack(${LLVM_MAIN_BINARY_DIR}/tools/mlir-hlo/include)
+add_system_include_hack(${IREE_COMPILER_API_SOURCE_DIR}/include)
+
+function(iree_compiler_target_includes target)
+  target_include_directories(${target} PUBLIC
+    $<BUILD_INTERFACE:${IREE_COMPILER_API_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${IREE_COMPILER_API_BINARY_DIR}/include>
+  )
+endfunction()
 
 # Common CMake module paths.
 list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
-list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake/modules)
 
 # Configure Python3 deps so that everyone downstream of here latches to the same
 # thing.
@@ -122,4 +130,8 @@ message(STATUS "Configuring IREE from (${IREE_MAIN_SOURCE_DIR} into ${IREE_MAIN_
 add_subdirectory("${IREE_MAIN_SOURCE_DIR}" "${IREE_MAIN_BINARY_DIR}" EXCLUDE_FROM_ALL)
 
 # Sub-directories.
+# Since building outside of the LLVM build system, setup options for local
+# sources.
+include(HandleLLVMOptions)
+add_subdirectory(lib)
 add_subdirectory(python)

--- a/llvm-projects/iree-compiler-api/build_tools/smoketest.py
+++ b/llvm-projects/iree-compiler-api/build_tools/smoketest.py
@@ -4,17 +4,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import io
+
 from iree.compiler import ir
+from iree.compiler import passmanager
 from iree.compiler.dialects import chlo
 from iree.compiler.dialects import mhlo
 from iree.compiler.dialects import iree_public
 from iree.compiler.dialects import builtin
 from iree.compiler.dialects import std
 from iree.compiler.dialects import linalg
-try:
-  from iree.compiler.dialects import linalg
-except ImportError as e:
-  print("KNOWN ISSUE: Linalg has an absolute path dependency issue:", e)
+from iree.compiler.dialects import linalg
 from iree.compiler.dialects import math
 from iree.compiler.dialects import memref
 from iree.compiler.dialects import shape
@@ -22,17 +22,31 @@ from iree.compiler.dialects import tensor
 from iree.compiler.dialects import tosa
 from iree.compiler.dialects import vector
 
+from iree.compiler.api import driver
+
 with ir.Context() as ctx:
-  try:
-    chlo.register_chlo_dialect(ctx)
-  except ImportError as e:
-    print(
-        "KNOWN ISSUE: For hidden visibility builds extensions need "
-        "an explicit dep on LLVMSupport (chlo):", e)
-  try:
-    mhlo.register_mhlo_dialect(ctx)
-  except ImportError as e:
-    print(
-        "KNOWN ISSUE: For hidden visibility builds extensions need "
-        "an explicit dep on LLVMSupport (mhlo):", e)
+  chlo.register_chlo_dialect(ctx)
+  mhlo.register_mhlo_dialect(ctx)
   iree_public.register_iree_public_dialect(ctx)
+
+  input_module = ir.Module.parse(r"""
+    builtin.module  {
+      builtin.func @fabs(%arg0: tensor<1x4xf32>, %arg1: tensor<4x1xf32>) -> tensor<4x4xf32> {
+        %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<1x4xf32>, tensor<4x1xf32>) -> tensor<4x4xf32>
+        %1 = "mhlo.abs"(%0) : (tensor<4x4xf32>) -> tensor<4x4xf32>
+        return %1 : tensor<4x4xf32>
+      }
+    }
+  """)
+
+  options = driver.CompilerOptions()
+  options.set_input_dialect_mhlo()
+  options.add_target_backend("cpu")
+  pm = passmanager.PassManager()
+  driver.build_iree_vm_pass_pipeline(options, pm)
+  pm.run(input_module)
+
+  print(input_module)
+  bytecode_io = io.BytesIO()
+  driver.translate_module_to_vm_bytecode(options, input_module, bytecode_io)
+  print(f"Bytecode module len = {len(bytecode_io.getbuffer())}")

--- a/llvm-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
+++ b/llvm-projects/iree-compiler-api/include/iree-compiler-c/Compiler.h
@@ -1,0 +1,67 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_PROJECTS_IREE_COMPILER_API_COMPILER_H
+#define IREE_LLVM_PROJECTS_IREE_COMPILER_API_COMPILER_H
+
+#include "mlir-c/Pass.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEFINE_C_API_STRUCT(name, storage) \
+  struct name {                            \
+    storage *ptr;                          \
+  };                                       \
+  typedef struct name name
+
+DEFINE_C_API_STRUCT(IreeCompilerOptions, void);
+
+//===----------------------------------------------------------------------===//
+// Registration.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED void ireeCompilerRegisterTargetBackends();
+
+//===----------------------------------------------------------------------===//
+// Compiler options.
+//===----------------------------------------------------------------------===//
+
+// Creates and destroys a compiler options structure.
+MLIR_CAPI_EXPORTED IreeCompilerOptions ireeCompilerOptionsCreate();
+MLIR_CAPI_EXPORTED void ireeCompilerOptionsDestroy(IreeCompilerOptions options);
+
+MLIR_CAPI_EXPORTED void ireeCompilerOptionsSetInputDialectMHLO(
+    IreeCompilerOptions options);
+MLIR_CAPI_EXPORTED void ireeCompilerOptionsSetInputDialectTOSA(
+    IreeCompilerOptions options);
+MLIR_CAPI_EXPORTED void ireeCompilerOptionsAddTargetBackend(
+    IreeCompilerOptions options, const char *targetBackend);
+
+//===----------------------------------------------------------------------===//
+// Compiler stages.
+//===----------------------------------------------------------------------===//
+
+// Builds a pass manager for transforming from an input module op to the IREE VM
+// dialect. This represents the primary compilation stage with serialization to
+// specific formats following.
+MLIR_CAPI_EXPORTED void ireeCompilerBuildIREEVMPassPipeline(
+    IreeCompilerOptions options, MlirOpPassManager passManager);
+
+// Translates a module op derived from the ireeCompilerBuildIREEVMPassPipeline
+// to serialized bytecode. The module op may either be an outer builtin ModuleOp
+// wrapping a VM::ModuleOp or a VM::ModuleOp.
+MLIR_CAPI_EXPORTED MlirLogicalResult ireeCompilerTranslateModuletoVMBytecode(
+    IreeCompilerOptions options, MlirOperation moduleOp,
+    MlirStringCallback dataCallback, void *dataUserObject);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // IREE_LLVM_PROJECTS_IREE_COMPILER_API_COMPILER_H

--- a/llvm-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
+++ b/llvm-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_mlir_public_c_api_library(IREECompilerAPICompilerCAPI
+  Compiler.cpp
+  # TODO: If installing, complains about IREEVM not being in any export set.
+  DISABLE_INSTALL
+  LINK_COMPONENTS
+    Support
+  LINK_LIBS PUBLIC
+    MLIRIR
+    iree::compiler::Dialect::VM::IR::IR
+    iree::compiler::Dialect::VM::Target::Bytecode::Bytecode
+    iree::compiler::Translation::IREEVM
+
+    # All HAL Targets.
+    iree::tools::init_targets
+)
+
+# TODO: Fix upstream so there is a way to know what the actual compile target
+# is (versus prefixing with "obj." which is conditional).
+iree_compiler_target_includes(obj.IREECompilerAPICompilerCAPI)

--- a/llvm-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
+++ b/llvm-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
@@ -1,0 +1,102 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-compiler-c/Compiler.h"
+
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h"
+#include "iree/compiler/Translation/IREEVM.h"
+#include "iree/tools/init_targets.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Pass.h"
+#include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Utils.h"
+#include "mlir/CAPI/Wrap.h"
+#include "mlir/IR/BuiltinOps.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+// TODO: There is a loose ::IREE namespace somewhere which means that we
+// have to fully qualify from the unnamed namespace.
+using HALTargetOptions = mlir::iree_compiler::IREE::HAL::TargetOptions;
+using VMTargetOptions = mlir::iree_compiler::IREE::VM::TargetOptions;
+using VMBytecodeTargetOptions =
+    mlir::iree_compiler::IREE::VM::BytecodeTargetOptions;
+
+namespace {
+// We have one composite options struct for everything. Not all components
+// are applicable to every translation.
+struct CompilerOptions {
+  BindingOptions bindingOptions;
+  InputDialectOptions inputDialectOptions;
+  HALTargetOptions executableOptions;
+  VMTargetOptions vmTargetOptions;
+  VMBytecodeTargetOptions vmBytecodeTargetOptions;
+};
+}  // namespace
+
+DEFINE_C_API_PTR_METHODS(IreeCompilerOptions, CompilerOptions)
+
+void ireeCompilerRegisterTargetBackends() { registerHALTargetBackends(); }
+
+IreeCompilerOptions ireeCompilerOptionsCreate() {
+  return wrap(new CompilerOptions);
+}
+
+void ireeCompilerOptionsDestroy(IreeCompilerOptions options) {
+  delete unwrap(options);
+}
+
+void ireeCompilerOptionsAddTargetBackend(IreeCompilerOptions options,
+                                         const char *targetBackend) {
+  unwrap(options)->executableOptions.targets.push_back(
+      std::string(targetBackend));
+}
+
+void ireeCompilerOptionsSetInputDialectMHLO(IreeCompilerOptions options) {
+  unwrap(options)->inputDialectOptions.type = InputDialectOptions::Type::mhlo;
+}
+
+void ireeCompilerOptionsSetInputDialectTOSA(IreeCompilerOptions options) {
+  unwrap(options)->inputDialectOptions.type = InputDialectOptions::Type::tosa;
+}
+
+void ireeCompilerBuildIREEVMPassPipeline(IreeCompilerOptions options,
+                                         MlirOpPassManager passManager) {
+  auto *optionsCpp = unwrap(options);
+  auto *passManagerCpp = unwrap(passManager);
+  buildIREEVMTransformPassPipeline(
+      optionsCpp->bindingOptions, optionsCpp->inputDialectOptions,
+      optionsCpp->executableOptions, optionsCpp->vmTargetOptions,
+      *passManagerCpp);
+}
+
+// Translates a module op derived from the ireeCompilerBuildIREEVMPassPipeline
+// to serialized bytecode. The module op may either be an outer builtin ModuleOp
+// wrapping a VM::ModuleOp or a VM::ModuleOp.
+MlirLogicalResult ireeCompilerTranslateModuletoVMBytecode(
+    IreeCompilerOptions options, MlirOperation moduleOp,
+    MlirStringCallback dataCallback, void *dataUserObject) {
+  auto *optionsCpp = unwrap(options);
+  Operation *moduleOpCpp = unwrap(moduleOp);
+  LogicalResult result = failure();
+
+  mlir::detail::CallbackOstream output(dataCallback, dataUserObject);
+  if (auto op = llvm::dyn_cast<mlir::ModuleOp>(moduleOpCpp)) {
+    result = iree_compiler::IREE::VM::translateModuleToBytecode(
+        op, optionsCpp->vmBytecodeTargetOptions, output);
+  } else if (auto op = llvm::dyn_cast<iree_compiler::IREE::VM::ModuleOp>(
+                 moduleOpCpp)) {
+    result = iree_compiler::IREE::VM::translateModuleToBytecode(
+        op, optionsCpp->vmBytecodeTargetOptions, output);
+  } else {
+    emitError(moduleOpCpp->getLoc()) << "expected a supported module operation";
+    result = failure();
+  }
+
+  return wrap(result);
+}

--- a/llvm-projects/iree-compiler-api/lib/CMakeLists.txt
+++ b/llvm-projects/iree-compiler-api/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CAPI)

--- a/llvm-projects/iree-compiler-api/python/CMakeLists.txt
+++ b/llvm-projects/iree-compiler-api/python/CMakeLists.txt
@@ -1,10 +1,41 @@
 include(AddMLIRPython)
 
 ################################################################################
+# Sources
+################################################################################
+
+declare_mlir_python_sources(IREECompilerAPIPythonSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/iree/compiler"
+  SOURCES
+    api/driver.py
+    version.py
+)
+declare_mlir_python_sources(IREECompilerAPIPythonExtensions)
+
+################################################################################
+# Extensions
+################################################################################
+
+declare_mlir_python_extension(IREECompilerAPIPythonExtensions.CompilerDriver
+  MODULE_NAME _ireeCompilerDriver
+  ADD_TO_PARENT IREECompilerAPIPythonExtensions
+  SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/CompilerModule.cpp
+  EMBED_CAPI_LINK_LIBS
+    IREECompilerAPICompilerCAPI
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
+################################################################################
 # Generate packages and shared library
 ################################################################################
 
 set(_source_components
+  # Local sources.
+  IREECompilerAPIPythonSources
+  IREECompilerAPIPythonExtensions
+
   # TODO: Core is now implicitly building/registering all dialects, increasing
   # build burden by ~5x. Make it stop.
   MLIRPythonSources.Core

--- a/llvm-projects/iree-compiler-api/python/CompilerModule.cpp
+++ b/llvm-projects/iree-compiler-api/python/CompilerModule.cpp
@@ -1,0 +1,104 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-compiler-c/Compiler.h"
+#include "mlir-c/Bindings/Python/Interop.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+namespace py = pybind11;
+
+namespace {
+
+struct PyCompilerOptions {
+  PyCompilerOptions() : options(ireeCompilerOptionsCreate()) {}
+  PyCompilerOptions(const PyCompilerOptions &) = delete;
+  void operator=(const PyCompilerOptions &) = delete;
+  PyCompilerOptions(PyCompilerOptions &&other) : options(other.options) {
+    other.options = {nullptr};
+  }
+  ~PyCompilerOptions() {
+    if (options.ptr) ireeCompilerOptionsDestroy(options);
+  }
+  IreeCompilerOptions options;
+};
+
+/// Accumulates int a python file-like object, either writing text (default)
+/// or binary.
+class PyFileAccumulator {
+ public:
+  PyFileAccumulator(pybind11::object fileObject, bool binary)
+      : pyWriteFunction(fileObject.attr("write")), binary(binary) {}
+
+  void *getUserData() { return this; }
+
+  MlirStringCallback getCallback() {
+    return [](MlirStringRef part, void *userData) {
+      pybind11::gil_scoped_acquire();
+      PyFileAccumulator *accum = static_cast<PyFileAccumulator *>(userData);
+      if (accum->binary) {
+        // Note: Still has to copy and not avoidable with this API.
+        pybind11::bytes pyBytes(part.data, part.length);
+        accum->pyWriteFunction(pyBytes);
+      } else {
+        pybind11::str pyStr(part.data,
+                            part.length);  // Decodes as UTF-8 by default.
+        accum->pyWriteFunction(pyStr);
+      }
+    };
+  }
+
+ private:
+  pybind11::object pyWriteFunction;
+  bool binary;
+};
+
+}  // namespace
+
+PYBIND11_MODULE(_ireeCompilerDriver, m) {
+  m.doc() = "iree-compiler driver api";
+  ireeCompilerRegisterTargetBackends();
+
+  py::class_<PyCompilerOptions>(m, "CompilerOptions")
+      .def(py::init<>())
+      .def("set_input_dialect_mhlo",
+           [](PyCompilerOptions &self) {
+             ireeCompilerOptionsSetInputDialectMHLO(self.options);
+           })
+      .def("set_input_dialect_tosa",
+           [](PyCompilerOptions &self) {
+             ireeCompilerOptionsSetInputDialectTOSA(self.options);
+           })
+      .def(
+          "add_target_backend",
+          [](PyCompilerOptions &self, const std::string &targetBackend) {
+            ireeCompilerOptionsAddTargetBackend(self.options,
+                                                targetBackend.c_str());
+          },
+          py::arg("target_backend"));
+
+  m.def(
+      "build_iree_vm_pass_pipeline",
+      [](PyCompilerOptions &options, MlirPassManager passManager) {
+        MlirOpPassManager opPassManager =
+            mlirPassManagerGetAsOpPassManager(passManager);
+        ireeCompilerBuildIREEVMPassPipeline(options.options, opPassManager);
+      },
+      py::arg("options"), py::arg("pass_manager"));
+
+  m.def(
+      "translate_module_to_vm_bytecode",
+      [](PyCompilerOptions &options, MlirModule module, py::object file) {
+        PyFileAccumulator accum(file, /*binary=*/true);
+        MlirOperation operation = mlirModuleGetOperation(module);
+        auto result = ireeCompilerTranslateModuletoVMBytecode(
+            options.options, operation, accum.getCallback(),
+            accum.getUserData());
+        if (mlirLogicalResultIsFailure(result)) {
+          throw std::runtime_error("failure translating module to bytecode");
+        }
+      },
+      py::arg("options"), py::arg("module"), py::arg("file"));
+}

--- a/llvm-projects/iree-compiler-api/python/iree/compiler/api/driver.py
+++ b/llvm-projects/iree-compiler-api/python/iree/compiler/api/driver.py
@@ -1,0 +1,7 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .._mlir_libs._ireeCompilerDriver import *

--- a/llvm-projects/iree-compiler-api/setup.py
+++ b/llvm-projects/iree-compiler-api/setup.py
@@ -70,7 +70,7 @@ class CMakeBuildPy(_build_py):
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
-    subprocess.check_call(["cmake", "--build", ".", "--target", "install"] +
+    subprocess.check_call(["cmake", "--build", ".", "--target", "install/strip"] +
                           build_args,
                           cwd=cmake_build_dir)
     shutil.copytree(os.path.join(cmake_install_dir, "python_package"),

--- a/llvm-projects/iree-compiler-api/setup.py
+++ b/llvm-projects/iree-compiler-api/setup.py
@@ -70,9 +70,9 @@ class CMakeBuildPy(_build_py):
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
-    subprocess.check_call(["cmake", "--build", ".", "--target", "install/strip"] +
-                          build_args,
-                          cwd=cmake_build_dir)
+    subprocess.check_call(
+        ["cmake", "--build", ".", "--target", "install/strip"] + build_args,
+        cwd=cmake_build_dir)
     shutil.copytree(os.path.join(cmake_install_dir, "python_package"),
                     target_dir,
                     symlinks=False,


### PR DESCRIPTION
* In-memory interop with MLIR C and Python API objects.
* Exposes a low-level driver API for constructing pass pipelines, options, translating/emitting (expect a higher level user API similar to what we already have which shells out to iree-translate).
* Includes access to all dialects that IREE can input.
* Minimal options plumbed through.
* Does not yet plumb through other exits (i.e. emit-c).
* It would be nice to do some more code organization on the C++ side, but that doesn't change the C-API.
* Will create a CLI later which uses the C-API (which can dynamic link and save us space).