### PR TITLE
Print the address of `main` in iree-translate (optionally)

### DIFF
--- a/bindings/python/iree/compiler/core.py
+++ b/bindings/python/iree/compiler/core.py
@@ -172,6 +172,9 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
   cl = [
       iree_translate,
       input_file,
+      # People are only looking at stderr here if the tool fails and there's
+      # already lots of output, so adding this doesn't cost much.
+      "--print-main-address",
       f"--iree-input-type={options.input_type.value}",
       f"--iree-vm-bytecode-module-output-format={options.output_format.value}",
   ]

--- a/iree/tools/iree-translate-main.cc
+++ b/iree/tools/iree-translate-main.cc
@@ -57,6 +57,12 @@ static llvm::cl::opt<bool> splitInputFile(
                    "process each chunk independently"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> printMainAddress(
+    "print-main-address",
+    llvm::cl::desc("Print the address of main to stderr to aid in symbolizing "
+                   "stack traces after the fact"),
+    llvm::cl::init(false));
+
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
   mlir::DialectRegistry registry;
@@ -88,6 +94,11 @@ int main(int argc, char **argv) {
                            llvm::cl::Required);
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "IREE translation driver\n");
+
+  if (printMainAddress) {
+    llvm::errs() << "iree-translate main is at "
+                 << reinterpret_cast<void *>(&main) << "\n";
+  }
 
   std::string errorMessage;
   auto input = mlir::openInputFile(inputFilename, &errorMessage);


### PR DESCRIPTION
This is a bit hacky, but it's the best way we could determine for
debugging weird intermittent crashes with unsymbolized stack traces that
we're seeing in some integration tests (the non-hermetic tests that we
only run internally at the moment).

The stack traces we get are offet, so we need to know the offset to pass
to llvm-sybmolizer `--adjust-vma`. Printing the address of main allows
us to calculate this offset. Additionally, because of ASLR, we need the
offset for the particular run that crashed.

Reproducing the failure locally has been tricky and it has obstinately
refused to appear with manual reruns with this modification patched in.
Since, while it's hacky, this doesn't really cause any harm, we decided
to commit the change to hopefully get a usable stack trace.
