### PR TITLE
Install python3.7-venv in samples Docker image.

### DIFF
--- a/build_tools/buildkite/samples.yml
+++ b/build_tools/buildkite/samples.yml
@@ -7,7 +7,7 @@
 steps:
   - label: "Test Colab notebooks"
     commands:
-      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:24aebb1f88f6c14550a70150e046ee618c1fae1d739a5dae736a5a7c77d6ee90 python3 colab/test_notebooks.py"
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:e4099b5ed2a2b9292402efb4c8537e5fb465099c5fc329df67d8dbe54761471e python3 colab/test_notebooks.py"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:
@@ -15,7 +15,7 @@ steps:
 
   - label: "Test Samples"
     commands:
-      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:24aebb1f88f6c14550a70150e046ee618c1fae1d739a5dae736a5a7c77d6ee90 build_tools/testing/test_samples.sh"
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/samples@sha256:e4099b5ed2a2b9292402efb4c8537e5fb465099c5fc329df67d8dbe54761471e build_tools/testing/test_samples.sh"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -16,5 +16,5 @@ gcr.io/iree-oss/cmake-bazel-frontends-nvidia@sha256:7a2189f9c2c5491878fdf6d38dda
 gcr.io/iree-oss/cmake-bazel-frontends-swiftshader@sha256:103676490242311b9fad841294689a7ce1c755b935a21d8d898c25cfe3ec15e8
 gcr.io/iree-oss/cmake-riscv@sha256:95489593bc9b0cd325ce9c1a32b47389c01b174a5b8190a16d937d2e8828d384
 gcr.io/iree-oss/cmake-bazel-frontends-android@sha256:cdb1b38772643f7acbc296b558ccc868900a47a1378cf63da3fbe469dcf42428
-gcr.io/iree-oss/samples@sha256:24aebb1f88f6c14550a70150e046ee618c1fae1d739a5dae736a5a7c77d6ee90
+gcr.io/iree-oss/samples@sha256:e4099b5ed2a2b9292402efb4c8537e5fb465099c5fc329df67d8dbe54761471e
 gcr.io/iree-oss/cmake-emscripten@sha256:8acad361d23cb586187c2ea29df3a1ab301b5283c3648beb328681d69ecd0ab0

--- a/build_tools/docker/samples/Dockerfile
+++ b/build_tools/docker/samples/Dockerfile
@@ -12,7 +12,7 @@
 FROM gcr.io/iree-oss/cmake-python-swiftshader@sha256:9c3e5b8ba0c8ab0a9ef55c7141c71365cb3fab6f63c197fd4c7195d054ca6906 AS final
 
 # Update setuptools per https://github.com/pypa/setuptools/issues/1694#issuecomment-466010982
-RUN apt-get update && apt-get install -y python3-venv python-setuptools && \
+RUN apt-get update && apt-get install -y python3-venv python3.7-venv python-setuptools && \
     python3 -m pip install --upgrade setuptools
 
 # Install additional packages often used in notebooks.


### PR DESCRIPTION
Expecting this to fix the https://buildkite.com/iree/iree-samples CI pipeline which has been broken since the Python 3.7 upgrade in https://github.com/google/iree/pull/6611