### PR TITLE
Introduce a noisy benchmark list to control threshold and comment

### DIFF
--- a/build_tools/android/common/noisy_benchmarks.py
+++ b/build_tools/android/common/noisy_benchmarks.py
@@ -1,0 +1,15 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""A list of noisy benchmarks and their average thresholds."""
+
+import re
+
+NOISY_BENCHMARKS = [
+    # (regular expression to match the benchmark name, average threshold)
+    (re.compile(r"^PoseNet.*GPU-Mali-G77"), "100%"),
+    (re.compile(r"^DeepLabV3.*GPU-Mali-G77"), "100%"),
+    (re.compile(r"^MobileSSD.*GPU-Mali-G77"), "100%"),
+]

--- a/build_tools/android/common/noisy_benchmarks.py
+++ b/build_tools/android/common/noisy_benchmarks.py
@@ -7,8 +7,17 @@
 
 import re
 
+# A list of noisy benchmarks. Each one is a tuple that contains the following
+# fields:
+# - A regular expression to match against the benchmark identifier.
+# - A threshold for computing the benchmark value average. Benchmark sample
+#   values from consecutive runs and within the given range will be considered
+#   as similar (with some noise). They will be used to compute the moving
+#   average. It is a string that sent to Dana as API call JSON payloadsdirectly.
+#   There are two formats supported: a percentage or an absolute value. So we
+#   use a string here. What value to set depends on the noise range of the
+#   particular benchmark.
 NOISY_BENCHMARKS = [
-    # (regular expression to match the benchmark name, average threshold)
     (re.compile(r"^PoseNet.*GPU-Mali-G77"), "100%"),
     (re.compile(r"^DeepLabV3.*GPU-Mali-G77"), "100%"),
     (re.compile(r"^MobileSSD.*GPU-Mali-G77"), "100%"),

--- a/build_tools/android/upload_benchmarks_to_dashboard.py
+++ b/build_tools/android/upload_benchmarks_to_dashboard.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Optional
 
 from common.benchmark_description import (BenchmarkInfo, BenchmarkResults,
                                           get_output)
+from common.noisy_benchmarks import NOISY_BENCHMARKS
 
 IREE_GITHUB_COMMIT_URL_PREFIX = 'https://github.com/google/iree/commit'
 IREE_PROJECT_ID = 'IREE'
@@ -206,9 +207,18 @@ def add_new_iree_series(series_id: str,
                         verbose: bool = False):
   """Posts a new series to the dashboard."""
   url = get_required_env_var('IREE_DASHBOARD_URL')
+
+  average_range = '5%'
+  # Adjust average threshold for noisy benchmarks.
+  for regex, threshold in NOISY_BENCHMARKS:
+    if regex.match(series_id):
+      average_range = threshold
+      break
+
   payload = compose_series_payload(IREE_PROJECT_ID,
                                    series_id,
                                    series_description,
+                                   average_range=average_range,
                                    override=override)
   post_to_dashboard(f'{url}/apis/addSerie',
                     payload,


### PR DESCRIPTION
These benchmarks seem to suffer from phone issues so they bounce
in large ranges. So introducing a filter list to reduce the noise
to avoid confusion while waiting for fixing the phones.