### PR TITLE
Move peephole optimization at the top of the flow pipeline

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -107,7 +107,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // to produce it from the original reflection metadata captured in the
   // previous pass.
   passManager.addPass(Shape::createExpandFunctionDynamicDimsPass());
-  
+
   passManager.addPass(createPadTensorToSubTensorInsertPass());
 
   // Elementwise, fusion, tiling and distribution.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -37,12 +37,6 @@ static llvm::cl::opt<bool> clDemoteF32ToF16(
                    "unconditionally before main flow conversions"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clEnable1x1ConvToMatmul(
-    "iree-flow-enable-1x1-conv-to-matmul",
-    llvm::cl::desc("Enable converting 1x1 linalg convolution ops to linalg "
-                   "matmul ops pass."),
-    llvm::cl::init(true));
-
 static llvm::cl::opt<bool> clEnableConvToImg2Col(
     "iree-flow-enable-conv-img2col-transform",
     llvm::cl::desc("Enable converting convolution ops to img2col form."),
@@ -73,6 +67,18 @@ namespace IREE {
 namespace Flow {
 
 void buildFlowTransformPassPipeline(OpPassManager &passManager) {
+   // Special case peephole optimizations.
+   passManager.addNestedPass<FuncOp>(createConvertConv2D1x1ToMatmulPass());
+  {
+    if (clEnableConvToImg2Col) {
+      passManager.addNestedPass<FuncOp>(createConvertConv2DToImg2ColPass());
+    }
+    // Pad linalg op
+    if (clEnablePaddingLinalgOps) {
+      passManager.addNestedPass<FuncOp>(
+          createPadLinalgOpsToIntegerMultiplePass(clLinalgOpsPaddingSize));
+    }
+  }
   passManager.addNestedPass<mlir::FuncOp>(createVerifyInputLegalityPass());
 
   // Simplify util.global accesses early on; this can help with dispatch
@@ -100,21 +106,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
   // to produce it from the original reflection metadata captured in the
   // previous pass.
   passManager.addPass(Shape::createExpandFunctionDynamicDimsPass());
-
-  // Special case peephole optimizations.
-  {
-    if (clEnable1x1ConvToMatmul) {
-      passManager.addNestedPass<FuncOp>(createConvertConv2D1x1ToMatmulPass());
-    }
-    if (clEnableConvToImg2Col) {
-      passManager.addNestedPass<FuncOp>(createConvertConv2DToImg2ColPass());
-    }
-    // Pad linalg op
-    if (clEnablePaddingLinalgOps) {
-      passManager.addNestedPass<FuncOp>(
-          createPadLinalgOpsToIntegerMultiplePass(clLinalgOpsPaddingSize));
-    }
-  }
+  
   passManager.addPass(createPadTensorToSubTensorInsertPass());
 
   // Elementwise, fusion, tiling and distribution.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -67,9 +67,9 @@ namespace IREE {
 namespace Flow {
 
 void buildFlowTransformPassPipeline(OpPassManager &passManager) {
-   // Special case peephole optimizations.
-   passManager.addNestedPass<FuncOp>(createConvertConv2D1x1ToMatmulPass());
+  // Special case peephole optimizations.
   {
+    passManager.addNestedPass<FuncOp>(createConvertConv2D1x1ToMatmulPass());
     if (clEnableConvToImg2Col) {
       passManager.addNestedPass<FuncOp>(createConvertConv2DToImg2ColPass());
     }
@@ -79,6 +79,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
           createPadLinalgOpsToIntegerMultiplePass(clLinalgOpsPaddingSize));
     }
   }
+
   passManager.addNestedPass<mlir::FuncOp>(createVerifyInputLegalityPass());
 
   // Simplify util.global accesses early on; this can help with dispatch


### PR DESCRIPTION
- Drop `-iree-flow-enable-1x1-conv-to-matmul` as it was true by default.
- Move the linalg -> linalg peephole optimizations passes to the top of the flow pipeline.