### PR TITLE
Zero fill uninitialized parts in CopySubBuffer test

### DIFF
--- a/iree/hal/cts/command_buffer_test.cc
+++ b/iree/hal/cts/command_buffer_test.cc
@@ -226,11 +226,18 @@ TEST_P(CommandBufferTest, CopySubBuffer) {
   std::memset(reference_buffer.data() + 8, i8_val, kBufferSize / 2 - 4);
 
   // Copy the host buffer to the device buffer.
+  uint8_t zero_val = 0x0;
   IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+  IREE_ASSERT_OK(iree_hal_command_buffer_fill_buffer(
+      command_buffer, device_buffer, /*target_offset=*/0, /*length=*/8,
+      &zero_val, /*pattern_length=*/1));
   IREE_ASSERT_OK(iree_hal_command_buffer_copy_buffer(
       command_buffer, /*source_buffer=*/host_buffer, /*source_offset=*/4,
       /*target_buffer=*/device_buffer, /*target_offset=*/8,
       /*length=*/kBufferSize / 2 - 4));
+  IREE_ASSERT_OK(iree_hal_command_buffer_fill_buffer(
+      command_buffer, device_buffer, /*target_offset=*/8 + kBufferSize / 2 - 4,
+      /*length=*/IREE_WHOLE_BUFFER, &zero_val, /*pattern_length=*/1));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
   IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_TRANSFER,


### PR DESCRIPTION
This avoids reading uninitialized content.