### PR TITLE
Change loop partition logic to consider all parallel dimensions

### DIFF
--- a/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
@@ -138,7 +138,7 @@ class RemoveTripOneLoop final : public OpRewritePattern<scf::ForOp> {
 static void removeOneTripTiledLoops(MLIRContext *context, FuncOp funcOp,
                                     linalg::LinalgOp rootLinalgOp,
                                     ArrayRef<int64_t> workloadPerWorkgroup) {
-  unsigned numParallelDims = getNumOuterParallelLoops(rootLinalgOp);
+  unsigned numParallelDims = rootLinalgOp.getNumParallelLoops();
   unsigned numTiledDims =
       std::min<size_t>(numParallelDims, kNumMaxParallelDims);
   ArrayRef<int64_t> outputShape = getUntiledResultShape(rootLinalgOp, 0);

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -60,11 +60,6 @@ inline LogicalResult setOpConfigAndEntryPointFnTranslation(
                                                passPipeline, workgroupSize);
 }
 
-/// Returns the number of outer parallel loops of a linalgOp.
-/// Note: To be used only if needed. Use the `getPartitionedLoops` method if
-/// this is used to "guess" which loops are distributed.
-unsigned getNumOuterParallelLoops(linalg::LinalgOp op);
-
 /// Returns the untiled type of a tiled view for both tensor and memref
 /// types. Either walks the `ViewOpInterface` chain (for memrefs) or the
 /// `subtensor` op chain (for tensors).

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -131,18 +131,6 @@ static void removeFusionGroupsAttribute(Operation *op) {
 // Utility methods
 //===----------------------------------------------------------------------===//
 
-/// Returns the number of consecutive outer loops that are "parallel". This is a
-/// copy of the function from
-/// iree/compiler/Codegen/CodegenUtils/FunctionUtils.h that is duplicated
-/// here to avoid adding an build dependency.
-static size_t getNumOuterParallelLoops(linalg::LinalgOp op) {
-  return op.iterator_types()
-      .getValue()
-      .take_while(
-          [](Attribute attr) -> bool { return isParallelIterator(attr); })
-      .size();
-}
-
 /// Given the `shape` of the computation with the first element being the
 /// slowest varying and last element being the fastest warying returns the
 /// workload value with
@@ -653,19 +641,19 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
 /// Returns the loops that are partitioned during dispatch region formations, in
 /// order, i.e. starting from the outer-most to innermost.
 static SmallVector<unsigned> getPartitionedLoops(Operation *op) {
-  SmallVector<unsigned> partitionedLoops;
   if (auto mmt4dOp = dyn_cast<linalg::Mmt4DOp>(op)) {
     return {0, 1};
   }
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-    size_t numOuterParallelLoops = getNumOuterParallelLoops(linalgOp);
-    partitionedLoops =
-        llvm::to_vector<4>(llvm::seq<unsigned>(0, numOuterParallelLoops));
-    if (partitionedLoops.size() > kNumMaxParallelDims) {
-      partitionedLoops.erase(
-          partitionedLoops.begin(),
-          std::next(partitionedLoops.begin(),
-                    numOuterParallelLoops - kNumMaxParallelDims));
+    SmallVector<unsigned> partitionedLoops;
+    for (auto indexedIterator : llvm::enumerate(linalgOp.iterator_types())) {
+      if (isParallelIterator(indexedIterator.value())) {
+        partitionedLoops.push_back(indexedIterator.index());
+      }
+    }
+    // Only keep the last kNumMaxParallelDims if we have more than that.
+    while (partitionedLoops.size() > kNumMaxParallelDims) {
+      partitionedLoops.erase(partitionedLoops.begin());
     }
     return partitionedLoops;
   }


### PR DESCRIPTION
This allows us to be resilient towards the implicit loop orders
in Linalg ops.

This fixes the performance problem for pooling op, which has 4
parallel loops (for N, OH, OW, OC), but as it is defined today,
the OC loop is behind some reduction loops for the window.
So it causes us only partitioning and distributing along (N,
OH, OW), which is typically small or even just 1. There are real
cases in DeepLabV3 that we have 1x1x1 for them, which means we
effectively are running everything using 1 thread on GPU.