### PR TITLE
[bindings/python] Correctly stringify iree_vm_variant_t

### DIFF
--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -527,7 +527,35 @@ void AppendListContents(std::string& out, iree_vm_list_t* list,
     if (i > 0) out.append(", ");
 
     if (iree_vm_variant_is_value(variant)) {
-      out += std::to_string(variant.i32);
+      // Convert a value type to a string.
+      switch (variant.type.value_type) {
+        case IREE_VM_VALUE_TYPE_I8: {
+          out += std::to_string(variant.i8);
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I16: {
+          out += std::to_string(variant.i16);
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I32: {
+          out += std::to_string(variant.i32);
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_I64: {
+          out += std::to_string(variant.i64);
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_F32: {
+          out += std::to_string(variant.f32);
+          break;
+        }
+        case IREE_VM_VALUE_TYPE_F64: {
+          out += std::to_string(variant.f64);
+          break;
+        }
+        default:
+          throw RaiseValueError("Unsupported VM value type to string");
+      }
     } else if (iree_vm_variant_is_ref(variant)) {
       // Pretty print a subset of ABI impacting known types.
       if (iree_hal_buffer_isa(variant.ref)) {

--- a/bindings/python/iree/runtime/vm_test.py
+++ b/bindings/python/iree/runtime/vm_test.py
@@ -78,6 +78,12 @@ class VmTest(absltest.TestCase):
     logging.info("variant_list: %s", l)
     self.assertEqual(l.size, 0)
 
+  def test_variant_list_i64(self):
+    l = iree.runtime.VmVariantList(5)
+    # Push a value that exceeds 32-bit range.
+    l.push_int(10 * 1000 * 1000 * 1000)
+    self.assertEqual(str(l), "<VmVariantList(1): [10000000000]>")
+
   def test_variant_list_buffers(self):
     ET = iree.runtime.HalElementType
     for dt, et in ((np.int8, ET.SINT_8), (np.int16, ET.SINT_16),


### PR DESCRIPTION
The previous code just handled the `i32` variant and would read garbage in other cases.