### PR TITLE
Change pass pipeline enum to use a StrEnumAttr. 

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -248,8 +248,8 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
     if (auto config = getLoweringConfig(computeOp)) {
       IREE::HAL::DispatchLoweringPassPipeline passPipeline =
           IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
-      if (auto passPipelineAttr = config.passPipeline()) {
-        passPipeline = passPipelineAttr.getValue();
+      if (auto setPassPipeline = getLoweringPassPipeline(config)) {
+        passPipeline = setPassPipeline.getValue();
       }
       SmallVector<int64_t, 4> workgroupSize;
       if (auto workgroupSizeAttr = config.workgroupSize()) {

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -128,10 +128,11 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
       auto entryPointOp = it.second;
       if (IREE::HAL::TranslationInfo translationInfo =
               getTranslationInfo(entryPointOp)) {
-        IREE::HAL::DispatchLoweringPassPipeline currPipeline =
-            translationInfo.passPipeline().getValue();
+        Optional<IREE::HAL::DispatchLoweringPassPipeline> currPipeline =
+            getLoweringPassPipeline(translationInfo);
+        if (!currPipeline) continue;
         if (passPipeline) {
-          if (currPipeline != passPipeline.getValue()) {
+          if (currPipeline.getValue() != passPipeline.getValue()) {
             moduleOp.emitError(
                 "unhandled compilation of entry point function with different "
                 "pass pipelines within a module");

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -74,7 +74,7 @@ hal.executable private @matmul_tensors  {
 
 // -----
 
-//      CHECK: #[[CONFIG:.+]] = {passPipeline = 0 : i32}
+//      CHECK: #[[CONFIG:.+]] = {passPipeline = "CPUDefault"}
 //  CHECK-NOT: #config
 //      CHECK: hal.executable.entry_point public @add_no_config
 // CHECK-SAME:     translation.info = #[[CONFIG]]
@@ -428,7 +428,7 @@ hal.executable private @preset_config_matmul_tensors  {
             %14 = affine.min affine_map<(d0)[s0] -> (-d0 + 512, s0)>(%arg1)[%workgroup_size_x]
             %15 = linalg.init_tensor [%13, %14] : tensor<?x?xf32>
             %16 = linalg.fill(%cst, %15) : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-            %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", lowering.config = {passPipeline = 1 : i32, tileSizes = [[32, 32, 32]]}} ins(%8, %10 : tensor<?x256xf32>, tensor<256x?xf32>) outs(%16 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", lowering.config = {passPipeline = "CPUVectorization", tileSizes = [[32, 32, 32]]}} ins(%8, %10 : tensor<?x256xf32>, tensor<256x?xf32>) outs(%16 : tensor<?x?xf32>) -> tensor<?x?xf32>
             flow.dispatch.tensor.store %17, %2, offsets = [%arg0, %arg1], sizes = [%11, %12], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:128x512xf32>
           }
         }
@@ -446,7 +446,7 @@ hal.executable private @preset_config_matmul_tensors  {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //      CHECK: hal.executable.entry_point
-// CHECK-SAME:     translation.info = {passPipeline = 1 : i32, workloadPerWorkgroup = [32, 32]}
+// CHECK-SAME:     translation.info = {passPipeline = "CPUVectorization", workloadPerWorkgroup = [32, 32]}
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
 //  CHECK-DAG:     %[[NWG_X:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
@@ -514,7 +514,7 @@ hal.executable @tensor_insert {
 }
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = 0 : i32, workloadPerWorkgroup = [64, 64]}
+// CHECK-SAME:   translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = constant 1 : index

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -77,10 +77,11 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
     auto entryPointOp = it.second;
     if (IREE::HAL::TranslationInfo translationInfo =
             getTranslationInfo(entryPointOp)) {
-      IREE::HAL::DispatchLoweringPassPipeline currPipeline =
-          translationInfo.passPipeline().getValue();
+      Optional<IREE::HAL::DispatchLoweringPassPipeline> currPipeline =
+          getLoweringPassPipeline(translationInfo);
+      if (!currPipeline) continue;
       if (passPipeline) {
-        if (currPipeline != passPipeline.getValue()) {
+        if (currPipeline.getValue() != passPipeline.getValue()) {
           moduleOp.emitError(
               "unhandled compilation of entry point function with different "
               "pass pipelines within a module");

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -36,7 +36,7 @@ hal.executable @add_dispatch_0 {
 //  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[128], [], [4]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //      CHECK: hal.executable.entry_point public @add_dispatch_0
-// CHECK-SAME:     passPipeline = 3 : i32
+// CHECK-SAME:     passPipeline = "LLVMGPUVectorize"
 // CHECK-SAME:     workloadPerWorkgroup = [128]
 // CHECK-SAME:     workgroup_size = [32 : index, 1 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index,
@@ -96,7 +96,7 @@ hal.executable private @dot_dispatch_1  {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
 //      CHECK: hal.executable.entry_point public @dot_dispatch_1
-// CHECK-SAME:     passPipeline = 4 : i32
+// CHECK-SAME:     passPipeline = "LLVMGPUMatmulSimt"
 // CHECK-SAME:     workloadPerWorkgroup = [2, 4]
 // CHECK-SAME:     workgroup_size = [2 : index, 4 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index,
@@ -143,7 +143,7 @@ hal.executable @reduction_dispatch {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG0:.+]] = {passPipeline = 2 : i32}
+//  CHECK-DAG: #[[CONFIG0:.+]] = {passPipeline = "LLVMGPUDistribute"}
 //  CHECK-DAG: #[[CONFIG1:.+]] = {tileSizes = {{\[}}[]{{\]}}}
 //      CHECK: hal.executable.entry_point public @predict_dispatch_153
 // CHECK-SAME:     translation.info = #[[CONFIG0]]
@@ -201,7 +201,7 @@ hal.executable @tensor_insert {
 }
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = 2 : i32, workloadPerWorkgroup = [128, 1]}
+// CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUDistribute", workloadPerWorkgroup = [128, 1]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = constant 1 : index
@@ -249,7 +249,7 @@ hal.executable @tensor_insert {
 //  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 128], [], [1, 4]{{\]}}}
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = 3 : i32, workloadPerWorkgroup = [128, 1]}
+// CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUVectorize", workloadPerWorkgroup = [128, 1]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = constant 1 : index

--- a/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -76,10 +76,11 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
     auto entryPointOp = it.second;
     if (IREE::HAL::TranslationInfo translationInfo =
             getTranslationInfo(entryPointOp)) {
-      IREE::HAL::DispatchLoweringPassPipeline currPipeline =
-          translationInfo.passPipeline().getValue();
+      Optional<IREE::HAL::DispatchLoweringPassPipeline> currPipeline =
+          getLoweringPassPipeline(translationInfo);
+      if (!currPipeline) continue;
       if (passPipeline) {
-        if (currPipeline != passPipeline.getValue()) {
+        if (currPipeline.getValue() != passPipeline.getValue()) {
           moduleOp.emitError(
               "unhandled compilation of entry point function with different "
               "pass pipelines within a module");

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -75,7 +75,7 @@ hal.executable @conv_112x112x512 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @conv_112x112x512
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [256, 8, 1]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [256, 8, 1]}
 //           CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[C2:.+]] = constant 2 : index
@@ -164,7 +164,7 @@ hal.executable @conv_112x112x32 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @conv_112x112x32
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 16, 4]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [32, 16, 4]}
 //           CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[C1:.+]] = constant 1 : index
@@ -252,7 +252,7 @@ hal.executable @conv_16x16x16 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @conv_16x16x16
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [16, 8, 8]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 8, 8]}
 //           CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[C1:.+]] = constant 1 : index
@@ -341,7 +341,7 @@ hal.executable @dwconv_28x28x144 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @dwconv_28x28x144
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [16, 8, 8]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 8, 8]}
 //           CHECK-SAME:   workgroup_size = [4 : index, 4 : index, 4 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[C9:.+]] = constant 9 : index
@@ -430,7 +430,7 @@ hal.executable @dwconv_4x4x8 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @dwconv_4x4x8
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [8, 4, 4]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [8, 4, 4]}
 //           CHECK-SAME:   workgroup_size = [2 : index, 4 : index, 4 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[C1:.+]] = constant 1 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -63,7 +63,7 @@ hal.executable @matmul_1024x2048x512 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @matmul_1024x2048x512
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [128, 16]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [128, 16]}
 //           CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -140,7 +140,7 @@ hal.executable @matmul_3136x24x96 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @matmul_3136x24x96
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [8, 224]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [8, 224]}
 //           CHECK-SAME:   workgroup_size = [2 : index, 32 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -217,7 +217,7 @@ hal.executable @matmul_196x64x192 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @matmul_196x64x192
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 28]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 28]}
 //           CHECK-SAME:   workgroup_size = [16 : index, 4 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -289,7 +289,7 @@ hal.executable @matmul_12544x96x16 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @matmul_12544x96x16
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 64]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [32, 64]}
 //           CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -366,7 +366,7 @@ hal.executable @matmul_49x160x576 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @matmul_49x160x576
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [32, 7]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [32, 7]}
 //           CHECK-SAME:   workgroup_size = [8 : index, 1 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -454,7 +454,7 @@ hal.executable @batch_matmul_4x384x384 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @batch_matmul_4x384x384
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [128, 16, 1]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [128, 16, 1]}
 //           CHECK-SAME:   workgroup_size = [32 : index, 2 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %[[Z:.+]]: index):
 //           CHECK-NEXT:   %[[X_COUNT:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 128)>()[%[[X]]]
@@ -541,7 +541,7 @@ hal.executable @batch_matmul_4x8x8 {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @batch_matmul_4x8x8
-//           CHECK-SAME:   translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [8, 8, 1]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [8, 8, 1]}
 //           CHECK-SAME:   workgroup_size = [2 : index, 8 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %[[Z:.+]]: index):
 //           CHECK-NEXT:   %[[X_COUNT:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%[[X]]]

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
@@ -35,7 +35,7 @@ hal.executable private @static_1d_sort  {
 // Check that the workgroup count and size are (1, 1, 1) for serializing the computation.
 
 // CHECK-LABEL: hal.executable.entry_point public @static_1d_sort
-//  CHECK-SAME:   translation.info = {passPipeline = 6 : i32}
+//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize"}
 //  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
 //  CHECK-NEXT: ^{{.+}}(%{{.+}}: index, %{{.+}}: index, %{{.+}}: index):
 //  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -99,7 +99,7 @@ hal.executable private @static_3d_sort  {
 }
 
 //          CHECK-LABEL: hal.executable.entry_point public @static_3d_sort
-//           CHECK-SAME:   translation.info = {passPipeline = 5 : i32, workloadPerWorkgroup = [16, 1]}
+//           CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute", workloadPerWorkgroup = [16, 1]}
 //           CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
 //           CHECK-NEXT: ^{{.+}}(%[[X:.+]]: index, %[[Y:.+]]: index, %{{.+}}: index):
 //           CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -151,7 +151,7 @@ hal.executable private @static_1d_fft  {
 // Check that the workgroup count and size are (1, 1, 1) for serializing the computation.
 
 // CHECK-LABEL: hal.executable.entry_point public @static_1d_fft
-//  CHECK-SAME:   translation.info = {passPipeline = 6 : i32}
+//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize"}
 //  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
 //  CHECK-NEXT: ^{{.+}}(%{{.+}}: index, %{{.+}}: index, %{{.+}}: index):
 //  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
@@ -202,7 +202,7 @@ hal.executable private @static_3d_fft  {
 // Right now n-D fft does not support tiling too.
 
 // CHECK-LABEL: hal.executable.entry_point public @static_3d_fft
-//  CHECK-SAME:   translation.info = {passPipeline = 6 : i32}
+//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize"}
 //  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
 //  CHECK-NEXT: ^{{.+}}(%{{.+}}: index, %{{.+}}: index, %{{.+}}: index):
 //  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
@@ -49,7 +49,7 @@ hal.executable @tensor_insert {
 }
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = 5 : i32, workloadPerWorkgroup = [64, 1]}
+// CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute", workloadPerWorkgroup = [64, 1]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = constant 1 : index
@@ -103,7 +103,7 @@ hal.executable @tensor_insert {
 //  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 16], [], [1, 1]{{\]}}}
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = 5 : i32, workloadPerWorkgroup = [16, 1]}
+// CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute", workloadPerWorkgroup = [16, 1]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = constant 1 : index

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -13,7 +13,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
     hal.executable.entry_point @fuse_and_vectorize_fill_matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8]}
     }
     builtin.module {
       func @fuse_and_vectorize_fill_matmul() {
@@ -83,7 +83,7 @@ hal.executable private @fuse_and_vectorize_matmul_add  {
     hal.executable.entry_point @fuse_and_vectorize_matmul_add attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8]}
     }
     builtin.module {
       func @fuse_and_vectorize_matmul_add() {

--- a/iree/compiler/Codegen/SPIRV/test/remove_one_trip_tiled_loop.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/remove_one_trip_tiled_loop.mlir
@@ -9,7 +9,7 @@ hal.executable private @static_shaped_conv  {
   hal.executable.variant @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirv-fb"> {
     hal.executable.entry_point @static_shaped_conv attributes {
       interface = @io, ordinal = 0 : index,
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [16, 4, 4]},
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 4, 4]},
       workgroup_size = [4 : index, 4 : index, 1 : index]
     }
     builtin.module {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -12,7 +12,7 @@ hal.executable private @batch_matmul_static_shape  {
     hal.executable.entry_point @batch_matmul_static_shape attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8, 1]}
     }
     builtin.module {
       func @batch_matmul_static_shape() {
@@ -380,7 +380,7 @@ hal.executable private @fused_fill_batch_matmul  {
     hal.executable.entry_point @fused_fill_batch_matmul attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8, 1]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8, 1]}
     }
     builtin.module {
       func @fused_fill_batch_matmul() {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -13,7 +13,7 @@ hal.executable private @conv_static_shape_f32  {
       interface = @io,
       ordinal = 0 : index,
       workgroup_size = [4: index, 4: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [16, 4, 4]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 4, 4]}
     } {
     ^bb0(%arg0 : index, %arg1 : index, %arg2 : index):
       %x = constant 2: index
@@ -112,7 +112,7 @@ hal.executable private @depthwise_conv_static_shape_f32  {
       interface = @io,
       ordinal = 0 : index,
       workgroup_size = [8: index, 2: index, 2: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [16, 4, 4]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 4, 4]}
     } {
     ^bb0(%arg0 : index, %arg1 : index, %arg2 : index):
       %x = constant 6: index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -12,7 +12,7 @@ hal.executable private @matmul_static_shape_f16  {
     hal.executable.entry_point @matmul_static_shape_f16 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8]}
     }
     builtin.module {
       func @matmul_static_shape_f16() {
@@ -78,7 +78,7 @@ hal.executable private @matmul_static_shape_f32  {
     hal.executable.entry_point @matmul_static_shape_f32 attributes {
       interface = @io, ordinal = 0 : index,
       workgroup_size = [16: index, 1: index, 1: index],
-      translation.info = {passPipeline = 6 : i32, workloadPerWorkgroup = [64, 8]}
+      translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [64, 8]}
     }
     builtin.module {
       func @matmul_static_shape_f32() {

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.cpp
@@ -28,8 +28,7 @@ IREE::HAL::TranslationInfo buildTranslationInfo(
     IREE::HAL::DispatchLoweringPassPipeline passPipeline,
     ArrayRef<int64_t> workloadPerWorkgroup, MLIRContext *context) {
   OpBuilder builder(context);
-  auto pipelineAttr =
-      IREE::HAL::DispatchLoweringPassPipelineAttr::get(context, passPipeline);
+  auto pipelineAttr = StringAttr::get(context, stringifyEnum(passPipeline));
   ArrayAttr workloadPerWorkgroupAttr = nullptr;
   if (!workloadPerWorkgroup.empty()) {
     workloadPerWorkgroupAttr = builder.getI64ArrayAttr(workloadPerWorkgroup);

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
@@ -62,7 +62,7 @@ IREE::HAL::TranslationInfo getTranslationInfo(
 /// Get the pass pipeline specified in the `translationInfo`
 inline Optional<IREE::HAL::DispatchLoweringPassPipeline>
 getLoweringPassPipeline(IREE::HAL::TranslationInfo translationInfo) {
-  return IREE::HAL::symbolizeEnum<IREE::HAL::DispatchLoweringPassPipeline>(
+  return IREE::HAL::symbolizeDispatchLoweringPassPipeline(
       translationInfo.passPipeline().getValue());
 }
 
@@ -154,7 +154,7 @@ inline SmallVector<int64_t, 4> getNativeVectorSize(Operation *op) {
 /// Get the pass pipeline specified in the `loweringConfig`
 inline Optional<IREE::HAL::DispatchLoweringPassPipeline>
 getLoweringPassPipeline(IREE::HAL::LoweringConfig config) {
-  return IREE::HAL::symbolizeEnum<IREE::HAL::DispatchLoweringPassPipeline>(
+  return IREE::HAL::symbolizeDispatchLoweringPassPipeline(
       config.passPipeline().getValue());
 }
 

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.h
@@ -59,6 +59,13 @@ IREE::HAL::TranslationInfo buildTranslationInfo(
 IREE::HAL::TranslationInfo getTranslationInfo(
     IREE::HAL::ExecutableEntryPointOp entryPointOp);
 
+/// Get the pass pipeline specified in the `translationInfo`
+inline Optional<IREE::HAL::DispatchLoweringPassPipeline>
+getLoweringPassPipeline(IREE::HAL::TranslationInfo translationInfo) {
+  return IREE::HAL::symbolizeEnum<IREE::HAL::DispatchLoweringPassPipeline>(
+      translationInfo.passPipeline().getValue());
+}
+
 /// Returns the workgroup size specified on the `entryPointOp`.
 SmallVector<int64_t> getWorkgroupSize(
     IREE::HAL::ExecutableEntryPointOp entryPointOp);
@@ -142,6 +149,13 @@ inline SmallVector<int64_t, 4> getNativeVectorSize(Operation *op) {
   auto configAttr = getLoweringConfig(op);
   if (!configAttr) return {};
   return getNativeVectorSize(configAttr);
+}
+
+/// Get the pass pipeline specified in the `loweringConfig`
+inline Optional<IREE::HAL::DispatchLoweringPassPipeline>
+getLoweringPassPipeline(IREE::HAL::LoweringConfig config) {
+  return IREE::HAL::symbolizeEnum<IREE::HAL::DispatchLoweringPassPipeline>(
+      config.passPipeline().getValue());
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
+++ b/iree/compiler/Dialect/HAL/IR/LoweringConfig.td
@@ -11,27 +11,27 @@ include "iree/compiler/Dialect/HAL/IR/HALDialect.td"
 
 // List of pre-existing pipelines for translating executables.
 def CPU_Default
-    : I32EnumAttrCase<"CPUDefault", 0>;
+    : StrEnumAttrCase<"CPUDefault">;
 def CPU_Vectorization
-    : I32EnumAttrCase<"CPUVectorization", 1>;
+    : StrEnumAttrCase<"CPUVectorization">;
 def LLVMGPU_SimpleDistribute
-    : I32EnumAttrCase<"LLVMGPUDistribute", 2>;
+    : StrEnumAttrCase<"LLVMGPUDistribute">;
 def LLVMGPU_Vectorize
-    : I32EnumAttrCase<"LLVMGPUVectorize", 3>;
+    : StrEnumAttrCase<"LLVMGPUVectorize">;
 def LLVMGPU_MatmulSimt
-    : I32EnumAttrCase<"LLVMGPUMatmulSimt", 4>;
+    : StrEnumAttrCase<"LLVMGPUMatmulSimt">;
 def SPIRV_SimpleDistribute
-    : I32EnumAttrCase<"SPIRVDistribute", 5>;
+    : StrEnumAttrCase<"SPIRVDistribute">;
 def SPIRV_Vectorize
-    : I32EnumAttrCase<"SPIRVVectorize", 6>;
+    : StrEnumAttrCase<"SPIRVVectorize">;
 def SPIRV_DistributeToGlobalID
-    : I32EnumAttrCase<"SPIRVDistributeToGlobalID", 7>;
+    : StrEnumAttrCase<"SPIRVDistributeToGlobalID">;
 def None
-    : I32EnumAttrCase<"None", 0x7FFFFFFF>;
+    : StrEnumAttrCase<"None">;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
 // to scalar/native-vector code.
-def DispatchLoweringPassPipelineEnum : I32EnumAttr<
+def DispatchLoweringPassPipelineEnum : StrEnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_Vectorization, LLVMGPU_SimpleDistribute,


### PR DESCRIPTION
Using `I32AttrEnum` is not maintainable. Adding a new pipeline enum in
the middle will have unintended consequences. String attributes are
more managable here.

Depends on PR #7006 