### PR TITLE
Add gcc CI build

### DIFF
--- a/build_tools/buildkite/cmake/build_configurations.yml
+++ b/build_tools/buildkite/cmake/build_configurations.yml
@@ -28,7 +28,6 @@ steps:
     commands:
       - "./scripts/git/submodule_versions.py init"
       - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/cmake-gcc@sha256:828a43d9d090b819445155bd0ed82fb0dd6daa4eddca705dbac8d0d8fd6a01f8 ./build_tools/cmake/clean_build.sh"
-    artifact_paths: "build-artifacts.tgz"
     env:
       IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
     agents:

--- a/build_tools/buildkite/cmake/build_configurations.yml
+++ b/build_tools/buildkite/cmake/build_configurations.yml
@@ -23,6 +23,17 @@ steps:
     agents:
       - "queue=build"
 
+  - label: ":gnu: Build with GCC"
+    key: "build-gcc"
+    commands:
+      - "./scripts/git/submodule_versions.py init"
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/cmake-gcc@sha256:828a43d9d090b819445155bd0ed82fb0dd6daa4eddca705dbac8d0d8fd6a01f8 ./build_tools/cmake/clean_build.sh"
+    artifact_paths: "build-artifacts.tgz"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    agents:
+      - "queue=build"
+
   - label: ":linux: Build host install"
     key: "build-host-install"
     commands:

--- a/build_tools/cmake/clean_build.sh
+++ b/build_tools/cmake/clean_build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2019 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/build_tools/docker/cmake-gcc/Dockerfile
+++ b/build_tools/docker/cmake-gcc/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# An image for building IREE using GCC with CMake. We're overriding the env
+# variables set in the base image. Is this terrible layering? Yes, but don't
+# blame me. I wasn't the one that made Dockerfile a really unextensible format.
+
+# apparently even building the compiler requires Python now 😭
+FROM gcr.io/iree-oss/cmake-python@sha256:055eba8441ada5e0241f102241747e8d61196dca7f04316a0bfd68d2769883dc AS final
+
+ENV CC /usr/bin/gcc-9
+ENV CXX /usr/bin/g++-9
+
+# Avoid apt-add-repository, which requires software-properties-common, which is
+# a rabbit hole of python version compatibility issues. See
+# https://mondwan.blogspot.com/2018/05/alternative-for-add-apt-repository-for.html
+# We use gcc-9 because it's what manylinux had (at time of authorship) and
+# we don't aim to support older versions. We need a more modern lld to handle
+# --push-state flags
+RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" >> /etc/apt/sources.list  \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F \
+  && apt-get update \
+  && apt-get install -y gcc-9 g++-9 lld-9 \
+  && rm /usr/bin/lld /usr/bin/ld.lld \
+  && ln -s lld-9 /usr/bin/lld \
+  && ln -s ld.lld-9 /usr/bin/ld.lld

--- a/build_tools/docker/manage_images.py
+++ b/build_tools/docker/manage_images.py
@@ -47,6 +47,7 @@ IMAGES_TO_DEPENDENCIES = {
     'cmake': ['base', 'util'],
     'cmake-android': ['cmake-python', 'util'],
     'cmake-emscripten': ['cmake'],
+    'cmake-gcc': ['cmake-python'],
     'cmake-python': ['cmake'],
     'cmake-python-vulkan': ['cmake-python', 'vulkan'],
     'cmake-python-swiftshader': ['cmake-python-vulkan', 'swiftshader'],

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -18,3 +18,4 @@ gcr.io/iree-oss/cmake-riscv@sha256:ced0115d6dfb8a3827c77290dfb39f541b8eaab6eae1b
 gcr.io/iree-oss/cmake-bazel-frontends-android@sha256:8ff36973858dfad252377ecd5a3a00c01876c2b83fccb91c72127d69496b84e4
 gcr.io/iree-oss/samples@sha256:7e0a025bfa9c3e6b836b505931d7e980d7f4bea451f285d52f908ac35231793e
 gcr.io/iree-oss/cmake-emscripten@sha256:d73aa7b643608e81ec253e62639ac6ec59387957509a3e894464ac8e6e8c6da8
+gcr.io/iree-oss/cmake-gcc@sha256:828a43d9d090b819445155bd0ed82fb0dd6daa4eddca705dbac8d0d8fd6a01f8


### PR DESCRIPTION
This will run post-submit as part of the Buildkite pipeline testing
various configurations. Only checks that things build, doesn't run any
tests.

This is mostly in support of releases. It uses gcc 9, even though the
latest on Ubuntu 18.04 is 7. We get some errors building with 7 and
debugging gcc errors is not high priority right now 🙂 There are also
oodles of warnings, mostly because we haven't correctly split the
diagnostic flags for gcc vs clang. Again, not a priority right now.

Tested:
Ran a build locally in the docker image. Kicked off a buildkite run
https://buildkite.com/iree/iree-build-configurations/builds/839

Fixes https://github.com/google/iree/issues/6959