### PR TITLE
Fix scaling issue in benchmark commenting and minor improvements

### DIFF
--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -37,7 +37,8 @@ class BenchmarkThreshold:
 
 
 # A list of benchmarks and their similarity thresholds.
-# Order matters here: if multiple regexes match a single benchmark, the first match is used.
+# Order matters here: if multiple regexes match a single benchmark, the first
+# match is used.
 BENCHMARK_THRESHOLDS = [
     # Unstable and noisy GPU benchmarks.
     BenchmarkThreshold(re.compile(r"^DeepLabV3.*GPU-Mali"), 90,
@@ -49,8 +50,9 @@ BENCHMARK_THRESHOLDS = [
     BenchmarkThreshold(re.compile(r"^PoseNet.*GPU-Mali"), 90,
                        ThresholdUnit.PERCENTAGE),
 
-    # Fast GPU benchmarks that complete around 10ms, so using percentage is not suitable.
-    BenchmarkThreshold(re.compile(r"^MobileNetV3Small.*GPU-Adreno"), 2,
+    # Fast GPU benchmarks that complete around 10ms; using percentage is
+    # not suitable.
+    BenchmarkThreshold(re.compile(r"^MobileNetV3Small.*GPU-Adreno"), 1,
                        ThresholdUnit.VALUE_MS),
 
     # Default threshold for all benchmarks: 5%.

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -275,7 +275,7 @@ def categorize_benchmarks_into_tables(benchmarks: Dict[
     current = results.mean_time
     base = results.base_mean_time
     if similar_threshold.unit == ThresholdUnit.PERCENTAGE:
-      ratio = abs(current - base) / base
+      ratio = abs(current - base) / base * 100
     else:
       ratio = abs(current - base)
 


### PR DESCRIPTION
Well, forgot to x100 when calculating the percentage number. :(
Also set Adreno GPU threshold to be 1ms given it's normally
pretty stable there.