### PR TITLE
Use llvm::TargetTransformInfo for native vector size.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -567,8 +567,8 @@ static std::string getStringAttrFromTargetAttr(ModuleOp module,
           module->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
     IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
     if (auto config = targetAttr.getConfiguration()) {
-      if (auto dataLayoutAttr = config.getAs<StringAttr>(attrName)) {
-        return dataLayoutAttr.getValue().str();
+      if (auto attr = config.getAs<StringAttr>(attrName)) {
+        return attr.getValue().str();
       }
     }
   }

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
@@ -540,17 +541,8 @@ class RemoveHALInterfaceOpPattern : public ConvertToLLVMPattern {
 
 class ConvertToLLVMPass : public ConvertToLLVMBase<ConvertToLLVMPass> {
  public:
-  ConvertToLLVMPass(std::string targetTriple = "",
-                    std::string targetDataLayout = "", bool unfuseFMA = false) {
-    this->targetTriple = targetTriple;
-    this->targetDataLayout = targetDataLayout;
-    unfuseFMAOps = unfuseFMA;
-  }
-  ConvertToLLVMPass(const ConvertToLLVMPass &pass) {
-    targetTriple = pass.targetTriple;
-    targetDataLayout = pass.targetDataLayout;
-    unfuseFMAOps = pass.unfuseFMAOps;
-  }
+  ConvertToLLVMPass() = default;
+  ConvertToLLVMPass(const ConvertToLLVMPass &pass) {}
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<LLVM::LLVMDialect>();
   }
@@ -565,23 +557,40 @@ class ConvertToLLVMPass : public ConvertToLLVMBase<ConvertToLLVMPass> {
       *this, "target-data-layout",
       llvm::cl::desc("Code generation target data layout."),
       llvm::cl::init("")};
-  Option<bool> unfuseFMAOps{
-      *this, "unfuse-fma-ops",
-      llvm::cl::desc("Enable rewriting llvm.fma to its unfused version."),
-      llvm::cl::init(false)};
 };
 
 }  // namespace
 
+static std::string getStringAttrFromTargetAttr(ModuleOp module,
+                                               StringRef attrName) {
+  if (auto variantOp =
+          module->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
+    IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
+    if (auto dataLayoutAttr =
+            targetAttr.getConfiguration().getAs<StringAttr>(attrName)) {
+      return dataLayoutAttr.getValue().str();
+    }
+  }
+  return "";
+}
+
 void ConvertToLLVMPass::runOnOperation() {
   auto module = getOperation();
+  std::string dataLayoutStr = targetDataLayout.getValue();
+  if (targetDataLayout.empty()) {
+    dataLayoutStr = getStringAttrFromTargetAttr(module, "data_layout");
+  }
+  std::string targetTripleStr = targetTriple.getValue();
+  if (targetTripleStr.empty()) {
+    targetTripleStr = getStringAttrFromTargetAttr(module, "target_triple");
+  }
 
   // Add required attributes to the module so that the lowering knows how to
   // handle structs and data layouts.
   module->setAttr(LLVM::LLVMDialect::getTargetTripleAttrName(),
-                  StringAttr::get(module->getContext(), targetTriple));
+                  StringAttr::get(module->getContext(), targetTripleStr));
   module->setAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
-                  StringAttr::get(module->getContext(), targetDataLayout));
+                  StringAttr::get(module->getContext(), dataLayoutStr));
 
   // Run Vector -> Vector transformations ahead of conversion to LLVM.
   {
@@ -685,17 +694,17 @@ void ConvertToLLVMPass::runOnOperation() {
   // Post conversion patterns.
   {
     OwningRewritePatternList postPatterns(&getContext());
-    if (unfuseFMAOps) {
+    // TODO(ravishankarm): Move this to a separate pass.
+    llvm::Triple triple(targetTripleStr);
+    if (triple.isWasm()) {
       populateUnfusedFMAOpsPassPatterns(&getContext(), postPatterns);
       (void)applyPatternsAndFoldGreedily(module, std::move(postPatterns));
     }
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass(
-    std::string targetTriple, std::string targetDataLayout, bool unfuseFMAOps) {
-  return std::make_unique<ConvertToLLVMPass>(targetTriple, targetDataLayout,
-                                             unfuseFMAOps);
+std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass() {
+  return std::make_unique<ConvertToLLVMPass>();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -619,7 +619,7 @@ void ConvertToLLVMPass::runOnOperation() {
   const auto &dataLayoutAnalysis = getAnalysis<DataLayoutAnalysis>();
   LowerToLLVMOptions options(&getContext(),
                              dataLayoutAnalysis.getAtOrAbove(module));
-  options.dataLayout = llvm::DataLayout(targetDataLayout);
+  options.dataLayout = llvm::DataLayout(dataLayoutStr);
   options.overrideIndexBitwidth(options.dataLayout.getPointerSizeInBits());
   LLVMTypeConverter converter(&getContext(), options, &dataLayoutAnalysis);
 

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -566,9 +566,10 @@ static std::string getStringAttrFromTargetAttr(ModuleOp module,
   if (auto variantOp =
           module->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
     IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
-    if (auto dataLayoutAttr =
-            targetAttr.getConfiguration().getAs<StringAttr>(attrName)) {
-      return dataLayoutAttr.getValue().str();
+    if (auto config = targetAttr.getConfiguration()) {
+      if (auto dataLayoutAttr = config.getAs<StringAttr>(attrName)) {
+        return dataLayoutAttr.getValue().str();
+      }
     }
   }
   return "";

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -86,6 +86,8 @@ static Optional<int64_t> getNativeVectorSize(FuncOp entryPointFn,
   if (!config) return {};
   auto nativeVectorSize = config.getAs<IntegerAttr>("native_vector_size");
   if (!nativeVectorSize) return {};
+  int64_t nativeVectorSizeVal = nativeVectorSize.getInt();
+  if (nativeVectorSizeVal == 0) return {};
   if (!elementType.isIntOrFloat()) return {};
   unsigned bitWidth = elementType.getIntOrFloatBitWidth() / 8;
   return nativeVectorSize.getInt() / bitWidth;

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -79,9 +79,12 @@ static Optional<int64_t> getNativeVectorSize(FuncOp entryPointFn,
                                              Type elementType) {
   auto variantOp =
       entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  if (!variantOp) return {};
   IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
-  auto nativeVectorSize =
-      targetAttr.getConfiguration().getAs<IntegerAttr>("native_vector_size");
+  if (!targetAttr) return {};
+  auto config = targetAttr.getConfiguration();
+  if (!config) return {};
+  auto nativeVectorSize = config.getAs<IntegerAttr>("native_vector_size");
   if (!nativeVectorSize) return {};
   if (!elementType.isIntOrFloat()) return {};
   unsigned bitWidth = elementType.getIntOrFloatBitWidth() / 8;

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -6,7 +6,11 @@ hal.executable @matmul_tensors attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+       native_vector_size = 16 : index,
+       target_triple = "x86_64-unknown-linux-gnu"
+    }> {
     hal.executable.entry_point @matmul_tensors attributes {
       interface = @io,
       ordinal = 0 : index
@@ -79,7 +83,11 @@ hal.executable @add_no_config attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+       native_vector_size = 16 : index,
+       target_triple = "x86_64-unknown-linux-gnu"
+    }> {
     hal.executable.entry_point @add_no_config attributes {
       interface = @io,
       ordinal = 0 : index
@@ -119,7 +127,11 @@ hal.executable @add attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+       native_vector_size = 16 : index,
+       target_triple = "x86_64-unknown-linux-gnu"
+    }> {
     hal.executable.entry_point @add attributes {
       interface = @io, ordinal = 0 : index,
       signature = (!flow.dispatch.tensor<readonly:?x?xf32>, !flow.dispatch.tensor<readonly:?xf32>,
@@ -194,7 +206,11 @@ hal.executable @add4D attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+       native_vector_size = 16 : index,
+       target_triple = "x86_64-unknown-linux-gnu"
+    }> {
     hal.executable.entry_point @add4D attributes {
       interface = @io, ordinal = 0 : index,
       signature = (!flow.dispatch.tensor<readonly:?x?x?x?xf32>, !flow.dispatch.tensor<readonly:?xf32>,
@@ -290,7 +306,11 @@ hal.executable @batch_matmul_tensors attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+       native_vector_size = 16 : index,
+       target_triple = "x86_64-unknown-linux-gnu"
+    }> {
     hal.executable.entry_point @batch_matmul_tensors attributes {
       interface = @io,
       ordinal = 0 : index

--- a/iree/compiler/Codegen/Passes.cpp
+++ b/iree/compiler/Codegen/Passes.cpp
@@ -18,14 +18,12 @@ void registerCodegenPasses() {
   // Generated.
   registerPasses();
 
-  static PassPipelineRegistration<LLVMCPUCodegenPassPipelineOptions>
-      linalgLLVMVPipeline(
-          "iree-codegen-linalg-to-llvm-pipeline",
-          "Runs the progressive lowering pipeline from Linalg to LLVM",
-          [](OpPassManager &passManager,
-             const LLVMCPUCodegenPassPipelineOptions &options) {
-            buildLLVMCPUCodegenPassPipeline(passManager, options);
-          });
+  static PassPipelineRegistration<> LinalgLLVMVPipeline(
+      "iree-codegen-linalg-to-llvm-pipeline",
+      "Runs the progressive lowering pipeline from Linalg to LLVM",
+      [](OpPassManager &passManager) {
+        buildLLVMCPUCodegenPassPipeline(passManager);
+      });
 
   static PassPipelineRegistration<> LinalgNVVMPipeline(
       "iree-codegen-linalg-to-nvvm-pipeline",

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -113,9 +113,7 @@ void populateShapeToLLVMConversionPatterns(MLIRContext *context,
 //------------------------------------------------------------------------------
 
 /// Performs the final conversion to LLVM dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass(
-    std::string targetTriple = "", std::string targetDataLayout = "",
-    bool unfuseFMAOps = false);
+std::unique_ptr<OperationPass<ModuleOp>> createConvertToLLVMPass();
 
 /// Pass to lower the module an hal.executable.variant operation to external
 /// dialect. Currently this pass lowers to LLVM dialect, but could be
@@ -179,28 +177,10 @@ void addCPUVectorizationPassPipeline(OpPassManager &passManager,
 // LLVMCPU Pass Pipelines for lowering to LLVM dialect.
 //----------------------------------------------------------------------------//
 
-/// Options for LLVM pipeline.
-struct LLVMCPUCodegenPassPipelineOptions
-    : public PassPipelineOptions<LLVMCPUCodegenPassPipelineOptions> {
-  Option<std::string> targetDataLayout{
-      *this, "target-data-layout",
-      llvm::cl::desc("Code generation target data layout."),
-      llvm::cl::init("")};
-  Option<std::string> targetTriple{
-      *this, "target-triple", llvm::cl::desc("Code generation target triple."),
-      llvm::cl::init("")};
-  Option<bool> unfuseFMAOps{
-      *this, "unfuse-fma-ops",
-      llvm::cl::desc("Enable rewriting llvm.fma to its unfused version."),
-      llvm::cl::init(false)};
-};
-
 /// Populates passes needed to lower a XLA HLO op to LLVM dialect via the
 /// structured ops path. The pass manager `pm` in here should operate on the
 /// module within the IREE::HAL::ExecutableOp.
-void buildLLVMCPUCodegenPassPipeline(
-    OpPassManager &passManager,
-    const LLVMCPUCodegenPassPipelineOptions &options);
+void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager);
 
 //------------------------------------------------------------------------------
 // LLVMGPU

--- a/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -17,6 +17,7 @@
 
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -321,7 +322,8 @@ void ConvertToSPIRVPass::runOnOperation() {
                     spirv::getEntryPointABIAttr(workgroupSize32, context));
   }
 
-  auto targetAttr = spirv::lookupTargetEnv(moduleOp);
+  spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(moduleOp);
+  moduleOp->setAttr(spirv::getTargetEnvAttrName(), targetAttr);
   SPIRVTypeConverter typeConverter(targetAttr);
   OwningRewritePatternList patterns(&getContext());
   ScfToSPIRVContext scfToSPIRVContext;

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -276,6 +276,13 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
 LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
   llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPointOps =
       getAllEntryPoints(module);
+  spirv::TargetEnvAttr targetEnvAttr = getSPIRVTargetEnvAttr(module);
+  if (!targetEnvAttr) {
+    return module.emitOpError(
+        "expected parent hal.executable.variant to have spv.target_env "
+        "attribute");
+  }
+  spirv::TargetEnv targetEnv(targetEnvAttr);
 
   for (auto funcOp : module.getOps<FuncOp>()) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());
@@ -288,9 +295,8 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
       return funcOp.emitOpError("failed to get compute ops");
     }
 
-    spirv::TargetEnv targetEnv(spirv::lookupTargetEnv(funcOp));
-    spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
-    int64_t subgroupSize = limits.subgroup_size().getValue().getSExtValue();
+    int64_t subgroupSize =
+        targetEnv.getResourceLimits().subgroup_size().getValue().getSExtValue();
 
     // If the dispatch region does not contain tiled and distributed Linalg ops,
     // invoke the pipeline to distribute to global invocations.

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -283,6 +284,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
         "attribute");
   }
   spirv::TargetEnv targetEnv(targetEnvAttr);
+  spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
 
   for (auto funcOp : module.getOps<FuncOp>()) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeMatrix.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeMatrix.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/SCF.h"
@@ -74,7 +75,8 @@ bool supportsCooperativeMatrix(Operation *op) {
 class CooperativeMatrixAnalysis {
  public:
   explicit CooperativeMatrixAnalysis(mlir::Operation *op) {
-    auto targetEnv = spirv::TargetEnv(spirv::lookupTargetEnv(op));
+    spirv::TargetEnvAttr targetEnvAttr = getSPIRVTargetEnvAttr(op);
+    spirv::TargetEnv targetEnv(targetEnvAttr);
     if (!targetEnv.allows(spirv::Capability::CooperativeMatrixNV) ||
         !targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix))
       return;
@@ -255,7 +257,7 @@ struct SPIRVVectorToCooperativeMatrixPass final
           SPIRVVectorToCooperativeMatrixPass> {
   void runOnOperation() override {
     FuncOp funcOp = getOperation();
-    auto targetAttr = spirv::lookupTargetEnv(funcOp);
+    spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(funcOp);
     SPIRVTypeConverter typeConverter(targetAttr);
 
     typeConverter.addConversion(

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -12,6 +12,7 @@
 
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -57,13 +58,13 @@ static Optional<SmallVector<int64_t, 4>> getCooperativeMatmulSubgroupSize(
 /// Returns true if the target environment attached to `op`'s ancestor op
 /// supports cooperative matrix.
 bool useCooperativeMatrix(Operation *op) {
-  auto targetEnv = spirv::TargetEnv(spirv::lookupTargetEnv(op));
+  auto targetEnv = spirv::TargetEnv(getSPIRVTargetEnvAttr(op));
   return targetEnv.allows(spirv::Capability::CooperativeMatrixNV) &&
          targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix);
 }
 
 Optional<SmallVector<int64_t, 4>> getSPIRVNativeVectorSize(Operation *op) {
-  auto targetEnv = spirv::TargetEnv(spirv::lookupTargetEnv(op));
+  auto targetEnv = spirv::TargetEnv(getSPIRVTargetEnvAttr(op));
   bool useCoopMatrix = useCooperativeMatrix(op);
 
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {

--- a/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -14,6 +14,7 @@
 
 #include "iree/compiler/Codegen/SPIRV/MemorySpace.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -27,6 +28,16 @@
 
 namespace mlir {
 namespace iree_compiler {
+
+spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op) {
+  auto variant = op->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  if (!variant) return nullptr;
+  IREE::HAL::ExecutableTargetAttr targetAttr = variant.target();
+  if (!targetAttr) return nullptr;
+  auto config = targetAttr.getConfiguration();
+  if (!config) return nullptr;
+  return config.getAs<spirv::TargetEnvAttr>(spirv::getTargetEnvAttrName());
+}
 
 LogicalResult updateWorkGroupSize(FuncOp funcOp,
                                   ArrayRef<int64_t> workGroupSize) {

--- a/iree/compiler/Codegen/SPIRV/Utils.h
+++ b/iree/compiler/Codegen/SPIRV/Utils.h
@@ -15,6 +15,7 @@
 
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -28,6 +29,12 @@ namespace mlir {
 namespace iree_compiler {
 
 static constexpr int kNumGPUDims = 3;
+
+//===----------------------------------------------------------------------===//
+// Attribute utils
+//===----------------------------------------------------------------------===//
+/// Given an operation, return the `spv.target_env` attribute.
+spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op);
 
 //===----------------------------------------------------------------------===//
 // Workgroup memory utils

--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -5,12 +5,13 @@ hal.executable @push_constant attributes {sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @push_constant attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @__push_constant_var__ : !spv.ptr<!spv.struct<(!spv.array<5 x i32, stride=4> [0])>, PushConstant>
       // CHECK: spv.func @push_constant()
@@ -40,12 +41,13 @@ hal.executable @resource_bindings_in_same_func attributes {sym_visibility = "pri
     hal.interface.binding @arg1, set=1, binding=3, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @resource_bindings_in_same_func attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @[[ARG0:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
       // CHECK: spv.GlobalVariable @[[ARG1_0:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
@@ -97,7 +99,8 @@ hal.executable @resource_bindings_in_multi_entry_func attributes {sym_visibility
     hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer", access="Write"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @resource_bindings_in_entry_func1 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
@@ -106,7 +109,7 @@ hal.executable @resource_bindings_in_multi_entry_func attributes {sym_visibility
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @[[FUNC1_ARG:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
       // CHECK: spv.GlobalVariable @[[FUNC1_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
@@ -157,12 +160,13 @@ hal.executable @interface_binding attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @interface_binding attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    module {
       func @interface_binding() {
         %c0 = constant 0 : index
         %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<8x5xf32>
@@ -203,12 +207,13 @@ hal.executable @interface_wg_id attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @interface_wg_id attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    module {
       func @interface_wg_id() {
         %0 = hal.interface.workgroup.id[0] : index
         %1 = hal.interface.workgroup.id[1] : index
@@ -241,12 +246,13 @@ hal.executable @interface_wg_count attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
     hal.executable.entry_point @interface_wg_count attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    module {
       func @interface_wg_count() {
         %0 = hal.interface.workgroup.count[0] : index
         %1 = hal.interface.workgroup.count[1] : index

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_matrix.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_matrix.mlir
@@ -7,12 +7,7 @@ hal.executable @matmul_cooperative_matrix attributes {sym_visibility = "private"
     hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_cooperative_matrix attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    module attributes {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env =
         #spv.target_env<#spv.vce<v1.5,
           [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
@@ -29,7 +24,12 @@ hal.executable @matmul_cooperative_matrix attributes {sym_visibility = "private"
            max_compute_shared_memory_size = 49152 : i32,
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
-           subgroup_size = 32 : i32}>} {
+           subgroup_size = 32 : i32}>}> {
+    hal.executable.entry_point @matmul_cooperative_matrix attributes {
+      interface = @io,
+      ordinal = 0 : index
+    }
+    module {
       func @matmul_cooperative_matrix() {
         %c32 = constant 32 : index
         %c4096 = constant 4096 : index

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -8,13 +8,14 @@ hal.executable @fuse_and_vectorize_fill_matmul attributes {sym_visibility = "pri
     hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @fuse_and_vectorize_fill_matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @fuse_and_vectorize_fill_matmul() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32
@@ -77,13 +78,14 @@ hal.executable @fuse_and_vectorize_matmul_add attributes {sym_visibility = "priv
     hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @fuse_and_vectorize_matmul_add attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @fuse_and_vectorize_matmul_add() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32

--- a/iree/compiler/Codegen/SPIRV/test/set_lowering_config.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/set_lowering_config.mlir
@@ -4,15 +4,15 @@ hal.executable @static_1d_sort attributes {sym_visibility = "private"} {
   hal.interface @io {
     hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_1d_sort attributes {interface = @io, ordinal = 0 : index}
-    builtin.module attributes {
+  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, ARM:IntegratedGPU, {
         max_compute_shared_memory_size = 32768 : i32,
         max_compute_workgroup_invocations = 512 : i32,
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
-    } {
+    }> {
+    hal.executable.entry_point @static_1d_sort attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       builtin.func @static_1d_sort() {
         %c0 = constant 0 : index
         %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:1000xi32>
@@ -52,15 +52,15 @@ hal.executable @static_3d_sort attributes {sym_visibility = "private"} {
     hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_3d_sort attributes {interface = @io, ordinal = 0 : index}
-    builtin.module attributes {
+  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, ARM:IntegratedGPU, {
         max_compute_shared_memory_size = 32768 : i32,
         max_compute_workgroup_invocations = 512 : i32,
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
-    } {
+    }> {
+    hal.executable.entry_point @static_3d_sort attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       builtin.func @static_3d_sort() {
         %c64 = constant 64 : index
         %c128 = constant 128 : index
@@ -117,15 +117,15 @@ hal.executable @static_1d_fft attributes {sym_visibility = "private"} {
     hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirvfb"> {
-    hal.executable.entry_point @static_1d_fft attributes {interface = @io, ordinal = 0 : index}
-    builtin.module attributes {
+  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirvfb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, ARM:IntegratedGPU, {
         max_compute_shared_memory_size = 32768 : i32,
         max_compute_workgroup_invocations = 512 : i32,
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
-    } {
+    }> {
+    hal.executable.entry_point @static_1d_fft attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       builtin.func @static_1d_fft() {
         %c0 = constant 0 : index
         %c2 = constant 2 : index
@@ -168,15 +168,15 @@ hal.executable @static_3d_fft attributes {sym_visibility = "private"} {
     hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
   }
-  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirvfb"> {
-    hal.executable.entry_point @static_3d_fft attributes {interface = @io, ordinal = 0 : index}
-    builtin.module attributes {
+  hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirvfb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, ARM:IntegratedGPU, {
         max_compute_shared_memory_size = 32768 : i32,
         max_compute_workgroup_invocations = 512 : i32,
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
-    } {
+    }> {
+    hal.executable.entry_point @static_3d_fft attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       builtin.func @static_3d_fft() {
         %c0 = constant 0 : index
         %c2 = constant 2 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
@@ -16,17 +16,17 @@ hal.executable @matmul attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env =
+        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+                        {max_compute_workgroup_invocations = 128 : i32,
+                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
     hal.executable.entry_point @matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 8: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [8, 16]}
     }
-    module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    module {
       func @matmul() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?xf32>
@@ -91,13 +91,21 @@ hal.executable @conv_1d attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3,
+          [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic,
+           GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative],
+          [SPV_KHR_storage_buffer_storage_class]>,
+          SwiftShader:CPU,
+          {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32,
+           max_compute_workgroup_invocations = 128 : i32,
+           max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}> {
     hal.executable.entry_point @conv_1d attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32, max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}  {
+    module {
       func @conv_1d() {
         %cst = constant 0.000000e+00 : f32
         %c0 = constant 0 : index
@@ -174,17 +182,17 @@ hal.executable @conv_no_padding attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env =
+        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+                        {max_compute_workgroup_invocations = 128 : i32,
+                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
     hal.executable.entry_point @conv_no_padding attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    module {
       func @conv_no_padding() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?x?x?xf32>
@@ -296,13 +304,20 @@ hal.executable @conv_3d attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3,
+          [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic,
+           GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative],
+          [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU,
+          {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32,
+           max_compute_workgroup_invocations = 128 : i32,
+           max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}> {
     hal.executable.entry_point @conv_3d attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32, max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}  {
+    module {
       func @conv_3d() {
         %cst = constant 0.000000e+00 : f32
         %c0 = constant 0 : index
@@ -370,13 +385,16 @@ module  {
       hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
     }
-    hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+    hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+        spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
+        {max_compute_workgroup_invocations = 128 : i32,
+         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
       hal.executable.entry_point @pooling_nhwc_max attributes {
         interface = @io, ordinal = 0 : index,
         workgroup_size = [32: index, 4: index, 1: index],
         translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
       }
-      module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}  {
+      module {
         func @pooling_nhwc_max() {
           %c0 = constant 0 : index
           %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<2x16x16x6xf32>

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -8,13 +8,14 @@ hal.executable @batch_matmul_static_shape attributes {sym_visibility = "private"
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @batch_matmul_static_shape attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @batch_matmul_static_shape() {
         %c0 = constant 0 : index
         %c4 = constant 4 : index
@@ -376,13 +377,14 @@ hal.executable @fused_fill_batch_matmul attributes {sym_visibility = "private"} 
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @fused_fill_batch_matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @fused_fill_batch_matmul() {
         %zero = constant 0.0 : f32
         %c0 = constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -8,7 +8,8 @@ hal.executable @conv_static_shape_f32 attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @conv_static_shape_f32 attributes {
       interface = @io,
       ordinal = 0 : index,
@@ -21,7 +22,7 @@ hal.executable @conv_static_shape_f32 attributes {sym_visibility = "private"} {
       %z = constant 28: index
       hal.return %x, %y, %z: index, index, index
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @conv_static_shape_f32() {
         %cst = constant 0.000000e+00 : f32
         %c32 = constant 32 : index
@@ -107,7 +108,8 @@ hal.executable @depthwise_conv_static_shape_f32 attributes {sym_visibility = "pr
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @depthwise_conv_static_shape_f32 attributes {
       interface = @io,
       ordinal = 0 : index,
@@ -120,7 +122,7 @@ hal.executable @depthwise_conv_static_shape_f32 attributes {sym_visibility = "pr
       %z = constant 14: index
       hal.return %x, %y, %z: index, index, index
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @depthwise_conv_static_shape_f32() {
         %cst = constant 0.000000e+00 : f32
         %c96 = constant 96 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -8,13 +8,14 @@ hal.executable @matmul_static_shape_f16 attributes {sym_visibility = "private"} 
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @matmul_static_shape_f16 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @matmul_static_shape_f16() {
         %cst = constant 0.000000e+00 : f16
         %c0 = constant 0 : index
@@ -74,13 +75,14 @@ hal.executable @matmul_static_shape_f32 attributes {sym_visibility = "private"} 
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
     hal.executable.entry_point @matmul_static_shape_f32 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    module {
       func @matmul_static_shape_f32() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32

--- a/iree/compiler/Codegen/SPIRV/test/vector_to_cooperative_matrix.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vector_to_cooperative_matrix.mlir
@@ -1,27 +1,36 @@
-// RUN: iree-opt -split-input-file -iree-spirv-vector-to-cooperative-matrix %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-spirv-vector-to-cooperative-matrix))))' %s | IreeFileCheck %s
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, CooperativeMatrixNV, Int8, StorageBuffer8BitAccess], [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  // CHECK-LABEL: func @kernel_matmul
-  func @kernel_matmul(%arg0: memref<8x32xi8>, %arg1: memref<32x8xi8>, %arg2: memref<8x8xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
-    %c0 = constant 0 : index
-    %cst = constant 0 : i32
-    %cst_i8 = constant 0 : i8
-    %0 = vector.transfer_read %arg0[%c0, %c0], %cst_i8 : memref<8x32xi8>, vector<8x32xi8>
-    %1 = vector.transfer_read %arg1[%c0, %c0], %cst_i8 : memref<32x8xi8>, vector<32x8xi8>
-    %2 = vector.transfer_read %arg2[%c0, %c0], %cst : memref<8x8xi32>, vector<8x8xi32>
-    %3 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %0, %1, %2 : vector<8x32xi8>, vector<32x8xi8> into vector<8x8xi32>
-    vector.transfer_write %3, %arg2[%c0, %c0] : vector<8x8xi32>, memref<8x8xi32>
-    // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
-    // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
-    // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
-    // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %[[C]]
-    // CHECK: spv.CooperativeMatrixStoreNV %{{.*}}, %[[R]], %{{.*}}, %{{.*}}
-    return
+hal.executable @kernel_matmul attributes {sym_visibility = "private"} {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+    gpu.container_module,
+    spv.target_env = #spv.target_env<#spv.vce<v1.0,
+        [Shader, CooperativeMatrixNV, Int8, StorageBuffer8BitAccess],
+        [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage]>,
+        {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+    module {
+      // CHECK-LABEL: func @kernel_matmul
+      func @kernel_matmul(%arg0: memref<8x32xi8>, %arg1: memref<32x8xi8>, %arg2: memref<8x8xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+        %c0 = constant 0 : index
+        %cst = constant 0 : i32
+        %cst_i8 = constant 0 : i8
+        %0 = vector.transfer_read %arg0[%c0, %c0], %cst_i8 : memref<8x32xi8>, vector<8x32xi8>
+        %1 = vector.transfer_read %arg1[%c0, %c0], %cst_i8 : memref<32x8xi8>, vector<32x8xi8>
+        %2 = vector.transfer_read %arg2[%c0, %c0], %cst : memref<8x8xi32>, vector<8x8xi32>
+        %3 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %0, %1, %2 : vector<8x32xi8>, vector<32x8xi8> into vector<8x8xi32>
+        vector.transfer_write %3, %arg2[%c0, %c0] : vector<8x8xi32>, memref<8x8xi32>
+        // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
+        // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
+        // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
+        // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %[[C]]
+        // CHECK: spv.CooperativeMatrixStoreNV %{{.*}}, %[[R]], %{{.*}}, %{{.*}}
+        return
+      }
+    }
   }
 }
 
@@ -32,38 +41,46 @@ module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.v
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer], [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  // CHECK-LABEL: func @kernel_matmul_licm
-  func @kernel_matmul_licm(%arg0: memref<4096x4096xi8>, %arg1: memref<4096x4096xi8>, %arg2: memref<4096x4096xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
-    %c32 = constant 32 : index
-    %c4096 = constant 4096 : index
-    %c0 = constant 0 : index
-    %c0_i32 = constant 0 : i32
-    %c0_i8 = constant 0 : i8
-    // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
-    %4 = vector.transfer_read %arg2[%c0, %c0], %c0_i32 {in_bounds = [true, true]} : memref<4096x4096xi32>, vector<16x16xi32>
-    // CHECK: %[[INIT:.+]] = builtin.unrealized_conversion_cast %[[C]] : !spv.coopmatrix<16x16xi32, Subgroup> to vector<16x16xi32>
-    // CHECK: %[[LOOP:.+]] = scf.for
-    // CHECK-SAME: iter_args(%[[ARG:.+]] = %[[INIT]])
-    %5 = scf.for %arg3 = %c0 to %c4096 step %c32 iter_args(%arg4 = %4) -> (vector<16x16xi32>) {
-      // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
-      %6 = vector.transfer_read %arg0[%c0, %arg3], %c0_i8 {in_bounds = [true, true]} : memref<4096x4096xi8>, vector<16x32xi8>
-      // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
-      %7 = vector.transfer_read %arg1[%arg3, %c0], %c0_i8 {in_bounds = [true, true]} : memref<4096x4096xi8>, vector<32x16xi8>
-      // CHECK: %[[C1:.+]] = builtin.unrealized_conversion_cast %[[ARG]] : vector<16x16xi32> to !spv.coopmatrix<16x16xi32, Subgroup>
-      // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %[[C1]]
-      %8 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %6, %7, %arg4 : vector<16x32xi8>, vector<32x16xi8> into vector<16x16xi32>
-      // CHECK: %[[YIELD:.+]] = builtin.unrealized_conversion_cast %[[R]] : !spv.coopmatrix<16x16xi32, Subgroup> to vector<16x16xi32>
-      // CHECK: scf.yield %[[YIELD]]
-      scf.yield %8 : vector<16x16xi32>
+hal.executable @kernel_matmul attributes {sym_visibility = "private"} {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      gpu.container_module,
+      spv.target_env = #spv.target_env<#spv.vce<v1.0,
+          [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer],
+          [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>,
+      {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+    module {
+      // CHECK-LABEL: func @kernel_matmul_licm
+      func @kernel_matmul_licm(%arg0: memref<4096x4096xi8>, %arg1: memref<4096x4096xi8>, %arg2: memref<4096x4096xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+        %c32 = constant 32 : index
+        %c4096 = constant 4096 : index
+        %c0 = constant 0 : index
+        %c0_i32 = constant 0 : i32
+        %c0_i8 = constant 0 : i8
+        // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
+        %4 = vector.transfer_read %arg2[%c0, %c0], %c0_i32 {in_bounds = [true, true]} : memref<4096x4096xi32>, vector<16x16xi32>
+        // CHECK: %[[INIT:.+]] = builtin.unrealized_conversion_cast %[[C]] : !spv.coopmatrix<16x16xi32, Subgroup> to vector<16x16xi32>
+        // CHECK: %[[LOOP:.+]] = scf.for
+        // CHECK-SAME: iter_args(%[[ARG:.+]] = %[[INIT]])
+        %5 = scf.for %arg3 = %c0 to %c4096 step %c32 iter_args(%arg4 = %4) -> (vector<16x16xi32>) {
+          // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
+          %6 = vector.transfer_read %arg0[%c0, %arg3], %c0_i8 {in_bounds = [true, true]} : memref<4096x4096xi8>, vector<16x32xi8>
+          // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
+          %7 = vector.transfer_read %arg1[%arg3, %c0], %c0_i8 {in_bounds = [true, true]} : memref<4096x4096xi8>, vector<32x16xi8>
+          // CHECK: %[[C1:.+]] = builtin.unrealized_conversion_cast %[[ARG]] : vector<16x16xi32> to !spv.coopmatrix<16x16xi32, Subgroup>
+          // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %[[C1]]
+          %8 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %6, %7, %arg4 : vector<16x32xi8>, vector<32x16xi8> into vector<16x16xi32>
+          // CHECK: %[[YIELD:.+]] = builtin.unrealized_conversion_cast %[[R]] : !spv.coopmatrix<16x16xi32, Subgroup> to vector<16x16xi32>
+          // CHECK: scf.yield %[[YIELD]]
+          scf.yield %8 : vector<16x16xi32>
+        }
+        // CHECK: %[[ACCv:.+]] = builtin.unrealized_conversion_cast %[[LOOP]] : vector<16x16xi32> to !spv.coopmatrix<16x16xi32, Subgroup>
+        // CHECK: spv.CooperativeMatrixStoreNV %{{.*}}, %[[ACCv]], %{{.*}}, %{{.*}}
+        vector.transfer_write %5, %arg2[%c0, %c0] : vector<16x16xi32>, memref<4096x4096xi32>
+        return
+      }
     }
-    // CHECK: %[[ACCv:.+]] = builtin.unrealized_conversion_cast %[[LOOP]] : vector<16x16xi32> to !spv.coopmatrix<16x16xi32, Subgroup>
-    // CHECK: spv.CooperativeMatrixStoreNV %{{.*}}, %[[ACCv]], %{{.*}}, %{{.*}}
-    vector.transfer_write %5, %arg2[%c0, %c0] : vector<16x16xi32>, memref<4096x4096xi32>
-    return
   }
 }
-
 // -----
 
 #map0 = affine_map<(d0, d1) -> (d1)>
@@ -71,27 +88,36 @@ module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.v
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer], [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
-  // CHECK-LABEL: func @kernel_matmul_vector_memref
-  func @kernel_matmul_vector_memref(%arg0: memref<4096x256xvector<4xi32>>, %arg1: memref<4096x256xvector<4xi32>>, %arg2: memref<4096x1024xvector<4xi32>>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
-    %c32 = constant 32 : index
-    %c4096 = constant 4096 : index
-    %c0 = constant 0 : index
-    %cst = constant dense<0> : vector<4xi32>
-    // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
-    %4 = vector.transfer_read %arg2[%c0, %c0], %cst : memref<4096x1024xvector<4xi32>>, vector<16x16xi32>
-    // CHECK: scf.for
-    %5 = scf.for %arg3 = %c0 to %c4096 step %c32 iter_args(%arg4 = %4) -> (vector<16x16xi32>) {
-      // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
-      %6 = vector.transfer_read %arg0[%c0, %arg3], %cst : memref<4096x256xvector<4xi32>>, vector<16x32xi8>
-      // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
-      %7 = vector.transfer_read %arg1[%arg3, %c0], %cst : memref<4096x256xvector<4xi32>>, vector<32x16xi8>
-      // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %{{.*}}
-      %8 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %6, %7, %arg4 : vector<16x32xi8>, vector<32x16xi8> into vector<16x16xi32>
-      scf.yield %8 : vector<16x16xi32>
+hal.executable @kernel_matmul attributes {sym_visibility = "private"} {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      gpu.container_module,
+      spv.target_env = #spv.target_env<#spv.vce<v1.0,
+      [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer],
+      [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>,
+      {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+    module {
+      // CHECK-LABEL: func @kernel_matmul_vector_memref
+      func @kernel_matmul_vector_memref(%arg0: memref<4096x256xvector<4xi32>>, %arg1: memref<4096x256xvector<4xi32>>, %arg2: memref<4096x1024xvector<4xi32>>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+        %c32 = constant 32 : index
+        %c4096 = constant 4096 : index
+        %c0 = constant 0 : index
+        %cst = constant dense<0> : vector<4xi32>
+        // CHECK: %[[C:.+]] = spv.CooperativeMatrixLoadNV
+        %4 = vector.transfer_read %arg2[%c0, %c0], %cst : memref<4096x1024xvector<4xi32>>, vector<16x16xi32>
+        // CHECK: scf.for
+        %5 = scf.for %arg3 = %c0 to %c4096 step %c32 iter_args(%arg4 = %4) -> (vector<16x16xi32>) {
+          // CHECK: %[[A:.+]] = spv.CooperativeMatrixLoadNV
+          %6 = vector.transfer_read %arg0[%c0, %arg3], %cst : memref<4096x256xvector<4xi32>>, vector<16x32xi8>
+          // CHECK: %[[B:.+]] = spv.CooperativeMatrixLoadNV
+          %7 = vector.transfer_read %arg1[%arg3, %c0], %cst : memref<4096x256xvector<4xi32>>, vector<32x16xi8>
+          // CHECK: %[[R:.+]] = spv.CooperativeMatrixMulAddNV %[[A]], %[[B]], %{{.*}}
+          %8 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"]} %6, %7, %arg4 : vector<16x32xi8>, vector<32x16xi8> into vector<16x16xi32>
+          scf.yield %8 : vector<16x16xi32>
+        }
+        // CHECK: spv.CooperativeMatrixStoreNV
+        vector.transfer_write %5, %arg2[%c0, %c0] : vector<16x16xi32>, memref<4096x1024xvector<4xi32>>
+        return
+      }
     }
-    // CHECK: spv.CooperativeMatrixStoreNV
-    vector.transfer_write %5, %arg2[%c0, %c0] : vector<16x16xi32>, memref<4096x1024xvector<4xi32>>
-    return
   }
 }

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
@@ -11,15 +11,15 @@ hal.executable @elementwise_static_shape attributes {sym_visibility = "private"}
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env =
+        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
+        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>}> {
     hal.executable.entry_point @elementwise_static_shape attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>} {
+    module {
       func @elementwise_static_shape() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<128xf32>
@@ -63,15 +63,15 @@ hal.executable @elementwise_transpose attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"llvm", "embedded-elf-x86_64"> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+      spv.target_env =
+        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
+        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>}> {
     hal.executable.entry_point @elementwise_transpose attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>} {
+    module {
       func @elementwise_transpose() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<128x8xf32>
@@ -100,3 +100,4 @@ hal.executable @elementwise_transpose attributes {sym_visibility = "private"} {
     }
   }
 }
+

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -8,12 +8,7 @@ hal.executable @matmul_static_shape attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape attributes {
-      interface = @io, ordinal = 0 : index,
-      workgroup_size = [32: index, 1: index, 1: index]
-    }
-    module attributes {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env =
         #spv.target_env<#spv.vce<v1.5,
           [Shader, Float64, Float16, Int64, Int16, Int8, StorageBuffer16BitAccess,
@@ -37,7 +32,12 @@ hal.executable @matmul_static_shape attributes {sym_visibility = "private"} {
            max_compute_shared_memory_size = 49152 : i32,
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
-           subgroup_size = 32 : i32}>} {
+           subgroup_size = 32 : i32}>}> {
+    hal.executable.entry_point @matmul_static_shape attributes {
+      interface = @io, ordinal = 0 : index,
+      workgroup_size = [32: index, 1: index, 1: index]
+    }
+    module {
       func @matmul_static_shape() {
         %c32 = constant 32 : index
         %c4096 = constant 4096 : index
@@ -270,12 +270,7 @@ hal.executable @matmul_static_shape attributes {sym_visibility = "private"} {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape attributes {
-      interface = @io, ordinal = 0 : index,
-      workgroup_size = [32: index, 1: index, 1: index]
-    }
-    module attributes {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env =
         #spv.target_env<#spv.vce<v1.5,
           [Shader, Float64, Float16, Int64, Int16, Int8, StorageBuffer16BitAccess,
@@ -299,7 +294,12 @@ hal.executable @matmul_static_shape attributes {sym_visibility = "private"} {
            max_compute_shared_memory_size = 49152 : i32,
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
-           subgroup_size = 32 : i32}>} {
+           subgroup_size = 32 : i32}>}> {
+    hal.executable.entry_point @matmul_static_shape attributes {
+      interface = @io, ordinal = 0 : index,
+      workgroup_size = [32: index, 1: index, 1: index]
+    }
+    module {
       func @matmul_static_shape() {
         %c32 = constant 32 : index
         %c4096 = constant 4096 : index

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -60,15 +60,6 @@ static LogicalResult declareVariantOps(IREE::Flow::ExecutableOp sourceOp,
     targetSymbolTable.insert(targetContainerOp);
     OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
     auto moduleOp = containerBuilder.create<ModuleOp>(sourceOp.getLoc());
-
-    // TODO(benvanik): something more structured here; for now we just copy over
-    // any dialect attrs from the configuration to the inner module.
-    auto configAttr = targetAttr.getConfiguration();
-    if (configAttr) {
-      for (auto item : configAttr) {
-        moduleOp->setAttr(item.first, item.second);
-      }
-    }
   }
 
   // Ensure that at least one target op got created. If it didn't that means

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -59,7 +59,7 @@ static LogicalResult declareVariantOps(IREE::Flow::ExecutableOp sourceOp,
             sourceOp.getLoc(), targetAttr.getSymbolNameFragment(), targetAttr);
     targetSymbolTable.insert(targetContainerOp);
     OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
-    auto moduleOp = containerBuilder.create<ModuleOp>(sourceOp.getLoc());
+    containerBuilder.create<ModuleOp>(sourceOp.getLoc());
   }
 
   // Ensure that at least one target op got created. If it didn't that means


### PR DESCRIPTION
Currently the native vector size is just set through an LLVM-style
flag in the LLVMCPU backend. Instead use the llvm::TargetTransformInfo
to get this information.

Also deprecate LLVMCPUCodegenOptions. Instead annotate the necessary
information on the `hal.executable.variant` and use when necessary.