### PR TITLE
Removing the internal_functions table from the VM flatbuffer.

### DIFF
--- a/bindings/python/iree/compiler/core.py
+++ b/bindings/python/iree/compiler/core.py
@@ -110,8 +110,6 @@ class CompilerOptions:
       debugging.
     strip_source_map: Whether to strip source map information (used to generate
       better errors).
-    strip_symbols: Whether to strip extra symbols not needed for execution
-      (but which may aid debugging).
     crash_reproducer_path: File name to output an MLIR crash dump to if there
       is a compiler failure.
     enable_tflite_bindings: Support the IREE TFLite runtime bindings API shim.
@@ -133,7 +131,6 @@ class CompilerOptions:
                extended_diagnostics: bool = False,
                strip_debug_ops: bool = False,
                strip_source_map: bool = False,
-               strip_symbols: bool = False,
                crash_reproducer_path: Optional[str] = None,
                enable_tflite_bindings: bool = False,
                enable_benchmark: bool = False):
@@ -148,7 +145,6 @@ class CompilerOptions:
     self.extended_diagnostics = extended_diagnostics
     self.strip_debug_ops = strip_debug_ops
     self.strip_source_map = strip_source_map
-    self.strip_symbols = strip_symbols
     self.crash_reproducer_path = crash_reproducer_path
     self.enable_tflite_bindings = enable_tflite_bindings
     self.enable_benchmark = enable_benchmark
@@ -203,8 +199,6 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
     cl.append("--iree-vm-bytecode-module-strip-debug-ops")
   if options.strip_source_map:
     cl.append("--iree-vm-bytecode-module-strip-source-map")
-  if options.strip_symbols:
-    cl.append("--iree-vm-bytecode-module-strip-symbols")
   crash_reproducer_path = tfs.alloc_optional(
       "core-reproducer.mlir", export_as=options.crash_reproducer_path)
   if crash_reproducer_path:

--- a/bindings/python/tests/compiler_core_test.py
+++ b/bindings/python/tests/compiler_core_test.py
@@ -159,7 +159,6 @@ class CompilerTest(unittest.TestCase):
         optimize=False,
         strip_debug_ops=True,
         strip_source_map=True,
-        strip_symbols=True,
         crash_reproducer_path="foobar.txt",
         # Re-enable when benchmarking pass is fixed: #6196
         # enable_benchmark=True,

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.h
@@ -44,8 +44,6 @@ struct BytecodeTargetOptions {
   // original source locations and the VM IR.
   std::string sourceListing;
 
-  // Strips all internal symbol names. Import and export names will remain.
-  bool stripSymbols = false;
   // Strips source map information.
   bool stripSourceMap = false;
   // Strips vm ops with the VM_DebugOnly trait.

--- a/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/TranslationFlags.cpp
@@ -46,12 +46,6 @@ static llvm::cl::opt<std::string> sourceListingFlag{
     llvm::cl::init(""),
 };
 
-static llvm::cl::opt<bool> stripSymbolsFlag{
-    "iree-vm-bytecode-module-strip-symbols",
-    llvm::cl::desc("Strips all internal symbol names from the module"),
-    llvm::cl::init(false),
-};
-
 static llvm::cl::opt<bool> stripSourceMapFlag{
     "iree-vm-bytecode-module-strip-source-map",
     llvm::cl::desc("Strips the source map from the module"),
@@ -76,7 +70,6 @@ BytecodeTargetOptions getBytecodeTargetOptionsFromFlags() {
   targetOptions.outputFormat = outputFormatFlag;
   targetOptions.optimize = optimizeFlag;
   targetOptions.sourceListing = sourceListingFlag;
-  targetOptions.stripSymbols = stripSymbolsFlag;
   targetOptions.stripSourceMap = stripSourceMapFlag;
   targetOptions.stripDebugOps = stripDebugOpsFlag;
   targetOptions.emitPolyglotZip = emitPolyglotZipFlag;

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/module_encoding_smoke.mlir
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/module_encoding_smoke.mlir
@@ -9,19 +9,18 @@ vm.module @simple_module {
   // CHECK: "local_name": "func"
   vm.export @func
 
-  // CHECK: "internal_functions":
-  // CHECK: "local_name": "func"
-  vm.func @func(%arg0 : i32) -> i32 {
-    vm.return %arg0 : i32
-  }
-
   // CHECK: "function_descriptors":
+
   // CHECK-NEXT: {
   // CHECK-NEXT:   "bytecode_offset": 0
   // CHECK-NEXT:   "bytecode_length": 8
   // CHECK-NEXT:   "i32_register_count": 1
   // CHECK-NEXT:   "ref_register_count": 0
   // CHECK-NEXT: }
+  vm.func @func(%arg0 : i32) -> i32 {
+    vm.return %arg0 : i32
+  }
+
   //      CHECK: "bytecode_data": [
   // CHECK-NEXT:   84,
   // CHECK-NEXT:   0,

--- a/iree/compiler/Dialect/VM/Target/Bytecode/test/reflection_attrs.mlir
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/test/reflection_attrs.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: simple_module
 vm.module @simple_module {
   vm.export @func
-  // CHECK: "internal_functions":
+  // CHECK: "exported_functions":
   // CHECK: "reflection_attrs":
   // CHECK:   "key": "f"
   // CHECK:   "value": "FOOBAR"

--- a/iree/compiler/Translation/test/smoketest.mlir
+++ b/iree/compiler/Translation/test/smoketest.mlir
@@ -5,12 +5,6 @@ module @simple_module {
 // CHECK: "exported_functions":
 // CHECK: "local_name": "func"
 
-// CHECK: "internal_functions":
-// CHECK: "local_name": "func"
-func @func(%arg0 : i32) -> i32 {
-  return %arg0 : i32
-}
-
 // CHECK: "function_descriptors":
 // CHECK-NEXT: {
 // CHECK-NEXT:   "bytecode_offset": 0
@@ -18,6 +12,10 @@ func @func(%arg0 : i32) -> i32 {
 // CHECK-NEXT:   "i32_register_count": 1
 // CHECK-NEXT:   "ref_register_count": 0
 // CHECK-NEXT: }
+func @func(%arg0 : i32) -> i32 {
+  return %arg0 : i32
+}
+
 // CHECK: "bytecode_data": [
 // CHECK-NEXT:   84,
 // CHECK-NEXT:   0,

--- a/iree/schemas/bytecode_module_def.fbs
+++ b/iree/schemas/bytecode_module_def.fbs
@@ -211,9 +211,6 @@ table BytecodeModuleDef {
   // Exported function definitions used to resolve imports.
   exported_functions:[ExportFunctionDef];
 
-  // All functions with internal linkage.
-  internal_functions:[InternalFunctionDef];
-
   // Read-only data segments (like non-code .text).
   // May optionally be compressed and decompressed by the loader.
   rodata_segments:[RodataSegmentDef];

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -504,6 +504,7 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_format_backtrace(
       status = iree_vm_source_location_format(&source_location, builder);
     }
     if (iree_status_is_unavailable(status)) {
+      // TODO(benvanik): if this is an import/export we can get that name.
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "-"));
     } else if (!iree_status_is_ok(status)) {
       return status;


### PR DESCRIPTION
It's not useful now that we have a source map.
This also drops `-iree-vm-bytecode-module-strip-symbols` as there's no
symbols to strip now.

Fixes #7063.