### PR TITLE
Include recursive package for core compiler tools.

### DIFF
--- a/bindings/python/iree/compiler/setup.py.in
+++ b/bindings/python/iree/compiler/setup.py.in
@@ -69,8 +69,12 @@ setup(
         "Development Status :: 3 - Alpha",
     ],
     python_requires=">=3.7",
-    packages=find_namespace_packages(
-        include=["iree.compiler", "iree.compiler.*", "iree.tools.core"]),
+    packages=find_namespace_packages(include=[
+        "iree.compiler",
+        "iree.compiler.*",
+        "iree.tools.core",
+        "iree.tools.core.*",
+    ]),
     package_data={
         "iree.tools.core": [f"iree-translate{exe_suffix}",],
     },


### PR DESCRIPTION
(Untested) follow-up to https://github.com/google/iree/pull/6654 for the core tools (mainly `iree-translate`).

Attempting to fix an error demonstrated [in this notebook](https://colab.research.google.com/gist/ScottTodd/8403b5858224ad8e6e42c65c069b26af/iree-native-tools.ipynb):
```
!iree-translate --help

Traceback (most recent call last):
  File "/usr/local/bin/iree-translate", line 5, in <module>
    from iree.tools.core.scripts.iree_translate.__main__ import main
ModuleNotFoundError: No module named 'iree.tools.core.scripts'
```

We have validation for the pip installs and scripts now, but based on https://github.com/google/iree/issues/6638#issuecomment-893121059, they should be running from a working directory other than where the pip install is?
https://github.com/google/iree/blob/dc13622f9aed080eb7096e0833925ce65d5d54ee/.github/workflows/validate_and_publish_release.yml#L41-L47