### PR TITLE
Move bufferization before configuration selection.

### DIFF
--- a/benchmarks/TensorFlow/CMakeLists.txt
+++ b/benchmarks/TensorFlow/CMakeLists.txt
@@ -176,7 +176,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
+    # "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
   DRIVER
     "vulkan"
@@ -198,7 +198,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-flow-dispatch-formation-enable-operand-fusion"
+    # "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   DRIVER

--- a/benchmarks/TensorFlow/CMakeLists.txt
+++ b/benchmarks/TensorFlow/CMakeLists.txt
@@ -176,7 +176,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    # "--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
   DRIVER
     "vulkan"
@@ -198,7 +198,7 @@ iree_mlir_benchmark_suite(
     "--iree-input-type=mhlo"
     "--iree-vulkan-target-triple=adreno-unknown-android11"
     "--iree-flow-inline-constants-max-byte-length=2048"
-    # "--iree-flow-dispatch-formation-enable-operand-fusion"
+    "--iree-flow-dispatch-formation-enable-operand-fusion"
     "--iree-enable-fusion-with-reduction-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   DRIVER

--- a/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
@@ -530,7 +530,7 @@ LogicalResult setRootConfig(FuncOp entryPoint,
       succeeded(setMaliSpecificConfig(entryPoint, op))) {
     return success();
   }
-  return success();
+  return setDefaultRootConfig(entryPoint, targetEnv, op);
 }
 
 static LogicalResult setMaliSpecificConfig(
@@ -618,7 +618,7 @@ static LogicalResult setRootConfig(
       succeeded(setMaliSpecificConfig(entryPoint, op))) {
     return success();
   }
-  return success();
+  return setDefaultRootConfig(entryPoint, targetEnv, op);
 }
 
 /// Helper function to generate the number of workgroups when the

--- a/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
@@ -666,7 +666,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     int64_t subgroupSize =
         targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
 
-    if (computeOps.empty() || !llvm::any_of(computeOps, [](Operation *op) {
+    if (computeOps.empty() || llvm::none_of(computeOps, [](Operation *op) {
           return hasMarker(op, getWorkgroupMarker());
         })) {
       // TODO(ravishankarm): `tensor.insert_slice` is not a compute op but still

--- a/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelDispatchUtils.cpp
@@ -550,6 +550,7 @@ static LogicalResult setMaliSpecificConfig(
       {{2, 2, 32}, {8, 2, 2}},
       {{1, 4, 16}, {4, 4, 1}},
       {{1, 1, 64}, {16, 1, 1}},
+      {{4, 4, 8}, {2, 4, 2}},
   };
 
   for (const auto &pair : tileWorkgroupSizePairs) {
@@ -665,7 +666,9 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     int64_t subgroupSize =
         targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
 
-    if (computeOps.empty()) {
+    if (computeOps.empty() || !llvm::any_of(computeOps, [](Operation *op) {
+          return hasMarker(op, getWorkgroupMarker());
+        })) {
       // TODO(ravishankarm): `tensor.insert_slice` is not a compute op but still
       // needs to be handled in dispatch region. For now it is handled in
       // ConvertToGPU pass. Eventually this will be handled as a compute
@@ -690,8 +693,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     }
 
     Operation *rootOperation = nullptr;
-    for (Operation *computeOp : reverse(computeOps)) {
-      if (!hasMarker(computeOp, getWorkgroupMarker())) continue;
+    for (Operation *computeOp : computeOps) {
       auto setConfigFn = [&](Operation *rootOp) -> LogicalResult {
         return TypeSwitch<Operation *, LogicalResult>(rootOp)
             .Case<linalg::BatchMatmulOp,
@@ -715,8 +717,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
 
     // If there are still no roots, check for any generic op.
     if (!rootOperation) {
-      for (Operation *computeOp : reverse(computeOps)) {
-        if (!hasMarker(computeOp, getWorkgroupMarker())) continue;
+      for (Operation *computeOp : computeOps) {
         if (isa<linalg::FillOp, linalg::CopyOp>(computeOp)) continue;
         if (failed(setDefaultRootConfig(funcOp, targetEnv, computeOp))) {
           return failure();
@@ -729,31 +730,6 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
           rootOperation = computeOp;
         }
       }
-    }
-
-    if (!rootOperation) {
-      /// TODO(ravishankarm): This is setting the configuration for ops that are
-      /// directly distributed to global invocation IDs. Remove this when
-      /// SPIRVConvertToGPU is deprecated.
-      for (Operation *computeOp : reverse(computeOps)) {
-        if (hasMarker(computeOp, getWorkgroupMarker())) continue;
-        if (isa<linalg::FillOp, linalg::CopyOp, linalg::GenericOp>(computeOp)) {
-          std::array<int64_t, 3> workgroupSize = {1, 1, 1};
-          auto linalgOp = cast<linalg::LinalgOp>(computeOp);
-          if (getNumOuterParallelLoops(linalgOp)) {
-            workgroupSize = {subgroupSize, 1, 1};
-          }
-          if (failed(setTranslationUsingDistributeToGlobalId(funcOp,
-                                                             workgroupSize))) {
-            return computeOp->emitOpError(
-                "failed to set translation info for distributing to global "
-                "IDs");
-          }
-          rootOperation = computeOp;
-          break;
-        }
-      }
-      if (rootOperation) continue;
     }
 
     // Propogate the configuration to the other ops.

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -58,8 +58,6 @@ static Value gpuAllocationFunction(OpBuilder &builder, Location loc,
 }
 
 void addSPIRVVectorizationPassPipeline(OpPassManager &pm) {
-  // Convert tensor to buffers.
-  addLinalgBufferizePasses(pm, gpuAllocationFunction);
   //===--------------------------------------------------------------------===//
   // Initial clean up.
   //===--------------------------------------------------------------------===//
@@ -89,8 +87,6 @@ void addSPIRVVectorizationPassPipeline(OpPassManager &pm) {
 }
 
 void addSPIRVDistributePassPipeline(OpPassManager &pm) {
-  // Convert tensor to buffers.
-  addLinalgBufferizePasses(pm, gpuAllocationFunction);
   //===--------------------------------------------------------------------===//
   // Initial clean up.
   //===--------------------------------------------------------------------===//
@@ -118,9 +114,6 @@ void addSPIRVDistributePassPipeline(OpPassManager &pm) {
 }
 
 void addSPIRVDistributeToGlobalIDPipeline(OpPassManager &pm) {
-  // Convert tensor to buffers.
-  addLinalgBufferizePasses(pm, gpuAllocationFunction);
-
   // Handle ops that cannot go through the previous tiling, distribution, and
   // vectorization flow. Only perform one level of distribution to map them to
   // GPU global invocation IDs for distribution.
@@ -181,6 +174,10 @@ static void addLowerToSPIRVPasses(OpPassManager &pm) {
 }
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm) {
+  {
+    OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
+    addLinalgBufferizePasses(nestedModulePM, gpuAllocationFunction);
+  }
   pm.addPass(createSPIRVLowerExecutableTargetPass());
   OpPassManager &nestedModulePM = pm.nest<ModuleOp>();
   addLowerToSPIRVPasses(nestedModulePM);


### PR DESCRIPTION
Current configuraiton selection in presence of operand fusion relies
on getting the original problem size. The current approach works
reliably only on buffer ops. So move bufferization before
configuration selection.