### PR TITLE
[CUDA] Fix crash when a kernel has dead binding

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -167,9 +167,9 @@ class ConvertFunc : public ConvertToLLVMPattern {
     TypeConverter::SignatureConversion signatureConverter(/*numOrigInputs=*/0);
     llvm::SmallDenseMap<Operation *, size_t> argMapping =
         getKernelArgMapping(funcOp);
-    // There may be dead symbols, we pick i32 as default argument type.
-    SmallVector<Type, 8> llvmInputTypes(argMapping.size(),
-                                        rewriter.getI32Type());
+    // There may be dead symbols, we pick i32 pointer as default argument type.
+    SmallVector<Type, 8> llvmInputTypes(
+        argMapping.size(), LLVM::LLVMPointerType::get(rewriter.getI32Type()));
     funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp input) {
       auto memrefType = input.getType().cast<MemRefType>();
       Type elType = memrefType.getElementType();

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -167,7 +167,9 @@ class ConvertFunc : public ConvertToLLVMPattern {
     TypeConverter::SignatureConversion signatureConverter(/*numOrigInputs=*/0);
     llvm::SmallDenseMap<Operation *, size_t> argMapping =
         getKernelArgMapping(funcOp);
-    SmallVector<Type, 8> llvmInputTypes(argMapping.size());
+    // There may be dead symbols, we pick i32 as default argument type.
+    SmallVector<Type, 8> llvmInputTypes(argMapping.size(),
+                                        rewriter.getI32Type());
     funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp input) {
       auto memrefType = input.getType().cast<MemRefType>();
       Type elType = memrefType.getElementType();

--- a/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -78,3 +78,35 @@ hal.interface @io attributes {sym_visibility = "private"} {
 //       CHECK:   llvm.insertvalue %[[PTR]], %{{.*}}[1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
 //      CHECK:    nvvm.read.ptx.sreg.tid.x
 //      CHECK:    llvm.fadd
+
+// -----
+
+// Test that we handle correctly the case where a symbol is dead.
+func @dead_symbol() {
+  %c0 = constant 0 : index
+  %c128 = constant 128 : index
+  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<16xi32>
+  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<16xf32>
+  %3 = "gpu.block_id"() {dimension = "x"} : () -> index
+  %4 = "gpu.block_dim"() {dimension = "x"} : () -> index
+  %5 = "gpu.thread_id"() {dimension = "x"} : () -> index
+  %6 = muli %3, %4 : index
+  %7 = addi %6, %5 : index
+  %10 = memref.load %1[%7] : memref<16xi32>
+  %11 = sitofp %10 : i32 to f32
+  %12 = addf %11, %11 : f32
+  memref.store %12, %2[%7] : memref<16xf32>
+  return
+}
+hal.interface private @io  {
+  // arg0 is dead
+  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+  hal.interface.binding @ret0, set=1, binding=2, type="StorageBuffer", access="Write|Discard"
+}
+
+// CHECK-LABEL: llvm.func @dead_symbol
+//  CHECK-SAME: (%[[ARG0:.+]]: i32,
+//  CHECK-SAME:  %[[ARG1:.+]]: !llvm.ptr<i32> {llvm.align = 16 : i32},
+//  CHECK-SAME:  %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32})
+//      CHECK:    llvm.fadd

--- a/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -106,7 +106,7 @@ hal.interface private @io  {
 }
 
 // CHECK-LABEL: llvm.func @dead_symbol
-//  CHECK-SAME: (%[[ARG0:.+]]: i32,
+//  CHECK-SAME: (%[[ARG0:.+]]: !llvm.ptr<i32>,
 //  CHECK-SAME:  %[[ARG1:.+]]: !llvm.ptr<i32> {llvm.align = 16 : i32},
 //  CHECK-SAME:  %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32})
 //      CHECK:    llvm.fadd


### PR DESCRIPTION
Since dead symbols are currently not being removed we need to handle the
case where a binding is not used. In this case just add a dummy i32
kernel argument