### PR TITLE
Only add bundled pybind11 if not already found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .pytype/
 
 # Visual Studio files
+.env
 .vs/
 .vscode/
 *.sdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ else()
   option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
 endif()
 
+option(IREE_BUILD_OLD_PYTHON_COMPILER_API "Builds the original Python compiler API" ON)
+
 #-------------------------------------------------------------------------------
 # Experimental project flags
 #-------------------------------------------------------------------------------
@@ -438,7 +440,7 @@ if(IREE_BUILD_TESTS)
   enable_testing(iree)
 endif()
 
-if(IREE_BUILD_PYTHON_BINDINGS)
+if(IREE_BUILD_PYTHON_BINDINGS AND NOT pybind11_FOUND)
   add_subdirectory(third_party/pybind11 EXCLUDE_FROM_ALL)
 endif()
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,7 +13,7 @@ set(PYBIND_EXTENSION_COPTS "-fvisibility=hidden")
 add_subdirectory(iree/runtime)
 add_subdirectory(iree/jax)
 
-if(${IREE_BUILD_COMPILER})
+if(IREE_BUILD_COMPILER AND IREE_BUILD_OLD_PYTHON_COMPILER_API)
 add_subdirectory(iree/compiler)
 add_subdirectory(iree/tools/core)
 endif()

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -215,8 +215,8 @@ function(iree_add_data_dependencies)
       # If this file is included in multiple rules, only create the target once.
       string(REPLACE "::" "_" _DATA_TARGET ${_DATA_LABEL})
       if(NOT TARGET ${_DATA_TARGET})
-        set(_INPUT_PATH "${CMAKE_SOURCE_DIR}/${_FILE_PATH}")
-        set(_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${_FILE_PATH}")
+        set(_INPUT_PATH "${PROJECT_SOURCE_DIR}/${_FILE_PATH}")
+        set(_OUTPUT_PATH "${PROJECT_BINARY_DIR}/${_FILE_PATH}")
         add_custom_target(${_DATA_TARGET}
           COMMAND ${CMAKE_COMMAND} -E copy ${_INPUT_PATH} ${_OUTPUT_PATH}
         )

--- a/llvm-external-projects/iree-compiler-api/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # a CMake min version of 3.0, which causes them to set it locally to OLD.
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 
-project(iree-compiler-backend LANGUAGES C CXX)
+project(iree-compiler-api LANGUAGES C CXX)
 
 # Directory layout.
 # When building in-tree, this directory exists relative to the overall
@@ -79,6 +79,10 @@ set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
 # TODO: Consider removing this upstream and just using the main
 # MLIR_ENABLE_BINDINGS_PYTHON option.
 set(MHLO_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
+
+# Required IREE settings.
+set(IREE_BUILD_PYTHON_BINDINGS ON CACHE BOOL "" FORCE)
+set(IREE_BUILD_OLD_PYTHON_COMPILER_API OFF CACHE BOOL "" FORCE)
 
 # TODO: Fix this upstream. Each of these system include hacks is broken in
 # a different way, so there is not an easy local fix. They should be removed

--- a/llvm-external-projects/iree-compiler-api/build_tools/build_intree.sh
+++ b/llvm-external-projects/iree-compiler-api/build_tools/build_intree.sh
@@ -11,12 +11,19 @@
 set -eu -o errtrace
 
 project_dir="$(cd $(dirname $0)/.. && pwd)"
+workspace_dir="$project_dir/../.."
 build_dir="$project_dir/build"
+
+# Write out a .env file to the workspace.
+echo "PYTHONPATH=$build_dir/python_package:$build_dir/iree/bindings/python" > $workspace_dir/.env
 
 cmake -GNinja -B"$build_dir" "$project_dir" \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
+  -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld \
+  -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld \
+  -DLLVM_OPTIMIZED_TABLEGEN=ON \
   "$@"
 
 cd $build_dir
-ninja
+ninja all iree/bindings/python/all


### PR DESCRIPTION
* Needed for use of IREE as a sub-project that also configures pybind11.
* Enables building of IREE python bindings as part of iree-compiler-api.
* Fixes an issue with IREE data deps to make them relative to the project, not the root.
* Tweaks some settings on the compiler-api build to make it better for dev.