### PR TITLE
Add tile and distribut support for linalg_ext.fft ops

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
@@ -211,6 +212,42 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
       IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization);
 }
 
+/// Sets the lowering configuration for dispatch region for linalg_ext.fft root
+/// op.
+static LogicalResult setRootConfig(FuncOp entryPointFn,
+                                   linalg_ext::FftOp fftOp) {
+  auto partitionedLoops = getPartitionedLoops(fftOp);
+  unsigned maxDepth = partitionedLoops.back() + 1;
+  SmallVector<int64_t, 4> workgroupTileSizes(maxDepth,
+                                             defaultWorkgroupTileSize);
+  llvm::DenseSet<unsigned> partitionedLoopsSet(partitionedLoops.begin(),
+                                               partitionedLoops.end());
+  for (auto dim : llvm::seq<int64_t>(0, workgroupTileSizes.size())) {
+    if (!partitionedLoopsSet.count(dim)) {
+      workgroupTileSizes[dim] = 0;
+    }
+  }
+
+  auto rank = fftOp.getOperandRank();
+  if (workgroupTileSizes.size() >= rank && workgroupTileSizes[rank - 1] != 0) {
+    APInt value;
+    if (matchPattern(fftOp.getStage(), m_ConstantInt(&value))) {
+      workgroupTileSizes[rank - 1] = 1 << value.getSExtValue();
+      workgroupTileSizes[rank - 1] =
+          std::max(workgroupTileSizes[rank - 1],
+                   static_cast<int64_t>(defaultWorkgroupTileSize));
+    } else {
+      fftOp.emitError("non-constant stage might not work for fft op");
+      return failure();
+    }
+  }
+  TileSizesListType tileSizes = {workgroupTileSizes};
+
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, fftOp, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+      IREE::HAL::DispatchLoweringPassPipeline::CPUDefault);
+}
+
 /// Sets the lowering configuration for dispatch region with root op being a
 /// generic op.
 static LogicalResult setDefaultRootConfig(FuncOp entryPointFn, Operation *op) {
@@ -272,7 +309,8 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
     } else {
       auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
         return TypeSwitch<Operation *, LogicalResult>(op)
-            .Case<linalg::Mmt4DOp, linalg::ContractionOpInterface>(
+            .Case<linalg::Mmt4DOp, linalg::ContractionOpInterface,
+                  linalg_ext::FftOp>(
                 [&](auto op) { return setRootConfig(entryPointFn, op); })
             .Default([&](Operation *op) { return success(); });
       };

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -553,7 +553,7 @@ hal.executable private @static_1d_fft_stage2  {
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
 //  CHECK-SAME:   translation.info = {
-//  CHECK-SAME:     passPipeline = "CPUVectorization"
+//  CHECK-SAME:     passPipeline = "CPUDefault"
 //  CHECK-SAME:     workloadPerWorkgroup = [64]}
 //  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
 //  CHECK-NEXT:   %[[C1:.+]] = constant 1 : index
@@ -618,7 +618,7 @@ hal.executable private @static_3d_fft_stage3  {
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
 //  CHECK-SAME:   translation.info = {
-//  CHECK-SAME:     passPipeline = "CPUVectorization"
+//  CHECK-SAME:     passPipeline = "CPUDefault"
 //  CHECK-SAME:   workloadPerWorkgroup = [64, 64, 64]}
 //  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
 //  CHECK-NEXT:   %[[T0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -521,3 +521,111 @@ hal.executable @tensor_insert {
 //  CHECK-DAG:   %[[NWGSX:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:   %[[NWGSY:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //      CHECK:   hal.return %[[NWGSX]], %[[NWGSY]], %[[C1]]
+
+// -----
+
+hal.executable private @static_1d_fft_stage2  {
+  hal.interface @io {
+    hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
+    hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  hal.executable.variant @system_elf_x86_64, target = #hal.executable.target<"llvm", "system-elf-x86_64"> {
+    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
+      builtin.func @static_1d_fft_stage2() {
+        %c0 = constant 0 : index
+        %c2 = constant 2 : index
+        %cst = constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
+        %cst_0 = constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
+        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %1 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %4:2 = linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
+        flow.dispatch.tensor.store %4#0, %0, offsets = [], sizes = [], strides = [] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        flow.dispatch.tensor.store %4#1, %1, offsets = [], sizes = [], strides = [] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        return
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[64]]}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//  CHECK-SAME:   translation.info = {
+//  CHECK-SAME:     passPipeline = "CPUVectorization"
+//  CHECK-SAME:     workloadPerWorkgroup = [64]}
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
+//  CHECK-NEXT:   %[[C1:.+]] = constant 1 : index
+//  CHECK-NEXT:   %[[T0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-NEXT:   hal.return %[[T0]], %[[C1]], %[[C1]]
+
+//       CHECK: func @static_1d_fft_stage2()
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+
+// -----
+
+
+hal.executable private @static_3d_fft_stage3  {
+  hal.interface @io {
+    hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
+    hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  hal.executable.variant @system_elf_x86_64, target = #hal.executable.target<"llvm", "system-elf-x86_64"> {
+    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
+      builtin.func @static_3d_fft_stage3() {
+        %c0 = constant 0 : index
+        %c3 = constant 3 : index
+        %c64 = constant 64 : index
+        %c128 = constant 128 : index
+        %c32 = constant 32 : index
+        %cst = constant dense<[1.000000e+00, 0.707106769, 6.12323426E-17, -0.707106769]> : tensor<4xf32>
+        %cst_0 = constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
+        %0 = memref.buffer_cast %cst_0 : memref<4xf32>
+        %1 = memref.buffer_cast %cst : memref<4xf32>
+        %2 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<64x128x32xf32>
+        %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c64 step %workgroup_count_z {
+          scf.for %arg1 = %workgroup_id_y to %c128 step %workgroup_count_y {
+            %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_x]
+            %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_x]
+            scf.for %arg2 = %4 to %c32 step %5 {
+              %6 = memref.subview %2[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %7 = memref.cast %6 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %8 = memref.subview %3[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %9 = memref.cast %8 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              linalg_ext.fft {__internal_linalg_transform__ = "workgroup"}
+                ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>)
+                outs(%7, %9 : memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>, memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>)
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[64, 64, 64]]}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//  CHECK-SAME:   translation.info = {
+//  CHECK-SAME:     passPipeline = "CPUVectorization"
+//  CHECK-SAME:   workloadPerWorkgroup = [64, 64, 64]}
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
+//  CHECK-NEXT:   %[[T0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-NEXT:   %[[T1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-NEXT:   %[[T2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
+//  CHECK-NEXT:   hal.return %[[T0]], %[[T1]], %[[T2]]
+
+//       CHECK: func @static_3d_fft_stage3()
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     lowering.config = #[[CONFIG]]

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -257,3 +257,110 @@ hal.executable @tensor_insert {
 //      CHECK:   hal.return %[[NWGSX]], %[[ARG1]], %[[C1]]
 //      CHECK:   linalg.copy
 // CHECK-SAME:     lowering.config = #[[CONFIG]]
+
+// -----
+
+hal.executable private @static_1d_fft_stage2  {
+  hal.interface @io {
+    hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
+    hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
+      builtin.func @static_1d_fft_stage2() {
+        %c0 = constant 0 : index
+        %c2 = constant 2 : index
+        %cst = constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
+        %cst_0 = constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
+        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %1 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
+        %4:2 = linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
+        flow.dispatch.tensor.store %4#0, %0, offsets = [], sizes = [], strides = [] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        flow.dispatch.tensor.store %4#1, %1, offsets = [], sizes = [], strides = [] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[4]]}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//       CHECK: hal.executable.entry_point public @static_1d_fft_stage2
+//  CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUDistribute"
+//  CHECK-SAME:   workloadPerWorkgroup = [4]}
+//  CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %{{.+}}: index, %{{.+}}: index):
+//  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
+//  CHECK-NEXT:   %[[T:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-NEXT:   hal.return %[[T]], %[[ONE]], %[[ONE]]
+
+//       CHECK: func @static_1d_fft_stage2()
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+
+// -----
+
+
+hal.executable private @static_3d_fft_stage3  {
+  hal.interface @io {
+    hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
+    hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module {
+      builtin.func @static_3d_fft_stage3() {
+        %c0 = constant 0 : index
+        %c3 = constant 3 : index
+        %c64 = constant 64 : index
+        %c128 = constant 128 : index
+        %c32 = constant 32 : index
+        %cst = constant dense<[1.000000e+00, 0.707106769, 6.12323426E-17, -0.707106769]> : tensor<4xf32>
+        %cst_0 = constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
+        %0 = memref.buffer_cast %cst_0 : memref<4xf32>
+        %1 = memref.buffer_cast %cst : memref<4xf32>
+        %2 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<64x128x32xf32>
+        %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c64 step %workgroup_count_z {
+          scf.for %arg1 = %workgroup_id_y to %c128 step %workgroup_count_y {
+            %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_x]
+            %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_x]
+            scf.for %arg2 = %4 to %c32 step %5 {
+              %6 = memref.subview %2[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %7 = memref.cast %6 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %8 = memref.subview %3[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %9 = memref.cast %8 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              linalg_ext.fft {__internal_linalg_transform__ = "workgroup"}
+                ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>)
+                outs(%7, %9 : memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>, memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>)
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 1, 8]]}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//       CHECK: hal.executable.entry_point public @static_3d_fft_stage3
+//  CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUDistribute"
+//  CHECK-SAME:   workloadPerWorkgroup = [8, 1, 1]}
+//  CHECK-SAME:   workgroup_size = [32 : index, 1 : index, 1 : index]
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
+//  CHECK-NEXT:   %[[T:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//  CHECK-NEXT:   hal.return %[[T]], %[[ARG1]], %[[ARG2]]
+
+//       CHECK: func @static_3d_fft_stage3()
+//       CHECK:   linalg_ext.fft
+//  CHECK-SAME:     lowering.config = #[[CONFIG]]

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -11,10 +11,12 @@
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/LoweringConfig.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
+#include "mlir/IR/Matchers.h"
 
 #define DEBUG_TYPE "iree-spirv-kernel-config"
 
@@ -162,6 +164,37 @@ static LogicalResult setOpConfig(spirv::ResourceLimitsAttr limits,
                                                workgroupSize);
 }
 
+static LogicalResult setOpConfig(spirv::ResourceLimitsAttr limits,
+                                 linalg_ext::FftOp op) {
+  const int64_t subgroupSize = limits.subgroup_size().getValue().getSExtValue();
+  auto pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVDistribute;
+
+  std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
+
+  auto partitionedLoops = getPartitionedLoops(op);
+  unsigned loopDepth = partitionedLoops.back() + 1;
+  SmallVector<int64_t, 4> workgroupTileSize(loopDepth, 0);
+
+  // Tiling along partitioned loops with size 1.
+  for (int64_t loopIndex : partitionedLoops) {
+    workgroupTileSize[loopIndex] = 1;
+  }
+  auto rank = op.getOperandRank();
+  if (workgroupTileSize.size() >= rank && workgroupTileSize[rank - 1] != 0) {
+    APInt value;
+    if (matchPattern(op.getStage(), m_ConstantInt(&value))) {
+      workgroupTileSize[rank - 1] = 1 << value.getSExtValue();
+    } else {
+      op.emitError("non-constant stage might not work for fft op");
+      return failure();
+    }
+  }
+  TileSizesListType tileSizes = {workgroupTileSize};
+  return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),
+                                               op, tileSizes, {}, pipeline,
+                                               workgroupSize);
+}
+
 //===----------------------------------------------------------------------===//
 // Default Configuration
 //===----------------------------------------------------------------------===//
@@ -284,7 +317,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
   // Otherwise fallback to use a default configuration.
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
   return TypeSwitch<Operation *, LogicalResult>(rootOp)
-      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>(
+      .Case<linalg::BatchMatmulOp, linalg::MatmulOp, linalg_ext::FftOp>(
           [limits](auto op) { return setOpConfig(limits, op); })
       .Case<linalg::Conv2DNhwcHwcfOp, linalg::DepthwiseConv2DNhwOp>(
           [limits](auto op) { return setDefaultOpConfig(limits, op); })

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
@@ -112,7 +112,7 @@ hal.executable private @static_3d_sort  {
 
 // -----
 
-hal.executable private @static_1d_fft  {
+hal.executable private @static_1d_fft_stage2  {
   hal.interface @io {
     hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
@@ -124,9 +124,9 @@ hal.executable private @static_1d_fft  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_1d_fft attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
     builtin.module {
-      builtin.func @static_1d_fft() {
+      builtin.func @static_1d_fft_stage2() {
         %c0 = constant 0 : index
         %c2 = constant 2 : index
         %cst = constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
@@ -140,30 +140,27 @@ hal.executable private @static_1d_fft  {
         flow.dispatch.tensor.store %4#1, %1, offsets = [], sizes = [], strides = [] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:32xf32>
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
-        hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
-      }
     }
   }
 }
 
-// Check that the workgroup count and size are (1, 1, 1) for serializing the computation.
-
-// CHECK-LABEL: hal.executable.entry_point public @static_1d_fft
-//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize"}
-//  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
-//  CHECK-NEXT: ^{{.+}}(%{{.+}}: index, %{{.+}}: index, %{{.+}}: index):
+// CHECK-LABEL: hal.executable.entry_point public @static_1d_fft_stage2
+//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute"
+//  CHECK-SAME:   workloadPerWorkgroup = [4]}
+//  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %{{.+}}: index, %{{.+}}: index):
 //  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
-//  CHECK-NEXT:   hal.return %[[ONE]], %[[ONE]], %[[ONE]]
+//  CHECK-NEXT:   %[[T:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%[[ARG0]]]
+//  CHECK-NEXT:   hal.return %[[T]], %[[ONE]], %[[ONE]]
 
-//       CHECK: func @static_1d_fft()
+//       CHECK: func @static_1d_fft_stage2()
 //       CHECK:   linalg_ext.fft
-//  CHECK-SAME:     lowering.config = {}
+//  CHECK-SAME:     lowering.config = {tileSizes = {{\[}}[4]]}
 
 // -----
 
-hal.executable private @static_3d_fft  {
+
+hal.executable private @static_3d_fft_stage3  {
   hal.interface @io {
     hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
@@ -175,39 +172,56 @@ hal.executable private @static_3d_fft  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_3d_fft attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
     builtin.module {
-      builtin.func @static_3d_fft() {
+      builtin.func @static_3d_fft_stage3() {
         %c0 = constant 0 : index
-        %c2 = constant 2 : index
-        %cst = constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
-        %cst_0 = constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
-        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:64x128x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:64x128x32xf32>
-        %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:64x128x32xf32> -> tensor<64x128x32xf32>
-        %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:64x128x32xf32> -> tensor<64x128x32xf32>
-        %4:2 = linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<64x128x32xf32>, tensor<64x128x32xf32>) : tensor<64x128x32xf32>, tensor<64x128x32xf32>
-        flow.dispatch.tensor.store %4#0, %0, offsets = [], sizes = [], strides = [] : tensor<64x128x32xf32> -> !flow.dispatch.tensor<readwrite:64x128x32xf32>
-        flow.dispatch.tensor.store %4#1, %1, offsets = [], sizes = [], strides = [] : tensor<64x128x32xf32> -> !flow.dispatch.tensor<readwrite:64x128x32xf32>
+        %c3 = constant 3 : index
+        %c64 = constant 64 : index
+        %c128 = constant 128 : index
+        %c32 = constant 32 : index
+        %cst = constant dense<[1.000000e+00, 0.707106769, 6.12323426E-17, -0.707106769]> : tensor<4xf32>
+        %cst_0 = constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
+        %0 = memref.buffer_cast %cst_0 : memref<4xf32>
+        %1 = memref.buffer_cast %cst : memref<4xf32>
+        %2 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<64x128x32xf32>
+        %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c64 step %workgroup_count_z {
+          scf.for %arg1 = %workgroup_id_y to %c128 step %workgroup_count_y {
+            %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_x]
+            %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_x]
+            scf.for %arg2 = %4 to %c32 step %5 {
+              %6 = memref.subview %2[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %7 = memref.cast %6 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %8 = memref.subview %3[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              %9 = memref.cast %8 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
+              linalg_ext.fft {__internal_linalg_transform__ = "workgroup"}
+                ins(%c3, %1, %0 : index, memref<4xf32>, memref<4xf32>)
+                outs(%7, %9 : memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>, memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>)
+            }
+          }
+        }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer", access="Read|Write"
-        hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
       }
     }
   }
 }
 
-// Right now n-D fft does not support tiling too.
 
-// CHECK-LABEL: hal.executable.entry_point public @static_3d_fft
-//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVVectorize"}
-//  CHECK-SAME:   workgroup_size = [1 : index, 1 : index, 1 : index]
-//  CHECK-NEXT: ^{{.+}}(%{{.+}}: index, %{{.+}}: index, %{{.+}}: index):
-//  CHECK-NEXT:   %[[ONE:.+]] = constant 1 : index
-//  CHECK-NEXT:   hal.return %[[ONE]], %[[ONE]], %[[ONE]]
+// CHECK-LABEL: hal.executable.entry_point public @static_3d_fft_stage3
+//  CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute"
+//  CHECK-SAME:   workloadPerWorkgroup = [8, 1, 1]}
+//  CHECK-SAME:   workgroup_size = [16 : index, 1 : index, 1 : index]
+//  CHECK-NEXT: ^{{.+}}(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index):
+//  CHECK-NEXT:   %[[T:.+]] = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%[[ARG0]]]
+//  CHECK-NEXT:   hal.return %[[T]], %[[ARG1]], %[[ARG2]]
 
-//       CHECK: func @static_3d_fft()
+//       CHECK: func @static_3d_fft_stage3()
 //       CHECK:   linalg_ext.fft
-//  CHECK-SAME:     lowering.config = {}
+//  CHECK-SAME:     lowering.config = {tileSizes = {{\[}}[1, 1, 8]]}

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -178,9 +178,17 @@ def LinalgExt_SortOp : LinalgExt_Op<"sort",
   }];
 }
 
-def LinalgExt_FftOp : LinalgExt_Op<"fft",
-    [DeclareOpInterfaceMethods<TiledOpInterface,
-        ["generateScalarImplementation"]>]> {
+def LinalgExt_FftOp : LinalgExt_Op<"fft", [
+  DeclareOpInterfaceMethods<TiledOpInterface,
+                            [
+                              "getPartitionableLoops", "getTiledImplementation",
+                              "generateScalarImplementation"
+                            ]>,
+  DeclareOpInterfaceMethods<LinalgExtInterface,
+                            // FftOp does not have a region, so we have to
+                            // overwrite the method.
+                            ["payloadUsesValueFromOperand"]>
+]> {
   let summary = "Fft operator";
   let description = [{
     Apply 1D FFT to innermost dim. This is an iterative FFT, not recurrsive.

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -131,10 +131,6 @@ static FailureOr<TiledOp> tileInterfaceOpImpl(
   // Generate an scf.for for the current loop depth.
   Value lb = loopBounds[loopDepth].offset;
   Value ub = loopBounds[loopDepth].size;
-  if (!matchPattern(loopBounds[loopDepth].stride, m_One())) {
-    return static_cast<LogicalResult>(
-        tilableOp.emitOpError("expected stride to be 1"));
-  }
   Value step = getValue(builder, loc, tileSizes[loopDepth]);
 
   // Update lb, ub and step for cyclic distribution.
@@ -342,7 +338,9 @@ struct InsertSliceTiledOpInterface
 LogicalResult TiledOpInterfaceBaseTilingPattern::matchAndRewriteBase(
     TiledOpInterface tilableOp, PatternRewriter &rewriter,
     TiledOp &result) const {
-  if (failed(filter.checkAndNotify(rewriter, tilableOp))) return failure();
+  if (failed(filter.checkAndNotify(rewriter, tilableOp))) {
+    return failure();
+  }
   if (failed(verifySupportedTilingOptions(rewriter, tilableOp, options))) {
     return failure();
   }
@@ -440,6 +438,20 @@ void TiledOpInterfaceTilingPass::runOnOperation() {
       linalg::LinalgTransformationFilter(
           Identifier::get("distribute_input", context),
           Identifier::get("distribute_output", context)));
+
+  patterns.add<TiledOpInterfaceTilingPattern>(
+      context,
+      linalg::LinalgTilingOptions().setTileSizes(ArrayRef<int64_t>{32}),
+      linalg::LinalgTransformationFilter(
+          Identifier::get("tiling_1d_stage5_fft_input", context),
+          Identifier::get("tiling_1d_stage5_fft_output", context)));
+
+  patterns.add<TiledOpInterfaceTilingPattern>(
+      context,
+      linalg::LinalgTilingOptions().setTileSizes(ArrayRef<int64_t>{10, 32}),
+      linalg::LinalgTransformationFilter(
+          Identifier::get("tiling_2d_stage5_fft_input", context),
+          Identifier::get("tiling_2d_stage5_fft_output", context)));
 
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -131,6 +131,12 @@ static FailureOr<TiledOp> tileInterfaceOpImpl(
   // Generate an scf.for for the current loop depth.
   Value lb = loopBounds[loopDepth].offset;
   Value ub = loopBounds[loopDepth].size;
+  // TODO(#7073): Put the check back. This is required by tiling linalg_ext.fft
+  // op. We can put the check back after updating linalg_ext.fft semantics.
+  // if (!matchPattern(loopBounds[loopDepth].stride, m_One())) {
+  // return static_cast<LogicalResult>(
+  // tilableOp.emitOpError("expected stride to be 1"));
+  //}
   Value step = getValue(builder, loc, tileSizes[loopDepth]);
 
   // Update lb, ub and step for cyclic distribution.


### PR DESCRIPTION
This implements tiling method of linalg_ext.fft op and set up the kernel
configurations for all the backends.

After tiling and distribute, the change of performance on
tensor<325x1024xf32> is:

| Backend          | Before (ms) | After (ms)|
|------------------|-------------|-----------|
| CPU (1-threaded) |    2.72 ms  |   3.72 ms |
| CPU (3-threaded) |    7.31 ms  |   2.85 ms |
| Vulkan SPIR-V    |     387 ms  |   7.13 ms |
| Cuda             |     344 ms  |   6.70 ms |

Note: tested on desktop machine.

The limitation of non-one strides in tiling is removed, and it should be
aligned in kernel configurations. The workgroup_size should be a mutiple
of M where M is 2^stage because of the merging algorithm. Currently,
only the stage of fft ops must be a constant.

After tiling, the shape of fft ops are not infered. Thus we have to
relax the verification of the op. Also addresses the issue that
interfrace method `payloadUsesValueFromOperand` expects a region from
LinalgExt ops. However, linalg_ext.fft op does not have a region. Thus,
we have to implement it manually.