### PR TITLE
Adapt iree-compiler-api so it builds standalone and as part of iree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0116 OLD)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(iree ASM C CXX)
+project(IREE ASM C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 set(IREE_IDE_FOLDER IREE)
@@ -339,6 +339,12 @@ else()
   message(STATUS "Adding bundled LLVM source dependency")
   iree_set_llvm_cmake_options()
 
+  # Enable MLIR Python bindings if IREE Python bindings enabled.
+  if(IREE_BUILD_PYTHON_BINDINGS)
+    set(MLIR_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
+    set(MHLO_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
+  endif()
+
   # Disable LLVM's warnings.
   set(LLVM_ENABLE_WARNINGS OFF CACHE BOOL "don't use global flags /facepalm")
 
@@ -537,3 +543,22 @@ endif()
 
 set(IREE_PUBLIC_INCLUDE_DIRS "${IREE_COMMON_INCLUDE_DIRS}"
     CACHE INTERNAL "IREE: Include Directories" FORCE)
+
+# Include the iree-compiler-api sub-project. We do this for development
+# and CI so that developers have access to the API and tools it provides
+# (otherwise, they would need to build multiple top-level projects).
+# However, logically, iree-compiler-api depends on iree, and for deployment
+# is always built standalone, taking responsibility to include iree and LLVM
+# as sub-projects.
+# The dependency mode is controlled by the variables
+# IREE_COMPILER_API_STANDALONE, which will be set if iree-compiler-api is
+# top-level. Otherwise, we set IREE_COMPILER_API_SUB_PROJECT, indicating it
+# is being embedded as a sub project.
+if(IREE_BUILD_COMPILER AND IREE_BUILD_PYTHON_BINDINGS)
+  if(NOT IREE_COMPILER_API_STANDALONE)
+    message(STATUS "Including iree-compiler-api as a sub-project")
+    set(IREE_COMPILER_API_SUB_PROJECT ON)
+    add_subdirectory(llvm-external-projects/iree-compiler-api
+        "${CMAKE_CURRENT_BINARY_DIR}/compiler-api")
+  endif()
+endif()

--- a/build_tools/bazel/build_core.sh
+++ b/build_tools/bazel/build_core.sh
@@ -6,7 +6,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Build IREE's core (//iree/... and //build_tools/...) with bazel.
+# Build IREE's core (//iree/..., //llvm-external-projects, //build_tools/...)
+# with bazel.
 # Designed for CI, but can be run manually.
 
 # Looks at environment variables and uses CI-friendly defaults if they are not
@@ -78,7 +79,9 @@ bazel \
   --bazelrc=build_tools/bazel/iree.bazelrc \
   query \
     --config=non_darwin \
-    //iree/... + //build_tools/... | \
+    //iree/... + //build_tools/... + \
+    //llvm-external-projects/iree-compiler-api/... + \
+    //llvm-external-projects/iree-dialects/... | \
       xargs bazel \
         --nosystem_rc --nohome_rc --noworkspace_rc \
         --bazelrc=build_tools/bazel/iree.bazelrc \

--- a/llvm-external-projects/iree-compiler-api/BUILD
+++ b/llvm-external-projects/iree-compiler-api/BUILD
@@ -1,0 +1,31 @@
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
+
+################################################################################
+# CAPI
+################################################################################
+
+cc_library(
+    name = "CAPI",
+    srcs = [
+        "lib/CAPI/Compiler.cpp",
+        "lib/CAPI/Tools.cpp",
+    ],
+    hdrs = [
+        "include/iree-compiler-c/Compiler.h",
+        "include/iree-compiler-c/Tools.h",
+    ],
+    includes = ["include"],
+    deps = [
+        "//iree/compiler/Dialect/VM/IR",
+        "//iree/compiler/Dialect/VM/Target/Bytecode",
+        "//iree/compiler/Translation:IREEVM",
+        "//iree/tools:init_targets",
+        "//iree/tools:iree_translate_lib",
+        "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/llvm-external-projects/iree-compiler-api/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/CMakeLists.txt
@@ -23,36 +23,42 @@ endif()
 # a CMake min version of 3.0, which causes them to set it locally to OLD.
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 
-project(iree-compiler-api LANGUAGES C CXX)
+project(IREE_COMPILER_API LANGUAGES C CXX)
 
-# Directory layout.
-# When building in-tree, this directory exists relative to the overall
-# repository. However, when building from a source package, sub-directories
-# will be populated below this directory. This is the primary place that the
-# switch is done.
-set(IREE_COMPILER_API_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(IREE_COMPILER_API_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-set(IREE_COMPILER_API_INTREE ON)
-if(IREE_COMPILER_API_INTREE)
+if(IREE_COMPILER_API_SUB_PROJECT)
+  # Building as part of a top-level IREE project.
+  message(STATUS "Building iree-compiler-api as part of IREE")
+  set(LLVM_MAIN_SRC_DIR "${IREE_SOURCE_DIR}/third_party/llvm-project/llvm")
+  set(LLVM_MAIN_BINARY_DIR "${IREE_BINARY_DIR}/third_party/llvm-project")
+  set(MLIR_MAIN_BINARY_DIR "${LLVM_MAIN_BINARY_DIR}/tools/mlir")
+else()
+  # Standalone build.
+  message(STATUS "Building iree-compiler-api standalone")
+  set(IREE_COMPILER_API_STANDALONE ON)
   set(IREE_BUILD_TESTS OFF)  # Conflicts with our tests if we are top-level.
   set(LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../iree-dialects")
-  set(IREE_MAIN_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../..")
+  set(IREE_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../..")
+  set(IREE_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/iree")
   set(LLVM_MAIN_SRC_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../../third_party/llvm-project/llvm")
+  set(LLVM_MAIN_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/llvm")
+  set(MLIR_MAIN_BINARY_DIR "${LLVM_MAIN_BINARY_DIR}/tools/mlir")
   set(LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../../third_party/mlir-hlo")
   enable_testing()
-else()
-  message(FATAL_ERROR "Non intree (source package) not yet supported")
 endif()
 
-# Configuration includes.
-include(${IREE_MAIN_SOURCE_DIR}/build_tools/cmake/iree_third_party_cmake_options.cmake)
+message(STATUS "iree-compiler-api Directories:
+  IREE_COMPILER_API_SOURCE_DIR = ${IREE_COMPILER_API_SOURCE_DIR}
+  IREE_COMPILER_API_BINARY_DIR = ${IREE_COMPILER_API_BINARY_DIR}
+  IREE_SOURCE_DIR = ${IREE_SOURCE_DIR}
+  IREE_BINARY_DIR = ${IREE_BINARY_DIR}
+  LLVM_MAIN_SRC_DIR = ${LLVM_MAIN_SRC_DIR}
+  LLVM_MAIN_BINARY_DIR = ${LLVM_MAIN_BINARY_DIR}
+")
 
-# Dependent directories.
 set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
-set(LLVM_MAIN_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/llvm")
-set(MLIR_MAIN_BINARY_DIR "${LLVM_MAIN_BINARY_DIR}/tools/mlir")
-set(IREE_MAIN_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/iree")
+
+# Configuration includes.
+include(${IREE_SOURCE_DIR}/build_tools/cmake/iree_third_party_cmake_options.cmake)
 
 # CMake settings.
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
@@ -61,30 +67,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 
-# Required MLIR settings.
-# TODO: We require an ordering of mlir-dependent external projects to be
-# loaded after mlir. We take advantage of the lexical ordering here by
-# prefixing, which feels gross but is stable. Investigate a better mechanism
-# upstream.
-iree_set_llvm_cmake_options()
-iree_add_llvm_external_project(mlir-iree-dialects MLIR_IREE_DIALECTS ${LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR})
-iree_add_llvm_external_project(mlir-hlo MLIR_HLO ${LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR})
-set(MLIR_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
-set(MLIR_BINDINGS_PYTHON_LOCK_VERSION OFF CACHE BOOL "" FORCE)
-# TODO: Conflicting gtest.
-set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
-# TODO: Conflicting benchmark.
-set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
-
-# Required mlir-hlo settings.
-# TODO: Consider removing this upstream and just using the main
-# MLIR_ENABLE_BINDINGS_PYTHON option.
-set(MHLO_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
-
-# Required IREE settings.
-set(IREE_BUILD_PYTHON_BINDINGS ON CACHE BOOL "" FORCE)
-set(IREE_BUILD_OLD_PYTHON_COMPILER_API OFF CACHE BOOL "" FORCE)
-
+# Hack system includes to account for LLVM not doing includes right.
 # TODO: Fix this upstream. Each of these system include hacks is broken in
 # a different way, so there is not an easy local fix. They should be removed
 # one be one until this project builds. Since this is the first time all of this
@@ -100,8 +83,8 @@ add_system_include_hack(${LLVM_MAIN_SRC_DIR}/include)
 add_system_include_hack(${LLVM_MAIN_BINARY_DIR}/include)
 add_system_include_hack(${MLIR_MAIN_SRC_DIR}/include)
 add_system_include_hack(${MLIR_MAIN_BINARY_DIR}/include)
-add_system_include_hack(${IREE_MAIN_SOURCE_DIR})
-add_system_include_hack(${IREE_MAIN_BINARY_DIR})
+add_system_include_hack(${IREE_SOURCE_DIR})
+add_system_include_hack(${IREE_BINARY_DIR})
 add_system_include_hack(${LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR}/include)
 add_system_include_hack(${LLVM_MAIN_BINARY_DIR}/tools/iree-dialects/include)
 add_system_include_hack(${LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR}/include)
@@ -127,13 +110,40 @@ find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION}
 mlir_detect_pybind11_install()
 find_package(pybind11 2.6 CONFIG REQUIRED)
 
-# Include LLVM.
-message(STATUS "Configuring LLVM from (${LLVM_MAIN_SRC_DIR} into ${LLVM_MAIN_BINARY_DIR})...")
-add_subdirectory("${LLVM_MAIN_SRC_DIR}" "${LLVM_MAIN_BINARY_DIR}" EXCLUDE_FROM_ALL)
+# Include IREE and LLVM if building standalone.
+if(IREE_COMPILER_API_STANDALONE)
+  # Required MLIR settings.
+  # TODO: We require an ordering of mlir-dependent external projects to be
+  # loaded after mlir. We take advantage of the lexical ordering here by
+  # prefixing, which feels gross but is stable. Investigate a better mechanism
+  # upstream.
+  iree_set_llvm_cmake_options()
+  iree_add_llvm_external_project(mlir-iree-dialects MLIR_IREE_DIALECTS ${LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR})
+  iree_add_llvm_external_project(mlir-hlo MLIR_HLO ${LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR})
+  set(MLIR_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
+  set(MLIR_BINDINGS_PYTHON_LOCK_VERSION OFF CACHE BOOL "" FORCE)
+  # TODO: Conflicting gtest.
+  set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
+  # TODO: Conflicting benchmark.
+  set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
 
-# Include IREE.
-message(STATUS "Configuring IREE from (${IREE_MAIN_SOURCE_DIR} into ${IREE_MAIN_BINARY_DIR}")
-add_subdirectory("${IREE_MAIN_SOURCE_DIR}" "${IREE_MAIN_BINARY_DIR}" EXCLUDE_FROM_ALL)
+  # Required mlir-hlo settings.
+  # TODO: Consider removing this upstream and just using the main
+  # MLIR_ENABLE_BINDINGS_PYTHON option.
+  set(MHLO_ENABLE_BINDINGS_PYTHON ON CACHE BOOL "" FORCE)
+
+  # Required IREE settings.
+  set(IREE_BUILD_PYTHON_BINDINGS ON CACHE BOOL "" FORCE)
+  set(IREE_BUILD_OLD_PYTHON_COMPILER_API OFF CACHE BOOL "" FORCE)
+
+  # Include LLVM.
+  message(STATUS "Configuring LLVM from (${LLVM_MAIN_SRC_DIR} into ${LLVM_MAIN_BINARY_DIR})...")
+  add_subdirectory("${LLVM_MAIN_SRC_DIR}" "${LLVM_MAIN_BINARY_DIR}" EXCLUDE_FROM_ALL)
+
+  # Include IREE.
+  message(STATUS "Configuring IREE from (${IREE_SOURCE_DIR} into ${IREE_BINARY_DIR}")
+  add_subdirectory("${IREE_SOURCE_DIR}" "${IREE_BINARY_DIR}" EXCLUDE_FROM_ALL)
+endif()
 
 # Sub-directories.
 # Since building outside of the LLVM build system, setup options for local

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -205,6 +205,7 @@ cc_library(
     hdrs = [
         "include/iree-dialects-c/Dialects.h",
     ],
+    includes = ["include"],
     deps = [
         ":IREEDialect",
         ":IREEPyDMDialect",


### PR DESCRIPTION
* We have use cases for three modes of depending:
  * For deployment (i.e. as Python package, other bindings, etc), iree-compiler-api is standalone and depends on IREE properly and it has to be built with specific, project wide compile/link flags.
  * For development, even though IREE cannot depend on iree-compiler-api, it is useful to build it as part of IREE so that devs have access to the whole project (i.e. can use ireec, the C and Python API, etc). It is also nice because when built this way on the CI, all of the tests run together, etc.
  * When included as an LLVM external project (i.e. when building IREE into another LLVM-based compiler), it is built as a sub-project of LLVM and includes IREE (this mode is not yet implemented).
* Before too much longer, I will probably bust the iree.runtime Python bindings out in a similar way for distribution, making them depend on IREE but also allowing them to be built as part of IREE for development/testing.