### PR TITLE
Revert "Fixing VM release-before-retain when the source and target alias."

### DIFF
--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -234,6 +234,11 @@ cc_test(
         "bytecode_dispatch_test.cc",
         "bytecode_module_test.cc",
     ],
+    tags = [
+        # TODO(benvanik): Fix type casting errors for --config=android_arm*.
+        "notap",
+        "manual",
+    ],
     deps = [
         ":bytecode_module",
         ":vm",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -204,6 +204,9 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
     iree::vm::test::all_bytecode_modules_c
+  LABELS
+    "notap"
+    "manual"
 )
 
 iree_cc_binary(

--- a/iree/vm/ref.c
+++ b/iree/vm/ref.c
@@ -106,18 +106,6 @@ iree_vm_ref_lookup_registered_type(iree_string_view_t full_name) {
   return NULL;
 }
 
-// Useful debugging tool:
-#if 0
-static void iree_vm_ref_trace(const char* msg, iree_vm_ref_t* ref) {
-  volatile iree_atomic_ref_count_t* counter = iree_vm_get_ref_counter_ptr(ref);
-  iree_string_view_t name = iree_vm_ref_type_name(ref->type);
-  fprintf(stderr, "%s %.*s 0x%p %d\n", msg, (int)name.size, name.data, ref->ptr,
-          counter->__val);
-}
-#else
-#define iree_vm_ref_trace(...)
-#endif  // 0
-
 IREE_API_EXPORT iree_status_t iree_vm_ref_wrap_assign(void* ptr,
                                                       iree_vm_ref_type_t type,
                                                       iree_vm_ref_t* out_ref) {
@@ -128,7 +116,7 @@ IREE_API_EXPORT iree_status_t iree_vm_ref_wrap_assign(void* ptr,
                             "type not registered");
   }
 
-  if (out_ref->ptr != NULL && out_ref->ptr != ptr) {
+  if (out_ref->ptr != NULL) {
     // Release existing value.
     iree_vm_ref_release(out_ref);
   }
@@ -139,7 +127,6 @@ IREE_API_EXPORT iree_status_t iree_vm_ref_wrap_assign(void* ptr,
   out_ref->offsetof_counter = type_descriptor->offsetof_counter;
   out_ref->type = type;
 
-  iree_vm_ref_trace("WRAP ASSIGN", out_ref);
   return iree_ok_status();
 }
 
@@ -151,29 +138,28 @@ IREE_API_EXPORT iree_status_t iree_vm_ref_wrap_retain(void* ptr,
     volatile iree_atomic_ref_count_t* counter =
         iree_vm_get_ref_counter_ptr(out_ref);
     iree_atomic_ref_count_inc(counter);
-    iree_vm_ref_trace("WRAP RETAIN", out_ref);
   }
   return iree_ok_status();
 }
 
 IREE_API_EXPORT void iree_vm_ref_retain(iree_vm_ref_t* ref,
                                         iree_vm_ref_t* out_ref) {
-  // NOTE: ref and out_ref may alias so we retain before we potentially release.
-  bool aliasing = iree_vm_ref_equal(ref, out_ref);
+  // NOTE: ref and out_ref may alias.
   iree_vm_ref_t temp_ref = *ref;
-  if (temp_ref.ptr) {
-    volatile iree_atomic_ref_count_t* counter =
-        iree_vm_get_ref_counter_ptr(&temp_ref);
-    iree_atomic_ref_count_inc(counter);
-    iree_vm_ref_trace("RETAIN", &temp_ref);
-  }
-  if (!aliasing) {
+  if (ref != out_ref && ref->ptr != out_ref->ptr) {
     // Output ref contains a value that should be released first.
     // Note that we check for it being the same as the new value so we don't
     // do extra work unless we have to.
     iree_vm_ref_release(out_ref);
   }
+
+  // Assign ref to out_ref and increment the counter.
   *out_ref = temp_ref;
+  if (out_ref->ptr) {
+    volatile iree_atomic_ref_count_t* counter =
+        iree_vm_get_ref_counter_ptr(out_ref);
+    iree_atomic_ref_count_inc(counter);
+  }
 }
 
 IREE_API_EXPORT iree_status_t iree_vm_ref_retain_checked(
@@ -189,21 +175,20 @@ IREE_API_EXPORT iree_status_t iree_vm_ref_retain_checked(
 IREE_API_EXPORT void iree_vm_ref_retain_or_move(int is_move, iree_vm_ref_t* ref,
                                                 iree_vm_ref_t* out_ref) {
   // NOTE: ref and out_ref may alias.
-  bool aliasing = ref == out_ref;
   iree_vm_ref_t temp_ref = *ref;
-  if (temp_ref.ptr && !is_move) {
-    // Retain by incrementing counter and preserving the source ref.
-    volatile iree_atomic_ref_count_t* counter =
-        iree_vm_get_ref_counter_ptr(&temp_ref);
-    iree_atomic_ref_count_inc(counter);
-    iree_vm_ref_trace("RETAIN", ref);
-  }
-  if (!aliasing) {
+  if (ref != out_ref) {
     // Output ref contains a value that should be released first.
     iree_vm_ref_release(out_ref);
   }
+
+  // Assign ref to out_ref and increment the counter if not moving.
   *out_ref = temp_ref;
-  if (is_move && !aliasing) {
+  if (out_ref->ptr && !is_move) {
+    // Retain by incrementing counter and preserving the source ref.
+    volatile iree_atomic_ref_count_t* counter =
+        iree_vm_get_ref_counter_ptr(out_ref);
+    iree_atomic_ref_count_inc(counter);
+  } else if (ref != out_ref) {
     // Move by not changing counter and clearing the source ref.
     memset(ref, 0, sizeof(*ref));
   }
@@ -224,14 +209,12 @@ IREE_API_EXPORT iree_status_t iree_vm_ref_retain_or_move_checked(
 IREE_API_EXPORT void iree_vm_ref_release(iree_vm_ref_t* ref) {
   if (ref->type == IREE_VM_REF_TYPE_NULL || ref->ptr == NULL) return;
 
-  iree_vm_ref_trace("RELEASE", ref);
   volatile iree_atomic_ref_count_t* counter = iree_vm_get_ref_counter_ptr(ref);
   if (iree_atomic_ref_count_dec(counter) == 1) {
     const iree_vm_ref_type_descriptor_t* type_descriptor =
         iree_vm_ref_get_type_descriptor(ref->type);
     if (type_descriptor->destroy) {
       // NOTE: this makes us not re-entrant, but I think that's OK.
-      iree_vm_ref_trace("DESTROY", ref);
       type_descriptor->destroy(ref->ptr);
     }
   }
@@ -245,7 +228,7 @@ IREE_API_EXPORT void iree_vm_ref_assign(iree_vm_ref_t* ref,
   // NOTE: ref and out_ref may alias.
   iree_vm_ref_t temp_ref = *ref;
   if (ref == out_ref) {
-    // Source == target; ignore entirely.
+    // Source == target; ignore.
     return;
   } else if (out_ref->ptr != NULL) {
     // Release existing value.
@@ -261,7 +244,7 @@ IREE_API_EXPORT void iree_vm_ref_move(iree_vm_ref_t* ref,
   // NOTE: ref and out_ref may alias.
   iree_vm_ref_t temp_ref = *ref;
   if (ref == out_ref) {
-    // Source == target; ignore entirely.
+    // Source == target; ignore.
     return;
   } else if (out_ref->ptr != NULL) {
     // Release existing value.
@@ -280,5 +263,5 @@ IREE_API_EXPORT bool iree_vm_ref_is_null(iree_vm_ref_t* ref) {
 }
 
 IREE_API_EXPORT bool iree_vm_ref_equal(iree_vm_ref_t* lhs, iree_vm_ref_t* rhs) {
-  return lhs == rhs || memcmp(lhs, rhs, sizeof(*lhs)) == 0;
+  return memcmp(lhs, rhs, sizeof(*lhs)) == 0;
 }


### PR DESCRIPTION
Reverts google/iree#7247

The original commit breaks builds on the benchmark pipeline (https://buildkite.com/iree/iree-benchmark/builds/1128#2fad7107-b8d3-4910-a7e0-b2c8aa2d0642)

<html>
<body>
<!--StartFragment-->

Aborted
--
  | --> benchmark: MobileNetV2 [fp32,imagenet] (TensorFlow) 3-thread,little-core,full-inference with IREE-VMVX @ Pixel-4 (CPU-ARMv8.2-A) <--
  | cmd: adb push /var/lib/buildkite-agent/builds/IREE-LAB-RPI4-PIXEL4-2-ubuntu-1/iree/iree-benchmark/build-host/benchmark_suites/TensorFlow/MobileNetV2-fp32,imagenet/iree-vmvx__CPU-ARM64-v8A__3-thread,little-core,full-inference/flagfile /data/local/tmp/iree-benchmarks/TensorFlow/MobileNetV2-fp32,imagenet/iree-vmvx__CPU-ARM64-v8A__3-thread,little-core,full-inference/flagfile
  | cmd: adb shell cd /data/local/tmp/iree-benchmarks/TensorFlow/MobileNetV2-fp32,imagenet/iree-vmvx__CPU-ARM64-v8A__3-thread,little-core,full-inference && taskset 0f /data/local/tmp/iree-benchmarks/normal-tools/iree-benchmark-module --flagfile=flagfile --benchmark_repetitions=3 --benchmark_format=json
  | I ../iree/tools/utils/vm_util.cc:185] Creating driver and device for 'vmvx'...
  | Aborted
  | Traceback (most recent call last):
  | File "build_tools/benchmarks/run_benchmarks_on_android.py", line 532, in <module>
  | main(parse_arguments())
  | File "build_tools/benchmarks/run_benchmarks_on_android.py", line 502, in main
  | results, captures = filter_and_run_benchmarks(
  | File "build_tools/benchmarks/run_benchmarks_on_android.py", line 404, in filter_and_run_benchmarks
  | run_results = run_benchmarks_for_category(
  | File "build_tools/benchmarks/run_benchmarks_on_android.py", line 321, in run_benchmarks_for_category
  | resultjson = adb_execute_in_dir(cmd, android_relative_dir, verbose=verbose)
  | File "build_tools/benchmarks/run_benchmarks_on_android.py", line 143, in adb_execute_in_dir
  | return execute_cmd_and_get_output(cmd, verbose=verbose)
  | File "/var/lib/buildkite-agent/builds/IREE-LAB-RPI4-PIXEL4-2-ubuntu-1/iree/iree-benchmark/build_tools/benchmarks/common/benchmark_definition.py", line 44, in execute_cmd_and_get_output
  | return subprocess.run(args,
  | File "/usr/lib/python3.8/subprocess.py", line 516, in run
  | raise CalledProcessError(retcode, process.args,
  | subprocess.CalledProcessError: Command '['adb', 'shell', 'cd', '/data/local/tmp/iree-benchmarks/TensorFlow/MobileNetV2-fp32,imagenet/iree-vmvx__CPU-ARM64-v8A__3-thread,little-core,full-inference', '&&', 'taskset', '0f', '/data/local/tmp/iree-benchmarks/normal-tools/iree-benchmark-module', '--flagfile=flagfile', '--benchmark_repetitions=3', '--benchmark_format=json']' returned non-zero exit status 134.
  | 🚨 Error: The command exited with status 1

<!--EndFragment-->
</body>
</html>
