### PR TITLE
Add iree-(run|benchmark)-trace console scripts to iree-runtime package.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -4,6 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+################################################################################
+# Package
+################################################################################
+
 iree_pyext_module(
   NAME
     PyExtRt
@@ -37,9 +41,27 @@ iree_py_library(
     "function.py"
     "system_api.py"
     "tracing.py"
+    "scripts/iree_benchmark_trace/__main__.py"
+    "scripts/iree_run_trace/__main__.py"
   PYEXT_DEPS
     ::PyExtRt
 )
+
+iree_symlink_tool(
+  TARGET runtime
+  FROM_TOOL_TARGET iree_tools_iree-benchmark-trace
+  TO_EXE_NAME iree-benchmark-trace
+)
+
+iree_symlink_tool(
+  TARGET runtime
+  FROM_TOOL_TARGET iree_tools_iree-run-trace
+  TO_EXE_NAME iree-run-trace
+)
+
+################################################################################
+# Tests
+################################################################################
 
 iree_py_test(
   NAME
@@ -69,6 +91,10 @@ iree_py_test(
     "vm_test.py"
 )
 
+################################################################################
+# Install
+################################################################################
+
 iree_py_install_package(
   COMPONENT IreePythonPackage-runtime
   PACKAGE_NAME iree_runtime
@@ -83,4 +109,12 @@ install(
   TARGETS bindings_python_iree_runtime_PyExtRt
   COMPONENT ${PY_INSTALL_COMPONENT}
   DESTINATION "${PY_INSTALL_MODULE_DIR}"
+)
+
+install(
+  TARGETS
+    iree_tools_iree-benchmark-trace
+    iree_tools_iree-run-trace
+  DESTINATION "${PY_INSTALL_MODULE_DIR}"
+  COMPONENT "${PY_INSTALL_COMPONENT}"
 )

--- a/bindings/python/iree/runtime/scripts/iree_benchmark_trace/__main__.py
+++ b/bindings/python/iree/runtime/scripts/iree_benchmark_trace/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import subprocess
+import sys
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "iree-benchmark-trace")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/bindings/python/iree/runtime/scripts/iree_run_trace/__main__.py
+++ b/bindings/python/iree/runtime/scripts/iree_run_trace/__main__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import subprocess
+import sys
+
+
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
+  exe = os.path.join(os.path.dirname(__file__), "..", "..", "iree-run-trace")
+  return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/bindings/python/iree/runtime/setup.py.in
+++ b/bindings/python/iree/runtime/setup.py.in
@@ -39,7 +39,21 @@ setup(
     # Matching the native extension as a data file keeps setuptools from
     # "building" it (i.e. turning it into a static binary).
     package_data={
-        "": [f"*{sysconfig.get_config_var('EXT_SUFFIX')}"],
+        "": [
+            f"*{sysconfig.get_config_var('EXT_SUFFIX')}",
+            "iree-run-trace*",
+            "iree-benchmark-trace*",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "iree-run-trace = iree.runtime.scripts.iree_run_trace.__main__:main",
+            "iree-benchmark-trace = iree.runtime.scripts.iree_benchmark_trace.__main__:main",
+        ],
     },
     zip_safe=False,
+    install_requires=[
+        "numpy",
+        "PyYAML",
+    ],
 )


### PR DESCRIPTION
* Now users of the python script have access to iree-run-trace and iree-benchmark-trace.
* Going to be used for the new TFLite tests.