### PR TITLE
Adjust PR comment benchmark similar threshold for noisy benchmarks

### DIFF
--- a/build_tools/benchmarks/common/noisy_benchmarks.py
+++ b/build_tools/benchmarks/common/noisy_benchmarks.py
@@ -13,12 +13,10 @@ import re
 # - A threshold for computing the benchmark value average. Benchmark sample
 #   values from consecutive runs and within the given range will be considered
 #   as similar (with some noise). They will be used to compute the moving
-#   average. It is a string that sent to Dana as API call JSON payloadsdirectly.
-#   There are two formats supported: a percentage or an absolute value. So we
-#   use a string here. What value to set depends on the noise range of the
-#   particular benchmark.
+#   average. The number will be interpreted as a percentage. What value to set
+#   depends on the noise range of the particular benchmark.
 NOISY_BENCHMARKS = [
-    (re.compile(r"^DeepLabV3.*GPU-Mali-G77"), "100%"),
-    (re.compile(r"^MobileSSD.*GPU-Mali-G77"), "100%"),
-    (re.compile(r"^PoseNet.*GPU-Mali-G77"), "100%"),
+    (re.compile(r"^DeepLabV3.*GPU-Mali-G77"), 100),
+    (re.compile(r"^MobileSSD.*GPU-Mali-G77"), 100),
+    (re.compile(r"^PoseNet.*GPU-Mali-G77"), 100),
 ]

--- a/build_tools/benchmarks/common/noisy_benchmarks.py
+++ b/build_tools/benchmarks/common/noisy_benchmarks.py
@@ -18,7 +18,7 @@ import re
 #   use a string here. What value to set depends on the noise range of the
 #   particular benchmark.
 NOISY_BENCHMARKS = [
-    (re.compile(r"^PoseNet.*GPU-Mali-G77"), "100%"),
     (re.compile(r"^DeepLabV3.*GPU-Mali-G77"), "100%"),
     (re.compile(r"^MobileSSD.*GPU-Mali-G77"), "100%"),
+    (re.compile(r"^PoseNet.*GPU-Mali-G77"), "100%"),
 ]

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -270,10 +270,7 @@ def categorize_benchmarks_into_tables(benchmarks: Dict[
     # Set different threshold for noisy benchmarks.
     for regex, threshold in NOISY_BENCHMARKS:
       if regex.match(name):
-        if threshold.endswith("%"):
-          similar_threshold = float(threshold.rstrip("%")) / 100
-        else:
-          raise ValueError("Absolute threshold value support unimplemented")
+        similar_threshold = float(threshold) / 100
         break
 
     current = results.mean_time

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -56,7 +56,7 @@ IREE_PROJECT_ID = 'IREE'
 MAX_BASE_COMMIT_QUERY_COUNT = 10
 PERFBOARD_SERIES_PREFIX = "https://perf.iree.dev/serie?IREE?"
 # The ratio below which benchmarks will be considered as similar with base.
-SIMILAR_BECNHMARK_THRESHOLD = 0.05
+DEFAULT_SIMILAR_BECNHMARK_THRESHOLD = 0.05
 # The max number of rows to show per table.
 TABLE_SIZE_CUT = 3
 THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
@@ -159,12 +159,6 @@ def aggregate_all_benchmarks(
       if name in aggregate_results:
         raise ValueError(f"Duplicated benchmarks: {name}")
 
-      # Filter noisy benchmarks out.
-      if any([regex.match(name) is not None for regex, _ in NOISY_BENCHMARKS]):
-        if verbose:
-          print(f"Skipping noisy benchmark '{name}'")
-        continue
-
       # Now scan all benchmark iterations and find the aggregate results.
       mean_time = file_results.get_aggregate_time(benchmark_index, "mean")
       median_time = file_results.get_aggregate_time(benchmark_index, "median")
@@ -256,14 +250,12 @@ def sort_benchmarks_and_get_table(benchmarks: Dict[str,
 
 def categorize_benchmarks_into_tables(benchmarks: Dict[
     str, AggregateBenchmarkLatency],
-                                      similar_threshold: float,
                                       size_cut: Optional[int] = None) -> str:
   """Splits benchmarks into regressed/improved/similar/raw categories and
   returns their markdown tables.
 
     Args:
-    - similar_threshold: the threshold under which a benchmark will be
-        considered as similar to its base commit.
+    - benchmarks: A dictionary of benchmark names to its aggregate info.
     - size_cut: If not None, only show the top N results for each table.
     """
   regressed, improved, similar, raw = {}, {}, {}, {}
@@ -273,6 +265,16 @@ def categorize_benchmarks_into_tables(benchmarks: Dict[
     if results.base_mean_time is None:
       raw[name] = results
       continue
+
+    similar_threshold = DEFAULT_SIMILAR_BECNHMARK_THRESHOLD
+    # Set different threshold for noisy benchmarks.
+    for regex, threshold in NOISY_BENCHMARKS:
+      if regex.match(name):
+        if threshold.endswith("%"):
+          similar_threshold = float(threshold.rstrip("%")) / 100
+        else:
+          raise ValueError("Absolute threshold value support unimplemented")
+        break
 
     current = results.mean_time
     base = results.base_mean_time
@@ -351,17 +353,13 @@ def get_benchmark_result_markdown(benchmark_files: Sequence[str],
   # Compose the full benchmark tables.
   full_table = [md.header("Full Benchmark Summary", 2)]
   full_table.append(md.unordered_list([commit_info, pr_info, buildkite_info]))
-  full_table.append(
-      categorize_benchmarks_into_tables(all_benchmarks,
-                                        SIMILAR_BECNHMARK_THRESHOLD))
+  full_table.append(categorize_benchmarks_into_tables(all_benchmarks))
 
   # Compose the abbreviated benchmark tables.
   abbr_table = [md.header(ABBR_PR_COMMENT_TITLE, 2)]
   abbr_table.append(commit_info)
   abbr_table.append(
-      categorize_benchmarks_into_tables(all_benchmarks,
-                                        SIMILAR_BECNHMARK_THRESHOLD,
-                                        TABLE_SIZE_CUT))
+      categorize_benchmarks_into_tables(all_benchmarks, TABLE_SIZE_CUT))
   abbr_table.append("For more information:")
   # We don't know until a Gist is really created. Use a placeholder for now
   # and replace later.

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -216,7 +216,7 @@ def add_new_iree_series(series_id: str,
   # Adjust average threshold for noisy benchmarks.
   for regex, threshold in NOISY_BENCHMARKS:
     if regex.match(series_id):
-      average_range = threshold
+      average_range = f'{threshold}%'
       break
 
   payload = compose_series_payload(IREE_PROJECT_ID,


### PR DESCRIPTION
Previously we were just omit all benchmarks marked as noisy. That
can miss real regressions sometime.