### PR TITLE
Integrate upstream cpp emitter changes

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -381,8 +381,8 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
     Operation *op = funcOp.getOperation();
     if (op->hasAttr("emitc.static")) output << "static ";
 
-    if (failed(emitter.emitTypes(*funcOp.getOperation(),
-                                 funcOp.getType().getResults())))
+    if (failed(
+            emitter.emitTypes(funcOp.getLoc(), funcOp.getType().getResults())))
       return failure();
     output << " " << funcOp.getName();
 
@@ -391,7 +391,7 @@ LogicalResult translateModuleToC(IREE::VM::ModuleOp moduleOp,
     bool error = false;
     llvm::interleaveComma(
         funcOp.getArguments(), output, [&](BlockArgument arg) {
-          if (failed(emitter.emitType(*funcOp.getOperation(), arg.getType())))
+          if (failed(emitter.emitType(funcOp.getLoc(), arg.getType())))
             error = true;
         });
     if (error) return failure();

--- a/third_party/mlir-emitc/include/emitc/Target/Cpp/CppEmitter.h
+++ b/third_party/mlir-emitc/include/emitc/Target/Cpp/CppEmitter.h
@@ -63,23 +63,23 @@ struct CppEmitter {
   explicit CppEmitter(raw_ostream &os, bool declareVariablesAtTop);
 
   /// Emits attribute or returns failure.
-  LogicalResult emitAttribute(Operation &op, Attribute attr);
+  LogicalResult emitAttribute(Location loc, Attribute attr);
 
   /// Emits operation 'op' with/without training semicolon or returns failure.
   LogicalResult emitOperation(Operation &op, bool trailingSemicolon);
 
   /// Emits type 'type' or returns failure.
-  LogicalResult emitType(Operation &op, Type type);
+  LogicalResult emitType(Location loc, Type type);
 
   /// Emits array of types as a std::tuple of the emitted types.
   /// - emits void for an empty array;
   /// - emits the type of the only element for arrays of size one;
   /// - emits a std::tuple otherwise;
-  LogicalResult emitTypes(Operation &op, ArrayRef<Type> types);
+  LogicalResult emitTypes(Location loc, ArrayRef<Type> types);
 
   /// Emits array of types as a std::tuple of the emitted types independently of
   /// the array size.
-  LogicalResult emitTupleType(Operation &op, ArrayRef<Type> types);
+  LogicalResult emitTupleType(Location loc, ArrayRef<Type> types);
 
   /// Emits an assignment for a variable which has been declared previously.
   LogicalResult emitVariableAssignment(OpResult result);
@@ -113,8 +113,8 @@ struct CppEmitter {
   /// Return the existing or a new label of a Block.
   StringRef getOrCreateName(Block &block);
 
-  /// Whether to map an mlir integer to a signed integer in C++.
-  bool shouldMapToSigned(IntegerType::SignednessSemantics val);
+  /// Whether to map an mlir integer to a unsigned integer in C++.
+  bool shouldMapToUnsigned(IntegerType::SignednessSemantics val);
 
   /// RAII helper function to manage entering/exiting C++ scopes.
   struct Scope {


### PR DESCRIPTION
Takes over upstream changes
* iml130/mlir-emitc@d2ea898
* iml130/mlir-emitc@a55966e
* iml130/mlir-emitc@45c5dc2
* iml130/mlir-emitc@9a97180
* iml130/mlir-emitc@2aef52c
* iml130/mlir-emitc@b401a08

and updates the Cpp emitter usage.