### PR TITLE
Harmonize `iree_c_module`: Drop default flag

### DIFF
--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -14,8 +14,7 @@ include(CMakeParseArguments)
 # H_FILE_OUTPUT: The H header file to output.
 # TRANSLATE_TOOL: Translation tool to invoke (CMake target). The default
 #     tool is "iree-translate".
-# FLAGS: Flags to pass to the translation tool (list of strings). The
-#     default flag set is "-iree-vm-ir-to-c-module".
+# FLAGS: Flags to pass to the translation tool (list of strings).
 # TESTONLY: When added, this target will only be built if user passes
 #    -DIREE_BUILD_TESTS=ON to CMake.
 #
@@ -44,12 +43,7 @@ function(iree_c_module)
   iree_package_name(_PACKAGE_NAME)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
 
-  # Set defaults for FLAGS and TRANSLATE_TOOL
-  if(DEFINED _RULE_FLAGS)
-    set(_FLAGS ${_RULE_FLAGS})
-  else()
-    set(_FLAGS "-iree-vm-ir-to-c-module")
-  endif()
+  # Set defaults for TRANSLATE_TOOL.
   if(DEFINED _RULE_TRANSLATE_TOOL)
     set(_TRANSLATE_TOOL ${_RULE_TRANSLATE_TOOL})
   else()
@@ -58,7 +52,7 @@ function(iree_c_module)
 
   iree_get_executable_path(_TRANSLATE_TOOL_EXECUTABLE ${_TRANSLATE_TOOL})
 
-  set(_ARGS "${_FLAGS}")
+  set(_ARGS "${_RULE_FLAGS}")
   list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_RULE_H_FILE_OUTPUT}")

--- a/iree/samples/emitc_modules/CMakeLists.txt
+++ b/iree/samples/emitc_modules/CMakeLists.txt
@@ -12,6 +12,9 @@ if(${IREE_ENABLE_EMITC})
       "add.mlir"
     H_FILE_OUTPUT
       "add_module.h"
+    FLAGS
+      "-iree-mlir-to-vm-c-module"
+      "-iree-hal-target-backends=vmvx"
   )
 
   iree_cc_test(
@@ -57,6 +60,9 @@ if(${IREE_ENABLE_EMITC})
       "import_module_a.mlir"
     H_FILE_OUTPUT
       "import_module_a.h"
+    FLAGS
+      "-iree-mlir-to-vm-c-module"
+      "-iree-hal-target-backends=vmvx"
   )
 
   iree_c_module(
@@ -66,5 +72,8 @@ if(${IREE_ENABLE_EMITC})
       "import_module_b.mlir"
     H_FILE_OUTPUT
       "import_module_b.h"
+    FLAGS
+      "-iree-mlir-to-vm-c-module"
+      "-iree-hal-target-backends=vmvx"
   )
 endif()

--- a/iree/vm/test/emitc/CMakeLists.txt
+++ b/iree/vm/test/emitc/CMakeLists.txt
@@ -54,6 +54,8 @@ iree_c_module(
     "../arithmetic_ops.mlir"
   H_FILE_OUTPUT
     "arithmetic_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -63,6 +65,8 @@ iree_c_module(
     "../arithmetic_ops_f32.mlir"
   H_FILE_OUTPUT
     "arithmetic_ops_f32.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -72,6 +76,8 @@ iree_c_module(
     "../arithmetic_ops_i64.mlir"
   H_FILE_OUTPUT
     "arithmetic_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -81,6 +87,8 @@ iree_c_module(
     "../assignment_ops.mlir"
   H_FILE_OUTPUT
     "assignment_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -90,6 +98,8 @@ iree_c_module(
     "../assignment_ops_f32.mlir"
   H_FILE_OUTPUT
     "assignment_ops_f32.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -99,6 +109,8 @@ iree_c_module(
     "../assignment_ops_i64.mlir"
   H_FILE_OUTPUT
     "assignment_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -108,6 +120,8 @@ iree_c_module(
     "../buffer_ops.mlir"
   H_FILE_OUTPUT
     "buffer_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -117,6 +131,8 @@ iree_c_module(
     "../call_ops.mlir"
   H_FILE_OUTPUT
     "call_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -126,6 +142,8 @@ iree_c_module(
     "../comparison_ops.mlir"
   H_FILE_OUTPUT
     "comparison_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -135,6 +153,8 @@ iree_c_module(
     "../comparison_ops_f32.mlir"
   H_FILE_OUTPUT
     "comparison_ops_f32.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -144,6 +164,8 @@ iree_c_module(
     "../comparison_ops_i64.mlir"
   H_FILE_OUTPUT
     "comparison_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -153,6 +175,8 @@ iree_c_module(
     "../control_flow_ops.mlir"
   H_FILE_OUTPUT
     "control_flow_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -162,6 +186,8 @@ iree_c_module(
     "../conversion_ops.mlir"
   H_FILE_OUTPUT
     "conversion_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -171,6 +197,8 @@ iree_c_module(
     "../conversion_ops_f32.mlir"
   H_FILE_OUTPUT
     "conversion_ops_f32.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -180,6 +208,8 @@ iree_c_module(
     "../conversion_ops_i64.mlir"
   H_FILE_OUTPUT
     "conversion_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -189,6 +219,8 @@ iree_c_module(
     "../global_ops.mlir"
   H_FILE_OUTPUT
     "global_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -198,6 +230,8 @@ iree_c_module(
     "../global_ops_f32.mlir"
   H_FILE_OUTPUT
     "global_ops_f32.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -207,6 +241,8 @@ iree_c_module(
     "../global_ops_i64.mlir"
   H_FILE_OUTPUT
     "global_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -216,6 +252,8 @@ iree_c_module(
     "../list_ops.mlir"
   H_FILE_OUTPUT
     "list_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -225,6 +263,8 @@ iree_c_module(
     "../list_variant_ops.mlir"
   H_FILE_OUTPUT
     "list_variant_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -234,6 +274,8 @@ iree_c_module(
     "../ref_ops.mlir"
   H_FILE_OUTPUT
     "ref_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -243,6 +285,8 @@ iree_c_module(
     "../shift_ops.mlir"
   H_FILE_OUTPUT
     "shift_ops.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 iree_c_module(
@@ -252,6 +296,8 @@ iree_c_module(
     "../shift_ops_i64.mlir"
   H_FILE_OUTPUT
     "shift_ops_i64.h"
+  FLAGS
+    "-iree-vm-ir-to-c-module"
 )
 
 endif()


### PR DESCRIPTION
Harmonizes `iree_c_module` with `iree_bytecode_module`. The latter
dropped setting a default flag and switched to explicitly passing the
flags.