### PR TITLE
Integrate upstream cpp emitter change

### DIFF
--- a/third_party/mlir-emitc/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/third_party/mlir-emitc/lib/Target/Cpp/TranslateToCpp.cpp
@@ -526,14 +526,16 @@ bool CppEmitter::hasBlockLabel(Block &block) {
 }
 
 LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
-  auto printInt = [&](APInt val, bool isSigned) {
+  auto printInt = [&](APInt val, bool isUnsigned) {
     if (val.getBitWidth() == 1) {
       if (val.getBoolValue())
         os << "true";
       else
         os << "false";
     } else {
-      val.print(os, isSigned);
+      SmallString<128> strValue;
+      val.toString(strValue, 10, !isUnsigned, false);
+      os << strValue;
     }
   };
 


### PR DESCRIPTION
Takes over the upstream change
* llvm/llvm-project@ec92f78

to fix printing negative integers, reported as part of #7026.