### PR TITLE
Add VerifyOutputLegality to flow transform pipeline.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "StripAndSplatConstantVariables.cpp",
         "TypeConverter.cpp",
         "VerifyInputLegality.cpp",
+        "VerifyOutputLegality.cpp",
     ],
     hdrs = [
         "DestructiveUpdateUtils.h",

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
         "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
     "StripAndSplatConstantVariables.cpp"
     "TypeConverter.cpp"
     "VerifyInputLegality.cpp"
+    "VerifyOutputLegality.cpp"
   DEPS
     ::PassesIncGen
     LLVMSupport

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     MLIRIR
     MLIRLinalg
     MLIRLinalgTransforms
+    MLIRMath
     MLIRMemRef
     MLIRMemRefTransforms
     MLIRPass

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -218,6 +218,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // Symbol DCE any remaining variables/functions that are now no longer
   // required.
   passManager.addPass(mlir::createSymbolDCEPass());
+
+  passManager.addNestedPass<mlir::FuncOp>(createVerifyOutputLegalityPass());
 }
 
 void registerFlowTransformPassPipeline() {

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -89,6 +89,9 @@ createExpandGlobalDynamicDimsPass();
 /// to be legalized before this pass.
 std::unique_ptr<OperationPass<mlir::FuncOp>> createVerifyInputLegalityPass();
 
+/// Verifies that the output from the Flow transformation pipeline is legal.
+std::unique_ptr<OperationPass<mlir::FuncOp>> createVerifyOutputLegalityPass();
+
 //===----------------------------------------------------------------------===//
 // Dispatches (flow.dispatch.workgroups)
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -142,4 +142,9 @@ def VerifyInputLegality: Pass<"iree-verify-input-legality", "mlir::FuncOp"> {
   let constructor = "mlir::iree_compiler::IREE::Flow::createVerifyInputLegalityPass()";
 }
 
+def VerifyOutputLegality: Pass<"iree-verify-output-legality", "mlir::FuncOp"> {
+  let summary = "Checks the legality of the IR at the end of IREE flow transformation pipeline.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createVerifyOutputLegalityPass()";
+}
+
 #endif  // IREE_DIALECT_FLOW_PASSES

--- a/iree/compiler/Dialect/Flow/Transforms/VerifyOutputLegality.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/VerifyOutputLegality.cpp
@@ -34,7 +34,8 @@ class VerifyOutputLegalityPass
       }
       // Certain standard ops for flow control are okay to operate on tensors.
       if (dyn_cast<mlir::ReturnOp>(op) || dyn_cast<mlir::CallOp>(op) ||
-          dyn_cast<mlir::BranchOp>(op) || dyn_cast<mlir::CondBranchOp>(op)) {
+          dyn_cast<mlir::BranchOp>(op) || dyn_cast<mlir::CondBranchOp>(op) ||
+          dyn_cast<mlir::ConstantOp>(op)) {
         return WalkResult::advance();
       }
 

--- a/iree/compiler/Dialect/Flow/Transforms/VerifyOutputLegality.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/VerifyOutputLegality.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+class VerifyOutputLegalityPass
+    : public VerifyOutputLegalityBase<VerifyOutputLegalityPass> {
+  void runOnOperation() override {
+    auto walkResult = getOperation().walk([&](Operation *op) -> WalkResult {
+      // We should generally only be operating on tensor types using flow
+      // dialect ops at this point. However, exhaustively allow/deny-listing
+      // all ops and dialects would be difficult to maintain, so we just keep a
+      // best-effort list.
+
+      // Only test ops in the standard and math dialects.
+      auto dialectNamespace = op->getDialect()->getNamespace();
+      if (dialectNamespace != StandardOpsDialect::getDialectNamespace() &&
+          dialectNamespace != math::MathDialect::getDialectNamespace()) {
+        return WalkResult::advance();
+      }
+      // Certain standard ops for flow control are okay to operate on tensors.
+      if (dyn_cast<mlir::ReturnOp>(op) || dyn_cast<mlir::CallOp>(op) ||
+          dyn_cast<mlir::BranchOp>(op) || dyn_cast<mlir::CondBranchOp>(op)) {
+        return WalkResult::advance();
+      }
+
+      for (auto resultType : op->getResultTypes()) {
+        if (resultType.isa<TensorType>()) {
+          return op->emitOpError("illegal operation returning ")
+                 << resultType
+                 << " in output from flow transformation, flow dialect "
+                    "ops should be used for acting on tensors at this point";
+        }
+      }
+      for (auto operand : op->getOperands()) {
+        auto operandType = operand.getType();
+        if (operandType.isa<TensorType>()) {
+          return op->emitOpError("illegal operand type ")
+                 << operandType
+                 << " in output from flow transformation, flow dialect "
+                    "ops should be used for acting on tensors at this point";
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted()) {
+      return signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<mlir::FuncOp>> createVerifyOutputLegalityPass() {
+  return std::make_unique<VerifyOutputLegalityPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -41,6 +41,7 @@ iree_lit_test_suite(
             "strip_and_splat_constant_variables.mlir",
             "transformation.mlir",
             "verify_input_ir.mlir",
+            "verify_output_ir.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_lit_test_suite(
     "strip_and_splat_constant_variables.mlir"
     "transformation.mlir"
     "verify_input_ir.mlir"
+    "verify_output_ir.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/Flow/Transforms/test/verify_output_ir.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/verify_output_ir.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt -iree-verify-output-legality -verify-diagnostics %s -split-input-file
+
+func @check_only_flow_uses_tensor_types(%arg0: tensor<i1>) -> tensor<i8> {
+  // expected-error @+1 {{illegal operation returning 'tensor<i8>' in output from flow transformation, flow dialect ops should be used for acting on tensors at this point}}
+  %0 = zexti %arg0 : tensor<i1> to tensor<i8>
+  return %0 : tensor<i8>
+}
+
+// -----
+
+func @flow_can_use_tensor_types(%arg0: !hal.buffer_view) -> !hal.buffer_view {
+  %0 = hal.tensor.cast %arg0 : !hal.buffer_view -> tensor<i32>
+  %1 = flow.tensor.load %0 : tensor<i32>
+  %2 = flow.ex.stream.fragment(%1) : (i32) -> tensor<i32> =
+      (%arg1: i32) -> tensor<i32> {
+    %3 = flow.tensor.splat %arg1 : tensor<i32>
+    flow.return %3 : tensor<i32>
+  }
+  %3 = hal.tensor.cast %2 : tensor<i32> -> !hal.buffer_view
+  return %3 : !hal.buffer_view
+}


### PR DESCRIPTION
Attempting to address this comment: https://github.com/google/iree/issues/6756#issuecomment-898607883

I tried to make the checks more restrictive, but bumped against many other ops (`custom`, `check`, `hal`, etc.) that were using tensor types at this point. I also considered running on `ModuleOp` instead of `FuncOp`, but most ops under the top level module are `flow.executable` ops (so everything under them is okay?).