### PR TITLE
Introduce reverse op to LinalgExt dialect.

### DIFF
--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -245,6 +245,53 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft", [
   }];
 }
 
+def LinalgExt_ReverseOp : LinalgExt_Op<"reverse", [
+  DeclareOpInterfaceMethods<TiledOpInterface,
+                            [
+                              "generateScalarImplementation"
+                            ]>,
+  DeclareOpInterfaceMethods<LinalgExtInterface,
+                            // ReverseOp does not have a region, so we have to
+                            // overwrite the method.
+                            ["payloadUsesValueFromOperand"]>
+]> {
+  let summary = "Reverse operator";
+  let description = [{
+    A temporary solution of a reverse op. The loop bound of the reverse
+    dimension is half of the shape because we can simply swap elements. E.g.,
+
+    for (int i = 0; i < n / 2; ++i) {
+      std::swap(a[i], a[n - 1 - i]);
+    }
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       I64Attr:$dimension
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let assemblyFormat = [{
+    `dimension` `(` $dimension `)`
+    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`:` type($results)^)?
+  }];
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value operand() {
+      return getOutputOperand(0)->get();
+    }
+    ShapedType getOperandType() {
+      return operand().getType().cast<ShapedType>();
+    }
+    int64_t getOperandRank() {
+      return getOperandType().getRank();
+    }
+    ArrayRef<int64_t> getOperandShape() {
+      return getOperandType().getShape();
+    }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Pure ops
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -246,15 +246,11 @@ def LinalgExt_FftOp : LinalgExt_Op<"fft", [
 }
 
 def LinalgExt_ReverseOp : LinalgExt_Op<"reverse", [
-  DeclareOpInterfaceMethods<TiledOpInterface,
-                            [
-                              "generateScalarImplementation"
-                            ]>,
+  DeclareOpInterfaceMethods<TiledOpInterface, ["generateScalarImplementation"]>,
   DeclareOpInterfaceMethods<LinalgExtInterface,
                             // ReverseOp does not have a region, so we have to
                             // overwrite the method.
-                            ["payloadUsesValueFromOperand"]>
-]> {
+                            ["payloadUsesValueFromOperand"]>]> {
   let summary = "Reverse operator";
   let description = [{
     A temporary solution of a reverse op. The loop bound of the reverse
@@ -279,7 +275,7 @@ def LinalgExt_ReverseOp : LinalgExt_Op<"reverse", [
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
     Value operand() {
       return getOutputOperand(0)->get();
-    }
+}
     ShapedType getOperandType() {
       return operand().getType().cast<ShapedType>();
     }

--- a/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -387,3 +387,42 @@ func @fft_tensor_coef_stage_5(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>,
 //  CHECK-SAME:    outs(%[[REAL]], %[[IMAG]] : tensor<1024xf32>, tensor<1024xf32>)
 //  CHECK-SAME:   : tensor<1024xf32>, tensor<1024xf32>
 //       CHECK:   return %[[RES]]#0, %[[RES]]#1
+
+// -----
+
+func @reverse_tensor(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
+  %0 = linalg_ext.reverse
+         dimension(0)
+         outs(%arg0 : tensor<3x5xi32>) : tensor<3x5xi32>
+  return %0 : tensor<3x5xi32>
+}
+// CHECK-LABEL: func @reverse_tensor
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<3x5xi32>
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.reverse dimension(0)
+//  CHECK-SAME:      outs(%[[ARG0]]
+
+// -----
+
+func @reverse_memref(%arg0: memref<3x5xi32>) {
+  linalg_ext.reverse
+    dimension(0)
+    outs(%arg0 : memref<3x5xi32>)
+  return
+}
+// CHECK-LABEL: func @reverse_memref
+//  CHECK-SAME:   %[[ARG0:.+]]: memref<3x5xi32>
+//       CHECK:   linalg_ext.reverse dimension(0)
+//  CHECK-SAME:      outs(%[[ARG0]]
+
+// -----
+
+func @reverse_dynamic_tensor(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %0 = linalg_ext.reverse
+         dimension(1)
+         outs(%arg0 : tensor<?x?xi32>) : tensor<?x?xi32>
+  return %0 : tensor<?x?xi32>
+}
+// CHECK-LABEL: func @reverse_dynamic_tensor
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xi32>
+//       CHECK:   %[[RESULT:.+]] = linalg_ext.reverse dimension(1)
+//  CHECK-SAME:      outs(%[[ARG0]]

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -481,3 +481,29 @@ func @fft_2D_coef_buf(%real: memref<?x16xf32>, %imag: memref<?x16xf32>,
 // CHECK:               %[[RES3:.+]] = subf %[[L_REAL]], %[[T_REAL]]
 // CHECK:               %[[RES4:.+]] = subf %[[L_IMAG]], %[[T_IMAG]]
 // CHECK:               linalg.yield %[[RES1]], %[[RES2]], %[[RES3]], %[[RES4]]
+
+// -----
+
+func @reverse_dim_0(%arg0: memref<?x?xi32>) {
+  linalg_ext.reverse
+    dimension(0)
+    outs(%arg0 : memref<?x?xi32>)
+  return
+}
+// CHECK-LABEL: func @reverse_dim_0
+// CHECK-SAME:    %[[BUF:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+// CHECK-DAG:     %[[C2:.+]] = constant 2 : index
+// CHECK-DAG:     %[[D0:.+]] = memref.dim %arg0, %c0 : memref<?x?xi32>
+// CHECK-DAG:     %[[D1:.+]] = memref.dim %arg0, %c1 : memref<?x?xi32>
+// CHECK-DAG:     %[[REV_UB:.+]] = divi_signed %[[D0]], %[[C2]] : index
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[REV_UB]] step %[[C1]]
+// CHECK:           scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C1]]
+// CHECK:             %[[T0:.+]] = memref.dim %[[BUF]], %[[C0]]
+// CHECK:             %[[T1:.+]] = subi %[[T0]], %[[C1]] : index
+// CHECK:             %[[T2:.+]] = subi %[[T1]], %[[I]] : index
+// CHECK:             %[[V0:.+]] = memref.load %[[BUF]][%[[I]], %[[J]]]
+// CHECK:             %[[V1:.+]] = memref.load %[[BUF]][%[[T2]], %[[J]]]
+// CHECK:             memref.store %[[V0]], %[[BUF]][%[[T2]], %[[J]]] : memref<?x?xi32>
+// CHECK:             memref.store %[[V1]], %[[BUF]][%[[I]], %[[J]]] : memref<?x?xi32>


### PR DESCRIPTION
Defines linalg_ext.reverse op and implements basic interface methods of
the op.

The reverse op in Linalg has Linalg unfriendly affine exprs, which
blocks tile and distribute transforms. This is a short/mid term solution
for tiling and distributing reverse ops.

It's a step toward https://github.com/google/iree/issues/5045