### PR TITLE
Tiled linalg.mmt4d -> vector.contract conversion

### DIFF
--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "SetNumWorkgroupsPass.cpp",
         "ShapeToLLVMConversion.cpp",
         "VectorizeConv.cpp",
+        "VectorizeMMT4d.cpp",
     ],
     deps = [
         "//iree/compiler/Codegen:PassHeaders",

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     "SetNumWorkgroupsPass.cpp"
     "ShapeToLLVMConversion.cpp"
     "VectorizeConv.cpp"
+    "VectorizeMMT4d.cpp"
   DEPS
     LLVMSupport
     MLIRAffine

--- a/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
+++ b/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
@@ -1,0 +1,132 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+/// A pattern to convert tiled linalg.mmt4d into vector contract.
+/// This converts linalg.mmt4d with operands <1x1xM0xK0>, <1x1xK0,N0>
+/// to vector.contract where K0 is the contraction dimension.
+struct VectorizeMMT4DOp : public OpRewritePattern<linalg::Mmt4DOp> {
+  using OpRewritePattern<linalg::Mmt4DOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Mmt4DOp mmt4DOp,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = mmt4DOp.inputs()[0];
+    auto rhs = mmt4DOp.inputs()[1];
+    auto dst = mmt4DOp.outputs()[0];
+
+    auto lhsType = lhs.getType().dyn_cast<ShapedType>();
+    auto rhsType = lhs.getType().dyn_cast<ShapedType>();
+
+    if (!lhsType || !rhsType || !lhsType.hasStaticShape() ||
+        !rhsType.hasStaticShape())
+      return failure();
+
+    int M1 = lhsType.getShape()[0];
+    int K1 = lhsType.getShape()[1];
+    int N1 = rhsType.getShape()[0];
+
+    if (M1 != 1 || K1 != 1 || N1 != 1) return failure();
+
+    int M0 = lhsType.getShape()[2];
+    int N0 = rhsType.getShape()[3];
+    int K0 = lhsType.getShape()[3];
+
+    auto loc = mmt4DOp.getLoc();
+    auto c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+
+    auto vecType = VectorType::get({1, 1, M0, N0}, rewriter.getF32Type());
+
+    auto lhsVecType2D = VectorType::get({M0, K0}, rewriter.getF32Type());
+    auto rhsVecType2D = VectorType::get({K0, N0}, rewriter.getF32Type());
+    auto dstVecType2D = VectorType::get({M0, N0}, rewriter.getF32Type());
+
+    auto identityMap = rewriter.getMultiDimIdentityMap(4);
+
+    auto lhsVec = rewriter.create<vector::TransferReadOp>(
+        loc, vecType, lhs, ValueRange{c0, c0, c0, c0}, identityMap);
+
+    auto rhsVec = rewriter.create<vector::TransferReadOp>(
+        loc, vecType, rhs, ValueRange{c0, c0, c0, c0}, identityMap);
+
+    auto dstVec = rewriter.create<vector::TransferReadOp>(
+        loc, vecType, dst, ValueRange{c0, c0, c0, c0}, identityMap);
+
+    Value lhsVec2D =
+        rewriter.create<vector::ShapeCastOp>(loc, lhsVecType2D, lhsVec);
+
+    Value rhsVec2D =
+        rewriter.create<vector::ShapeCastOp>(loc, rhsVecType2D, rhsVec);
+
+    Value dstVec2D =
+        rewriter.create<vector::ShapeCastOp>(loc, dstVecType2D, dstVec);
+
+    auto m = rewriter.getAffineDimExpr(0);
+    auto n = rewriter.getAffineDimExpr(1);
+    auto k = rewriter.getAffineDimExpr(2);
+
+    auto map0 = AffineMap::get(3, 0, {m, k}, rewriter.getContext());
+    auto map1 = AffineMap::get(3, 0, {k, n}, rewriter.getContext());
+    auto map2 = AffineMap::get(3, 0, {m, n}, rewriter.getContext());
+
+    ArrayAttr indexingMaps = rewriter.getAffineMapArrayAttr({map0, map1, map2});
+
+    ArrayAttr iterators = rewriter.getStrArrayAttr(
+        {getParallelIteratorTypeName(), getParallelIteratorTypeName(),
+         getReductionIteratorTypeName()});
+
+    Value contractResult = rewriter.create<vector::ContractionOp>(
+        loc, lhsVec2D, rhsVec2D, dstVec2D, indexingMaps, iterators);
+
+    Value contractResult4D =
+        rewriter.create<vector::ShapeCastOp>(loc, vecType, contractResult);
+
+    rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+        mmt4DOp, contractResult4D, dst, ValueRange{c0, c0, c0, c0},
+        identityMap);
+
+    return success();
+    ;
+  }
+};
+
+struct LinalgToVectorVectorizeMMT4dPass
+    : public LinalgToVectorVectorizeMMT4dBase<
+          LinalgToVectorVectorizeMMT4dPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(&getContext());
+    patterns.insert<VectorizeMMT4DOp>(context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace
+
+void populateLinalgToVectorVectorizeMMT4dPatterns(
+    MLIRContext *context, OwningRewritePatternList &patterns) {
+  patterns.insert<VectorizeMMT4DOp>(context);
+}
+
+std::unique_ptr<OperationPass<FuncOp>>
+createLinalgToVectorVectorizeMMT4dPass() {
+  return std::make_unique<LinalgToVectorVectorizeMMT4dPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/Common/test/BUILD
+++ b/iree/compiler/Codegen/Common/test/BUILD
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "remove_dead_allocs.mlir",
             "transpose_canonicalization.mlir",
             "vectorize_linalg_conv.mlir",
+            "vectorize_linalg_mmt4d.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "remove_dead_allocs.mlir"
     "transpose_canonicalization.mlir"
     "vectorize_linalg_conv.mlir"
+    "vectorize_linalg_mmt4d.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Codegen/Common/test/vectorize_linalg_mmt4d.mlir
+++ b/iree/compiler/Codegen/Common/test/vectorize_linalg_mmt4d.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt -split-input-file -iree-codegen-vectorize-linalg-mmt4d -canonicalize -cse %s | IreeFileCheck %s
+
+func @tiled_mmt4d(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: memref<1x1x4x4xf32>) {
+    linalg.mmt4d ins(%lhs, %rhs: memref<1x1x4x4xf32>, memref<1x1x4x4xf32>) outs(%dst: memref<1x1x4x4xf32>)
+    return
+}
+
+// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK: func @tiled_mmt4d(%[[LHS:.+]]: memref<1x1x4x4xf32>, %[[RHS:.+]]: memref<1x1x4x4xf32>, %[[DST:.+]]: memref<1x1x4x4xf32>
+//      CHECK:   %[[LHS_4DVEC:.+]] = vector.transfer_read %[[LHS]]
+//      CHECK:   %[[RHS_4DVEC:.+]] = vector.transfer_read %[[RHS]]
+//      CHECK:   %[[DST_4DVEC:.+]] = vector.transfer_read %[[DST]]
+//      CHECK:   %[[LHS_2DVEC:.+]] = vector.shape_cast %[[LHS_4DVEC]] : vector<1x1x4x4xf32> to vector<4x4xf32>
+//      CHECK:   %[[RHS_2DVEC:.+]] = vector.shape_cast %[[RHS_4DVEC]] : vector<1x1x4x4xf32> to vector<4x4xf32>
+//      CHECK:   %[[DST_2DVEC:.+]] = vector.shape_cast %[[DST_4DVEC]] : vector<1x1x4x4xf32> to vector<4x4xf32>
+//      CHECK:   %[[RESULT_2D:.+]] = vector.contract
+// CHECK-SAME:        indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+// CHECK-SAME:        %[[LHS_2DVEC]], %[[RHS_2DVEC]], %[[DST_2DVEC]] : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+//      CHECK:   %[[RESULT_4D:.+]] = vector.shape_cast %[[RESULT_2D]] : vector<4x4xf32> to vector<1x1x4x4xf32>
+

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -159,7 +159,7 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
       return SmallVector<int64_t>(mmt4dL1TileSizes.begin(),
                                   mmt4dL1TileSizes.end());
     }
-    return {32, 32, 4, 4, 4, 4};
+    return {1, 1, 4, 4, 1, 4};
   };
 
   auto getVectorSizes = [&]() -> SmallVector<int64_t> {

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
@@ -217,6 +217,16 @@ void LLVMCPUVectorizationPass::runOnOperation() {
     return;
   }
 
+  // Op specific conversion.
+  {
+    RewritePatternSet vectorizeOpsPattenrs(context);
+    populateLinalgToVectorVectorizeMMT4dPatterns(context, vectorizeOpsPattenrs);
+    if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                            std::move(vectorizeOpsPattenrs)))) {
+      return signalPassFailure();
+    }
+  }
+
   // Apply vectorization patterns.
   {
     RewritePatternSet vectorizationPatterns(context);

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -77,6 +77,9 @@ std::unique_ptr<OperationPass<FuncOp>> createLinalgBufferizePass(
 /// Creates a pass to vectorize a very specific form of linalg.conv ops.
 std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeConvPass();
 
+/// Creates a pass to vectorize a very specific form of linalg.conv ops.
+std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeMMT4dPass();
+
 /// Pass to optimize vector transfer_read and transfer_write.
 std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass();
 
@@ -94,6 +97,10 @@ createSetNumWorkgroupsPass(ArrayRef<int64_t> workgroupSize = {});
 /// static-sized subviews. To match, output shape must be 1x1xWoxCo, where Co
 /// Co is a multiple of 4, and filter shape must be 1x1x4xCo.
 void populateLinalgToVectorVectorizeConvPatterns(
+    MLIRContext *context, OwningRewritePatternList &patterns);
+
+/// Populates `patterns` to convert linalg.mmt4d to vector.contract.
+void populateLinalgToVectorVectorizeMMT4dPatterns(
     MLIRContext *context, OwningRewritePatternList &patterns);
 
 /// Populates `patterns` with conversions of Shape dialect to LLVM Dialect.

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -74,9 +74,15 @@ def LinalgToVectorVectorizeConv :
     Pass<"iree-codegen-vectorize-linalg-conv", "FuncOp"> {
   let summary = "Vectorize a very specific form of linalg.conv";
   let constructor =
-      "mlir::iree_compiler::createLinalgToVectorVectorizeConvPass();";
+      "mlir::iree_compiler::createLinalgToVectorVectorizeConvPass()";
 }
 
+def LinalgToVectorVectorizeMMT4d :
+    Pass<"iree-codegen-vectorize-linalg-mmt4d", "FuncOp"> {
+  let summary = "Vectorize a very specific form of linalg.mmt4d";
+  let constructor =
+      "mlir::iree_compiler::createLinalgToVectorVectorizeMMT4dPass()";
+}
 //------------------------------------------------------------------------------
 // LLVMCPU
 //------------------------------------------------------------------------------

--- a/iree/test/microbenchmarks/linalg_mmt4d.mlir
+++ b/iree/test/microbenchmarks/linalg_mmt4d.mlir
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+// Linalg matmul ops.
+//===----------------------------------------------------------------------===//
+
+func @matmul_384x384x512() -> tensor<384x512xf32> {
+    %lhs = util.unfoldable_constant dense<1.0> : tensor<384x384xf32>
+    %rhs = util.unfoldable_constant dense<1.0> : tensor<384x512xf32>
+    %dst = util.unfoldable_constant dense<1.0> : tensor<384x512xf32>
+    %0 = linalg.matmul ins(%lhs, %rhs : tensor<384x384xf32>, tensor<384x512xf32>) outs(%dst : tensor<384x512xf32>) -> tensor<384x512xf32>
+    return %0 : tensor<384x512xf32>
+}
+
+func @mmt4d_384x384x512() -> tensor<96x128x4x4xf32> {
+    %lhs = util.unfoldable_constant dense<1.0> : tensor<96x96x4x4xf32>
+    %rhs = util.unfoldable_constant dense<1.0> : tensor<128x96x4x4xf32>
+    %dst = util.unfoldable_constant dense<1.0> : tensor<96x128x4x4xf32>
+    %0 = linalg.mmt4d ins(%lhs, %rhs : tensor<96x96x4x4xf32>, tensor<128x96x4x4xf32>) outs(%dst : tensor<96x128x4x4xf32>) -> tensor<96x128x4x4xf32>
+    return %0 : tensor<96x128x4x4xf32>
+}


### PR DESCRIPTION
This converts tiled `linalg.mmt4d` to `vector.contract and adds a microbenchmark 
that showed its 1.7x faster than linalg.matmul 

```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
BM_mmt4d_384x384x512/process_time/real_time        3.66 ms         3.65 ms          191
BM_matmul_384x384x512/process_time/real_time       6.29 ms         6.27 ms          111
```