### PR TITLE
Mmt4d: support arbitrary (M0,K0,N0) triplets and various cleanups.

### DIFF
--- a/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
+++ b/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
@@ -14,8 +14,8 @@ namespace iree_compiler {
 
 namespace {
 
-/// A pattern to convert tiled linalg.mmt4d into vector contract.
-/// This converts linalg.mmt4d with operands <1x1xM0xK0>, <1x1xK0,N0>
+/// Converts linalg.mmt4d into vector.contract.
+/// This converts linalg.mmt4d with operands <1x1xM0xK0>, <1x1xK0xN0>
 /// to vector.contract where K0 is the contraction dimension.
 struct VectorizeMMT4DOp : public OpRewritePattern<linalg::Mmt4DOp> {
   using OpRewritePattern<linalg::Mmt4DOp>::OpRewritePattern;
@@ -29,16 +29,28 @@ struct VectorizeMMT4DOp : public OpRewritePattern<linalg::Mmt4DOp> {
     auto lhsType = lhs.getType().dyn_cast<ShapedType>();
     auto rhsType = rhs.getType().dyn_cast<ShapedType>();
 
+    // This pattern expects tensors of static shapes.
+    // In practice, dynamic shapes are meant to be handled by other passes,
+    // ahead of this point. Dynamic outer dimensions (?x?xM0xK0) should be
+    // handled by a tiling pass typically running just ahead of the present
+    // pass. Dynamic inner dimensions (M1xK1x?x?) mean that the IR is not yet
+    // specialized to a specific SIMD ISA, and should be handled by dispatching
+    // to specialized code paths where these inner dimensions become static
+    // (M1xK1x?x? --> M1xK1xM0xK0)
     if (!lhsType || !rhsType || !lhsType.hasStaticShape() ||
         !rhsType.hasStaticShape())
       return failure();
 
-    int M1 = lhsType.getShape()[0];
-    int K1 = lhsType.getShape()[1];
-    int N1 = rhsType.getShape()[0];
+    // We expect the incoming mmt4d to already have been maximally tiled, so
+    // that the outer dimensions are equal to 1.
+    {
+      int M1 = lhsType.getShape()[0];
+      int K1 = lhsType.getShape()[1];
+      int N1 = rhsType.getShape()[0];
+      if (M1 != 1 || K1 != 1 || N1 != 1) return failure();
+    }
 
-    if (M1 != 1 || K1 != 1 || N1 != 1) return failure();
-
+    // Read the inner dimensions.
     int M0 = lhsType.getShape()[2];
     int N0 = rhsType.getShape()[2];
     int K0 = lhsType.getShape()[3];
@@ -56,50 +68,45 @@ struct VectorizeMMT4DOp : public OpRewritePattern<linalg::Mmt4DOp> {
 
     auto identityMap = rewriter.getMultiDimIdentityMap(4);
 
+    // Read the input tensors into vectors.
     auto lhsVec = rewriter.create<vector::TransferReadOp>(
         loc, lhsVecType, lhs, ValueRange{c0, c0, c0, c0}, identityMap);
-
     auto rhsVec = rewriter.create<vector::TransferReadOp>(
         loc, rhsVecType, rhs, ValueRange{c0, c0, c0, c0}, identityMap);
-
     auto dstVec = rewriter.create<vector::TransferReadOp>(
         loc, dstVecType, dst, ValueRange{c0, c0, c0, c0}, identityMap);
 
+    // Convert the input vectors from 4D shapes (1x1xM0xK0) to 2D shapes (M0xK0)
     Value lhsVec2D =
         rewriter.create<vector::ShapeCastOp>(loc, lhsVecType2D, lhsVec);
-
     Value rhsVec2D =
         rewriter.create<vector::ShapeCastOp>(loc, rhsVecType2D, rhsVec);
-
     Value dstVec2D =
         rewriter.create<vector::ShapeCastOp>(loc, dstVecType2D, dstVec);
 
+    // Generate the vector.contract on 2D vectors replacing the mmt4d op.
     auto m = rewriter.getAffineDimExpr(0);
     auto n = rewriter.getAffineDimExpr(1);
     auto k = rewriter.getAffineDimExpr(2);
-
     auto map0 = AffineMap::get(3, 0, {m, k}, rewriter.getContext());
     auto map1 = AffineMap::get(3, 0, {n, k}, rewriter.getContext());
     auto map2 = AffineMap::get(3, 0, {m, n}, rewriter.getContext());
-
     ArrayAttr indexingMaps = rewriter.getAffineMapArrayAttr({map0, map1, map2});
-
     ArrayAttr iterators = rewriter.getStrArrayAttr(
         {getParallelIteratorTypeName(), getParallelIteratorTypeName(),
          getReductionIteratorTypeName()});
-
     Value contractResult = rewriter.create<vector::ContractionOp>(
         loc, lhsVec2D, rhsVec2D, dstVec2D, indexingMaps, iterators);
 
+    // Convert the output vector from 2D shape (M0xN0) to 4D shape (1x1xM0xN0)
     Value contractResult4D =
         rewriter.create<vector::ShapeCastOp>(loc, dstVecType, contractResult);
 
+    // Replace the mmt4d op by the equivalent graph.
     rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
         mmt4DOp, contractResult4D, dst, ValueRange{c0, c0, c0, c0},
         identityMap);
-
     return success();
-    ;
   }
 };
 

--- a/iree/compiler/Codegen/Common/test/vectorize_linalg_mmt4d.mlir
+++ b/iree/compiler/Codegen/Common/test/vectorize_linalg_mmt4d.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -iree-codegen-vectorize-linalg-mmt4d -canonicalize -cse %s | IreeFileCheck %s
 
-func @tiled_mmt4d(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: memref<1x1x4x4xf32>) {
+func @tiled_mmt4d_4x4x4(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: memref<1x1x4x4xf32>) {
     linalg.mmt4d ins(%lhs, %rhs: memref<1x1x4x4xf32>, memref<1x1x4x4xf32>) outs(%dst: memref<1x1x4x4xf32>)
     return
 }
@@ -8,7 +8,7 @@ func @tiled_mmt4d(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: me
 // CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK: func @tiled_mmt4d(%[[LHS:.+]]: memref<1x1x4x4xf32>, %[[RHS:.+]]: memref<1x1x4x4xf32>, %[[DST:.+]]: memref<1x1x4x4xf32>
+// CHECK: func @tiled_mmt4d_4x4x4(%[[LHS:.+]]: memref<1x1x4x4xf32>, %[[RHS:.+]]: memref<1x1x4x4xf32>, %[[DST:.+]]: memref<1x1x4x4xf32>
 //      CHECK:   %[[LHS_4DVEC:.+]] = vector.transfer_read %[[LHS]]
 //      CHECK:   %[[RHS_4DVEC:.+]] = vector.transfer_read %[[RHS]]
 //      CHECK:   %[[DST_4DVEC:.+]] = vector.transfer_read %[[DST]]
@@ -20,4 +20,32 @@ func @tiled_mmt4d(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: me
 // CHECK-SAME:        iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
 // CHECK-SAME:        %[[LHS_2DVEC]], %[[RHS_2DVEC]], %[[DST_2DVEC]] : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
 //      CHECK:   %[[RESULT_4D:.+]] = vector.shape_cast %[[RESULT_2D]] : vector<4x4xf32> to vector<1x1x4x4xf32>
+
+func @tiled_mmt4d(%lhs: memref<1x1x4x4xf32>, %rhs: memref<1x1x4x4xf32>, %dst: memref<1x1x4x4xf32>) {
+    linalg.mmt4d ins(%lhs, %rhs: memref<1x1x4x4xf32>, memref<1x1x4x4xf32>) outs(%dst: memref<1x1x4x4xf32>)
+    return
+}
+
+// -----
+
+func @tiled_mmt4d_8x2x4(%lhs: memref<1x1x8x2xf32>, %rhs: memref<1x1x4x2xf32>, %dst: memref<1x1x8x4xf32>) {
+    linalg.mmt4d ins(%lhs, %rhs: memref<1x1x8x2xf32>, memref<1x1x4x2xf32>) outs(%dst: memref<1x1x8x4xf32>)
+    return
+}
+
+// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK: func @tiled_mmt4d_8x2x4(%[[LHS:.+]]: memref<1x1x8x2xf32>, %[[RHS:.+]]: memref<1x1x4x2xf32>, %[[DST:.+]]: memref<1x1x8x4xf32>
+//      CHECK:   %[[LHS_4DVEC:.+]] = vector.transfer_read %[[LHS]]
+//      CHECK:   %[[RHS_4DVEC:.+]] = vector.transfer_read %[[RHS]]
+//      CHECK:   %[[DST_4DVEC:.+]] = vector.transfer_read %[[DST]]
+//      CHECK:   %[[LHS_2DVEC:.+]] = vector.shape_cast %[[LHS_4DVEC]] : vector<1x1x8x2xf32> to vector<8x2xf32>
+//      CHECK:   %[[RHS_2DVEC:.+]] = vector.shape_cast %[[RHS_4DVEC]] : vector<1x1x4x2xf32> to vector<4x2xf32>
+//      CHECK:   %[[DST_2DVEC:.+]] = vector.shape_cast %[[DST_4DVEC]] : vector<1x1x8x4xf32> to vector<8x4xf32>
+//      CHECK:   %[[RESULT_2D:.+]] = vector.contract
+// CHECK-SAME:        indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+// CHECK-SAME:        %[[LHS_2DVEC]], %[[RHS_2DVEC]], %[[DST_2DVEC]] : vector<8x2xf32>, vector<4x2xf32> into vector<8x4xf32>
+//      CHECK:   %[[RESULT_4D:.+]] = vector.shape_cast %[[RESULT_2D]] : vector<8x4xf32> to vector<1x1x8x4xf32>
 

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -33,6 +33,7 @@ cc_library(
     srcs = [
         "ConvertConv2D1x1ToMatmulPass.cpp",
         "ConvertConv2DToImg2ColPass.cpp",
+        "ConvertLinalgMatmulToMmt4D.cpp",
         "ConvertToFlow.cpp",
         "DeduplicateExecutables.cpp",
         "DestructiveUpdateUtils.cpp",
@@ -45,7 +46,6 @@ cc_library(
         "InjectDispatchTracing.cpp",
         "InsertConstantClones.cpp",
         "InterchangeGenericOps.cpp",
-        "MatmulToMMT4dConversion.cpp",
         "OutlineDispatchRegions.cpp",
         "OutlineLargeConstants.cpp",
         "PadLinalgOps.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
   SRCS
     "ConvertConv2D1x1ToMatmulPass.cpp"
     "ConvertConv2DToImg2ColPass.cpp"
+    "ConvertLinalgMatmulToMmt4D.cpp"
     "ConvertToFlow.cpp"
     "DeduplicateExecutables.cpp"
     "DestructiveUpdateUtils.cpp"
@@ -42,7 +43,6 @@ iree_cc_library(
     "InjectDispatchTracing.cpp"
     "InsertConstantClones.cpp"
     "InterchangeGenericOps.cpp"
-    "MatmulToMMT4dConversion.cpp"
     "OutlineDispatchRegions.cpp"
     "OutlineLargeConstants.cpp"
     "PadLinalgOps.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/MatmulToMMT4dConversion.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/MatmulToMMT4dConversion.cpp
@@ -19,6 +19,8 @@ namespace Flow {
 namespace {
 
 // Expands a 2d tensor operand to 4d given its target shape.
+// Does not transpose.
+// Example: (M, N) --> (M1, M0, N1, N0)
 static Value expandTo4D(mlir::Location loc, PatternRewriter &rewriter,
                         Value operand, ArrayRef<int64_t> targetShape) {
   auto operandType = operand.getType().cast<RankedTensorType>();
@@ -31,8 +33,9 @@ static Value expandTo4D(mlir::Location loc, PatternRewriter &rewriter,
 }
 
 // Creates a linalg.generic that transposes operand using permutation indices.
-static Value transposeOperand(mlir::Location loc, PatternRewriter &rewriter,
-                              Value operand, ArrayRef<int64_t> indices) {
+// Example: (M1, M0, N1, N0) -> (M1, N1, M0, N0) if indices = {0, 2, 1, 3}.
+static Value transpose(mlir::Location loc, PatternRewriter &rewriter,
+                       Value operand, ArrayRef<int64_t> indices) {
   RankedTensorType operandTensorType =
       operand.getType().cast<RankedTensorType>();
   auto nloops = indices.size();
@@ -68,6 +71,7 @@ static Value transposeOperand(mlir::Location loc, PatternRewriter &rewriter,
 };
 
 // Collapses a 4d tensor operand to 2d given its target shape.
+// Example: (M1, M0, N1, N0) -> (M, N)
 static Value collapseTo2D(mlir::Location loc, PatternRewriter &rewriter,
                           Value operand, ArrayRef<int64_t> targetShape) {
   auto operandType = operand.getType().cast<RankedTensorType>();
@@ -79,18 +83,18 @@ static Value collapseTo2D(mlir::Location loc, PatternRewriter &rewriter,
   return reshapedOperand;
 }
 
-// Converts linalg.matmul -> linalg.mmt4d where M0, N0, K0 are compile time
-// constants.
+// Converts linalg.matmul to an equivalent subgraph using linalg.mmt4d.
+// Currently, M0, N0, K0 are compile time constants.
 // TODO(ataei): Move this pattern to linalg transforms upstream.
 class LinalgMatmulOpToLinalgMMT4dOpPattern
     : public OpRewritePattern<linalg::MatmulOp> {
  public:
-  LinalgMatmulOpToLinalgMMT4dOpPattern(MLIRContext *context, int M0, int N0,
-                                       int K0, PatternBenefit benefit = 1)
+  LinalgMatmulOpToLinalgMMT4dOpPattern(MLIRContext *context, int M0, int K0,
+                                       int N0, PatternBenefit benefit = 1)
       : OpRewritePattern<linalg::MatmulOp>(context, benefit),
-        M0Size(M0),
-        N0Size(N0),
-        K0Size(K0) {}
+        M0(M0),
+        K0(K0),
+        N0(N0) {}
 
   LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
                                 PatternRewriter &rewriter) const override {
@@ -114,28 +118,28 @@ class LinalgMatmulOpToLinalgMMT4dOpPattern
       return failure();
 
     int m = lhsType.getShape()[0];
-    int n = rhsType.getShape()[1];
     int k = rhsType.getShape()[0];
+    int n = rhsType.getShape()[1];
 
-    if (m % M0Size != 0 || n % N0Size != 0 || k % K0Size != 0) return failure();
+    if (m % M0 != 0 || n % N0 != 0 || k % K0 != 0) return failure();
 
-    int m1 = m / M0Size;
-    int n1 = n / N0Size;
-    int k1 = k / K0Size;
+    int m1 = m / M0;
+    int k1 = k / K0;
+    int n1 = n / N0;
 
-    auto lhs4D = expandTo4D(loc, rewriter, lhs, {m1, M0Size, k1, K0Size});
-    auto rhs4D = expandTo4D(loc, rewriter, rhs, {k1, K0Size, n1, N0Size});
-    auto dst4D = expandTo4D(loc, rewriter, dst, {m1, M0Size, n1, N0Size});
+    auto lhs4D = expandTo4D(loc, rewriter, lhs, {m1, M0, k1, K0});
+    auto rhs4D = expandTo4D(loc, rewriter, rhs, {k1, K0, n1, N0});
+    auto dst4D = expandTo4D(loc, rewriter, dst, {m1, M0, n1, N0});
 
-    auto lhs4DT = transposeOperand(loc, rewriter, lhs4D, {0, 2, 1, 3});
-    auto rhs4DT = transposeOperand(loc, rewriter, rhs4D, {2, 0, 3, 1});
-    auto dst4DT = transposeOperand(loc, rewriter, dst4D, {0, 2, 1, 3});
+    auto lhs4DT = transpose(loc, rewriter, lhs4D, {0, 2, 1, 3});
+    auto rhs4DT = transpose(loc, rewriter, rhs4D, {2, 0, 3, 1});
+    auto dst4DT = transpose(loc, rewriter, dst4D, {0, 2, 1, 3});
 
     auto mmt4DResult = rewriter.create<linalg::Mmt4DOp>(
         loc, dst4DT.getType(), ValueRange{lhs4DT, rhs4DT}, ValueRange{dst4DT});
 
     auto mmt4dResultTransposed =
-        transposeOperand(loc, rewriter, mmt4DResult.getResult(0), {0, 2, 1, 3});
+        transpose(loc, rewriter, mmt4DResult.getResult(0), {0, 2, 1, 3});
 
     Value result = collapseTo2D(loc, rewriter, mmt4dResultTransposed, {m, n});
 
@@ -145,9 +149,9 @@ class LinalgMatmulOpToLinalgMMT4dOpPattern
   }
 
  private:
-  int M0Size;
-  int N0Size;
-  int K0Size;
+  const int M0;
+  const int K0;
+  const int N0;
 };
 
 /// Canonicalizes [linalg.init_tensor -> linalg.fill -> linalg.generic] ->
@@ -226,8 +230,8 @@ class ConvertLinalgMatmulOpToLinalgMMT4dPass final
     // Main pattern.
     {
       OwningRewritePatternList patterns(&getContext());
-      patterns.insert<LinalgMatmulOpToLinalgMMT4dOpPattern>(context, M0, N0,
-                                                            K0);
+      patterns.insert<LinalgMatmulOpToLinalgMMT4dOpPattern>(context, M0, K0,
+                                                            N0);
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }
     // Canonicalization.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -60,11 +60,6 @@ static llvm::cl::opt<int> clLinalgOpsPaddingSize(
                    "flow-padding-size"),
     llvm::cl::init(4));
 
-static llvm::cl::opt<bool> clEnableMatmulToMMT4d(
-    "iree-flow-enable-matmul-to-mmt4d",
-    llvm::cl::desc("Enable converting linalg.matmul into linalg.mmt4d"),
-    llvm::cl::init(false));
-
 // TODO(#1159): enable by default or remove this option once it works on
 //              a broader set of programs
 static llvm::cl::opt<bool> clEnableLinalgDetensorize(
@@ -118,13 +113,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
     if (clEnablePaddingLinalgOps) {
       passManager.addNestedPass<FuncOp>(
           createPadLinalgOpsToIntegerMultiplePass(clLinalgOpsPaddingSize));
-    }
-    // Convert linalg.matmul -> linalg.mmt4d
-    if (clEnableMatmulToMMT4d) {
-      passManager.addNestedPass<FuncOp>(
-          createConvertLinalgMatmulOpToLinalgMMT4dPass(clLinalgOpsPaddingSize,
-                                                       clLinalgOpsPaddingSize,
-                                                       clLinalgOpsPaddingSize));
     }
   }
   passManager.addPass(createPadTensorToSubTensorInsertPass());

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -57,8 +57,7 @@ std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
 
 /// Pass to convert a linalg.matmul into linalg.mmt4d given M0, N0 and K0 are
 /// compile time constants.
-std::unique_ptr<OperationPass<FuncOp>>
-createConvertLinalgMatmulOpToLinalgMMT4dPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass();
 
 /// Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -58,8 +58,7 @@ std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
 /// Pass to convert a linalg.matmul into linalg.mmt4d given M0, N0 and K0 are
 /// compile time constants.
 std::unique_ptr<OperationPass<FuncOp>>
-createConvertLinalgMatmulOpToLinalgMMT4dPass(int M0 = 4, int N0 = 4,
-                                             int K0 = 4);
+createConvertLinalgMatmulOpToLinalgMMT4dPass();
 
 /// Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -112,10 +112,10 @@ def PadLinalgOps :
   let constructor = "mlir::iree_compiler::IREE::Flow::createPadLinalgOpsToIntegerMultiplePass()";
 }
 
-def ConvertMatmulToMMT4d :
-    Pass<"iree-flow-convert-matmul-to-mmt4d", "FuncOp"> {
+def ConvertLinalgMatmulToMmt4D :
+    Pass<"iree-flow-convert-linalg-matmul-to-mmt4d", "FuncOp"> {
   let summary = "Convert linalg.matmul to linalg.mmt4d";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulOpToLinalgMMT4dPass()";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulToMmt4DPass()";
   let options = [
     Option<"M0", "M0", "int", /*default=*/"mlir::ShapedType::kDynamicSize",
            "Specifies an explicit M-axis tile size, overriding the default heuristic.">,

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -116,6 +116,14 @@ def ConvertMatmulToMMT4d :
     Pass<"iree-flow-convert-matmul-to-mmt4d", "FuncOp"> {
   let summary = "Convert linalg.matmul to linalg.mmt4d";
   let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulOpToLinalgMMT4dPass()";
+  let options = [
+    Option<"M0", "M0", "int", /*default=*/"mlir::ShapedType::kDynamicSize",
+           "Specifies an explicit M-axis tile size, overriding the default heuristic.">,
+    Option<"K0", "K0", "int", /*default=*/"mlir::ShapedType::kDynamicSize",
+           "Specifies an explicit K-axis tile size, overriding the default heuristic.">,
+    Option<"N0", "N0", "int", /*default=*/"mlir::ShapedType::kDynamicSize",
+           "Specifies an explicit N-axis tile size, overriding the default heuristic.">,
+  ];
 }
 
 

--- a/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file --iree-flow-convert-matmul-to-mmt4d='M0=8 K0=2 N0=4' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file --iree-flow-convert-linalg-matmul-to-mmt4d='M0=8 K0=2 N0=4' %s | IreeFileCheck %s
 
 func @check_mmt4d(%arg0: tensor<24x8xf32>, %arg1: tensor<8x32xf32>, %arg2: tensor<24x32xf32>) -> tensor<24x32xf32> {
     %0 = linalg.matmul ins(%arg0, %arg1 : tensor<24x8xf32>, tensor<8x32xf32>) outs(%arg2 : tensor<24x32xf32>) -> tensor<24x32xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file --iree-flow-convert-matmul-to-mmt4d %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file --iree-flow-convert-matmul-to-mmt4d='M0=4 K0=4 N0=4' %s | IreeFileCheck %s
 
 func @check_mmt4d(%arg0: tensor<24x8xf32>, %arg1: tensor<8x32xf32>, %arg2: tensor<24x32xf32>) -> tensor<24x32xf32> {
     %0 = linalg.matmul ins(%arg0, %arg1 : tensor<24x8xf32>, tensor<8x32xf32>) outs(%arg2 : tensor<24x32xf32>) -> tensor<24x32xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/matmul_to_mmt4d.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file --iree-flow-convert-matmul-to-mmt4d='M0=4 K0=4 N0=4' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file --iree-flow-convert-matmul-to-mmt4d='M0=8 K0=2 N0=4' %s | IreeFileCheck %s
 
 func @check_mmt4d(%arg0: tensor<24x8xf32>, %arg1: tensor<8x32xf32>, %arg2: tensor<24x32xf32>) -> tensor<24x32xf32> {
     %0 = linalg.matmul ins(%arg0, %arg1 : tensor<24x8xf32>, tensor<8x32xf32>) outs(%arg2 : tensor<24x32xf32>) -> tensor<24x32xf32>
@@ -9,46 +9,46 @@ func @check_mmt4d(%arg0: tensor<24x8xf32>, %arg1: tensor<8x32xf32>, %arg2: tenso
 // CHECK-DAG:#[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3, d0, d2)>
 //      CHECK: @check_mmt4d(%[[LHS:.+]]: tensor<24x8xf32>, %[[RHS:.+]]: tensor<8x32xf32>, %[[DST:.+]]: tensor<24x32xf32>)
 //      CHECK: %[[LHS4D:.+]] = linalg.tensor_expand_shape %[[LHS]]
-// CHECK-SAME:   tensor<24x8xf32> into tensor<6x4x2x4xf32>
+// CHECK-SAME:   tensor<24x8xf32> into tensor<3x8x4x2xf32>
 //      CHECK: %[[RHS4D:.+]] = linalg.tensor_expand_shape %[[RHS]]
-// CHECK-SAME:   tensor<8x32xf32> into tensor<2x4x8x4xf32>
+// CHECK-SAME:   tensor<8x32xf32> into tensor<4x2x8x4xf32>
 //      CHECK: %[[DST4D:.+]] = linalg.tensor_expand_shape %[[DST]]
-// CHECK-SAME:   tensor<24x32xf32> into tensor<6x4x8x4xf32>
-//      CHECK: %[[LHS4DT_INIT:.+]] = linalg.init_tensor [6, 2, 4, 4] : tensor<6x2x4x4xf32>
+// CHECK-SAME:   tensor<24x32xf32> into tensor<3x8x8x4xf32>
+//      CHECK: %[[LHS4DT_INIT:.+]] = linalg.init_tensor [3, 4, 8, 2] : tensor<3x4x8x2xf32>
 //      CHECK: %[[LHS4DT:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP0]], #[[MAP1]]]
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel"]
-// CHECK-SAME:   ins(%[[LHS4D]] : tensor<6x4x2x4xf32>) outs(%[[LHS4DT_INIT]] : tensor<6x2x4x4xf32>) {
+// CHECK-SAME:   ins(%[[LHS4D]] : tensor<3x8x4x2xf32>) outs(%[[LHS4DT_INIT]] : tensor<3x4x8x2xf32>) {
 // CHECK-NEXT:     ^bb0(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:       linalg.yield
-// CHECK-NEXT:    } -> tensor<6x2x4x4xf32>
-//      CHECK: %[[RHS4DT_INIT:.+]] = linalg.init_tensor [8, 2, 4, 4] : tensor<8x2x4x4xf32>
+// CHECK-NEXT:    } -> tensor<3x4x8x2xf32>
+//      CHECK: %[[RHS4DT_INIT:.+]] = linalg.init_tensor [8, 4, 4, 2] : tensor<8x4x4x2xf32>
 //      CHECK: %[[RHS4DT:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP2]], #[[MAP1]]],
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel"]
-// CHECK-SAME:   ins(%[[RHS4D]] : tensor<2x4x8x4xf32>) outs(%[[RHS4DT_INIT]] : tensor<8x2x4x4xf32>) {
+// CHECK-SAME:   ins(%[[RHS4D]] : tensor<4x2x8x4xf32>) outs(%[[RHS4DT_INIT]] : tensor<8x4x4x2xf32>) {
 // CHECK-NEXT:     ^bb0(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:         linalg.yield %arg3 : f32
-// CHECK-NEXT:   } -> tensor<8x2x4x4xf32>
-// CHECK-NEXT: %[[DST4DT_INIT:.+]] = linalg.init_tensor [6, 8, 4, 4] : tensor<6x8x4x4xf32>
+// CHECK-NEXT:   } -> tensor<8x4x4x2xf32>
+// CHECK-NEXT: %[[DST4DT_INIT:.+]] = linalg.init_tensor [3, 8, 8, 4] : tensor<3x8x8x4xf32>
 //      CHECK: %[[DST4DT:.+]] = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[MAP0]], #[[MAP1]]]
 // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-// CHECK-SAME:    ins(%[[DST4D]] : tensor<6x4x8x4xf32>) outs(%[[DST4DT_INIT]] : tensor<6x8x4x4xf32>) {
+// CHECK-SAME:    ins(%[[DST4D]] : tensor<3x8x8x4xf32>) outs(%[[DST4DT_INIT]] : tensor<3x8x8x4xf32>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:          linalg.yield %arg3 : f32
-// CHECK-NEXT:    } -> tensor<6x8x4x4xf32>
-//      CHECK: %[[MMT4D:.+]] = linalg.mmt4d ins(%[[LHS4DT]], %[[RHS4DT]] : tensor<6x2x4x4xf32>, tensor<8x2x4x4xf32>) outs(%[[DST4DT]] : tensor<6x8x4x4xf32>) -> tensor<6x8x4x4xf32>
-//      CHECK: %[[MMT4DT_INIT:.+]] = linalg.init_tensor [6, 4, 8, 4] : tensor<6x4x8x4xf32>
+// CHECK-NEXT:    } -> tensor<3x8x8x4xf32>
+//      CHECK: %[[MMT4D:.+]] = linalg.mmt4d ins(%[[LHS4DT]], %[[RHS4DT]] : tensor<3x4x8x2xf32>, tensor<8x4x4x2xf32>) outs(%[[DST4DT]] : tensor<3x8x8x4xf32>) -> tensor<3x8x8x4xf32>
+//      CHECK: %[[MMT4DT_INIT:.+]] = linalg.init_tensor [3, 8, 8, 4] : tensor<3x8x8x4xf32>
 //      CHECK: %[[MMT4DT:.+]] = linalg.generic
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]]]
 // CHECK-SAME:    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-// CHECK-SAME:    ins(%[[MMT4D]] : tensor<6x8x4x4xf32>) outs(%[[MMT4DT_INIT]] : tensor<6x4x8x4xf32>) {
+// CHECK-SAME:    ins(%[[MMT4D]] : tensor<3x8x8x4xf32>) outs(%[[MMT4DT_INIT]] : tensor<3x8x8x4xf32>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:           linalg.yield %arg3 : f32
-// CHECK-NEXT:    } -> tensor<6x4x8x4xf32>
+// CHECK-NEXT:    } -> tensor<3x8x8x4xf32>
 //      CHECK: %[[RESULT:.+]] = linalg.tensor_collapse_shape %[[MMT4DT]]
-// CHECK-SAME:    tensor<6x4x8x4xf32> into tensor<24x32xf32>
+// CHECK-SAME:    tensor<3x8x8x4xf32> into tensor<24x32xf32>
 //      CHECK: return %[[RESULT]] : tensor<24x32xf32>
 
 // -----
@@ -65,8 +65,8 @@ func @check_mmt4d_with_init_tensor_and_fill(%arg0: tensor<24x8xf32>, %arg1: tens
 //      CHECK: @check_mmt4d_with_init_tensor_and_fill(%[[LHS:.+]]: tensor<24x8xf32>, %[[RHS:.+]]: tensor<8x32xf32>)
 //      CHECK: %[[ZERO:.+]] = constant 0.000000e+00 : f32
 //      CHECK: %[[LHS4D:.+]] = linalg.tensor_expand_shape %[[LHS]]
-// CHECK-SAME:   tensor<24x8xf32> into tensor<6x4x2x4xf32>
+// CHECK-SAME:   tensor<24x8xf32> into tensor<3x8x4x2xf32>
 //      CHECK: %[[RHS4D:.+]] = linalg.tensor_expand_shape %[[RHS]]
-// CHECK-SAME:   tensor<8x32xf32> into tensor<2x4x8x4xf32>
-//      CHECK: %[[DST_INIT:.+]] = linalg.init_tensor [6, 8, 4, 4] : tensor<6x8x4x4xf32>
+// CHECK-SAME:   tensor<8x32xf32> into tensor<4x2x8x4xf32>
+//      CHECK: %[[DST_INIT:.+]] = linalg.init_tensor [3, 8, 8, 4] : tensor<3x8x8x4xf32>
 //      CHECK: [[DST:.+]] linalg.fill(%[[ZERO:.+]], %[[DST_INIT]])


### PR DESCRIPTION
* Make M0,K0,N0 options of the pass converting matmul to mmt4d.
* Support cases where M0,K0,N0 are distinct.
* Expand tests.
* Renaming MMT4d -> Mmt4D for consistency.
* Consistently use the ordering: M, K, N  (and not: M, N, K).
* Add comments.
* Remove the "iree-flow-enable-matmul-to-mmt4d" pass pipeline option. For now we will use iree-opt for matmul to mmt4d conversion.