### PR TITLE
function.py: Add support for mashaling list types on returns.

### DIFF
--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -381,11 +381,22 @@ def _vm_to_scalar(type_bound: type):
   return convert
 
 
+def _vm_to_pylist(inv: Invocation, vm_list: VmVariantList, vm_index: int, desc):
+  # The descriptor for a pylist is like:
+  #   ['pylist', element_type]
+  sub_vm_list = vm_list.get_as_list(vm_index)
+  element_type_desc = desc[1:]
+  py_items = _extract_vm_sequence_to_python(
+      inv, sub_vm_list, element_type_desc * len(sub_vm_list))
+  return py_items
+
+
 VM_TO_PYTHON_CONVERTERS = {
     "ndarray": _vm_to_ndarray,
     "sdict": _vm_to_sdict,
     "slist": _vm_to_slist,
     "stuple": _vm_to_stuple,
+    "py_homogeneous_list": _vm_to_pylist,
 
     # Scalars.
     "i8": _vm_to_scalar(int),

--- a/bindings/python/iree/runtime/function_test.py
+++ b/bindings/python/iree/runtime/function_test.py
@@ -218,6 +218,26 @@ class FunctionTest(absltest.TestCase):
     # assertEqual on bool arrays is fraught for... reasons.
     self.assertEqual("array([ True, False])", repr(result))
 
+  def testReturnTypeList(self):
+    vm_list = VmVariantList(2)
+    vm_list.push_int(1)
+    vm_list.push_int(2)
+
+    def invoke(arg_list, ret_list):
+      ret_list.push_list(vm_list)
+
+    vm_context = MockVmContext(invoke)
+    vm_function = MockVmFunction(reflection={
+        "iree.abi":
+            json.dumps({
+                "a": [],
+                "r": [["py_homogeneous_list", "i64"]],
+            })
+    })
+    invoker = FunctionInvoker(vm_context, self.device, vm_function, tracer=None)
+    result = invoker()
+    self.assertEqual("[1, 2]", repr(result))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/docs/developers/design_docs/function_abi.md
+++ b/docs/developers/design_docs/function_abi.md
@@ -183,3 +183,5 @@ type specific fields:
 -   `["sdict", ["key", {slot_type}]...]`: An anonymous structure with named
     slots. Note that when passing these types, the keys are not passed to the
     function (only the slot values).
+-   `["py_homogeneous_list", {element_type}]`: A Python list of unknown size
+    with elements sharing a common type bound given by `element_type`.


### PR DESCRIPTION
I implemented minimal support here for what I needed for npcomp based on our discussions. Part of me wants to remove the `py_` from `py_homogeneous_list`, as that's a pretty general concept independent of Python. Thoughts?

Also happy to flesh out arg handling too -- just at a checkpoint now where my first e2e test passes.