### PR TITLE
[pydm] Add basics of runtime library integration.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Dialect.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Dialect.h
@@ -17,6 +17,7 @@ namespace iree_pydm {
 // Each built-in (to the compiler) type has a unique code, enumerated here.
 // Generally, the closed part of the type system will have type codes <
 // FirstCustom.
+// If editing, also update the constants in rtl/modules/constants.py.
 enum class BuiltinTypeCode : int {
   // Built-in types, ordered by rough "core-ness" so that lower numbers
   // are easier to spot for common cases.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Ops.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/IR/Ops.td
@@ -144,6 +144,13 @@ def IREEPyDM_FuncOp : IREEPyDM_Op<"func", [
     }
   }];
 
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name, "FunctionType":$type), [{
+      build($_builder, $_state, name, TypeAttr::get(type),
+            nullptr, nullptr, nullptr, nullptr);
+    }]>
+  ];
+
   let parser = [{ return ::parseFuncOp(parser, result); }];
   let printer = [{ return ::print(*this, p); }];
   let verifier = [{ return ::verify(*this); }];
@@ -433,6 +440,58 @@ def IREEPyDM_MakeTupleOp : IREEPyDM_PureOp<"make_tuple"> {
   let results = (outs IREEPyDM_TupleType:$tuple);
   let assemblyFormat = [{
     $slots `:` type($slots) `->` type(results) attr-dict
+  }];
+}
+
+def IREEPyDM_DynamicUnpackOp : IREEPyDM_PureOp<"dynamic_unpack"> {
+  let summary = "Dynamically unpacks a tuple/sequence into a fixed number of values";
+  let description = [{
+    This is the most generic form of sequence unpacking for use in extracting
+    values, when the arity is statically known. When more specific types are
+    known, this op will generally decay into a more statically verifiable
+    form or be elided entirely.
+
+    This op includes dynamic result casting so as to keep everything related
+    to the unpack local to a single op until/if more information is known.
+  }];
+  let arguments = (ins IREEPyDM_AnyValueType:$sequence);
+  let results = (outs
+    IREEPyDM_ExceptionResultType:$exc_result,
+    Variadic<IREEPyDM_AnyValueType>:$slots);
+  let assemblyFormat = [{
+    $sequence `:` type($sequence) `->` type($exc_result) `,` `[` type($slots) `]` attr-dict
+  }];
+}
+
+def IREEPyDM_GetTypeCodeOp : IREEPyDM_PureOp<"get_type_code"> {
+  let summary = "Gets the type code (BuiltinTypeCode) of an arbitrary value";
+  let description = [{
+    Every PyDM value has a type that can be represented by a type code.
+    See the `BuiltinTypeCode` enumeration for constants and encodings.
+  }];
+  let arguments = (ins IREEPyDM_AnyValueType:$value);
+  let results = (outs IREEPyDM_IntegerType);
+  let assemblyFormat = [{
+    $value `:` type($value) attr-dict
+  }];
+}
+
+def IREEPyDM_GetNumericPromotionOrderOp : IREEPyDM_PureOp<"get_numeric_promotion_order"> {
+  let summary = "Gets the promotion order of a value";
+  let description = [{
+    Every numeric type is assigned a promotion order which:
+      - When equal, means that no promotion is needed.
+      - Is greater then another, means the both should be promoted based on
+        the greater.
+    TODO: There are additional special considerations for unsigned->signed
+    promotion. This order only represents signed.
+
+    Non-numeric values have a promotion order of 0.
+  }];
+  let arguments = (ins IREEPyDM_AnyValueType:$value);
+  let results = (outs IREEPyDM_IntegerType);
+  let assemblyFormat = [{
+    $value `:` type($value) attr-dict
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h
@@ -19,6 +19,7 @@ class IREEDialect;
 namespace iree_pydm {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertIREEPyDMToIREEPass();
+std::unique_ptr<OperationPass<ModuleOp>> createLowerIREEPyDMToRTLPass();
 
 #define GEN_PASS_REGISTRATION
 #include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h.inc"

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/IREEPyDM/Transforms/Passes.td
@@ -9,6 +9,17 @@
 
 include "mlir/Pass/PassBase.td"
 
+def LowerIREEPyDMToRTL : Pass<"lower-iree-pydm-to-rtl", "ModuleOp"> {
+  let summary = "Lowers PyDM ops with runtime implementations to calls";
+  let description = [{
+    Once type propagation and optimizations are done, most still-remaining
+    generic (object-based) ops need to be lowered to runtime library calls.
+    This pass makes such conversions and emits imports.
+  }];
+  let constructor = "mlir::iree_pydm::createLowerIREEPyDMToRTLPass()";
+}
+
+
 def ConvertIREEPyDMToIREE : Pass<"convert-iree-pydm-to-iree", "ModuleOp"> {
   let summary = "Convert iree_pydm modules to the IREE+related dialects";
   let description = [{
@@ -16,7 +27,6 @@ def ConvertIREEPyDMToIREE : Pass<"convert-iree-pydm-to-iree", "ModuleOp"> {
     dialect + various standard dialects.
   }];
   let constructor = "mlir::iree_pydm::createConvertIREEPyDMToIREEPass()";
-  let dependentDialects = ["iree::IREEDialect"];
 }
 
 #endif // IREE_LLVM_EXTERNAL_PROJECTS_IREE_DIALECTS_DIALECT_IREEPYDM_CONVERSION_TO_IREE_PASSES_TD

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(RTL)
 add_subdirectory(ToIREE)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/RTL/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/RTL/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(IREEDialectsIREEPyDMRTLPasses
+  LowerToRTLPass.cpp
+
+  DEPENDS
+  MLIRIREEPyDMTransformsPassesIncGen
+
+  LINK_LIBS PUBLIC
+  IREEDialectsIREEPyDMDialect
+  IREEDialectsIREEDialect
+  MLIRIR
+  MLIRTransformUtils
+)
+
+iree_dialects_target_includes(IREEDialectsIREEPyDMRTLPasses)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/RTL/LowerToRTLPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/IREEPyDM/Transforms/RTL/LowerToRTLPass.cpp
@@ -1,0 +1,170 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "../PassDetail.h"
+#include "iree-dialects/Dialect/IREE/IREEDialect.h"
+#include "iree-dialects/Dialect/IREE/IREEOps.h"
+#include "iree-dialects/Dialect/IREEPyDM/IR/Ops.h"
+#include "iree-dialects/Dialect/IREEPyDM/Transforms/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::iree_pydm;
+
+namespace pydm_d = mlir::iree_pydm;
+
+namespace {
+
+class RtlFunc {
+ protected:
+  static FunctionType makeRaisingSignature(Builder b, ArrayRef<Type> inputs,
+                                           Type output) {
+    return b.getType<FunctionType>(
+        inputs, TypeRange{b.getType<pydm_d::ExceptionResultType>(), output});
+  }
+};
+
+template <typename RtlFuncTy>
+Operation *importRtlFunc(SymbolTable &symbolTable) {
+  OpBuilder builder(symbolTable.getOp()->getContext());
+  auto name = builder.getStringAttr(RtlFuncTy::getRtlName());
+  auto *existing = symbolTable.lookup(name);
+  if (existing) return existing;
+
+  // Does not exist - create detached and insert.
+  FunctionType signature = RtlFuncTy::getRtlSignature(builder);
+  OperationState state(symbolTable.getOp()->getLoc(),
+                       pydm_d::FuncOp::getOperationName());
+  pydm_d::FuncOp::build(builder, state, name, signature);
+  auto funcOp = Operation::create(state);
+  SymbolTable::setSymbolVisibility(funcOp, SymbolTable::Visibility::Private);
+  symbolTable.insert(funcOp);
+  return funcOp;
+}
+
+struct ObjectAsBoolFunc : public RtlFunc {
+  static StringRef getRtlName() { return "pydmrtl$object_as_bool"; }
+  static FunctionType getRtlSignature(Builder b) {
+    return makeRaisingSignature(b, {b.getType<pydm_d::ObjectType>(nullptr)},
+                                b.getType<pydm_d::BoolType>());
+  }
+};
+
+struct DynamicBinaryPromoteFunc : public RtlFunc {
+  static StringRef getRtlName() { return "pydmrtl$dynamic_binary_promote"; }
+  static FunctionType getRtlSignature(Builder b) {
+    return makeRaisingSignature(b,
+                                {b.getType<pydm_d::ObjectType>(nullptr),
+                                 b.getType<pydm_d::ObjectType>(nullptr)},
+                                b.getType<pydm_d::TupleType>());
+  }
+};
+
+template <typename RtlFuncTy, typename OpTy>
+class EmitImportCallBase : public OpRewritePattern<OpTy> {
+ public:
+  EmitImportCallBase(SymbolTable &symbolTable, PatternBenefit benefit = 1)
+      : OpRewritePattern<OpTy>::OpRewritePattern(
+            symbolTable.getOp()->getContext(), benefit),
+        symbolTable(symbolTable) {}
+
+ protected:
+  Value emitImportCall(Location loc, ValueRange inputs,
+                       PatternRewriter &rewriter) const {
+    auto rtlName = RtlFuncTy::getRtlName();
+    importRtlFunc<RtlFuncTy>(symbolTable);
+    FunctionType signature = RtlFuncTy::getRtlSignature(rewriter);
+    auto symbolRef = rewriter.getType<FlatSymbolRefAttr>(rtlName);
+    auto callOp = rewriter.create<pydm_d::CallOp>(loc, signature.getResults(),
+                                                  symbolRef, inputs);
+    rewriter.create<pydm_d::RaiseOnFailureOp>(loc, callOp.exc_result());
+    return callOp.result();
+  }
+
+  void replaceOpWithCall(Operation *op, ValueRange inputs,
+                         PatternRewriter &rewriter) const {
+    Value callResult = emitImportCall(op->getLoc(), inputs, rewriter);
+    assert(op->getNumResults() != 0 && "expected op with results");
+    if (op->getNumResults() == 1) {
+      // No unpack.
+      rewriter.replaceOp(op, {callResult});
+    } else {
+      // Unpack 1 -> N.
+      SmallVector<Type> unpackTypes = {
+          rewriter.getType<pydm_d::ExceptionResultType>()};
+      unpackTypes.append(op->getResultTypes().begin(),
+                         op->getResultTypes().end());
+      auto unpackOp = rewriter.create<pydm_d::DynamicUnpackOp>(
+          op->getLoc(), unpackTypes, callResult);
+      rewriter.create<pydm_d::RaiseOnFailureOp>(op->getLoc(),
+                                                unpackOp.exc_result());
+      rewriter.replaceOp(op, unpackOp.slots());
+    }
+  }
+
+ private:
+  SymbolTable &symbolTable;
+};
+
+struct ObjectAsBoolPattern
+    : public EmitImportCallBase<ObjectAsBoolFunc, pydm_d::AsBoolOp> {
+  using EmitImportCallBase::EmitImportCallBase;
+
+  LogicalResult matchAndRewrite(pydm_d::AsBoolOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    auto valueType = srcOp.value().getType().dyn_cast<pydm_d::ObjectType>();
+    if (!valueType)
+      return rewriter.notifyMatchFailure(srcOp, "not an !object<>");
+    replaceOpWithCall(srcOp, {srcOp.value()}, rewriter);
+    return success();
+  }
+};
+
+struct DynamicBinaryPromotePattern
+    : public EmitImportCallBase<DynamicBinaryPromoteFunc,
+                                pydm_d::DynamicBinaryPromoteOp> {
+  using EmitImportCallBase::EmitImportCallBase;
+
+  LogicalResult matchAndRewrite(pydm_d::DynamicBinaryPromoteOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    replaceOpWithCall(srcOp, {srcOp.left(), srcOp.right()}, rewriter);
+    return success();
+  }
+};
+
+struct LowerIREEPyDMToRTLPass
+    : public LowerIREEPyDMToRTLBase<LowerIREEPyDMToRTLPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<mlir::iree::IREEDialect, BuiltinDialect, StandardOpsDialect>();
+  }
+
+  void runOnOperation() override {
+    auto *context = &getContext();
+    auto moduleOp = getOperation();
+    SymbolTable symbolTable(moduleOp);
+    RewritePatternSet patterns(context);
+    patterns.insert<DynamicBinaryPromotePattern, ObjectAsBoolPattern>(
+        symbolTable);
+
+    GreedyRewriteConfig config;
+    if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns),
+                                            config))) {
+      emitError(getOperation().getLoc())
+          << "did not converge while lowering to rtl";
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::iree_pydm::createLowerIREEPyDMToRTLPass() {
+  return std::make_unique<LowerIREEPyDMToRTLPass>();
+}

--- a/llvm-external-projects/iree-dialects/python/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/python/CMakeLists.txt
@@ -28,6 +28,7 @@ declare_mlir_dialect_python_bindings(
     dialects/iree_pydm/__init__.py
   SOURCES_GLOB
     dialects/iree_pydm/importer/*.py
+    dialects/iree_pydm/rtl/*.py
   DIALECT_NAME iree_pydm
 )
 
@@ -56,6 +57,7 @@ set(_source_components
   # TODO: Core is now implicitly building/registering all dialects, increasing
   # build burden by ~5x. Make it stop.
   MLIRPythonSources.Core
+  MLIRPythonSources.Dialects.builtin
   MLIRPythonSources.Dialects.std
   IREEDialectsPythonSources
   IREEDialectsPythonExtensions

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/importer/__init__.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/importer/__init__.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .util import ImportContext, ImportHooks, ImportStage
+from .util import (create_context, DefaultImportHooks, FuncProvidingIntrinsic,
+                   ImportContext, ImportHooks, ImportStage)
 from .importer import Importer
-from .intrinsic_def import def_ir_macro_intrinsic, def_pattern_call_intrinsic, def_pyfunc_intrinsic
+from .intrinsic_def import (def_ir_macro_intrinsic, def_pattern_call_intrinsic,
+                            def_pyfunc_intrinsic)

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/importer/test_util.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/importer/test_util.py
@@ -13,5 +13,5 @@ def test_import_global(f):
   ic = ImportContext()
   imp = Importer(ic)
   imp.import_global_function(f)
-  print(ic.module.operation)
+  print(ic._root_module)
   return f

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/__init__.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/base.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/base.py
@@ -1,0 +1,103 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Base helpers for the RTL DSL."""
+
+from typing import List, Optional
+
+import functools
+
+from ..importer import (
+    create_context,
+    def_pyfunc_intrinsic,
+    DefaultImportHooks,
+    FuncProvidingIntrinsic,
+    ImportContext,
+    ImportStage,
+)
+
+from ... import builtin as builtin_d
+from .... import ir
+
+
+class RtlModule:
+  """Declares a runtime library module.
+
+  This is typically included in a Python module which exports functions as:
+
+  ```
+  RTL_MODULE = RtlModule("booleans")
+
+  @RTL_MODULE.export_pyfunc
+  def object_as_bool(v) -> bool:
+    ...
+  ```
+  """
+
+  def __init__(self, name: str, symbol_prefix: str = "pydmrtl$"):
+    self.name = name
+    self.symbol_prefix = symbol_prefix
+    self.exported_funcs: List[FuncProvidingIntrinsic] = []
+
+  def export_pyfunc(self,
+                    f=None,
+                    *,
+                    symbol: Optional[str] = None,
+                    visibility: Optional[str] = None) -> FuncProvidingIntrinsic:
+    """Marks a python function for export in the created module.
+
+    This is typically used as a decorator and returns a FuncProvidingIntrinsic.
+    """
+    if f is None:
+      return functools.partial(self.export_pyfunc,
+                               symbol=symbol,
+                               visibility=visibility)
+    if symbol is None:
+      symbol = f.__name__
+    symbol = self.symbol_prefix + symbol
+    intrinsic = def_pyfunc_intrinsic(f, symbol=symbol, visibility=visibility)
+    self.exported_funcs.append(intrinsic)
+    return intrinsic
+
+  def internal_pyfunc(
+      self,
+      f=None,
+      *,
+      symbol: Optional[str] = None,
+      visibility: Optional[str] = "private") -> FuncProvidingIntrinsic:
+    if f is None:
+      return functools.partial(self.internal_pyfunc,
+                               symbol=symbol,
+                               visibility=visibility)
+    if symbol is None:
+      symbol = f.__name__
+    symbol = self.symbol_prefix + symbol
+    intrinsic = def_pyfunc_intrinsic(f, symbol=symbol, visibility=visibility)
+    return intrinsic
+
+
+class RtlBuilder:
+  """A build session for a combined runtime library."""
+
+  def __init__(self, context: Optional[ir.Context] = None):
+    self.context = context if context else create_context()
+    # TODO: Use hooks that import constants, etc.
+    self.hooks = DefaultImportHooks()
+    self.root_module = ir.Module.create(
+        ir.Location.unknown(context=self.context))
+    self.module_op = self.root_module.operation
+
+  def emit_module(self, rtl_module: RtlModule):
+    root_body = self.module_op.regions[0].blocks[0]
+    with ir.InsertionPoint(root_body), ir.Location.unknown():
+      sub_module = builtin_d.ModuleOp()
+      sub_module.sym_name = ir.StringAttr.get(rtl_module.name)
+    ic = ImportContext(context=self.context, module=sub_module)
+    stage = ImportStage(ic=ic, hooks=self.hooks)
+
+    # Export functions.
+    for f in rtl_module.exported_funcs:
+      # Getting the symbol implies exporting it into the module.
+      f.get_or_create_provided_func_symbol(stage)

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/booleans.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/booleans.py
@@ -1,0 +1,26 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Runtime library functions relating to booleans."""
+
+from .constants import *
+from .macros import *
+from ..base import RtlModule
+
+RTL_MODULE = RtlModule("booleans")
+
+
+@RTL_MODULE.export_pyfunc
+def object_as_bool(v) -> bool:
+  if is_type(v, TYPE_BOOL):
+    return unbox_unchecked_bool(v)
+  elif is_type(v, TYPE_NONE):
+    return False
+  elif is_type(v, TYPE_INTEGER):
+    return raw_compare_ne(unbox_unchecked_integer(v), 0)
+  elif is_type(v, TYPE_REAL):
+    return raw_compare_ne(unbox_unchecked_real(v), 0.0)
+  # TODO: List, Str, Bytes, Tuple, user objects, etc.
+  return True

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/constants.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/constants.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Constants that are inlined into RTL modules."""
+
+# TypeCode constants. These are mirrored from the BuiltinTypeCode enum on the
+# C++ side (and must match or chaos will ensue).
+TYPE_NONE = 1
+TYPE_TUPLE = 2
+TYPE_LIST = 3
+TYPE_STR = 4
+TYPE_BYTES = 5
+TYPE_EXCEPTION_RESULT = 6
+TYPE_TYPE = 7
+TYPE_BOOL = 8
+TYPE_INTEGER = 9
+TYPE_REAL = 0xa
+TYPE_COMPLEX = 0xb
+TYPE_OBJECT = 0x100

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/macros.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/macros.py
@@ -1,0 +1,121 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Macros that can be used freely when building RTL modules."""
+
+from ...importer import (
+    def_ir_macro_intrinsic,
+    ImportStage,
+)
+
+from .... import iree_pydm as d
+from ..... import ir
+
+
+@def_ir_macro_intrinsic
+def get_type_code(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Gets the TypeCode (see C++ BuiltinTypeCode) associated with a value."""
+  return d.GetTypeCodeOp(d.IntegerType.get(), value).result
+
+
+@def_ir_macro_intrinsic
+def is_type(stage: ImportStage, value: ir.Value,
+            type_code: ir.Value) -> ir.Value:
+  """Efficiently checks whether a value has a given type code."""
+  ic = stage.ic
+  if not d.IntegerType.isinstance(type_code.type):
+    ic.abort(f"is_type() macro must be called with a constant type_code. "
+             f"Got {type_code}")
+  actual_type_code = get_type_code(stage, value)
+  cmp_result = d.ApplyCompareOp(d.BoolType.get(), ir.StringAttr.get("eq"),
+                                type_code, actual_type_code).result
+  return cmp_result
+
+
+@def_ir_macro_intrinsic
+def get_numeric_promotion_order(stage: ImportStage,
+                                value: ir.Value) -> ir.Value:
+  """Gets the numeric promotion order.
+
+  See get_numeric_promotion_order op.
+  """
+  return d.GetNumericPromotionOrderOp(d.IntegerType.get(), value).result
+
+
+@def_ir_macro_intrinsic
+def promote_numeric_to_integer(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Promotes the value to IntegerType."""
+  return d.PromoteNumericOp(d.IntegerType.get(), value).result
+
+
+@def_ir_macro_intrinsic
+def promote_numeric_to_real(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Promotes the value to RealType."""
+  return d.PromoteNumericOp(d.RealType.get(), value).result
+
+
+@def_ir_macro_intrinsic
+def unbox_unchecked_bool(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Unboxes an object value to a bool, not checking for success."""
+  return d.UnboxOp(d.ExceptionResultType.get(), d.BoolType.get(),
+                   value).primitive
+
+
+@def_ir_macro_intrinsic
+def unbox_unchecked_integer(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Unboxes an object value to an integer, not checking for success."""
+  return d.UnboxOp(d.ExceptionResultType.get(), d.IntegerType.get(),
+                   value).primitive
+
+
+@def_ir_macro_intrinsic
+def unbox_unchecked_real(stage: ImportStage, value: ir.Value) -> ir.Value:
+  """Unboxes an object value to a real, not checking for success."""
+  return d.UnboxOp(d.ExceptionResultType.get(), d.RealType.get(),
+                   value).primitive
+
+
+@def_ir_macro_intrinsic
+def raw_compare_eq(stage: ImportStage, left: ir.Value,
+                   right: ir.Value) -> ir.Value:
+  """Emits an ApplyCompareOp for 'eq'."""
+  return d.ApplyCompareOp(d.BoolType.get(), ir.StringAttr.get("eq"), left,
+                          right).result
+
+
+@def_ir_macro_intrinsic
+def raw_compare_gt(stage: ImportStage, left: ir.Value,
+                   right: ir.Value) -> ir.Value:
+  """Emits an ApplyCompareOp for 'gt'."""
+  return d.ApplyCompareOp(d.BoolType.get(), ir.StringAttr.get("gt"), left,
+                          right).result
+
+
+@def_ir_macro_intrinsic
+def raw_compare_ge(stage: ImportStage, left: ir.Value,
+                   right: ir.Value) -> ir.Value:
+  """Emits an ApplyCompareOp for 'ge'."""
+  return d.ApplyCompareOp(d.BoolType.get(), ir.StringAttr.get("ge"), left,
+                          right).result
+
+
+@def_ir_macro_intrinsic
+def raw_compare_ne(stage: ImportStage, left: ir.Value,
+                   right: ir.Value) -> ir.Value:
+  """Emits an ApplyCompareOp for 'ne'."""
+  return d.ApplyCompareOp(d.BoolType.get(), ir.StringAttr.get("ne"), left,
+                          right).result
+
+
+@def_ir_macro_intrinsic
+def raise_value_error(stage: ImportStage, dummy_return: ir.Value) -> ir.Value:
+  """Raises a value error.
+
+  This needs to be changed completely when more capabilities are available.
+  It is only enough now to get program flow correct.
+  """
+  exc_result = d.FailureOp(d.ExceptionResultType.get()).result
+  d.RaiseOnFailureOp(exc_result)
+  return dummy_return

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/numerics.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/modules/numerics.py
@@ -1,0 +1,52 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RTL functions for numeric operations (on scalars)."""
+
+from .constants import *
+from .macros import *
+from ..base import RtlModule
+
+RTL_MODULE = RtlModule("numerics")
+
+
+@RTL_MODULE.export_pyfunc
+def dynamic_binary_promote(left, right) -> tuple:
+  left_order = get_numeric_promotion_order(left)
+  right_order = get_numeric_promotion_order(right)
+  # Note that since we are defining the numeric promotion rules, we have to
+  # use raw functions to compare (or else we would be using the thing we are
+  # defining).
+  if raw_compare_eq(left_order, right_order):
+    return left, right
+  elif raw_compare_gt(left_order, right_order):
+    return left, _promote_to(get_type_code(left), right)
+  else:
+    return _promote_to(get_type_code(right), left), right
+
+
+@RTL_MODULE.internal_pyfunc
+def _promote_to(type_code: int, value):
+  if raw_compare_eq(type_code, TYPE_INTEGER):
+    return _promote_to_integer(value)
+  elif raw_compare_eq(type_code, TYPE_REAL):
+    return _promote_to_real(value)
+  return raise_value_error(None)
+
+
+@RTL_MODULE.internal_pyfunc
+def _promote_to_integer(value) -> int:
+  if is_type(value, TYPE_BOOL):
+    return promote_numeric_to_integer(unbox_unchecked_bool(value))
+  return raise_value_error(0)
+
+
+@RTL_MODULE.internal_pyfunc
+def _promote_to_real(value) -> float:
+  if is_type(value, TYPE_BOOL):
+    return promote_numeric_to_real(unbox_unchecked_bool(value))
+  elif is_type(value, TYPE_INTEGER):
+    return promote_numeric_to_real(unbox_unchecked_integer(value))
+  return raise_value_error(0.0)

--- a/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/rtl_builder.py
+++ b/llvm-external-projects/iree-dialects/python/mlir/dialects/iree_pydm/rtl/rtl_builder.py
@@ -1,0 +1,57 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Python DSL for building the PyDM runtime library.
+
+Usage:
+  python -m ...rtl_builder [module, [module...]] [--verbose]
+
+By default, this will print an MLIR module in assembly format with all imported
+runtime library modules.
+"""
+
+import importlib
+import argparse
+import logging
+import sys
+
+from .base import (
+    RtlBuilder,
+    RtlModule,
+)
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Build RTL modules")
+  parser.add_argument("modules",
+                      metavar="M",
+                      type=str,
+                      nargs="*",
+                      help="RTL module to build")
+  parser.add_argument("--verbose", dest="verbose", action="store_true")
+  parser.set_defaults(modules=(".booleans", ".numerics"), verbose=False)
+  args = parser.parse_args()
+  relative_package = __package__ + ".modules"
+
+  if args.verbose:
+    logging.basicConfig(level=logging.DEBUG)
+
+  builder = RtlBuilder()
+  for module_name in args.modules:
+    logging.info("Loading module %s (from %s)", module_name, relative_package)
+    m = importlib.import_module(module_name, package=relative_package)
+    if not hasattr(m, "RTL_MODULE"):
+      raise ValueError(f"Expected {module_name} to have attribute RTL_MODULE")
+    rtl_module = m.RTL_MODULE
+    if not isinstance(rtl_module, RtlModule):
+      raise ValueError(f"Expected {module_name}.RTL_MODULE to be an RtlModule")
+    logging.info("Emitting module %s", rtl_module.name)
+    builder.emit_module(rtl_module)
+
+  print(builder.root_module)
+
+
+if __name__ == "__main__":
+  main()

--- a/llvm-external-projects/iree-dialects/test/iree_pydm/rtl/lower_to_rtl.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_pydm/rtl/lower_to_rtl.mlir
@@ -1,0 +1,38 @@
+// RUN: iree-dialects-opt -split-input-file -lower-iree-pydm-to-rtl %s | FileCheck --enable-var-scope --dump-input-filter=all %s
+
+// CHECK-LABEL: @object_as_bool
+// Doubles as a check for the general machinery.
+iree_pydm.func @object_as_bool(%arg0 : !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.bool) {
+  // CHECK: %[[EXC:.*]], %[[V:.*]] = call @pydmrtl$object_as_bool(%arg0) : (!iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.bool)
+  // CHECK: raise_on_failure %[[EXC]]
+  // CHECK: return %[[V]]
+  %0 = as_bool %arg0 : !iree_pydm.object -> !iree_pydm.bool
+  return %0 : !iree_pydm.bool
+}
+// CHECK: iree_pydm.func private @pydmrtl$object_as_bool(!iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.bool)
+
+// -----
+// CHECK-LABEL: @no_duplicate_import
+// Doubles as a check for the general machinery.
+iree_pydm.func @no_duplicate_import(%arg0 : !iree_pydm.object, %arg1 : !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.tuple) {
+  %0 = as_bool %arg0 : !iree_pydm.object -> !iree_pydm.bool
+  %1 = as_bool %arg1 : !iree_pydm.object -> !iree_pydm.bool
+  %2 = make_tuple %0, %1 : !iree_pydm.bool, !iree_pydm.bool -> !iree_pydm.tuple
+  return %2 : !iree_pydm.tuple
+}
+// CHECK: iree_pydm.func private @pydmrtl$object_as_bool
+// CHECK-NOT: iree_pydm.func private @pydmrtl$object_as_bool
+
+// -----
+// CHECK-LABEL: @dynamic_binary_promote
+// Doubles as a check for the general machinery.
+iree_pydm.func @dynamic_binary_promote(%arg0 : !iree_pydm.object, %arg1 : !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.object) {
+  // CHECK: %[[exc_result:.*]], %[[result:.*]] = call @pydmrtl$dynamic_binary_promote(%arg0, %arg1) : (!iree_pydm.object, !iree_pydm.object) -> (!iree_pydm.exception_result, !iree_pydm.tuple)
+  // CHECK: raise_on_failure %[[exc_result]]
+  // CHECK: %[[exc_result_0:.*]], %[[slots:.*]]:2 = dynamic_unpack %[[result]] : !iree_pydm.tuple -> !iree_pydm.exception_result, [!iree_pydm.object, !iree_pydm.object]
+  // CHECK: raise_on_failure %[[exc_result_0]]
+  // CHECK: make_tuple %[[slots]]#0, %[[slots]]#1
+  %left, %right = dynamic_binary_promote %arg0, %arg1 : !iree_pydm.object, !iree_pydm.object
+  %result = make_tuple %left, %right : !iree_pydm.object, !iree_pydm.object -> !iree_pydm.tuple
+  return %result : !iree_pydm.tuple
+}

--- a/llvm-external-projects/iree-dialects/test/python/iree_pydm/importer/intrinsics.py
+++ b/llvm-external-projects/iree-dialects/test/python/iree_pydm/importer/intrinsics.py
@@ -24,7 +24,7 @@ def intrinsic_return_first_true(a: int, b: int) -> int:
 
 # CHECK-LABEL: @test_intrinsic_function_no_args
 # CHECK: dynamic_call @__return_one() : () -> (!iree_pydm.exception_result, !iree_pydm.object)
-# CHECK: func private @__return_one()
+# CHECK: func @__return_one()
 @test_import_global
 def test_intrinsic_function_no_args():
   value = intrinsic_return_one()
@@ -44,7 +44,7 @@ def test_intrinsic_function_double_call():
 # CHECK: %[[ZERO:.*]] = constant 0 : i64 -> !iree_pydm.integer
 # CHECK: %[[ONE:.*]] = constant 1 : i64 -> !iree_pydm.integer
 # CHECK: dynamic_call @__return_first_true(%[[ZERO]], %[[ONE]]) : (!iree_pydm.integer, !iree_pydm.integer) -> (!iree_pydm.exception_result, !iree_pydm.object)
-# CHECK: func private @__return_first_true
+# CHECK: func @__return_first_true
 @test_import_global
 def test_intrinsic_function_args():
   value = intrinsic_return_first_true(0, 1)
@@ -98,8 +98,8 @@ logical_not = def_pattern_call_intrinsic(match_generic=[logical_not_generic],
 # CHECK: %[[TRUE:.*]] = constant true
 # CHECK: pattern_match_call(%[[TRUE]]) : (!iree_pydm.bool) -> (!iree_pydm.exception_result, !iree_pydm.object)
 # CHECK-SAME:   matching generic [@__logical_not_generic] specific [@__logical_not_bool]
-# CHECK-DAG: func private @__logical_not_generic
-# CHECK-DAG: func private @__logical_not_bool
+# CHECK-DAG: func @__logical_not_generic
+# CHECK-DAG: func @__logical_not_bool
 @test_import_global
 def test_pattern_call():
   return logical_not(True)

--- a/llvm-external-projects/iree-dialects/test/python/iree_pydm/importer/structural.py
+++ b/llvm-external-projects/iree-dialects/test/python/iree_pydm/importer/structural.py
@@ -10,3 +10,13 @@ from mlir.dialects.iree_pydm.importer.test_util import *
 @test_import_global
 def expr_statement(x: int):
   x
+
+
+# CHECK-LABEL @make_tuple
+@test_import_global
+def make_tuple(x, y) -> tuple:
+  # CHECK: %[[X:.*]] = load_var %x
+  # CHECK: %[[Y:.*]] = load_var %y
+  # CHECK: %[[RESULT:.*]] = make_tuple %[[X]], %[[Y]]
+  # CHECK: return %[[RESULT]]
+  return x, y

--- a/llvm-external-projects/iree-dialects/test/python/iree_pydm/rtl_builder.py
+++ b/llvm-external-projects/iree-dialects/test/python/iree_pydm/rtl_builder.py
@@ -1,0 +1,3 @@
+# RUN: %PYTHON -m mlir.dialects.iree_pydm.rtl.rtl_builder | iree-dialects-opt -canonicalize
+# This test is only verifying that the runtime library builds and validates
+# by passing it through opt.

--- a/llvm-external-projects/iree-dialects/test/python/iree_pydm/to_iree/basic_structure.py
+++ b/llvm-external-projects/iree-dialects/test/python/iree_pydm/to_iree/basic_structure.py
@@ -6,11 +6,13 @@ from typing import List
 from mlir.dialects.iree_pydm.importer.test_util import *
 
 
+# CHECK-LABEL: @return_none_no_args
 @test_import_global
 def return_none_no_args():
   return None
 
 
+# CHECK-LABEL: @weak_integer_arg_and_return
 @test_import_global
 def weak_integer_arg_and_return(a: int) -> int:
   return a

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBS
   MLIRTransforms
   IREEDialectsIREEDialect
   IREEDialectsIREEPyDMDialect
+  IREEDialectsIREEPyDMRTLPasses
   IREEDialectsIREEPyDMToIREEPasses
 )
 


### PR DESCRIPTION
* A pass to lower dynamic operations (i.e. on objects or otherwise requiring non trivial lowerings) to runtime library calls.
* A DSL for using the compiler to build low-level runtime library modules.
* Implemented basic support for dynamic AsBool and DynamicBinaryPromote, which are unavoidable in programs that do anything real.
* Missing a linker to pull it all together -- will come next.
* Studiously ignoring the poor quality of the frontend code and focusing on generality for the moment. Most of this stuff is imminently optimizable but it is important to get general correctness first.
* Example output of the RTL builder: https://gist.github.com/stellaraccident/1ff49e4a6108f22f1e82ad7934d9ab85