### PR TITLE
[snapshot] Fix checkout fetch depth to update the latest-snapshot branch

### DIFF
--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          fetch-depth: 200
 
       - name: Updating latest-snapshot branch
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: refs/heads/latest-snapshot
+          force: true

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          fetch-depth: 200
 
       - name: Updating latest-snapshot branch
         uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -29,10 +29,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          # Get all history. Otherwise the latest-snapshot branch can't be
+          # fast-forwarded.
+          fetch-depth: 0
 
       - name: Updating latest-snapshot branch
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
-          branch: refs/heads/latest-snapshot
-          force: true
+          branch: latest-snapshot


### PR DESCRIPTION
Fix https://github.com/google/iree/runs/3491586526?check_suite_focus=true
with a long enough fetch depth so the latest-snapshot branch can be
properly updated.

Test offline with the workflow CLIs and the testing branch can be
properly fast-forwarded.