### PR TITLE
Adding iree_string_builder_t.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -25,6 +25,8 @@ cc_library(
         "assert.h",
         "status.c",
         "status.h",
+        "string_builder.c",
+        "string_builder.h",
         "string_view.c",
         "string_view.h",
         "time.c",
@@ -60,6 +62,16 @@ cc_test(
     deps = [
         ":base",
         ":cc",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "string_builder_test",
+    srcs = ["string_builder_test.cc"],
+    deps = [
+        ":base",
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
     ],

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -18,6 +18,8 @@ iree_cc_library(
     "assert.h"
     "status.c"
     "status.h"
+    "string_builder.c"
+    "string_builder.h"
     "string_view.c"
     "string_view.h"
     "time.c"
@@ -50,6 +52,17 @@ iree_cc_test(
   DEPS
     ::base
     ::cc
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
+    string_builder_test
+  SRCS
+    "string_builder_test.cc"
+  DEPS
+    ::base
     iree::testing::gtest
     iree::testing::gtest_main
 )

--- a/iree/base/allocator.h
+++ b/iree/base/allocator.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "iree/base/alignment.h"
 #include "iree/base/attributes.h"
 #include "iree/base/config.h"
 #include "iree/base/status.h"
@@ -244,6 +245,11 @@ static inline iree_allocator_t iree_allocator_system(void) {
 static inline iree_allocator_t iree_allocator_null(void) {
   iree_allocator_t v = {NULL, NULL};
   return v;
+}
+
+// Returns true if the allocator is `iree_allocator_null()`.
+static inline bool iree_allocator_is_null(iree_allocator_t allocator) {
+  return allocator.ctl == NULL;
 }
 
 #ifdef __cplusplus

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -91,14 +91,15 @@
 #ifndef IREE_BASE_API_H_
 #define IREE_BASE_API_H_
 
-#include "iree/base/alignment.h"    // IWYU pragma: export
-#include "iree/base/allocator.h"    // IWYU pragma: export
-#include "iree/base/assert.h"       // IWYU pragma: export
-#include "iree/base/attributes.h"   // IWYU pragma: export
-#include "iree/base/config.h"       // IWYU pragma: export
-#include "iree/base/status.h"       // IWYU pragma: export
-#include "iree/base/string_view.h"  // IWYU pragma: export
-#include "iree/base/time.h"         // IWYU pragma: export
+#include "iree/base/alignment.h"       // IWYU pragma: export
+#include "iree/base/allocator.h"       // IWYU pragma: export
+#include "iree/base/assert.h"          // IWYU pragma: export
+#include "iree/base/attributes.h"      // IWYU pragma: export
+#include "iree/base/config.h"          // IWYU pragma: export
+#include "iree/base/status.h"          // IWYU pragma: export
+#include "iree/base/string_builder.h"  // IWYU pragma: export
+#include "iree/base/string_view.h"     // IWYU pragma: export
+#include "iree/base/time.h"            // IWYU pragma: export
 
 #ifdef __cplusplus
 extern "C" {

--- a/iree/base/string_builder.c
+++ b/iree/base/string_builder.c
@@ -1,0 +1,143 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/string_builder.h"
+
+#include "iree/base/alignment.h"
+
+// Minimum alignment for storage buffer allocations.
+#define IREE_STRING_BUILDER_ALIGNMENT 128
+
+IREE_API_EXPORT void iree_string_builder_initialize(
+    iree_allocator_t allocator, iree_string_builder_t* out_builder) {
+  memset(out_builder, 0, sizeof(*out_builder));
+  out_builder->allocator = allocator;
+}
+
+IREE_API_EXPORT void iree_string_builder_deinitialize(
+    iree_string_builder_t* builder) {
+  if (builder->buffer != NULL) {
+    iree_allocator_free(builder->allocator, builder->buffer);
+  }
+  memset(builder, 0, sizeof(*builder));
+}
+
+IREE_API_EXPORT const char* iree_string_builder_buffer(
+    const iree_string_builder_t* builder) {
+  return builder->buffer;
+}
+
+IREE_API_EXPORT iree_host_size_t
+iree_string_builder_size(const iree_string_builder_t* builder) {
+  return builder->size;
+}
+
+IREE_API_EXPORT iree_host_size_t
+iree_string_builder_capacity(const iree_string_builder_t* builder) {
+  return builder->capacity;
+}
+
+IREE_API_EXPORT iree_string_view_t
+iree_string_builder_view(const iree_string_builder_t* builder) {
+  return iree_make_string_view(iree_string_builder_buffer(builder),
+                               iree_string_builder_size(builder));
+}
+
+IREE_API_EXPORT char* iree_string_builder_take_storage(
+    iree_string_builder_t* builder) {
+  char* buffer = builder->buffer;
+  if (builder->size == 0) {
+    // In empty cases we return NULL and need to clean up inline as the user is
+    // expecting to be able to discard the builder after this returns.
+    if (builder->buffer != NULL) {
+      iree_allocator_free(builder->allocator, builder->buffer);
+      builder->buffer = NULL;
+    }
+    buffer = NULL;
+  }
+  builder->size = 0;
+  builder->capacity = 0;
+  builder->buffer = NULL;
+  return buffer;
+}
+
+IREE_API_EXPORT iree_status_t iree_string_builder_reserve(
+    iree_string_builder_t* builder, iree_host_size_t minimum_capacity) {
+  if (iree_allocator_is_null(builder->allocator)) return iree_ok_status();
+  iree_host_size_t new_capacity = builder->capacity;
+  if (builder->capacity < minimum_capacity) {
+    new_capacity =
+        iree_host_align(minimum_capacity, IREE_STRING_BUILDER_ALIGNMENT);
+  }
+  if (builder->capacity >= new_capacity) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(iree_allocator_realloc(builder->allocator, new_capacity,
+                                              (void**)&builder->buffer));
+  builder->buffer[builder->size] = 0;
+  builder->capacity = new_capacity;
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_string_builder_append_string(
+    iree_string_builder_t* builder, iree_string_view_t value) {
+  // Ensure capacity for the value + NUL terminator.
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_reserve(builder, builder->size + value.size + 1));
+  if (builder->buffer != NULL) {
+    // Only copy the bytes if we are not doing a size calculation.
+    memcpy(builder->buffer + builder->size, value.data, value.size);
+    builder->buffer[builder->size + value.size] = 0;  // NUL
+  }
+  builder->size += value.size;
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_string_builder_append_cstring(
+    iree_string_builder_t* builder, const char* value) {
+  return iree_string_builder_append_string(builder,
+                                           iree_make_cstring_view(value));
+}
+
+static iree_status_t iree_string_builder_append_format_impl(
+    iree_string_builder_t* builder, const char* format, va_list varargs_0,
+    va_list varargs_1) {
+  // Try to directly print into the buffer we have. This may work if we have
+  // capacity but otherwise will yield us the size we need to grow our buffer.
+  int n = vsnprintf(builder->buffer ? builder->buffer + builder->size : NULL,
+                    builder->buffer ? builder->capacity - builder->size : 0,
+                    format, varargs_0);
+  if (IREE_UNLIKELY(n < 0)) {
+    return iree_make_status(IREE_STATUS_INTERNAL, "printf try failed");
+  }
+  if (n < builder->capacity - builder->size) {
+    // Printed into the buffer.
+    builder->size += n;
+    return iree_ok_status();
+  }
+
+  // Reserve new minimum capacity.
+  IREE_RETURN_IF_ERROR(iree_string_builder_reserve(
+      builder, iree_string_builder_size(builder) + n + /*NUL*/ 1));
+
+  // Try printing again.
+  vsnprintf(builder->buffer ? builder->buffer + builder->size : NULL,
+            builder->buffer ? builder->capacity - builder->size : 0, format,
+            varargs_1);
+  builder->size += n;
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t IREE_PRINTF_ATTRIBUTE(2, 3)
+    iree_string_builder_append_format(iree_string_builder_t* builder,
+                                      const char* format, ...) {
+  va_list varargs_0, varargs_1;
+  va_start(varargs_0, format);
+  va_start(varargs_1, format);
+  iree_status_t status = iree_string_builder_append_format_impl(
+      builder, format, varargs_0, varargs_1);
+  va_end(varargs_1);
+  va_end(varargs_0);
+  return status;
+}

--- a/iree/base/string_builder.h
+++ b/iree/base/string_builder.h
@@ -1,0 +1,120 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_STRING_BUILDER_H_
+#define IREE_BASE_STRING_BUILDER_H_
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "iree/base/allocator.h"
+#include "iree/base/attributes.h"
+#include "iree/base/status.h"
+#include "iree/base/string_view.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Lightweight string builder.
+// Used to dynamically produce strings in a growable buffer.
+//
+// Usage:
+//  iree_string_builder_t builder;
+//  iree_string_builder_initialize(iree_allocator_system(), &builder);
+//  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(&builder, "hel"));
+//  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(&builder, "lo"));
+//  fprintf(stream, "%.*s", (int)iree_string_builder_size(&builder),
+//                          iree_string_builder_buffer(&builder));
+//  iree_string_builder_deinitialize(&builder);
+//
+// Usage for preallocation:
+//  iree_string_builder_t builder;
+//  iree_string_builder_initialize(iree_allocator_null(), &builder);
+//  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(&builder, "123"));
+//  // str_length is total number of characters (excluding NUL).
+//  iree_host_size_t str_length = iree_string_builder_size(builder);
+//  iree_string_builder_deinitialize(&builder);
+typedef struct iree_string_builder_t {
+  // Allocator used for buffer storage.
+  // May be iree_allocator_null() to have the builder total up the required
+  // size.
+  iree_allocator_t allocator;
+  // Allocated storage buffer, if any.
+  char* buffer;
+  // Total length of the string in the buffer in characters (excluding NUL).
+  iree_host_size_t size;
+  // Total allocated buffer capacity in bytes.
+  iree_host_size_t capacity;
+} iree_string_builder_t;
+
+// Initializes a string builder in |out_builder| with the given |allocator|.
+IREE_API_EXPORT void iree_string_builder_initialize(
+    iree_allocator_t allocator, iree_string_builder_t* out_builder);
+
+// Deinitializes |builder| and releases allocated storage.
+IREE_API_EXPORT void iree_string_builder_deinitialize(
+    iree_string_builder_t* builder);
+
+// Returns a pointer into the builder storage.
+// The pointer is only valid so long as the string builder is initialized and
+// unmodified.
+IREE_API_EXPORT const char* iree_string_builder_buffer(
+    const iree_string_builder_t* builder);
+
+// Returns the total length of the string in the buffer in characters (excluding
+// NUL).
+IREE_API_EXPORT iree_host_size_t
+iree_string_builder_size(const iree_string_builder_t* builder);
+
+// Returns the total allocated buffer capacity in bytes.
+IREE_API_EXPORT iree_host_size_t
+iree_string_builder_capacity(const iree_string_builder_t* builder);
+
+// Returns a string view into the builder storage.
+// The pointer is only valid so long as the string builder is initialized and
+// unmodified.
+IREE_API_EXPORT iree_string_view_t
+iree_string_builder_view(const iree_string_builder_t* builder);
+
+// Releases the storage from the builder and returns ownership to the caller.
+// The caller must free the string using the same allocator used by the builder.
+// Returns NULL if the string builder is empty.
+//
+// Usage:
+//  iree_string_builder_t builder;
+//  iree_string_builder_initialize(iree_allocator_system(), &builder);
+//  ...
+//  char* buffer = iree_string_builder_take_storage(&builder);
+//  iree_host_size_t buffer_size = iree_string_builder_size(&builder);
+//  iree_string_builder_deinitialize(&builder);
+//  ...
+//  iree_allocator_free(iree_allocator_system(), buffer);
+IREE_API_EXPORT IREE_MUST_USE_RESULT char* iree_string_builder_take_storage(
+    iree_string_builder_t* builder);
+
+// Reserves storage for at least |minimum_capacity|.
+IREE_API_EXPORT iree_status_t iree_string_builder_reserve(
+    iree_string_builder_t* builder, iree_host_size_t minimum_capacity);
+
+// Appends a string to the builder.
+IREE_API_EXPORT iree_status_t iree_string_builder_append_string(
+    iree_string_builder_t* builder, iree_string_view_t value);
+
+// Appends a NUL-terminated C string to the builder.
+IREE_API_EXPORT iree_status_t iree_string_builder_append_cstring(
+    iree_string_builder_t* builder, const char* value);
+
+// Appends a printf-style formatted string to the builder.
+IREE_API_EXPORT IREE_PRINTF_ATTRIBUTE(2, 3) iree_status_t
+    iree_string_builder_append_format(iree_string_builder_t* builder,
+                                      const char* format, ...);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_STRING_BUILDER_H_

--- a/iree/base/string_builder_test.cc
+++ b/iree/base/string_builder_test.cc
@@ -1,0 +1,164 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <string>
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+struct StringBuilder {
+  static StringBuilder MakeSystem() {
+    iree_string_builder_t builder;
+    iree_string_builder_initialize(iree_allocator_system(), &builder);
+    return StringBuilder(builder);
+  }
+
+  static StringBuilder MakeEmpty() {
+    iree_string_builder_t builder;
+    iree_string_builder_initialize(iree_allocator_null(), &builder);
+    return StringBuilder(builder);
+  }
+
+  explicit StringBuilder(iree_string_builder_t builder)
+      : builder(std::move(builder)) {}
+
+  ~StringBuilder() { iree_string_builder_deinitialize(&builder); }
+
+  operator iree_string_builder_t*() { return &builder; }
+
+  std::string ToString() const {
+    return std::string(builder.buffer, builder.size);
+  }
+
+  iree_string_builder_t builder;
+};
+
+TEST(StringBuilderTest, QueryEmpty) {
+  auto builder = StringBuilder::MakeEmpty();
+  EXPECT_EQ(iree_string_builder_buffer(builder),
+            static_cast<const char*>(NULL));
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  EXPECT_EQ(iree_string_builder_capacity(builder), 0);
+  EXPECT_TRUE(iree_string_view_is_empty(iree_string_builder_view(builder)));
+  EXPECT_EQ(iree_string_builder_take_storage(builder),
+            static_cast<char*>(NULL));
+}
+
+TEST(StringBuilderTest, QueryAppendString) {
+  auto builder = StringBuilder::MakeEmpty();
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, ""));
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "a"));
+  EXPECT_EQ(iree_string_builder_size(builder), 1);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "abc"));
+  EXPECT_EQ(iree_string_builder_size(builder), 1 + 3);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, ""));
+  EXPECT_EQ(iree_string_builder_size(builder), 1 + 3);
+
+  char kLongString[1024];
+  memset(kLongString, 'x', IREE_ARRAYSIZE(kLongString));
+  IREE_EXPECT_OK(iree_string_builder_append_string(
+      builder,
+      iree_make_string_view(kLongString, IREE_ARRAYSIZE(kLongString))));
+  EXPECT_EQ(iree_string_builder_size(builder),
+            1 + 3 + IREE_ARRAYSIZE(kLongString));
+}
+
+TEST(StringBuilderTest, QueryFormat) {
+  auto builder = StringBuilder::MakeEmpty();
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, ""));
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "abc"));
+  EXPECT_EQ(iree_string_builder_size(builder), 3);
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "a%cc", 'b'));
+  EXPECT_EQ(iree_string_builder_size(builder), 6);
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "%*c", 1024, 'x'));
+  EXPECT_EQ(iree_string_builder_size(builder), 6 + 1024);
+}
+
+TEST(StringBuilderTest, Empty) {
+  auto builder = StringBuilder::MakeSystem();
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  EXPECT_GE(iree_string_builder_capacity(builder), 0);
+  EXPECT_TRUE(iree_string_view_is_empty(iree_string_builder_view(builder)));
+  EXPECT_EQ(iree_string_builder_take_storage(builder),
+            static_cast<char*>(NULL));
+}
+
+TEST(StringBuilderTest, AppendString) {
+  auto builder = StringBuilder::MakeSystem();
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, ""));
+  EXPECT_EQ(builder.ToString(), "");
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "a"));
+  EXPECT_EQ(builder.ToString(), "a");
+  EXPECT_EQ(strlen(builder.builder.buffer), 1);  // NUL check
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "abc"));
+  EXPECT_EQ(builder.ToString(), "aabc");
+  EXPECT_EQ(strlen(builder.builder.buffer), 1 + 3);  // NUL check
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, ""));
+  EXPECT_EQ(builder.ToString(), "aabc");
+  EXPECT_EQ(iree_string_builder_size(builder), 1 + 3);
+  EXPECT_EQ(strlen(builder.builder.buffer), 1 + 3);  // NUL check
+
+  char kLongString[1024];
+  memset(kLongString, 'x', IREE_ARRAYSIZE(kLongString));
+  IREE_EXPECT_OK(iree_string_builder_append_string(
+      builder,
+      iree_make_string_view(kLongString, IREE_ARRAYSIZE(kLongString))));
+  EXPECT_EQ(iree_string_builder_size(builder),
+            1 + 3 + IREE_ARRAYSIZE(kLongString));
+  EXPECT_EQ(strlen(builder.builder.buffer),
+            1 + 3 + IREE_ARRAYSIZE(kLongString));  // NUL check
+  EXPECT_EQ(builder.ToString(),
+            std::string("aabc") +
+                std::string(kLongString, IREE_ARRAYSIZE(kLongString)));
+}
+
+TEST(StringBuilderTest, TakeStorage) {
+  auto builder = StringBuilder::MakeSystem();
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "a"));
+  EXPECT_EQ(builder.ToString(), "a");
+  IREE_EXPECT_OK(iree_string_builder_append_cstring(builder, "abc"));
+  EXPECT_EQ(builder.ToString(), "aabc");
+  EXPECT_EQ(iree_string_builder_size(builder), 1 + 3);
+  EXPECT_EQ(strlen(builder.builder.buffer),
+            1 + 3);  // NUL check
+
+  char* storage = iree_string_builder_take_storage(builder);
+  EXPECT_EQ(iree_string_builder_buffer(builder),
+            static_cast<const char*>(NULL));
+  EXPECT_EQ(iree_string_builder_size(builder), 0);
+  EXPECT_EQ(iree_string_builder_capacity(builder), 0);
+  EXPECT_NE(storage, static_cast<char*>(NULL));
+  EXPECT_STREQ(storage, "aabc");
+  EXPECT_EQ(builder.builder.buffer, static_cast<char*>(NULL));
+  iree_allocator_free(builder.builder.allocator, storage);
+}
+
+TEST(StringBuilderTest, Format) {
+  auto builder = StringBuilder::MakeSystem();
+  EXPECT_EQ(builder.ToString(), "");
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, ""));
+  EXPECT_EQ(builder.ToString(), "");
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "abc"));
+  EXPECT_EQ(builder.ToString(), "abc");
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "a%cc", 'b'));
+  EXPECT_EQ(builder.ToString(), "abcabc");
+  IREE_EXPECT_OK(iree_string_builder_append_format(builder, "%*c", 1024, 'x'));
+  EXPECT_EQ(iree_string_builder_size(builder), 6 + 1024);
+  EXPECT_EQ(strlen(builder.builder.buffer), 6 + 1024);  // NUL check
+  EXPECT_EQ(builder.ToString(),
+            std::string("abcabc") + std::string(1023, ' ') + std::string("x"));
+}
+
+}  // namespace

--- a/iree/hal/string_util.c
+++ b/iree/hal/string_util.c
@@ -81,7 +81,7 @@ iree_hal_format_shape(const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
     int n = snprintf(buffer ? buffer + buffer_length : NULL,
                      buffer ? buffer_capacity - buffer_length : 0,
                      (i < shape_rank - 1) ? "%dx" : "%d", shape[i]);
-    if (n < 0) {
+    if (IREE_UNLIKELY(n < 0)) {
       return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                               "snprintf failed to write dimension %zu", i);
     } else if (buffer && n >= buffer_capacity - buffer_length) {


### PR DESCRIPTION
This could be used in more places in the future such as the HAL
string_util to avoid so much pointer manipulation.