### PR TITLE
NFC: Remove crufty insertion point search.

### DIFF
--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -57,6 +57,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Affine",
         "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:CFGTransforms",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:GPUDialect",

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     LLVMSupport
     MLIRAffine
     MLIRAffineUtils
+    MLIRAnalysis
     MLIRGPUOps
     MLIRIR
     MLIRLLVMCommonConversion


### PR DESCRIPTION
To start creating the memrefs for the output (when bufferizing a
`flow.tensor.store`), the result buffer has to be allocated before any
uses of it. Replace the crufty insertion point search with just
cloning of operations. They get CSE-ed anyway.