### PR TITLE
Increase benchmarking timeout to 40mins as we have more benchmarks

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -37,7 +37,7 @@ steps:
       - "android-version=11"
       - "queue=benchmark-android"
     artifact_paths: "benchmark-results-pixel-4.json"
-    timeout_in_minutes: "30"
+    timeout_in_minutes: "40"
 
   - label: "Benchmark on Galaxy S20 (exynos-990, mali-g77)"
     commands:
@@ -53,7 +53,7 @@ steps:
       - "android-version=11"
       - "queue=benchmark-android"
     artifact_paths: "benchmark-results-galaxy-s20.json"
-    timeout_in_minutes: "30"
+    timeout_in_minutes: "40"
 
   - wait
 


### PR DESCRIPTION
It's approaching the 30min limit. This is to get us more grace time.
Need to look at the benchmarks and perform configuration
tweaking/pruning/cleanup.