### PR TITLE
Disabling promote_workgroup_memory.mlir run line.

### DIFF
--- a/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -24,7 +24,6 @@ iree_lit_test_suite(
             "fold_gpu_procid_uses.mlir",
             "pipeline_matmul_cooperative_matrix.mlir",
             "pipeline_matmul_vectorization.mlir",
-            "promote_workgroup_memory.mlir",
             "remove_one_trip_tiled_loop.mlir",
             "tile_and_vectorize.mlir",
             "tile_and_vectorize_batch_matmul.mlir",
@@ -37,6 +36,7 @@ iree_lit_test_suite(
             "vectorize_load_store.mlir",
         ],
         include = ["*.mlir"],
+        exclude = ["promote_workgroup_memory.mlir"],
     ),
     data = [
         "//iree/tools:IreeFileCheck",

--- a/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -19,7 +19,6 @@ iree_lit_test_suite(
     "fold_gpu_procid_uses.mlir"
     "pipeline_matmul_cooperative_matrix.mlir"
     "pipeline_matmul_vectorization.mlir"
-    "promote_workgroup_memory.mlir"
     "remove_one_trip_tiled_loop.mlir"
     "tile_and_vectorize.mlir"
     "tile_and_vectorize_batch_matmul.mlir"

--- a/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
@@ -1,6 +1,5 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-tile-and-distribute,iree-spirv-vectorize,canonicalize,cse))))'
 // TODO(antiagainst): Fix promotion to workgroup and enable the test.
-// | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-tile-and-distribute,iree-spirv-vectorize,canonicalize,cse))))' | IreeFileCheck %s
 
 hal.executable @matmul_promote_workgroup_memory attributes {sym_visibility = "private"} {
   hal.interface @io {


### PR DESCRIPTION
This causes hangs when running ctest on Windows.