### PR TITLE
Explicitly create parent directory before creating symlink

### DIFF
--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -255,15 +255,20 @@ function(iree_symlink_tool)
   iree_package_name(_PACKAGE_NAME)
   set(_TARGET "${_PACKAGE_NAME}_${ARG_TARGET}")
   set(_FROM_TOOL_TARGET ${ARG_FROM_TOOL_TARGET})
+  set(_TO_TOOL_PATH "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TO_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+  get_filename_component(_TO_TOOL_DIR "${_TO_TOOL_PATH}" DIRECTORY)
+
 
   add_custom_command(
     TARGET "${_TARGET}"
     BYPRODUCTS
       "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TO_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX}"
     COMMAND
+      ${CMAKE_COMMAND} -E make_directory "${_TO_TOOL_DIR}"
+    COMMAND
       ${CMAKE_COMMAND} -E create_symlink
         "$<TARGET_FILE:${_FROM_TOOL_TARGET}>"
-        "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TO_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX}"
+        "${_TO_TOOL_PATH}"
   )
 endfunction()
 

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -234,11 +234,18 @@ function(iree_py_library)
 
   # Symlink each file as its own target.
   foreach(SRC_FILE ${ARG_SRCS})
+    # SRC_FILE could have other path components in it, so we need to make a
+    # directory for it. Ninja does this automatically, but make doesn't. See
+    # https://github.com/google/iree/issues/6801
+    set(_SRC_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${SRC_FILE}")
+    get_filename_component(_SRC_BIN_DIR "${_SRC_BIN_PATH}" DIRECTORY)
     add_custom_command(
       TARGET ${_NAME}
+      COMMAND
+        ${CMAKE_COMMAND} -E make_directory "${_SRC_BIN_DIR}"
       COMMAND ${CMAKE_COMMAND} -E create_symlink
-        "${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/${SRC_FILE}"
-      BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${SRC_FILE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FILE}" "${_SRC_BIN_PATH}"
+      BYPRODUCTS "${_SRC_BIN_PATH}"
     )
   endforeach()
 


### PR DESCRIPTION
Ninja always creates the directories for its outputs, but apparently
Make doesn't.

Tested: ran a build with make and it now completes successfully.

Fixes https://github.com/google/iree/issues/6801