### PR TITLE
Adding runtime VM backtraces.

### DIFF
--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -159,6 +159,11 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 //
 // See the `-iree-vm-target-extension=` compiler option for more information.
 
+#if !defined(IREE_VM_BACKTRACE_ENABLE)
+// Enables backtraces in VM failures when debugging information is available.
+#define IREE_VM_BACKTRACE_ENABLE 1
+#endif  // !IREE_VM_BACKTRACE_ENABLE
+
 #if !defined(IREE_VM_EXT_I64_ENABLE)
 // Enables the 64-bit integer instruction extension.
 // Targeted from the compiler with `-iree-vm-target-extension=i64`.

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -56,6 +56,9 @@ static iree_status_t iree_vm_context_run_function(
 
   iree_vm_execution_result_t result;
   status = module->begin_call(module->self, stack, &call, &result);
+  if (!iree_status_is_ok(status)) {
+    status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
+  }
 
   // TODO(benvanik): ensure completed synchronously.
 

--- a/iree/vm/invocation.c
+++ b/iree/vm/invocation.c
@@ -210,6 +210,9 @@ IREE_API_EXPORT iree_status_t iree_vm_invoke(
       stack, iree_vm_context_state_resolver(context), allocator);
   iree_status_t status =
       iree_vm_invoke_within(context, stack, function, policy, inputs, outputs);
+  if (!iree_status_is_ok(status)) {
+    status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
+  }
   iree_vm_stack_deinitialize(stack);
 
   IREE_TRACE_ZONE_END(z0);

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -12,6 +12,8 @@
 
 #include "iree/base/alignment.h"
 #include "iree/base/api.h"
+#include "iree/base/attributes.h"
+#include "iree/base/string_builder.h"
 #include "iree/base/tracing.h"
 #include "iree/vm/module.h"
 #include "iree/vm/ref.h"
@@ -202,6 +204,24 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_function_enter(
 // Leaves the current stack frame.
 IREE_API_EXPORT iree_status_t
 iree_vm_stack_function_leave(iree_vm_stack_t* stack);
+
+// Formats a backtrace of the current stack to the given string |builder|.
+IREE_API_EXPORT iree_status_t iree_vm_stack_format_backtrace(
+    iree_vm_stack_t* stack, iree_string_builder_t* builder);
+
+// Annotates |status| with the backtrace of |stack| and returns |base_status|.
+IREE_API_EXPORT IREE_MUST_USE_RESULT iree_status_t
+iree_vm_stack_annotate_backtrace(iree_vm_stack_t* stack,
+                                 iree_status_t base_status);
+
+#if IREE_VM_BACKTRACE_ENABLE && \
+    (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS)
+#define IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, base_status) \
+  iree_vm_stack_annotate_backtrace(stack, base_status)
+#else
+#define IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, base_status) \
+  (base_status)
+#endif  // IREE_VM_BACKTRACE_ENABLE && IREE_STATUS_FEATURE_ANNOTATIONS
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
These annotate status messages from within VM invocations with the cross-module backtrace. Bytecode modules that have a debug database embedded will include the source locations in a format closely matching the MLIR pretty printing of LocationAttr.

Users who don't care about backtraces can disable them with `-DIREE_VM_BACKTRACE_ENABLE=0` to save on binary size. Modules get debug databases by default but can be stripped with `-iree-vm-bytecode-module-strip-source-map`. Stacks are still useful if symbol names are included (you'll see func + pc), while the smallest module files stripped with `-iree-vm-bytecode-module-strip-symbols` as well will just show function ordinals/pcs that we could later symbolize offline.

Example error message showing original model source location:
```
E D:\Dev\iree\iree\tools\iree-run-mlir-main.cc:457] Failure for: D:\Dev\iree\iree\modules\hal\module.c:359: INTERNAL; DO NOT SUBMIT; while invoking native function hal.buffer.load; while calling import; 
[ 1]   native hal.buffer.load:0 -
[ 0] bytecode module.main:1770 D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:69:9
      at D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:137:10
      at D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:128:1; Evaluating export function 0; Evaluating functions
```
=
![image](https://user-images.githubusercontent.com/75337/128610686-77c69187-811b-4890-8d53-3f0bdac7d113.png)

If a source listing is produced (`-iree-vm-bytecode-source-listing=`) those will be included as well:
```
E D:\Dev\iree\iree\tools\iree-run-mlir-main.cc:457] Failure for: D:\Dev\iree\iree\modules\hal\module.c:359]: INTERNAL; DO NOT SUBMIT; while invoking native function hal.buffer.load; while calling import; 
[ 1]   native hal.buffer.load:0 -
[ 0] bytecode module.main:1770 [
    D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:69:9
      at D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:137:10
      at D:\Dev\iree/iree/test/e2e/models/unidirectional_lstm.mlir:128:1,
    "vm"(D:\Dev\iree/../iree-tmp/vm.mlir:154:4)
  ]; Evaluating export function 0; Evaluating functions
```
=
![image](https://user-images.githubusercontent.com/75337/128610691-3cd36272-235b-4c90-a126-721a0e9a3896.png)
(points at the next pc)

Users can add additional locations in intermediate dialects by inserting `-snapshot-op-locations{tag=foo,fileName=bar.mlir}` in the pipeline (could do it after mhlo/linalg/etc).

Fixes #55 (!).