### PR TITLE
Fixing C++ breakage from copybara import.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
@@ -100,8 +100,8 @@ LogicalResult runLLVMIRPasses(const LLVMTargetOptions &options,
                 compileKernel, recover, moduleUseAfterScope, useOdrIndicator));
             modulePassManager.addPass(
                 createModuleToFunctionPassAdaptor(llvm::AddressSanitizerPass(
-                    {compileKernel, recover, useAfterScope,
-                     llvm::AsanDetectStackUseAfterReturnMode::Runtime})));
+                    compileKernel, recover, useAfterScope,
+                    llvm::AsanDetectStackUseAfterReturnMode::Runtime)));
           });
     } break;
   }


### PR DESCRIPTION
This is just weird and makes MSVC unhappy. Some kind of implicit cast/initializer-list/inline-construction wonkiness that no one should ever do.