### PR TITLE
Remove testonly label from iree-benchmark-[module,trace].

### DIFF
--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -19,7 +19,6 @@ exports_files([
 
 cc_binary(
     name = "iree-benchmark-module",
-    testonly = True,
     srcs = ["iree-benchmark-module-main.cc"],
     deps = [
         "//iree/base",

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -73,7 +73,6 @@ iree_cc_binary(
     iree::vm
     iree::vm::bytecode_module
     iree::vm::cc
-  TESTONLY
 )
 
 iree_cc_binary(
@@ -95,7 +94,6 @@ iree_cc_binary(
     iree::tools::utils::yaml_util
     iree::vm
     yaml
-  TESTONLY
 )
 
 iree_cc_binary(


### PR DESCRIPTION
These are useful to deploy alongside `iree-run-module` and other tools, independent of `IREE_BUILD_TESTS`.