### PR TITLE
Fix tensor.dim + flow.dispatch.tensor.load canonicalization

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/test/tile_pad_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_pad_and_vectorize.mlir
@@ -46,7 +46,9 @@ module  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
   }
 }
-// CHECK-LABEL: @dot_383x383x513_dispatch_0
+//     CHECK: #[[MAP1:.+]] = affine_map<(d0) -> (64, -d0 + 383)>
+//     CHECK: #[[MAP2:.+]] = affine_map<(d0) -> (64, -d0 + 513)>
+//     CHECK: @dot_383x383x513_dispatch_0
 // CHECK-DAG: %[[CST:.+]] = constant 0.000000e+00 : f32
 // CHECK-DAG: %[[C0:.+]] = constant 0 : index
 // CHECK-DAG: %[[C4:.+]] = constant 4 : index
@@ -56,12 +58,16 @@ module  {
 //     CHECK: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x383xf32>
 //     CHECK: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x513xf32>
 //     CHECK: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:383x513xf32>
+//     CHECK: scf.for %[[I_WG_IDX:.+]] = {{.*}} to %c383
+//     CHECK: scf.for %[[J_WG_IDX:.+]] = {{.*}} to %c513
+//     CHECK: %[[LHS_WG_TILE_DIM0:.+]] = affine.min #[[MAP1]](%[[I_WG_IDX]])
 //     CHECK: %[[LHS_WG_TILE:.+]] = flow.dispatch.tensor.load %[[LHS]]
+//     CHECK: %[[RHS_WG_TILE_DIM1:.+]] = affine.min #[[MAP2]](%[[J_WG_IDX]])
 //     CHECK: %[[RHS_WG_TILE:.+]] = flow.dispatch.tensor.load %[[RHS]]
 //     CHECK: %[[DST_WG_TILE_INIT:.+]] = linalg.init_tensor
 //     CHECK: %[[DST_WG_TILE_INIT_C0:.+]] = linalg.fill(%[[CST]], %[[DST_WG_TILE_INIT]])
-//     CHECK: {{.*}} = scf.for {{.*}} = %[[C0]] to %[[C383]] step %[[C32]] iter_args(%[[DST_WG_TILE_0:.+]] = %[[DST_WG_TILE_INIT_C0]])
-//     CHECK:    {{.*}} = scf.for {{.*}} = %[[C0]] to %[[C513]] step %[[C32]] iter_args(%[[DST_WG_TILE_1:.+]] = %[[DST_WG_TILE_0]])
+//     CHECK: {{.*}} = scf.for {{.*}} = %[[C0]] to %[[LHS_WG_TILE_DIM0]] step %[[C32]] iter_args(%[[DST_WG_TILE_0:.+]] = %[[DST_WG_TILE_INIT_C0]])
+//     CHECK:    {{.*}} = scf.for {{.*}} = %[[C0]] to %[[RHS_WG_TILE_DIM1]] step %[[C32]] iter_args(%[[DST_WG_TILE_1:.+]] = %[[DST_WG_TILE_0]])
 //     CHECK:       {{.*}} = scf.for {{.*}} = %[[C0]] to %[[C383]] step %[[C32]] iter_args(%[[DST_WG_TILE_2:.+]] = %[[DST_WG_TILE_1]])
 //     CHECK:           %[[LHS_L1_TILE:.+]] = tensor.extract_slice %[[LHS_WG_TILE]]
 //     CHECK:           %[[RHS_L1_TILE:.+]] = tensor.extract_slice %[[RHS_WG_TILE]]

--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -258,12 +258,15 @@ namespace {
 // arbitrarily late into the pipeline. Often, they keep alive
 // DispatchTensorLoadOp's that would otherwise be dead!
 //
-// To fix this, we convert the `std.dim` ops to `flow.dispatch.shape` ops.
+// To fix this:
+// (1) In the case of loading full tensor we convert the `std.dim` ops to
+// `flow.dispatch.shape` ops.
 // ```
 // dim(flow.dispatch.tensor.load(%x), %const)
 // ->
 // shapex.ranked_dim(flow.dispatch.shape(%x), %const)
 // ``
+// (2) When we are loading a tile we get replace dim with the size from sizes.
 struct ConvertDimOfDispatchInputLoadToDispatchShape
     : public OpRewritePattern<tensor::DimOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -276,10 +279,23 @@ struct ConvertDimOfDispatchInputLoadToDispatchShape
     Optional<int64_t> constantIndex = op.getConstantIndex();
     if (!constantIndex.hasValue()) return failure();
 
-    auto rankedShape =
-        rewriter.create<DispatchShapeOp>(op.getLoc(), loadOp.source());
-    rewriter.replaceOpWithNewOp<Shape::RankedDimOp>(op, rankedShape,
-                                                    *constantIndex);
+    // Full tensor:
+    if (loadOp.sizes().empty()) {
+      auto rankedShape =
+          rewriter.create<DispatchShapeOp>(op.getLoc(), loadOp.source());
+      rewriter.replaceOpWithNewOp<Shape::RankedDimOp>(op, rankedShape,
+                                                      *constantIndex);
+    } else {  // Tensor tile :
+      if (loadOp.getMixedSizes()[*constantIndex].is<Attribute>()) {
+        rewriter.replaceOpWithNewOp<ConstantOp>(
+            op, loadOp.getMixedSizes()[*constantIndex]
+                    .get<Attribute>()
+                    .dyn_cast<IntegerAttr>());
+      } else {
+        rewriter.replaceOp(
+            op, {loadOp.getMixedSizes()[*constantIndex].get<Value>()});
+      }
+    }
     return success();
   }
 };


### PR DESCRIPTION
This issue shows up when tile distributed linalg ops on tensors (progress towards #6973), this PR fixes the tile loop bounds.