### PR TITLE
Release the new iree-compiler-api vs the old.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -187,6 +187,7 @@ jobs:
         run: |
           # TODO: Can be removed once pip 21.3 is released.
           export CIBW_ENVIRONMENT="PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+          export CIBW_BEFORE_BUILD="pip install --upgrade pip=21.2.4"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -147,7 +147,7 @@ jobs:
         if: "matrix.build_package == 'main-dist-linux'"
         shell: bash
         run: |
-          docker run -it --rm -w=/work \
+          docker run --rm -w=/work \
             -v $PWD:/work \
             "${CIBW_MANYLINUX_X86_64_IMAGE}" \
             bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py main-dist'

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -32,62 +32,50 @@ jobs:
       matrix:
         include:
           # Ubuntu packages.
-          # - os: ubuntu-18.04
-          #   build_package: main-dist
-          #   experimental: false
-          # - os: ubuntu-18.04
-          #   build_package: py-runtime-pkg
-          #   experimental: false
-          # - os: ubuntu-18.04
-          #   build_package: py-xla-compiler-tools-pkg
-          #   experimental: false
-          # - os: ubuntu-18.04
-          #   build_package: py-tflite-compiler-tools-pkg
-          #   experimental: false
-          # - os: ubuntu-18.04
-          #   build_package: py-tf-compiler-tools-pkg
-          #   experimental: false
-          # # Only needs to be built on Linux because platform independent.
-          # - os: ubuntu-18.04
-          #   build_package: py-pure-pkgs
-          #   experimental: false
+          - os: ubuntu-18.04
+            build_package: main-dist
+            experimental: false
           - os: ubuntu-18.04
             build_package: py-compiler-pkg
-            experimental: true
+            experimental: false
+          - os: ubuntu-18.04
+            build_package: py-runtime-pkg
+            experimental: false
+          - os: ubuntu-18.04
+            build_package: py-xla-compiler-tools-pkg
+            experimental: false
+          - os: ubuntu-18.04
+            build_package: py-tflite-compiler-tools-pkg
+            experimental: false
+          - os: ubuntu-18.04
+            build_package: py-tf-compiler-tools-pkg
+            experimental: false
+          # Only needs to be built on Linux because platform independent.
+          - os: ubuntu-18.04
+            build_package: py-pure-pkgs
+            experimental: false
 
           # Windows packages.
-          # - os: windows-2019
-          #   build_package: main-dist
-          #   experimental: false
-          # - os: windows-2019
-          #   build_package: py-runtime-pkg
-          #   experimental: false
-          # - os: windows-2019
-          #   build_package: py-xla-compiler-tools-pkg
-          #   experimental: true
-          # - os: windows-2019
-          #   build_package: py-tflite-compiler-tools-pkg
-          #   experimental: true
-          # - os: windows-2019
-          #   build_package: py-tf-compiler-tools-pkg
-          #   experimental: true
+          - os: windows-2019
+            build_package: main-dist
+            experimental: false
+          - os: windows-2019
+            build_package: py-compiler-pkg
+            experimental: false
+          - os: windows-2019
+            build_package: py-runtime-pkg
+            experimental: false
 
           # Macos packages.
-          # - os: macos-latest
-          #   build_package: main-dist
-          #   experimental: true
-          # - os: macos-latest
-          #   build_package: py-runtime-pkg
-          #   experimental: true
-          # - os: macos-latest
-          #   build_package: py-xla-compiler-tools-pkg
-          #   experimental: true
-          # - os: macos-latest
-          #   build_package: py-tflite-compiler-tools-pkg
-          #   experimental: true
-          # - os: macos-latest
-          #   build_package: py-tf-compiler-tools-pkg
-          #   experimental: true
+          - os: macos-latest
+            build_package: main-dist
+            experimental: true
+          - os: macos-latest
+            build_package: py-compiler-pkg
+            experimental: true
+          - os: macos-latest
+            build_package: py-runtime-pkg
+            experimental: true
     env:
       CIBW_BUILD_VERBOSITY: 1
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -90,13 +90,12 @@ jobs:
           #   experimental: true
     env:
       CIBW_BUILD_VERBOSITY: 1
-      # TODO: Can be removed once pip 21.3 is released.
-      CIBW_ENVIRONMENT: "PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
 
+      # TODO: in-tree-build can be removed once pip 21.3 is released.
       # Note that on Linux, we run under docker with an altered path.
-      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output"
-      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout"
-      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout'"
+      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
 
       # Needs the bazel manylinux image.
       # TODO: Move this to our repo and pin.

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -187,7 +187,10 @@ jobs:
         if: "matrix.build_package == 'py-compiler-pkg'"
         shell: bash
         run: |
-          export CIBW_BEFORE_BUILD="pip install --upgrade pip==21.2.4"
+          # Need a newer pip to use in-tree-build. *but* the old default pip
+          # can't accept the in-tree-build feature while upgrading itself.
+          # Facepalm.
+          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -90,6 +90,9 @@ jobs:
           #   experimental: true
     env:
       CIBW_BUILD_VERBOSITY: 1
+      # TODO: Can be removed once pip 21.3 is released.
+      CIBW_ENVIRONMENT: "PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+
       # Note that on Linux, we run under docker with an altered path.
       CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output"
       CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout"
@@ -185,8 +188,6 @@ jobs:
         if: "matrix.build_package == 'py-compiler-pkg'"
         shell: bash
         run: |
-          # TODO: Can be removed once pip 21.3 is released.
-          export CIBW_ENVIRONMENT="PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
           export CIBW_BEFORE_BUILD="pip install --upgrade pip==21.2.4"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           # TODO: Can be removed once pip 21.3 is released.
           export CIBW_ENVIRONMENT="PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
-          export CIBW_BEFORE_BUILD="pip install --upgrade pip=21.2.4"
+          export CIBW_BEFORE_BUILD="pip install --upgrade pip==21.2.4"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -190,7 +190,7 @@ jobs:
           # Need a newer pip to use in-tree-build. *but* the old default pip
           # can't accept the in-tree-build feature while upgrading itself.
           # Facepalm.
-          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4 && pip install -r ./main_checkout/build_tools/github_actions/ci_requirements.txt"
+          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -81,9 +81,9 @@ jobs:
 
       # TODO: in-tree-build can be removed once pip 21.3 is released.
       # Note that on Linux, we run under docker with an altered path.
-      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
-      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
-      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' CMAKE_GENERATOR=Ninja"
 
       # Needs the bazel manylinux image.
       # TODO: Move this to our repo and pin.
@@ -171,14 +171,18 @@ jobs:
           python -m cibuildwheel --output-dir bindist $package_dir
 
       # Experimental iree.compiler package.
-      - name: Build compiler wheels (experimental)
+      - name: Build compiler wheels
         if: "matrix.build_package == 'py-compiler-pkg'"
         shell: bash
         run: |
           # Need a newer pip to use in-tree-build. *but* the old default pip
           # can't accept the in-tree-build feature while upgrading itself.
-          # Facepalm.
-          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4"
+          # Facepalm. Since there is no way to customize CIBW, we just manually
+          # install a pre-release build of 21.3, in which the in-tree-build
+          # feature is enabled by default, obviating the need to configure it.
+          # After the 2021 October release, this can just be changed to install
+          # pip >= 21.3 from official sources. I'm sorry about this folks.
+          export CIBW_BEFORE_BUILD="python -m pip install --upgrade pip==21.3dev0 -f https://github.com/stellaraccident/pip/releases/tag/21.3dev20210925"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -33,9 +33,6 @@ jobs:
         include:
           # Ubuntu packages.
           - os: ubuntu-18.04
-            build_package: main-dist
-            experimental: false
-          - os: ubuntu-18.04
             build_package: py-compiler-pkg
             experimental: false
           - os: ubuntu-18.04
@@ -57,9 +54,6 @@ jobs:
 
           # Windows packages.
           - os: windows-2019
-            build_package: main-dist
-            experimental: false
-          - os: windows-2019
             build_package: py-compiler-pkg
             experimental: false
           - os: windows-2019
@@ -67,9 +61,6 @@ jobs:
             experimental: false
 
           # Macos packages.
-          - os: macos-latest
-            build_package: main-dist
-            experimental: true
           - os: macos-latest
             build_package: py-compiler-pkg
             experimental: true
@@ -81,9 +72,11 @@ jobs:
 
       # TODO: in-tree-build can be removed once pip 21.3 is released.
       # Note that on Linux, we run under docker with an altered path.
+      # Note that on Windows, we need to configure the compiler api project to
+      # but its CMake build directory on a short path to avoid path overflow.
       CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output CMAKE_GENERATOR=Ninja"
       CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout CMAKE_GENERATOR=Ninja"
-      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' CMAKE_GENERATOR=Ninja IREE_COMPILER_API_CMAKE_BUILD_DIR=D:/b"
 
       # Needs the bazel manylinux image.
       # TODO: Move this to our repo and pin.
@@ -142,7 +135,7 @@ jobs:
       # wheels (which are OS but not python version specific). The latter is
       # purely opportunistic: it adds incrementally to the former and would
       # otherwise take additional runner hours to build.
-      - name: Build core installation and compiler wheels
+      - name: Build core installation
         if: "matrix.build_package == 'main-dist'"
         shell: bash
         run: |

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -51,6 +51,9 @@ jobs:
           - os: ubuntu-18.04
             build_package: py-pure-pkgs
             experimental: false
+          - os: ubuntu-18.04
+            build_package: py-compiler-pkg
+            experimental: true
 
           # Windows packages.
           - os: windows-2019
@@ -176,6 +179,15 @@ jobs:
           # *output* of the build :( Make source packages.
           mkdir -p $package_dir && touch $package_dir/setup.py
           python -m cibuildwheel --output-dir bindist $package_dir
+
+      # Experimental iree.compiler package.
+      - name: Build compiler wheels (experimental)
+        if: "matrix.build_package == 'py-compiler-pkg'"
+        shell: bash
+        run: |
+          # TODO: Can be removed once pip 21.3 is released.
+          export CIBW_ENVIRONMENT="PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+          python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no
       # actual building, aside from setting up sources. If there are multiples,

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -190,7 +190,7 @@ jobs:
           # Need a newer pip to use in-tree-build. *but* the old default pip
           # can't accept the in-tree-build feature while upgrading itself.
           # Facepalm.
-          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4"
+          export CIBW_BEFORE_BUILD="PIP_USE_FEATURE='' pip install --upgrade pip==21.2.4 && pip install -r ./main_checkout/build_tools/github_actions/ci_requirements.txt"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Pure python packages only need to do a minimal CMake configure and no

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -33,6 +33,9 @@ jobs:
         include:
           # Ubuntu packages.
           - os: ubuntu-18.04
+            build_package: main-dist-linux
+            experimental: false
+          - os: ubuntu-18.04
             build_package: py-compiler-pkg
             experimental: false
           - os: ubuntu-18.04
@@ -131,27 +134,28 @@ jobs:
           EOF
           cat ./main_checkout/version_info.json
 
-      # The main distribution builds the main binary package, tests and compiler
-      # wheels (which are OS but not python version specific). The latter is
-      # purely opportunistic: it adds incrementally to the former and would
-      # otherwise take additional runner hours to build.
-      - name: Build core installation
-        if: "matrix.build_package == 'main-dist'"
+      # The main distribution consists of the project being built, installed
+      # and archived. We have to split it per operating system, and Linux
+      # is special because we build under a manylinux container which gives
+      # broad compatibility. We use the Python based manylinux containers
+      # since they come packaged with all dev tools we need. Note that the
+      # manylinux containers have a default python 2.x with all supported
+      # python versions under /opt/python (need to add one to the path). It
+      # is not enough to just invoke it directly because then pip managed
+      # console scripts (like cmake, ninja) will not be on the path.
+      - name: Main distribution (Linux)
+        if: "matrix.build_package == 'main-dist-linux'"
         shell: bash
         run: |
-          # Just need to build for one examplar python3 variant.
-          export CIBW_BUILD="cp38-*"
-          package_dir="./iree-install/python_packages/iree_compiler"
-          export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py main-dist"
-          # TODO: cibuildwheel sanity checks this, but our setup.py is the
-          # *output* of the build :( Make source packages.
-          mkdir -p $package_dir && touch $package_dir/setup.py
-          python -m cibuildwheel --output-dir bindist $package_dir
+          docker run -it --rm -w=/work \
+            -v $PWD:/work \
+            "${CIBW_MANYLINUX_X86_64_IMAGE}" \
+            bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py main-dist'
 
       # Runtime wheels are version specific, so we build one for each python
       # version. We do this serially by deleting the CMakeCache and install
       # directory between runs. Most of the build will be incremental.
-      # We save a little bit of time by disabling the compiler build.
+      # We save a lot of time by disabling the compiler build.
       - name: Build runtime wheels
         if: "matrix.build_package == 'py-runtime-pkg'"
         shell: bash

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -32,62 +32,62 @@ jobs:
       matrix:
         include:
           # Ubuntu packages.
-          - os: ubuntu-18.04
-            build_package: main-dist
-            experimental: false
-          - os: ubuntu-18.04
-            build_package: py-runtime-pkg
-            experimental: false
-          - os: ubuntu-18.04
-            build_package: py-xla-compiler-tools-pkg
-            experimental: false
-          - os: ubuntu-18.04
-            build_package: py-tflite-compiler-tools-pkg
-            experimental: false
-          - os: ubuntu-18.04
-            build_package: py-tf-compiler-tools-pkg
-            experimental: false
-          # Only needs to be built on Linux because platform independent.
-          - os: ubuntu-18.04
-            build_package: py-pure-pkgs
-            experimental: false
+          # - os: ubuntu-18.04
+          #   build_package: main-dist
+          #   experimental: false
+          # - os: ubuntu-18.04
+          #   build_package: py-runtime-pkg
+          #   experimental: false
+          # - os: ubuntu-18.04
+          #   build_package: py-xla-compiler-tools-pkg
+          #   experimental: false
+          # - os: ubuntu-18.04
+          #   build_package: py-tflite-compiler-tools-pkg
+          #   experimental: false
+          # - os: ubuntu-18.04
+          #   build_package: py-tf-compiler-tools-pkg
+          #   experimental: false
+          # # Only needs to be built on Linux because platform independent.
+          # - os: ubuntu-18.04
+          #   build_package: py-pure-pkgs
+          #   experimental: false
           - os: ubuntu-18.04
             build_package: py-compiler-pkg
             experimental: true
 
           # Windows packages.
-          - os: windows-2019
-            build_package: main-dist
-            experimental: false
-          - os: windows-2019
-            build_package: py-runtime-pkg
-            experimental: false
-          - os: windows-2019
-            build_package: py-xla-compiler-tools-pkg
-            experimental: true
-          - os: windows-2019
-            build_package: py-tflite-compiler-tools-pkg
-            experimental: true
-          - os: windows-2019
-            build_package: py-tf-compiler-tools-pkg
-            experimental: true
+          # - os: windows-2019
+          #   build_package: main-dist
+          #   experimental: false
+          # - os: windows-2019
+          #   build_package: py-runtime-pkg
+          #   experimental: false
+          # - os: windows-2019
+          #   build_package: py-xla-compiler-tools-pkg
+          #   experimental: true
+          # - os: windows-2019
+          #   build_package: py-tflite-compiler-tools-pkg
+          #   experimental: true
+          # - os: windows-2019
+          #   build_package: py-tf-compiler-tools-pkg
+          #   experimental: true
 
           # Macos packages.
-          - os: macos-latest
-            build_package: main-dist
-            experimental: true
-          - os: macos-latest
-            build_package: py-runtime-pkg
-            experimental: true
-          - os: macos-latest
-            build_package: py-xla-compiler-tools-pkg
-            experimental: true
-          - os: macos-latest
-            build_package: py-tflite-compiler-tools-pkg
-            experimental: true
-          - os: macos-latest
-            build_package: py-tf-compiler-tools-pkg
-            experimental: true
+          # - os: macos-latest
+          #   build_package: main-dist
+          #   experimental: true
+          # - os: macos-latest
+          #   build_package: py-runtime-pkg
+          #   experimental: true
+          # - os: macos-latest
+          #   build_package: py-xla-compiler-tools-pkg
+          #   experimental: true
+          # - os: macos-latest
+          #   build_package: py-tflite-compiler-tools-pkg
+          #   experimental: true
+          # - os: macos-latest
+          #   build_package: py-tf-compiler-tools-pkg
+          #   experimental: true
     env:
       CIBW_BUILD_VERBOSITY: 1
       # Note that on Linux, we run under docker with an altered path.

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -93,9 +93,9 @@ jobs:
 
       # TODO: in-tree-build can be removed once pip 21.3 is released.
       # Note that on Linux, we run under docker with an altered path.
-      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
-      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
-      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=ninja"
+      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' PIP_USE_FEATURE=in-tree-build CMAKE_GENERATOR=Ninja"
 
       # Needs the bazel manylinux image.
       # TODO: Move this to our repo and pin.

--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <algorithm>>
 #include <cctype>
 #include <fstream>
 #include <iomanip>

--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <algorithm>>
+#include <algorithm>
 #include <cctype>
 #include <fstream>
 #include <iomanip>

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -117,9 +117,6 @@ def configure_bazel():
 def build_main_dist():
   """Builds the main distribution binaries.
 
-  Also builds python packages associated with the full distribution:
-    - iree-install/python_packages/iree_compiler
-
   Additional packages that are installable as part of a full build and do not
   benefit from a more restricted build can be added here.
   """
@@ -138,7 +135,7 @@ def build_main_dist():
       f"-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}",
       f"-DCMAKE_BUILD_TYPE=Release",
       f"-DIREE_BUILD_COMPILER=ON",
-      f"-DIREE_BUILD_PYTHON_BINDINGS=ON",
+      f"-DIREE_BUILD_PYTHON_BINDINGS=OFF",
       f"-DIREE_BUILD_SAMPLES=OFF",
   ],
                  check=True)

--- a/build_tools/github_actions/cmake_ci.py
+++ b/build_tools/github_actions/cmake_ci.py
@@ -160,23 +160,24 @@ def invoke_generate():
   ### HACK: Add a Python3_LIBRARY because cmake needs it, but it legitimately
   ### does not exist on manylinux (or any linux static python).
   # Need to explicitly tell cmake about the python library.
-  python_libdir = sysconfig.get_config_var('LIBDIR')
-  python_library = sysconfig.get_config_var('LIBRARY')
-  if python_libdir and not os.path.isabs(python_library):
-    python_library = os.path.join(python_libdir, python_library)
+  if platform.system() == "Linux":
+    python_libdir = sysconfig.get_config_var('LIBDIR')
+    python_library = sysconfig.get_config_var('LIBRARY')
+    if python_libdir and not os.path.isabs(python_library):
+      python_library = os.path.join(python_libdir, python_library)
 
-  # On manylinux, python is a static build, which should be fine, but CMake
-  # disagrees. Fake it by letting it see a library that will never be needed.
-  if python_library and not os.path.exists(python_library):
-    python_libdir = os.path.join(tempfile.gettempdir(), 'fake_python', 'lib')
-    os.makedirs(python_libdir, exist_ok=True)
-    python_library = os.path.join(python_libdir,
-                                  sysconfig.get_config_var('LIBRARY'))
-    subprocess.check_call(["ar", "q", python_library])
+    # On manylinux, python is a static build, which should be fine, but CMake
+    # disagrees. Fake it by letting it see a library that will never be needed.
+    if python_library and not os.path.exists(python_library):
+      python_libdir = os.path.join(tempfile.gettempdir(), 'fake_python', 'lib')
+      os.makedirs(python_libdir, exist_ok=True)
+      python_library = os.path.join(python_libdir,
+                                    sysconfig.get_config_var('LIBRARY'))
+      subprocess.check_call(["ar", "q", python_library])
 
-  if python_library:
-    cmake_args.append(f'-DPython3_LIBRARY:PATH={python_library}')
-    cmake_args.append(f'-DPYTHON_LIBRARY:PATH={python_library}')
+    if python_library:
+      cmake_args.append(f'-DPython3_LIBRARY:PATH={python_library}')
+      cmake_args.append(f'-DPYTHON_LIBRARY:PATH={python_library}')
 
   ### Detect generator.
   if use_tool_path('ninja'):

--- a/llvm-external-projects/iree-compiler-api/BUILD.bazel
+++ b/llvm-external-projects/iree-compiler-api/BUILD.bazel
@@ -1,3 +1,6 @@
+# NOTE: This must be BUILD.bazel (not BUILD) because otherwise, you can't
+# build python packages in this directory (which creates "build" directories)
+# on case-inensitive file systems.
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],

--- a/llvm-external-projects/iree-compiler-api/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/CMakeLists.txt
@@ -44,6 +44,12 @@ else()
   set(LLVM_MAIN_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/llvm")
   set(MLIR_MAIN_BINARY_DIR "${LLVM_MAIN_BINARY_DIR}/tools/mlir")
   set(LLVM_EXTERNAL_MLIR_HLO_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../../third_party/mlir-hlo")
+  # Resources generated on windows must have valid version numbers.
+  # See set_windows_version_resource_properties.
+  set(LLVM_VERSION_MAJOR 0)
+  set(LLVM_VERSION_MINOR 0)
+  set(LLVM_VERSION_PATCH 0)
+  set(PACKAGE_VERSION 0)
   enable_testing()
 endif()
 

--- a/llvm-external-projects/iree-compiler-api/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/CMakeLists.txt
@@ -36,6 +36,7 @@ else()
   message(STATUS "Building iree-compiler-api standalone")
   set(IREE_COMPILER_API_STANDALONE ON)
   set(IREE_BUILD_TESTS OFF)  # Conflicts with our tests if we are top-level.
+  set(IREE_BUILD_SAMPLES OFF)
   set(LLVM_EXTERNAL_MLIR_IREE_DIALECTS_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../iree-dialects")
   set(IREE_SOURCE_DIR "${IREE_COMPILER_API_SOURCE_DIR}/../..")
   set(IREE_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/iree")

--- a/llvm-external-projects/iree-compiler-api/build_tools/build_python_wheels.sh
+++ b/llvm-external-projects/iree-compiler-api/build_tools/build_python_wheels.sh
@@ -17,7 +17,7 @@ repo_root="$(cd $(dirname $0)/.. && pwd)"
 wheelhouse="$repo_root/wheels"
 mkdir -p "$wheelhouse"
 
-echo "---- BUILDING iree-compiler-experimental ----"
+echo "---- BUILDING iree-compiler ----"
 if [ -x "$(command -v ccache)" ]; then
   echo "Using ccache"
   export CMAKE_C_COMPILER_LAUNCHER=ccache
@@ -31,8 +31,8 @@ $PYTHON -m pip wheel "${repo_root}" \
   --use-feature=in-tree-build \
   -w "$wheelhouse" -v
 
-echo "---- INSTALLING iree-compiler-experimental ----"
-$PYTHON -m pip install -f "$wheelhouse" --force-reinstall iree-compiler-experimental
+echo "---- INSTALLING iree-compiler ----"
+$PYTHON -m pip install -f "$wheelhouse" --force-reinstall iree-compiler-dev
 
 echo "---- QUICK SMOKE TEST ----"
 $PYTHON $repo_root/build_tools/smoketest.py

--- a/llvm-external-projects/iree-compiler-api/build_tools/build_python_wheels.sh
+++ b/llvm-external-projects/iree-compiler-api/build_tools/build_python_wheels.sh
@@ -17,7 +17,7 @@ repo_root="$(cd $(dirname $0)/.. && pwd)"
 wheelhouse="$repo_root/wheels"
 mkdir -p "$wheelhouse"
 
-echo "---- BUILDING iree-compiler-api ----"
+echo "---- BUILDING iree-compiler-experimental ----"
 if [ -x "$(command -v ccache)" ]; then
   echo "Using ccache"
   export CMAKE_C_COMPILER_LAUNCHER=ccache
@@ -31,8 +31,8 @@ $PYTHON -m pip wheel "${repo_root}" \
   --use-feature=in-tree-build \
   -w "$wheelhouse" -v
 
-echo "---- INSTALLING iree-compiler-api ----"
-$PYTHON -m pip install -f "$wheelhouse" --force-reinstall iree-compiler-api
+echo "---- INSTALLING iree-compiler-experimental ----"
+$PYTHON -m pip install -f "$wheelhouse" --force-reinstall iree-compiler-experimental
 
 echo "---- QUICK SMOKE TEST ----"
 $PYTHON $repo_root/build_tools/smoketest.py

--- a/llvm-external-projects/iree-compiler-api/build_tools/smoketest.py
+++ b/llvm-external-projects/iree-compiler-api/build_tools/smoketest.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import io
+import subprocess
 
 from iree.compiler import ir
 from iree.compiler import passmanager
@@ -24,6 +25,7 @@ from iree.compiler.dialects import vector
 
 from iree.compiler.api import driver
 
+# Test the compiler API.
 with ir.Context() as ctx:
   chlo.register_chlo_dialect(ctx)
   mhlo.register_mhlo_dialect(ctx)
@@ -50,3 +52,7 @@ with ir.Context() as ctx:
   bytecode_io = io.BytesIO()
   driver.translate_module_to_vm_bytecode(options, input_module, bytecode_io)
   print(f"Bytecode module len = {len(bytecode_io.getbuffer())}")
+
+# Check console scripts.
+subprocess.check_output(["ireec", "-help"])
+subprocess.check_output(["iree-translate", "-help"])

--- a/llvm-external-projects/iree-compiler-api/pyproject.toml
+++ b/llvm-external-projects/iree-compiler-api/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     # There is no fundamental reason to pin this CMake version, beyond
     # build stability.
     "cmake==3.18",
+    "ninja==1.10.2",
     # MLIR build depends.
     "numpy",
     # Version 2.7.0 excluded: https://github.com/pybind/pybind11/issues/3136

--- a/llvm-external-projects/iree-compiler-api/python/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/python/CMakeLists.txt
@@ -96,6 +96,10 @@ add_mlir_python_modules(IREECompilerPythonModules
   )
 
 
+################################################################################
+# Tools linked against the shared CAPI library
+################################################################################
+
 # Build the ireec tool into _mlir_libs.
 add_executable(
   IREECompilerIREECTool
@@ -106,6 +110,11 @@ set_target_properties(IREECompilerIREECTool
   PROPERTIES
     OUTPUT_NAME "ireec"
     RUNTIME_OUTPUT_DIRECTORY "${IREE_COMPILER_API_BINARY_DIR}/python_package/iree/compiler/_mlir_libs"
-    BUILD_RPATH_USE_ORIGIN ON
 )
+mlir_python_setup_extension_rpath(IREECompilerIREECTool)
 add_dependencies(IREECompilerPythonModules IREECompilerIREECTool)
+
+# Install tools.
+install(TARGETS IREECompilerIREECTool
+  DESTINATION "python_package/iree/compiler/_mlir_libs"
+)

--- a/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/binaries.py
+++ b/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/binaries.py
@@ -28,6 +28,7 @@ __all__ = [
 
 _BUILTIN_TOOLS = [
     "ireec",
+    "iree-translate",
 ]
 
 # In normal distribution circumstances, each named tool is associated with
@@ -128,6 +129,9 @@ def find_tool(exe_name: str) -> str:
 
 
 def _get_builtin_tool(exe_name: str) -> Optional[str]:
+  # Transitional note: iree-translate is allowed and resolves to "ireec".
+  if exe_name == "iree-translate":
+    exe_name = "ireec"
   if platform.system() == "Windows":
     exe_name = exe_name + ".exe"
   this_path = os.path.dirname(__file__)

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -72,15 +72,18 @@ class CMakeBuildPy(_build_py):
   def run(self):
     subprocess.check_call(["cmake", "--version"])
 
-    target_dir = self.build_lib
+    target_dir = os.path.abspath(self.build_lib)
+    print(f"Building in target dir: {target_dir}", file=sys.stderr)
     os.makedirs(target_dir, exist_ok=True)
     cmake_build_dir = os.getenv("IREE_COMPILER_API_CMAKE_BUILD_DIR")
     if not cmake_build_dir:
       cmake_build_dir = os.path.join(target_dir, "..", "cmake_build")
     os.makedirs(cmake_build_dir, exist_ok=True)
     cmake_build_dir = os.path.abspath(cmake_build_dir)
+    print(f"CMake build dir: {cmake_build_dir}", file=sys.stderr)
     cmake_install_dir = os.path.abspath(
         os.path.join(target_dir, "..", "cmake_install"))
+    print(f"CMake install dir: {cmake_install_dir}", file=sys.stderr)
     src_dir = os.path.abspath(os.path.dirname(__file__))
     cfg = "Release"
     cmake_args = [
@@ -115,19 +118,19 @@ class CMakeBuildPy(_build_py):
     cmake_cache_file = os.path.join(cmake_build_dir, "CMakeCache.txt")
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
-    print(f"Configuring with: {cmake_args}")
+    print(f"Configuring with: {cmake_args}", file=sys.stderr)
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
     subprocess.check_call(
         ["cmake", "--build", ".", "--target", "install/strip"] + build_args,
         cwd=cmake_build_dir)
-    print("Build complete.")
+    print("Build complete.", file=sys.stderr)
     if os.path.exists(target_dir):
       shutil.rmtree(target_dir)
-    print("Copying install to target.")
+    print("Copying install to target.", file=sys.stderr)
     shutil.copytree(os.path.join(cmake_install_dir, "python_package"),
                     target_dir,
                     symlinks=False)
-    print("Target populated.")
+    print("Target populated.", file=sys.stderr)
 
 
 class NoopBuildExtension(_build_ext):

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -14,7 +14,7 @@
 #
 # It is recommended to build with Ninja and ccache. To do so, set environment
 # variables by prefixing to above invocations:
-#   CMAKE_GENERATOR=Ninja CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache
+#   CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache
 #
 # On CIs, it is often advantageous to re-use/control the CMake build directory.
 # This can be set with the IREE_COMPILER_API_CMAKE_BUILD_DIR env var.
@@ -61,6 +61,7 @@ class CMakeBuildPy(_build_py):
     src_dir = os.path.abspath(os.path.dirname(__file__))
     cfg = "Release"
     cmake_args = [
+        "-GNinja",
         "-DCMAKE_INSTALL_PREFIX={}".format(cmake_install_dir),
         "-DPython3_EXECUTABLE={}".format(sys.executable),
         "-DPython3_INCLUDE_DIRS={}".format(sysconfig.get_path("include")),

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -103,8 +103,7 @@ class CMakeBuildPy(_build_py):
       os.makedirs(fake_libdir, exist_ok=True)
       fake_library = os.path.join(fake_libdir,
                                   sysconfig.get_config_var('LIBRARY'))
-      with open(fake_library, "wb"):
-        pass
+      subprocess.check_call(["ar", "q", fake_library])
       cmake_args.append("-DPython3_LIBRARY:PATH={}".format(fake_library))
 
     build_args = []

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -118,10 +118,13 @@ class CMakeBuildPy(_build_py):
     cmake_cache_file = os.path.join(cmake_build_dir, "CMakeCache.txt")
     if os.path.exists(cmake_cache_file):
       os.remove(cmake_cache_file)
+    install_target = "install/strip"
+    if platform.system() == "Windows":
+      install_target = "install"
     print(f"Configuring with: {cmake_args}", file=sys.stderr)
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
     subprocess.check_call(
-        ["cmake", "--build", ".", "--target", "install/strip"] + build_args,
+        ["cmake", "--build", ".", "--target", install_target] + build_args,
         cwd=cmake_build_dir)
     print("Build complete.", file=sys.stderr)
     if os.path.exists(target_dir):

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -72,6 +72,7 @@ class CMakeBuildPy(_build_py):
     subprocess.check_call(["cmake", "--version"])
 
     target_dir = self.build_lib
+    os.makedirs(target_dir, exist_ok=True)
     cmake_build_dir = os.getenv("IREE_COMPILER_API_CMAKE_BUILD_DIR")
     if not cmake_build_dir:
       cmake_build_dir = os.path.join(target_dir, "..", "cmake_build")

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -116,7 +116,7 @@ class NoopBuildExtension(_build_ext):
 
 
 setup(
-    name="iree-compiler-api",
+    name="iree-compiler-experimental",
     version="0.0.1",
     author="IREE Authors",
     author_email="iree-discuss@googlegroups.com",


### PR DESCRIPTION
This is a relatively twisty set of changes needed to completely replace the old iree.compiler package with iree-compiler-api on Linux/Windows/Mac. You will note a fair number of shenanigans required, but it does work.

Functional changes:

* Adds ireec and iree-translate console scripts to new package.
* Allows iree-translate to alias to ireec for compatibility.
* Scopes the CMake python library build hack to just Linux.
* Removes TF builds for Windows and MacOS. I can add these back in but having a bunch of experimental/broken things was making testing much more expensive. I think we should just leave them out.