### PR TITLE
Enable tile + distribute of tensor.insert_slice.

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -107,11 +107,13 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addPass(createTensorConstantBufferizePass());
   pm.addPass(createFoldTensorExtractOpPass());
 
+  pm.addNestedPass<FuncOp>(createLLVMGPUVectorLoweringPass());
+
   // SCF -> STD
   pm.addNestedPass<FuncOp>(createLowerToCFGPass());
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(createCSEPass());
-  pm.addNestedPass<FuncOp>(createLLVMGPUVectorLoweringPass());
+
   pm.addNestedPass<FuncOp>(createStdExpandOpsPass());
   pm.addPass(createLowerAffinePass());
 

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
@@ -31,16 +31,116 @@ static Value getValue(OpBuilder &builder, Location loc,
   return valueOrAttr.get<Value>();
 }
 
+//===----------------------------------------------------------------------===//
+// Interface implementations for external operations.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct InsertSliceTiledOpInterface
+    : public TiledOpInterface::ExternalModel<InsertSliceTiledOpInterface,
+                                             tensor::InsertSliceOp> {
+  SmallVector<Value> getDestinationOperands(Operation *op) const {
+    SmallVector<Value> dest;
+    dest.push_back(cast<tensor::InsertSliceOp>(op).dest());
+    return dest;
+  }
+
+  SmallVector<StringRef> getLoopIteratorTypes(Operation *op) const {
+    auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
+    return SmallVector<StringRef>(insertSliceOp.getSourceType().getRank(),
+                                  getParallelIteratorTypeName());
+  }
+
+  SmallVector<Range> getLoopBounds(Operation *op, OpBuilder &b) const {
+    auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
+    Value source = insertSliceOp.source();
+    RankedTensorType sourceType = insertSliceOp.getSourceType();
+    Location loc = op->getLoc();
+    Value zero = b.create<ConstantIndexOp>(loc, 0);
+    Value one = b.create<ConstantIndexOp>(loc, 1);
+    SmallVector<Range> loopBounds(sourceType.getRank(),
+                                  Range{zero, nullptr, one});
+    for (auto dim :
+         llvm::seq<int64_t>(0, insertSliceOp.getSourceType().getRank())) {
+      loopBounds[dim].size = b.create<tensor::DimOp>(loc, source, dim);
+    }
+    return loopBounds;
+  }
+
+  Operation *getTiledImplementation(Operation *op, OpBuilder &b,
+                                    ValueRange outputs,
+                                    ArrayRef<OpFoldResult> offsets,
+                                    ArrayRef<OpFoldResult> sizes,
+                                    SmallVectorImpl<Value> &results) const {
+    auto insertOp = cast<tensor::InsertSliceOp>(op);
+    // Compute a subtensor of the source based on the offsets.
+    auto opStrides = insertOp.getMixedStrides();
+    if (!llvm::all_of(opStrides, [&](OpFoldResult valueOrAttr) {
+          Optional<int64_t> intVal = getConstantIntValue(valueOrAttr);
+          return intVal && *intVal == 1;
+        })) {
+      op->emitOpError("unable to tile operation with non-unit stride");
+      return nullptr;
+    }
+    Location loc = insertOp.getLoc();
+    auto oneAttr = b.getI64IntegerAttr(1);
+    SmallVector<OpFoldResult> strides(offsets.size(), oneAttr);
+    auto extractSliceOp = b.create<tensor::ExtractSliceOp>(
+        loc, insertOp.source(), offsets, sizes, strides);
+
+    // The offsets for the insert is based on the op offsets plus the offsets of
+    // the loops passed in.
+    auto opOffsets = insertOp.getMixedOffsets();
+    auto opSizes = insertOp.getMixedSizes();
+    unsigned offsetIndex = 0;
+    ArrayRef<int64_t> sourceShape = insertOp.getSourceType().getShape();
+    int64_t destRank = insertOp.getType().getRank();
+    SmallVector<OpFoldResult> resultOffsets(destRank);
+    SmallVector<OpFoldResult> resultSizes(destRank);
+    for (auto opOffset : llvm::enumerate(opOffsets)) {
+      // Check for rank-reducing by checking that
+      // 1) The corresponding opSize value is 1
+      // 2) The current rank of the source is not 1.
+      // Then the opOffset is for the rank-reduced dimension. Skip.
+      unsigned opOffsetIndex = opOffset.index();
+      OpFoldResult opOffsetVal = opOffset.value();
+      Optional<int64_t> opSizeVal = getConstantIntValue(opSizes[opOffsetIndex]);
+      if (opSizeVal && *opSizeVal == 1 && sourceShape[offsetIndex] != 1) {
+        resultOffsets[opOffsetIndex] = opOffsetVal;
+        resultSizes[opOffsetIndex] = oneAttr;
+        continue;
+      }
+      OpFoldResult offset = offsets[offsetIndex];
+      if (opOffsetVal.is<Attribute>() && offset.is<Attribute>()) {
+        resultOffsets[opOffsetIndex] = b.getI64IntegerAttr(
+            *getConstantIntValue(opOffsetVal) + *getConstantIntValue(offset));
+      } else {
+        AffineMap map = AffineMap::get(
+            1, 1, {b.getAffineDimExpr(0) + b.getAffineSymbolExpr(0)});
+        resultOffsets[opOffsetIndex] =
+            b.create<AffineApplyOp>(loc, map,
+                                    ValueRange{getValue(b, loc, offset),
+                                               getValue(b, loc, opOffsetVal)})
+                .getResult();
+      }
+      resultSizes[opOffsetIndex] = sizes[offsetIndex];
+      offsetIndex++;
+    }
+    SmallVector<OpFoldResult> resultStrides(destRank, oneAttr);
+    auto tiledInsertOp = b.create<tensor::InsertSliceOp>(
+        loc, extractSliceOp.result(), outputs[0], resultOffsets, resultSizes,
+        resultStrides);
+    results.push_back(tiledInsertOp.result());
+    return extractSliceOp;
+  }
+};
+}  // namespace
+
 void registerTiledOpInterfaceExternalModels(DialectRegistry &registry) {
   LLVM_DEBUG({
     llvm::dbgs() << "Adding tiled op interface for tensor.insert_slice\n";
   });
-  // TODO(ravishankarm): For now this is commented out since there are a lot of
-  // upstream bugs exposed by this. Leaving the restructuring in place, but
-  // avoiding the interface hook till those are addressed.
-  //
-  // registry.addOpInterface<tensor::InsertSliceOp,
-  // InsertSliceTiledOpInterface>();
+  registry.addOpInterface<tensor::InsertSliceOp, InsertSliceTiledOpInterface>();
 }
 
 }  // namespace linalg_ext

--- a/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -235,112 +235,6 @@ FailureOr<TiledOp> tileInterfaceOp(OpBuilder &b, TiledOpInterface tilableOp,
                              loopBounds, 0, offsets, distributionInfo);
 }
 
-//===----------------------------------------------------------------------===//
-// Interface implementations for external operations.
-//===----------------------------------------------------------------------===//
-
-namespace {
-struct InsertSliceTiledOpInterface
-    : public TiledOpInterface::ExternalModel<InsertSliceTiledOpInterface,
-                                             tensor::InsertSliceOp> {
-  SmallVector<Value> getDestinationOperands(Operation *op) const {
-    SmallVector<Value> dest;
-    dest.push_back(cast<tensor::InsertSliceOp>(op).dest());
-    return dest;
-  }
-
-  SmallVector<StringRef> getLoopIteratorTypes(Operation *op) const {
-    auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
-    return SmallVector<StringRef>(insertSliceOp.getSourceType().getRank(),
-                                  getParallelIteratorTypeName());
-  }
-
-  SmallVector<Range> getLoopBounds(Operation *op, OpBuilder &b) const {
-    auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
-    Value source = insertSliceOp.source();
-    RankedTensorType sourceType = insertSliceOp.getSourceType();
-    Location loc = op->getLoc();
-    Value zero = b.create<ConstantIndexOp>(loc, 0);
-    Value one = b.create<ConstantIndexOp>(loc, 1);
-    SmallVector<Range> loopBounds(sourceType.getRank(),
-                                  Range{zero, nullptr, one});
-    for (auto dim :
-         llvm::seq<int64_t>(0, insertSliceOp.getSourceType().getRank())) {
-      loopBounds[dim].size = b.create<tensor::DimOp>(loc, source, dim);
-    }
-    return loopBounds;
-  }
-
-  Operation *getTiledImplementation(Operation *op, OpBuilder &b,
-                                    ValueRange outputs,
-                                    ArrayRef<OpFoldResult> offsets,
-                                    ArrayRef<OpFoldResult> sizes,
-                                    SmallVectorImpl<Value> &results) const {
-    auto insertOp = cast<tensor::InsertSliceOp>(op);
-    // Compute a subtensor of the source based on the offsets.
-    auto opStrides = insertOp.getMixedStrides();
-    if (!llvm::all_of(opStrides, [&](OpFoldResult valueOrAttr) {
-          Optional<int64_t> intVal = getConstantIntValue(valueOrAttr);
-          return intVal && *intVal == 1;
-        })) {
-      op->emitOpError("unable to tile operation with non-unit stride");
-      return nullptr;
-    }
-    Location loc = insertOp.getLoc();
-    auto oneAttr = b.getI64IntegerAttr(1);
-    SmallVector<OpFoldResult> strides(offsets.size(), oneAttr);
-    auto extractSliceOp = b.create<tensor::ExtractSliceOp>(
-        loc, insertOp.source(), offsets, sizes, strides);
-
-    // The offsets for the insert is based on the op offsets plus the offsets of
-    // the loops passed in.
-    auto opOffsets = insertOp.getMixedOffsets();
-    auto opSizes = insertOp.getMixedSizes();
-    unsigned offsetIndex = 0;
-    ArrayRef<int64_t> sourceShape = insertOp.getSourceType().getShape();
-    int64_t destRank = insertOp.getType().getRank();
-    SmallVector<OpFoldResult> resultOffsets(destRank);
-    SmallVector<OpFoldResult> resultSizes(destRank);
-    auto zeroAttr = b.getI64IntegerAttr(0);
-    for (auto opOffset : llvm::enumerate(opOffsets)) {
-      // Check for rank-reducing by checking that
-      // 1) The corresponding opSize value is 1
-      // 2) The current rank of the source is not 1.
-      // Then the opOffset is for the rank-reduced dimension. Skip.
-      unsigned opOffsetIndex = opOffset.index();
-      Optional<int64_t> opSizeVal = getConstantIntValue(opSizes[opOffsetIndex]);
-      if (opSizeVal && *opSizeVal == 1 && sourceShape[offsetIndex] != 1) {
-        resultOffsets[opOffsetIndex] = zeroAttr;
-        resultSizes[opOffsetIndex] = oneAttr;
-        continue;
-      }
-      OpFoldResult opOffsetVal = opOffset.value();
-      OpFoldResult offset = offsets[offsetIndex];
-      if (opOffsetVal.is<Attribute>() && offset.is<Attribute>()) {
-        resultOffsets[opOffsetIndex] = b.getI64IntegerAttr(
-            *getConstantIntValue(opOffsetVal) + *getConstantIntValue(offset));
-      } else {
-        AffineMap map = AffineMap::get(
-            1, 1, {b.getAffineDimExpr(0) + b.getAffineSymbolExpr(0)});
-        resultOffsets[opOffsetIndex] =
-            b.create<AffineApplyOp>(loc, map,
-                                    ValueRange{getValue(b, loc, offset),
-                                               getValue(b, loc, opOffsetVal)})
-                .getResult();
-      }
-      resultSizes[opOffsetIndex] = sizes[offsetIndex];
-      offsetIndex++;
-    }
-    SmallVector<OpFoldResult> resultStrides(destRank, oneAttr);
-    auto tiledInsertOp = b.create<tensor::InsertSliceOp>(
-        loc, extractSliceOp.result(), outputs[0], resultOffsets, resultSizes,
-        resultStrides);
-    results.push_back(tiledInsertOp.result());
-    return extractSliceOp;
-  }
-};
-}  // namespace
-
 LogicalResult TiledOpInterfaceBaseTilingPattern::matchAndRewriteBase(
     TiledOpInterface tilableOp, PatternRewriter &rewriter,
     TiledOp &result) const {
@@ -373,7 +267,6 @@ struct TiledOpInterfaceTilingPass
                 linalg_ext::LinalgExtDialect, memref::MemRefDialect,
                 StandardOpsDialect, tensor::TensorDialect, scf::SCFDialect>();
   }
-  LogicalResult initialize(MLIRContext *context) override;
   void runOnOperation() override;
 };
 }  // namespace
@@ -381,13 +274,6 @@ struct TiledOpInterfaceTilingPass
 template <typename OpTy>
 static Value buildFlowWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
   return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
-}
-
-LogicalResult TiledOpInterfaceTilingPass::initialize(MLIRContext *context) {
-  // TODO(ravishankarm): When the interface is added during registration, remove
-  // this initialization.
-  tensor::InsertSliceOp::attachInterface<InsertSliceTiledOpInterface>(*context);
-  return success();
 }
 
 void TiledOpInterfaceTilingPass::runOnOperation() {

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -683,3 +683,34 @@ func @reverse_tensor_multi_dim(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
 // CHECK:            scf.yield %[[RES3]]
 // CHECK:          scf.yield %[[RES2]]
 // CHECK:        return %[[RES]]
+
+// -----
+
+func @dynamic_insert_slice(%arg0 : tensor<?xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
+  %c0 = constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?xf32>
+  %0 = tensor.insert_slice %arg0 into %arg1[%arg2, %arg3] [1, %d0] [1, 1]
+      {__internal_linalg_transform__ = "tiling_input"} : tensor<?xf32> into tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0, s1] -> (10, -d0 + s1)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+//      CHECK: func @dynamic_insert_slice(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9_]+]]: index
+//  CHECK-DAG:  %[[C0:.+]] = constant 0 : index
+//  CHECK-DAG:  %[[C10:.+]] = constant 10 : index
+//      CHECK:  %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xf32>
+//      CHECK:  %[[RESULT:.+]] = scf.for %[[ARG4:.+]] = %[[C0]] to %[[D0]]
+// CHECK-SAME:      step %[[C10]] iter_args(%[[ARG5:.+]] = %[[ARG1]])
+//      CHECK:    %[[TILESIZE:.+]] = affine.min #[[MAP0]](%[[ARG4]])[%[[C10]], %[[D0]]]
+//      CHECK:    %[[EXTRACT:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG4]]] [%[[TILESIZE]]]
+//      CHECK:    %[[OFFSET:.+]] = affine.apply #[[MAP1]](%[[ARG4]])[%[[ARG3]]]
+//      CHECK:    %[[INSERT:.+]] = tensor.insert_slice %[[EXTRACT]] into %[[ARG5]]
+// CHECK-SAME:        [%[[ARG2]], %[[OFFSET]]] [1, %[[TILESIZE]]]
+//      CHECK:    scf.yield %[[INSERT]]
+//      CHECK:  return %[[RESULT]]
+


### PR DESCRIPTION
This patch adds the external model for implementing `TiledOpInterface`
into IREE during initialization so that it is always available. This
allows tile + distribute of this operation at the flow level.

To get the distribution to work correctly, the arguments for the
destination and result in the dispatch region op need to be tied. The
current logic for legalization of dispatch region and tie-ing operands
does not support this. So this PR also reworks all of that to be more
robust.