### PR TITLE
[spirv] Move Linalg to Loop conversion out of TileAndVectorizePass

### DIFF
--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -73,6 +73,7 @@ void addSPIRVVectorizationPassPipeline(OpPassManager &pm) {
   // GPU global invocation IDs for distribution.
   // TODO(antiagainst): Handle all the cases uniformly and remove this pass.
   pm.addNestedPass<FuncOp>(createSPIRVCopyToWorkgroupMemoryPass());
+  pm.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
   pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());


### PR DESCRIPTION
Now we have dynamic pipeline and ConvertToGPUPass is out of the
TileAndVectorize pipeline. So we can sort out this weird ordering!