### PR TITLE
End-to-end example for lowering config driver lowering.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -150,6 +150,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           executableLoweringPipeline.nest<ModuleOp>();
       switch (passPipeline.getValue()) {
         case IREE::HAL::DispatchLoweringPassPipeline::CPUDefault:
+        case IREE::HAL::DispatchLoweringPassPipeline::None:
           addCPUDefaultPassPipeline(nestedModulePM);
           break;
         case IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization:

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -143,14 +143,15 @@ hal.executable @reduction_dispatch {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[]{{\]}}}
+//  CHECK-DAG: #[[CONFIG0:.+]] = {passPipeline = 2 : i32}
+//  CHECK-DAG: #[[CONFIG1:.+]] = {tileSizes = {{\[}}[]{{\]}}}
 //      CHECK: hal.executable.entry_point @predict_dispatch_153
-// CHECK-SAME:     passPipeline = 2 : i32
+// CHECK-SAME:     translation.info = #[[CONFIG0]]
 // CHECK-SAME:     workgroup_size = [1 : index, 1 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index,
 //  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
 //      CHECK:     hal.return %[[C1]], %[[C1]], %[[C1]]
 //      CHECK: linalg.fill
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
+// CHECK-SAME:   lowering.config = #[[CONFIG1]]
 //      CHECK: linalg.generic
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
+// CHECK-SAME:   lowering.config = #[[CONFIG1]]

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -43,20 +43,22 @@ void setTranslationInfo(FuncOp entryPointFn,
 /// formation to tile and distribute the ops.
 SmallVector<unsigned> getPartitionedLoops(Operation *op);
 
-// /// Usually the tile sizes for the first level of tiling decides the
-// workgroup
-// /// size for the dispatch on the CPU backend. This is a general helper that
-// /// converts tile sizes of the first level into workgroup sizes.
-// SmallVector<int64_t, 3> getWorkloadPerWorkgroup(
-//     ArrayRef<int64_t> firstLevelTileSizes, ArrayRef<int64_t>
-//     partitionedLoops);
-
 /// Sets translation for the entry-point function based on op configuration.
 LogicalResult setOpConfigAndEntryPointFnTranslation(
-    FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
-    ArrayRef<int64_t> nativeVectorSizes,
+    FuncOp entryPointFn, Operation *op, IREE::HAL::LoweringConfig config,
     IREE::HAL::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workgroupSize = {});
+inline LogicalResult setOpConfigAndEntryPointFnTranslation(
+    FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
+    ArrayRef<int64_t> nativeVectorSize,
+    IREE::HAL::DispatchLoweringPassPipeline passPipeline,
+    ArrayRef<int64_t> workgroupSize = {}) {
+  IREE::HAL::LoweringConfig config =
+      buildConfigAttr(tileSizes, nativeVectorSize, op->getContext());
+  setLoweringConfig(op, config);
+  return setOpConfigAndEntryPointFnTranslation(entryPointFn, op, config,
+                                               passPipeline, workgroupSize);
+}
 
 /// Returns the number of outer parallel loops of a linalgOp.
 /// Note: To be used only if needed. Use the `getPartitionedLoops` method if

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
@@ -109,7 +109,8 @@ IREE::HAL::LoweringConfig buildConfigAttr(TileSizesListTypeRef tileSizes,
     nativeVectorSizeAttr = builder.getI64ArrayAttr(nativeVectorSize);
   }
   return IREE::HAL::LoweringConfig::get(tileSizesAttr, nativeVectorSizeAttr,
-                                        context);
+                                        /*passPipeline = */ nullptr,
+                                        /*workgroupSize = */ nullptr, context);
 }
 
 TileSizesListType getTileSizes(IREE::HAL::LoweringConfig config) {

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -26,6 +26,8 @@ def SPIRV_Vectorize
     : I32EnumAttrCase<"SPIRVVectorize", 6>;
 def SPIRV_DistributeToGlobalID
     : I32EnumAttrCase<"SPIRVDistributeToGlobalID", 7>;
+def None
+    : I32EnumAttrCase<"None", 0x7FFFFFFF>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
@@ -33,8 +35,8 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_Vectorization, LLVMGPU_SimpleDistribute,
-     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, SPIRV_SimpleDistribute, SPIRV_Vectorize,
-     SPIRV_DistributeToGlobalID]> {
+     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, SPIRV_SimpleDistribute,
+     SPIRV_Vectorize, SPIRV_DistributeToGlobalID, None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }
 
@@ -58,6 +60,12 @@ def HAL_LoweringConfigAttr :
         DefaultValuedAttr<TileSizesListAttr, "{}">>,
     StructFieldAttr<"nativeVectorSize",
         DefaultValuedAttr<I64ArrayAttr, "{}">>,
+    StructFieldAttr<"passPipeline",
+        DefaultValuedAttr<
+            DispatchLoweringPassPipelineEnum,
+            "IREE::HAL::DispatchLoweringPassPipeline::None">>,
+    StructFieldAttr<"workgroupSize",
+        DefaultValuedAttr<I64ArrayAttr, "{}">>
   ]>;
 
 #endif // IREE_COMPILER_DIALECT_HAL_IR_LOWERINGCONFIG

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -34,7 +34,6 @@ iree_lit_test_suite(
             "dynamic_torch_index_select_scalar.mlir",
             "dynamic_torch_index_select_vector.mlir",
             "globals.mlir",
-            "lowering_config.mlir",
             "scalar.mlir",
             "tensor_cast.mlir",
             "trace_dispatch_tensors.mlir",
@@ -51,6 +50,7 @@ iree_lit_test_suite(
             "dynamic_linalg_matmul_on_tensors_fuse_1.mlir",
             "dynamic_linalg_matmul_on_tensors_fuse_2.mlir",
             "linalg_ext_ops.mlir",
+            "lowering_config.mlir",
         ] + BACKEND_TESTS,
     ),
     data = [

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -65,6 +65,7 @@ iree_check_single_backend_test_suite(
     name = "check_regression_linalg_ops_dylib-llvm-aot",
     srcs = [
         "linalg_ext_ops.mlir",
+        "lowering_config.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["-iree-input-type=mhlo"],
     driver = "dylib",

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "dynamic_torch_index_select_scalar.mlir",
             "dynamic_torch_index_select_vector.mlir",
             "globals.mlir",
+            "lowering_config.mlir",
             "scalar.mlir",
             "tensor_cast.mlir",
             "trace_dispatch_tensors.mlir",

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_check_single_backend_test_suite(
   SRCS
     "linalg_ext_ops.mlir"
     "linalg_ops.mlir"
+    "lowering_config.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
   DRIVER

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -22,7 +22,6 @@ iree_lit_test_suite(
     "dynamic_torch_index_select_scalar.mlir"
     "dynamic_torch_index_select_vector.mlir"
     "globals.mlir"
-    "lowering_config.mlir"
     "scalar.mlir"
     "tensor_cast.mlir"
     "trace_dispatch_tensors.mlir"

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "dynamic_torch_index_select_scalar.mlir"
     "dynamic_torch_index_select_vector.mlir"
     "globals.mlir"
+    "lowering_config.mlir"
     "scalar.mlir"
     "tensor_cast.mlir"
     "trace_dispatch_tensors.mlir"

--- a/iree/test/e2e/regression/lowering_config.mlir
+++ b/iree/test/e2e/regression/lowering_config.mlir
@@ -1,0 +1,12 @@
+#config1 = {tileSizes = [[32, 32, 32]], passPipeline = 1 : i32}
+#config2 = {tileSizes = [[64, 64, 64]], passPipeline = 1 : i32}
+func @lowering_config_test() {
+  %a = util.unfoldable_constant dense<1.0> : tensor<128x256xf32>
+  %b = util.unfoldable_constant dense<2.0> : tensor<256x512xf32>
+  %c = util.unfoldable_constant dense<2.0> : tensor<256x1024xf32>
+  %d = "mhlo.dot"(%a, %b) {lowering.config = #config1} : (tensor<128x256xf32>, tensor<256x512xf32>) -> tensor<128x512xf32>
+  %e = "mhlo.dot"(%a, %c) {lowering.config = #config2} : (tensor<128x256xf32>, tensor<256x1024xf32>) -> tensor<128x1024xf32>
+  check.expect_almost_eq_const(%d, dense<512.0> : tensor<128x512xf32>) : tensor<128x512xf32>
+  check.expect_almost_eq_const(%e, dense<512.0> : tensor<128x1024xf32>) : tensor<128x1024xf32>
+  return
+}


### PR DESCRIPTION
Changes here (along with pending LLVM/MHLO changes) allow the CPU
compilation to be controlled using lowering configuration that is
specified on the operation. To plumb this through, the lowering config
can be used to specify a pass-pipeline and workgroup size as
well.