### PR TITLE
Start to populate the IREE dialect.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEBase.td
@@ -1,0 +1,115 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_BASE_TD
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_BASE_TD
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+def IREE_Dialect : Dialect {
+  let name = "iree";
+  let summary = "Public ops/type/attributes legal for input to IREE's compiler";
+  let description = [{
+    IREE's compiler allows as input a number of common dialects. This dialect
+    contains structural and unique ops that do not exist elsewhere or that IREE
+    has an interest in maintaining as a stable set.
+
+    The contents of this dialect often mirror various constructs in IREE's
+    internal implementation. The focus here is on simplicity and stability
+    over time. Generally, this dialect does not use "advanced" features and
+    should be broadly source compatible over a range of LLVM versions. There
+    are of course, limits, and source-compatibility is not guaranteed, since
+    LLVM/MLIR's API surface is itself unstable.
+  }];
+  let cppNamespace = "::mlir::iree";
+}
+
+class IREE_Op<string mnemonic, list<OpTrait> traits = []> :
+    Op<IREE_Dialect, mnemonic, traits>;
+class IREE_PureOp<string mnemonic, list<OpTrait> traits = []> :
+    Op<IREE_Dialect, mnemonic, !listconcat(traits, [NoSideEffect])>;
+class IREE_Type<string name> : TypeDef<IREE_Dialect, name>;
+
+//===----------------------------------------------------------------------===//
+// Predicates
+//===----------------------------------------------------------------------===//
+
+class IREE_AliasedSymbolRefAttr : Attr<CPred<"$_self.isa<FlatSymbolRefAttr>()">,
+                                        "symbol reference attribute"> {
+  let storageType = [{ FlatSymbolRefAttr }];
+  let returnType = [{ StringRef }];
+  let valueType = NoneType;
+  let constBuilderCall = "$_builder.getSymbolRefAttr($0)";
+}
+
+class IREE_AnyPtrOf<list<Type> types> :
+    Type<And<[
+      CPred<"$_self.isa<::mlir::iree::PtrType>()">,
+      Or<!foreach(type, types,
+          SubstLeaves<
+              "$_self",
+              "$_self.cast<::mlir::iree::PtrType>().getTargetType()",
+              type.predicate>)>,
+    ]>, !interleave(!foreach(type, types, type.summary), " or ")> {
+  string builderCall = "";
+}
+
+def IREE_PrimitiveType : AnyTypeOf<[Index, AnySignlessInteger, AnyFloat]>;
+def IREE_Tensor : TypeAlias<AnyRankedTensor>;
+
+def IREE_AnyList : DialectType<
+    IREE_Dialect,
+    CPred<"$_self.isa<::mlir::iree::ListType>()">,
+      "list"> {
+  let description = [{
+    A mutable, resizable list of some type.
+  }];
+}
+
+class IREE_ListOf<Type type> :
+    Type<And<[
+      CPred<"$_self.isa<::mlir::iree::ListType>()">,
+      SubstLeaves<"$_self",
+                  "$_self.cast<::mlir::iree::ListType>().getElementType()",
+                  type.predicate>
+    ]>, "list<" # type.summary # ">"> {
+  // Set the builder call if the base type has a builder call.
+  string builderCall = !if(!empty(type.builderCall),
+                           "", "::mlir::iree::ListType::get(" # type.builderCall # ")");
+}
+
+def IREE_ElementTypeParameter : TypeParameter<
+    "::mlir::Type", "A type suitable as an element type of a container">;
+def IREE_PtrTargetTypeParameter : TypeParameter<
+    "::mlir::Type", "A type suitable as a target type of a pointer">;
+
+def IREE_Dim : TypeAlias<Index>;
+def IREE_Dims : Variadic<IREE_Dim>;
+def IREE_Shape : Variadic<IREE_Dim>;
+def IREE_ShapeDynamicDims : Variadic<IREE_Dim>;
+
+def IREE_VariableRefAttr : IREE_AliasedSymbolRefAttr;
+def IREE_VariablePtr : IREE_AnyPtrOf<[IREE_Tensor, IREE_PrimitiveType]>;
+
+class IREE_IndexAttrBase<string descr> :
+    TypedAttrBase<
+      Index, "IntegerAttr",
+      And<[
+        CPred<"$_self.isa<IntegerAttr>()">,
+        CPred<"$_self.cast<IntegerAttr>().getType().isIndex()">,
+      ]>,
+      descr> {
+  let returnType = [{ APInt }];
+}
+def IREE_IndexAttr : IREE_IndexAttrBase<"size_t">;
+
+def IREE_TiedOpStorageAttr :
+    TypedArrayAttrBase<IREE_IndexAttr, "64-bit integer array attribute"> {
+  let constBuilderCall = "$_builder.getI64ArrayAttr($0)";
+}
+
+#endif // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_BASE_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEDialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEDialect.h
@@ -13,4 +13,7 @@
 // clobbering order).
 #include "iree-dialects/Dialect/IREE/IREEOpsDialect.h.inc"
 
+#define GET_TYPEDEF_CLASSES
+#include "iree-dialects/Dialect/IREE/IREEOpsTypes.h.inc"
+
 #endif  // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_DIALECT_H

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEDialect.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEDialect.td
@@ -7,27 +7,104 @@
 #ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_DIALECT_TD
 #define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_DIALECT_TD
 
-include "mlir/IR/OpBase.td"
+include "iree-dialects/Dialect/IREE/IREEBase.td"
 
-def IREE_Dialect : Dialect {
-  let name = "iree";
-  let summary = "Public ops/type/attributes legal for input to IREE's compiler";
+//===----------------------------------------------------------------------===//
+// Types
+//===----------------------------------------------------------------------===//
+
+def IREE_BufferViewType : IREE_Type<"BufferView"> {
+  let mnemonic = "buffer_view";
+
+  let summary = "View into a buffer, with runtime shape and element type";
+
   let description = [{
-    IREE's compiler allows as input a number of common dialects. This dialect
-    contains structural and unique ops that do not exist elsewhere or that IREE
-    has an interest in maintaining as a stable set.
+    BufferViews represent views onto backing IREE runtime Buffer objects,
+    adding runtime shape and element type parameters to the backing buffer.
+    BufferViews are typically accepted and returned at boundaries with
+    external code.
 
-    The contents of this dialect often mirror various constructs in IREE's
-    internal implementation. The focus here is on simplicity and stability
-    over time. Generally, this dialect does not use "advanced" features and
-    should be broadly source compatible over a range of LLVM versions. There
-    are of course, limits, and source-compatibility is not guaranteed, since
-    LLVM/MLIR's API surface is itself unstable.
+    In the runtime and lower level compiler, BufferView's are fully modeled;
+    however, as boundary types, not all features are exposed publicly. Since
+    within compiled tensor programs, it is typical to operate in terms of
+    fully typed tensors, the primary mechanism for getting or using a
+    BufferView at the high level is by casting to/from a tensor. It is left
+    to higher level code to ensure that aliasing rules are enforced at such
+    boundaries.
   }];
-  let cppNamespace = "::mlir::iree";
+  let printer = [{
+    $_printer << "buffer_view";
+  }];
+
+  let parser = [{
+    return get($_ctxt);
+  }];
 }
 
-class IREE_Op<string mnemonic, list<OpTrait> traits = []> :
-    Op<IREE_Dialect, mnemonic, traits>;
+def IREE_VariantType : IREE_Type<"Variant"> {
+  let mnemonic = "variant";
+
+  let summary = "Represents any legal or reference type in the IREE runtime";
+
+  let description = [{
+    The variant type is typically used to parameterize container types that
+    can contain any legal primitive, reference or null in the IREE type system.
+  }];
+  let printer = [{
+    $_printer << "variant";
+  }];
+
+  let parser = [{
+    return get($_ctxt);
+  }];
+}
+
+def IREE_ListType : IREE_Type<"List"> {
+  let mnemonic = "list";
+
+  let summary = "A one dimensional list of runtime values";
+
+  let description = [{
+    Represents a list of arbitrary type. Primitive types can be expected to
+    be efficiently stored in an unboxed form. Reference types and variants
+    are permitted.
+
+    Lists can either be homogenous, with a fixed element type, or heterogenous
+    by parameterizing them with a VariantType.
+  }];
+
+  let parameters = (ins IREE_ElementTypeParameter:$elementType);
+
+  let printer = [{
+    $_printer << "list<" << getElementType() << ">";
+  }];
+
+  let parser = [{
+    Type elementType;
+    if ($_parser.parseLess() || $_parser.parseType(elementType) ||
+        $_parser.parseGreater())
+      return Type();
+    return get($_ctxt, elementType);
+  }];
+}
+
+def IREE_PtrType : IREE_Type<"Ptr"> {
+  let mnemonic = "ptr";
+
+  let summary = "Pointer to a concrete type";
+  let parameters = (ins IREE_PtrTargetTypeParameter:$targetType);
+
+  let printer = [{
+    $_printer << "list<" << getTargetType() << ">";
+  }];
+
+  let parser = [{
+    Type targetType;
+    if ($_parser.parseLess() || $_parser.parseType(targetType) ||
+        $_parser.parseGreater())
+      return Type();
+    return get($_ctxt, targetType);
+  }];
+}
 
 #endif // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_DIALECT_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.h
@@ -7,10 +7,13 @@
 #ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_OPS_H
 #define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_OPS_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "iree-dialects/Dialect/IREE/IREEDialect.h"
 
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/IREE/IREEOps.h.inc"

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.h
@@ -7,13 +7,13 @@
 #ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_OPS_H
 #define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_OPS_H
 
+#include "iree-dialects/Dialect/IREE/IREEDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-#include "iree-dialects/Dialect/IREE/IREEDialect.h"
 
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/IREE/IREEOps.h.inc"

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREE/IREEOps.td
@@ -9,11 +9,506 @@
 
 include "iree-dialects/Dialect/IREE/IREEDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/SymbolInterfaces.td"
 
-def IREE_DummyOp : IREE_Op<"dummy", [NoSideEffect]> {
-  let summary = "Dummy op to be removed once dialect is populated properly.";
-  let arguments = (ins);
-  let results = (outs);
+def IREE_NullOp : IREE_PureOp<"null"> {
+  let summary = "a null value";
+  let description = [{
+    Initializes reference and variant types with a null value.
+  }];
+
+  let results = (outs
+    AnyType:$result
+  );
+
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Casts
+//===----------------------------------------------------------------------===//
+
+def IREE_TensorToBufferView : IREE_PureOp<"cast.tensor_to_buffer_view"> {
+  let summary = "Casts a tensor to a BufferView, capturing dynamic dims";
+  let arguments = (ins
+    IREE_Tensor:$source,
+    IREE_ShapeDynamicDims:$source_dims
+  );
+  let results = (outs IREE_BufferViewType:$target);
+
+  let assemblyFormat = [{
+    $source `:` type($source) (`{` $source_dims^ `}`)? `->` type($target)
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_BufferViewToTensor : IREE_PureOp<"cast.buffer_view_to_tensor"> {
+  let summary = "Casts a BufferView to a tensor, providing dynamic dims";
+  let arguments = (ins
+    IREE_BufferViewType:$source,
+    IREE_ShapeDynamicDims:$target_dims
+  );
+  let results = (outs IREE_Tensor:$target);
+
+  let assemblyFormat = [{
+    $source `:` type($source) `->` type($target) (`{` $target_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Global variables
+//===----------------------------------------------------------------------===//
+
+def IREE_VariableOp : IREE_Op<"variable", [
+    Symbol,
+  ]> {
+  let summary = [{stateful variable declaration}];
+  let description = [{
+    Declares a persistent variable that maintains its value.
+  }];
+
+  let arguments = (ins
+    StrAttr:$sym_name,
+    TypeAttr:$type,
+    UnitAttr:$is_mutable,
+    OptionalAttr<FlatSymbolRefAttr>:$initializer,
+    OptionalAttr<AnyAttr>:$initial_value
+  );
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringRef":$name, "bool":$isMutable,
+      "FuncOp":$initializer, CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "StringRef":$name, "bool":$isMutable, "Type":$type,
+      "Attribute":$initialValue, CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "StringRef":$name, "bool":$isMutable, "Type":$type,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+  ];
+}
+
+def IREE_VariableAddressOp : IREE_PureOp<"variable.address"> {
+  let summary = [{returns an address reference to a variable}];
+  let description = [{
+    Returns the address of a variable as a typed reference. Can be used with the
+    variable load and store indirect ops.
+  }];
+
+  let arguments = (ins
+    IREE_VariableRefAttr:$variable
+  );
+  let results = (outs
+    IREE_VariablePtr:$result
+  );
+
+  let assemblyFormat = "$variable attr-dict `:` type($result)";
+}
+
+def IREE_VariableLoadOp : IREE_Op<"variable.load"> {
+  let summary = [{loads a value from a global variable}];
+  let description = [{
+    Returns a copy of the variable value.
+  }];
+
+  let arguments = (ins
+    IREE_VariableRefAttr:$variable
+  );
+  let results = (outs
+    AnyType:$result
+  );
+
+  let assemblyFormat = "$variable attr-dict `:` type($result)";
+}
+
+def IREE_VariableLoadIndirectOp : IREE_Op<"variable.load.indirect"> {
+  let summary = [{loads a value from a global variable}];
+  let description = [{
+    Returns a copy of the variable value.
+  }];
+
+  let arguments = (ins
+    IREE_VariablePtr:$variable
+  );
+  let results = (outs
+    AnyType:$result
+  );
+
+  let assemblyFormat = "$variable attr-dict `:` type($variable) `->` type($result)";
+}
+
+def IREE_VariableStoreOp : IREE_Op<"variable.store"> {
+  let summary = [{stores a value into a global variable}];
+  let description = [{
+    Stores a copy of the value into a variable.
+  }];
+
+  let arguments = (ins
+    AnyType:$value,
+    IREE_VariableRefAttr:$variable
+  );
+
+  let assemblyFormat = "$value `,` $variable attr-dict `:` type($value)";
+}
+
+def IREE_VariableStoreIndirectOp : IREE_Op<"variable.store.indirect"> {
+  let summary = [{stores a value into a global variable}];
+  let description = [{
+    Stores a copy of the value into a variable.
+  }];
+
+  let arguments = (ins
+    AnyType:$value,
+    IREE_VariablePtr:$variable
+  );
+
+  let assemblyFormat = "$value `,` $variable attr-dict `:` type($value) `->` type($variable)";
+}
+
+//===----------------------------------------------------------------------===//
+// Buffer Views
+//===----------------------------------------------------------------------===//
+
+def IREE_BufferViewRankOp : IREE_PureOp<"buffer_view.rank"> {
+  let summary = [{buffer view rank query}];
+  let description = [{
+    Returns the rank of the buffer view.
+  }];
+
+  let arguments = (ins
+    IREE_BufferViewType:$buffer_view
+  );
+  let results = (outs
+    IREE_Dim:$result
+  );
+
+  let assemblyFormat = [{
+    $buffer_view attr-dict `:` type($result)
+  }];
+}
+
+def IREE_BufferViewDimOp : IREE_PureOp<"buffer_view.dim"> {
+  let summary = [{buffer view dimension value query}];
+  let description = [{
+    Returns the value of the given dimension.
+  }];
+
+  let arguments = (ins
+    IREE_BufferViewType:$buffer_view,
+    IndexAttr:$index
+  );
+  let results = (outs
+    IREE_Dim:$result
+  );
+
+  let assemblyFormat = [{
+    $buffer_view `,` $index attr-dict `:` type($result)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Mutable Lists
+//===----------------------------------------------------------------------===//
+
+def IREE_ListCreateOp : IREE_PureOp<
+    "list.create", [MemoryEffects<[MemAlloc]>]> {
+  let summary = [{creates a new empty list}];
+  let description = [{
+    Creates a new empty list with an optional initial capacity.
+  }];
+
+  let arguments = (ins
+    Optional<Index>:$initial_capacity
+  );
+  let results = (outs
+    IREE_AnyList:$result
+  );
+
+  let assemblyFormat = "($initial_capacity^)? attr-dict `:` type($result)";
+}
+
+def IREE_ListSizeOp : IREE_Op<"list.size", [MemoryEffects<[MemRead]>]> {
+  let summary = [{the size of the list in elements}];
+  let description = [{
+    Returns the current size of the list in elements.
+  }];
+
+  let arguments = (ins
+    IREE_AnyList:$list
+  );
+  let results = (outs
+    Index:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` type($list)";
+}
+
+def IREE_ListResizeOp : IREE_Op<"list.resize", [MemoryEffects<[MemWrite]>]> {
+  let summary = [{resizes the list to a new count in elements}];
+  let description = [{
+    Resizes the list to contain `new_size` elements. This will either truncate
+    the list if the existing size is greater than `new_size` or extend the list
+    with the default list value of the element type.
+  }];
+
+  let arguments = (ins
+    IREE_AnyList:$list,
+    Index:$new_size
+  );
+
+  let assemblyFormat = "operands attr-dict `:` type($list)";
+}
+
+def IREE_ListGetOp : IREE_Op<"list.get", [MemoryEffects<[MemRead]>]> {
+  let summary = [{element accessor}];
+  let description = [{
+    Returns the value of the element at the given index. Note that the value
+    may be null if the element is null or the type does not match.
+  }];
+
+  let arguments = (ins
+    IREE_AnyList:$list,
+    Index:$index
+  );
+  let results = (outs
+    AnyType:$result
+  );
+
+  let assemblyFormat = "$list `[` $index `]` attr-dict `:` type($list) `->` type($result)";
+}
+
+def IREE_ListSetOp : IREE_Op<"list.set", [MemoryEffects<[MemWrite]>]> {
+  let summary = [{element mutator}];
+  let description = [{
+    Sets the element at the given index to the new value.
+  }];
+
+  let arguments = (ins
+    IREE_AnyList:$list,
+    Index:$index,
+    AnyType:$value
+  );
+
+  let assemblyFormat = "$list `[` $index `]` `,` $value attr-dict `:` type($list) `,` type($value)";
+}
+
+//===----------------------------------------------------------------------===//
+// Tensor ops
+//===----------------------------------------------------------------------===//
+
+def IREE_TensorReshapeOp : IREE_PureOp<"tensor.reshape", [
+    AllElementTypesMatch<["source", "result"]>,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{reshapes a tensor}];
+  let description = [{
+    Reshapes a tensor to a new shape without modifying the contents.
+  }];
+
+  let arguments = (ins
+    IREE_Tensor:$source,
+    IREE_ShapeDynamicDims:$source_dims,
+    IREE_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $source `:`
+    type($source) (`{` $source_dims^ `}`)? `->`
+    type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_TensorLoadOp : IREE_PureOp<"tensor.load", [
+    TypesMatchWith<"value type matches element type of target operand",
+                   "source", "result",
+                   "$_self.cast<ShapedType>().getElementType()">,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{loads a value from a tensor element}];
+  let description = [{
+    Returns the element at the given location from within the tensor.
+  }];
+
+  let arguments = (ins
+    IREE_Tensor:$source,
+    IREE_ShapeDynamicDims:$source_dims,
+    Variadic<IREE_Dim>:$indices
+  );
+  let results = (outs
+    AnyTypeOf<[IREE_PrimitiveType, AnyVector]>:$result
+  );
+
+  let assemblyFormat = [{
+    $source (`[` $indices^ `]`)? `:`
+    type($source) (`{` $source_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+
+}
+
+def IREE_TensorStoreOp : IREE_PureOp<"tensor.store", [
+    AllTypesMatch<["target", "result"]>,
+    TypesMatchWith<"value type matches element type of target operand",
+                   "target", "value",
+                   "$_self.cast<ShapedType>().getElementType()">,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{stores a value into a tensor element}];
+  let description = [{
+    Returns a tensor with the element at the given index set to the given value.
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[IREE_PrimitiveType, AnyVector]>:$value,
+    IREE_Tensor:$target,
+    IREE_ShapeDynamicDims:$target_dims,
+    Variadic<IREE_Dim>:$indices
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $value `,` $target (`[` $indices^ `]`)? `:`
+    type($target) (`{` $target_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_TensorSplatOp : IREE_PureOp<"tensor.splat", [
+    TypesMatchWith<"value type matches element type of result",
+                   "result", "value",
+                   "$_self.cast<ShapedType>().getElementType()">,
+  ]> {
+  let summary = [{splats a value into a shaped tensor}];
+  let description = [{
+    Returns a tensor initialized to the given primitive value.
+  }];
+
+  let arguments = (ins
+    IREE_PrimitiveType:$value,
+    IREE_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $value `:` type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_TensorCloneOp : IREE_PureOp<"tensor.clone", [
+    AllTypesMatch<["operand", "result"]>,
+  ]> {
+  let summary = [{performs a full tensor clone operation}];
+  let description = [{
+    Clones the input tensor into an identical output tensor.
+  }];
+
+  let arguments = (ins
+    IREE_Tensor:$operand,
+    IREE_ShapeDynamicDims:$operand_dims
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $operand `:` type($result) (`{` $operand_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_TensorSliceOp : IREE_PureOp<"tensor.slice", [
+    AllRanksMatch<["source", "result"]>,
+    AllElementTypesMatch<["source", "result"]>,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{slices out a subregion of a tensor}];
+  let description = [{
+    Clones a subregion of a tensor.
+  }];
+
+  let arguments = (ins
+    IREE_Tensor:$source,
+    IREE_ShapeDynamicDims:$source_dims,
+    Variadic<IREE_Dim>:$start_indices,
+    Variadic<IREE_Dim>:$lengths,
+    IREE_ShapeDynamicDims:$result_dims
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $source `[` $start_indices `for` $lengths `]` `:`
+    type($source) (`{` $source_dims^ `}`)? `->`
+    type($result) (`{` $result_dims^ `}`)?
+    attr-dict-with-keyword
+  }];
+}
+
+def IREE_TensorUpdateOp : IREE_PureOp<"tensor.update", [
+    AllRanksMatch<["update", "target", "result"]>,
+    AllTypesMatch<["target", "result"]>,
+    AllElementTypesMatch<["update", "target", "result"]>,
+    AttrSizedOperandSegments,
+  ]> {
+  let summary = [{updates a tensor with the contents of another tensor}];
+  let description = [{
+    Updates the target tensor with the contents of the update tensor at the
+    given offset indices.
+  }];
+
+  let arguments = (ins
+    IREE_Tensor:$target,
+    IREE_ShapeDynamicDims:$target_dims,
+    Variadic<IREE_Dim>:$start_indices,
+    IREE_Tensor:$update,
+    IREE_ShapeDynamicDims:$update_dims,
+    OptionalAttr<IREE_TiedOpStorageAttr>:$tied_operands
+  );
+  let results = (outs
+    IREE_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $update `,` $target `[` $start_indices `]` `:`
+    type($update) (`{` $update_dims^ `}`)? `->`
+    `(` type($result) `,` $target_dims `,` $tied_operands `)`
+    attr-dict-with-keyword
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "Value":$target,
+      "ValueRange":$start_indices,
+      "Value":$update)>,
+  ];
+}
+
+def IREE_TensorTraceOp : IREE_Op<"tensor.trace", []> {
+  let summary = [{trace value(s) operation}];
+  let description = [{
+    Traces out to a runtime trace sink (console, log file, etc) the given
+    tensors and titles them with the given key. The key is informational only
+    and useful for titling/marking specific sets of tensors for easier
+    searching.
+  }];
+
+  let arguments = (ins
+    StrAttr:$key,
+    Variadic<IREE_Tensor>:$operands
+  );
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }
 
 #endif // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREE_IREE_OPS_TD

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
@@ -6,6 +6,9 @@
 
 #include "iree-dialects/Dialect/IREE/IREEDialect.h"
 
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LLVM.h"
 #include "iree-dialects/Dialect/IREE/IREEOps.h"
 
 using namespace mlir;
@@ -13,9 +16,28 @@ using namespace mlir::iree;
 
 #include "iree-dialects/Dialect/IREE/IREEOpsDialect.cpp.inc"
 
+#define GET_TYPEDEF_CLASSES
+#include "iree-dialects/Dialect/IREE/IREEOpsTypes.cpp.inc"
+
 void IREEDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "iree-dialects/Dialect/IREE/IREEOps.cpp.inc"
+      >();
   addOperations<
 #define GET_OP_LIST
 #include "iree-dialects/Dialect/IREE/IREEOps.cpp.inc"
       >();
+}
+
+Type IREEDialect::parseType(DialectAsmParser &parser) const {
+  StringRef typeTag;
+  Type genType;
+  if (succeeded(parser.parseKeyword(&typeTag)))
+    generatedTypeParser(getContext(), parser, typeTag, genType);
+  return genType;
+}
+
+void IREEDialect::printType(Type type, DialectAsmPrinter &printer) const {
+  generatedTypePrinter(type, printer);
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
@@ -39,5 +39,5 @@ Type IREEDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void IREEDialect::printType(Type type, DialectAsmPrinter &printer) const {
-  generatedTypePrinter(type, printer);
+  (void)generatedTypePrinter(type, printer);
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
@@ -6,10 +6,10 @@
 
 #include "iree-dialects/Dialect/IREE/IREEDialect.h"
 
+#include "iree-dialects/Dialect/IREE/IREEOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/Support/LLVM.h"
-#include "iree-dialects/Dialect/IREE/IREEOps.h"
 
 using namespace mlir;
 using namespace mlir::iree;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEOps.cpp
@@ -7,7 +7,13 @@
 #include "iree-dialects/Dialect/IREE/IREEOps.h"
 
 #include "iree-dialects/Dialect/IREE/IREEDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/TypeUtilities.h"
+
+using namespace mlir;
+using namespace mlir::iree;
 
 #define GET_OP_CLASSES
 #include "iree-dialects/Dialect/IREE/IREEOps.cpp.inc"


### PR DESCRIPTION
* A selection of types and ops that I have found useful to use from frontends.
* Mostly 1:1 with internal dialects, with the exception of cast ops, which I disaggregated to simplify.
* Stripped most builders, verifiers, canonicalizers, op interfaces, etc in favor of pure declarative.
* No tests yet. Will test as part of the transforms to lower level.