### PR TITLE
Adds support for sourcing referenced trace modules from stdin.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,3 +134,4 @@ jobs:
         uses: ibiqlik/action-yamllint@v1
         with:
           strict: true
+          file_or_dir: .github/**/*.yml build_tools/buildkite/**/*.yml

--- a/iree/base/internal/file_io.h
+++ b/iree/base/internal/file_io.h
@@ -34,6 +34,17 @@ iree_status_t iree_file_read_contents(const char* path,
 iree_status_t iree_file_write_contents(const char* path,
                                        iree_const_byte_span_t content);
 
+// Reads the contents of stdin until EOF into memory.
+// The contents will specify up until EOF and the allocation will have a
+// trailing NUL to allow use as a C-string (assuming the contents themselves
+// don't contain NUL).
+//
+// Returns the contents of the file in |out_contents|.
+// |allocator| is used to allocate the memory and the caller must use the same
+// allocator when freeing it.
+iree_status_t iree_stdin_read_contents(iree_allocator_t allocator,
+                                       iree_byte_span_t* out_contents);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/iree/tools/test/iree-benchmark-module.mlir
+++ b/iree/tools/test/iree-benchmark-module.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=abs --function_input=f32=-2 | IreeFileCheck %s
+// RUN: iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=abs --function_input=f32=-2 | IreeFileCheck %s
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan --entry_function=abs --function_input=f32=-2 | IreeFileCheck %s)
 // RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || (iree-translate --iree-hal-target-backends=dylib-llvm-aot -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=dylib --entry_function=abs --function_input=f32=-2 | IreeFileCheck %s)
 

--- a/iree/tools/test/iree-run-module.mlir
+++ b/iree/tools/test/iree-run-module.mlir
@@ -1,4 +1,4 @@
-// RUN: (iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vmvx --entry_function=abs --function_input=f32=-2) | IreeFileCheck %s
+// RUN: (iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vmvx --entry_function=abs --function_input=f32=-2) | IreeFileCheck %s
 // RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || ((iree-translate --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=vulkan --entry_function=abs --function_input=f32=-2) | IreeFileCheck %s)
 // RUN: [[ $IREE_LLVMAOT_DISABLE == 1 ]] || ((iree-translate --iree-hal-target-backends=dylib-llvm-aot -iree-mlir-to-vm-bytecode-module %s | iree-run-module --driver=dylib --entry_function=abs --function_input=f32=-2) | IreeFileCheck %s)
 

--- a/iree/tools/test/multiple_args.mlir
+++ b/iree/tools/test/multiple_args.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | IreeFileCheck %s
+// RUN: iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | IreeFileCheck %s
 // RUN: iree-run-mlir --iree-hal-target-backends=vmvx --function-input='2xi32=[1 2]' --function-input='2xi32=[3 4]' %s | IreeFileCheck %s
-// RUN: iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | IreeFileCheck --check-prefix=BENCHMARK %s
+// RUN: iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=multi_input --function_input="2xi32=[1 2]" --function_input="2xi32=[3 4]" | IreeFileCheck --check-prefix=BENCHMARK %s
 
 // BENCHMARK-LABEL: BM_multi_input
 // CHECK-LABEL: EXEC @multi_input

--- a/iree/tools/test/multiple_exported_functions.mlir
+++ b/iree/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-translate --iree-input-type=mhlo --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx | IreeFileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan | IreeFileCheck %s)
+// RUN: iree-translate -iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx | IreeFileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-translate -iree-input-type=mhlo -iree-hal-target-backends=vulkan-spirv -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vulkan | IreeFileCheck %s)
 
 module {
   func @foo1() -> tensor<4xf32> {

--- a/iree/tools/test/repeated_return.mlir
+++ b/iree/tools/test/repeated_return.mlir
@@ -1,5 +1,5 @@
-// RUN: (iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=many_tensor) | IreeFileCheck %s
-// RUN: iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=many_tensor | IreeFileCheck --check-prefix=BENCHMARK %s
+// RUN: (iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=many_tensor) | IreeFileCheck %s
+// RUN: iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=many_tensor | IreeFileCheck --check-prefix=BENCHMARK %s
 // RUN: iree-run-mlir -iree-hal-target-backends=vmvx %s | IreeFileCheck %s
 
 // BENCHMARK-LABEL: BM_many_tensor

--- a/iree/tools/test/scalars.mlir
+++ b/iree/tools/test/scalars.mlir
@@ -1,5 +1,5 @@
-// RUN: (iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=scalar --function_input=42) | IreeFileCheck %s
-// RUN: iree-translate --iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=scalar --function_input=42 | IreeFileCheck --check-prefix=BENCHMARK %s
+// RUN: (iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-module --entry_function=scalar --function_input=42) | IreeFileCheck %s
+// RUN: iree-translate -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-benchmark-module --driver=vmvx --entry_function=scalar --function_input=42 | IreeFileCheck --check-prefix=BENCHMARK %s
 // RUN: (iree-run-mlir --iree-hal-target-backends=vmvx --function-input=42 %s) | IreeFileCheck %s
 
 // BENCHMARK-LABEL: BM_scalar


### PR DESCRIPTION
Now iree-benchmark-trace/iree-run-trace can be used from the
command line without the need for file paths embedded in the trace.
Just set the module path to `<stdin>` instead of a file name and pipe in
the vmfb.

Example:
```yaml
type: module_load
module:
  name: module
  type: bytecode
  path: <stdin>
```

```bash
iree-translate -iree-input-type=mhlo -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module foo.mlir | \
    iree-run-trace --driver=vmvx trace.yaml
```