### PR TITLE
[spirv] Split per-target CodeGen configuration to separate files

### DIFF
--- a/iree/compiler/Codegen/SPIRV/BUILD
+++ b/iree/compiler/Codegen/SPIRV/BUILD
@@ -15,6 +15,8 @@ cc_library(
     srcs = [
         "ConvertToSPIRVPass.cpp",
         "KernelConfig.cpp",
+        "MaliConfig.cpp",
+        "NVIDIAConfig.cpp",
         "Passes.cpp",
         "SPIRVCopyToWorkgroupMemory.cpp",
         "SPIRVDistributeToGlobalID.cpp",

--- a/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -20,6 +20,8 @@ iree_cc_library(
   SRCS
     "ConvertToSPIRVPass.cpp"
     "KernelConfig.cpp"
+    "MaliConfig.cpp"
+    "NVIDIAConfig.cpp"
     "Passes.cpp"
     "SPIRVCopyToWorkgroupMemory.cpp"
     "SPIRVDistributeToGlobalID.cpp"

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -4,334 +4,210 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-//===- KernelDispatchUtils.cpp - Utilities for generating dispatch info ---===//
-//
-// This file defines utility functions that can be used to get the information
-// about tile sizes to use to partition work across workgroups, the workgroup
-// sizes and to create information the dispatch on the host side needs to
-// execute an entry point function (e.g. total number of workgroups).
-//
-//===----------------------------------------------------------------------===//
-
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 
-#include "iree/compiler/Codegen/Passes.h"
-#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
-#include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
-#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/Support/Debug.h"
-#include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/Dialect/Linalg/Analysis/DependenceAnalysis.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/Dialect/Vector/VectorTransforms.h"
-#include "mlir/IR/BlockAndValueMapping.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Operation.h"
-#include "mlir/IR/PatternMatch.h"
 
-#define DEBUG_TYPE "kernel-dispatch-utils"
+#define DEBUG_TYPE "iree-spirv-kernel-config"
 
 namespace mlir {
 namespace iree_compiler {
 
-/// Given `nprocs` try to distribute it evenly across 2 logical x and y.
-static std::tuple<int64_t, int64_t> distributeProcs2D(int64_t nprocs) {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+/// Given `nprocs`, tries to distribute it evenly across 2 logical dimensions.
+std::tuple<int64_t, int64_t> distributeProcs2D(int64_t nprocs) {
   int64_t nprocs_x = std::max<int64_t>(
       1, static_cast<int64_t>(
              llvm::PowerOf2Ceil(static_cast<uint64_t>(std::sqrt(nprocs)))));
   return std::make_tuple(nprocs_x, nprocs / nprocs_x);
 }
 
-/// Returns the minimum of `shape` and `tileSize` if shape is static. If `shape`
-/// is dynamic returns `tileSize`.
-static int64_t getMinIfShapeStatic(int64_t shape, int64_t tileSize) {
+/// Returns the minimum of `shape` and `tileSize` if shape is static.
+/// Returns `tileSize` otherwise.
+int64_t getMinIfStaticShape(int64_t shape, int64_t tileSize) {
   if (shape == ShapedType::kDynamicSize) return tileSize;
   return std::min(shape, tileSize);
 }
 
-namespace {
-struct TileWorkgroupSizePair {
-  // How many scalar elements each workgroup should handle along each dimension.
-  std::array<int64_t, 3> tileSize;
-  std::array<int64_t, 3> workgroupSize;
-};
-}  // namespace
-
-static void getMaliBestMatMulTileSizes(
-    Type elementType, SmallVectorImpl<TileWorkgroupSizePair> &tileSizes,
-    int64_t dstSize) {
-  if (elementType.isF16()) {
-    const int64_t smallMatrixSizeThreshold = 512 * 512;
-    // For smaller destination size we cannot fill out the GPU with bigger tile
-    // sizes. Instead we pick smaller tiles along M and N to increase the number
-    // of workgroups and a larger K tile size since we have lower pressure and
-    // need extra instructions to hide latency.
-    // TODO: The threshold needs to be fine tuned by doing exploration based on
-    // matrix shapes.
-    if (dstSize <= smallMatrixSizeThreshold) {
-      tileSizes.push_back(TileWorkgroupSizePair({{16, 32, 16}, {8, 2, 1}}));
-    } else {
-      tileSizes.push_back(TileWorkgroupSizePair({{16, 64, 4}, {8, 2, 1}}));
-      tileSizes.push_back(TileWorkgroupSizePair({{8, 128, 4}, {8, 2, 1}}));
-      tileSizes.push_back(TileWorkgroupSizePair({{16, 32, 4}, {8, 2, 1}}));
-    }
-  } else {
-    // TODO: Heuristic picked based on MobileNet performance. We need
-    // auto-tuning to be able to make a smarter choice.
-    const int64_t smallMatrixSizeThreshold = 20000;
-    if (dstSize <= smallMatrixSizeThreshold) {
-      tileSizes.push_back(TileWorkgroupSizePair({{4, 32, 16}, {8, 2, 1}}));
-    }
-    tileSizes.push_back(TileWorkgroupSizePair({{12, 32, 4}, {8, 2, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{14, 32, 4}, {8, 2, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{10, 32, 4}, {8, 2, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{7, 64, 4}, {16, 1, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{8, 32, 4}, {8, 2, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{6, 32, 4}, {8, 2, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{24, 16, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{16, 16, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{24, 8, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{40, 8, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{32, 8, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{16, 8, 4}, {2, 8, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{1, 32, 16}, {8, 1, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{1, 32, 8}, {8, 1, 1}}));
-    tileSizes.push_back(TileWorkgroupSizePair({{1, 32, 4}, {8, 1, 1}}));
-  }
+/// Defines the workgroup count region on entry point ops for the
+/// `SPIRVDistributeToGlobalID` pipeline.
+// TODO(ravishankarm): Remove this when that pipeline is deprecated.
+LogicalResult setTranslationUsingDistributeToGlobalId(
+    FuncOp funcOp, ArrayRef<int64_t> workgroupSize) {
+  auto entryPointOp = getEntryPoint(funcOp);
+  MLIRContext *context = entryPointOp.getContext();
+  auto translationInfo = buildTranslationInfo(
+      IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistributeToGlobalID,
+      /*workloadPerWorkgroup =*/{}, context);
+  setTranslationInfo(entryPointOp, translationInfo, workgroupSize);
+  OpBuilder builder(context);
+  int64_t workgroupSizeX = workgroupSize[0];
+  auto numWorkgroupsFn = [workgroupSizeX](OpBuilder &b, Location loc,
+                                          std::array<Value, 3> workload) {
+    AffineExpr e1, e2, e3;
+    bindSymbols(b.getContext(), e1, e2, e3);
+    AffineExpr expr = e1 * e2 * e3;
+    expr = expr.ceilDiv(workgroupSizeX);
+    Value numWorkgroupsX = linalg::applyMapToValues(
+        b, loc, AffineMap::get(0, 3, expr), workload)[0];
+    Value one = b.create<ConstantIndexOp>(loc, 1);
+    return std::array<Value, 3>{numWorkgroupsX, one, one};
+  };
+  return defineWorkgroupCountRegion(builder, funcOp, numWorkgroupsFn);
 }
 
-/// Launch configuration for Mali GPU configuration.
-static LogicalResult setMaliSpecificConfig(FuncOp entryPoint,
-                                           const spirv::TargetEnv &targetEnv,
-                                           linalg::BatchMatmulOp op) {
-  if (targetEnv.getVendorID() != spirv::Vendor::ARM) return failure();
+//===----------------------------------------------------------------------===//
+// Matmul Default Configuration
+//===----------------------------------------------------------------------===//
 
-  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
-  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
-  // If the shape size is unknonw fall back to none vectorized path.
-  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
-      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
-    return failure();
-  }
+Optional<detail::SPIRVCodeGenConfig> getOpConfig(
+    spirv::ResourceLimitsAttr limits, linalg::BatchMatmulOp op) {
+  unsigned maxWorkgroupSize =
+      limits.max_compute_workgroup_invocations().getInt();
 
-  // Get a vector of best tile size ordered from best to worst.
-  SmallVector<TileWorkgroupSizePair, 4> workgroupLevelTs;
-  int64_t dstSize = lhsShape[0] * lhsShape[1] * rhsShape[2];
-  getMaliBestMatMulTileSizes(
-      op.inputs()[0].getType().cast<ShapedType>().getElementType(),
-      workgroupLevelTs, dstSize);
-  for (TileWorkgroupSizePair pair : workgroupLevelTs) {
-    if (lhsShape[1] % pair.tileSize[0] != 0 ||
-        rhsShape[2] % pair.tileSize[1] != 0 ||
-        lhsShape[2] % pair.tileSize[2] != 0) {
-      continue;
-    }
+  // This is just being hard-wired for now to be minimal viable, but this can be
+  // decided better when we have better estimates of device charecteristics.
+  const int64_t numRowsPerThread = 1;
+  const int64_t numColsPerThread = 1;
+  const int64_t numBatchesPerThread = 1;
+  const int64_t tileSizeK = 0;
 
-    SmallVector<int64_t, 4> batchTs;
-    batchTs.append({1, pair.tileSize[0], pair.tileSize[1], pair.tileSize[2]});
-    TileSizesListType tileSizes;
-    tileSizes.emplace_back(batchTs);
-    // No tiling at the subgroup level since this target doesn't use subgroup op
-    // or shared memory.
-    tileSizes.emplace_back();
-    SmallVector<int64_t, 4> invocationLevelTs = {
-        batchTs[0], batchTs[1] / pair.workgroupSize[1],
-        batchTs[2] / pair.workgroupSize[0], batchTs[3]};
-    tileSizes.emplace_back(invocationLevelTs);
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-        IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize,
-        pair.workgroupSize);
-  }
-  return failure();
-}
-
-/// Launch config for `linalg.batchmatmul`.
-static LogicalResult setRootConfig(FuncOp entryPoint,
-                                   const spirv::TargetEnv &targetEnv,
-                                   linalg::BatchMatmulOp op) {
-  if (succeeded(setMaliSpecificConfig(entryPoint, targetEnv, op))) {
-    return success();
-  }
-  unsigned maxWorkgroupSize = targetEnv.getResourceLimits()
-                                  .max_compute_workgroup_invocations()
-                                  .getInt();
   std::array<int64_t, 3> workgroupSize = {1, 1, 1};
   std::tie(workgroupSize[0], workgroupSize[1]) =
       distributeProcs2D(maxWorkgroupSize);
-  // This is just being hard-wired for now to be minimal viable, but this can be
-  // decided better when we have better estimates of device charecteristics.
-  const int64_t nRowsPerWorkitem = 1;
-  const int64_t nColsPerWorkitem = 1;
-  const int64_t nBatchesPerWorkitem = 1;
+
+  detail::SPIRVCodeGenConfig config = {};
+  config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute;
+
+  config.workgroupTileSizes = {numBatchesPerThread,
+                               numRowsPerThread * workgroupSize[1],
+                               numColsPerThread * workgroupSize[0], tileSizeK};
+
+  config.invocationTileSizes = {numBatchesPerThread, numRowsPerThread,
+                                numColsPerThread, 0};
+
+  config.workgroupSize = {1, 1, 1};
+  std::tie(config.workgroupSize[0], config.workgroupSize[1]) =
+      distributeProcs2D(maxWorkgroupSize);
+
+  config.workgroupSize = workgroupSize;
+
+  return config;
+}
+
+Optional<detail::SPIRVCodeGenConfig> getOpConfig(
+    spirv::ResourceLimitsAttr limits, linalg::MatmulOp op) {
+  unsigned maxWorkgroupSize =
+      limits.max_compute_workgroup_invocations().getInt();
+
+  std::array<int64_t, 3> workgroupSize = {1, 1, 1};
+  std::tie(workgroupSize[0], workgroupSize[1]) =
+      distributeProcs2D(maxWorkgroupSize);
+
+  const int numRowsPerThread = 1;
+  const int numColsPerThread = 1;
   int64_t tileSizeK = 0;
-  SmallVector<int64_t, 4> workgroupLevel = {
-      nBatchesPerWorkitem, nRowsPerWorkitem * workgroupSize[1],
-      nColsPerWorkitem * workgroupSize[0], tileSizeK};
-  SmallVector<int64_t, 4> invocationLevel = {
-      nBatchesPerWorkitem, nRowsPerWorkitem, nColsPerWorkitem, 0};
-
-  TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(workgroupLevel));
-  tileSizes.emplace_back();  // subgroup level
-  tileSizes.emplace_back(std::move(invocationLevel));
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-      IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute, workgroupSize);
-}
-
-/// Returns the size of the co-operative matrix multiply operations on the
-/// device.
-static Optional<SmallVector<int64_t, 4>> getCooperativeMatmulSubgroupSize(
-    spirv::ResourceLimitsAttr resourceLimits, Type lhsType, Type rhsType,
-    Type initType, Type resultType) {
-  for (auto coopMatmulProperties :
-       resourceLimits.cooperative_matrix_properties_nv()
-           .getAsRange<spirv::CooperativeMatrixPropertiesNVAttr>()) {
-    if (coopMatmulProperties.a_type().getValue() == lhsType &&
-        coopMatmulProperties.b_type().getValue() == rhsType &&
-        coopMatmulProperties.c_type().getValue() == initType &&
-        coopMatmulProperties.result_type().getValue() == resultType &&
-        coopMatmulProperties.scope().getValue() == spirv::Scope::Subgroup) {
-      return SmallVector<int64_t, 4>{
-          coopMatmulProperties.m_size().getValue().getSExtValue(),
-          coopMatmulProperties.n_size().getValue().getSExtValue(),
-          coopMatmulProperties.k_size().getValue().getSExtValue()};
-    }
-  }
-  return llvm::None;
-}
-
-/// Launch configuration for using spv.CooperativeMatrixMulAddNV
-/// operations. Needs two levels of tiling.
-static LogicalResult setConfigForCooperativeMatmul(
-    FuncOp entryPoint, const spirv::TargetEnv &targetEnv, linalg::MatmulOp op) {
-  if (!targetEnv.allows(spirv::Capability::CooperativeMatrixNV) ||
-      !targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix))
-    return failure();
 
   ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
   ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
-  // If the shape size is unknonw fall back to none vectorized path.
-  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
-      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
-    return failure();
-  }
 
-  auto resourceLimits = targetEnv.getResourceLimits();
-  auto getElementType = [](Value v) {
-    return v.getType().cast<ShapedType>().getElementType();
-  };
-  auto outputElementType = getElementType(op.outputs()[0]);
-  Optional<SmallVector<int64_t, 4>> coopMatmulSize =
-      getCooperativeMatmulSubgroupSize(
-          resourceLimits, getElementType(op.inputs()[0]),
-          getElementType(op.inputs()[1]), outputElementType, outputElementType);
-  if (!coopMatmulSize) return failure();
+  int64_t M = lhsShape[0];
+  int64_t N = rhsShape[1];
+  int64_t K = lhsShape[1];
 
-  // Check that the matmul sizes are a multiple of the tilesize.
-  auto isMultipleOf = [](int64_t s, int64_t ts) {
-    return !ShapedType::isDynamic(s) && (s % ts) == 0;
-  };
+  detail::SPIRVCodeGenConfig config = {};
+  config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute;
 
-  if (!isMultipleOf(lhsShape[0], (*coopMatmulSize)[0]) ||
-      !isMultipleOf(rhsShape[1], (*coopMatmulSize)[1]) ||
-      !isMultipleOf(lhsShape[1], (*coopMatmulSize)[2]) ||
-      !isMultipleOf(rhsShape[0], (*coopMatmulSize)[2]))
-    return failure();
+  config.workgroupTileSizes = {
+      getMinIfStaticShape(M, numRowsPerThread * workgroupSize[1]),
+      getMinIfStaticShape(N, numColsPerThread * workgroupSize[0]),
+      getMinIfStaticShape(K, tileSizeK)};
 
-  // For now this is being hard-wired to be {4, 4, 2}. This can actually be set
-  // to whatever, but ultimately depends on register pressure.
-  const int64_t numVecMatmulPerSubgroupX = 4;
-  const int64_t numVecMatmulPerSubgroupY = 4;
-  const int64_t numVecMatmulPerSubgroupK = 2;
-  SmallVector<int64_t, 4> ts = {
-      numVecMatmulPerSubgroupY * (*coopMatmulSize)[0],
-      numVecMatmulPerSubgroupX * (*coopMatmulSize)[1],
-      numVecMatmulPerSubgroupK * (*coopMatmulSize)[2]};
-  TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(ts));
+  config.invocationTileSizes = {1, 1, 0};
 
-  int64_t subgroupSize =
-      resourceLimits.subgroup_size().getValue().getSExtValue();
-  std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
-  SmallVector<int64_t, 4> subgroupTs = {
-      numVecMatmulPerSubgroupY * (*coopMatmulSize)[0],
-      numVecMatmulPerSubgroupX * (*coopMatmulSize)[1]};
-  tileSizes.emplace_back(std::move(subgroupTs));
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-      IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize, workgroupSize);
+  config.workgroupSize = workgroupSize;
+
+  return config;
 }
 
-/// Launch config for element-wise linalg.generic.
-LogicalResult setDefaultRootConfig(FuncOp entryPoint,
-                                   const spirv::TargetEnv &targetEnv,
-                                   Operation *op) {
+//===----------------------------------------------------------------------===//
+// Default Configuration
+//===----------------------------------------------------------------------===//
+
+Optional<detail::SPIRVCodeGenConfig> getDefaultOpConfig(
+    spirv::ResourceLimitsAttr limits, Operation *op) {
+  detail::SPIRVCodeGenConfig config = {};
+
   auto partitionedLoops = getPartitionedLoops(op);
   if (partitionedLoops.empty()) {
-    // Serialized computation.
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, /*tileSizes =*/TileSizesListType{{}},
-        /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-        IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize, {1, 1, 1});
+    config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+    config.workgroupSize = {1, 1, 1};
+    return config;
   }
 
-  // Skip vectorization for non-minor identity inputs as it generates
-  // transfer_read ops with permutation maps that we currently cannot lower.
-  // TODO: Remove this restriction once the lowering of the permutation map is
-  // supported in core.
-  int64_t subgroupSize =
-      targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
+  const int64_t subgroupSize = limits.subgroup_size().getValue().getSExtValue();
+  int64_t numElementsPerWorkgroup = subgroupSize;
+  int64_t numElementsPerThread = 1;
+  auto pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute;
 
-  int64_t lowerWorkgroupTs = subgroupSize;
-  int64_t lowerThreadTs = 1;
-  IREE::HAL::DispatchLoweringPassPipeline pipeline =
-      IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute;
+  // Returns true if the given `operand` has 32-bit element type.
+  auto has32BitElementType = [](Value operand) {
+    auto shapedType = operand.getType().dyn_cast<ShapedType>();
+    Type elementType =
+        (shapedType ? shapedType.getElementType() : operand.getType());
+    return elementType.isa<FloatType>() || elementType.isInteger(32);
+  };
+
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
     bool vectorize = false;
-    // TODO(thomasraoux): Lowering of integers other than i32 may require
-    // emulation. This is currently not supported for vector operation.
-    // Re-enable this when the bug is fixed on SPIR-V lowering side.
     auto outputShape = getUntiledResultShape(linalgOp, 0);
+
     if (!linalgOp.hasIndexSemantics() &&
+        // Skip vectorization for non-minor identity inputs as it generates
+        // vector.transfer_read ops with permutation maps that we currently
+        // cannot lower.
+        // TODO: Remove this restriction once the lowering of the permutation
+        // map is supported in core.
         llvm::all_of(linalgOp.getIndexingMaps(),
                      [](AffineMap &map) { return map.isMinorIdentity(); }) &&
-        llvm::all_of(
-            linalgOp->getOperands(),
-            [](Value operand) {
-              auto shapedType = operand.getType().dyn_cast<ShapedType>();
-              Type elementType = (shapedType ? shapedType.getElementType()
-                                             : operand.getType());
-              return elementType.isa<FloatType>() || elementType.isInteger(32);
-            }) &&
+        // TODO(thomasraoux): Lowering of integers other than i32 may require
+        // emulation. This is currently not supported for vector operation.
+        // Re-enable this when the bug is fixed on SPIR-V lowering side.
+        llvm::all_of(linalgOp->getOperands(), has32BitElementType) &&
         llvm::all_of(outputShape,
                      [](int64_t dim) { return !ShapedType::isDynamic(dim); })) {
       vectorize = true;
     }
+
     SmallVector<int64_t, 4> candidateTileSizes;
     if (vectorize) candidateTileSizes.push_back(4 * subgroupSize);
     candidateTileSizes.push_back(subgroupSize);
+
     for (int64_t size : candidateTileSizes) {
       if (outputShape.back() % size != 0) continue;
-      lowerWorkgroupTs = size;
+      numElementsPerWorkgroup = size;
       break;
     }
-    if (lowerWorkgroupTs <= subgroupSize ||
-        outputShape.back() % lowerWorkgroupTs != 0) {
+
+    if (numElementsPerWorkgroup <= subgroupSize ||
+        outputShape.back() % numElementsPerWorkgroup != 0) {
       vectorize = false;
     }
+
     if (vectorize) {
-      lowerThreadTs = lowerWorkgroupTs / subgroupSize;
+      numElementsPerThread = numElementsPerWorkgroup / subgroupSize;
       pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
     }
   }
@@ -347,314 +223,53 @@ LogicalResult setDefaultRootConfig(FuncOp entryPoint,
     workgroupTileSize[loopIndex] = threadTileSize[loopIndex] = 1;
   }
   // Overwrite the configuration for the innermost dimension.
-  workgroupTileSize.back() = lowerWorkgroupTs;
-  threadTileSize.back() = lowerThreadTs;
+  workgroupTileSize.back() = numElementsPerWorkgroup;
+  threadTileSize.back() = numElementsPerThread;
 
-  TileSizesListType tileSizes;
-  tileSizes.emplace_back(workgroupTileSize);  // Workgroup level
-  tileSizes.emplace_back();                   // Subgroup level
-  tileSizes.emplace_back(threadTileSize);     // Invocation level
+  config.pipeline = pipeline;
+  config.workgroupTileSizes = workgroupTileSize;
+  config.invocationTileSizes = threadTileSize;
+  config.workgroupSize = workgroupSize;
 
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes,
-      /*nativeVectorSizes =*/ArrayRef<int64_t>{}, pipeline, workgroupSize);
+  return config;
 }
 
-/// Launch configuration for different known GPU configuration.
-static LogicalResult setTargetSpecificConfig(FuncOp entryPoint,
-                                             const spirv::TargetEnv &targetEnv,
-                                             linalg::MatmulOp op) {
-  if (targetEnv.getVendorID() != spirv::Vendor::ARM) return failure();
+Optional<detail::SPIRVCodeGenConfig> getSPIRVOpConfig(
+    const spirv::TargetEnv &targetEnv, Operation *rootOp) {
+  Optional<detail::SPIRVCodeGenConfig> config;
+  // First try to find a proper CodeGen configuration for the current
+  // target architecture.
+  switch (targetEnv.getVendorID()) {
+    case spirv::Vendor::ARM:
+      config = detail::getMaliCodeGenConfig(targetEnv, rootOp);
+      break;
+    case spirv::Vendor::NVIDIA:
+      config = detail::getNVIDIACodeGenConfig(targetEnv, rootOp);
+      break;
+    default:
+      break;
+  }
+  if (config) return config;
 
-  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
-  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
-  // If the shape size is unknonw fall back to none vectorized path.
-  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
-      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
-    return failure();
+  // Then try to use a default configuration.
+  spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
+  if (auto matmulOp = dyn_cast<linalg::BatchMatmulOp>(rootOp)) {
+    config = getOpConfig(limits, matmulOp);
+  } else if (auto matmulOp = dyn_cast<linalg::MatmulOp>(rootOp)) {
+    config = getOpConfig(limits, matmulOp);
+  } else if (isa<linalg::DepthwiseConvInputNHWCFilterHWCOp,
+                 linalg::ConvInputNHWCFilterHWCFOp>(rootOp)) {
+    config = getDefaultOpConfig(limits, rootOp);
   }
 
-  // Pick ideal tile size based on the type.
-  SmallVector<TileWorkgroupSizePair, 4> workgroupLevelTs;
-  int64_t dstSize = lhsShape[0] * rhsShape[1];
-  getMaliBestMatMulTileSizes(
-      op.inputs()[0].getType().cast<ShapedType>().getElementType(),
-      workgroupLevelTs, dstSize);
-  for (TileWorkgroupSizePair pair : workgroupLevelTs) {
-    if (lhsShape[0] % pair.tileSize[0] != 0 ||
-        rhsShape[1] % pair.tileSize[1] != 0 ||
-        lhsShape[1] % pair.tileSize[2] != 0) {
-      continue;
-    }
+  return config;
+};
 
-    TileSizesListType tileSizes;
-    SmallVector<int64_t, 4> matmulTS(pair.tileSize.begin(),
-                                     pair.tileSize.end());
-    tileSizes.emplace_back(matmulTS);
-    // No tiling at the subgroup level since this target doesn't use subgroup op
-    // or shared memory.
-    tileSizes.emplace_back();
-    SmallVector<int64_t, 4> invocationLevelTs = {
-        matmulTS[0] / pair.workgroupSize[1],
-        matmulTS[1] / pair.workgroupSize[0], matmulTS[2]};
-    tileSizes.emplace_back(invocationLevelTs);
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPoint, op, tileSizes,
-        /*nativeVectorSizes =*/ArrayRef<int64_t>{},
-        IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize,
-        pair.workgroupSize);
-  }
-  return failure();
-}
+}  // namespace
 
-LogicalResult setRootConfig(FuncOp entryPoint,
-                            const spirv::TargetEnv &targetEnv,
-                            linalg::MatmulOp op) {
-  if (succeeded(setConfigForCooperativeMatmul(entryPoint, targetEnv, op))) {
-    return success();
-  }
-  if (succeeded(setTargetSpecificConfig(entryPoint, targetEnv, op))) {
-    return success();
-  }
-
-  unsigned maxWorkgroupSize = targetEnv.getResourceLimits()
-                                  .max_compute_workgroup_invocations()
-                                  .getInt();
-  std::array<int64_t, 3> workgroupSize = {1, 1, 1};
-  std::tie(workgroupSize[0], workgroupSize[1]) =
-      distributeProcs2D(maxWorkgroupSize);
-  const int nRowsPerWorkitem = 1;
-  const int nColsPerWorkitem = 1;
-  int64_t tileSizeK = 0;
-
-  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
-  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
-
-  int64_t M = lhsShape[0];
-  int64_t N = rhsShape[1];
-  int64_t K = lhsShape[1];
-
-  SmallVector<int64_t, 4> workgroupLevel = {
-      getMinIfShapeStatic(M, nRowsPerWorkitem * workgroupSize[1]),
-      getMinIfShapeStatic(N, nColsPerWorkitem * workgroupSize[0]),
-      getMinIfShapeStatic(K, tileSizeK)};
-  SmallVector<int64_t, 4> invocationLevel = {1, 1, 0};
-
-  TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(workgroupLevel));
-  tileSizes.emplace_back();  // subgroup level
-  tileSizes.emplace_back(std::move(invocationLevel));
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPoint, op, tileSizes, /*nativeVectorSizes =*/ArrayRef<int64_t>{},
-      IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute, workgroupSize);
-}
-
-static LogicalResult setMaliSpecificConfig(
-    FuncOp entryFn, linalg::ConvInputNHWCFilterHWCFOp op) {
-  ArrayRef<int64_t> inputShape = getUntiledShape(op.inputs()[0]);
-  ArrayRef<int64_t> outputShape =
-      getUntiledResultShape(cast<linalg::LinalgOp>(op.getOperation()), 0);
-  if (llvm::any_of(inputShape, ShapedType::isDynamic) ||
-      llvm::any_of(outputShape, ShapedType::isDynamic)) {
-    return failure();
-  }
-
-  bool isInputTilable = inputShape[3] % 4 == 0 || inputShape[3] < 4;
-  if (!isInputTilable) return failure();
-
-  // A list of preferred tile sizes and workgroup sizes. This is for Mali
-  // G77 now and it's fairly ad-hoc. We need to have a better story for
-  // incorporating such information.
-  static const TileWorkgroupSizePair tileWorkgroupSizePairs[] = {
-      {{4, 4, 16}, {4, 4, 1}},
-      {{2, 2, 64}, {16, 1, 1}},
-      {{4, 8, 8}, {2, 4, 2}},
-      {{2, 2, 32}, {8, 2, 1}},
-      {{1, 1, 32}, {8, 1, 1}}};
-
-  for (const auto &pair : tileWorkgroupSizePairs) {
-    const std::array<int64_t, 3> &tileSize = pair.tileSize;
-    const std::array<int64_t, 3> &workgroupSize = pair.workgroupSize;
-
-    bool isOutputTilable = (outputShape[0] == 1) &&
-                           (outputShape[1] % tileSize[0] == 0) &&
-                           (outputShape[2] % tileSize[1] == 0) &&
-                           (outputShape[3] % tileSize[2] == 0);
-    if (!isOutputTilable) continue;
-
-    TileSizesListType tileSizes;
-    SmallVector<int64_t, 4> workgroupLevel = {
-        /*batch=*/0, /*output_height=*/tileSize[0],
-        /*output_width=*/tileSize[1], /*output_channel=*/tileSize[2]};
-    tileSizes.emplace_back(std::move(workgroupLevel));
-
-    // No tiling at the subgroup level given that we don't use subgroup
-    // level syncrhonization  or shared memory.
-    tileSizes.emplace_back();
-
-    SmallVector<int64_t, 4> invocationLevel = {
-        /*batch=*/0, /*output_height=*/tileSize[0] / workgroupSize[2],
-        /*output_width=*/tileSize[1] / workgroupSize[1],
-        /*output_channel=*/tileSize[2] / workgroupSize[0]};
-    tileSizes.emplace_back(invocationLevel);
-
-    // Finally, for each invocation, we use tiling to generate loops to loop
-    // over the filter's height (step 1), width (step 1), and input channel
-    // (step 4) dimensions.
-    SmallVector<int64_t, 4> fourthLevel = {0, 0, 0, 0, 1, 1, 4};
-    tileSizes.emplace_back(fourthLevel);
-
-    if (failed(setOpConfigAndEntryPointFnTranslation(
-            entryFn, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-            IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize,
-            workgroupSize)))
-      return failure();
-
-    // Let the entry point region to return fully static number of workgroups.
-    // This is needed for folding `affine.min` ops to expose static-shaped tiled
-    // convolution for vectorization.
-    // TODO(#5034): Use a proper way to prove tilability and fold `affine.min`s.
-    auto numWorkgroupsFn = [&](OpBuilder &b, Location loc,
-                               std::array<Value, 3>) {
-      std::array<Value, 3> xyz;
-      for (unsigned i = 0; i < 3; ++i) {
-        int64_t count = outputShape[i + 1] / tileSize[i];
-        xyz[2 - i] = b.create<ConstantIndexOp>(loc, count);
-      }
-      return xyz;
-    };
-
-    OpBuilder builder(op.getContext());
-    return defineWorkgroupCountRegion(builder, entryFn, numWorkgroupsFn);
-  }
-  return failure();
-}
-
-LogicalResult setRootConfig(FuncOp entryPoint,
-                            const spirv::TargetEnv &targetEnv,
-                            linalg::ConvInputNHWCFilterHWCFOp op) {
-  if (targetEnv.getVendorID() == spirv::Vendor::ARM &&
-      succeeded(setMaliSpecificConfig(entryPoint, op))) {
-    return success();
-  }
-  return setDefaultRootConfig(entryPoint, targetEnv, op);
-}
-
-static LogicalResult setMaliSpecificConfig(
-    FuncOp entryFn, linalg::DepthwiseConvInputNHWCFilterHWCOp op) {
-  ArrayRef<int64_t> inputShape = getUntiledShape(op.inputs()[0]);
-  ArrayRef<int64_t> outputShape =
-      getUntiledResultShape(cast<linalg::LinalgOp>(op.getOperation()), 0);
-  if (llvm::any_of(inputShape, ShapedType::isDynamic) ||
-      llvm::any_of(outputShape, ShapedType::isDynamic)) {
-    return failure();
-  }
-
-  // A list of preferred tile sizes and workgroup sizes. This is for Mali
-  // G77 now and it's fairly ad-hoc. We need to have a better story for
-  // incorporating such information.
-  static const TileWorkgroupSizePair tileWorkgroupSizePairs[] = {
-      {{2, 2, 32}, {8, 2, 2}},
-      {{1, 4, 16}, {4, 4, 1}},
-      {{1, 1, 64}, {16, 1, 1}},
-      {{4, 4, 8}, {2, 4, 2}},
-  };
-
-  for (const auto &pair : tileWorkgroupSizePairs) {
-    const std::array<int64_t, 3> &tileSize = pair.tileSize;
-    const std::array<int64_t, 3> &workgroupSize = pair.workgroupSize;
-
-    bool isOutputTilable = outputShape[0] == 1 &&
-                           (outputShape[1] % tileSize[0] == 0) &&
-                           (outputShape[2] % tileSize[1] == 0) &&
-                           (outputShape[3] % tileSize[2] == 0);
-    if (!isOutputTilable) continue;
-
-    SmallVector<int64_t, 4> workgroupLevel = {/*batch=*/0,
-                                              /*output_height=*/tileSize[0],
-                                              /*output_width=*/tileSize[1],
-                                              /*output_channel=*/tileSize[2]};
-    TileSizesListType tileSizes;
-    tileSizes.emplace_back(std::move(workgroupLevel));
-
-    // No tiling at the subgroup level given that we don't use subgroup
-    // level syncrhonization  or shared memory.
-    tileSizes.emplace_back();
-
-    SmallVector<int64_t, 4> invocationLevel = {
-        /*batch=*/0, /*output_height=*/tileSize[0] / workgroupSize[2],
-        /*output_width=*/tileSize[1] / workgroupSize[1],
-        /*output_channel=*/tileSize[2] / workgroupSize[0]};
-    tileSizes.emplace_back(invocationLevel);
-
-    // Finally, for each invocation, we use tiling to generate loops to loop
-    // over the filter's height (step 1) and width (step 1) dimensions.
-    SmallVector<int64_t, 4> fourthLevel = {0, 0, 0, 0, 1, 1};
-    tileSizes.emplace_back(fourthLevel);
-
-    if (failed(setOpConfigAndEntryPointFnTranslation(
-            entryFn, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-            IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize,
-            workgroupSize)))
-      return failure();
-
-    // Let the entry point region to return fully static number of workgroups.
-    // This is needed for folding `affine.min` ops to expose static-shaped tiled
-    // convolution for vectorization.
-    // TODO(#5034): Use a proper way to prove tilability and fold `affine.min`s.
-    auto numWorkgroupsFn = [&](OpBuilder &b, Location loc,
-                               std::array<Value, 3>) {
-      std::array<Value, 3> xyz;
-      for (unsigned i = 0; i < 3; ++i) {
-        int64_t count = outputShape[i + 1] / tileSize[i];
-        xyz[2 - i] = b.create<ConstantIndexOp>(loc, count);
-      }
-      return xyz;
-    };
-
-    OpBuilder builder(op.getContext());
-    return defineWorkgroupCountRegion(builder, entryFn, numWorkgroupsFn);
-  }
-  return failure();
-}
-
-static LogicalResult setRootConfig(
-    FuncOp entryPoint, const spirv::TargetEnv &targetEnv,
-    linalg::DepthwiseConvInputNHWCFilterHWCOp op) {
-  if (targetEnv.getVendorID() == spirv::Vendor::ARM &&
-      succeeded(setMaliSpecificConfig(entryPoint, op))) {
-    return success();
-  }
-  return setDefaultRootConfig(entryPoint, targetEnv, op);
-}
-
-/// Helper function to generate the number of workgroups when the
-/// `SPIRVDistributeToGlobalID` is used.
-// TODO(ravishankarm): Remove this when that pipeline is deprecated.
-static LogicalResult setTranslationUsingDistributeToGlobalId(
-    FuncOp funcOp, ArrayRef<int64_t> workgroupSize) {
-  auto entryPointOp = getEntryPoint(funcOp);
-  MLIRContext *context = entryPointOp.getContext();
-  auto translationInfo = buildTranslationInfo(
-      IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistributeToGlobalID,
-      /*workloadPerWorkgroup =*/{}, context);
-  setTranslationInfo(entryPointOp, translationInfo, workgroupSize);
-  OpBuilder builder(context);
-  int64_t workgroupSizeX = workgroupSize[0];
-  auto numWorkgroupsFn =
-      [workgroupSizeX](OpBuilder &b, Location loc,
-                       std::array<Value, 3> workload) -> std::array<Value, 3> {
-    AffineExpr e1, e2, e3;
-    bindSymbols(b.getContext(), e1, e2, e3);
-    AffineExpr expr = e1 * e2 * e3;
-    expr = expr.ceilDiv(workgroupSizeX);
-    Value numWorkgroupsX = linalg::applyMapToValues(
-        b, loc, AffineMap::get(0, 3, expr), workload)[0];
-    Value one = b.create<ConstantIndexOp>(loc, 1);
-    return {numWorkgroupsX, one, one};
-  };
-  return defineWorkgroupCountRegion(builder, funcOp, numWorkgroupsFn);
-}
+//===----------------------------------------------------------------------===//
+// Entry Point
+//===----------------------------------------------------------------------===//
 
 LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
   llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
@@ -664,32 +279,36 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());
     if (!entryPointOp) continue;
     if (getTranslationInfo(entryPointOp)) continue;
+
     SmallVector<Operation *, 4> computeOps;
     SmallVector<Operation *, 4> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
       return funcOp.emitOpError("failed to get compute ops");
     }
-    spirv::TargetEnv targetEnv(spirv::lookupTargetEnv(funcOp));
-    int64_t subgroupSize =
-        targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
 
+    spirv::TargetEnv targetEnv(spirv::lookupTargetEnv(funcOp));
+    spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
+    int64_t subgroupSize = limits.subgroup_size().getValue().getSExtValue();
+
+    // If the dispatch region does not contain tiled and distributed Linalg ops,
+    // invoke the pipeline to distribute to global invocations.
     if (computeOps.empty() || llvm::none_of(computeOps, [](Operation *op) {
           return hasMarker(op, getWorkgroupMarker());
         })) {
+      auto isInsertExtractSliceOp = [](Operation *op) {
+        return isa<tensor::InsertSliceOp, tensor::ExtractSliceOp>(op);
+      };
       // TODO(ravishankarm): `tensor.insert_slice` is not a compute op but still
       // needs to be handled in dispatch region. For now it is handled in
       // ConvertToGPU pass. Eventually this will be handled as a compute
       // op. This is just to keep scope of change to dynamic pass pipelines
       // limited. Remove this when dropping ConvertToGPU pass.
-      if (failed(getFilteredOps(
-              funcOp,
-              [](Operation *op) {
-                return isa<tensor::InsertSliceOp, tensor::ExtractSliceOp>(op);
-              },
-              computeOps, tiledLoops)) ||
+      if (failed(getFilteredOps(funcOp, isInsertExtractSliceOp, computeOps,
+                                tiledLoops)) ||
           computeOps.empty()) {
         continue;
       }
+
       std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
       if (failed(
               setTranslationUsingDistributeToGlobalId(funcOp, workgroupSize))) {
@@ -700,46 +319,56 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     }
 
     Operation *rootOperation = nullptr;
+    Optional<detail::SPIRVCodeGenConfig> spirvConfig;
+
+    // Try to find a configuration according to a matmul/convolution op and use
+    // it as the root op.
     for (Operation *computeOp : computeOps) {
-      auto setConfigFn = [&](Operation *rootOp) -> LogicalResult {
-        return TypeSwitch<Operation *, LogicalResult>(rootOp)
-            .Case<linalg::BatchMatmulOp,
-                  linalg::DepthwiseConvInputNHWCFilterHWCOp,
-                  linalg::ConvInputNHWCFilterHWCFOp, linalg::MatmulOp>(
-                [&](auto op) { return setRootConfig(funcOp, targetEnv, op); })
-            .Default([&](Operation *) { return success(); });
-      };
-      if (failed(setConfigFn(computeOp))) {
-        return failure();
-      }
-      // Check if the op configuration was set.
-      if (getLoweringConfig(computeOp)) {
+      if (auto opConfig = getSPIRVOpConfig(targetEnv, computeOp)) {
         if (rootOperation) {
           return computeOp->emitOpError(
               "unhandled multiple roots in dispatch region");
         }
         rootOperation = computeOp;
+        spirvConfig = opConfig;
       }
     }
 
-    // If there are still no roots, check for any generic op.
+    // If there are still no root op, check for any linalg.generic op.
     if (!rootOperation) {
       for (Operation *computeOp : computeOps) {
         if (isa<linalg::FillOp, linalg::CopyOp>(computeOp)) continue;
-        if (failed(setDefaultRootConfig(funcOp, targetEnv, computeOp))) {
-          return failure();
-        }
-        if (getLoweringConfig(computeOp)) {
+
+        if (auto opConfig = getDefaultOpConfig(limits, computeOp)) {
           if (rootOperation) {
             return computeOp->emitOpError(
                 "unhandled multiple roots in dispatch region");
           }
           rootOperation = computeOp;
+          spirvConfig = opConfig;
         }
       }
     }
 
-    // Propogate the configuration to the other ops.
+    // Now compose and attach the `lowering.config` attribute to the root op.
+    assert(rootOperation && "failed to discover root operation!");
+
+    TileSizesListType tileSizes;
+    tileSizes.push_back(spirvConfig->workgroupTileSizes);
+    tileSizes.push_back(spirvConfig->subgroupTileSizes);
+    tileSizes.push_back(spirvConfig->invocationTileSizes);
+    if (!spirvConfig->convFilterTileSizes.empty()) {
+      tileSizes.push_back(spirvConfig->convFilterTileSizes);
+    }
+
+    if (failed(setOpConfigAndEntryPointFnTranslation(
+            funcOp, rootOperation, tileSizes,
+            /*nativeVectorSizes=*/ArrayRef<int64_t>(), spirvConfig->pipeline,
+            spirvConfig->workgroupSize))) {
+      return failure();
+    }
+
+    // Propogate the `lowering.config` attribute to the other ops.
     // TODO(ravishankarm, antiagainst): This is a very specific use (and
     // fragile). In general, this should not be needed. Things are already tiled
     // and distributed. The rest of the compilation must be structured to either
@@ -749,6 +378,27 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     for (auto op : computeOps) {
       if (op == rootOperation) continue;
       setLoweringConfig(op, config);
+    }
+
+    if (spirvConfig->workgroupCount) {
+      // Let the entry point region to return fully static number of workgroups.
+      // This is needed for folding `affine.min` ops to expose static-shaped
+      // tiled convolution for vectorization.
+      // TODO(#5034): Use a proper way to prove tilability and fold
+      // `affine.min`s.
+      auto numWorkgroupsFn = [&](OpBuilder &b, Location loc,
+                                 std::array<Value, 3>) {
+        std::array<Value, 3> xyz;
+        for (unsigned i = 0; i < 3; ++i) {
+          auto count = spirvConfig->workgroupCount->at(i);
+          xyz[i] = b.create<ConstantIndexOp>(loc, count);
+        }
+        return xyz;
+      };
+
+      OpBuilder builder(rootOperation->getContext());
+      if (failed(defineWorkgroupCountRegion(builder, funcOp, numWorkgroupsFn)))
+        return failure();
     }
   }
   return success();

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -15,10 +15,45 @@
 #ifndef IREE_COMPILER_CODEGEN_SPIRV_KERNELCONFIG_H_
 #define IREE_COMPILER_CODEGEN_SPIRV_KERNELCONFIG_H_
 
+#include <array>
+
+#include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 namespace iree_compiler {
+
+namespace detail {
+
+struct SPIRVCodeGenConfig {
+  /// The pipeline to use for SPIR-V CodeGen.
+  IREE::HAL::DispatchLoweringPassPipeline pipeline;
+
+  /// Tiling sizes along each level. The following are all optional; if empty,
+  /// it means no tiling along the particular level.
+  SmallVector<int64_t, 4> workgroupTileSizes;
+  SmallVector<int64_t, 4> subgroupTileSizes;
+  SmallVector<int64_t, 4> invocationTileSizes;
+  SmallVector<int64_t, 4> convFilterTileSizes;
+
+  /// Workgroup size and count. Workgroup count is optional. If existing, it
+  /// will override the default workgorup count settings on entry point ops.
+  std::array<int64_t, 3> workgroupSize;
+  // TODO(#5034): The workgroup count shouldn't exist. It's now needed for
+  // exposing static shape for convolution CodeGen. Remove this after we have
+  // a better way there.
+  llvm::Optional<std::array<int64_t, 3>> workgroupCount;
+};
+
+/// Returns a SPIR-V CodeGen configuration for the given target environment and
+/// operation. Returns llvm::None if there is no configuration.
+llvm::Optional<SPIRVCodeGenConfig> getMaliCodeGenConfig(
+    const spirv::TargetEnv &targetEnv, Operation *op);
+llvm::Optional<SPIRVCodeGenConfig> getNVIDIACodeGenConfig(
+    const spirv::TargetEnv &targetEnv, Operation *op);
+
+}  // namespace detail
 
 /// Attaches the `translation.info` attribute to entry points in `moduleOp` and
 /// `lowering.config` attributes to all root ops in `moduleOp`'s region.

--- a/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -1,0 +1,342 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- MaliConfig.h - Mali CodeGen Configurations -------------------------===//
+//
+// This file contains CodeGen configurations for Mali GPUs.
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+
+#include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace detail {
+
+namespace {
+
+struct TileWorkgroupSizePair {
+  // How many scalar elements each workgroup should handle along each dimension.
+  std::array<int64_t, 3> tileSize;
+  // The number of threads per workgroup along each dimension.
+  std::array<int64_t, 3> workgroupSize;
+};
+
+//===----------------------------------------------------------------------===//
+// Matmul
+//===----------------------------------------------------------------------===//
+
+/// Writes preferred matmul workgroup tile sizes and workgroup size into
+/// `pairs` for the given matmul `scale` (MxNxK) and `elementType`.
+void getMatmulTileAndWorkgroupSizes(
+    int64_t scale, Type elementType,
+    SmallVectorImpl<TileWorkgroupSizePair> &pairs) {
+  if (elementType.isF16()) {
+    const int64_t smallMatrixSizeThreshold = 512 * 512;
+    // For smaller destination size we cannot fill out the GPU with bigger tile
+    // sizes. Instead we pick smaller tiles along M and N to increase the number
+    // of workgroups and a larger K tile size since we have lower pressure and
+    // need extra instructions to hide latency.
+    // TODO: The threshold needs to be fine tuned by doing exploration based on
+    // matrix shapes.
+    if (scale <= smallMatrixSizeThreshold) {
+      pairs.push_back(TileWorkgroupSizePair({{16, 32, 16}, {8, 2, 1}}));
+    } else {
+      pairs.push_back(TileWorkgroupSizePair({{16, 64, 4}, {8, 2, 1}}));
+      pairs.push_back(TileWorkgroupSizePair({{8, 128, 4}, {8, 2, 1}}));
+      pairs.push_back(TileWorkgroupSizePair({{16, 32, 4}, {8, 2, 1}}));
+    }
+    return;
+  }
+
+  // TODO: Heuristic picked based on MobileNet performance. We need
+  // auto-tuning to be able to make a smarter choice.
+  const int64_t smallMatrixSizeThreshold = 20000;
+
+  if (scale <= smallMatrixSizeThreshold) {
+    pairs.push_back(TileWorkgroupSizePair({{4, 32, 16}, {8, 2, 1}}));
+  }
+  pairs.push_back(TileWorkgroupSizePair({{12, 32, 4}, {8, 2, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{14, 32, 4}, {8, 2, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{10, 32, 4}, {8, 2, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{7, 64, 4}, {16, 1, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{8, 32, 4}, {8, 2, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{6, 32, 4}, {8, 2, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{24, 16, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{16, 16, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{24, 8, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{40, 8, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{32, 8, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{16, 8, 4}, {2, 8, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{1, 32, 16}, {8, 1, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{1, 32, 8}, {8, 1, 1}}));
+  pairs.push_back(TileWorkgroupSizePair({{1, 32, 4}, {8, 1, 1}}));
+}
+
+/// Launch configuration for Mali GPU configuration.
+Optional<SPIRVCodeGenConfig> getOpConfig(linalg::BatchMatmulOp op) {
+  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
+  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
+
+  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
+      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
+    return llvm::None;
+  }
+
+  // Get a vector of best tile size ordered from best to worst.
+  Type elementType =
+      op.inputs()[0].getType().cast<ShapedType>().getElementType();
+  int64_t matmulScale = lhsShape[0] * lhsShape[1] * rhsShape[2];
+  SmallVector<TileWorkgroupSizePair, 4> pairs;
+  getMatmulTileAndWorkgroupSizes(matmulScale, elementType, pairs);
+
+  for (TileWorkgroupSizePair pair : pairs) {
+    if (lhsShape[1] % pair.tileSize[0] != 0 ||
+        rhsShape[2] % pair.tileSize[1] != 0 ||
+        lhsShape[2] % pair.tileSize[2] != 0) {
+      continue;
+    }
+
+    SPIRVCodeGenConfig config = {};
+    config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+
+    SmallVector<int64_t, 4> numElementsPerWorkgroup;
+    numElementsPerWorkgroup = {1, pair.tileSize[0], pair.tileSize[1],
+                               pair.tileSize[2]};
+
+    config.workgroupTileSizes = numElementsPerWorkgroup;
+
+    // No tiling at the subgroup level since this target doesn't use subgroup op
+    // or shared memory.
+
+    config.invocationTileSizes = {
+        numElementsPerWorkgroup[0],
+        numElementsPerWorkgroup[1] / pair.workgroupSize[1],
+        numElementsPerWorkgroup[2] / pair.workgroupSize[0],
+        numElementsPerWorkgroup[3]};
+
+    config.workgroupSize = pair.workgroupSize;
+
+    return config;
+  }
+  return llvm::None;
+}
+
+Optional<SPIRVCodeGenConfig> getOpConfig(linalg::MatmulOp op) {
+  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
+  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
+
+  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
+      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
+    return llvm::None;
+  }
+
+  Type elementType =
+      op.inputs()[0].getType().cast<ShapedType>().getElementType();
+  int64_t matmulScale = lhsShape[0] * rhsShape[1];
+  SmallVector<TileWorkgroupSizePair, 4> pairs;
+  getMatmulTileAndWorkgroupSizes(matmulScale, elementType, pairs);
+
+  for (TileWorkgroupSizePair pair : pairs) {
+    if (lhsShape[0] % pair.tileSize[0] != 0 ||
+        rhsShape[1] % pair.tileSize[1] != 0 ||
+        lhsShape[1] % pair.tileSize[2] != 0) {
+      continue;
+    }
+
+    SPIRVCodeGenConfig config = {};
+    config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+
+    SmallVector<int64_t, 4> numElementsPerWorkgroup(pair.tileSize.begin(),
+                                                    pair.tileSize.end());
+
+    config.workgroupTileSizes = numElementsPerWorkgroup;
+
+    // No tiling at the subgroup level since this target doesn't use subgroup op
+    // or shared memory.
+
+    config.invocationTileSizes = {
+        numElementsPerWorkgroup[0] / pair.workgroupSize[1],
+        numElementsPerWorkgroup[1] / pair.workgroupSize[0],
+        numElementsPerWorkgroup[2]};
+
+    config.workgroupSize = pair.workgroupSize;
+
+    return config;
+  }
+  return llvm::None;
+}
+
+//===----------------------------------------------------------------------===//
+// Convolution
+//===----------------------------------------------------------------------===//
+
+Optional<SPIRVCodeGenConfig> getOpConfig(linalg::ConvInputNHWCFilterHWCFOp op) {
+  auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
+  ArrayRef<int64_t> inputShape = getUntiledShape(op.inputs()[0]);
+  ArrayRef<int64_t> outputShape = getUntiledResultShape(linalgOp, 0);
+
+  if (llvm::any_of(inputShape, ShapedType::isDynamic) ||
+      llvm::any_of(outputShape, ShapedType::isDynamic)) {
+    return llvm::None;
+  }
+
+  bool isInputTilable = inputShape[3] % 4 == 0 || inputShape[3] < 4;
+  if (!isInputTilable) return llvm::None;
+
+  // A list of preferred tile sizes and workgroup sizes.
+  // TODO(antiagainst): This is for Valhall now; need to consider other Mali
+  // architectures.
+  static const TileWorkgroupSizePair tileWorkgroupSizePairs[] = {
+      {{4, 4, 16}, {4, 4, 1}},
+      {{2, 2, 64}, {16, 1, 1}},
+      {{4, 8, 8}, {2, 4, 2}},
+      {{2, 2, 32}, {8, 2, 1}},
+      {{1, 1, 32}, {8, 1, 1}}};
+
+  for (const auto &pair : tileWorkgroupSizePairs) {
+    const std::array<int64_t, 3> &tileSize = pair.tileSize;
+    const std::array<int64_t, 3> &workgroupSize = pair.workgroupSize;
+
+    bool isOutputTilable = (outputShape[0] == 1) &&
+                           (outputShape[1] % tileSize[0] == 0) &&
+                           (outputShape[2] % tileSize[1] == 0) &&
+                           (outputShape[3] % tileSize[2] == 0);
+    if (!isOutputTilable) continue;
+
+    SPIRVCodeGenConfig config = {};
+    config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+
+    config.workgroupTileSizes = {/*batch=*/0, /*output_height=*/tileSize[0],
+                                 /*output_width=*/tileSize[1],
+                                 /*output_channel=*/tileSize[2]};
+
+    // No tiling at the subgroup level given that we don't use subgroup
+    // level syncrhonization or shared memory.
+
+    config.invocationTileSizes = {
+        /*batch=*/0, /*output_height=*/tileSize[0] / workgroupSize[2],
+        /*output_width=*/tileSize[1] / workgroupSize[1],
+        /*output_channel=*/tileSize[2] / workgroupSize[0]};
+
+    // Finally, for each invocation, we use tiling to generate loops to loop
+    // over the filter's height (step 1), width (step 1), and input channel
+    // (step 4) dimensions.
+    config.convFilterTileSizes = {0, 0, 0, 0, 1, 1, 4};
+
+    config.workgroupSize = workgroupSize;
+
+    // Define fully static number of workgroups. This is needed for folding
+    // `affine.min` ops to expose static-shaped tiled convolution for
+    // vectorization.
+    // TODO(#5034): Use a proper way to prove tilability and fold `affine.min`s.
+    config.workgroupCount = std::array<int64_t, 3>();
+    for (unsigned i = 0; i < 3; ++i) {
+      (*config.workgroupCount)[2 - i] = outputShape[i + 1] / tileSize[i];
+    }
+
+    return config;
+  }
+  return llvm::None;
+}
+
+Optional<SPIRVCodeGenConfig> getOpConfig(
+    linalg::DepthwiseConvInputNHWCFilterHWCOp op) {
+  auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
+  ArrayRef<int64_t> inputShape = getUntiledShape(op.inputs()[0]);
+  ArrayRef<int64_t> outputShape = getUntiledResultShape(linalgOp, 0);
+
+  if (llvm::any_of(inputShape, ShapedType::isDynamic) ||
+      llvm::any_of(outputShape, ShapedType::isDynamic)) {
+    return llvm::None;
+  }
+
+  // A list of preferred tile sizes and workgroup sizes.
+  // TODO(antiagainst): This is for Valhall now; need to consider other Mali
+  // architectures.
+  static const TileWorkgroupSizePair tileWorkgroupSizePairs[] = {
+      {{2, 2, 32}, {8, 2, 2}},
+      {{1, 4, 16}, {4, 4, 1}},
+      {{1, 1, 64}, {16, 1, 1}},
+      {{4, 4, 8}, {2, 4, 2}},
+  };
+
+  for (const auto &pair : tileWorkgroupSizePairs) {
+    const std::array<int64_t, 3> &tileSize = pair.tileSize;
+    const std::array<int64_t, 3> &workgroupSize = pair.workgroupSize;
+
+    bool isOutputTilable = outputShape[0] == 1 &&
+                           (outputShape[1] % tileSize[0] == 0) &&
+                           (outputShape[2] % tileSize[1] == 0) &&
+                           (outputShape[3] % tileSize[2] == 0);
+    if (!isOutputTilable) continue;
+
+    SPIRVCodeGenConfig config = {};
+    config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+
+    config.workgroupTileSizes = {/*batch=*/0,
+                                 /*output_height=*/tileSize[0],
+                                 /*output_width=*/tileSize[1],
+                                 /*output_channel=*/tileSize[2]};
+
+    // No tiling at the subgroup level given that we don't use subgroup
+    // level syncrhonization  or shared memory.
+
+    config.invocationTileSizes = {
+        /*batch=*/0, /*output_height=*/tileSize[0] / workgroupSize[2],
+        /*output_width=*/tileSize[1] / workgroupSize[1],
+        /*output_channel=*/tileSize[2] / workgroupSize[0]};
+
+    // Finally, for each invocation, we use tiling to generate loops to loop
+    // over the filter's height (step 1) and width (step 1) dimensions.
+    config.convFilterTileSizes = {0, 0, 0, 0, 1, 1};
+
+    config.workgroupSize = workgroupSize;
+
+    // Define fully static number of workgroups. This is needed for folding
+    // `affine.min` ops to expose static-shaped tiled convolution for
+    // vectorization.
+    // TODO(#5034): Use a proper way to prove tilability and fold `affine.min`s.
+    config.workgroupCount = std::array<int64_t, 3>();
+    for (unsigned i = 0; i < 3; ++i) {
+      (*config.workgroupCount)[2 - i] = outputShape[i + 1] / tileSize[i];
+    }
+
+    return config;
+  }
+  return llvm::None;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Entry Point
+//===----------------------------------------------------------------------===//
+
+Optional<SPIRVCodeGenConfig> getMaliCodeGenConfig(const spirv::TargetEnv &,
+                                                  Operation *op) {
+  if (auto matmulOp = dyn_cast<linalg::BatchMatmulOp>(op)) {
+    return getOpConfig(matmulOp);
+  }
+  if (auto matmulOp = dyn_cast<linalg::MatmulOp>(op)) {
+    return getOpConfig(matmulOp);
+  }
+  if (auto convOp = dyn_cast<linalg::ConvInputNHWCFilterHWCFOp>(op)) {
+    return getOpConfig(convOp);
+  }
+  if (auto convOp = dyn_cast<linalg::DepthwiseConvInputNHWCFilterHWCOp>(op)) {
+    return getOpConfig(convOp);
+  }
+  return llvm::None;
+}
+
+}  // namespace detail
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -1,0 +1,119 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- NVIDIAConfig.h - NVIDIA CodeGen Configurations ---------------------===//
+//
+// This file contains CodeGen configurations for NVIDIA GPUs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace detail {
+
+namespace {
+
+/// Returns the cooperative matrix (M, N, K) sizes that are supported by the
+/// target environment and match the given parameters.
+Optional<SmallVector<int64_t, 4>> getCooperativeMatrixSize(
+    spirv::ResourceLimitsAttr resourceLimits, Type lhsType, Type rhsType,
+    Type initType, Type resultType) {
+  for (auto coopMatmulProperties :
+       resourceLimits.cooperative_matrix_properties_nv()
+           .getAsRange<spirv::CooperativeMatrixPropertiesNVAttr>()) {
+    if (coopMatmulProperties.a_type().getValue() == lhsType &&
+        coopMatmulProperties.b_type().getValue() == rhsType &&
+        coopMatmulProperties.c_type().getValue() == initType &&
+        coopMatmulProperties.result_type().getValue() == resultType &&
+        coopMatmulProperties.scope().getValue() == spirv::Scope::Subgroup) {
+      return SmallVector<int64_t, 4>{
+          coopMatmulProperties.m_size().getValue().getSExtValue(),
+          coopMatmulProperties.n_size().getValue().getSExtValue(),
+          coopMatmulProperties.k_size().getValue().getSExtValue()};
+    }
+  }
+  return llvm::None;
+}
+
+Optional<SPIRVCodeGenConfig> getOpConfig(const spirv::TargetEnv &targetEnv,
+                                         linalg::MatmulOp op) {
+  if (!targetEnv.allows(spirv::Capability::CooperativeMatrixNV) ||
+      !targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix)) {
+    return llvm::None;
+  }
+
+  ArrayRef<int64_t> lhsShape = getUntiledShape(op.inputs()[0]);
+  ArrayRef<int64_t> rhsShape = getUntiledShape(op.inputs()[1]);
+
+  if (llvm::any_of(lhsShape, ShapedType::isDynamic) ||
+      llvm::any_of(rhsShape, ShapedType::isDynamic)) {
+    return llvm::None;
+  }
+
+  auto resourceLimits = targetEnv.getResourceLimits();
+  auto getElementType = [](Value v) {
+    return v.getType().cast<ShapedType>().getElementType();
+  };
+
+  auto outputElementType = getElementType(op.outputs()[0]);
+
+  Optional<SmallVector<int64_t, 4>> coopMatSize = getCooperativeMatrixSize(
+      resourceLimits, getElementType(op.inputs()[0]),
+      getElementType(op.inputs()[1]), outputElementType, outputElementType);
+  if (!coopMatSize) return llvm::None;
+
+  // Check that the matmul sizes are a multiple of the tilesize.
+  auto isMultipleOf = [](int64_t s, int64_t ts) {
+    return !ShapedType::isDynamic(s) && (s % ts) == 0;
+  };
+
+  if (!isMultipleOf(lhsShape[0], (*coopMatSize)[0]) ||
+      !isMultipleOf(rhsShape[1], (*coopMatSize)[1]) ||
+      !isMultipleOf(lhsShape[1], (*coopMatSize)[2]) ||
+      !isMultipleOf(rhsShape[0], (*coopMatSize)[2])) {
+    return llvm::None;
+  }
+
+  // For now this is being hard-wired to be {4, 4, 2}. This can actually be set
+  // to whatever, but ultimately depends on register pressure.
+  const int64_t numVecMatmulPerSubgroupX = 4;
+  const int64_t numVecMatmulPerSubgroupY = 4;
+  const int64_t numVecMatmulPerSubgroupK = 2;
+
+  SPIRVCodeGenConfig config = {};
+  config.pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
+
+  config.workgroupTileSizes = {numVecMatmulPerSubgroupY * (*coopMatSize)[0],
+                               numVecMatmulPerSubgroupX * (*coopMatSize)[1],
+                               numVecMatmulPerSubgroupK * (*coopMatSize)[2]};
+
+  config.subgroupTileSizes = {numVecMatmulPerSubgroupY * (*coopMatSize)[0],
+                              numVecMatmulPerSubgroupX * (*coopMatSize)[1]};
+
+  int64_t subgroupSize =
+      resourceLimits.subgroup_size().getValue().getSExtValue();
+  config.workgroupSize = {subgroupSize, 1, 1};
+
+  return config;
+}
+
+}  // namespace
+
+Optional<SPIRVCodeGenConfig> getNVIDIACodeGenConfig(
+    const spirv::TargetEnv &targetEnv, Operation *op) {
+  if (auto matmulOp = dyn_cast<linalg::MatmulOp>(op)) {
+    return getOpConfig(targetEnv, matmulOp);
+  }
+  return llvm::None;
+}
+
+}  // namespace detail
+}  // namespace iree_compiler
+}  // namespace mlir


### PR DESCRIPTION
The `KernelConfig.cpp` file has been hosting configuration for
all targets for a while. It has grown out of control. This trims
it down and moves per-target configuration to their own files.
`KernelConfig.cpp` now only contains the default configuration.
It improves structure and makes supporting more targets easier.

This also moves the `lowering.config` attribute composition and
attachment to one central place, instead of duplicated in all
configuration querying functions.