### PR TITLE
[spirv] Remove unnecessary `spv.target_env` attributes in tests

### DIFF
--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -11,7 +11,7 @@ hal.executable private @push_constant  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    builtin.module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @__push_constant_var__ : !spv.ptr<!spv.struct<(!spv.array<5 x i32, stride=4> [0])>, PushConstant>
       // CHECK: spv.func @push_constant()
@@ -47,7 +47,7 @@ hal.executable private @resource_bindings_in_same_func  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    builtin.module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @[[ARG0:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
       // CHECK: spv.GlobalVariable @[[ARG1_0:.+]] bind(1, 3) {aliased} : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
@@ -109,7 +109,7 @@ hal.executable private @resource_bindings_in_multi_entry_func  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>} {
+    builtin.module {
       // CHECK-LABEL: spv.module
       // CHECK: spv.GlobalVariable @[[FUNC1_ARG:.+]] bind(1, 2) : !spv.ptr<!spv.struct<(!spv.array<16 x f32, stride=4> [0])>, StorageBuffer>
       // CHECK: spv.GlobalVariable @[[FUNC1_RET:.+]] bind(3, 4) : !spv.ptr<!spv.struct<(!spv.array<4 x vector<4xf32>, stride=16> [0])>, StorageBuffer>
@@ -166,7 +166,7 @@ hal.executable private @interface_binding  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    builtin.module {
       func @interface_binding() {
         %c0 = constant 0 : index
         %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<8x5xf32>
@@ -213,7 +213,7 @@ hal.executable private @interface_wg_id  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    builtin.module {
       func @interface_wg_id() {
         %0 = hal.interface.workgroup.id[0] : index
         %1 = hal.interface.workgroup.id[1] : index
@@ -252,7 +252,7 @@ hal.executable private @interface_wg_count  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, SwiftShader:CPU, {}>}  {
+    builtin.module {
       func @interface_wg_count() {
         %0 = hal.interface.workgroup.count[0] : index
         %1 = hal.interface.workgroup.count[1] : index

--- a/iree/compiler/Codegen/SPIRV/test/distribute_to_global_id.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/distribute_to_global_id.mlir
@@ -8,16 +8,8 @@ hal.executable private @parallel_4D  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @parallel_4D attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3,
-        [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-        {max_compute_workgroup_invocations = 128 : i32,
-         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    hal.executable.entry_point @parallel_4D attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       func @parallel_4D() {
         %c0 = constant 0 : index
         %dim0 = hal.interface.load.constant offset = 0 : index
@@ -88,16 +80,8 @@ hal.executable private @parallel_4D_static  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @parallel_4D_static attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3,
-        [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-        {max_compute_workgroup_invocations = 128 : i32,
-         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    hal.executable.entry_point @parallel_4D_static attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       func @parallel_4D_static() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<3x4x5x6xf32>
@@ -160,16 +144,8 @@ hal.executable private @scalar_add  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @scalar_add attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3,
-        [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-        {max_compute_workgroup_invocations = 128 : i32,
-         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    hal.executable.entry_point @scalar_add attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
       func @scalar_add() attributes {hal.num_workgroups_fn = @scalar_add__num_workgroups__} {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<f32>

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -15,7 +15,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @fuse_and_vectorize_fill_matmul() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32
@@ -85,7 +85,7 @@ hal.executable private @fuse_and_vectorize_matmul_add  {
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @fuse_and_vectorize_matmul_add() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32

--- a/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
@@ -12,11 +12,7 @@ hal.executable private @matmul_promote_workgroup_memory  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 8: index, 1: index]
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    builtin.module {
       func @matmul_promote_workgroup_memory() {
         %c32 = constant 32 : index
         %c50 = constant 50 : index
@@ -90,11 +86,7 @@ hal.executable private @conv_promote_workgroup_memory  {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index]
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    builtin.module {
       func @conv_promote_workgroup_memory() {
         %c0 = constant 0 : index
         %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<3x4x6x14xf32>

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
@@ -16,21 +16,13 @@ hal.executable private @matmul  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 8: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [8, 16]}
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    builtin.module {
       func @matmul() {
         %c0 = constant 0 : index
         %M = hal.interface.load.constant offset = 0 : index
@@ -98,21 +90,13 @@ hal.executable private @conv_1d  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3,
-          [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic,
-           GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative],
-          [SPV_KHR_storage_buffer_storage_class]>,
-          SwiftShader:CPU,
-          {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32,
-           max_compute_workgroup_invocations = 128 : i32,
-           max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_1d attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32, max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}  {
+    builtin.module {
       func @conv_1d() {
         %cst = constant 0.000000e+00 : f32
         %c0 = constant 0 : index
@@ -189,21 +173,13 @@ hal.executable private @conv_no_padding  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_no_padding attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-                        {max_compute_workgroup_invocations = 128 : i32,
-                         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+    builtin.module {
       func @conv_no_padding() {
         %c0 = constant 0 : index
         %n = hal.interface.load.constant offset = 0 : index
@@ -324,20 +300,13 @@ hal.executable private @conv_3d  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3,
-          [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic,
-           GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative],
-          [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU,
-          {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32,
-           max_compute_workgroup_invocations = 128 : i32,
-           max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_3d attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, {cooperative_matrix_properties_nv = [], max_compute_shared_memory_size = 16384 : i32, max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>, subgroup_size = 4 : i32}>}  {
+    builtin.module {
       func @conv_3d() {
         %cst = constant 0.000000e+00 : f32
         %c0 = constant 0 : index
@@ -405,16 +374,13 @@ module  {
       hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
     }
-    hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-        spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>,
-        {max_compute_workgroup_invocations = 128 : i32,
-         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+    hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
       hal.executable.entry_point @pooling_nhwc_max attributes {
         interface = @io, ordinal = 0 : index,
         workgroup_size = [32: index, 4: index, 1: index],
         translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 4, 1]}
       }
-      builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}  {
+      builtin.module {
         func @pooling_nhwc_max() {
           %c0 = constant 0 : index
           %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<2x16x16x6xf32>

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -8,14 +8,13 @@ hal.executable private @batch_matmul_static_shape  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @batch_matmul_static_shape attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @batch_matmul_static_shape() {
         %c0 = constant 0 : index
         %c4 = constant 4 : index
@@ -377,14 +376,13 @@ hal.executable private @fused_fill_batch_matmul  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @fused_fill_batch_matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @fused_fill_batch_matmul() {
         %zero = constant 0.0 : f32
         %c0 = constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -8,8 +8,7 @@ hal.executable private @conv_static_shape_f32  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @conv_static_shape_f32 attributes {
       interface = @io,
       ordinal = 0 : index,
@@ -22,7 +21,7 @@ hal.executable private @conv_static_shape_f32  {
       %z = constant 28: index
       hal.return %x, %y, %z: index, index, index
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @conv_static_shape_f32() {
         %cst = constant 0.000000e+00 : f32
         %c32 = constant 32 : index
@@ -108,8 +107,7 @@ hal.executable private @depthwise_conv_static_shape_f32  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @depthwise_conv_static_shape_f32 attributes {
       interface = @io,
       ordinal = 0 : index,
@@ -122,7 +120,7 @@ hal.executable private @depthwise_conv_static_shape_f32  {
       %z = constant 14: index
       hal.return %x, %y, %z: index, index, index
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @depthwise_conv_static_shape_f32() {
         %cst = constant 0.000000e+00 : f32
         %c96 = constant 96 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -8,14 +8,13 @@ hal.executable private @matmul_static_shape_f16  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul_static_shape_f16 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @matmul_static_shape_f16() {
         %cst = constant 0.000000e+00 : f16
         %c0 = constant 0 : index
@@ -75,14 +74,13 @@ hal.executable private @matmul_static_shape_f32  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @matmul_static_shape_f32 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
     }
-    builtin.module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], [SPV_KHR_storage_buffer_storage_class]>, ARM:IntegratedGPU, {}>}  {
+    builtin.module {
       func @matmul_static_shape_f32() {
         %c0 = constant 0 : index
         %cst = constant 0.000000e+00 : f32

--- a/iree/compiler/Codegen/SPIRV/test/vector_to_cooperative_matrix.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vector_to_cooperative_matrix.mlir
@@ -7,14 +7,13 @@
 
 hal.executable private @kernel_matmul  {
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-    gpu.container_module,
     spv.target_env = #spv.target_env<#spv.vce<v1.0,
         [Shader, CooperativeMatrixNV, Int8, StorageBuffer8BitAccess],
         [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage]>,
         {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
     builtin.module {
       // CHECK-LABEL: func @kernel_matmul
-      func @kernel_matmul(%arg0: memref<8x32xi8>, %arg1: memref<32x8xi8>, %arg2: memref<8x8xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      func @kernel_matmul(%arg0: memref<8x32xi8>, %arg1: memref<32x8xi8>, %arg2: memref<8x8xi32>) {
         %c0 = constant 0 : index
         %cst = constant 0 : i32
         %cst_i8 = constant 0 : i8
@@ -43,14 +42,13 @@ hal.executable private @kernel_matmul  {
 
 hal.executable private @kernel_matmul  {
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      gpu.container_module,
       spv.target_env = #spv.target_env<#spv.vce<v1.0,
           [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer],
           [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>,
-      {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+          {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
     builtin.module {
       // CHECK-LABEL: func @kernel_matmul_licm
-      func @kernel_matmul_licm(%arg0: memref<4096x4096xi8>, %arg1: memref<4096x4096xi8>, %arg2: memref<4096x4096xi32>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      func @kernel_matmul_licm(%arg0: memref<4096x4096xi8>, %arg1: memref<4096x4096xi8>, %arg2: memref<4096x4096xi32>) {
         %c32 = constant 32 : index
         %c4096 = constant 4096 : index
         %c0 = constant 0 : index
@@ -90,14 +88,13 @@ hal.executable private @kernel_matmul  {
 
 hal.executable private @kernel_matmul  {
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      gpu.container_module,
       spv.target_env = #spv.target_env<#spv.vce<v1.0,
-      [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer],
-      [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>,
-      {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
+        [Shader, CooperativeMatrixNV, Int8, Float16, StorageUniform16, StorageBuffer8BitAccess, Float16Buffer],
+        [SPV_KHR_storage_buffer_storage_class, SPV_NV_cooperative_matrix, SPV_KHR_8bit_storage, SPV_KHR_16bit_storage]>,
+        {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>}> {
     builtin.module {
       // CHECK-LABEL: func @kernel_matmul_vector_memref
-      func @kernel_matmul_vector_memref(%arg0: memref<4096x256xvector<4xi32>>, %arg1: memref<4096x256xvector<4xi32>>, %arg2: memref<4096x1024xvector<4xi32>>) attributes {spv.entry_point_abi = {local_size = dense<[32, 1, 1]> : vector<3xi32>}} {
+      func @kernel_matmul_vector_memref(%arg0: memref<4096x256xvector<4xi32>>, %arg1: memref<4096x256xvector<4xi32>>, %arg2: memref<4096x1024xvector<4xi32>>) {
         %c32 = constant 32 : index
         %c4096 = constant 4096 : index
         %c0 = constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_copy_to_workgroup_memory.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_copy_to_workgroup_memory.mlir
@@ -5,7 +5,7 @@
 
 #map0 = affine_map<(d0, d1)[s0] -> (d0 * 4096 + s0 + d1)>
 
-module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+module attributes {spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
   func @copy(%arg0: memref<4096x4096xf32>) attributes {spv.entry_point_abi = {local_size = dense<[128, 1, 1]> : vector<3xi32>}} {
     %a = memref.alloc() : memref<128x32xf32, 3>
     %c0 = constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
@@ -11,18 +11,12 @@ hal.executable private @elementwise_static_shape  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @elementwise_static_shape attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>} {
+    builtin.module {
       func @elementwise_static_shape() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<128xf32>
@@ -66,18 +60,12 @@ hal.executable private @elementwise_transpose  {
     hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
-  hal.executable.variant @vulkan, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>}> {
+  hal.executable.variant @vulkan, target = #hal.executable.target<"spirv", "vulkan-spirv-fb"> {
     hal.executable.entry_point @elementwise_transpose attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    builtin.module attributes {
-      spv.target_env =
-        #spv.target_env<#spv.vce<v1.5, [Shader], []>,
-        NVIDIA:DiscreteGPU, {subgroup_size = 32 : i32}>} {
+    builtin.module {
       func @elementwise_transpose() {
         %c0 = constant 0 : index
         %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<128x8xf32>

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -10,16 +10,7 @@ hal.executable private @matmul_static_shape  {
   }
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env =
-        #spv.target_env<#spv.vce<v1.5,
-          [Shader, Float64, Float16, Int64, Int16, Int8, StorageBuffer16BitAccess,
-           StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess,
-           UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform,
-           GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot,
-           GroupNonUniformShuffle, GroupNonUniformShuffleRelative, VariablePointers,
-           VariablePointersStorageBuffer, CooperativeMatrixNV],
-          [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage,
-           SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers,
-           SPV_NV_cooperative_matrix]>, NVIDIA:DiscreteGPU,
+        #spv.target_env<#spv.vce<v1.5, [Shader, CooperativeMatrixNV], [SPV_NV_cooperative_matrix]>, NVIDIA:DiscreteGPU,
           {cooperative_matrix_properties_nv = [
             {a_type = i8, b_type = i8, c_type = i32, k_size = 32 : i32,
              m_size = 8 : i32, n_size = 8 : i32, result_type = i32, scope = 3 : i32},
@@ -272,16 +263,7 @@ hal.executable private @matmul_static_shape  {
   }
   hal.executable.variant @vulkan, target = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env =
-        #spv.target_env<#spv.vce<v1.5,
-          [Shader, Float64, Float16, Int64, Int16, Int8, StorageBuffer16BitAccess,
-           StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess,
-           UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform,
-           GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot,
-           GroupNonUniformShuffle, GroupNonUniformShuffleRelative, VariablePointers,
-           VariablePointersStorageBuffer, CooperativeMatrixNV],
-          [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage,
-           SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers,
-           SPV_NV_cooperative_matrix]>, NVIDIA:DiscreteGPU,
+        #spv.target_env<#spv.vce<v1.5, [Shader, CooperativeMatrixNV], [SPV_NV_cooperative_matrix]>, NVIDIA:DiscreteGPU,
           {cooperative_matrix_properties_nv = [
             {a_type = i8, b_type = i8, c_type = i32, k_size = 32 : i32,
              m_size = 8 : i32, n_size = 8 : i32, result_type = i32, scope = 3 : i32},


### PR DESCRIPTION
Now the CodeGen config is fetched and attached as attributes to the
ops in an early step by `SPIRVLowerExecutableTargetPass` by querying
the `spv.target_env`. We don't need the `spv.target_env` in many
of the existing tests anymore, if the test does not involve the
`SPIRVLowerExecutableTargetPass` pass.