### PR TITLE
Fix compilation error for vm.cast folders

### DIFF
--- a/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -1509,7 +1509,7 @@ OpFoldResult CastF32SI32Op::fold(ArrayRef<Attribute> operands) {
   return constFoldCastOp<FloatAttr, IntegerAttr>(
       IntegerType::get(getContext(), 32), operands, [&](const APFloat &a) {
         bool isExact = false;
-        llvm::APSInt b;
+        llvm::APSInt b(/*BitWidth=*/32, /*isUnsigned=*/false);
         a.convertToInteger(b, APFloat::rmNearestTiesToAway, &isExact);
         return b;
       });
@@ -1519,7 +1519,7 @@ OpFoldResult CastF32UI32Op::fold(ArrayRef<Attribute> operands) {
   return constFoldCastOp<FloatAttr, IntegerAttr>(
       IntegerType::get(getContext(), 32), operands, [&](const APFloat &a) {
         bool isExact = false;
-        llvm::APSInt b;
+        llvm::APSInt b(/*BitWidth=*/32, /*isUnsigned=*/false);
         a.convertToInteger(b, APFloat::rmNearestTiesToAway, &isExact);
         b.setIsUnsigned(true);
         return b;

--- a/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
@@ -450,3 +450,63 @@ vm.module @cmp_nz_ref_folds {
     vm.return %ne : i32
   }
 }
+
+// -----
+
+// CHECK-LABEL: @cast_si32_f32_folds
+vm.module @cast_si32_f32_folds {
+  // CHECK-LABEL: @cast_exact
+  vm.func @cast_exact() -> f32 {
+    // CHECK: %0 = vm.const.f32 -2.000000e+00 : f32
+    // CHECK-NEXT: vm.return %0 : f32
+    %c-2 = vm.const.i32 -2 : i32
+    %1 = vm.cast.si32.f32 %c-2 : i32 -> f32
+    vm.return %1 : f32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @cast_ui32_f32_folds
+vm.module @cast_ui32_f32_folds {
+  // CHECK-LABEL: @cast_exact
+  vm.func @cast_exact() -> f32 {
+    // CHECK: %0 = vm.const.f32 4.000000e+00 : f32
+    // CHECK-NEXT: vm.return %0 : f32
+    %c4 = vm.const.i32 4 : i32
+    %1 = vm.cast.ui32.f32 %c4 : i32 -> f32
+    vm.return %1 : f32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @cast_f32_si32_folds
+vm.module @cast_f32_si32_folds {
+  // CHECK-LABEL: @cast_exact
+  vm.func @cast_exact() -> i32 {
+    // CHECK: %c-2 = vm.const.i32 -2 : i32
+    // CHECK-NEXT: vm.return %c-2 : i32
+    %c-2 = vm.const.f32 -2.0 : f32
+    %1 = vm.cast.f32.si32 %c-2 : f32 -> i32
+    vm.return %1 : i32
+  }
+
+  // CHECK-LABEL: @cast_round_neg
+  vm.func @cast_round_neg() -> i32 {
+    // CHECK: %c-3 = vm.const.i32 -3 : i32
+    // CHECK-NEXT: vm.return %c-3 : i32
+    %0 = vm.const.f32 -2.5 : f32
+    %1 = vm.cast.f32.si32 %0 : f32 -> i32
+    vm.return %1 : i32
+  }
+
+  // CHECK-LABEL: @cast_round_pos
+  vm.func @cast_round_pos() -> i32 {
+    // CHECK: %c3 = vm.const.i32 3 : i32
+    // CHECK-NEXT: vm.return %c3 : i32
+    %0 = vm.const.f32 2.5 : f32
+    %1 = vm.cast.f32.si32 %0 : f32 -> i32
+    vm.return %1 : i32
+  }
+}

--- a/iree/compiler/Dialect/VM/IR/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/comparison_ops.mlir
@@ -155,3 +155,47 @@ vm.module @my_module {
     vm.return %rnz : i32
   }
 }
+
+// -----
+
+// CHECK-LABEL: @cast_si32_f32
+vm.module @my_module {
+  vm.func @cast_si32_f32(%arg0 : i32) -> f32 {
+    // CHECK: %0 = vm.cast.si32.f32 %arg0 : i32 -> f32
+    %0 = vm.cast.si32.f32 %arg0 : i32 -> f32
+    vm.return %0 : f32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @cast_ui32_f32
+vm.module @my_module {
+  vm.func @cast_ui32_f32(%arg0 : i32) -> f32 {
+    // CHECK: %0 = vm.cast.ui32.f32 %arg0 : i32 -> f32
+    %0 = vm.cast.ui32.f32 %arg0 : i32 -> f32
+    vm.return %0 : f32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @cast_f32_si32
+vm.module @my_module {
+  vm.func @cast_f32_si32(%arg0 : f32) -> i32 {
+    // CHECK: %0 = vm.cast.f32.si32 %arg0 : f32 -> i32
+    %0 = vm.cast.f32.si32 %arg0 : f32 -> i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @cast_f32_ui32
+vm.module @my_module {
+  vm.func @cast_f32_ui32(%arg0 : f32) -> i32 {
+    // CHECK: %0 = vm.cast.f32.ui32 %arg0 : f32 -> i32
+    %0 = vm.cast.f32.ui32 %arg0 : f32 -> i32
+    vm.return %0 : i32
+  }
+}

--- a/iree/vm/test/conversion_ops_f32.mlir
+++ b/iree/vm/test/conversion_ops_f32.mlir
@@ -54,6 +54,26 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
+  vm.export @test_cast_f32_si32_away_from_zero_pos
+  vm.func @test_cast_f32_si32_away_from_zero_pos() {
+    %c1 = vm.const.f32 2.5 : f32
+    %c1dno = util.do_not_optimize(%c1) : f32
+    %v = vm.cast.f32.si32 %c1dno : f32 -> i32
+    %c2 = vm.const.i32 3 : i32
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
+    vm.return
+  }
+
+  vm.export @test_cast_f32_si32_away_from_zero_neg
+  vm.func @test_cast_f32_si32_away_from_zero_neg() {
+    %c1 = vm.const.f32 -2.5 : f32
+    %c1dno = util.do_not_optimize(%c1) : f32
+    %v = vm.cast.f32.si32 %c1dno : f32 -> i32
+    %c2 = vm.const.i32 -3 : i32
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
+    vm.return
+  }
+
   vm.export @test_cast_f32_ui32_int_max
   vm.func @test_cast_f32_ui32_int_max() {
     %c1 = vm.const.f32 4294967295.0 : f32
@@ -61,6 +81,16 @@ vm.module @conversion_ops_f32 {
     %v = vm.cast.f32.ui32 %c1dno : f32 -> i32
     %c2 = vm.const.i32 0 : i32
     vm.check.eq %v, %c2, "cast floating-point value to an unsigned integer" : i32
+    vm.return
+  }
+
+  vm.export @test_cast_f32_ui32_away_from_zero
+  vm.func @test_cast_f32_ui32_away_from_zero() {
+    %c1 = vm.const.f32 2.5 : f32
+    %c1dno = util.do_not_optimize(%c1) : f32
+    %v = vm.cast.f32.ui32 %c1dno : f32 -> i32
+    %c2 = vm.const.i32 3 : i32
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
 


### PR DESCRIPTION
This fixes an error in the `vm.cast.f32.*` folders and adds corresponding tests.