### PR TITLE
Fix typo in IREEDialect.cpp

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREE/IREEDialect.cpp
@@ -22,7 +22,7 @@ using namespace mlir::iree;
 void IREEDialect::initialize() {
   addTypes<
 #define GET_TYPEDEF_LIST
-#include "iree-dialects/Dialect/IREE/IREEOps.cpp.inc"
+#include "iree-dialects/Dialect/IREE/IREEOpsTypes.cpp.inc"
       >();
   addOperations<
 #define GET_OP_LIST


### PR DESCRIPTION
It wasn't adding any types, resulting in confusing errors.