### PR TITLE
Removing uses of non-iree_allocator_t allocation in the runtime.

### DIFF
--- a/iree/base/internal/flags.c
+++ b/iree/base/internal/flags.c
@@ -392,12 +392,8 @@ void iree_flags_parse_checked(iree_flags_parse_mode_t mode, int* argc,
   if (iree_status_is_ok(status)) return;
 
   fprintf(stderr, "\x1b[31mFLAGS ERROR: (╯°□°)╯︵👻\x1b[0m\n");
-  char* buffer = NULL;
-  iree_host_size_t buffer_length = 0;
-  iree_status_to_string(status, &buffer, &buffer_length);
-  fprintf(stderr, "%.*s\n\n", (int)buffer_length, buffer);
+  iree_status_fprint(stderr, status);
   fflush(stderr);
-  iree_allocator_free(iree_allocator_system(), buffer);
 
   exit(EXIT_FAILURE);
 }

--- a/iree/base/status.h
+++ b/iree/base/status.h
@@ -407,12 +407,6 @@ IREE_API_EXPORT bool iree_status_format(iree_status_t status,
                                         char* buffer,
                                         iree_host_size_t* out_buffer_length);
 
-// Converts the status to an allocated string value.
-// The caller must free the buffer with the system allocator.
-IREE_API_EXPORT bool iree_status_to_string(iree_status_t status,
-                                           char** out_buffer,
-                                           iree_host_size_t* out_buffer_length);
-
 // Prints |status| to the given |file| as a string with all available
 // annotations. This will produce multiple lines of output and should be used
 // only when dumping a status on failure.

--- a/iree/hal/buffer_heap.c
+++ b/iree/hal/buffer_heap.c
@@ -57,7 +57,7 @@ iree_status_t iree_hal_heap_buffer_create(
   }
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_heap_buffer_wrap(
@@ -91,7 +91,7 @@ IREE_API_EXPORT iree_status_t iree_hal_heap_buffer_wrap(
   }
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static void iree_hal_heap_buffer_destroy(iree_hal_buffer_t* base_buffer) {

--- a/iree/hal/local/elf/elf_module.h
+++ b/iree/hal/local/elf/elf_module.h
@@ -36,6 +36,9 @@ typedef struct iree_elf_import_table_t {
 
 // An ELF module mapped directly from memory.
 typedef struct iree_elf_module_t {
+  // Allocator used for additional dynamic memory when needed.
+  iree_allocator_t host_allocator;
+
   // Base host virtual address the module is loaded into.
   uint8_t* vaddr_base;
   // Total size, in bytes, of the virtual address space reservation.

--- a/iree/hal/local/elf/platform.h
+++ b/iree/hal/local/elf/platform.h
@@ -143,11 +143,12 @@ typedef uint32_t iree_memory_view_flags_t;
 // Implemented by VirtualAlloc+MEM_RESERVE/mmap+PROT_NONE.
 iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
                                        iree_host_size_t total_length,
+                                       iree_allocator_t allocator,
                                        void** out_base_address);
 
 // Releases a range of virtual address
-void iree_memory_view_release(void* base_address,
-                              iree_host_size_t total_length);
+void iree_memory_view_release(void* base_address, iree_host_size_t total_length,
+                              iree_allocator_t allocator);
 
 // Commits pages overlapping the byte ranges defined by |byte_ranges|.
 // Ranges will be adjusted to the page granularity of the view.

--- a/iree/hal/local/elf/platform/apple.c
+++ b/iree/hal/local/elf/platform/apple.c
@@ -80,6 +80,7 @@ static int iree_memory_access_to_prot(iree_memory_access_t access) {
 
 iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
                                        iree_host_size_t total_length,
+                                       iree_allocator_t allocator,
                                        void** out_base_address) {
   *out_base_address = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -105,8 +106,8 @@ iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
   return status;
 }
 
-void iree_memory_view_release(void* base_address,
-                              iree_host_size_t total_length) {
+void iree_memory_view_release(void* base_address, iree_host_size_t total_length,
+                              iree_allocator_t allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // NOTE: return value ignored as this is a shutdown path.

--- a/iree/hal/local/elf/platform/generic.c
+++ b/iree/hal/local/elf/platform/generic.c
@@ -41,30 +41,20 @@ void iree_memory_jit_context_end(void) {}
 
 iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
                                        iree_host_size_t total_length,
+                                       iree_allocator_t allocator,
                                        void** out_base_address) {
   *out_base_address = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_status_t status = iree_ok_status();
-
-  void* base_address =
-      iree_aligned_alloc(IREE_MEMORY_PAGE_SIZE_NORMAL, total_length);
-  if (base_address == NULL) {
-    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
-                              "malloc failed on reservation");
-  }
-
-  *out_base_address = base_address;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, total_length, out_base_address);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
-void iree_memory_view_release(void* base_address,
-                              iree_host_size_t total_length) {
+void iree_memory_view_release(void* base_address, iree_host_size_t total_length,
+                              iree_allocator_t allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_aligned_free(base_address);
-
+  iree_allocator_free(allocator, base_address);
   IREE_TRACE_ZONE_END(z0);
 }
 

--- a/iree/hal/local/elf/platform/linux.c
+++ b/iree/hal/local/elf/platform/linux.c
@@ -55,6 +55,7 @@ static int iree_memory_access_to_prot(iree_memory_access_t access) {
 
 iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
                                        iree_host_size_t total_length,
+                                       iree_allocator_t allocator,
                                        void** out_base_address) {
   *out_base_address = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -74,8 +75,8 @@ iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
   return status;
 }
 
-void iree_memory_view_release(void* base_address,
-                              iree_host_size_t total_length) {
+void iree_memory_view_release(void* base_address, iree_host_size_t total_length,
+                              iree_allocator_t allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // NOTE: return value ignored as this is a shutdown path.

--- a/iree/hal/local/elf/platform/windows.c
+++ b/iree/hal/local/elf/platform/windows.c
@@ -68,6 +68,7 @@ static DWORD iree_memory_access_to_win32_page_flags(
 
 iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
                                        iree_host_size_t total_length,
+                                       iree_allocator_t allocator,
                                        void** out_base_address) {
   *out_base_address = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -86,8 +87,8 @@ iree_status_t iree_memory_view_reserve(iree_memory_view_flags_t flags,
   return status;
 }
 
-void iree_memory_view_release(void* base_address,
-                              iree_host_size_t total_length) {
+void iree_memory_view_release(void* base_address, iree_host_size_t total_length,
+                              iree_allocator_t allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
   // NOTE: return value ignored as this is a shutdown path.
   VirtualFree(base_address, 0, MEM_RELEASE);


### PR DESCRIPTION
With these changes the only place using alternative allocation is the iree_status_t allocator (because that must be aligned) and that location is allowed to fail allocation gracefully (and in super embedded scenarios status allocation should be disabled entirely!). `iree_allocator_system()` is now only used during status allocation and as such when disabled the system allocator should be stripped during linking.