### PR TITLE
[snapshot release]: Push the snapshot to a snapshot branch

### DIFF
--- a/.github/workflows/schedule_snapshot_release.yml
+++ b/.github/workflows/schedule_snapshot_release.yml
@@ -35,13 +35,6 @@ jobs:
           branch: main
           tags: true
 
-      - name: Updating snapshot branch
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          branch: snapshot
-          tags: false
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/schedule_snapshot_release.yml
+++ b/.github/workflows/schedule_snapshot_release.yml
@@ -35,6 +35,13 @@ jobs:
           branch: main
           tags: true
 
+      - name: Updating snapshot branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          branch: snapshot
+          tags: false
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -24,3 +24,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
+
+      # Future different releases should publish to different branches
+      - name: Updating latest-snapshot branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          branch: latest-snapshot
+          tags: false

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -25,7 +25,11 @@ jobs:
         with:
           release_id: ${{ github.event.inputs.release_id }}
 
-      # Future different releases should publish to different branches
+      - name: Checking out repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+
       - name: Updating latest-snapshot branch
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -31,4 +31,3 @@ jobs:
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot
-          tags: false


### PR DESCRIPTION
An external user can track the particular branch to sync to the latest
snapshot.

This fixes https://github.com/google/iree/issues/5143