### PR TITLE
missing #include <limits>

### DIFF
--- a/iree/base/internal/span.h
+++ b/iree/base/internal/span.h
@@ -26,6 +26,10 @@
 #endif  // __has_include(<span>)
 #endif  // __has_include
 
+#ifndef IREE_HAVE_STD_SPAN
+#include <limits>
+#endif
+
 namespace iree {
 
 #if defined(IREE_HAVE_STD_SPAN)


### PR DESCRIPTION
When IREE_HAVE_STD_SPAN is not defined, std::numeric_limits will be
used.
But std::numeric_limits is defined in <limits>, which is not included.