### PR TITLE
Avoid crash when InterfaceBindingSubspanOp doesn't return Memref

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -543,7 +543,10 @@ class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
         cast<IREE::HAL::InterfaceBindingSubspanOp>(op).queryBindingOp();
     IREE::HAL::InterfaceBindingSubspanOpAdaptor newOperands(
         operands, op->getAttrDictionary());
-    MemRefType memRefType = op->getResult(0).getType().cast<MemRefType>();
+    MemRefType memRefType = op.getType().dyn_cast<MemRefType>();
+    if (!memRefType)
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert result to memref type");
     auto memRefDesc = abi.loadBinding(
         op->getLoc(), interfaceBindingOp.binding().getZExtValue(),
         newOperands.byte_offset(), memRefType, newOperands.dynamic_dims(),

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -543,10 +543,11 @@ class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
         cast<IREE::HAL::InterfaceBindingSubspanOp>(op).queryBindingOp();
     IREE::HAL::InterfaceBindingSubspanOpAdaptor newOperands(
         operands, op->getAttrDictionary());
-    MemRefType memRefType = op.getType().dyn_cast<MemRefType>();
+    MemRefType memRefType = op->getResult(0).getType().dyn_cast<MemRefType>();
     if (!memRefType)
       return rewriter.notifyMatchFailure(
-          op, "failed to convert result to memref type");
+          op,
+          "failed to convert interface.binding.subspan result to memref type");
     auto memRefDesc = abi.loadBinding(
         op->getLoc(), interfaceBindingOp.binding().getZExtValue(),
         newOperands.byte_offset(), memRefType, newOperands.dynamic_dims(),


### PR DESCRIPTION
`InterfaceBindingSubspanOp` can return any type:
https://github.com/google/iree/blob/4f02b7e604c9/iree/compiler/Dialect/HAL/IR/HALOps.td#L2350