### PR TITLE
Update how we get the fork remote name in build cop scripts

### DIFF
--- a/scripts/git/google_to_main.sh
+++ b/scripts/git/google_to_main.sh
@@ -49,6 +49,9 @@ if [[ -z "$(which gh)" ]]; then
   exit 1
 fi
 
-# Workaround https://github.com/cli/cli/issues/1820
-GITHUB_USERNAME="$(gh config get -h github.com user)"
-gh pr create --base main --head="${GITHUB_USERNAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"
+# Extract the GitHub owner of the fork from either an ssh or https GitHub URL.
+# Workaround for https://github.com/cli/cli/issues/1820,
+# https://github.com/cli/cli/issues/1985, and
+# https://github.com/cli/cli/issues/575
+FORK_NAME="$(git remote get-url ${FORK_REMOTE?} | sed 's|.*[/:]\([A-Za-z]*\)/iree\(.git\)\?|\1|')"
+gh pr create --base main --head="${FORK_NAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"

--- a/scripts/git/main_to_google.sh
+++ b/scripts/git/main_to_google.sh
@@ -49,6 +49,9 @@ if [[ -z "$(which gh)" ]]; then
   exit 1
 fi
 
-# Workaround https://github.com/cli/cli/issues/1820
-GITHUB_USERNAME="$(gh config get -h github.com user)"
-gh pr create --base google --head="${GITHUB_USERNAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"
+# Extract the GitHub owner of the fork from either an ssh or https GitHub URL.
+# Workaround for https://github.com/cli/cli/issues/1820,
+# https://github.com/cli/cli/issues/1985, and
+# https://github.com/cli/cli/issues/575
+FORK_NAME="$(git remote get-url ${FORK_REMOTE?} | sed 's|.*[/:]\([A-Za-z]*\)/iree\(.git\)\?|\1|')"
+gh pr create --base google --head="${FORK_NAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"

--- a/scripts/git/update_llvm_dependent_submodules.sh
+++ b/scripts/git/update_llvm_dependent_submodules.sh
@@ -65,5 +65,8 @@ if [[ -z "$(which gh)" ]]; then
 fi
 
 # Extract the GitHub owner of the fork from either an ssh or https GitHub URL.
+# Workaround for https://github.com/cli/cli/issues/1820,
+# https://github.com/cli/cli/issues/1985, and
+# https://github.com/cli/cli/issues/575
 FORK_NAME="$(git remote get-url ${FORK_REMOTE?} | sed 's|.*[/:]\([A-Za-z]*\)/iree\(.git\)\?|\1|')"
 gh pr create --base="${BASE_BRANCH?}" --head="${FORK_NAME?}:${PR_BRANCH?}" --title="${TITLE?}" --body="${BODY?}"


### PR DESCRIPTION
I fixed this for update_llvm_dependent_submodules.sh in
https://github.com/google/iree/pull/4357 but missed the main<->google
scripts, which we didn't notice because all the build cops already had
that config setting.

Tested:
Ran scripts in both directions, creating
https://github.com/google/iree/pull/6783 and
https://github.com/google/iree/pull/6784