### PR TITLE
[iree-import-public] Copy attrs in generic pattern.

### DIFF
--- a/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -212,6 +212,7 @@ class GenericTypeConvert : public ConversionPattern {
       Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     llvm::SmallVector<NamedAttribute, 4> newAttr;
+    llvm::append_range(newAttr, op->getAttrs());
     llvm::SmallVector<Type, 4> newResults;
     (void)getTypeConverter()->convertTypes(op->getResultTypes(), newResults);
     OperationState state(op->getLoc(), op->getName().getStringRef(), operands,

--- a/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
+++ b/iree/compiler/InputConversion/Common/test/iree_import_public.mlir
@@ -15,6 +15,14 @@ builtin.func @list_func(%arg0 : !iree.list<!iree.variant>) -> !iree.list<!iree.v
 }
 
 // -----
+// CHECK-LABEL: func @list_func_call
+// CHECK: call @list_func_call(%arg0) : (!util.list<?>) -> !util.list<?>
+builtin.func @list_func_call(%arg0 : !iree.list<!iree.variant>) -> !iree.list<!iree.variant> {
+  call @list_func_call(%arg0) : (!iree.list<!iree.variant>) -> !iree.list<!iree.variant>
+  return %arg0 : !iree.list<!iree.variant>
+}
+
+// -----
 // CHECK-LABEL: func @ptr_func
 // CHECK-SAME: (%arg0: !util.ptr<!hal.buffer_view>) -> !util.ptr<!hal.buffer_view>
 builtin.func @ptr_func(%arg0 : !iree.ptr<!iree.buffer_view>) -> !iree.ptr<!iree.buffer_view> {


### PR DESCRIPTION
This was resulting in `std.call` not being converted properly.