### PR TITLE
Add `lld` symlinks to the installed directory

### DIFF
--- a/docs/website/docs/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/deployment-configurations/bare-metal.md
@@ -70,6 +70,11 @@ and add the additional `-iree-llvm-static-library-output-path=` flag to specify
 the static library destination. This will produce a `.h\.o` file to link
 directly into the target application.
 
+When building the binary, you may want to use the linker `lld` built at
+`third_party/llvm-project/llvm/bin` (or in the `install/bin` from the host
+compiler distribution) instead of the system default linker
+to have the codegen and linker in sync.
+
 ## Build bare-metal runtime from the source
 
 A few CMake options and macros should be set to build a subset of IREE runtime

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -479,18 +479,35 @@ if(${IREE_BUILD_COMPILER})
   )
 
   if(NOT LLD_SYMLINKS_TO_CREATE)
-  set(LLD_SYMLINKS_TO_CREATE
-    lld-link ld.lld ld64.lld wasm-ld)
+    if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+      set(LLD_SYMLINKS_TO_CREATE
+          lld-link.exe wasm-ld.exe)
+    else()
+      set(LLD_SYMLINKS_TO_CREATE
+          ld.lld ld64.lld wasm-ld)
+    endif()
   endif()
 
   foreach(link ${LLD_SYMLINKS_TO_CREATE})
-    install(
-      CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink lld ${link} \
-          WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin)"
-    )
-    install(
-      CODE "message(\"-- Create symlink: bin/${link} -> bin/lld\")"
-    )
+    if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+      install(
+        CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_hardlink lld.exe ${link} \
+            WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin)"
+      )
+      install(
+        CODE "message(\
+          \"-- Create link: ${CMAKE_INSTALL_PREFIX}/bin/${link} -> ${CMAKE_INSTALL_PREFIX}/bin/lld.exe\")"
+      )
+    else()
+      install(
+        CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink lld ${link} \
+            WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin)"
+      )
+      install(
+        CODE "message(
+          \"-- Create link: ${CMAKE_INSTALL_PREFIX}/bin/${link} -> ${CMAKE_INSTALL_PREFIX}/bin/lld\")"
+      )
+    endif()
   endforeach()
 
   # General test dependency binary/scripts installed.

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -480,7 +480,7 @@ if(${IREE_BUILD_COMPILER})
 
   if(NOT LLD_SYMLINKS_TO_CREATE)
   set(LLD_SYMLINKS_TO_CREATE
-    lld-link ld.lld ld64.lld ld64.lld.darwinnew ld64.lld.darwinold wasm-ld)
+    lld-link ld.lld ld64.lld wasm-ld)
   endif()
 
   foreach(link ${LLD_SYMLINKS_TO_CREATE})

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -478,6 +478,21 @@ if(${IREE_BUILD_COMPILER})
     RUNTIME DESTINATION bin
   )
 
+  if(NOT LLD_SYMLINKS_TO_CREATE)
+  set(LLD_SYMLINKS_TO_CREATE
+    lld-link ld.lld ld64.lld ld64.lld.darwinnew ld64.lld.darwinold wasm-ld)
+  endif()
+
+  foreach(link ${LLD_SYMLINKS_TO_CREATE})
+    install(
+      CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink lld ${link} \
+          WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin)"
+    )
+    install(
+      CODE "message(\"-- Create symlink: bin/${link} -> bin/lld\")"
+    )
+  endforeach()
+
   # General test dependency binary/scripts installed.
   install(
     PROGRAMS


### PR DESCRIPTION
Allow users to use the `lld` built from the source without updating
additional platform-specific linker names.

Also update the static_library webdoc to show how to use the linker.