### PR TITLE
Fix conversion of vm.list.alloc to not crash on missing capacity.

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertListOps.cpp
@@ -27,9 +27,14 @@ class ListCreateOpConversion
       IREE::Util::ListCreateOp srcOp, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     IREE::Util::ListCreateOpAdaptor srcOperands(operands);
+    Value initialCapacity = srcOperands.initial_capacity();
+    if (!initialCapacity) {
+      initialCapacity = rewriter.create<IREE::VM::ConstI32Op>(
+          srcOp.getLoc(), rewriter.getI32IntegerAttr(0));
+    }
     rewriter.replaceOpWithNewOp<IREE::VM::ListAllocOp>(
         srcOp, typeConverter->convertType(srcOp.result().getType()),
-        srcOperands.initial_capacity());
+        initialCapacity);
     return success();
   }
 };

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/list_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/list_ops.mlir
@@ -32,6 +32,10 @@ module @list_ops { module {
     // CHECK: vm.list.set.ref %[[LIST]], %c11, %[[BUFFER_VIEW]] : (!vm.list<?>, i32, !vm.ref<!hal.buffer_view>)
     util.list.set %list[%c11], %buffer_view : !hal.buffer_view -> !util.list<?>
 
+    // CHECK: %[[ZERO_CAPACITY:.+]] = vm.const.i32 0
+    // CHECK: %[[LIST:.+]] = vm.list.alloc %[[ZERO_CAPACITY]] : (i32) -> !vm.list<?>
+    %list_no_capacity = util.list.create : !util.list<?>
+
     return
   }
 } }


### PR DESCRIPTION
* Upper layer dialects have this as optional but VM does not.