### PR TITLE
Adding vm.initializer and making global initialization nicer.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/constant_ops.mlir
@@ -11,8 +11,13 @@ hal.constant_pool @pool attributes {buffer_constraints = #hal.buffer_constraints
   hal.constant_storage @_storage1 = dense<[6, 7, 8, 0]> : vector<4xi8>
 }
 
-// CHECK: vm.global.ref private @pool_storage0_buffer initializer(@pool_storage0_buffer_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_storage0_buffer : !vm.ref<!hal.buffer>
 util.global private @pool_storage0_buffer initializer(@pool_storage0_buffer_initializer) : !hal.buffer
+// CHECK-NEXT: vm.initializer {
+// CHECK-NEXT:   %[[REF:.+]] = vm.call @pool_storage0_buffer_initializer() : () -> !vm.ref<!hal.buffer>
+// CHECK-NEXT:   vm.global.store.ref %[[REF]], @pool_storage0_buffer : !vm.ref<!hal.buffer>
+// CHECK-NEXT:   vm.return
+// CHECK-NEXT: }
 // CHECK: vm.func private @pool_storage0_buffer_initializer() -> !vm.ref<!hal.buffer>
 func private @pool_storage0_buffer_initializer() -> !hal.buffer {
   %c0 = constant 0 : index
@@ -29,11 +34,11 @@ func private @pool_storage0_buffer_initializer() -> !hal.buffer {
   return %mapped : !hal.buffer
 }
 
-// CHECK: vm.global.ref private @pool_storage1_buffer initializer(@pool_storage1_buffer_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_storage1_buffer : !vm.ref<!hal.buffer>
 util.global private @pool_storage1_buffer initializer(@pool_storage1_buffer_initializer) : !hal.buffer
 func private @pool_storage1_buffer_initializer() -> !hal.buffer
 
-// CHECK: vm.global.ref private @pool_splats initializer(@pool_splats_initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref private @pool_splats : !vm.ref<!hal.buffer>
 util.global private @pool_splats initializer(@pool_splats_initializer) : !hal.buffer
 // CHECK: vm.func private @pool_splats_initializer() -> !vm.ref<!hal.buffer>
 func private @pool_splats_initializer() -> !hal.buffer {

--- a/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -90,12 +90,15 @@ ParseResult parseTypeOrAttr(OpAsmParser &parser, TypeAttr &typeAttr,
 
 void printTypeOrAttr(OpAsmPrinter &p, Operation *op, TypeAttr type,
                      Attribute attr) {
+  bool needsSpace = false;
   if (!attr || attr.getType() != type.getValue()) {
-    p << " : ";
+    p << ": ";
     p.printAttribute(type);
+    needsSpace = true;  // subsequent attr value needs a space separator
   }
   if (attr) {
-    p << " = ";
+    if (needsSpace) p << ' ';
+    p << "= ";
     p.printAttribute(attr);
   }
 }

--- a/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -178,7 +178,7 @@ def Util_GlobalOp : Util_Op<"global", [
     (`mutable` $is_mutable^)?
     $sym_name
     attr-dict
-    (`initializer` `(` $initializer^ `)`):(``)?
+    (`initializer` `(` $initializer^ `)`)?
     custom<TypeOrAttr>($type, $initial_value)
   }];
 

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/global_ops.mlir
@@ -8,8 +8,14 @@ util.global private @v_private_const = 5 : i32
 
 // -----
 
-// CHECK: vm.global.ref public @v_initialized initializer(@initializer) : !vm.ref<!hal.buffer>
+// CHECK: vm.global.ref public @v_initialized : !vm.ref<!hal.buffer>
 util.global public @v_initialized initializer(@initializer) : !hal.buffer
+// CHECK-NEXT: vm.initializer {
+// CHECK-NEXT:   %[[REF:.+]] = vm.call @initializer() : () -> !vm.ref<!hal.buffer>
+// CHECK-NEXT:   vm.global.store.ref %[[REF]], @v_initialized : !vm.ref<!hal.buffer>
+// CHECK-NEXT:   vm.return
+// CHECK-NEXT: }
+// CHECK-NEXT: vm.func private @initializer() -> !vm.ref<!hal.buffer>
 func private @initializer() -> !hal.buffer
 
 // -----

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -218,14 +218,13 @@ def VM_GlobalOpInterface : OpInterface<"VMGlobalOp"> {
     }]>,
     InterfaceMethod<[{}], "StringRef", "getSymbolName", (ins)>,
     InterfaceMethod<[{}], "bool", "isMutable", (ins)>,
-    InterfaceMethod<[{}], "Optional<StringRef>", "getInitializerAttr", (ins)>,
     InterfaceMethod<[{}], "Optional<Attribute>", "getInitialValueAttr", (ins)>,
+    InterfaceMethod<[{}], "void", "setInitialValue", (ins "Attribute":$value)>,
     InterfaceMethod<[{}], "Optional<IntegerAttr>", "getOrdinalAttr", (ins)>,
     InterfaceMethod<[{}], "int", "getOrdinal", (ins), [{
       return $_self.getOrdinalAttr().getValue().template cast<IntegerAttr>().getInt();
     }]>,
     InterfaceMethod<[{}], "void", "makeMutable", (ins)>,
-    InterfaceMethod<[{}], "void", "clearInitializer", (ins)>,
     InterfaceMethod<[{}], "void", "clearInitialValue", (ins)>,
   ];
 }

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -281,6 +281,47 @@ LogicalResult ImportOp::verifyType() {
   return success();
 }
 
+void InitializerOp::build(OpBuilder &builder, OperationState &result,
+                          ArrayRef<NamedAttribute> attrs) {
+  result.addAttribute(
+      "type", TypeAttr::get(FunctionType::get(builder.getContext(), {}, {})));
+  result.addRegion();
+  result.attributes.append(attrs.begin(), attrs.end());
+}
+
+static ParseResult parseInitializerOp(OpAsmParser &parser,
+                                      OperationState *result) {
+  result->addAttribute(
+      "type", TypeAttr::get(FunctionType::get(result->getContext(), {}, {})));
+  if (parser.parseOptionalAttrDictWithKeyword(result->attributes)) {
+    return failure();
+  }
+  auto &body = *result->addRegion();
+  if (failed(parser.parseRegion(body))) {
+    return failure();
+  }
+  return success();
+}
+
+static void printInitializerOp(OpAsmPrinter &p, InitializerOp &op) {
+  p << "vm.initializer";
+  p.printOptionalAttrDictWithKeyword(op->getAttrs(), /*elidedAttrs=*/{"type"});
+  p.printRegion(op.body());
+}
+
+Block *InitializerOp::addEntryBlock() {
+  assert(empty() && "function already has an entry block");
+  auto *entry = new Block();
+  push_back(entry);
+  return entry;
+}
+
+Block *InitializerOp::addBlock() {
+  assert(!empty() && "function should at least have an entry block");
+  push_back(new Block());
+  return &back();
+}
+
 //===----------------------------------------------------------------------===//
 // Globals
 //===----------------------------------------------------------------------===//
@@ -375,13 +416,13 @@ static LogicalResult verifyGlobalLoadOp(Operation *op) {
   auto *globalOp =
       op->getParentOfType<VM::ModuleOp>().lookupSymbol(globalAttr.getValue());
   if (!globalOp) {
-    return op->emitOpError() << "Undefined global: " << globalAttr;
+    return op->emitOpError() << "undefined global: " << globalAttr;
   }
   auto globalType = globalOp->getAttrOfType<TypeAttr>("type");
   auto loadType = op->getResult(0).getType();
   if (globalType.getValue() != loadType) {
     return op->emitOpError()
-           << "Global type mismatch; global " << globalAttr << " is "
+           << "global type mismatch; global " << globalAttr << " is "
            << globalType << " but load is " << loadType;
   }
   return success();
@@ -392,18 +433,21 @@ static LogicalResult verifyGlobalStoreOp(Operation *op) {
   auto *globalOp =
       op->getParentOfType<VM::ModuleOp>().lookupSymbol(globalAttr.getValue());
   if (!globalOp) {
-    return op->emitOpError() << "Undefined global: " << globalAttr;
+    return op->emitOpError() << "undefined global: " << globalAttr;
   }
   auto globalType = globalOp->getAttrOfType<TypeAttr>("type");
   auto storeType = op->getOperand(0).getType();
   if (globalType.getValue() != storeType) {
     return op->emitOpError()
-           << "Global type mismatch; global " << globalAttr << " is "
+           << "global type mismatch; global " << globalAttr << " is "
            << globalType << " but store is " << storeType;
   }
   if (!globalOp->getAttrOfType<UnitAttr>("is_mutable")) {
-    return op->emitOpError() << "Global " << globalAttr
-                             << " is not mutable and cannot be stored to";
+    // Allow stores to immutable globals in initializers.
+    if (!op->getParentOfType<IREE::VM::InitializerOp>()) {
+      return op->emitOpError() << "global " << globalAttr
+                               << " is not mutable and cannot be stored to";
+    }
   }
   return success();
 }

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -44,6 +44,7 @@ def VM_ModuleOp : VM_Op<"module", [
     custom<SymbolVisibility>($sym_visibility)
     $sym_name
     attr-dict-with-keyword
+    ``
     regions
   }];
 
@@ -241,6 +242,50 @@ def VM_ImportOp : VM_Op<"import", [
   }];
 }
 
+def VM_InitializerOp : VM_Op<"initializer", [
+    IsolatedFromAbove,
+    HasParent<"IREE::VM::ModuleOp">,
+    NativeOpTrait<"FunctionLike">,
+    CallableOpInterface,
+  ]> {
+  let summary = [{global initialization function}];
+  let description = [{
+    A function that is called in definition order upon module initialization.
+    Must not load any globals that are defined or initialized after it in the
+    module.
+  }];
+
+  let arguments = (ins
+    TypeAttr:$type
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs
+    )>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Add an entry block to an empty function and set up the block arguments
+    /// to match the signature of the function.
+    Block *addEntryBlock();
+    Block *addBlock();
+
+    unsigned getNumFuncArguments() { return 0; }
+    unsigned getNumFuncResults() { return 0; }
+
+    LogicalResult verifyType() { return success(); }
+
+    Region *getCallableRegion() { return &body(); }
+    ArrayRef<Type> getCallableResults() { return {}; }
+  }];
+
+  let hasCanonicalizer = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Globals
 //===----------------------------------------------------------------------===//
@@ -259,7 +304,6 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
     SymbolNameAttr:$sym_name,
     TypeAttr:$type,
     UnitAttr:$is_mutable,
-    OptionalAttr<FlatSymbolRefAttr>:$initializer,
     OptionalAttr<attr_type>:$initial_value,
     OptionalAttr<VM_Ordinal>:$ordinal
   );
@@ -269,25 +313,23 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
     (`mutable` $is_mutable^)?
     $sym_name
     attr-dict
-    (`initializer` `(` $initializer^ `)`):(``)?
     custom<TypeOrAttr>($type, $initial_value)
   }];
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "StringRef":$name, "bool":$isMutable, "Type":$type,
-      "Optional<StringRef>":$initializer, "Optional<Attribute>":$initialValue,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs),
+    OpBuilder<(ins
+      "StringRef":$name, "bool":$isMutable, "Type":$type,
+      "Optional<Attribute>":$initialValue,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs
+    ),
     [{
       $_state.addAttribute(SymbolTable::getSymbolAttrName(),
                           $_builder.getStringAttr(name));
       if (isMutable) {
         $_state.addAttribute("is_mutable", $_builder.getUnitAttr());
       }
-      if (initializer.hasValue()) {
-        $_state.addAttribute("initializer",
-                            $_builder.getSymbolRefAttr(initializer.getValue()));
-      } else if (initialValue.hasValue() &&
+      if (initialValue.hasValue() &&
                  (initialValue.getValue().isa<IntegerAttr>() ||
                   initialValue.getValue().isa<FloatAttr>())) {
         $_state.addAttribute("initial_value", initialValue.getValue());
@@ -295,25 +337,12 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
       $_state.addAttribute("type", TypeAttr::get(type));
       $_state.attributes.append(attrs.begin(), attrs.end());
     }]>,
-    OpBuilder<(ins "StringRef":$name, "bool":$isMutable,
-      "IREE::VM::FuncOp":$initializer,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs),
+    OpBuilder<(ins
+      "StringRef":$name, "bool":$isMutable, "Type":$type,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs
+    ),
     [{
-      build($_builder, $_state, name, isMutable,
-            initializer.getType().getResult(0), initializer.getName(),
-            llvm::None, attrs);
-    }]>,
-    OpBuilder<(ins "StringRef":$name, "bool":$isMutable, "Type":$type,
-      "Attribute":$initialValue, CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs),
-    [{
-      build($_builder, $_state, name, isMutable, type, llvm::None, initialValue,
-            attrs);
-    }]>,
-    OpBuilder<(ins "StringRef":$name, "bool":$isMutable, "Type":$type,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs),
-    [{
-      build($_builder, $_state, name, isMutable, type, llvm::None, llvm::None,
-            attrs);
+      build($_builder, $_state, name, isMutable, type, llvm::None, attrs);
     }]>,
   ];
 
@@ -322,9 +351,8 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
     Type getStorageType() { return type(); }
     bool isMutable() { return is_mutable(); }
     void makeMutable() { (*this)->setAttr("is_mutable", UnitAttr::get(getContext())); }
-    Optional<StringRef> getInitializerAttr() { return initializer(); }
-    void clearInitializer() { (*this)->removeAttr("initializer"); }
     Optional<Attribute> getInitialValueAttr() { return initial_valueAttr(); }
+    void setInitialValue(Attribute value) { (*this)->setAttr("initial_value", (value)); }
     void clearInitialValue() { (*this)->removeAttr("initial_value"); }
     Optional<IntegerAttr> getOrdinalAttr() { return ordinalAttr(); }
   }];
@@ -3485,7 +3513,6 @@ def VM_CallVariadicOp : VM_CallBaseOp<"call.variadic"> {
 
 def VM_ReturnOp : VM_Op<"return", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
-    HasParent<"IREE::VM::FuncOp">,
     Terminator,
   ]> {
   let summary = "return operation";
@@ -3493,7 +3520,7 @@ def VM_ReturnOp : VM_Op<"return", [
     Represents a return operation within a function.
 
     ```
-    vm.func @foo(%0, %1) : (i32, f8) {
+    vm.func @foo(%0: i32, %1: f8) -> (i32, f8) {
       vm.return %0, %1 : i32, f8
     }
     ```

--- a/iree/compiler/Dialect/VM/IR/test/BUILD
+++ b/iree/compiler/Dialect/VM/IR/test/BUILD
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "list_op_verification.mlir",
             "list_ops.mlir",
             "shift_ops.mlir",
+            "structural_folding.mlir",
             "structural_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/IR/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "list_op_verification.mlir"
     "list_ops.mlir"
     "shift_ops.mlir"
+    "structural_folding.mlir"
     "structural_ops.mlir"
   DATA
     iree::tools::IreeFileCheck

--- a/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
@@ -5,10 +5,11 @@
 // CHECK-LABEL: @global_i32_folds
 vm.module @global_i32_folds {
   // CHECK: vm.global.i32 public mutable @g0 = 123 : i32
-  vm.global.i32 mutable @g0 initializer(@g0init) : i32
-  vm.func @g0init() -> i32 {
+  vm.global.i32 mutable @g0 : i32
+  vm.initializer {
     %c123 = vm.const.i32 123 : i32
-    vm.return %c123 : i32
+    vm.global.store.i32 %c123, @g0 : i32
+    vm.return
   }
 
   // CHECK: vm.global.i32 public mutable @g1 : i32
@@ -17,10 +18,11 @@ vm.module @global_i32_folds {
   vm.global.i32 @g2 = 0 : i32
 
   // CHECK: vm.global.i32 public mutable @g3 : i32
-  vm.global.i32 mutable @g3 initializer(@g3init) : i32
-  vm.func @g3init() -> i32 {
+  vm.global.i32 mutable @g3 : i32
+  vm.initializer {
     %c0 = vm.const.i32 0 : i32
-    vm.return %c0 : i32
+    vm.global.store.i32 %c0, @g3 : i32
+    vm.return
   }
 }
 
@@ -29,10 +31,11 @@ vm.module @global_i32_folds {
 // CHECK-LABEL: @global_ref_folds_null
 vm.module @global_ref_folds_null {
   // CHECK: vm.global.ref public mutable @g0 : !vm.ref<?>
-  vm.global.ref mutable @g0 initializer(@g0init) : !vm.ref<?>
-  vm.func @g0init() -> !vm.ref<?> {
+  vm.global.ref mutable @g0 : !vm.ref<?>
+  vm.initializer {
     %null = vm.const.ref.zero : !vm.ref<?>
-    vm.return %null : !vm.ref<?>
+    vm.global.store.ref %null, @g0 : !vm.ref<?>
+    vm.return
   }
 }
 

--- a/iree/compiler/Dialect/VM/IR/test/structural_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_folding.mlir
@@ -1,0 +1,9 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(canonicalize)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @empty_initializer
+vm.module @empty_initializer {
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
@@ -67,3 +67,34 @@ vm.module @import_funcs {
   // CHECK-NEXT: vm.import @my.fn_varargs(%foo : vector<3xi32> ..., %bar : tuple<i32, i32> ...) -> i32
   vm.import @my.fn_varargs(%foo : vector<3xi32> ..., %bar : tuple<i32, i32> ...) -> i32
 }
+
+// -----
+
+// CHECK-LABEL: @initializers
+vm.module @initializers {
+  // CHECK-NEXT: vm.initializer {
+  // CHECK-NEXT:   vm.return
+  // CHECK-NEXT: }
+  vm.initializer {
+    vm.return
+  }
+
+  // CHECK-NEXT: vm.initializer attributes {foo} {
+  // CHECK-NEXT:   vm.return
+  // CHECK-NEXT: }
+  vm.initializer attributes {foo} {
+    vm.return
+  }
+
+  // CHECK-NEXT: vm.initializer {
+  vm.initializer {
+    // CHECK-NEXT: %zero = vm.const.i32 0 : i32
+    %zero = vm.const.i32 0 : i32
+    // CHECK-NEXT:   vm.br ^bb1(%zero : i32)
+    vm.br ^bb1(%zero: i32)
+    // CHECK-NEXT: ^bb1(%0: i32):
+  ^bb1(%0: i32):
+    // CHECK-NEXT:   vm.return
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
@@ -9,22 +9,16 @@ vm.module @initEmpty {
 
 // CHECK-LABEL: @initI32
 vm.module @initI32 {
-  // CHECK: vm.global.i32 public mutable @g0 : i32
-  vm.global.i32 mutable @g0 initializer(@g0init) : i32
-  vm.func @g0init() -> i32 {
-    %c123 = vm.const.i32 123 : i32
-    vm.return %c123 : i32
-  }
+  // CHECK: vm.global.i32 private @g0
+  vm.global.i32 private @g0 : i32 = 0 : i32
 
-  // CHECK: vm.global.i32 public mutable @g1 : i32
-  vm.global.i32 mutable @g1 = 123 : i32
+  // CHECK: vm.global.i32 private mutable @g1 : i32
+  vm.global.i32 private mutable @g1 = 123 : i32
 
-  // CHECK: vm.global.i32 public mutable @g2 : i32
-  vm.global.i32 @g2 = 123 : i32
+  // CHECK: vm.global.i32 private mutable @g2 : i32
+  vm.global.i32 private @g2 = 123 : i32
 
   // CHECK: vm.func private @__init() {
-  // CHECK-NEXT:   %0 = vm.call @g0init()
-  // CHECK-NEXT:   vm.global.store.i32 %0, @g0
   // CHECK-NEXT:   %c123 = vm.const.i32 123 : i32
   // CHECK-NEXT:   vm.global.store.i32 %c123, @g1
   // CHECK-NEXT:   %c123_0 = vm.const.i32 123 : i32
@@ -37,22 +31,70 @@ vm.module @initI32 {
 
 // CHECK-LABEL: @initRef
 vm.module @initRef {
-  // CHECK: vm.global.ref public mutable @g0 : !vm.ref<?>
-  vm.global.ref mutable @g0 initializer(@g0init) : !vm.ref<?>
-  vm.func @g0init() -> !vm.ref<?> {
-    %null = vm.const.ref.zero : !vm.ref<?>
-    vm.return %null : !vm.ref<?>
+  // CHECK: vm.global.ref private mutable @g0 : !vm.ref<?>
+  vm.global.ref private mutable @g0 : !vm.ref<?>
+
+  // CHECK: vm.global.ref private mutable @g1 : !vm.ref<?>
+  vm.global.ref private mutable @g1 : !vm.ref<?>
+
+  // CHECK: vm.global.ref private @g2 : !vm.ref<?>
+  vm.global.ref private @g2 : !vm.ref<?>
+
+  // CHECK-NOT: vm.func private @__init()
+}
+
+// -----
+
+// CHECK-LABEL: @initializers
+vm.module @initializers {
+  // CHECK: vm.global.i32 private mutable @g0 : i32
+  vm.global.i32 private @g0 : i32
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %c123 = vm.const.i32 123 : i32
+    vm.global.store.i32 %c123, @g0 : i32
+    vm.return
   }
 
-  // CHECK: vm.global.ref public mutable @g1 : !vm.ref<?>
-  vm.global.ref mutable @g1 : !vm.ref<?>
+  // CHECK: vm.global.ref private mutable @g1 : !vm.ref<?>
+  vm.global.ref private mutable @g1 : !vm.ref<?>
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %null = vm.const.ref.zero : !vm.ref<?>
+    vm.global.store.ref %null, @g1 : !vm.ref<?>
+    vm.return
+  }
 
-  // CHECK: vm.global.ref public @g2 : !vm.ref<?>
-  vm.global.ref @g2 : !vm.ref<?>
+  // CHECK: vm.global.ref private mutable @g2 : !vm.ref<?>
+  vm.global.ref private mutable @g2 : !vm.ref<?>
+  // CHECK-NOT: vm.initializer
+  vm.initializer {
+    %g1 = vm.global.load.ref @g1 : !vm.ref<?>
+    vm.global.store.ref %g1, @g2 : !vm.ref<?>
+    vm.return
+  }
 
-  // CHECK: vm.func private @__init() {
-  // CHECK-NEXT:   %ref = vm.call @g0init()
-  // CHECK-NEXT:   vm.global.store.ref %ref, @g0
+  //      CHECK: vm.func private @__init() {
+  // CHECK-NEXT:   %c123 = vm.const.i32 123 : i32
+  // CHECK-NEXT:   vm.global.store.i32 %c123, @g0 : i32
+  // CHECK-NEXT:   %null = vm.const.ref.zero : !vm.ref<?>
+  // CHECK-NEXT:   vm.global.store.ref %null, @g1 : !vm.ref<?>
+  // CHECK-NEXT:   %g1 = vm.global.load.ref @g1 : !vm.ref<?>
+  // CHECK-NEXT:   vm.global.store.ref %g1, @g2 : !vm.ref<?>
   // CHECK-NEXT:   vm.return
   // CHECK-NEXT: }
+}
+
+// -----
+
+// CHECK-LABEL: @unused_globals
+vm.module @unused_globals {
+  // CHECK: vm.global.i32 private mutable @used
+  vm.global.i32 private @used : i32 = 1 : i32
+  // CHECK-NOT: vm.global.i32 private @unused
+  vm.global.i32 private @unused : i32 = 2 : i32
+  vm.func @foo() {
+    %0 = vm.global.load.i32 @used : i32
+    vm.return
+  }
 }


### PR DESCRIPTION
The existing mechanism made it impossible to have multiple globals
initialized with the results of a single call; now one can initialize
globals with arbitrary code while preserving the invariant that each
global is initialized in an explicit order.

Additional verifiers can be added that ensure proper module initialization
ordering (no loads before initialized, etc) - filed as #6824.

Future changes will apply a similar refactoring to `util.global`.