### PR TITLE
Fix CMakeLists to disable bert test

### DIFF
--- a/iree/test/e2e/models/CMakeLists.txt
+++ b/iree/test/e2e/models/CMakeLists.txt
@@ -33,7 +33,6 @@ iree_check_single_backend_test_suite(
   NAME
     check_linalg_on_tensors_dylib-llvm-aot_dylib
   SRCS
-    "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
@@ -47,7 +46,6 @@ iree_check_single_backend_test_suite(
   NAME
     check_linalg_on_tensors_vulkan-spirv_vulkan
   SRCS
-    "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
@@ -61,7 +59,6 @@ iree_check_single_backend_test_suite(
   NAME
     check_linalg_on_tensors_cuda_cuda
   SRCS
-    "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"
   TARGET_BACKEND
     "cuda"


### PR DESCRIPTION
Bert test was disabled in bazel build but not CMake files. Updated CMake
files to match.