### PR TITLE
Make ctest CI invocations error if there are no tests

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -23,7 +23,7 @@ steps:
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       - "cd build-android/"
-      - "ctest --timeout 900 --output-on-failure"
+      - "ctest --no-tests=error --timeout 900 --output-on-failure"
     agents:
       - "android-soc=exynos-990"
       - "queue=test-android"
@@ -37,7 +37,7 @@ steps:
       - "tar xzf build-artifacts.tgz"
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       - "cd build-android/"
-      - "ctest --timeout 900 --output-on-failure"
+      - "ctest --no-tests=error --timeout 900 --output-on-failure"
     agents:
       - "android-soc=exynos-9820"
       - "queue=test-android"
@@ -53,7 +53,7 @@ steps:
       - "cd build-android/"
       # vulkan tests using khr_shader_float16_int8 are failing on pixel4.
       # Disabling it until we identify the root cause.
-      - "ctest --timeout 900 --output-on-failure --label-exclude \"^vulkan_uses_vk_khr_shader_float16_int8\\$\""
+      - "ctest --no-tests=error --timeout 900 --output-on-failure --label-exclude \"^vulkan_uses_vk_khr_shader_float16_int8\\$\""
     agents:
       - "android-soc=snapdragon-855"
       - "queue=test-android"

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -67,4 +67,4 @@ fi
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
 cd "$BUILD_DIR"
-ctest --timeout 900 --output-on-failure --label-exclude "${label_exclude_regex?}"
+ctest --no-tests=error --timeout 900 --output-on-failure --label-exclude "${label_exclude_regex?}"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -64,6 +64,6 @@ ninja
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
 
 echo "Testing with CTest"
-ctest --timeout 900 --output-on-failure \
+ctest --no-tests=error --timeout 900 --output-on-failure \
    --tests-regex "^integrations/tensorflow/|^bindings/python/" \
    --label-exclude "^nokokoro$|^vulkan_uses_vk_khr_shader_float16_int8$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -68,7 +68,7 @@ export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-1}
 # Only test drivers that use the GPU, since we run all tests on non-GPU machines
 # as well.
 echo "Testing with CTest"
-ctest --timeout 900 --output-on-failure \
+ctest --no-tests=error --timeout 900 --output-on-failure \
    --tests-regex "^integrations/tensorflow/|^bindings/python/" \
    --label-regex "^driver=vulkan$|^driver=cuda$" \
    --label-exclude "^nokokoro$"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -125,6 +125,6 @@ excluded_tests_regex="($(IFS="|" ; echo "${excluded_tests[*]?}"))"
 cd ${CMAKE_BUILD_DIR?}
 
 echo "Testing with ctest"
-ctest --timeout 900 --output-on-failure \
+ctest --no-tests=error --timeout 900 --output-on-failure \
   --label-exclude "^driver=cuda$|^driver=vulkan$" \
   --exclude-regex "${excluded_tests_regex?}"


### PR DESCRIPTION
https://github.com/google/iree/pull/6695 accidentally reverted all the
integration tests and ctest happily returned success