### PR TITLE
Fix iree_hal_allocator memory statistics format

### DIFF
--- a/iree/hal/allocator.c
+++ b/iree/hal/allocator.c
@@ -22,16 +22,16 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_format(
 
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
       builder,
-      "  HOST_LOCAL: %12" PRIdsz "b peak / %12" PRIdsz
-      "b allocated / %12" PRIdsz "b freed / %12" PRIdsz "b live\n",
+      "  HOST_LOCAL: %12" PRIdsz "B peak / %12" PRIdsz
+      "B allocated / %12" PRIdsz "B freed / %12" PRIdsz "B live\n",
       statistics->host_bytes_peak, statistics->host_bytes_allocated,
       statistics->host_bytes_freed,
       (statistics->host_bytes_allocated - statistics->host_bytes_freed)));
 
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
       builder,
-      "DEVICE_LOCAL: %12" PRIdsz "b peak / %12" PRIdsz
-      "b allocated / %12" PRIdsz "b freed / %12" PRIdsz "b live\n",
+      "DEVICE_LOCAL: %12" PRIdsz "B peak / %12" PRIdsz
+      "B allocated / %12" PRIdsz "B freed / %12" PRIdsz "B live\n",
       statistics->device_bytes_peak, statistics->device_bytes_allocated,
       statistics->device_bytes_freed,
       (statistics->device_bytes_allocated - statistics->device_bytes_freed)));


### PR DESCRIPTION
The memory stats is shown in Bytes. Fix the printout unit.

```
EXEC @simple_mul
result[0]: hal.buffer_view
4xf32=1 4 9 16
[[ iree_hal_allocator_t memory statistics ]]
  HOST_LOCAL:           32B peak /           32B allocated /           32B freed /            0B live
DEVICE_LOCAL:           16B peak /           16B allocated /           16B freed /            0B live
```