### PR TITLE
Revisit CPU lowering configuration settings.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -265,8 +265,8 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
                     matmulL1TileSize, vectorSizeVals[i]));
   }
   l1TileSizes.push_back(matmulL1TileSize);
+  vectorSizeVals.push_back(vectorSize);
   vectorTileSizes.assign(vectorSizeVals.begin(), vectorSizeVals.end());
-  vectorTileSizes.push_back(vectorSize);
   TileSizesListType tileSizes;
   tileSizes.push_back({});  // Empty here since there is nothing to do in first
                             // level tiling.

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -268,7 +268,9 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
         getTileSize(0, workloadPerWorkgroup[tiledLoops.size() - 1 - i],
                     matmulL1TileSize, vectorSizeVals[i]));
   }
-  l1TileSizes.push_back(matmulL1TileSize);
+  // L1 tile size for k dimensions.
+  int64_t K = lhsShapedType.getShape().back();
+  l1TileSizes.push_back(getTileSize(0, K, matmulL1TileSize, vectorSize));
   vectorSizeVals.push_back(vectorSize);
   vectorTileSizes.assign(vectorSizeVals.begin(), vectorSizeVals.end());
   TileSizesListType tileSizes;

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -27,11 +27,9 @@ namespace iree_compiler {
 
 // TODO(ravishankarm): This needs to be put in a common place for the CPU and
 // GPU backends to use.
-static llvm::cl::list<unsigned> clLLVMTileSizes(
-    "iree-llvm-tile-size",
-    llvm::cl::desc("Set tile sizes to use for tiling Linalg operations in "
-                   "LLVM code generation"),
-    llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated);
+static llvm::cl::opt<int> clNativeVectorSizeInBytes(
+    "iree-codegen-llvm-vector-size-in-bytes",
+    llvm::cl::desc("linalg.matmul vector tile size"), llvm::cl::init(16));
 
 static llvm::cl::opt<int> matmulWorkgroupTileSize(
     "iree-codegen-llvm-matmul-workgroup-size",
@@ -79,105 +77,173 @@ static llvm::cl::opt<int> defaultWorkgroupTileSize(
         "linalg.generic and linalg.indexed_generic workgroup tile size"),
     llvm::cl::init(64));
 
-static Optional<int64_t> getNativeVectorSize(FuncOp entryPointFn,
-                                             Type elementType) {
-  Optional<int64_t> nativeVectorSizeInBytes = llvm::None;
-  if (auto variantOp =
-          entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
-    if (IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target()) {
-      if (auto config = targetAttr.getConfiguration()) {
-        if (auto nativeVectorSizeAttr =
-                config.getAs<IntegerAttr>("native_vector_size")) {
-          if (int64_t nativeVectorSizeVal = nativeVectorSizeAttr.getInt()) {
-            nativeVectorSizeInBytes = nativeVectorSizeVal;
-          }
-        }
-      }
-    }
+/// Looks for the `native_vector_size` attribute in the hal.executable.variant
+/// op.
+static Optional<int64_t> getNativeVectorSizeInBytes(FuncOp entryPointFn) {
+  auto variantOp =
+      entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  if (!variantOp) return llvm::None;
+  IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
+  if (!targetAttr) return llvm::None;
+  auto config = targetAttr.getConfiguration();
+  if (!config) return llvm::None;
+  auto nativeVectorSizeAttr = config.getAs<IntegerAttr>("native_vector_size");
+  if (!nativeVectorSizeAttr) return llvm::None;
+  int64_t nativeVectorSizeVal = nativeVectorSizeAttr.getInt();
+  if (!nativeVectorSizeVal) return llvm::None;
+  return nativeVectorSizeVal;
+}
+
+/// Return the type length in bytes. Looks throuigh all the interface binding
+/// ops to see the ABI types and guess-timates the type size to use.
+static unsigned getReferenceTypeLengthInBytes(FuncOp entryPointFn) {
+  unsigned referenceTypeLengthInBytes = 4;
+  entryPointFn.walk([&](IREE::HAL::InterfaceBindingSubspanOp subSpanOp) {
+    Type type = subSpanOp.getResult().getType();
+    Type elementType = TypeSwitch<Type, Type>(type)
+                           .Case<ShapedType, IREE::Flow::DispatchTensorType>(
+                               [&](auto shapedType) -> Type {
+                                 if (shapedType.getRank() > 0) {
+                                   return shapedType.getElementType();
+                                 }
+                                 return nullptr;
+                               })
+                           .Default([&](Type t) -> Type { return nullptr; });
+    if (!elementType || !elementType.isIntOrFloat()) return;
+    unsigned typeWidthInBytes =
+        std::max<unsigned>(elementType.getIntOrFloatBitWidth() / 8, 1);
+    referenceTypeLengthInBytes =
+        std::min<unsigned>(referenceTypeLengthInBytes, typeWidthInBytes);
+  });
+  return referenceTypeLengthInBytes;
+}
+
+static SmallVector<int64_t> getDefaultWorkloadPerWorkgroup(
+    ArrayRef<TiledLoopInfo> tiledLoops, int64_t nativeVectorSizeInElements) {
+  if (tiledLoops.empty()) {
+    return {};
   }
-  // TODO(ravishankarm): For now still picking the value from the
-  // `iree-codegen-llvm-matmul-vector-size` option to avoid some issues on
-  // RISCV-32 side.
-  if (nativeVectorSizeInBytes) {
-    if (elementType.isIntOrFloat()) {
-      unsigned bitWidth = elementType.getIntOrFloatBitWidth() / 8;
-      return (*nativeVectorSizeInBytes) / bitWidth;
-    }
+  int64_t useDefaultWorkgroupTileSize = defaultWorkgroupTileSize;
+  unsigned maxDim = 0;
+  for (auto tiledLoop : tiledLoops) {
+    maxDim = std::max<unsigned>(tiledLoop.distributionDim, maxDim);
   }
-  return matmulVectorSize.getValue();
+  SmallVector<int64_t> workloadPerWorkgroup(maxDim + 1, 1);
+  if (tiledLoops.size() == 1) {
+    useDefaultWorkgroupTileSize *= 2;
+  } else if (tiledLoops.size() == 3) {
+    useDefaultWorkgroupTileSize /= 2;
+  }
+
+  for (auto tiledLoop : tiledLoops) {
+    if (!tiledLoop.ub || !tiledLoop.ub.is<Attribute>() || !tiledLoop.lb ||
+        !tiledLoop.lb.is<Attribute>()) {
+      workloadPerWorkgroup[tiledLoop.distributionDim] =
+          defaultWorkgroupTileSize;
+      continue;
+    }
+    int64_t lb = tiledLoop.lb.get<Attribute>().cast<IntegerAttr>().getInt();
+    int64_t ub = tiledLoop.ub.get<Attribute>().cast<IntegerAttr>().getInt();
+    int64_t candidateTileSize =
+        (tiledLoop.distributionDim == 0 ? nativeVectorSizeInElements : 1);
+    if (ub <= lb) {
+      // Avoid tiling this loop.
+      candidateTileSize = 0;
+    } else {
+      candidateTileSize = std::max<int64_t>(
+          llvm::PowerOf2Floor(static_cast<uint64_t>(ub - lb) / 2),
+          (tiledLoop.distributionDim == 0 ? nativeVectorSizeInElements : 1));
+    }
+
+    workloadPerWorkgroup[tiledLoop.distributionDim] =
+        std::min<int64_t>(candidateTileSize, useDefaultWorkgroupTileSize);
+  }
+  return workloadPerWorkgroup;
+}
+
+/// Sets the default launch configuration to use for a tiled + distributed
+/// dispatch region based on the `tiledLoops` found.
+static LogicalResult setDefaultLaunchConfig(
+    FuncOp entryPointFn, ArrayRef<TiledLoopInfo> tiledLoops) {
+  unsigned typeWidthInBytes = getReferenceTypeLengthInBytes(entryPointFn);
+  int64_t nativeVectorSizeInBytes = clNativeVectorSizeInBytes;
+  if (auto fromConfig = getNativeVectorSizeInBytes(entryPointFn)) {
+    nativeVectorSizeInBytes = fromConfig.getValue();
+  }
+  int64_t nativeVectorSizeInElements =
+      nativeVectorSizeInBytes / typeWidthInBytes;
+  SmallVector<int64_t> workloadPerWorkgroup =
+      getDefaultWorkloadPerWorkgroup(tiledLoops, nativeVectorSizeInElements);
+
+  setTranslationInfo(
+      entryPointFn, IREE::HAL::DispatchLoweringPassPipeline::CPUDefault,
+      /*workgroupSize =*/ArrayRef<int64_t>{}, workloadPerWorkgroup);
+  return success();
 }
 
 /// Sets the lowering configuration for dispatch region with root op that
 /// implements the contraction operation interface.
-static LogicalResult setRootConfig(
-    FuncOp entryPointFn, linalg::ContractionOpInterface contractionOp) {
+static LogicalResult setRootConfig(FuncOp entryPointFn,
+                                   linalg::ContractionOpInterface contractionOp,
+                                   ArrayRef<TiledLoopInfo> tiledLoops) {
   if (getLoweringConfig(contractionOp)) return success();
-  Type elementType =
-      contractionOp.lhs().getType().cast<ShapedType>().getElementType();
-  auto vectorSize = getNativeVectorSize(entryPointFn, elementType);
-  if (!vectorSize) return success();
-  int64_t vectorSizeVal = *vectorSize;
 
-  if (contractionOp.isRowMajorMatmul()) {
-    int mWorkgroupSize = matmulWorkgroupTileSize;
-    int nWorkgroupSize = matmulWorkgroupTileSize;
-    int mL1TileSize = matmulL1TileSize;
-    int nL1TileSize = matmulL1TileSize;
-    int kL1TileSize = matmulL1TileSize;
-    auto lhsShape = getUntiledShape(contractionOp.lhs());
-    auto rhsShape = getUntiledShape(contractionOp.rhs());
-    if (!vectorSize) return success();
-    if (!lhsShape.empty() && !rhsShape.empty()) {
-      // Find largest tile size that is a multiple of the vector size.
-      auto getTileSize = [vectorSizeVal](int dim, int maxSize) -> int {
-        if (dim == ShapedType::kDynamicSize) return maxSize;
-        if (dim < vectorSizeVal) return vectorSizeVal;
-        for (int i = std::min(maxSize, dim); i > 0; --i) {
-          if (dim % i == 0 && i % vectorSizeVal == 0) {
-            return i;
-          }
-        }
-        return maxSize;
-      };
-      mWorkgroupSize = getTileSize(lhsShape[0], mWorkgroupSize);
-      nWorkgroupSize = getTileSize(rhsShape[1], nWorkgroupSize);
-      mL1TileSize = getTileSize(mWorkgroupSize, mL1TileSize);
-      nL1TileSize = getTileSize(nWorkgroupSize, nL1TileSize);
-      kL1TileSize = getTileSize(rhsShape[0], kL1TileSize);
+  auto lhsShapedType = contractionOp.lhs().getType().cast<ShapedType>();
+  Type elementType = lhsShapedType.getElementType();
+  if (!elementType.isIntOrFloat()) return success();
+  unsigned byteWidth = elementType.getIntOrFloatBitWidth() / 8;
+  int64_t vectorSize;
+  if (Optional<int64_t> nativeVectorSizeVal =
+          getNativeVectorSizeInBytes(entryPointFn)) {
+    vectorSize = nativeVectorSizeVal.getValue() / byteWidth;
+  } else {
+    vectorSize = matmulVectorSize;
+  }
+
+  // Use the default distribution for the matmul loops.
+  bool isBatchMatmul = lhsShapedType.getRank() == 3;
+  if (isBatchMatmul) {
+    if (tiledLoops.size() != 3) {
+      return contractionOp.emitOpError(
+          "expected op to be distributed along 3 dimensions");
     }
-    TileSizesListType tileSizes = {
-        {mWorkgroupSize, nWorkgroupSize},
-        {mL1TileSize, nL1TileSize, kL1TileSize},
-        {vectorSizeVal, vectorSizeVal, vectorSizeVal}};
-    SmallVector<int64_t, 4> nativeVectorSize = {vectorSizeVal, vectorSizeVal,
-                                                vectorSizeVal};
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPointFn, contractionOp, tileSizes, nativeVectorSize,
-        IREE::HAL::DispatchLoweringPassPipeline::CPUTensorToVectors);
+  } else if (tiledLoops.size() != 2) {
+    return contractionOp.emitOpError(
+        "expected op tbe distributed along 2 dimensions");
   }
-  if (contractionOp.isRowMajorBatchMatmul()) {
-    // TODO(ataei, ravishankarm): This should just use the configuration for
-    // matmul above. setting the tile size to 1 for all the batch dimensions.
-    TileSizesListType tileSizes = {
-        {1, batchMatmulWorkgroupTileSize, batchMatmulWorkgroupTileSize},
-        {1, batchMatmulL1TileSize, batchMatmulL1TileSize,
-         batchMatmulL1TileSize},
-        {1, vectorSizeVal, vectorSizeVal, vectorSizeVal}};
-    SmallVector<int64_t, 4> nativeVectorSize = {1, vectorSizeVal, vectorSizeVal,
-                                                vectorSizeVal};
-    return setOpConfigAndEntryPointFnTranslation(
-        entryPointFn, contractionOp, tileSizes, nativeVectorSize,
-        IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization);
+  SmallVector<int64_t> workloadPerWorkgroup = getDefaultWorkloadPerWorkgroup(
+      isBatchMatmul ? tiledLoops.drop_front() : tiledLoops, vectorSize);
+  setTranslationInfo(
+      entryPointFn, IREE::HAL::DispatchLoweringPassPipeline::CPUTensorToVectors,
+      /*workgroupSize =*/ArrayRef<int64_t>{}, workloadPerWorkgroup);
+
+  SmallVector<int64_t, 4> l1TileSizes, vectorTileSizes, nativeVectorSize;
+  if (isBatchMatmul) {
+    l1TileSizes.push_back(1);
+    vectorTileSizes.push_back(1);
+    nativeVectorSize.push_back(1);
   }
+  l1TileSizes.append(3, matmulL1TileSize);
+  vectorTileSizes.append(3, vectorSize);
+  nativeVectorSize.append(3, vectorSize);
+  TileSizesListType tileSizes;
+  tileSizes.push_back({});  // Empty here since there is nothing to do in first
+                            // level tiling.
+  tileSizes.emplace_back(std::move(l1TileSizes));
+  tileSizes.emplace_back(std::move(vectorTileSizes));
+  IREE::HAL::LoweringConfig config =
+      buildConfigAttr(tileSizes, nativeVectorSize, entryPointFn.getContext());
+  setLoweringConfig(contractionOp, config);
   return success();
 }
 
-/// Sets the lowering configuration for dispatch region for linalg.mmt4d root op
-static LogicalResult setRootConfig(FuncOp entryPointFn,
-                                   linalg::Mmt4DOp mmt4dOp) {
-  // TODO(ataei): These are hand tuned for some performance benchmarks for now,
-  // we want to adapt the same strategy as matmul that dynamically sets tile
-  // size.
+/// Sets the lowering configuration for dispatch region for linalg.mmt4d root
+/// op
+static LogicalResult setRootConfig(FuncOp entryPointFn, linalg::Mmt4DOp mmt4dOp,
+                                   ArrayRef<TiledLoopInfo> tiledLoops) {
+  // TODO(ataei): These are hand tuned for some performance benchmarks for
+  // now, we want to adapt the same strategy as matmul that dynamically sets
+  // tile size.
   auto getWorkgroupTileSizes = [&]() -> SmallVector<int64_t> {
     if (!mmt4dWorkgroupTileSizes.empty()) {
       return SmallVector<int64_t>(mmt4dWorkgroupTileSizes.begin(),
@@ -222,10 +288,10 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
       IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization);
 }
 
-/// Sets the lowering configuration for dispatch region for linalg_ext.fft root
-/// op.
-static LogicalResult setRootConfig(FuncOp entryPointFn,
-                                   linalg_ext::FftOp fftOp) {
+/// Sets the lowering configuration for dispatch region for linalg_ext.fft
+/// root op.
+static LogicalResult setRootConfig(FuncOp entryPointFn, linalg_ext::FftOp fftOp,
+                                   ArrayRef<TiledLoopInfo> tiledLoops) {
   auto partitionedLoops = getPartitionedLoops(fftOp);
   unsigned maxDepth = partitionedLoops.back() + 1;
   SmallVector<int64_t, 4> workgroupTileSizes(maxDepth,
@@ -254,81 +320,31 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
   TileSizesListType tileSizes = {workgroupTileSizes};
 
   return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, fftOp, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
+      entryPointFn, fftOp, tileSizes,
+      /*nativeVectorSizes=*/ArrayRef<int64_t>{},
       IREE::HAL::DispatchLoweringPassPipeline::CPUDefault);
 }
 
-/// Sets the lowering configuration for dispatch region with root op being a
-/// generic op.
-static LogicalResult setDefaultRootConfig(FuncOp entryPointFn, Operation *op) {
-  auto partitionedLoops = getPartitionedLoops(op);
-  if (partitionedLoops.empty()) {
-    // Return success without doing anything. Eventually default will be used.
-    return success();
-  }
-  unsigned maxDepth = partitionedLoops.back() + 1;
-  SmallVector<int64_t, 4> workgroupTileSizes(maxDepth,
-                                             defaultWorkgroupTileSize);
-  llvm::DenseSet<unsigned> partitionedLoopsSet(partitionedLoops.begin(),
-                                               partitionedLoops.end());
-  for (auto dim : llvm::seq<int64_t>(0, workgroupTileSizes.size())) {
-    if (!partitionedLoopsSet.count(dim)) {
-      workgroupTileSizes[dim] = 0;
-    }
-  }
-  TileSizesListType tileSizes = {workgroupTileSizes};
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, op, tileSizes, /*nativeVectorSizes=*/ArrayRef<int64_t>{},
-      IREE::HAL::DispatchLoweringPassPipeline::CPUVectorization);
-}
-
-/// Finds the root operation in the given list of linalg operations and sets its
-/// configuration. Returns the root operation.
+/// Finds the root operation in the given list of linalg operations and sets
+/// its configuration. Returns error for multiple root operations.
 static LogicalResult setRootConfig(FuncOp entryPointFn,
-                                   ArrayRef<Operation *> computeOps) {
+                                   ArrayRef<Operation *> computeOps,
+                                   ArrayRef<TiledLoopInfo> tiledLoops) {
   Operation *rootOp = nullptr;
   for (auto computeOp : computeOps) {
     if (!hasMarker(computeOp, getWorkgroupMarker())) continue;
 
-    /// If the op already has a lowering config, then check for whether it
-    /// specifies a pass-pipeline and workgroup size as well. If so use those.
-    if (auto config = getLoweringConfig(computeOp)) {
-      IREE::HAL::DispatchLoweringPassPipeline passPipeline =
-          IREE::HAL::DispatchLoweringPassPipeline::CPUDefault;
-      if (auto setPassPipeline = getLoweringPassPipeline(config)) {
-        passPipeline = setPassPipeline.getValue();
-      }
-      SmallVector<int64_t, 4> workgroupSize;
-      if (auto workgroupSizeAttr = config.workgroupSize()) {
-        workgroupSize = llvm::to_vector<4>(
-            llvm::map_range(workgroupSizeAttr, [](Attribute intAttr) {
-              return intAttr.cast<IntegerAttr>().getInt();
-            }));
-      }
-      if (failed(setOpConfigAndEntryPointFnTranslation(
-              entryPointFn, computeOp, config, passPipeline, workgroupSize))) {
-        return failure();
-      }
-      // Reset the op configuration to drop the pass-pipeline and workgroup size
-      // info. The op does not carry that information anymore.
-      auto resetConfig = IREE::HAL::LoweringConfig::get(
-          config.tileSizes(), config.nativeVectorSize(),
-          /*passPipeline =*/nullptr,
-          /*workgroupSize =*/nullptr, computeOp->getContext());
-      setLoweringConfig(computeOp, resetConfig);
-    } else {
-      auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
-        return TypeSwitch<Operation *, LogicalResult>(op)
-            .Case<linalg::Mmt4DOp, linalg::ContractionOpInterface,
-                  linalg_ext::FftOp>(
-                [&](auto op) { return setRootConfig(entryPointFn, op); })
-            .Default([&](Operation *op) { return success(); });
-      };
-      if (failed(setRootConfigFn(computeOp))) {
-        return failure();
-      }
+    auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
+      return TypeSwitch<Operation *, LogicalResult>(op)
+          .Case<linalg::Mmt4DOp, linalg::ContractionOpInterface,
+                linalg_ext::FftOp>([&](auto op) {
+            return setRootConfig(entryPointFn, op, tiledLoops);
+          })
+          .Default([&](Operation *op) { return success(); });
+    };
+    if (failed(setRootConfigFn(computeOp))) {
+      return failure();
     }
-
     if (getLoweringConfig(computeOp)) {
       if (rootOp) {
         return computeOp->emitError(
@@ -337,15 +353,51 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
       rootOp = computeOp;
     }
   }
+  return success();
+}
 
-  // If no root operation found, set a configuration for all ops.
-  if (!rootOp) {
-    for (auto computeOp : computeOps) {
-      if (!hasMarker(computeOp, getWorkgroupMarker())) continue;
-      if (failed(setDefaultRootConfig(entryPointFn, computeOp))) {
+/// Sets the translation information to use for a dispatch region.
+static LogicalResult setTranslationInfoAndRootConfig(
+    FuncOp entryPointFn, ArrayRef<Operation *> computeOps,
+    ArrayRef<TiledLoopInfo> tiledLoops) {
+  // First check if the operations have a preset pipeline.
+  for (auto computeOp : computeOps) {
+    if (!hasMarker(computeOp, getWorkgroupMarker())) continue;
+
+    if (auto config = getLoweringConfig(computeOp)) {
+      // Check if the op has a preset pipeline.
+      auto passPipeline = getLoweringPassPipeline(config);
+      if (!passPipeline) continue;
+
+      // If the function already has a translation, error out.
+      if (auto translationInfo = getTranslationInfo(entryPointFn)) {
+        return computeOp->emitOpError(
+            "multiple ops within dispatch trying to set the translation "
+            "info");
+      }
+
+      SmallVector<int64_t, 4> workgroupSize;
+      if (auto workgroupSizeAttr = config.workgroupSize()) {
+        workgroupSize = llvm::to_vector<4>(
+            llvm::map_range(workgroupSizeAttr, [](Attribute intAttr) {
+              return intAttr.cast<IntegerAttr>().getInt();
+            }));
+      }
+      if (failed(setOpConfigAndEntryPointFnTranslation(
+              entryPointFn, computeOp, config, *passPipeline, workgroupSize))) {
         return failure();
       }
     }
+  }
+
+  // Next set the configuration of the operations.
+  if (failed(setRootConfig(entryPointFn, computeOps, tiledLoops))) {
+    return failure();
+  }
+
+  // Check if the translation info for the entry point is already set.
+  if (!getTranslationInfo(entryPointFn)) {
+    return setDefaultLaunchConfig(entryPointFn, tiledLoops);
   }
   return success();
 }
@@ -357,31 +409,17 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());
     if (!entryPointOp) continue;
     if (getTranslationInfo(entryPointOp)) continue;
-    SmallVector<Operation *, 4> computeOps;
-    SmallVector<Operation *, 4> tiledLoops;
+    SmallVector<Operation *> computeOps;
+    SmallVector<TiledLoopInfo> tiledLoops;
+
     // If there are no linalg ops, not using Linalg based lowering.
-    if (succeeded(getComputeOps(funcOp, computeOps, tiledLoops)) &&
-        !computeOps.empty()) {
-      if (failed(setRootConfig(funcOp, computeOps))) {
-        return failure();
-      }
+    if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
+      return failure();
     }
 
-    // If the function entry point already doesnt have a lowering info attribute
-    // on it, just add the default.
-    SmallVector<int64_t> workloadPerWorkgroup;
-    if (!tiledLoops.empty()) {
-      // If the tiled loops are not empty then this could be a corner case of
-      // tensor.insert_slice being tiled and distributed, that just shows up as
-      // a `flow.dispatch.tensor.load` and a `flow.dispatch.tensor.store`. For
-      // now just treat the tiled loops not being empty as an indicator of
-      // that. Need a better way of information flow from flow dialect to hal.
-      workloadPerWorkgroup.resize(tiledLoops.size(), defaultWorkgroupTileSize);
-    }
-    if (!getTranslationInfo(entryPointOp)) {
-      setTranslationInfo(funcOp,
-                         IREE::HAL::DispatchLoweringPassPipeline::CPUDefault,
-                         /*workgroupSize =*/{}, workloadPerWorkgroup);
+    if (failed(
+            setTranslationInfoAndRootConfig(funcOp, computeOps, tiledLoops))) {
+      return failure();
     }
   }
   return success();

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.h
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.h
@@ -14,12 +14,12 @@ namespace mlir {
 namespace iree_compiler {
 
 enum class TilingLevel : unsigned {
-  // Tile linalg operations to workgroup threads.
+  // Tile linalg operations to threads.
   WorkGroupTiles = 0,
   // Tile linalg operation on workgroup thread into L1 block tiles.
-  Level1Tiles = 1,
+  L1Tiles = 1,
   // Tile linalg operations on L1 block tiles into vector tiles.
-  Level2Tiles = 2,
+  VectorTiles = 2,
   NumTileLevels = 3
 };
 

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndVectorizeLinalgTensorOps.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndVectorizeLinalgTensorOps.cpp
@@ -80,9 +80,8 @@ void LLVMCPUTileAndVectorizePass::runOnOperation() {
         linalg::LinalgTilingOptions().setTileSizeComputationFunction(
             [](OpBuilder &builder,
                Operation *operation) -> SmallVector<Value, 4> {
-              return getTileSizes(
-                  builder, operation,
-                  static_cast<unsigned>(TilingLevel::Level1Tiles));
+              return getTileSizes(builder, operation,
+                                  static_cast<unsigned>(TilingLevel::L1Tiles));
             }),
         linalg::LinalgTransformationFilter(
             Identifier::get(getWorkgroupMarker(), context),
@@ -117,7 +116,7 @@ void LLVMCPUTileAndVectorizePass::runOnOperation() {
                Operation *operation) -> SmallVector<Value, 4> {
               return getTileSizes(
                   builder, operation,
-                  static_cast<unsigned>(TilingLevel::Level2Tiles));
+                  static_cast<unsigned>(TilingLevel::VectorTiles));
             }),
         linalg::LinalgTransformationFilter(
             Identifier::get(getWorkgroupL1TileMarker(), context),

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorization.cpp
@@ -169,9 +169,8 @@ void LLVMCPUVectorizationPass::runOnOperation() {
         linalg::LinalgTilingOptions().setTileSizeComputationFunction(
             [](OpBuilder &builder,
                Operation *operation) -> SmallVector<Value, 4> {
-              return getTileSizes(
-                  builder, operation,
-                  static_cast<unsigned>(TilingLevel::Level1Tiles));
+              return getTileSizes(builder, operation,
+                                  static_cast<unsigned>(TilingLevel::L1Tiles));
             }),
         linalg::LinalgTransformationFilter(
             Identifier::get(enablePromoteWorkgroupToFullTiles
@@ -193,7 +192,7 @@ void LLVMCPUVectorizationPass::runOnOperation() {
                Operation *operation) -> SmallVector<Value, 4> {
               return getTileSizes(
                   builder, operation,
-                  static_cast<unsigned>(TilingLevel::Level2Tiles));
+                  static_cast<unsigned>(TilingLevel::VectorTiles));
             }),
         linalg::LinalgTransformationFilter(
             Identifier::get(getWorkgroupL1TileMarker(), context),

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -959,7 +959,7 @@ hal.executable private @matmul_static {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[], [28, 8, 32], [4, 4, 4]{{\]}}
+//   CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[], [28, 8, 24], [4, 4, 4]{{\]}}
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
 //       CHECK: hal.executable.entry_point public @matmul_static attributes

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -35,11 +35,11 @@ hal.executable private @matmul_tensors  {
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %8 = muli %workgroup_size_y, %workgroup_id_y : index
-        %9 = muli %workgroup_size_y, %workgroup_count_y : index
+        %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_id_y]
+        %9 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_count_y]
         scf.for %arg0 = %8 to %M step %9 {
-          %10 = muli %workgroup_size_x, %workgroup_id_x : index
-          %11 = muli %workgroup_size_x, %workgroup_count_x : index
+          %10 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_id_x]
+          %11 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_count_x]
           scf.for %arg1 = %10 to %N step %11 {
             %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %N]
             %13 = memref.subview %0[%arg0, 0] [%12, %K] [1, 1] : memref<?x?xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>>
@@ -59,9 +59,10 @@ hal.executable private @matmul_tensors  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[64, 64], [32, 32, 32], [4, 4, 4]{{\]}}}
+//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}{{\[}}{{\]}}, [32, 32, 32], [4, 4, 4]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @matmul_tensors
+// CHECK-SAME:   translation.info = {passPipeline = "CPUTensorToVectors", workloadPerWorkgroup = [64, 64]}
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -73,12 +74,6 @@ hal.executable private @matmul_tensors  {
 // CHECK-SAME:   lowering.config = #[[CONFIG]]
 
 // -----
-
-//      CHECK: #[[CONFIG:.+]] = {passPipeline = "CPUDefault"}
-//  CHECK-NOT: #config
-//      CHECK: hal.executable.entry_point public @add_no_config
-// CHECK-SAME:     translation.info = #[[CONFIG]]
-//  CHECK-NOT:     #config
 
 hal.executable private @add_no_config  {
   hal.interface @io {
@@ -124,6 +119,11 @@ hal.executable private @add_no_config  {
   }
 }
 
+//       CHECK:  #[[CONFIG:[a-zA-Z]+]] = {passPipeline = "CPUDefault"}
+//       CHECK:  hal.executable private @add_no_config
+//       CHECK:  hal.executable.entry_point public @add_no_config
+//  CHECK-SAME:      translation.info = #[[CONFIG]]
+
 // -----
 
 hal.executable private @add  {
@@ -158,11 +158,11 @@ hal.executable private @add  {
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
-        %8 = muli %workgroup_size_y, %workgroup_id_y : index
-        %9 = muli %workgroup_size_y, %workgroup_count_y : index
+        %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_id_y]
+        %9 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_count_y]
         scf.for %arg0 = %8 to %M step %9 {
-          %10 = muli %workgroup_size_x, %workgroup_id_x : index
-          %11 = muli %workgroup_size_x, %workgroup_count_x : index
+          %10 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_id_x]
+          %11 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_count_x]
           scf.for %arg1 = %10 to %N step %11 {
             %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %M]
             %13 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg1)[%workgroup_size_x, %N]
@@ -192,9 +192,9 @@ hal.executable private @add  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[64, 64]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @add
+// CHECK-SAME:   translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64]}
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -203,7 +203,6 @@ hal.executable private @add  {
 //  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
 //      CHECK: linalg.generic
-// CHECK-SAME:  lowering.config = #[[CONFIG]]
 
 // -----
 
@@ -248,14 +247,14 @@ hal.executable private @add4D  {
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
-        %28 = muli %workgroup_size_z, %workgroup_id_z : index
-        %29 = muli %workgroup_size_z, %workgroup_count_z : index
+        %28 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_z, %workgroup_id_z]
+        %29 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_z, %workgroup_count_z]
         scf.for %arg20 = %28 to %M step %29 {
-          %8 = muli %workgroup_size_y, %workgroup_id_y : index
-          %9 = muli %workgroup_size_y, %workgroup_count_y : index
+          %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_id_y]
+          %9 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_count_y]
           scf.for %arg0 = %8 to %N step %9 {
-            %10 = muli %workgroup_size_x, %workgroup_id_x : index
-            %11 = muli %workgroup_size_x, %workgroup_count_x : index
+            %10 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_id_x]
+            %11 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_count_x]
             scf.for %arg1 = %10 to %K step %11 {
               %212 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg20)[%workgroup_size_z, %M]
               %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %N]
@@ -296,9 +295,9 @@ hal.executable private @add4D  {
       }
     }
   }
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[0, 64, 64, 64]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @add4D
+// CHECK-SAME:   translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64, 64]}
 // CHECK-NEXT:   (%[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: index)
@@ -307,7 +306,6 @@ hal.executable private @add4D  {
 //  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
 //      CHECK:    hal.return %[[D0]], %[[D1]], %[[D2]] : index, index, index
 //      CHECK: linalg.generic
-// CHECK-SAME:  lowering.config = #[[CONFIG]]
 
 // -----
 
@@ -352,14 +350,14 @@ hal.executable private @batch_matmul_tensors  {
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
-        %28 = muli %workgroup_size_z, %workgroup_id_z : index
-        %29 = muli %workgroup_size_z, %workgroup_count_z : index
+        %28 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_z, %workgroup_id_z]
+        %29 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_z, %workgroup_count_z]
         scf.for %arg20 = %28 to %B step %29 {
-          %8 = muli %workgroup_size_y, %workgroup_id_y : index
-          %9 = muli %workgroup_size_y, %workgroup_count_y : index
+          %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_id_y]
+          %9 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_y, %workgroup_count_y]
           scf.for %arg0 = %8 to %M step %9 {
-            %10 = muli %workgroup_size_x, %workgroup_id_x : index
-            %11 = muli %workgroup_size_x, %workgroup_count_x : index
+            %10 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_id_x]
+            %11 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_size_x, %workgroup_count_x]
             scf.for %arg1 = %10 to %N step %11 {
               %212 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg20)[%workgroup_size_z, %B]
               %12 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg0)[%workgroup_size_y, %N]
@@ -380,15 +378,16 @@ hal.executable private @batch_matmul_tensors  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [1, 4, 4, 4], tileSizes = {{\[}}[1, 32, 32], [1, 16, 16, 16], [1, 4, 4, 4]{{\]}}
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
+//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [1, 4, 4, 4], tileSizes = {{\[}}[], [1, 32, 32, 32], [1, 4, 4, 4]{{\]}}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
 // CHECK-NEXT: (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:  %[[ARG2:[a-zA-Z0-9]+]]: index)
+//  CHECK-DAG:  %[[C1:.+]] = constant 1 : index
 //  CHECK-DAG:  %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:  %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//      CHECK:  hal.return %[[D0]], %[[D1]], %[[ARG2]]
+//      CHECK:  hal.return %[[D0]], %[[D1]], %[[C1]]
 //      CHECK:  linalg.batch_matmul
 // CHECK-SAME:    lowering.config = #[[CONFIG]]
 
@@ -442,7 +441,7 @@ hal.executable private @preset_config_matmul_tensors  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [], tileSizes = {{\[}}[32, 32, 32]{{\]}}}
+//  CHECK-DAG: #[[CONFIG:.+]] = {passPipeline = "CPUVectorization", tileSizes = {{\[}}[32, 32, 32]{{\]}}}
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //      CHECK: hal.executable.entry_point
@@ -589,14 +588,21 @@ hal.executable private @static_3d_fft_stage3  {
         %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+        %lb_z = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_z, %workgroup_size_z]
+        %step_z = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_z, %workgroup_size_z]
         scf.for %arg0 = %workgroup_id_z to %c64 step %workgroup_count_z {
+          %lb_y = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+          %step_y = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
           scf.for %arg1 = %workgroup_id_y to %c128 step %workgroup_count_y {
-            %4 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_id_x]
-            %5 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%workgroup_count_x]
+            %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+            %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
             scf.for %arg2 = %4 to %c32 step %5 {
               %6 = memref.subview %2[%arg0, %arg1, %arg2] [1, 1, 4] [1, 1, 1] : memref<64x128x32xf32> to memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
               %7 = memref.cast %6 : memref<1x1x4xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>> to memref<?x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 32 + d2)>>
@@ -694,8 +700,5 @@ hal.executable private @outs_fusion {
     }
   }
 }
-//      CHECK: #[[CONFIG:.+]] = {tileSizes = {{\[}}[64, 64]{{\]}}}
-//      CHECK: linalg.generic
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
-//      CHECK: linalg.generic
-// CHECK-SAME:   lowering.config = #[[CONFIG]]
+//      CHECK: hal.executable.entry_point public @outs_fusion_fn
+// CHECK-SAME:   translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64]}

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -702,3 +702,506 @@ hal.executable private @outs_fusion {
 }
 //      CHECK: hal.executable.entry_point public @outs_fusion_fn
 // CHECK-SAME:   translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64]}
+
+// -----
+
+hal.executable private @conv {
+  hal.executable.variant public @system_elf_x86_64, target = #hal.executable.target<"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-linux-gnu"}> {
+    hal.executable.entry_point public @conv attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @conv() {
+        %c0 = constant 0 : index
+        %0 = hal.interface.load.constant offset = 0 : index
+        %1 = hal.interface.load.constant offset = 1 : index
+        %2 = hal.interface.load.constant offset = 2 : index
+        %3 = hal.interface.load.constant offset = 3 : index
+        %4 = hal.interface.load.constant offset = 4 : index
+        %5 = hal.interface.load.constant offset = 5 : index
+        %6 = hal.interface.load.constant offset = 6 : index
+        %7 = hal.interface.load.constant offset = 7 : index
+        %8 = hal.interface.load.constant offset = 8 : index
+        %9 = hal.interface.load.constant offset = 9 : index
+        %10 = hal.interface.load.constant offset = 10 : index
+        %11 = hal.interface.load.constant offset = 11 : index
+        %12 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?x?x?xf32>{%0, %1, %2, %3}
+        %13 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:?x?x?x?xf32>{%4, %5, %6, %7}
+        %14 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?x?x?xf32>{%8, %9, %10, %11}
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        %15 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_z, %workgroup_size_z]
+        %16 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_z, %workgroup_size_z]
+        scf.for %arg0 = %15 to %5 step %16 {
+          %17 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+          %18 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+          scf.for %arg1 = %17 to %6 step %18 {
+            %19 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+            %20 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+            scf.for %arg2 = %19 to %3 step %20 {
+              %21 = affine.min affine_map<(d0)[s0, s1, s2] -> (s0 + s2 - 1, -d0 + s0 + s1)>(%arg0)[%0, %5, %workgroup_size_z]
+              %22 = affine.min affine_map<(d0)[s0, s1, s2] -> (s0 + s2 - 1, -d0 + s0 + s1)>(%arg1)[%1, %6, %workgroup_size_y]
+              %23 = flow.dispatch.tensor.load %14, offsets = [0, %arg0, %arg1, 0], sizes = [%8, %21, %22, %11], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:?x?x?x?xf32> -> tensor<?x?x?x?xf32>
+              %24 = affine.min affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>(%arg2)[%3, %workgroup_size_x]
+              %25 = flow.dispatch.tensor.load %12, offsets = [0, 0, 0, %arg2], sizes = [%0, %1, %2, %24], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:?x?x?x?xf32> -> tensor<?x?x?x?xf32>
+              %26 = affine.min affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>(%arg0)[%5, %workgroup_size_z]
+              %27 = affine.min affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>(%arg1)[%6, %workgroup_size_y]
+              %28 = affine.min affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>(%arg2)[%3, %workgroup_size_x]
+              %29 = flow.dispatch.tensor.load %13, offsets = [0, %arg0, %arg1, %arg2], sizes = [%4, %26, %27, %28], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:?x?x?x?xf32> -> tensor<?x?x?x?xf32>
+              %30 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%23, %25 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%29 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+              flow.dispatch.tensor.store %30, %13, offsets = [0, %arg0, %arg1, %arg2], sizes = [%4, %26, %27, %28], strides = [1, 1, 1, 1] : tensor<?x?x?x?xf32> -> !flow.dispatch.tensor<readwrite:?x?x?x?xf32>
+            }
+          }
+        }
+        return
+      }
+      hal.interface private @io attributes {push_constants = 12 : index} {
+        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b1_rw_external, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+        hal.interface.binding public @s0b2_ro_external, set=0, binding=2, type="StorageBuffer", access="Read"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @conv attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64, 64, 64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]
+//  CHECK-DAG:     %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]
+//  CHECK-DAG:     %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]
+//      CHECK:     hal.return %[[D0]], %[[D1]], %[[D2]]
+//      CHECK:     linalg.conv_2d_nhwc_hwcf
+//  CHECK-NOT:       lowering.config
+
+// -----
+
+hal.executable private @conv_static {
+  hal.executable.variant public @system_elf_x86_64, target = #hal.executable.target<"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-pc-linux-gnu"}> {
+    hal.executable.entry_point public @conv_static attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @conv_static() {
+        %cst = constant 0.000000e+00 : f32
+        %c80 = constant 80 : index
+        %c96 = constant 96 : index
+        %c0 = constant 0 : index
+        %0 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x161x161x96xf32>
+        %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:3x3x96xf32>
+        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x80x80x96xf32>
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %workgroup_size_z = hal.interface.workgroup.size[2] : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        %3 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_z, %workgroup_size_z]
+        %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_z, %workgroup_size_z]
+        scf.for %arg0 = %3 to %c80 step %4 {
+          %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+          %6 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+          scf.for %arg1 = %5 to %c80 step %6 {
+            %7 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+            %8 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+            scf.for %arg2 = %7 to %c96 step %8 {
+              %9 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg0)
+              %10 = affine.min affine_map<(d0)[s0] -> (s0 * 2 + 1, d0 * -2 + 163)>(%arg0)[%workgroup_size_z]
+              %11 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg1)
+              %12 = affine.min affine_map<(d0)[s0] -> (s0 * 2 + 1, d0 * -2 + 163)>(%arg1)[%workgroup_size_y]
+              %13 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 96)>(%arg2)[%workgroup_size_x]
+              %14 = flow.dispatch.tensor.load %0, offsets = [0, %9, %11, %arg2], sizes = [1, %10, %12, %13], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:1x161x161x96xf32> -> tensor<1x?x?x?xf32>
+              %15 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 96)>(%arg2)[%workgroup_size_x]
+              %16 = flow.dispatch.tensor.load %1, offsets = [0, 0, %arg2], sizes = [3, 3, %15], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:3x3x96xf32> -> tensor<3x3x?xf32>
+              %17 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 80)>(%arg0)[%workgroup_size_z]
+              %18 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 80)>(%arg1)[%workgroup_size_y]
+              %19 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 96)>(%arg2)[%workgroup_size_x]
+              %20 = affine.min affine_map<(d0)[s0] -> (-d0 + 80, s0)>(%arg0)[%workgroup_size_z]
+              %21 = affine.min affine_map<(d0)[s0] -> (-d0 + 80, s0)>(%arg1)[%workgroup_size_y]
+              %22 = affine.min affine_map<(d0)[s0] -> (-d0 + 96, s0)>(%arg2)[%workgroup_size_x]
+              %23 = linalg.init_tensor [1, %20, %21, %22] : tensor<1x?x?x?xf32>
+              %24 = linalg.fill(%cst, %23) {__internal_linalg_transform__ = "workgroup"} : f32, tensor<1x?x?x?xf32> -> tensor<1x?x?x?xf32> 
+              %25 = linalg.depthwise_conv2D_nhw {__internal_linalg_transform__ = "workgroup", dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%14, %16 : tensor<1x?x?x?xf32>, tensor<3x3x?xf32>) outs(%24 : tensor<1x?x?x?xf32>) -> tensor<1x?x?x?xf32>
+              flow.dispatch.tensor.store %25, %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, %17, %18, %19], strides = [1, 1, 1, 1] : tensor<1x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:1x80x80x96xf32>
+            }
+          }
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
+//      CHECK: hal.executable.entry_point public @conv_static attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [32, 32, 32]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]
+//  CHECK-DAG:     %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]
+//  CHECK-DAG:     %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]
+//      CHECK:     hal.return %[[D0]], %[[D1]], %[[D2]]
+//      CHECK:     linalg.depthwise_conv2D_nhw
+//  CHECK-NOT:       lowering.config
+
+// -----
+
+hal.executable private @generic_static {
+  hal.executable.variant public @system_elf_x86_64, target = #hal.executable.target<"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-pc-linux-gnu"}> {
+    hal.executable.entry_point public @generic_static attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @generic_static() {
+        %c16 = constant 16 : index
+        %c96 = constant 96 : index
+        %c0 = constant 0 : index
+        %0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:96x16xf32>
+        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:16x96xf32>
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %2 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+        %3 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+        scf.for %arg0 = %2 to %c16 step %3 {
+          %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+          %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+          scf.for %arg1 = %4 to %c96 step %5 {
+            %6 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 96)>(%arg1)[%workgroup_size_x]
+            %7 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 16)>(%arg0)[%workgroup_size_y]
+            %8 = flow.dispatch.tensor.load %0, offsets = [%arg1, %arg0], sizes = [%6, %7], strides = [1, 1] : !flow.dispatch.tensor<readonly:96x16xf32> -> tensor<?x?xf32>
+            %9 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 16)>(%arg0)[%workgroup_size_y]
+            %10 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 96)>(%arg1)[%workgroup_size_x]
+            %11 = linalg.init_tensor [%9, %10] : tensor<?x?xf32>
+            %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<?x?xf32>) outs(%11 : tensor<?x?xf32>) attrs =  {__internal_linalg_transform__ = "workgroup"} {
+            ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
+              linalg.yield %arg2 : f32
+            } -> tensor<?x?xf32>
+            flow.dispatch.tensor.store %12, %1, offsets = [%arg0, %arg1], sizes = [%9, %10], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:16x96xf32>
+          }
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b1_xw_external, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//      CHECK: hal.executable.entry_point public @generic_static attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [32, 8]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]
+//  CHECK-DAG:     %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]
+//      CHECK:     hal.return %[[D0]], %[[D1]], %[[C1]]
+//      CHECK:     linalg.generic
+//  CHECK-NOT:       lowering.config
+
+// -----
+
+hal.executable private @matmul_static {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @matmul_static attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @matmul_static() {
+        %cst = constant 0.000000e+00 : f32
+        %c196 = constant 196 : index
+        %c40 = constant 40 : index
+        %c0 = constant 0 : index
+        %c8 = constant 8 : index
+        %c28 = constant 28 : index
+        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:196x240xf32>
+        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:240x40xf32>
+        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:196x40xf32>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        %3 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_y, %workgroup_size_y]
+        %4 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_y, %workgroup_size_y]
+        scf.for %arg0 = %3 to %c196 step %4 {
+          %5 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_id_x, %workgroup_size_x]
+          %6 = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%workgroup_count_x, %workgroup_size_x]
+          scf.for %arg1 = %5 to %c40 step %6 {
+            %7 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [28, 240], strides = [1, 1] : !flow.dispatch.tensor<readonly:196x240xf32> -> tensor<28x240xf32>
+            %8 = tensor.cast %7 : tensor<28x240xf32> to tensor<?x240xf32>
+            %9 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [240, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:240x40xf32> -> tensor<240x8xf32>
+            %10 = tensor.cast %9 : tensor<240x8xf32> to tensor<240x?xf32>
+            %11 = linalg.init_tensor [%c28, %c8] : tensor<?x?xf32>
+            %12 = linalg.fill(%cst, %11) {__internal_linalg_transform__ = "workgroup"} : f32, tensor<?x?xf32> -> tensor<?x?xf32> 
+            %13 = linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%8, %10 : tensor<?x240xf32>, tensor<240x?xf32>) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%c28, %c8], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:196x40xf32>
+          }
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer", access="Read"
+        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = {nativeVectorSize = [4, 4, 4], tileSizes = {{\[}}[], [28, 8, 32], [4, 4, 4]{{\]}}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
+//       CHECK: hal.executable.entry_point public @matmul_static attributes
+//  CHECK-SAME:     translation.info = {passPipeline = "CPUTensorToVectors", workloadPerWorkgroup = [8, 28]}
+//  CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
+//   CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//   CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
+//   CHECK-DAG:     %[[D1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//       CHECK:     hal.return %[[D0]], %[[D1]], %[[C1]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering.config = #[[CONFIG]]
+
+// -----
+
+hal.executable private @test_exp_0 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_0 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_0() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<(d0)[s0,s1] -> (d0 + s0 * s1)>(%lb)[%id, %size]
+        %stride = affine.apply affine_map<(d0)[s0,s1] -> (d0 * s0 * s1)>(%step)[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_0 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]
+
+// -----
+
+hal.executable private @test_exp_1 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_1 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_1() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<()[s0,s1] -> (5 + s0 * s1)>()[%id, %size]
+        %stride = affine.apply affine_map<(d0)[s0,s1] -> (s0 * d0 * s1)>(%step)[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_1 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]
+
+// -----
+
+hal.executable private @test_exp_2 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_2 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_2() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<(d0)[s0,s1] -> (d0 + s0 * s1)>(%lb)[%id, %size]
+        %stride = affine.apply affine_map<(d0)[s0,s1] -> (s0 * s1 * d0)>(%step)[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_2 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]
+
+// -----
+
+hal.executable private @test_exp_3 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_3 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_3() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<(d0)[s0,s1] -> (d0 + s0 * s1)>(%lb)[%id, %size]
+        %stride = affine.apply affine_map<()[s0,s1] -> (5 * s0 * s1)>()[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_3 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]
+
+// -----
+
+hal.executable private @test_exp_4 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_4 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_4() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<(d0)[s0,s1] -> (s0 * s1 + d0)>(%lb)[%id, %size]
+        %stride = affine.apply affine_map<()[s0,s1] -> (s0 * 5 * s1)>()[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_4 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]
+
+// -----
+
+hal.executable private @test_exp_5 {
+  hal.executable.variant public @system_elf_arm_64, target = #hal.executable.target<"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
+    hal.executable.entry_point public @test_exp_5 attributes {interface = @io, ordinal = 0 : index}
+    builtin.module  {
+      func @test_exp_5() {
+        %c0 = constant 0 : index
+        %size = hal.interface.workgroup.size[0] : index
+        %count = hal.interface.workgroup.count[0] : index
+        %id = hal.interface.workgroup.id[0] : index
+        %lb = hal.interface.load.constant offset = 0 : index
+        %ub = hal.interface.load.constant offset = 1 : index
+        %step = hal.interface.load.constant offset = 2 : index
+        %read = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %write = hal.interface.binding.subspan @i0::@arg0[%c0] : memref<?xf32>{%ub}
+        %offset = affine.apply affine_map<()[s0,s1] -> (s0 * s1 + 5)>()[%id, %size]
+        %stride = affine.apply affine_map<()[s0,s1] -> (s0 * s1 * 5)>()[%count, %size]
+        scf.for %iv = %offset to %ub step %stride {
+          %val = memref.load %read[%iv] : memref<?xf32>
+          memref.store %val, %write[%iv] : memref<?xf32>
+        }
+        return
+      }
+      hal.interface private @io {
+        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+      }
+    }
+  }
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//      CHECK: hal.executable.entry_point public @test_exp_5 attributes
+// CHECK-SAME:     translation.info = {passPipeline = "CPUDefault", workloadPerWorkgroup = [64]}
+// CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:     %[[C1:.+]] = constant 1 : index
+//  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP]]()[%[[ARG0]]]
+//      CHECK:     hal.return %[[D0]], %[[C1]], %[[C1]]

--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -282,8 +282,8 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     auto entryPointOp = entryPointOps.lookup(funcOp.getName());
     if (!entryPointOp) continue;
     if (getTranslationInfo(entryPointOp)) continue;
-    SmallVector<Operation *, 4> computeOps;
-    SmallVector<Operation *, 4> tiledLoops;
+    SmallVector<Operation *> computeOps;
+    SmallVector<TiledLoopInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
       return funcOp.emitOpError("failed to get compute ops");
     }

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -513,8 +513,8 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     if (!entryPointOp) continue;
     if (getTranslationInfo(entryPointOp)) continue;
 
-    SmallVector<Operation *, 4> computeOps;
-    SmallVector<Operation *, 4> tiledLoops;
+    SmallVector<Operation *> computeOps;
+    SmallVector<TiledLoopInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
       return funcOp.emitOpError("failed to get compute ops");
     }

--- a/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
@@ -198,7 +198,7 @@ class SPIRVRemoveOneTripTiledLoopPass
     // This pass seems to be only needed for the convolution vectorization. So
     // filter out the necessary conv ops.
     SmallVector<Operation *> rootOp;
-    SmallVector<Operation *> tiledLoops;
+    SmallVector<TiledLoopInfo> tiledLoops;
     if (failed(getFilteredOps(
             funcOp,
             [](Operation *op) {

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/IR/AffineExprVisitor.h"
 #include "mlir/IR/SymbolTable.h"
 
 namespace mlir {
@@ -38,6 +39,12 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
     entryPointOps[op.sym_name()] = op;
   }
   return entryPointOps;
+}
+
+IREE::HAL::TranslationInfo getTranslationInfo(FuncOp funcOp) {
+  auto entryPointOp = getEntryPoint(funcOp);
+  if (!entryPointOp) return nullptr;
+  return getTranslationInfo(entryPointOp);
 }
 
 void setTranslationInfo(FuncOp entryPointFn,
@@ -177,19 +184,306 @@ ArrayRef<int64_t> getUntiledResultShape(linalg::LinalgOp linalgOp,
   return result.getType().cast<ShapedType>().getShape();
 }
 
+//===----------------------------------------------------------------------===//
+// Get the tiled loops in the computation.
+//===----------------------------------------------------------------------===//
+
+/// Returns the first of `exprs` which is of the type `T`.
+template <typename T>
+static AffineExpr getAffineExprOfType(ArrayRef<AffineExpr> exprs) {
+  for (auto expr : exprs) {
+    if (expr.isa<T>()) return expr;
+  }
+  return nullptr;
+}
+
+/// Returns true if the `expr` is on of the types in {`T1`, `T2`, `T3...`}.
+template <typename T>
+static bool isaAffineExprOfType(AffineExpr expr) {
+  return expr.isa<T>();
+}
+template <typename T1, typename T2, typename... T3>
+static bool isaAffineExprOfType(AffineExpr expr) {
+  if (expr.isa<T1>()) {
+    return true;
+  }
+  return isaAffineExprOfType<T2, T3...>(expr);
+}
+
+/// Returns a Value that repreesnts the value for symbol or dim expr for the map
+/// in the `applyOp`.
+static Value getValueForDimOrSymbol(AffineApplyOp applyOp, AffineExpr expr) {
+  unsigned numDims = applyOp.getAffineMap().getNumDims();
+  if (auto dimExpr = expr.dyn_cast<AffineDimExpr>()) {
+    return applyOp.getOperand(dimExpr.getPosition());
+  }
+  if (auto symbolExpr = expr.dyn_cast<AffineSymbolExpr>()) {
+    return applyOp.getOperand(numDims + symbolExpr.getPosition());
+  }
+  return nullptr;
+}
+static SmallVector<Value> getValuesForDimsOrSymbols(
+    AffineApplyOp applyOp, ArrayRef<AffineExpr> exprs) {
+  SmallVector<Value> vals;
+  for (auto expr : exprs) {
+    vals.push_back(getValueForDimOrSymbol(applyOp, expr));
+  }
+  return vals;
+}
+
+/// Returns the dimension of `flow.dispatch.workgroup.(size|count|id)`.
+template <typename T>
+static Optional<unsigned> getDimension(Operation *op) {
+  if (auto tOp = dyn_cast<T>(op)) {
+    return tOp.dimension().getZExtValue();
+  }
+  return llvm::None;
+}
+template <typename T1, typename T2, typename... T3>
+static Optional<unsigned> getDimension(Operation *op) {
+  if (!op) return llvm::None;
+  if (auto dimension = getDimension<T1>(op)) {
+    return dimension;
+  }
+  return getDimension<T2, T3...>(op);
+}
+
+/// Checks that all `vals` are defined by
+/// `flow.dispatch.workgroup.(size|count|id)` using the same `dimension`. If any
+/// element of `vals` is not defined by one of these ops, or the dimensions dont
+/// match, returns llvm::None. On success returns the dimension.  If
+/// `refDimension` is passed checks if the dimension matches the given value.
+template <typename... T>
+static Optional<unsigned> checkDimensions(
+    ArrayRef<Value> vals, Optional<unsigned> refDimension = llvm::None) {
+  for (auto v : vals) {
+    auto currDimension = getDimension<T...>(v.getDefiningOp());
+    if (!currDimension) return llvm::None;
+    if (refDimension) {
+      if (refDimension.getValue() != currDimension.getValue()) {
+        return llvm::None;
+      }
+    } else {
+      refDimension = currDimension.getValue();
+    }
+  }
+  return refDimension;
+}
+
+namespace {
+/// Visitor to walk `lb` of a distributed loop. Expected the expression to be of
+/// the form `a + b * c`, where `a` is the original `lb` and `b`, `c` are either
+/// hal.interface.workgroup.id or hal.interface.workgroup.size.
+class LowerBoundExprVisitor
+    : public AffineExprVisitor<LowerBoundExprVisitor, LogicalResult> {
+ public:
+  LowerBoundExprVisitor(AffineApplyOp applyOp, TiledLoopInfo &loopInfo)
+      : applyOp(applyOp), loopInfo(loopInfo) {}
+
+  LogicalResult visitSymbolExpr(AffineSymbolExpr /*expr*/) { return failure(); }
+  LogicalResult visitDimExpr(AffineDimExpr /*expr*/) { return failure(); }
+  LogicalResult visitConstantExpr(AffineConstantExpr /*expr*/) {
+    return failure();
+  }
+  LogicalResult visitAffineBinaryOpExpr(AffineBinaryOpExpr /*expr*/) {
+    return failure();
+  }
+
+  LogicalResult visitAddExpr(AffineBinaryOpExpr expr) {
+    AffineExpr offsetExpr =
+        getAffineExprOfType<AffineBinaryOpExpr>({expr.getLHS(), expr.getRHS()});
+    if (!offsetExpr) {
+      // One of the expressions has to be a binary op expr.
+      return failure();
+    }
+    // The other expression must be the undistributed `lb`.
+    AffineExpr lbExpr =
+        (offsetExpr == expr.getLHS() ? expr.getRHS() : expr.getLHS());
+    if (isaAffineExprOfType<AffineDimExpr, AffineSymbolExpr>(lbExpr)) {
+      Value v = getValueForDimOrSymbol(applyOp, lbExpr);
+      if (!v) {
+        return failure();
+      }
+      loopInfo.lb = getAsOpFoldResult(v);
+    } else if (auto constExpr = lbExpr.dyn_cast<AffineConstantExpr>()) {
+      loopInfo.lb = IntegerAttr::get(IndexType::get(applyOp.getContext()),
+                                     constExpr.getValue());
+    } else {
+      return failure();
+    }
+    return visit(offsetExpr);
+  }
+
+  LogicalResult visitMulExpr(AffineBinaryOpExpr expr) {
+    SmallVector<Value> vals =
+        getValuesForDimsOrSymbols(applyOp, {expr.getLHS(), expr.getRHS()});
+    if (vals.size() != 2 || !vals[0] || !vals[1]) {
+      return failure();
+    }
+    Optional<unsigned> dimension =
+        checkDimensions<IREE::HAL::InterfaceWorkgroupIDOp,
+                        IREE::HAL::InterfaceWorkgroupSizeOp>(vals);
+    if (!dimension) {
+      return failure();
+    }
+    loopInfo.distributionDim = dimension.getValue();
+    if (!loopInfo.lb) {
+      loopInfo.lb = IntegerAttr::get(IndexType::get(applyOp.getContext()), 0);
+    }
+    return success();
+  }
+
+ private:
+  AffineApplyOp applyOp;
+  TiledLoopInfo &loopInfo;
+};
+
+/// Visitor to walk the `step` of a distributed loop. Expected the expression to
+/// be of the form `a * b * c`, where they could be the dynamic `step` or
+/// defined by `hal.interface.workgroup.size`/`hal.interface.workgroup.count`
+/// operation.
+class StepExprVisitor
+    : public AffineExprVisitor<StepExprVisitor, LogicalResult> {
+ public:
+  StepExprVisitor(AffineApplyOp applyOp, TiledLoopInfo &loopInfo)
+      : applyOp(applyOp), loopInfo(loopInfo) {}
+
+  LogicalResult visitSymbolExpr(AffineSymbolExpr /*expr*/) { return failure(); }
+  LogicalResult visitDimExpr(AffineDimExpr /*expr*/) { return failure(); }
+  LogicalResult visitConstantExpr(AffineConstantExpr /*expr*/) {
+    return failure();
+  }
+  LogicalResult visitAffineBinaryOpExpr(AffineBinaryOpExpr /*expr*/) {
+    return failure();
+  }
+
+  LogicalResult visitMulExpr(AffineBinaryOpExpr expr) {
+    // Check if one of the operands is a binary op expr.
+    SmallVector<AffineExpr> sentinels;
+    if (auto e = getAffineExprOfType<AffineBinaryOpExpr>(
+            {expr.getLHS(), expr.getRHS()})) {
+      AffineExpr otherExpr =
+          (e == expr.getLHS() ? expr.getRHS() : expr.getLHS());
+      if (failed(processSentinel(otherExpr, sentinels))) {
+        return failure();
+      }
+      expr = e.cast<AffineBinaryOpExpr>();
+    } else {
+      loopInfo.step = IntegerAttr::get(IndexType::get(applyOp.getContext()), 1);
+    }
+
+    if (failed(processSentinel(expr.getLHS(), sentinels)) ||
+        failed(processSentinel(expr.getRHS(), sentinels))) {
+      return failure();
+    }
+    // Either there are 3 sentinels and step isnt set, or there are two
+    // sentinels and the step is set.
+    if (sentinels.size() == 3) {
+      if (loopInfo.step) {
+        return failure();
+      }
+      auto it = sentinels.begin();
+      for (auto ie = sentinels.end(); it != ie; ++it) {
+        Value v = getValueForDimOrSymbol(applyOp, *it);
+        if (!v.getDefiningOp<IREE::HAL::InterfaceWorkgroupSizeOp>() &&
+            !v.getDefiningOp<IREE::HAL::InterfaceWorkgroupCountOp>()) {
+          loopInfo.step = getAsOpFoldResult(v);
+          break;
+        }
+      }
+      if (it != sentinels.end()) {
+        sentinels.erase(it);
+      }
+    }
+
+    if (sentinels.size() != 2 || !loopInfo.step) {
+      return failure();
+    }
+    if (!checkDimensions<IREE::HAL::InterfaceWorkgroupCountOp,
+                         IREE::HAL::InterfaceWorkgroupSizeOp>(
+            getValuesForDimsOrSymbols(applyOp, sentinels),
+            loopInfo.distributionDim)) {
+      return failure();
+    }
+    return success();
+  }
+
+ private:
+  LogicalResult processSentinel(AffineExpr e,
+                                SmallVectorImpl<AffineExpr> &sentinels) {
+    if (isaAffineExprOfType<AffineDimExpr, AffineSymbolExpr>(e)) {
+      sentinels.push_back(e);
+      return success();
+    } else if (auto constExpr = e.dyn_cast<AffineConstantExpr>()) {
+      if (loopInfo.step) {
+        return failure();
+      }
+      loopInfo.step = IntegerAttr::get(IndexType::get(applyOp.getContext()),
+                                       constExpr.getValue());
+      return success();
+    }
+    return failure();
+  }
+
+  AffineApplyOp applyOp;
+  TiledLoopInfo &loopInfo;
+};
+}  // namespace
+
+/// Checks if the `forOp` is a tiled + distributed op. Looks for the op of this
+/// form
+/// ```
+///   %dim = constant ... : index
+///   %id = flow.dispatch.workgroup.id[%dim]
+///   %count = flow.dispatch.workgroup.count[%dim]
+///   %size = flow.dispatch.workgroup.size[%dim]
+///   %offset = affine.apply affine_map<(d0)[s0, s1] -> (d0 + s0 *
+///   s1)>(%lb)[%id, %size] %new_step = affine.apply affine_map<(d0)[s0, s1] ->
+///   (d0 * s0 * s1)>(%step)[%id, %size] scf.for %iv = %offset to %ub step
+///   %new_step {
+///     ...
+///   }
+/// ```
+static Optional<TiledLoopInfo> isTiledLoop(MLIRContext *context,
+                                           scf::ForOp forOp) {
+  TiledLoopInfo loopInfo;
+  auto lbApplyOp = forOp.lowerBound().getDefiningOp<AffineApplyOp>();
+  if (!lbApplyOp) {
+    return llvm::None;
+  }
+  LowerBoundExprVisitor lbVisitor(lbApplyOp, loopInfo);
+  auto stepApplyOp = forOp.step().getDefiningOp<AffineApplyOp>();
+  if (!stepApplyOp) {
+    return llvm::None;
+  }
+  StepExprVisitor stepVisitor(stepApplyOp, loopInfo);
+  if (failed(lbVisitor.visit(lbApplyOp.getAffineMap().getResults()[0])) ||
+      failed(stepVisitor.visit(stepApplyOp.getAffineMap().getResults()[0]))) {
+    return llvm::None;
+  }
+  if (!loopInfo.lb || !loopInfo.step) {
+    return llvm::None;
+  }
+  loopInfo.ub = getAsOpFoldResult(forOp.upperBound());
+  return loopInfo;
+}
+
 LogicalResult getFilteredOps(FuncOp funcOp, RootOpFilteringFn filteringFn,
                              SmallVectorImpl<Operation *> &filteredOps,
-                             SmallVectorImpl<Operation *> &tiledLoops) {
+                             SmallVectorImpl<TiledLoopInfo> &tiledLoops) {
   Region &region = funcOp.body();
   if (!llvm::hasSingleElement(region)) {
     return funcOp.emitError("unable dispatch function with multiple blocks");
   }
   Block *body = &region.front();
+  MLIRContext *context = funcOp.getContext();
   auto forOps = body->getOps<scf::ForOp>();
   while (!forOps.empty()) {
     if (!llvm::hasSingleElement(forOps)) return failure();
     scf::ForOp forOp = *(forOps.begin());
-    tiledLoops.push_back(forOp.getOperation());
+    if (auto tiledLoopInfo = isTiledLoop(context, forOp)) {
+      tiledLoops.emplace_back(std::move(tiledLoopInfo.getValue()));
+    }
     body = forOp.getBody();
     forOps = body->getOps<scf::ForOp>();
   }
@@ -203,7 +497,7 @@ LogicalResult getFilteredOps(FuncOp funcOp, RootOpFilteringFn filteringFn,
 
 LogicalResult getComputeOps(FuncOp funcOp,
                             SmallVectorImpl<Operation *> &computeOps,
-                            SmallVectorImpl<Operation *> &tiledLoops) {
+                            SmallVectorImpl<TiledLoopInfo> &tiledLoops) {
   if (failed(getFilteredOps(
           funcOp,
           [](Operation *op) {
@@ -230,41 +524,6 @@ LogicalResult getComputeOps(FuncOp funcOp,
   }
   if (marker.hasValue()) {
     for (auto op : computeOps) {
-      setMarker(op, marker.getValue());
-    }
-  }
-  return success();
-}
-
-LogicalResult getLinalgOps(FuncOp funcOp,
-                           SmallVectorImpl<linalg::LinalgOp> &linalgOps,
-                           SmallVectorImpl<Operation *> &tiledLoops) {
-  {
-    SmallVector<Operation *> computeOps;
-    if (failed(getFilteredOps(
-            funcOp, [](Operation *op) { return isa<linalg::LinalgOp>(op); },
-            computeOps, tiledLoops))) {
-      return failure();
-    }
-    for (auto op : computeOps) {
-      linalgOps.push_back(cast<linalg::LinalgOp>(op));
-    }
-  }
-
-  // Propagate markers to all ops. If one of the ops has a marker all ops in
-  // this loop need to have marker since body of the loop maps to a workgroup.
-  // TODO(ravishankarm): Temporary WAR till a better story w.r.t markers is
-  // figured out.
-  Optional<StringRef> marker = llvm::None;
-  for (auto op : linalgOps) {
-    if (hasMarker(op)) {
-      assert(!marker || marker.getValue() == getMarkerOrNull(op) &&
-                            "expected all markers within op to be the same");
-      marker = getMarkerOrNull(op);
-    }
-  }
-  if (marker.hasValue()) {
-    for (auto op : linalgOps) {
       setMarker(op, marker.getValue());
     }
   }

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -231,7 +231,9 @@ static SmallVector<Value> getValuesForDimsOrSymbols(
   return vals;
 }
 
-/// Returns the dimension of `flow.dispatch.workgroup.(size|count|id)`.
+/// Returns the dimension for any operation that has the `dimension`
+/// attribute. Currently tested for `flow.dispatch.workgroup.(size|count|id)`,
+/// `hal.interface.workgroup.(size|count|id)`.
 template <typename T>
 static Optional<unsigned> getDimension(Operation *op) {
   if (auto tOp = dyn_cast<T>(op)) {
@@ -248,8 +250,9 @@ static Optional<unsigned> getDimension(Operation *op) {
   return getDimension<T2, T3...>(op);
 }
 
-/// Checks that all `vals` are defined by
-/// `flow.dispatch.workgroup.(size|count|id)` using the same `dimension`. If any
+/// Checks that all `vals` are defined by either
+/// `flow.dispatch.workgroup.(size|count|id)` or
+/// `hal.interface.workgroup.(size|count|id)` using the same `dimension`. If any
 /// element of `vals` is not defined by one of these ops, or the dimensions dont
 /// match, returns llvm::None. On success returns the dimension.  If
 /// `refDimension` is passed checks if the dimension matches the given value.


### PR DESCRIPTION
The current configurations on CPU backends (and all backends) rely on
looking at operations within the dispatch region to pick a
default. This makes it hard to set a good default to ensure good tile
+ distribute of operations. For every op a configuration method is
needed.

Instead one can just look at the loops and get an idea of the problem
size. These loops are created by tile + distribute at the flow level
using parametric tile sizes. The bounds of the loop are already
determined from the problem sizes. Ideally we would have a loop
representation that does not immediately materialize the distributed
loop, but rather maintains the loop in undistributed form, with
additional operands that specify the id/count/size to use when
materializing the distributed loop (defering the materialization to a
later convenient point).

In absense of this, in this PR, the tiled loop as generated today is
recognized by "lifting" it back to the untiled version based on the
know distribution pattern used at the flow level. From this the
original problem size is known as well and used for default
distribution without having to look at the code within the dispatch
region.