### PR TITLE
Make mismatched arity error easier to parse

### DIFF
--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -496,8 +496,8 @@ def _merge_python_sequence_to_vm(inv: Invocation, vm_list, py_list, descs):
     descs = [None] * len(py_list)
   elif len(py_list) != len(descs):
     _raise_argument_error(
-        inv, f"mismatched function call arity: "
-        f"expected={descs}, got={py_list}")
+        inv, f"mismatched call arity: expected {len(descs)} arguments but got "
+        f"{len(py_list)}. Expected signature=\n{descs}\nfor input=\n{py_list}")
   for py_value, desc in zip(py_list, descs):
     inv.current_arg = py_value
     inv.current_desc = desc


### PR DESCRIPTION
Makes parsing mismatched arity errors easier for large inputs by calling out the discrepancy up front. I also added newlines because they make it easier for me to parse long error messages like this, but could remove them if desired.

I think it would also be better to log the signature of the passed input instead of logging the input itself, since no shape information is provided in the logs (see below), but I'm not sure how best to implement that using the runtime bindings.

```python
# Example logged input arg
array([[0.00000e+00, 1.00000e+00, 2.00000e+00, ..., 3.17000e+02,
        3.18000e+02, 3.19000e+02],
       [3.20000e+02, 3.21000e+02, 3.22000e+02, ..., 6.37000e+02,
        6.38000e+02, 6.39000e+02],
       [6.40000e+02, 6.41000e+02, 6.42000e+02, ..., 9.57000e+02,
        9.58000e+02, 9.59000e+02],
       ...,
       [1.62880e+05, 1.62881e+05, 1.62882e+05, ..., 1.63197e+05,
        1.63198e+05, 1.63199e+05],
       [1.63200e+05, 1.63201e+05, 1.63202e+05, ..., 1.63517e+05,
        1.63518e+05, 1.63519e+05],
       [1.63520e+05, 1.63521e+05, 1.63522e+05, ..., 1.63837e+05,
        1.63838e+05, 1.63839e+05]], dtype=float32)
```