### PR TITLE
Support global ref ops and fix passing of refs on function boundaries in the C target

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -315,13 +315,17 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
     Type objType = elementType.cast<IREE::VM::RefType>().getObjectType();
 
     std::string typeName;
-    if (objType.isa<IREE::VM::BufferType>())
-      typeName = "\"vm.buffer\"";
-    else if (objType.isa<IREE::VM::ListType>())
-      typeName = "\"vm.list\"";
-    else {
-      return None;
+
+    if (objType.isa<IREE::VM::ListType>()) {
+      typeName = "!vm.list";
+    } else {
+      llvm::raw_string_ostream sstream(typeName);
+      objType.print(sstream);
+      sstream.flush();
     }
+
+    // Remove leading '!' and wrap in quotes
+    typeName = std::string("\"") + typeName.substr(1) + std::string("\"");
 
     auto typeNameCStringView = rewriter.create<emitc::CallOp>(
         /*location=*/loc,

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
@@ -33,14 +33,19 @@ struct VMAnalysis {
   }
 
   int getRefRegisterOrdinal(Value ref) {
-    return registerAllocation.mapToRegister(originalValue(ref)).ordinal();
+    auto originalRef = originalValue(ref);
+    assert(originalRef.getType().isa<IREE::VM::RefType>());
+    return registerAllocation.mapToRegister(originalRef).ordinal();
   }
 
   bool isLastValueUse(Value ref, Operation *op) {
-    return valueLiveness.isLastValueUse(originalValue(ref), op);
+    auto originalRef = originalValue(ref);
+    assert(originalRef.getType().isa<IREE::VM::RefType>());
+    return valueLiveness.isLastValueUse(originalRef, op);
   }
 
   void remapValue(Value original, Value replacement) {
+    assert(original.getType().isa<IREE::VM::RefType>());
     mapping[replacement] = original;
     return;
   }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_add_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_add_f32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_add_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_select_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_select_f32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_select_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i32

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_f32o

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 vm.module @module {
   // CHECK-LABEL: @module_cmp_eq_i64

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 vm.module @my_module {
   // CHECK-LABEL: @my_module_const_f32_zero

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_trunc
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_cast
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_trunc_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_shl_i32
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='vm.module(iree-vm-ordinal-allocation),vm.module(iree-convert-vm-to-emitc)' %s | IreeFileCheck %s
 
 // CHECK-LABEL: @my_module_shl_i64
 vm.module @my_module {

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -42,16 +42,6 @@ static void printModuleComment(IREE::VM::ModuleOp &moduleOp,
          << std::string(77, '=') << "\n";
 }
 
-static void printSeparatingComment(llvm::raw_ostream &output) {
-  output << "//" << std::string(77, '=')
-         << "\n"
-            "// The code below setups functions and lookup tables to "
-            "implement the vm\n"
-            "// interface\n"
-            "//"
-         << std::string(77, '=') << "\n";
-}
-
 static LogicalResult printRodataBuffers(IREE::VM::ModuleOp &moduleOp,
                                         mlir::emitc::CppEmitter &emitter) {
   llvm::raw_ostream &output = emitter.ostream();

--- a/iree/vm/ops_emitc.h
+++ b/iree/vm/ops_emitc.h
@@ -10,9 +10,6 @@
 // This file contains utility macros used for things that EmitC  can't handle
 // directly.
 
-// Assign a value to a variable
-#define EMITC_ASSIGN_VALUE(var, value) (var) = (value)
-
 // Assign a value through a pointer variable
 #define EMITC_DEREF_ASSIGN_VALUE(ptr, value) *(ptr) = (value)
 

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -22,7 +22,7 @@ vm.module @call_ops {
     vm.return
   }
 
-  // Check that unused ref argument slots are handled properly
+  // Check that reused ref argument slots are handled properly
   vm.export @test_call_r_v_reuse_reg
   vm.func @test_call_r_v_reuse_reg() {
     %ref = vm.const.ref.zero : !vm.buffer
@@ -31,13 +31,9 @@ vm.module @call_ops {
     vm.return
   }
 
-  // Check passing ref arguments doesn't alter values on the call site
-  // TODO(simon-camp): This doesn't work with the current pass pipeline defined
-  // in the CModuleTarget. We run the reigster allocation pass before removing
-  // do_not_optimize ops to prevent constant folding of the tests happening
-  // during the vm to emitc conversion. 
-  vm.export @test_call_r_v_preserve_ref attributes {emitc.exclude}
-  vm.func private @test_call_r_v_preserve_ref() {
+  // Check passing refs as arguments doesn't alter values on the call site
+  vm.export @test_call_r_v_preserve_ref
+  vm.func @test_call_r_v_preserve_ref() {
     %ref = vm.const.ref.zero : !vm.buffer
     %unused = vm.const.ref.rodata @buffer : !vm.buffer
     %unusued_dno_1 = util.do_not_optimize(%unused) : !vm.buffer

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -1,5 +1,7 @@
 vm.module @call_ops {
 
+  vm.rodata private @buffer dense<[1, 2, 3]> : tensor<3xi8>
+
   vm.export @fail_call_v_v
   vm.func @fail_call_v_v() {
     vm.call @_v_v_fail() : () -> ()
@@ -17,6 +19,32 @@ vm.module @call_ops {
   vm.func @test_call_r_v() {
     %ref = vm.const.ref.zero : !vm.ref<?>
     vm.call @_r_v(%ref) : (!vm.ref<?>) -> ()
+    vm.return
+  }
+
+  // Check that unused ref argument slots are handled properly
+  vm.export @test_call_r_v_reuse_reg
+  vm.func @test_call_r_v_reuse_reg() {
+    %ref = vm.const.ref.zero : !vm.buffer
+    %unused = vm.const.ref.zero : !vm.buffer
+    vm.call @_r_v_reuse_reg(%ref, %unused) : (!vm.buffer, !vm.buffer) -> ()
+    vm.return
+  }
+
+  // Check passing ref arguments doesn't alter values on the call site
+  // TODO(simon-camp): This doesn't work with the current pass pipeline defined
+  // in the CModuleTarget. We run the reigster allocation pass before removing
+  // do_not_optimize ops to prevent constant folding of the tests happening
+  // during the vm to emitc conversion. 
+  vm.export @test_call_r_v_preserve_ref attributes {emitc.exclude}
+  vm.func private @test_call_r_v_preserve_ref() {
+    %ref = vm.const.ref.zero : !vm.buffer
+    %unused = vm.const.ref.rodata @buffer : !vm.buffer
+    %unusued_dno_1 = util.do_not_optimize(%unused) : !vm.buffer
+    vm.check.nz %unused : !vm.buffer
+    vm.call @_r_v_preserve_reg(%ref, %unused) : (!vm.buffer, !vm.buffer) -> ()
+    %unusued_dno_2 = util.do_not_optimize(%unused) : !vm.buffer
+    vm.check.nz %unusued_dno_2 : !vm.buffer
     vm.return
   }
 
@@ -66,12 +94,27 @@ vm.module @call_ops {
     vm.return
   }
 
+  vm.func @_r_v_reuse_reg(%arg : !vm.ref<?>, %unused : !vm.ref<?>) attributes {noinline} {
+    %ref = vm.const.ref.zero : !vm.ref<?>
+    %ref_dno = util.do_not_optimize(%ref) : !vm.ref<?>
+    vm.check.eq %arg, %ref_dno, "Expected %arg to be NULL" : !vm.ref<?>
+    vm.return
+  }
+
+  vm.func @_r_v_preserve_reg(%arg1 : !vm.ref<?>, %arg2 : !vm.ref<?>) attributes {noinline} {
+    %ref = vm.const.ref.zero : !vm.ref<?>
+    %ref_dno = util.do_not_optimize(%ref) : !vm.ref<?>
+    vm.check.eq %arg1, %ref_dno, "Expected %arg1 to be NULL" : !vm.ref<?>
+    vm.check.nz %arg2, "Expected %arg2 to be not NULL" : !vm.ref<?>
+    vm.return
+  }
+
   vm.func @_v_i() -> i32 attributes {noinline} {
     %c1 = vm.const.i32 1 : i32
     vm.return %c1 : i32
   }
 
-  vm.func private @_v_r() -> !vm.ref<?> attributes {noinline} {
+  vm.func @_v_r() -> !vm.ref<?> attributes {noinline} {
     %ref = vm.const.ref.zero : !vm.ref<?>
     vm.return %ref : !vm.ref<?>
   }

--- a/iree/vm/test/global_ops.mlir
+++ b/iree/vm/test/global_ops.mlir
@@ -6,13 +6,26 @@ vm.module @global_ops {
 
   vm.global.i32 private @c42 = 42 : i32
   vm.global.i32 private mutable @c107_mut = 107 : i32
+  vm.global.ref mutable @g0 : !vm.buffer
   // TODO(simon-camp): Add test for initializer
 
+  vm.rodata private @buffer dense<[1, 2, 3]> : tensor<3xi8>
+
+  // TODO(simon-camp) This test gets constant folded
   vm.export @test_global_load_i32
   vm.func @test_global_load_i32() {
     %actual = vm.global.load.i32 @c42 : i32
     %expected = vm.const.i32 42 : i32
     vm.check.eq %actual, %expected, "@c42 != 42" : i32
+    vm.return
+  }
+
+  vm.export @test_global_load_ref
+  vm.func @test_global_load_ref() {
+    %actual = vm.global.load.ref @g0 : !vm.buffer
+    %expected = vm.const.ref.zero : !vm.buffer
+    %expecteddno = util.do_not_optimize(%expected) : !vm.buffer
+    vm.check.eq %actual, %expecteddno : !vm.buffer
     vm.return
   }
 
@@ -22,6 +35,15 @@ vm.module @global_ops {
     vm.global.store.i32 %c17, @c107_mut : i32
     %actual = vm.global.load.i32 @c107_mut : i32
     vm.check.eq %actual, %c17, "@c107_mut != 17" : i32
+    vm.return
+  }
+
+  vm.export @test_global_store_ref
+  vm.func @test_global_store_ref() {
+    %ref_buffer = vm.const.ref.rodata @buffer : !vm.buffer
+    vm.global.store.ref %ref_buffer, @g0 : !vm.buffer
+    %actual = vm.global.load.ref @g0 : !vm.buffer
+    vm.check.eq %actual, %ref_buffer, "@g0 != buffer" : !vm.buffer
     vm.return
   }
 


### PR DESCRIPTION
The generated code for function calls works as follows:

On the call-site:
- create an `iree_vm_ref_t` for every ref operand and result
- populate new operand refs with `iree_vm_ref_retain_or_move(origOperand, newOperand)`

In the callee:
- populate result arguments with `iree_vm_ref_move(origResult, outArgResult)`


Additionally conversions for global ref ops were added.