### PR TITLE
Fixing undefined behavior in value liveness test printing.

### DIFF
--- a/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -47,7 +47,8 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
   // Block names are their order in the function.
   DenseMap<Block *, int> blockOrdinals;
   for (auto &block : funcOp.getBlocks()) {
-    blockOrdinals[&block] = blockOrdinals.size();
+    int ordinal = blockOrdinals.size();
+    blockOrdinals[std::addressof(block)] = ordinal;
   }
 
   // Keep asm state to make getting the SSA value names fast.


### PR DESCRIPTION
MSVC (at least) was evaluating the insertion prior to querying the size
leading to an off-by-one when printing.