### PR TITLE
Fix bug in lowering of ops through DistributeToGlobalID pipeline.

### DIFF
--- a/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
+++ b/iree/compiler/Codegen/Common/SetNumWorkgroupsPass.cpp
@@ -49,7 +49,8 @@ void SetNumWorkgroupsPass::runOnOperation() {
       getAllEntryPoints(module);
   for (auto funcOp : module.getOps<FuncOp>()) {
     auto entryPointOp = entryPoints.lookup(funcOp.getName());
-    if (!entryPointOp) continue;
+    if (!entryPointOp || !entryPointOp.workgroup_count_region().empty())
+      continue;
     SmallVector<int64_t, 4> currWorkloadPerWorkgroup;
 
     // First check if there is a workload provided.

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -277,7 +277,8 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
     // on it, just add the default.
     if (!getTranslationInfo(entryPointOp)) {
       setTranslationInfo(funcOp,
-                         IREE::HAL::DispatchLoweringPassPipeline::CPUDefault);
+                         IREE::HAL::DispatchLoweringPassPipeline::CPUDefault,
+                         /*workgroupSize =*/{}, /*workloadPerWorkgroup =*/{});
     }
   }
   return success();

--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -179,7 +179,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
       // distribute.
       setTranslationInfo(
           funcOp, IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute,
-          {1, 1, 1});
+          {1, 1, 1}, /*workloadPerWorkgroup=*/{});
       continue;
     }
 
@@ -208,7 +208,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
       // distribute.
       setTranslationInfo(
           funcOp, IREE::HAL::DispatchLoweringPassPipeline::LLVMGPUDistribute,
-          {1, 1, 1});
+          {1, 1, 1}, /*workloadPerWorkgroup=*/{});
       continue;
     }
     if (failed(setRootConfig(funcOp, rootOperation))) continue;

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -52,11 +52,11 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
 
 void setTranslationInfo(FuncOp entryPointFn,
                         IREE::HAL::DispatchLoweringPassPipeline passPipeline,
-                        ArrayRef<int64_t> workgroupSize) {
+                        ArrayRef<int64_t> workgroupSize,
+                        ArrayRef<int64_t> workloadPerWorkgroup) {
   auto entryPointOp = getEntryPoint(entryPointFn);
   auto translationInfo = buildTranslationInfo(
-      passPipeline, /*workloadPerWorkgroup=*/ArrayRef<int64_t>{},
-      entryPointFn.getContext());
+      passPipeline, workloadPerWorkgroup, entryPointFn.getContext());
   setTranslationInfo(entryPointOp, translationInfo, workgroupSize);
 }
 

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -34,7 +34,8 @@ IREE::HAL::ExecutableEntryPointOp getEntryPoint(FuncOp funcOp);
 /// set.
 void setTranslationInfo(FuncOp entryPointFn,
                         IREE::HAL::DispatchLoweringPassPipeline passPipeline,
-                        ArrayRef<int64_t> workgroupSize = {});
+                        ArrayRef<int64_t> workgroupSize,
+                        ArrayRef<int64_t> workloadPerWorkgroup);
 
 /// Returns the loops that are partitioned during dispatch region formations, in
 /// order, i.e. starting from the outer-most to innermost.


### PR DESCRIPTION
The number of workgroups is computed in a way that is not similar to
how it is done on the tile + distribute path. Fixing that fixes the
remaining correctness issues.