### PR TITLE
Initial commit of PyDM to IREE lowering pipeline.

### DIFF
--- a/llvm-external-projects/iree-dialects/docs/Dialect/IREEPyDM/LowerToIREE.md
+++ b/llvm-external-projects/iree-dialects/docs/Dialect/IREEPyDM/LowerToIREE.md
@@ -1,0 +1,102 @@
+# Lowering IREEPyDM to IREE
+
+At the top-level, a program expressed in IREEPyDM ("PyDM") can be lowered to
+IREE via the overall conversion pass `-convert-iree-pydm-to-iree`; however,
+additional steps are needed to link a runtime library, etc.
+
+This document provides application notes for how the conversion is
+implemented.
+
+## Type Conversion
+
+Generally, types in PyDM map 1:1 with IREE types in a way which facilitates
+a direct conversion.
+
+## `object` and `object<type>` records
+
+Objects map to IREE variant lists (`!iree.list<?>`) of N elements, where the
+elements are laid out as:
+
+* [0]: Type Code - i32 representing the type code of the object.
+* [1] (optional): Data corresponding to the type.
+* [2] (optional): i64 TypeID - if the `id()` function has been evaluated for
+  this object, then this element will contain the unique id.
+
+### Type Codes
+
+The special type code `0` means "not assigned", which is distinct from `None`.
+Other built-in types correspond to the `BuiltinTypeCode` enum in the dialect.
+
+The following specifies the contents of the `data` field (1) of the object
+record, per type code:
+
+* `None`: No contents
+* `Tuple`: An `!iree.list` of objects
+* `List`: An `!iree.list` of objects
+* `Str`: TODO: needs to be a union of i8/i16/i32 codepoint array
+* `Bytes`: TODO: should be a memory buffer of some kind
+* `ExceptionResult`: TODO: should hold a boxed exception of some kind
+* `Type`: An object representing the type
+* `Bool`: Implementation defined `iree_vm_value_type_t` field (typically
+  `iree_vm_value_type_t.i8`).
+* `Integer`: Implementation defined `iree_vm_value_type_t` field (typically
+  `iree_vm_value_type_t.i32`).
+* `Real`: Implementation defined `iree_vm_value_type_t` field (typically
+  `iree_vm_value_type_t.f32`).
+* `Complex`: TODO
+* `Integer1` / `UInteger1`: `iree_vm_value_type_t.i8`
+* `Integer2` / `UInteger2`: `iree_vm_value_type_t.i16`
+* `Integer4` / `UInteger4`: `iree_vm_value_type_t.i32
+* `Integer8` / `UInteger8`: `iree_vm_value_type_t.i64
+* `Float2` : `iree_vm_value_type_t.i16` with bit value of an IEEE FP16
+* `Float4` : `iree_vm_value_type_t.f32`
+* `Float8` : `iree_vm_value_type_t.f64`
+* `BFloat2` : `iree_vm_value_type_t.i16` with bit value of a BFloat16 (thanks
+  Google).
+* `Complex4` : TODO
+* `Complex8` : TODO
+* `Object` (and custom): An object record, as described here
+
+### Mutability
+
+The VM enforces no immutability constraints on the object records here (i.e.
+they are just lists). If the compiler believes that it can recycle an object,
+it is free to resize it appropriately and re-assign its contents. In this
+way, things like closure cells and free variable cells can just be
+allocated object records that that compiler completely reassigns the contents
+of on assignment.
+
+## Unboxed values
+
+All values can exist in the program unboxed and will have a VM IR type which
+corresponds to their runtime variant form (i.e. `!iree.list`, `i32`, etc).
+
+## `!iree_pydm.exception_result`
+
+The `exception_result` type is returned from every PyDM function indicating
+whether the call completed successfully or in an error state. We encode it as
+a signed `i32` value at runtime, where:
+
+* `0` : indicates normal termination.
+* `<0` : signals one of a predefined list of primitive exception types
+  which do not contain any detail (i.e. `ValueException` analog).
+* `>0` : is an index into a global exception lookup table with slots
+  corresponding to logical threads of execution.
+
+### Pre-defined exception codes:
+
+* `-1` : `StopIteration` - Standard exception which indicates exhaustion of
+  an iterator.
+* `-2` : `StopAsyncIteration` - Standard exception which indicates exhaustion
+  of an async iterator.
+* `-3` : `RuntimeError` - general catch-all failure exception class.
+* `-4` : `ValueError`
+* `-5` : `NotImplementedError`
+* `-6` : `KeyError`
+* `-7` : `IndexError`
+* `-8` : `AttributeError`
+* `-9` : `TypeError`
+* `-10` : `UnboundLocalError`
+
+These pre-defined exception codes are allocated when the compiler has a need
+to raise or interoperate with an exception category.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Dialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Dialect.h
@@ -18,19 +18,50 @@ namespace iree_pydm {
 // Generally, the closed part of the type system will have type codes <
 // FirstCustom.
 enum class BuiltinTypeCode : int {
-  Bool = 1,
-  Bytes,
-  ExceptionResult,
-  Integer,
-  List,
-  None,
-  Object,
-  Real,
-  Str,
-  Tuple,
-  Type,
+  // Built-in types, ordered by rough "core-ness" so that lower numbers
+  // are easier to spot for common cases.
+  None = 0x1,
+  Tuple = 0x2,
+  List = 0x3,
+  Str = 0x4,
+  Bytes = 0x5,
+  ExceptionResult = 0x6,
+  Type = 0x7,
 
-  FirstCustom = 100,
+  // Weak-sized numeric types are of implementation defined size and are
+  // always considered lower in the promotion order than a discrete
+  // sized type of the same class.
+  Bool = 0x8,
+  Integer = 0x9,
+  Real = 0xa,
+  Complex = 0xb,
+
+  // Discrete sized integer types.
+  // TODO: Fiddle with all of these values so that promotion can be
+  // done cleverly with bit twiddling of some kind.
+  Integer1 = 0x10,
+  Integer2 = 0x11,
+  Integer4 = 0x12,
+  Integer8 = 0x13,
+  UInteger1 = 0x14,
+  UInteger2 = 0x15,
+  UInteger4 = 0x16,
+  UInteger8 = 0x17,
+
+  // Discrete sized FP types.
+  Float2 = 0x18,
+  Float4 = 0x19,
+  Float8 = 0x1a,
+  BFloat2 = 0x1b,
+
+  // Complex.
+  Complex4 = 0x1c,
+  Complex8 = 0x1d,
+
+  // Objects start at 0x100, with 0x100 being the generic "object" type
+  // and then all following corresponding to user-defined types.
+  Object = 0x100,
+  FirstCustom = 0x101,
 };
 
 /// Base class for all unboxed primitive types.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Ops.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Ops.td
@@ -119,6 +119,11 @@ def IREEPyDM_FuncOp : IREEPyDM_Op<"func", [
           .cast<FunctionType>();
     }
 
+    /// Returns the python return type of the function (second return type).
+    Type getPyReturnType() {
+      return getType().getResult(1);
+    }
+
     /// Hook for OpTrait::FunctionLike, returns the number of function
     /// arguments. Depends on the type attribute being correct as checked by
     /// verifyType.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name IREEPyDMTransforms)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix IREEPyDMTransforms)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix IREEPyDMTransforms)
+add_public_tablegen_target(MLIRIREEPyDMTransformsPassesIncGen)

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h
@@ -1,0 +1,29 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSES_H
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSES_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+namespace iree {
+class IREEDialect;
+}
+
+namespace iree_pydm {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertIREEPyDMToIREEPass();
+
+#define GEN_PASS_REGISTRATION
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h.inc"
+
+}  // namespace iree_pydm
+}  // namespace mlir
+
+#endif  // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSES_H

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.td
@@ -1,0 +1,22 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_CONVERSION_TO_IREE_PASSES_TD
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_CONVERSION_TO_IREE_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertIREEPyDMToIREE : Pass<"convert-iree-pydm-to-iree", "ModuleOp"> {
+  let summary = "Convert iree_pydm modules to the IREE+related dialects";
+  let description = [{
+    Converts whole modules from Python in the iree_pydm dialect to the IREE
+    dialect + various standard dialects.
+  }];
+  let constructor = "mlir::iree_pydm::createConvertIREEPyDMToIREEPass()";
+  let dependentDialects = ["iree::IREEDialect"];
+}
+
+#endif // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_CONVERSION_TO_IREE_PASSES_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/Patterns.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/Patterns.h
@@ -1,0 +1,27 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_PATTERNS_H
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_PATTERNS_H
+
+namespace mlir {
+
+class MLIRContext;
+class TypeConverter;
+class RewritePatternSet;
+
+namespace iree_pydm {
+
+/// Populates patterns to lower from the iree_pydm dialect to the IREE
+// standard input dialects for core language structures.
+void populatePyDMToIREELoweringPatterns(MLIRContext *context,
+                                        TypeConverter &typeConverter,
+                                        RewritePatternSet &patterns);
+
+}  // namespace iree_pydm
+}  // namespace mlir
+
+#endif  // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_LOWERING_PATTERNS_H

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.h
@@ -1,0 +1,38 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_TYPECONVERTER_H
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_TYPECONVERTER_H
+
+#include "mlir/IR/Builders.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_pydm {
+
+class LoweringTypeConverter : public mlir::TypeConverter {
+ public:
+  enum class WeakFloatType {
+    F32,
+    F64,
+  };
+  LoweringTypeConverter();
+
+  // Type mappings for builtin, weakly typed integer and floating point types.
+  Type getBoolType(Builder b) const;
+  Type getWeakIntegerType(Builder b) const;
+  Type getWeakFloatType(Builder b) const;
+
+ private:
+  bool boolBits = 32;
+  int weakIntegerBits = 32;
+  WeakFloatType weakFloatType = WeakFloatType::F32;
+};
+
+}  // namespace iree_pydm
+}  // namespace mlir
+
+#endif  // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_TOIREE_TYPECONVERTER_H

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ToIREE)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/PassDetail.h
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/PassDetail.h
@@ -1,0 +1,26 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSDETAIL_H
+#define IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSDETAIL_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+namespace iree {
+class IREEDialect;
+}
+
+namespace iree_pydm {
+
+#define GEN_PASS_CLASSES
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h.inc"
+
+}  // namespace iree_pydm
+}  // namespace mlir
+
+#endif  // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_TRANSFORMS_PASSDETAIL_H

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_library(IREEDialectsIREEPyDMToIREEPasses
+  ConversionPass.cpp
+  LoweringPatterns.cpp
+  TypeConverter.cpp
+
+  DEPENDS
+  MLIRIREEPyDMTransformsPassesIncGen
+
+  LINK_LIBS PUBLIC
+  IREEDialectsIREEPyDMDialect
+  IREEDialectsIREEDialect
+  MLIRIR
+  MLIRTransformUtils
+)
+
+iree_dialects_target_includes(IREEDialectsIREEPyDMToIREEPasses)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/ConversionPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/ConversionPass.cpp
@@ -1,0 +1,54 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "../PassDetail.h"
+#include "iree-dialects/Dialect/IREE/IREEDialect.h"
+#include "iree-dialects/Dialect/IREE/IREEOps.h"
+#include "iree-dialects/Dialect/IREEPyDM/IR/Ops.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/Patterns.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinDialect.h"
+
+using namespace mlir;
+using namespace mlir::iree_pydm;
+
+namespace {
+
+struct ConvertIREEPyDMToIREEPass
+    : public ConvertIREEPyDMToIREEBase<ConvertIREEPyDMToIREEPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::iree::IREEDialect, BuiltinDialect, StandardOpsDialect,
+                    math::MathDialect>();
+  }
+
+  void runOnOperation() override {
+    auto *context = &getContext();
+    auto moduleOp = getOperation();
+    LoweringTypeConverter typeConverter;
+    RewritePatternSet patterns(context);
+    populatePyDMToIREELoweringPatterns(context, typeConverter, patterns);
+
+    ConversionTarget target(*context);
+    target.addIllegalDialect<IREEPyDMDialect>();
+    target.addLegalDialect<BuiltinDialect>();
+    target.addLegalDialect<mlir::iree::IREEDialect>();
+    target.addLegalDialect<mlir::math::MathDialect>();
+    target.addLegalDialect<StandardOpsDialect>();
+    if (failed(applyPartialConversion(moduleOp, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::iree_pydm::createConvertIREEPyDMToIREEPass() {
+  return std::make_unique<ConvertIREEPyDMToIREEPass>();
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/LoweringPatterns.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/LoweringPatterns.cpp
@@ -1,0 +1,400 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/IREE/IREEOps.h"
+#include "iree-dialects/Dialect/IREEPyDM/IR/Ops.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/Patterns.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::iree_pydm;
+
+namespace iree_d = mlir::iree;
+namespace builtin_d = mlir;
+namespace std_d = mlir;
+namespace pydm_d = mlir::iree_pydm;
+
+namespace {
+
+enum class ExceptionCode : int {
+  Success = 0,
+  StopIteration = -1,
+  StopAsyncIteration = -2,
+  RuntimeError = -3,
+  ValueError = -4,
+  NotImplementedError = -5,
+  KeyError = -6,
+  IndexError = -7,
+  AttributeError = -8,
+  TypeError = -9,
+  UnboundLocalError = -10,
+};
+
+}  // namespace
+
+static Value getNullValue(Location loc, OpBuilder &builder, Type t) {
+  return TypeSwitch<Type, Value>(t)
+      .Case<iree_d::ListType>([&](auto t) -> Value {
+        return builder.create<iree_d::NullOp>(loc, t);
+      })
+      .Default([&](Type t) -> Value {
+        auto attr = builder.getZeroAttr(t);
+        assert(attr && "could not get zero attr for builtin type");
+        return builder.create<std_d::ConstantOp>(loc, t, attr);
+      });
+}
+
+/// Creates a slow path block at the end of the function. The current block
+/// will always dominate.
+static Block *createSlowPathBlock(OpBuilder &builder) {
+  Region *parentRegion = builder.getInsertionBlock()->getParent();
+  return builder.createBlock(parentRegion, parentRegion->end());
+}
+
+static Type getVariantListType(Builder &builder) {
+  return builder.getType<iree_d::ListType>(
+      builder.getType<iree_d::VariantType>());
+}
+
+static Value getSuccessStatusValue(Location loc, OpBuilder &builder) {
+  return builder.create<std_d::ConstantOp>(loc, builder.getI32IntegerAttr(0));
+}
+
+static Value getFailureStatusValue(Location loc, OpBuilder &builder,
+                                   ExceptionCode code) {
+  return builder.create<std_d::ConstantOp>(
+      loc, builder.getI32IntegerAttr(static_cast<int>(code)));
+}
+
+static Value createUndefObjectList(Location loc, OpBuilder &builder) {
+  return builder.create<iree_d::ListCreateOp>(loc, getVariantListType(builder),
+                                              /*capacity=*/nullptr);
+}
+
+void resetObjectList(Location loc, OpBuilder &builder, Value list, int typeCode,
+                     Value data) {
+  // Note: The list can record optional runtime state at positions > 1, so
+  // to truly reset, we have to resize. Low level optimizations should be able
+  // to elide this if it turns out to be unnecessary.
+  auto size = builder.create<std_d::ConstantOp>(loc, builder.getIndexAttr(2));
+  builder.create<iree_d::ListResizeOp>(loc, list, size);
+  auto index0 = builder.create<std_d::ConstantOp>(loc, builder.getIndexAttr(0));
+  Value typeCodeValue = builder.create<std_d::ConstantOp>(
+      loc, builder.getI32IntegerAttr(typeCode));
+  builder.create<iree_d::ListSetOp>(loc, list, index0, typeCodeValue);
+  auto index1 = builder.create<std_d::ConstantOp>(loc, builder.getIndexAttr(1));
+  builder.create<iree_d::ListSetOp>(loc, list, index1, data);
+}
+
+static Value createObjectList(Location loc, OpBuilder &builder, int typeCode,
+                              Value data) {
+  auto list = createUndefObjectList(loc, builder);
+  resetObjectList(loc, builder, list, typeCode, data);
+  return list;
+}
+
+namespace {
+
+class AllocFreeVarOpConversion
+    : public OpConversionPattern<pydm_d::AllocFreeVarOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::AllocFreeVarOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    // TODO: We may want to initialize the list structurally in some way.
+    // This will fail either way on read from unassigned variable, but we need
+    // to see what works better for good runtime error messages.
+    auto loc = srcOp.getLoc();
+    Value list = createUndefObjectList(loc, rewriter);
+    rewriter.replaceOp(srcOp, list);
+    return success();
+  }
+};
+
+class BoxOpConversion : public OpConversionPattern<pydm_d::BoxOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::BoxOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+    auto origType =
+        srcOp.primitive().getType().dyn_cast<pydm_d::PythonTypeInterface>();
+    if (!origType)
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "not a PythonTypeInterface type");
+    auto typeCode = origType.getTypeCode();
+    auto list = createObjectList(loc, rewriter, static_cast<int>(typeCode),
+                                 operands[0]);
+    rewriter.replaceOp(srcOp, list);
+    return success();
+  }
+};
+
+class FuncOpConversion : public OpConversionPattern<pydm_d::FuncOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::FuncOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    FunctionType srcFuncType = srcOp.getType();
+    TypeConverter::SignatureConversion signatureConversion(
+        srcOp.getNumArguments());
+
+    // Convert function arguments.
+    for (unsigned i = 0, e = srcFuncType.getNumInputs(); i < e; ++i) {
+      if (failed(getTypeConverter()->convertSignatureArg(
+              i, srcFuncType.getInput(i), signatureConversion))) {
+        return rewriter.notifyMatchFailure(srcOp, "argument failed to convert");
+      }
+    }
+
+    // Convert function results.
+    SmallVector<Type, 1> convertedResultTypes;
+    if (failed(getTypeConverter()->convertTypes(srcFuncType.getResults(),
+                                                convertedResultTypes))) {
+      return rewriter.notifyMatchFailure(srcOp, "results failed to convert");
+    }
+
+    // Create new function with converted argument and result types.
+    // Note that attributes are dropped. Consider preserving some if needed.
+    auto newFuncType = mlir::FunctionType::get(
+        srcOp.getContext(), signatureConversion.getConvertedTypes(),
+        convertedResultTypes);
+    auto newFuncOp = rewriter.create<mlir::FuncOp>(
+        srcOp.getLoc(), srcOp.getName(), newFuncType);
+    rewriter.inlineRegionBefore(srcOp.getBody(), newFuncOp.getBody(),
+                                newFuncOp.end());
+
+    // Tell the rewriter to convert the region signature.
+    TypeConverter &typeConverter = *getTypeConverter();
+    if (failed(rewriter.convertRegionTypes(&newFuncOp.getBody(), typeConverter,
+                                           &signatureConversion))) {
+      return failure();
+    }
+
+    rewriter.replaceOp(srcOp, llvm::None);
+    return success();
+  }
+};
+
+class LoadVarOpConversion : public OpConversionPattern<pydm_d::LoadVarOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::LoadVarOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+    auto resultType =
+        getTypeConverter()->convertType(srcOp.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(
+          srcOp, "could not convert load_var result type");
+    auto list = operands[0];
+    auto index1 =
+        rewriter.create<std_d::ConstantOp>(loc, rewriter.getIndexAttr(1));
+    rewriter.replaceOpWithNewOp<iree_d::ListGetOp>(srcOp, resultType, list,
+                                                   index1);
+    return success();
+  }
+};
+
+/// Converts a `none` operation to a `constant 0 : i32`.
+/// See also the type conversion rule for `NoneType` which must align.
+/// TODO: What we are really reaching for is a zero width type.
+class NoneOpConversion : public OpConversionPattern<pydm_d::NoneOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::NoneOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    Type i32 = rewriter.getI32Type();
+    rewriter.replaceOpWithNewOp<std_d::ConstantOp>(
+        srcOp, i32, rewriter.getIntegerAttr(i32, 0));
+    return success();
+  }
+};
+
+/// Raises an excpetion (failing status) on failure.
+/// This pattern matches raise_on_failure ops at function scope. Those nested
+/// within exception blocks are different.
+class RaiseOnFailureOpConversion
+    : public OpConversionPattern<pydm_d::RaiseOnFailureOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::RaiseOnFailureOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+
+    Value status = operands[0];
+    // Get the containing function return type so that we can create a suitable
+    // null return value.
+    auto parentFunc = srcOp->getParentOfType<builtin_d::FuncOp>();
+    if (!parentFunc)
+      return rewriter.notifyMatchFailure(srcOp, "not contained by a func");
+    Type convertedReturnType = parentFunc.getType().getResult(1);
+
+    // Split the entry block.
+    Block *entryBlock = rewriter.getInsertionBlock();
+    Block *continuationBlock = rewriter.splitBlock(
+        rewriter.getInsertionBlock(), rewriter.getInsertionPoint());
+    Block *raiseAndReturnBlock = createSlowPathBlock(rewriter);
+
+    // Branch on success conditional.
+    rewriter.setInsertionPointToEnd(entryBlock);
+    Value successValue = getSuccessStatusValue(loc, rewriter);
+    Value isSuccess = rewriter.create<std_d::CmpIOp>(
+        loc, std_d::CmpIPredicate::eq, successValue, status);
+    rewriter.create<std_d::CondBranchOp>(loc, isSuccess, continuationBlock,
+                                         raiseAndReturnBlock);
+    rewriter.eraseOp(srcOp);
+
+    // Raise and return block.
+    rewriter.setInsertionPointToEnd(raiseAndReturnBlock);
+    auto nullReturnValue = getNullValue(loc, rewriter, convertedReturnType);
+    rewriter.create<std_d::ReturnOp>(loc, ValueRange{status, nullReturnValue});
+    return success();
+  }
+};
+
+/// Converts to a successful return (0 exception result and actual value).
+class ReturnOpConversion : public OpConversionPattern<pydm_d::ReturnOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::ReturnOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+    auto zeroResult =
+        rewriter.create<std_d::ConstantOp>(loc, rewriter.getI32IntegerAttr(0));
+    rewriter.replaceOpWithNewOp<std_d::ReturnOp>(
+        srcOp, ValueRange{zeroResult, operands[0]});
+    return success();
+  }
+};
+
+class StoreVarOpConversion : public OpConversionPattern<pydm_d::StoreVarOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::StoreVarOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+
+    auto origStoreType =
+        srcOp.value().getType().dyn_cast<pydm_d::PythonTypeInterface>();
+    if (!origStoreType)
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "not a python type for value()");
+    int typeCode = static_cast<int>(origStoreType.getTypeCode());
+
+    auto list = operands[0];
+    auto newValue = operands[1];
+    resetObjectList(loc, rewriter, list, typeCode, newValue);
+    rewriter.eraseOp(srcOp);
+    return success();
+  }
+};
+
+class UnboxOpConversion : public OpConversionPattern<pydm_d::UnboxOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      pydm_d::UnboxOp srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    auto loc = srcOp.getLoc();
+    auto list = operands[0];
+
+    // Target exception result type.
+    Type statusType = getTypeConverter()->convertType(srcOp.status().getType());
+    // Target unboxed type.
+    Type targetUnboxedType =
+        getTypeConverter()->convertType(srcOp.primitive().getType());
+    if (!targetUnboxedType || !statusType)
+      return rewriter.notifyMatchFailure(
+          srcOp, "could not convert unbox result types");
+
+    // Compute the target type code.
+    auto origUnboxedType =
+        srcOp.primitive().getType().dyn_cast<pydm_d::PythonTypeInterface>();
+    if (!origUnboxedType)
+      return rewriter.notifyMatchFailure(
+          srcOp, "not a python type for primitive() unboxed result");
+    int typeCode = static_cast<int>(origUnboxedType.getTypeCode());
+
+    // Split the entry block.
+    Block *entryBlock = rewriter.getInsertionBlock();
+    Block *continuationBlock = rewriter.splitBlock(
+        rewriter.getInsertionBlock(), rewriter.getInsertionPoint());
+    Block *typesMatchBlock = rewriter.createBlock(continuationBlock);
+    Block *slowPathMismatchBlock = createSlowPathBlock(rewriter);
+    continuationBlock->addArguments({statusType, targetUnboxedType});
+    rewriter.replaceOp(srcOp, continuationBlock->getArguments());
+
+    // Type code extraction and comparison.
+    {
+      rewriter.setInsertionPointToEnd(entryBlock);
+      auto index0 =
+          rewriter.create<std_d::ConstantOp>(loc, rewriter.getIndexAttr(0));
+      Value requiredTypeCodeValue = rewriter.create<std_d::ConstantOp>(
+          loc, rewriter.getI32IntegerAttr(typeCode));
+      Value actualTypeCodeValue = rewriter.create<iree_d::ListGetOp>(
+          loc, rewriter.getI32Type(), list, index0);
+      Value typeCodeEqual = rewriter.create<std_d::CmpIOp>(
+          loc, std_d::CmpIPredicate::eq, requiredTypeCodeValue,
+          actualTypeCodeValue);
+      rewriter.create<std_d::CondBranchOp>(loc, typeCodeEqual, typesMatchBlock,
+                                           slowPathMismatchBlock);
+    }
+
+    // Fast path types match block.
+    {
+      rewriter.setInsertionPointToEnd(typesMatchBlock);
+      auto index1 =
+          rewriter.create<std_d::ConstantOp>(loc, rewriter.getIndexAttr(1));
+      Value successResult = getSuccessStatusValue(loc, rewriter);
+      Value unboxedValue = rewriter.create<iree_d::ListGetOp>(
+          loc, targetUnboxedType, list, index1);
+      rewriter.create<std_d::BranchOp>(loc, continuationBlock,
+                                       ValueRange{successResult, unboxedValue});
+    }
+
+    // Slow path coercion on mismatch.
+    // TODO: Currently just fails - should emit a runtime call.
+    {
+      rewriter.setInsertionPointToEnd(slowPathMismatchBlock);
+      Value failureResult =
+          getFailureStatusValue(loc, rewriter, ExceptionCode::ValueError);
+      Value nullResult = getNullValue(loc, rewriter, targetUnboxedType);
+      rewriter.create<std_d::BranchOp>(loc, continuationBlock,
+                                       ValueRange{failureResult, nullResult});
+    }
+
+    return success();
+  }
+};
+
+}  // namespace
+
+void mlir::iree_pydm::populatePyDMToIREELoweringPatterns(
+    MLIRContext *context, TypeConverter &typeConverter,
+    RewritePatternSet &patterns) {
+  // Structural.
+  patterns.insert<AllocFreeVarOpConversion, BoxOpConversion, FuncOpConversion,
+                  LoadVarOpConversion, RaiseOnFailureOpConversion,
+                  ReturnOpConversion, StoreVarOpConversion, UnboxOpConversion>(
+      typeConverter, context);
+
+  // Constants and constructors.
+  patterns.insert<NoneOpConversion>(typeConverter, context);
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.cpp
@@ -1,0 +1,75 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/ToIREE/TypeConverter.h"
+
+#include "iree-dialects/Dialect/IREE/IREEDialect.h"
+#include "iree-dialects/Dialect/IREEPyDM/IR/Dialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+using namespace mlir;
+using namespace mlir::iree_pydm;
+
+namespace iree_d = mlir::iree;
+namespace builtin_d = mlir;
+namespace pydm_d = mlir::iree_pydm;
+
+static Type getVariantListType(Builder &builder) {
+  return builder.getType<iree_d::ListType>(
+      builder.getType<iree_d::VariantType>());
+}
+
+LoweringTypeConverter::LoweringTypeConverter() {
+  addConversion([](pydm_d::NoneType t) -> Optional<Type> {
+    // TODO: This should really be a zero-width opaque value in the VM. Just
+    // making it an integer now.
+    return builtin_d::IntegerType::get(t.getContext(), 32);
+  });
+  addConversion([](pydm_d::ExceptionResultType t) -> Optional<Type> {
+    return builtin_d::IntegerType::get(t.getContext(), 32);
+  });
+  addConversion([](pydm_d::ObjectType t) -> Optional<Type> {
+    Builder b(t.getContext());
+    return getVariantListType(b);
+  });
+
+  // Integer type hierarchy.
+  addConversion([&](pydm_d::IntegerType t) -> Optional<Type> {
+    Builder b(t.getContext());
+    return getWeakIntegerType(b);
+  });
+
+  // Variable references.
+  addConversion([](pydm_d::FreeVarRefType t) -> Optional<Type> {
+    // Just an object record.
+    Builder b(t.getContext());
+    return getVariantListType(b);
+  });
+
+  // Explicit conversions for allowed built-in types (avoids default conversion
+  // which can mask issues).
+  addConversion([](builtin_d::IntegerType t) -> Optional<Type> { return t; });
+  addConversion([](builtin_d::FloatType t) -> Optional<Type> { return t; });
+  addConversion([](builtin_d::IndexType t) -> Optional<Type> { return t; });
+}
+
+Type LoweringTypeConverter::getBoolType(Builder b) const {
+  return b.getIntegerType(boolBits);
+}
+
+Type LoweringTypeConverter::getWeakIntegerType(Builder b) const {
+  return b.getIntegerType(weakIntegerBits);
+}
+
+Type LoweringTypeConverter::getWeakFloatType(Builder b) const {
+  switch (weakFloatType) {
+    case WeakFloatType::F32:
+      return b.getF32Type();
+    case WeakFloatType::F64:
+      return b.getF64Type();
+  }
+}

--- a/llvm-external-projects/iree-dialects/test/iree_pydm/to_iree/structural.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_pydm/to_iree/structural.mlir
@@ -1,0 +1,111 @@
+// RUN: iree-dialects-opt -split-input-file -convert-iree-pydm-to-iree %s | FileCheck --enable-var-scope --dump-input-filter=all %s
+
+// CHECK-LABEL: @none_constant
+iree_pydm.func @none_constant() -> (!iree_pydm.exception_result, !iree_pydm.none) {
+  // CHECK: %[[CST0:.*]] = constant 0 : i32
+  // CHECK: %[[CST1:.*]] = constant 0 : i32
+  // CHECK: return %[[CST1]], %[[CST0]]
+  %0 = none
+  return %0 : !iree_pydm.none
+}
+
+// -----
+// CHECK-LABEL: @box
+// NOTE: "9" is the type code for integer
+iree_pydm.func @box(%arg0 : !iree_pydm.integer) -> (!iree_pydm.exception_result, !iree_pydm.object<!iree_pydm.integer>) {
+  // CHECK: %[[LIST:.*]] = iree.list.create : !iree.list<!iree.variant>
+  // CHECK: %[[c2:.*]] = constant 2 : index
+  // CHECK: iree.list.resize %[[LIST]], %c2 : !iree.list<!iree.variant>
+  // CHECK: %[[c0:.*]] = constant 0 : index
+  // CHECK: %[[c9:.*]] = constant 9 : i32
+  // CHECK: iree.list.set %[[LIST]][%[[c0]]], %[[c9]] : !iree.list<!iree.variant>, i32
+  // CHECK: %[[c1:.*]] = constant 1 : index
+  // CHECK: iree.list.set %[[LIST]][%[[c1]]], %arg0 : !iree.list<!iree.variant>, i32
+  // CHECK: %[[c0_i32:.*]] = constant 0 : i32
+  // return %[[c0_i32]], %[[LIST]] : i32, !iree.list<!iree.variant>
+  %0 = box %arg0 : !iree_pydm.integer -> !iree_pydm.object<!iree_pydm.integer>
+  return %0 : !iree_pydm.object<!iree_pydm.integer>
+}
+
+// -----
+// CHECK-LABEL: @alloc_store_load_var
+// NOTE: 256 is the type code for a plain object
+iree_pydm.func @alloc_store_load_var(%arg0 : !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.object) {
+  // CHECK: %[[A:.*]] = iree.list.create : !iree.list<!iree.variant>
+  %a = alloc_free_var "a" -> !iree_pydm.free_var_ref
+  // CHECK: %[[c2:.*]] = constant 2 : index
+  // CHECK: iree.list.resize %[[A]], %[[c2]] : !iree.list<!iree.variant>
+  // CHECK: %[[c0:.*]] = constant 0 : index
+  // CHECK: %[[object_code:.*]] = constant 256 : i32
+  // CHECK: iree.list.set %[[A]][%[[c0]]], %[[object_code]]
+  // CHECK: %[[c1:.*]] = constant 1 : index
+  // CHECK: iree.list.set %[[A]][%[[c1]]], %arg0 : !iree.list<!iree.variant>, !iree.list<!iree.variant>
+  store_var %a = %arg0 : !iree_pydm.free_var_ref, !iree_pydm.object
+  // CHECK: %[[c1_0:.*]] = constant 1 : index
+  // CHECK: %[[LOADED:.*]] = iree.list.get %[[A]][%[[c1_0]]] : !iree.list<!iree.variant> -> !iree.list<!iree.variant>
+  %0 = load_var %a : !iree_pydm.free_var_ref -> !iree_pydm.object
+  // CHECK: return {{.*}}, %[[LOADED]]
+  return %0 : !iree_pydm.object
+}
+
+// -----
+// CHECK-LABEL: @unbox
+// NOTE: "9" is the type code for integer
+iree_pydm.func @unbox(%arg0 : !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.integer) {
+  // CHECK:  %[[c0:.*]] = constant 0 : index
+  // CHECK: %[[NEEDED_TYPE_CODE:.*]] = constant 9 : i32
+  // CHECK: %[[TYPE_CODE:.*]] = iree.list.get %arg0[%[[c0]]] : !iree.list<!iree.variant> -> i32
+  // CHECK: %[[TYPE_EQ:.*]] = cmpi eq, %[[NEEDED_TYPE_CODE]], %[[TYPE_CODE]] : i32
+  // CHECK: cond_br %[[TYPE_EQ]], ^bb1, ^bb4
+
+  // bb1: On equal
+  // CHECK: ^bb1:
+  // CHECK: %[[c1:.*]] = constant 1 : index
+  // CHECK: %[[c0_i32:.*]] = constant 0 : i32
+  // CHECK: %[[CONTENTS:.*]] = iree.list.get %arg0[%[[c1]]] : !iree.list<!iree.variant> -> i32
+  // CHECK: br ^bb2(%[[c0_i32]], %[[CONTENTS]] : i32, i32)
+
+  // bb2: Check status code (from raise_on_failure)
+  // CHECK: ^bb2(%3: i32, %4: i32):  // 2 preds: ^bb1, ^bb4
+
+  // bb3: Return success
+  // CHECK: ^bb3
+
+  // bb4: Signal ValueError (-4 == ValueError)
+  // CHECK: ^bb4:
+  // CHECK: %[[VALUE_ERROR_CODE:.*]] = constant -4 : i32
+  // CHECK: %[[c0_i32_2:.*]] = constant 0 : i32
+  // CHECK: br ^bb2(%[[VALUE_ERROR_CODE]], %[[c0_i32_2]] : i32, i32)
+  %status, %primitive = unbox %arg0 : !iree_pydm.object -> !iree_pydm.integer
+  raise_on_failure %status : !iree_pydm.exception_result
+  return %primitive : !iree_pydm.integer
+}
+
+// -----
+// CHECK-LABEL: @raise_on_failure_object_return
+iree_pydm.func @raise_on_failure_object_return(%arg0 : !iree_pydm.exception_result, %arg1: !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.object) {
+  // CHECK: %[[c0_i32:.*]] = constant 0 : i32
+  // CHECK: %[[CMP:.*]] = cmpi eq, %[[c0_i32]], %arg0 : i32
+  // CHECK: cond_br %[[CMP]], ^bb1, ^bb2
+  // bb1: success
+  // CHECK: ^bb1:
+  // CHECK: %[[c0_i32_0:.*]] = constant 0 : i32
+  // CHECK: return %[[c0_i32_0]], %arg1 : i32, !iree.list<!iree.variant>
+  // bb2: failure
+  // CHECK: ^bb2:
+  // CHECK: %[[NULL:.*]] = iree.null : !iree.list<!iree.variant>
+  // CHECK: return %arg0, %[[NULL]] : i32, !iree.list<!iree.variant>
+  raise_on_failure %arg0 : !iree_pydm.exception_result
+  return %arg1 : !iree_pydm.object
+}
+
+// -----
+// CHECK-LABEL: @raise_on_failure_builtin
+iree_pydm.func @raise_on_failure_builtin(%arg0 : !iree_pydm.exception_result, %arg1: !iree_pydm.integer) -> (!iree_pydm.exception_result, !iree_pydm.integer) {
+  // bb2: failure
+  // CHECK: ^bb2:
+  // CHECK: %[[ZERO:.*]] = constant 0 : i32
+  // CHECK: return %arg0, %[[ZERO]] : i32, i32
+  raise_on_failure %arg0 : !iree_pydm.exception_result
+  return %arg1 : !iree_pydm.integer
+}

--- a/llvm-external-projects/iree-dialects/test/python/iree_pydm/to_iree/basic_structure.py
+++ b/llvm-external-projects/iree-dialects/test/python/iree_pydm/to_iree/basic_structure.py
@@ -1,0 +1,16 @@
+# RUN: %PYTHON %s | iree-dialects-opt -convert-iree-pydm-to-iree | FileCheck --enable-var-scope --dump-input-filter=all %s
+# This test isn't currently checking anything except that e2e lowering doesn't
+# crash.
+
+from typing import List
+from mlir.dialects.iree_pydm.importer.test_util import *
+
+
+@test_import_global
+def return_none_no_args():
+  return None
+
+
+@test_import_global
+def weak_integer_arg_and_return(a: int) -> int:
+  return a

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBS
   MLIRTransforms
   IREEDialectsIREEDialect
   IREEDialectsIREEPyDMDialect
+  IREEDialectsIREEPyDMToIREEPasses
 )
 
 add_llvm_tool(iree-dialects-opt

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
@@ -6,6 +6,7 @@
 
 #include "iree-dialects/Dialect/IREE/IREEDialect.h"
 #include "iree-dialects/Dialect/IREEPyDM/IR/Dialect.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/AsmState.h"
@@ -15,6 +16,8 @@
 #include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
+using namespace mlir::iree;
+using namespace mlir::iree_pydm;
 
 int main(int argc, char **argv) {
   registerAsmPrinterCLOptions();
@@ -22,6 +25,9 @@ int main(int argc, char **argv) {
 
   registerTransformsPasses();
   registerSCFPasses();
+
+  // Local dialects.
+  registerIREEPyDMTransformsPasses();
 
   DialectRegistry registry;
   registry.insert<


### PR DESCRIPTION
* Type conversion basics.
* Lowerings for AllocFreeVarOp, BoxOp, FuncOp, LoadVarOp, RaiseOnFailureOp, ReturnOp, StoreVarOp, UnboxOp, NoneOp
* Sufficient to lower simple functions taking arguments and returning values based on them, with or without typing.
* This is about as far as we can go without a runtime library, which comes next.