### PR TITLE
Integrate upstream cpp emitter changes

### DIFF
--- a/third_party/mlir-emitc/include/emitc/Target/Cpp/CppEmitter.h
+++ b/third_party/mlir-emitc/include/emitc/Target/Cpp/CppEmitter.h
@@ -15,6 +15,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/IndentedOstream.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/Support/raw_ostream.h"
 #include <stack>
@@ -141,7 +142,7 @@ struct CppEmitter {
   bool hasBlockLabel(Block &block);
 
   /// Returns the output stream.
-  raw_ostream &ostream() { return os; };
+  raw_indented_ostream &ostream() { return os; };
 
   /// Returns if all variables for op results and basic block arguments need to
   /// be declared at the beginning of a function.
@@ -152,7 +153,7 @@ private:
   using BlockMapper = llvm::ScopedHashTable<Block *, std::string>;
 
   /// Output stream to emit to.
-  raw_ostream &os;
+  raw_indented_ostream os;
 
   /// Boolean to enforce that all variables for op results and block
   /// arguments are declared at the beginning of the function. This also
@@ -172,8 +173,10 @@ private:
 };
 
 /// Translates the given operation to C++ code. The operation or operations in
-/// the region of 'op' need almost all be in EmitC dialect.
-LogicalResult translateToCpp(Operation &op, raw_ostream &os,
+/// the region of 'op' need almost all be in EmitC dialect. The parameter
+/// 'declareVariablesAtTop' enforces that all variables for op results and block
+/// arguments are declared at the beginning of the function.
+LogicalResult translateToCpp(Operation *op, raw_ostream &os,
                              bool declareVariablesAtTop = false);
 } // namespace emitc
 } // namespace mlir


### PR DESCRIPTION
Takes over upstream changes:
* iml130/mlir-emitc@e973e19
* iml130/mlir-emitc@25c55a9
* iml130/mlir-emitc@ec53616
* iml130/mlir-emitc@5da8961