### PR TITLE
Remove canonicalizer pass suspected of causing a performance regression.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -129,7 +129,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(
       IREE::Flow::createConvertLinalgTensorOpsPass(
           /*runBeforeDispatchRegionFormation=*/true));
-  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(
       IREE::Flow::createDispatchLinalgOnTensorsPass());
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());


### PR DESCRIPTION
Context:
* https://github.com/google/iree/pull/6626
* https://perf.iree.dev/serie?IREE?MobileNetV2%20[fp32,imagenet]%20(TensorFlow)%201-thread,big-core,full-inference%20with%20IREE-Dylib%20@%20SM-G980F%20(CPU-ARMv8.2-A)

![image](https://user-images.githubusercontent.com/4010439/128926209-75fc6985-4613-4cbe-9d1a-68ed27cd7507.png)
