### PR TITLE
Fixing loading embedded ELFs with unaligned segments on linux/mac.

### DIFF
--- a/iree/hal/local/elf/platform.h
+++ b/iree/hal/local/elf/platform.h
@@ -36,6 +36,23 @@ static inline uintptr_t iree_page_align_end(uintptr_t addr,
   return iree_page_align_start(addr + (page_alignment - 1), page_alignment);
 }
 
+// Computes a page-aligned range base and total length from a range.
+// This will produce a starting address <= the range offset and a length >=
+// the range length.
+static inline void iree_page_align_range(void* base_address,
+                                         iree_byte_range_t range,
+                                         iree_host_size_t page_alignment,
+                                         void** out_start_address,
+                                         iree_host_size_t* out_aligned_length) {
+  void* range_start = (void*)iree_page_align_start(
+      (uintptr_t)base_address + range.offset, page_alignment);
+  void* range_end = (void*)iree_page_align_end(
+      (uintptr_t)base_address + range.offset + range.length, page_alignment);
+  *out_start_address = range_start;
+  *out_aligned_length =
+      (iree_host_size_t)range_end - (iree_host_size_t)range_start;
+}
+
 //==============================================================================
 // Memory subsystem information and control
 //==============================================================================

--- a/iree/hal/local/elf/platform/apple.c
+++ b/iree/hal/local/elf/platform/apple.c
@@ -125,9 +125,11 @@ iree_status_t iree_memory_view_commit_ranges(
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < range_count; ++i) {
-    void* range_start = (void*)iree_page_align_start(
-        (uintptr_t)base_address + ranges[i].offset, getpagesize());
-    void* result = mmap(range_start, ranges[i].length, mmap_prot, mmap_flags,
+    void* range_start = NULL;
+    iree_host_size_t aligned_length = 0;
+    iree_page_align_range(base_address, ranges[i], getpagesize(), &range_start,
+                          &aligned_length);
+    void* result = mmap(range_start, aligned_length, mmap_prot, mmap_flags,
                         IREE_MEMORY_MMAP_FD, 0);
     if (result == MAP_FAILED) {
       status = iree_make_status(iree_status_code_from_errno(errno),
@@ -150,9 +152,11 @@ iree_status_t iree_memory_view_protect_ranges(void* base_address,
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < range_count; ++i) {
-    void* range_start = (void*)iree_page_align_start(
-        (uintptr_t)base_address + ranges[i].offset, getpagesize());
-    int ret = mprotect(range_start, ranges[i].length, mmap_prot);
+    void* range_start = NULL;
+    iree_host_size_t aligned_length = 0;
+    iree_page_align_range(base_address, ranges[i], getpagesize(), &range_start,
+                          &aligned_length);
+    int ret = mprotect(range_start, aligned_length, mmap_prot);
     if (ret != 0) {
       status = iree_make_status(iree_status_code_from_errno(errno),
                                 "mprotect failed");

--- a/iree/hal/local/elf/platform/linux.c
+++ b/iree/hal/local/elf/platform/linux.c
@@ -94,10 +94,12 @@ iree_status_t iree_memory_view_commit_ranges(
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < range_count; ++i) {
-    void* range_start = (void*)iree_page_align_start(
-        (uintptr_t)base_address + ranges[i].offset, getpagesize());
+    void* range_start = NULL;
+    iree_host_size_t aligned_length = 0;
+    iree_page_align_range(base_address, ranges[i], getpagesize(), &range_start,
+                          &aligned_length);
     void* result =
-        mmap(range_start, ranges[i].length, mmap_prot, mmap_flags, -1, 0);
+        mmap(range_start, aligned_length, mmap_prot, mmap_flags, -1, 0);
     if (result == MAP_FAILED) {
       status = iree_make_status(iree_status_code_from_errno(errno),
                                 "mmap commit failed");
@@ -119,9 +121,11 @@ iree_status_t iree_memory_view_protect_ranges(void* base_address,
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; i < range_count; ++i) {
-    void* range_start = (void*)iree_page_align_start(
-        (uintptr_t)base_address + ranges[i].offset, getpagesize());
-    int ret = mprotect(range_start, ranges[i].length, mmap_prot);
+    void* range_start = NULL;
+    iree_host_size_t aligned_length = 0;
+    iree_page_align_range(base_address, ranges[i], getpagesize(), &range_start,
+                          &aligned_length);
+    int ret = mprotect(range_start, aligned_length, mmap_prot);
     if (ret != 0) {
       status = iree_make_status(iree_status_code_from_errno(errno),
                                 "mprotect failed");


### PR DESCRIPTION
Segments may start at arbitrary locations and require that we are aligned
to the natural page size of the OS before calling into mmap/mprotect.