### PR TITLE
Adding a VM bytecode disassembler and flags for tracing to stderr.

### DIFF
--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -78,8 +78,9 @@ VmContext VmContext::Create(VmInstance* instance,
   iree_vm_context_t* context;
   if (!modules) {
     // Simple create with open allowed modules.
-    auto status = iree_vm_context_create(instance->raw_ptr(),
-                                         iree_allocator_system(), &context);
+    auto status =
+        iree_vm_context_create(instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE,
+                               iree_allocator_system(), &context);
     CheckApiStatus(status, "Error creating vm context");
   } else {
     // Closed set of modules.
@@ -89,8 +90,8 @@ VmContext VmContext::Create(VmInstance* instance,
       module_handles[i] = (*modules)[i]->raw_ptr();
     }
     auto status = iree_vm_context_create_with_modules(
-        instance->raw_ptr(), module_handles.data(), module_handles.size(),
-        iree_allocator_system(), &context);
+        instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE, module_handles.data(),
+        module_handles.size(), iree_allocator_system(), &context);
     CheckApiStatus(status, "Error creating vm context with modules");
   }
 
@@ -111,8 +112,9 @@ void VmContext::RegisterModules(std::vector<VmModule*> modules) {
 
 void VmContext::Invoke(iree_vm_function_t f, VmVariantList& inputs,
                        VmVariantList& outputs) {
-  CheckApiStatus(iree_vm_invoke(raw_ptr(), f, nullptr, inputs.raw_ptr(),
-                                outputs.raw_ptr(), iree_allocator_system()),
+  CheckApiStatus(iree_vm_invoke(raw_ptr(), f, IREE_VM_INVOCATION_FLAG_NONE,
+                                nullptr, inputs.raw_ptr(), outputs.raw_ptr(),
+                                iree_allocator_system()),
                  "Error invoking function");
 }
 

--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -156,6 +156,7 @@ static iree_status_t _TfLiteInterpreterShapeFrameApply(
   iree_vm_value_t index_value = iree_vm_value_make_i32(index);
   IREE_IGNORE_ERROR(iree_vm_list_set_value(frame->arg_list, 0, &index_value));
   return iree_vm_invoke(interpreter->context, apply_fn,
+                        IREE_VM_INVOCATION_FLAG_NONE,
                         /*policy=*/NULL, frame->arg_list, /*outputs=*/NULL,
                         interpreter->allocator);
 }
@@ -369,9 +370,9 @@ static iree_status_t _TfLiteInterpreterCreate(
   // tflite_resolver_module that we would register to resolve tflite ops into
   // IREE functions that will call custom ops through TfLiteRegistrations.
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-      interpreter->instance, interpreter->all_modules,
-      IREE_ARRAYSIZE(interpreter->all_modules), interpreter->allocator,
-      &interpreter->context));
+      interpreter->instance, IREE_VM_CONTEXT_FLAG_NONE,
+      interpreter->all_modules, IREE_ARRAYSIZE(interpreter->all_modules),
+      interpreter->allocator, &interpreter->context));
 
   // Setup all I/O tensors and buffer views.
   IREE_RETURN_IF_ERROR(_TfLiteInterpreterPopulateIO(interpreter));
@@ -444,6 +445,7 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResetVariableTensors(
       interpreter->model->exports._reset_variables;
   if (!iree_vm_function_is_null(reset_variables_fn)) {
     status = iree_vm_invoke(interpreter->context, reset_variables_fn,
+                            IREE_VM_INVOCATION_FLAG_NONE,
                             /*policy=*/NULL, /*inputs=*/NULL, /*outputs=*/NULL,
                             interpreter->allocator);
   }
@@ -572,6 +574,7 @@ static iree_status_t _TfLiteInterpreterInvoke(TfLiteInterpreter* interpreter) {
   // emits it as '_main'.
   IREE_RETURN_IF_ERROR(
       iree_vm_invoke(interpreter->context, interpreter->model->exports._main,
+                     IREE_VM_INVOCATION_FLAG_NONE,
                      /*policy=*/NULL, interpreter->input_list,
                      interpreter->output_list, interpreter->allocator));
 

--- a/docs/website/docs/bindings/c-api.md
+++ b/docs/website/docs/bindings/c-api.md
@@ -162,8 +162,9 @@ Create a VM context and load modules into it:
 iree_vm_context_t* context = NULL;
 iree_vm_module_t* modules[2] = {hal_module, bytecode_module};
 IREE_CHECK_OK(iree_vm_context_create_with_modules(
-    instance, modules, IREE_ARRAYSIZE(modules), iree_allocator_system(),
-    &context));
+    instance, IREE_VM_CONTEXT_FLAG_NONE,
+    modules, IREE_ARRAYSIZE(modules),
+    iree_allocator_system(), &context));
 // References to the modules can be released now.
 iree_vm_module_release(hal_module);
 iree_vm_module_release(bytecode_module);

--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -71,6 +71,7 @@
 
 #if !defined(IREE_HOST_SIZE_T)
 #define IREE_HOST_SIZE_T size_t
+#define PRIhsz "zu"
 #endif  // !IREE_HOST_SIZE_T
 
 // Size, in bytes, of a buffer on the local host.
@@ -177,6 +178,36 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 // Enables backtraces in VM failures when debugging information is available.
 #define IREE_VM_BACKTRACE_ENABLE 1
 #endif  // !IREE_VM_BACKTRACE_ENABLE
+
+#if !defined(IREE_VM_EXECUTION_TRACING_ENABLE)
+// Enables disassembly of vm bytecode functions and stderr dumping of execution.
+// Increases code size quite, lowers VM performance, and is generally unsafe;
+// include only when debugging or running on trusted inputs.
+#ifdef NDEBUG
+#define IREE_VM_EXECUTION_TRACING_ENABLE 0
+#else
+#define IREE_VM_EXECUTION_TRACING_ENABLE 1
+#endif  // NDEBUG
+#endif  // !IREE_VM_EXECUTION_TRACING_ENABLE
+
+#if !defined(IREE_VM_EXECUTION_TRACING_FORCE_ENABLE)
+// Forces tracing of VM execution by default ignoring runtime flags that may
+// otherwise control the behavior. This can be used to enable tracing in tools
+// that do not have flag parsing or plumbing for per-invocation flags.
+#define IREE_VM_EXECUTION_TRACING_FORCE_ENABLE 0
+#endif  // !IREE_VM_EXECUTION_TRACING_FORCE_ENABLE
+#if defined(IREE_VM_EXECUTION_TRACING_FORCE_ENABLE)
+#define IREE_VM_EXECUTION_TRACING_ENABLE 1
+#endif  // IREE_VM_EXECUTION_TRACING_FORCE_ENABLE
+
+#if !defined(IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE)
+// Enables printing of the source location of an op when tracing its execution.
+// This may be messy depending on the origin of the locations in the program;
+// for example today the python locs are entire stack traces. Improvements to
+// printing of more complex source locations (or a way to prune them in the
+// compiler) would let this be turned on by default.
+#define IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE 0
+#endif  // !IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE
 
 #if !defined(IREE_VM_EXT_I64_ENABLE)
 // Enables the 64-bit integer instruction extension.

--- a/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/iree/hal/local/loaders/vmvx_module_loader.c
@@ -300,7 +300,8 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   // On-stack stack. We really do abuse the stack too much here.
   // TODO(benvanik): pass in an iree_arena_t that can be used for this.
   IREE_VM_INLINE_STACK_INITIALIZE(
-      stack, iree_vm_context_state_resolver(executable->context),
+      stack, IREE_VM_INVOCATION_FLAG_NONE,
+      iree_vm_context_state_resolver(executable->context),
       executable->base.host_allocator);
 
   // Direct call interface.
@@ -448,8 +449,8 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
         bytecode_module,
     };
     status = iree_vm_context_create_with_modules(
-        executable_loader->instance, modules, IREE_ARRAYSIZE(modules),
-        executable_loader->host_allocator, &context);
+        executable_loader->instance, IREE_VM_CONTEXT_FLAG_NONE, modules,
+        IREE_ARRAYSIZE(modules), executable_loader->host_allocator, &context);
   }
 
   // Executable takes ownership of the entire context (including the bytecode

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -62,8 +62,8 @@ class CheckTest : public ::testing::Test {
   void SetUp() override {
     std::vector<iree_vm_module_t*> modules = {hal_module_, check_module_};
     IREE_ASSERT_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
     allocator_ = iree_hal_device_allocator(device_);
   }
 
@@ -172,7 +172,7 @@ class CheckTest : public ::testing::Test {
             iree_make_cstring_view(function_name), &function),
         "exported function '%s' not found", function_name);
     // TODO(#2075): don't directly invoke native functions like this.
-    return iree_vm_invoke(context_, function,
+    return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                           /*policy=*/nullptr, inputs_.get(),
                           /*outputs=*/nullptr, iree_allocator_system());
   }

--- a/iree/runtime/session.c
+++ b/iree/runtime/session.c
@@ -25,6 +25,7 @@
 IREE_API_EXPORT void iree_runtime_session_options_initialize(
     iree_runtime_session_options_t* out_options) {
   memset(out_options, 0, sizeof(*out_options));
+  out_options->context_flags = IREE_VM_CONTEXT_FLAG_NONE;
   out_options->builtin_modules = IREE_RUNTIME_SESSION_BUILTIN_ALL;
 }
 
@@ -86,7 +87,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_create_with_device(
 
   // Create the context empty so that we can add our modules to it.
   iree_status_t status = iree_vm_context_create(
-      /*instance=*/NULL, host_allocator, &session->context);
+      /*instance=*/NULL, options->context_flags, host_allocator,
+      &session->context);
 
   // Add the HAL module; it is always required when using the runtime API.
   // Lower-level usage of the VM can avoid the HAL if it's not required.
@@ -257,6 +259,7 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call(
 
   iree_status_t status =
       iree_vm_invoke(iree_runtime_session_context(session), *function,
+                     IREE_VM_INVOCATION_FLAG_NONE,
                      /*policy=*/NULL, input_list, output_list,
                      iree_runtime_session_host_allocator(session));
 
@@ -282,7 +285,7 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call_direct(
 
   // Allocate a VM stack on the host stack and initialize it.
   IREE_VM_INLINE_STACK_INITIALIZE(
-      stack,
+      stack, IREE_VM_INVOCATION_FLAG_NONE,
       iree_vm_context_state_resolver(iree_runtime_session_context(session)),
       iree_runtime_session_host_allocator(session));
 

--- a/iree/runtime/session.h
+++ b/iree/runtime/session.h
@@ -54,6 +54,9 @@ typedef uint64_t iree_runtime_session_builtins_t;
 
 // Options used to configure session creation.
 typedef struct iree_runtime_session_options_t {
+  // Flags controlling the execution environment.
+  iree_vm_context_flags_t context_flags;
+
   // A bitmask identifying which IREE builtin modules should be enabled.
   // Session creation will fail if a requested module is not built into the
   // runtime binary.

--- a/iree/samples/custom_modules/custom_modules_test.cc
+++ b/iree/samples/custom_modules/custom_modules_test.cc
@@ -61,8 +61,8 @@ class CustomModulesTest : public ::testing::Test {
     std::vector<iree_vm_module_t*> modules = {hal_module_, native_module_,
                                               bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
   }
 
   virtual void TearDown() {
@@ -113,6 +113,7 @@ TEST_F(CustomModulesTest, ReverseAndPrint) {
 
   // Synchronously invoke the function.
   IREE_ASSERT_OK(iree_vm_invoke(context_, LookupFunction("reverseAndPrint"),
+                                IREE_VM_INVOCATION_FLAG_NONE,
                                 /*policy=*/nullptr, inputs.get(), outputs.get(),
                                 iree_allocator_system()));
 
@@ -157,6 +158,7 @@ TEST_F(CustomModulesTest, PrintTensor) {
 
   // Synchronously invoke the function.
   IREE_ASSERT_OK(iree_vm_invoke(context_, LookupFunction("printTensor"),
+                                IREE_VM_INVOCATION_FLAG_NONE,
                                 /*policy=*/nullptr, inputs.get(), outputs.get(),
                                 iree_allocator_system()));
 
@@ -201,6 +203,7 @@ TEST_F(CustomModulesTest, RoundTripTensor) {
 
   // Synchronously invoke the function.
   IREE_ASSERT_OK(iree_vm_invoke(context_, LookupFunction("roundTripTensor"),
+                                IREE_VM_INVOCATION_FLAG_NONE,
                                 /*policy=*/nullptr, inputs.get(), outputs.get(),
                                 iree_allocator_system()));
 

--- a/iree/samples/emitc_modules/add_module_test.cc
+++ b/iree/samples/emitc_modules/add_module_test.cc
@@ -25,8 +25,8 @@ class VMAddModuleTest : public ::testing::Test {
 
     std::vector<iree_vm_module_t*> modules = {add_module};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
 
     iree_vm_module_release(add_module);
   }
@@ -56,10 +56,10 @@ class VMAddModuleTest : public ::testing::Test {
         /*element_type=*/nullptr, 1, iree_allocator_system(), &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
-    IREE_RETURN_IF_ERROR(iree_vm_invoke(context_, function,
-                                        /*policy=*/nullptr, input_list.get(),
-                                        output_list.get(),
-                                        iree_allocator_system()));
+    IREE_RETURN_IF_ERROR(
+        iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
+                       /*policy=*/nullptr, input_list.get(), output_list.get(),
+                       iree_allocator_system()));
 
     // Load the output result.
     iree_vm_value_t ret_value;
@@ -93,10 +93,10 @@ class VMAddModuleTest : public ::testing::Test {
         /*element_type=*/nullptr, 1, iree_allocator_system(), &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
-    IREE_RETURN_IF_ERROR(iree_vm_invoke(context_, function,
-                                        /*policy=*/nullptr, input_list.get(),
-                                        output_list.get(),
-                                        iree_allocator_system()));
+    IREE_RETURN_IF_ERROR(
+        iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
+                       /*policy=*/nullptr, input_list.get(), output_list.get(),
+                       iree_allocator_system()));
 
     // Load the output result.
     iree_vm_value_t ret_value;

--- a/iree/samples/emitc_modules/import_module_test.cc
+++ b/iree/samples/emitc_modules/import_module_test.cc
@@ -29,8 +29,8 @@ class VMImportModuleTest : public ::testing::Test {
     // Note: order matters as module_a imports from module_b
     std::vector<iree_vm_module_t*> modules = {module_b, module_a};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
 
     iree_vm_module_release(module_a);
     iree_vm_module_release(module_b);
@@ -61,10 +61,10 @@ class VMImportModuleTest : public ::testing::Test {
         /*element_type=*/nullptr, 1, iree_allocator_system(), &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
-    IREE_RETURN_IF_ERROR(iree_vm_invoke(context_, function,
-                                        /*policy=*/nullptr, input_list.get(),
-                                        output_list.get(),
-                                        iree_allocator_system()));
+    IREE_RETURN_IF_ERROR(
+        iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
+                       /*policy=*/nullptr, input_list.get(), output_list.get(),
+                       iree_allocator_system()));
 
     // Load the output result.
     iree_vm_value_t ret_value;

--- a/iree/samples/simple_embedding/simple_embedding.c
+++ b/iree/samples/simple_embedding/simple_embedding.c
@@ -51,8 +51,8 @@ iree_status_t Run() {
   iree_vm_context_t* context = NULL;
   iree_vm_module_t* modules[] = {hal_module, bytecode_module};
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-      instance, &modules[0], IREE_ARRAYSIZE(modules), iree_allocator_system(),
-      &context));
+      instance, IREE_VM_CONTEXT_FLAG_NONE, &modules[0], IREE_ARRAYSIZE(modules),
+      iree_allocator_system(), &context));
   iree_vm_module_release(hal_module);
   iree_vm_module_release(bytecode_module);
 
@@ -124,9 +124,9 @@ iree_status_t Run() {
                        "can't allocate output vm list");
 
   // Synchronously invoke the function.
-  IREE_RETURN_IF_ERROR(iree_vm_invoke(context, main_function,
-                                      /*policy=*/NULL, inputs, outputs,
-                                      iree_allocator_system()));
+  IREE_RETURN_IF_ERROR(iree_vm_invoke(
+      context, main_function, IREE_VM_INVOCATION_FLAG_NONE,
+      /*policy=*/NULL, inputs, outputs, iree_allocator_system()));
 
   // Get the result buffers from the invocation.
   iree_hal_buffer_view_t* ret_buffer_view =

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -258,8 +258,8 @@ extern "C" int iree_main(int argc, char** argv) {
   iree_vm_context_t* iree_context = nullptr;
   std::vector<iree_vm_module_t*> modules = {hal_module, bytecode_module};
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
-      iree_instance, modules.data(), modules.size(), iree_allocator_system(),
-      &iree_context));
+      iree_instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+      iree_allocator_system(), &iree_context));
   IREE_LOG(INFO) << "Context with modules is ready for use";
 
   // Lookup the async entry point function.
@@ -431,6 +431,7 @@ extern "C" int iree_main(int argc, char** argv) {
 
         // Asynchronously invoke the function.
         IREE_CHECK_OK(iree_vm_invoke(iree_context, main_function,
+                                     IREE_VM_INVOCATION_FLAG_NONE,
                                      /*policy=*/nullptr, inputs.get(),
                                      outputs.get(), iree_allocator_system()));
 

--- a/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
+++ b/iree/testing/vulkan/iree-run-module-vulkan-gui-main.cc
@@ -117,9 +117,9 @@ Status RunModuleAndUpdateImGuiWindow(
                                            iree_allocator_system(), &outputs));
 
   IREE_LOG(INFO) << "EXEC @" << function_name;
-  IREE_RETURN_IF_ERROR(iree_vm_invoke(context, function, /*policy=*/nullptr,
-                                      function_inputs.get(), outputs.get(),
-                                      iree_allocator_system()));
+  IREE_RETURN_IF_ERROR(iree_vm_invoke(
+      context, function, IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/nullptr,
+      function_inputs.get(), outputs.get(), iree_allocator_system()));
 
   std::ostringstream oss;
   IREE_RETURN_IF_ERROR(PrintVariantList(outputs.get(), &oss));
@@ -320,8 +320,8 @@ extern "C" int iree_main(int argc, char** argv) {
   iree_vm_context_t* iree_context = nullptr;
   std::vector<iree_vm_module_t*> modules = {hal_module, bytecode_module};
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
-      iree_instance, modules.data(), modules.size(), iree_allocator_system(),
-      &iree_context));
+      iree_instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+      iree_allocator_system(), &iree_context));
   IREE_LOG(INFO) << "Context with modules is ready for use";
 
   // Lookup the entry point function.

--- a/iree/tools/android/run_module_app/src/main.cc
+++ b/iree/tools/android/run_module_app/src/main.cc
@@ -111,8 +111,8 @@ Status RunModule(const IreeModuleInvocation& invocation) {
   // Order matters. The input module will likely be dependent on the hal module.
   std::array<iree_vm_module_t*, 2> modules = {hal_module, input_module};
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-                           instance, modules.data(), modules.size(),
-                           iree_allocator_system(), &context),
+                           instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(),
+                           modules.size(), iree_allocator_system(), &context),
                        "creating context");
 
   const std::string& function_name = invocation.entry_function;
@@ -141,8 +141,9 @@ Status RunModule(const IreeModuleInvocation& invocation) {
 
   LOGI("Execute @%s", function_name.c_str());
   IREE_RETURN_IF_ERROR(
-      iree_vm_invoke(context, function, /*policy=*/nullptr, inputs.get(),
-                     outputs.get(), iree_allocator_system()),
+      iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                     /*policy=*/nullptr, inputs.get(), outputs.get(),
+                     iree_allocator_system()),
       "invoking function '%s'", function_name.c_str());
 
   std::ostringstream oss;

--- a/iree/tools/iree-benchmark-module-main.cc
+++ b/iree/tools/iree-benchmark-module-main.cc
@@ -96,8 +96,9 @@ static void BenchmarkFunction(const std::string& benchmark_name, int batch_size,
     vm::ref<iree_vm_list_t> outputs;
     IREE_CHECK_OK(iree_vm_list_create(/*element_type=*/nullptr, 16,
                                       iree_allocator_system(), &outputs));
-    IREE_CHECK_OK(iree_vm_invoke(context, function, /*policy=*/nullptr, inputs,
-                                 outputs.get(), iree_allocator_system()));
+    IREE_CHECK_OK(iree_vm_invoke(
+        context, function, IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/nullptr,
+        inputs, outputs.get(), iree_allocator_system()));
   }
 }
 
@@ -207,8 +208,8 @@ class IREEBenchmark {
     // module.
     std::array<iree_vm_module_t*, 2> modules = {hal_module_, input_module_};
     IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
 
     IREE_TRACE_FRAME_MARK_END_NAMED("init");
     return iree_ok_status();

--- a/iree/tools/iree-benchmark-trace-main.c
+++ b/iree/tools/iree-benchmark-trace-main.c
@@ -197,8 +197,8 @@ static iree_status_t iree_replay_benchmark_run_file(
   // Setup replay state used for this benchmark.
   iree_trace_replay_t replay;
   IREE_RETURN_IF_ERROR(iree_trace_replay_initialize(
-      registration->root_path, registration->instance, iree_allocator_system(),
-      &replay));
+      registration->root_path, registration->instance,
+      IREE_VM_CONTEXT_FLAG_NONE, iree_allocator_system(), &replay));
   iree_trace_replay_set_hal_driver_override(
       &replay, iree_make_cstring_view(FLAG_driver));
 
@@ -214,10 +214,10 @@ static iree_status_t iree_replay_benchmark_run_file(
     for (size_t i = 0; i < call_list.count; ++i) {
       iree_replay_benchmark_call_t* call = &call_list.items[i];
       for (int32_t j = 0; j < FLAG_call_iterations; ++j) {
-        IREE_RETURN_IF_ERROR(iree_vm_invoke(replay.context, call->function,
-                                            /*policy=*/NULL, call->input_list,
-                                            call->output_list,
-                                            replay.host_allocator));
+        IREE_RETURN_IF_ERROR(iree_vm_invoke(
+            replay.context, call->function, IREE_VM_INVOCATION_FLAG_NONE,
+            /*policy=*/NULL, call->input_list, call->output_list,
+            replay.host_allocator));
         IREE_RETURN_IF_ERROR(iree_vm_list_resize(call->output_list, 0));
       }
     }

--- a/iree/tools/iree-check-module-main.cc
+++ b/iree/tools/iree-check-module-main.cc
@@ -40,6 +40,8 @@
 #define IREE_FORCE_BINARY_STDIN()
 #endif  // IREE_PLATFORM_WINDOWS
 
+IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
+
 IREE_FLAG(string, driver, "vmvx", "Backend driver to use.");
 
 IREE_FLAG(
@@ -60,15 +62,18 @@ class CheckModuleTest : public ::testing::Test {
       : instance_(instance), modules_(modules), function_(function) {}
   void SetUp() override {
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules_.data(), modules_.size(), iree_allocator_system(),
-        &context_));
+        instance_,
+        FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
+                             : IREE_VM_CONTEXT_FLAG_NONE,
+        modules_.data(), modules_.size(), iree_allocator_system(), &context_));
   }
   void TearDown() override { iree_vm_context_release(context_); }
 
   void TestBody() override {
-    IREE_EXPECT_OK(iree_vm_invoke(context_, function_, /*policy=*/nullptr,
-                                  /*inputs=*/nullptr, /*outputs=*/nullptr,
-                                  iree_allocator_system()));
+    IREE_EXPECT_OK(iree_vm_invoke(
+        context_, function_, IREE_VM_INVOCATION_FLAG_NONE,
+        /*policy=*/nullptr,
+        /*inputs=*/nullptr, /*outputs=*/nullptr, iree_allocator_system()));
   }
 
  private:

--- a/iree/tools/iree-run-trace-main.c
+++ b/iree/tools/iree-run-trace-main.c
@@ -17,6 +17,8 @@
 #include "iree/tools/utils/yaml_util.h"
 #include "iree/vm/api.h"
 
+IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
+
 IREE_FLAG(string, driver, "vmvx", "Backend driver to use.");
 
 // Runs the trace in |file| using |root_path| as the base for any path lookups
@@ -26,7 +28,10 @@ static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
                                          iree_vm_instance_t* instance) {
   iree_trace_replay_t replay;
   IREE_RETURN_IF_ERROR(iree_trace_replay_initialize(
-      root_path, instance, iree_allocator_system(), &replay));
+      root_path, instance,
+      FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
+                           : IREE_VM_CONTEXT_FLAG_NONE,
+      iree_allocator_system(), &replay));
   iree_trace_replay_set_hal_driver_override(
       &replay, iree_make_cstring_view(FLAG_driver));
 

--- a/iree/tools/utils/trace_replay.c
+++ b/iree/tools/utils/trace_replay.c
@@ -18,16 +18,17 @@
 #include "iree/modules/hal/module.h"
 #include "iree/vm/bytecode_module.h"
 
-iree_status_t iree_trace_replay_initialize(iree_string_view_t root_path,
-                                           iree_vm_instance_t* instance,
-                                           iree_allocator_t host_allocator,
-                                           iree_trace_replay_t* out_replay) {
+iree_status_t iree_trace_replay_initialize(
+    iree_string_view_t root_path, iree_vm_instance_t* instance,
+    iree_vm_context_flags_t context_flags, iree_allocator_t host_allocator,
+    iree_trace_replay_t* out_replay) {
   memset(out_replay, 0, sizeof(*out_replay));
 
   IREE_RETURN_IF_ERROR(iree_hal_module_register_types());
 
   out_replay->root_path = root_path;
   out_replay->instance = instance;
+  out_replay->context_flags = context_flags;
   out_replay->host_allocator = host_allocator;
   iree_vm_instance_retain(out_replay->instance);
   return iree_ok_status();
@@ -55,8 +56,9 @@ iree_status_t iree_trace_replay_event_context_load(iree_trace_replay_t* replay,
   replay->context = NULL;
 
   // Create new context.
-  return iree_vm_context_create(replay->instance, replay->host_allocator,
-                                &replay->context);
+  // TODO(benvanik): allow setting flags from the trace files.
+  return iree_vm_context_create(replay->instance, replay->context_flags,
+                                replay->host_allocator, &replay->context);
 }
 
 static iree_status_t iree_trace_replay_create_device(
@@ -762,7 +764,8 @@ iree_status_t iree_trace_replay_event_call(iree_trace_replay_t* replay,
       iree_vm_list_create(/*element_type=*/NULL, /*initial_capacity=*/8,
                           replay->host_allocator, &output_list);
   if (iree_status_is_ok(status)) {
-    status = iree_vm_invoke(replay->context, function, /*policy=*/NULL,
+    status = iree_vm_invoke(replay->context, function,
+                            IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/NULL,
                             input_list, output_list, replay->host_allocator);
   }
   iree_vm_list_release(input_list);
@@ -798,7 +801,8 @@ static iree_status_t iree_trace_replay_event_call_stdout(
       iree_vm_list_create(/*element_type=*/NULL, /*initial_capacity=*/8,
                           replay->host_allocator, &output_list);
   if (iree_status_is_ok(status)) {
-    status = iree_vm_invoke(replay->context, function, /*policy=*/NULL,
+    status = iree_vm_invoke(replay->context, function,
+                            IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/NULL,
                             input_list, output_list, replay->host_allocator);
   }
   iree_vm_list_release(input_list);

--- a/iree/tools/utils/trace_replay.h
+++ b/iree/tools/utils/trace_replay.h
@@ -20,6 +20,7 @@ typedef struct iree_trace_replay_t {
   iree_allocator_t host_allocator;
   iree_string_view_t root_path;
   iree_vm_instance_t* instance;
+  iree_vm_context_flags_t context_flags;
   iree_string_view_t driver;
 
   iree_vm_context_t* context;
@@ -29,10 +30,10 @@ typedef struct iree_trace_replay_t {
 // Initializes a trace replay context.
 // Relative paths will be joined with |root_path| to form a fully-qualified
 // path (may be cwd, may be file source, etc).
-iree_status_t iree_trace_replay_initialize(iree_string_view_t root_path,
-                                           iree_vm_instance_t* instance,
-                                           iree_allocator_t host_allocator,
-                                           iree_trace_replay_t* out_replay);
+iree_status_t iree_trace_replay_initialize(
+    iree_string_view_t root_path, iree_vm_instance_t* instance,
+    iree_vm_context_flags_t context_flags, iree_allocator_t host_allocator,
+    iree_trace_replay_t* out_replay);
 
 // Deinitializes a trace replay context and releases all resources.
 void iree_trace_replay_deinitialize(iree_trace_replay_t* replay);

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -181,6 +181,8 @@ cc_test(
 cc_library(
     name = "bytecode_module",
     srcs = [
+        "bytecode_disasm.c",
+        "bytecode_disasm.h",
         "bytecode_dispatch.c",
         "bytecode_dispatch_util.h",
         "bytecode_module.c",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -171,6 +171,8 @@ iree_cc_library(
   HDRS
     "bytecode_module.h"
   SRCS
+    "bytecode_disasm.c"
+    "bytecode_disasm.h"
     "bytecode_dispatch.c"
     "bytecode_dispatch_util.h"
     "bytecode_module.c"

--- a/iree/vm/bytecode_disasm.c
+++ b/iree/vm/bytecode_disasm.c
@@ -1,0 +1,2204 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/vm/bytecode_disasm.h"
+
+#include <inttypes.h>
+
+#include "iree/base/config.h"
+#include "iree/vm/ops.h"
+
+#define BEGIN_DISASM_PREFIX(op_name, ext) \
+  case IREE_VM_OP_CORE_##op_name: {       \
+    switch (bytecode_data[pc++]) {
+#define END_DISASM_PREFIX()                            \
+  default:                                             \
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED, \
+                            "unhandled ext opcode");   \
+    }                                                  \
+    break;                                             \
+    }
+#define UNHANDLED_DISASM_PREFIX(op_name, ext)                      \
+  case IREE_VM_OP_CORE_##op_name: {                                \
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,             \
+                            "unhandled dispatch extension " #ext); \
+  }
+
+#define DISASM_OP(ext, op_name) case IREE_VM_OP_##ext##_##op_name:
+
+#define VM_ParseConstI8(name) \
+  OP_I8(0);                   \
+  ++pc;
+#define VM_ParseConstI32(name) \
+  OP_I32(0);                   \
+  pc += 4;
+#define VM_ParseConstI64(name) \
+  OP_I64(0);                   \
+  pc += 8;
+#define VM_ParseConstF32(name) \
+  OP_F32(0);                   \
+  pc += 4;
+#define VM_ParseConstF64(name) \
+  OP_F64(0);                   \
+  pc += 8;
+#define VM_ParseOpcode(opcode) VM_ParseConstI8(#opcode)
+#define VM_ParseFuncAttr(name) VM_ParseConstI32(name)
+#define VM_ParseGlobalAttr(name) VM_ParseConstI32(name)
+#define VM_ParseRodataAttr(name) VM_ParseConstI32(name)
+#define VM_ParseType(name)             \
+  iree_vm_map_type(module, OP_I32(0)); \
+  pc += 4;
+#define VM_ParseTypeOf(name) VM_ParseType(name)
+#define VM_ParseIntAttr32(name) VM_ParseConstI32(name)
+#define VM_ParseIntAttr64(name) VM_ParseConstI64(name)
+#define VM_ParseFloatAttr32(name) VM_ParseConstF32(name)
+#define VM_ParseFloatAttr64(name) VM_ParseConstF64(name)
+#define VM_ParseStrAttr(name, out_str)                   \
+  (out_str)->size = (iree_host_size_t)OP_I16(0);         \
+  (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
+  pc += 2 + (out_str)->size;
+#define VM_ParseBranchTarget(block_name) VM_ParseConstI32(name)
+#define VM_ParseBranchOperands(operands_name) \
+  VM_DecBranchOperandsImpl(bytecode_data, &pc)
+#define VM_ParseOperandRegI32(name) \
+  OP_I16(0) & regs->i32_mask;       \
+  pc += kRegSize;
+#define VM_ParseOperandRegI64(name)  \
+  OP_I16(0) & (regs->i32_mask & ~1); \
+  pc += kRegSize;
+#define VM_ParseOperandRegF32(name) \
+  OP_I16(0) & regs->i32_mask;       \
+  pc += kRegSize;
+#define VM_ParseOperandRegF64(name)  \
+  OP_I16(0) & (regs->i32_mask & ~1); \
+  pc += kRegSize;
+#define VM_ParseOperandRegRef(name, out_is_move)                    \
+  OP_I16(0) & regs->ref_mask;                                       \
+  *(out_is_move) = 0; /*= OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT;*/ \
+  pc += kRegSize;
+#define VM_ParseVariadicOperands(name) \
+  VM_DecVariadicOperandsImpl(bytecode_data, &pc)
+#define VM_ParseResultRegI32(name) \
+  OP_I16(0) & regs->i32_mask;      \
+  pc += kRegSize;
+#define VM_ParseResultRegI64(name)   \
+  OP_I16(0) & (regs->i32_mask & ~1); \
+  pc += kRegSize;
+#define VM_ParseResultRegF32(name) \
+  OP_I16(0) & regs->i32_mask;      \
+  pc += kRegSize;
+#define VM_ParseResultRegF64(name)   \
+  OP_I16(0) & (regs->i32_mask & ~1); \
+  pc += kRegSize;
+#define VM_ParseResultRegRef(name, out_is_move)                     \
+  OP_I16(0) & regs->ref_mask;                                       \
+  *(out_is_move) = 0; /*= OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT;*/ \
+  pc += kRegSize;
+#define VM_ParseVariadicResults(name) VM_ParseVariadicOperands(name)
+
+#define EMIT_REG_NAME(reg)                \
+  if ((reg)&IREE_REF_REGISTER_TYPE_BIT) { \
+    EMIT_REF_REG_NAME(reg);               \
+  } else {                                \
+    EMIT_I32_REG_NAME(reg);               \
+  }
+#define EMIT_I32_REG_NAME(reg)                            \
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
+      b, "%%i%u", ((reg)&IREE_I32_REGISTER_MASK)));
+#define EMIT_I64_REG_NAME(reg)                            \
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
+      b, "%%i%u:%u", ((reg)&IREE_I32_REGISTER_MASK),      \
+      ((reg)&IREE_I32_REGISTER_MASK) + 1));
+#define EMIT_F32_REG_NAME(reg) EMIT_I32_REG_NAME(reg)
+#define EMIT_REF_REG_NAME(reg)                            \
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
+      b, "%%r%u", ((reg)&IREE_REF_REGISTER_MASK)));
+
+#define EMIT_REG_VALUE(regs, reg)                                           \
+  if ((reg)&IREE_REF_REGISTER_TYPE_BIT) {                                   \
+    iree_vm_ref_t* ref = &(regs)->ref[(reg)&IREE_REF_REGISTER_MASK];        \
+    if (iree_vm_ref_is_null(ref)) {                                         \
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "null"));  \
+    } else {                                                                \
+      iree_string_view_t type_name = iree_vm_ref_type_name(ref->type);      \
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(               \
+          b, "!%.*s/0x%p", (int)type_name.size, type_name.data, ref->ptr)); \
+    }                                                                       \
+  } else {                                                                  \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(                 \
+        b, "%u", ((regs)->i32[(reg)&IREE_I32_REGISTER_MASK])));             \
+  }
+
+static iree_status_t iree_vm_bytecode_disasm_emit_type_name(
+    const iree_vm_type_def_t* type_def, iree_string_builder_t* b) {
+  if (iree_vm_type_def_is_value(type_def)) {
+    const char* type_name;
+    switch (type_def->value_type) {
+      case IREE_VM_VALUE_TYPE_I8:
+        type_name = "i8";
+        break;
+      case IREE_VM_VALUE_TYPE_I16:
+        type_name = "i16";
+        break;
+      case IREE_VM_VALUE_TYPE_I32:
+        type_name = "i32";
+        break;
+      case IREE_VM_VALUE_TYPE_I64:
+        type_name = "i64";
+        break;
+      case IREE_VM_VALUE_TYPE_F32:
+        type_name = "f32";
+        break;
+      case IREE_VM_VALUE_TYPE_F64:
+        type_name = "f64";
+        break;
+      default:
+        type_name = "unknown";
+        break;
+    }
+    return iree_string_builder_append_cstring(b, type_name);
+  } else if (iree_vm_type_def_is_ref(type_def)) {
+    iree_string_view_t type_name = iree_vm_ref_type_name(type_def->ref_type);
+    return iree_string_builder_append_format(b, "%.*s", (int)type_name.size,
+                                             type_name.data);
+  } else {
+    return iree_string_builder_append_cstring(b, "*");
+  }
+}
+#define EMIT_TYPE_NAME(type_def) \
+  iree_vm_bytecode_disasm_emit_type_name(type_def, b);
+
+static iree_status_t iree_vm_bytecode_disasm_emit_operand_list(
+    const iree_vm_registers_t* regs, const iree_vm_register_list_t* list,
+    iree_vm_bytecode_disasm_format_t format, iree_string_builder_t* b) {
+  bool include_values =
+      regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES);
+  for (uint16_t i = 0; i < list->size; ++i) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+    }
+    uint16_t reg = list->registers[i];
+    EMIT_REG_NAME(reg);
+    if (include_values) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      EMIT_REG_VALUE(regs, reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+    }
+  }
+  return iree_ok_status();
+}
+#define EMIT_OPERAND_REG_LIST(reg_list) \
+  iree_vm_bytecode_disasm_emit_operand_list(regs, reg_list, format, b)
+static iree_status_t iree_vm_bytecode_disasm_emit_result_list(
+    const iree_vm_register_list_t* list,
+    iree_vm_bytecode_disasm_format_t format, iree_string_builder_t* b) {
+  for (uint16_t i = 0; i < list->size; ++i) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+    }
+    uint16_t reg = list->registers[i];
+    EMIT_REG_NAME(reg);
+  }
+  return iree_ok_status();
+}
+#define EMIT_RESULT_REG_LIST(reg_list) \
+  iree_vm_bytecode_disasm_emit_result_list(reg_list, format, b)
+static iree_status_t iree_vm_bytecode_disasm_emit_remap_list(
+    const iree_vm_registers_t* regs,
+    const iree_vm_register_remap_list_t* remap_list,
+    iree_vm_bytecode_disasm_format_t format, iree_string_builder_t* b) {
+  bool include_values =
+      regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES);
+  for (uint16_t i = 0; i < remap_list->size; ++i) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+    }
+    EMIT_REG_NAME(remap_list->pairs[i].src_reg);
+    if (include_values) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      EMIT_REG_VALUE(regs, remap_list->pairs[i].src_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+    }
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "->"));
+    EMIT_REG_NAME(remap_list->pairs[i].dst_reg);
+  }
+  return iree_ok_status();
+}
+#define EMIT_REMAP_LIST(remap_list) \
+  iree_vm_bytecode_disasm_emit_remap_list(regs, remap_list, format, b)
+
+#define EMIT_OPTIONAL_VALUE_I32(expr)                                          \
+  if (regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES)) {       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(b, "(%" PRId32 ")", \
+                                                           (int32_t)(expr)));  \
+  }
+#define EMIT_OPTIONAL_VALUE_I64(expr)                                    \
+  if (regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES)) { \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(              \
+        b, "(%" PRId64 ")", *(int64_t*)&(expr)));                        \
+  }
+#define EMIT_OPTIONAL_VALUE_F32(expr)                                    \
+  if (regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES)) { \
+    IREE_RETURN_IF_ERROR(                                                \
+        iree_string_builder_append_format(b, "(%f)", *(float*)&(expr))); \
+  }
+#define EMIT_OPTIONAL_VALUE_F64(expr)                                     \
+  if (regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES)) {  \
+    IREE_RETURN_IF_ERROR(                                                 \
+        iree_string_builder_append_format(b, "(%f)", *(double*)&(expr))); \
+  }
+#define EMIT_OPTIONAL_VALUE_REF(expr)                                         \
+  if (regs && (format & IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES)) {      \
+    iree_vm_ref_t* ref = (expr);                                              \
+    if (iree_vm_ref_is_null(ref)) {                                           \
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "(null)"));  \
+    } else {                                                                  \
+      iree_string_view_t type_name = iree_vm_ref_type_name(ref->type);        \
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(                 \
+          b, "(!%.*s/0x%p)", (int)type_name.size, type_name.data, ref->ptr)); \
+    }                                                                         \
+  }
+
+#define DISASM_OP_CORE_UNARY_I32(op_name, op_mnemonic)                \
+  DISASM_OP(CORE, op_name) {                                          \
+    uint16_t operand_reg = VM_ParseOperandRegI32("operand");          \
+    uint16_t result_reg = VM_ParseResultRegI32("result");             \
+    EMIT_I32_REG_NAME(result_reg);                                    \
+    IREE_RETURN_IF_ERROR(                                             \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic)); \
+    EMIT_I32_REG_NAME(operand_reg);                                   \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);                  \
+    break;                                                            \
+  }
+
+#define DISASM_OP_CORE_BINARY_I32(op_name, op_mnemonic)                \
+  DISASM_OP(CORE, op_name) {                                           \
+    uint16_t lhs_reg = VM_ParseOperandRegI32("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegI32("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I32_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I32_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+#define DISASM_OP_CORE_TERNARY_I32(op_name, op_mnemonic)               \
+  DISASM_OP(CORE, op_name) {                                           \
+    uint16_t a_reg = VM_ParseOperandRegI32("a");                       \
+    uint16_t b_reg = VM_ParseOperandRegI32("b");                       \
+    uint16_t c_reg = VM_ParseOperandRegI32("c");                       \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I32_REG_NAME(a_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[a_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I32_REG_NAME(b_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[b_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I32_REG_NAME(c_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[c_reg]);                         \
+    break;                                                             \
+  }
+
+#define DISASM_OP_EXT_I64_UNARY_I64(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_I64, op_name) {                                       \
+    uint16_t operand_reg = VM_ParseOperandRegI64("operand");          \
+    uint16_t result_reg = VM_ParseResultRegI64("result");             \
+    EMIT_I64_REG_NAME(result_reg);                                    \
+    IREE_RETURN_IF_ERROR(                                             \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic)); \
+    EMIT_I64_REG_NAME(operand_reg);                                   \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);                  \
+    break;                                                            \
+  }
+
+#define DISASM_OP_EXT_I64_BINARY_I64(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_I64, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegI64("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegI64("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegI64("result");              \
+    EMIT_I64_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I64_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I64_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+#define DISASM_OP_EXT_I64_TERNARY_I64(op_name, op_mnemonic)            \
+  DISASM_OP(EXT_I64, op_name) {                                        \
+    uint16_t a_reg = VM_ParseOperandRegI64("a");                       \
+    uint16_t b_reg = VM_ParseOperandRegI64("b");                       \
+    uint16_t c_reg = VM_ParseOperandRegI64("c");                       \
+    uint16_t result_reg = VM_ParseResultRegI64("result");              \
+    EMIT_I64_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I64_REG_NAME(a_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[a_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I64_REG_NAME(b_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[b_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I64_REG_NAME(c_reg);                                          \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[c_reg]);                         \
+    break;                                                             \
+  }
+
+#define DISASM_OP_EXT_F32_UNARY_F32(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_F32, op_name) {                                       \
+    uint16_t operand_reg = VM_ParseOperandRegF32("operand");          \
+    uint16_t result_reg = VM_ParseResultRegF32("result");             \
+    EMIT_F32_REG_NAME(result_reg);                                    \
+    IREE_RETURN_IF_ERROR(                                             \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic)); \
+    EMIT_F32_REG_NAME(operand_reg);                                   \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);                  \
+    break;                                                            \
+  }
+
+#define DISASM_OP_EXT_F32_BINARY_F32(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_F32, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegF32("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegF32("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegF32("result");              \
+    EMIT_F32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F32_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F32_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+#define DISASM_OP_EXT_F32_TERNARY_F32(op_name, op_mnemonic)            \
+  DISASM_OP(EXT_F32, op_name) {                                        \
+    uint16_t a_reg = VM_ParseOperandRegF32("a");                       \
+    uint16_t b_reg = VM_ParseOperandRegF32("b");                       \
+    uint16_t c_reg = VM_ParseOperandRegF32("c");                       \
+    uint16_t result_reg = VM_ParseResultRegF32("result");              \
+    EMIT_F32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F32_REG_NAME(a_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[a_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F32_REG_NAME(b_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[b_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F32_REG_NAME(c_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[c_reg]);                         \
+    break;                                                             \
+  }
+
+iree_status_t iree_vm_bytecode_disasm_op(
+    iree_vm_bytecode_module_t* module,
+    iree_vm_bytecode_module_state_t* module_state, uint16_t function_ordinal,
+    iree_vm_source_offset_t pc, const iree_vm_registers_t* regs,
+    iree_vm_bytecode_disasm_format_t format, iree_string_builder_t* b) {
+  const uint8_t* IREE_RESTRICT bytecode_data =
+      module->bytecode_data.data +
+      module->function_descriptor_table[function_ordinal].bytecode_offset;
+
+  switch (bytecode_data[pc++]) {
+    //===------------------------------------------------------------------===//
+    // Globals
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, GlobalLoadI32) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseResultRegI32("value");
+      EMIT_I32_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.global.load.i32 .rwdata[%u]", byte_offset));
+      EMIT_OPTIONAL_VALUE_I32(
+          vm_global_load_i32(module_state->rwdata_storage.data, byte_offset));
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalStoreI32) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.global.store.i32 "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", .rwdata[%u]", byte_offset));
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalLoadIndirectI32) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseResultRegI32("value");
+      EMIT_I32_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, " = vm.global.load.indirect.i32 .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      EMIT_OPTIONAL_VALUE_I32(vm_global_load_i32(
+          module_state->rwdata_storage.data, regs->i32[byte_offset_reg]));
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalStoreIndirectI32) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, "vm.global.store.indirect.i32 "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalLoadRef) {
+      uint32_t global = VM_ParseGlobalAttr("global");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("value");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("value", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.global.load.ref .refs[%u]", global));
+      EMIT_OPTIONAL_VALUE_REF(&module_state->global_ref_table[global]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : !"));
+      EMIT_TYPE_NAME(type_def);
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalStoreRef) {
+      uint32_t global = VM_ParseGlobalAttr("global");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("value");
+      bool value_is_move;
+      uint16_t value_reg = VM_ParseOperandRegRef("value", &value_is_move);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.global.store.ref "));
+      EMIT_REF_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[value_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", .refs[%u] : !", global));
+      EMIT_TYPE_NAME(type_def);
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalLoadIndirectRef) {
+      uint16_t global_reg = VM_ParseOperandRegI32("global");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("value");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("value", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, " = vm.global.load.indirect.ref .refs["));
+      EMIT_I32_REG_NAME(global_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[global_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      EMIT_OPTIONAL_VALUE_REF(
+          &module_state->global_ref_table[regs->i32[global_reg]]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : !"));
+      EMIT_TYPE_NAME(type_def);
+      break;
+    }
+
+    DISASM_OP(CORE, GlobalStoreIndirectRef) {
+      uint16_t global_reg = VM_ParseOperandRegI32("global");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("value");
+      bool value_is_move;
+      uint16_t value_reg = VM_ParseOperandRegRef("value", &value_is_move);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, "vm.global.store.indirect.ref "));
+      EMIT_REF_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(b, ", .refs["));
+      EMIT_I32_REG_NAME(global_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[global_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(b, "] : !"));
+      EMIT_TYPE_NAME(type_def);
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Constants
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, ConstI32) {
+      int32_t value = VM_ParseIntAttr32("value");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.const.i32 %d  // 0x%08X", value, value));
+      break;
+    }
+
+    DISASM_OP(CORE, ConstI32Zero) {
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.const.i32.zero"));
+      break;
+    }
+
+    DISASM_OP(CORE, ConstRefZero) {
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.const.ref.zero"));
+      break;
+    }
+
+    DISASM_OP(CORE, ConstRefRodata) {
+      uint32_t rodata_ordinal = VM_ParseRodataAttr("rodata");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("value", &result_is_move);
+      iree_vm_buffer_t* buffer =
+          &module_state->rodata_ref_table[rodata_ordinal];
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.const.ref.rodata %u  // 0x%p %" PRIhsz "b", rodata_ordinal,
+          buffer->data.data, buffer->data.data_length));
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Buffers
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, BufferAlloc) {
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.alloc "));
+      EMIT_I32_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferClone) {
+      bool source_is_move;
+      uint16_t source_reg = VM_ParseOperandRegRef("source", &source_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.clone "));
+      EMIT_REF_REG_NAME(source_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[source_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferLength) {
+      bool buffer_is_move;
+      uint16_t buffer_reg = VM_ParseOperandRegRef("buffer", &buffer_is_move);
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.length "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferCopy) {
+      bool source_buffer_is_move;
+      uint16_t source_buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &source_buffer_is_move);
+      uint16_t source_offset_reg = VM_ParseOperandRegI32("source_offset");
+      bool target_buffer_is_move;
+      uint16_t target_buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &target_buffer_is_move);
+      uint16_t target_offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.copy "));
+      EMIT_REF_REG_NAME(source_buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[source_buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(source_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[source_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(target_buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[target_buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(target_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[target_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferCompare) {
+      bool lhs_buffer_is_move;
+      uint16_t lhs_buffer_reg =
+          VM_ParseOperandRegRef("lhs_buffer", &lhs_buffer_is_move);
+      uint16_t lhs_offset_reg = VM_ParseOperandRegI32("lhs_offset");
+      bool rhs_buffer_is_move;
+      uint16_t rhs_buffer_reg =
+          VM_ParseOperandRegRef("rhs_buffer", &rhs_buffer_is_move);
+      uint16_t rhs_offset_reg = VM_ParseOperandRegI32("rhs_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.compare "));
+      EMIT_REF_REG_NAME(lhs_buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[lhs_buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(lhs_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[lhs_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(rhs_buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[rhs_buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(rhs_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[rhs_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferFillI8) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.i8 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32((uint8_t)regs->i32[value_reg]);
+      break;
+    }
+    DISASM_OP(CORE, BufferFillI16) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.i16 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint16_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg] / sizeof(uint16_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32((uint16_t)regs->i32[value_reg]);
+      break;
+    }
+    DISASM_OP(CORE, BufferFillI32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.i32 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint32_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg] / sizeof(uint32_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[value_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, BufferLoadI8U) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i8.u "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg]);
+      break;
+    }
+    DISASM_OP(CORE, BufferLoadI8S) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i8.s "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg]);
+      break;
+    }
+    DISASM_OP(CORE, BufferLoadI16U) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i16.u "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint16_t));
+      break;
+    }
+    DISASM_OP(CORE, BufferLoadI16S) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i16.s "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint16_t));
+      break;
+    }
+    DISASM_OP(CORE, BufferLoadI32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i32 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint32_t));
+      break;
+    }
+
+    DISASM_OP(CORE, BufferStoreI8) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.i8 "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32((uint8_t)regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg]);
+      break;
+    }
+    DISASM_OP(CORE, BufferStoreI16) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.i16 "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32((uint16_t)regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint16_t));
+      break;
+    }
+    DISASM_OP(CORE, BufferStoreI32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegI32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.i32 "));
+      EMIT_I32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint32_t));
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Lists
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, ListAlloc) {
+      const iree_vm_type_def_t* element_type_def =
+          VM_ParseTypeOf("element_type");
+      uint16_t initial_capacity_reg = VM_ParseOperandRegI32("initial_capacity");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.alloc "));
+      EMIT_I32_REG_NAME(initial_capacity_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[initial_capacity_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " : !vm.list<"));
+      EMIT_TYPE_NAME(element_type_def);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ">"));
+      break;
+    }
+
+    DISASM_OP(CORE, ListReserve) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t minimum_capacity_reg = VM_ParseOperandRegI32("minimum_capacity");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.reserve "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(minimum_capacity_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[minimum_capacity_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListSize) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.size "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListResize) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t new_size_reg = VM_ParseOperandRegI32("new_size");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.resize "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(new_size_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[new_size_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListGetI32) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.get.i32 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListSetI32) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t raw_value_reg = VM_ParseOperandRegI32("raw_value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.set.i32 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(raw_value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[raw_value_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListGetRef) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("result");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.get.ref "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, ListSetRef) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      bool operand_is_move;
+      uint16_t operand_reg = VM_ParseOperandRegRef("value", &operand_is_move);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.set.ref "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[operand_reg]);
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Conditional assignment
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, SelectI32) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      uint16_t true_value_reg = VM_ParseOperandRegI32("true_value");
+      uint16_t false_value_reg = VM_ParseOperandRegI32("false_value");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.select.i32 "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " ? "));
+      EMIT_I32_REG_NAME(true_value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[true_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
+      EMIT_I32_REG_NAME(false_value_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[false_value_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, SelectRef) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      const iree_vm_type_def_t* type_def = VM_ParseTypeOf("true_value");
+      bool true_value_is_move;
+      uint16_t true_value_reg =
+          VM_ParseOperandRegRef("true_value", &true_value_is_move);
+      bool false_value_is_move;
+      uint16_t false_value_reg =
+          VM_ParseOperandRegRef("false_value", &false_value_is_move);
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.select.ref "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " ? "));
+      EMIT_REF_REG_NAME(true_value_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[true_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
+      EMIT_REF_REG_NAME(false_value_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[false_value_reg]);
+      break;
+    }
+
+    DISASM_OP(CORE, SwitchI32) {
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      int32_t default_value = VM_ParseIntAttr32("default_value");
+      const iree_vm_register_list_t* value_reg_list =
+          VM_ParseVariadicOperands("values");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.switch.i32 "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "["));
+      EMIT_OPERAND_REG_LIST(value_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "] else %u", default_value));
+      break;
+    }
+
+    DISASM_OP(CORE, SwitchRef) {
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      bool default_is_move;
+      uint16_t default_value_reg =
+          VM_ParseOperandRegRef("default_value", &default_is_move);
+      const iree_vm_register_list_t* value_reg_list =
+          VM_ParseVariadicOperands("values");
+      bool result_is_move;
+      uint16_t result_reg = VM_ParseResultRegRef("result", &result_is_move);
+      EMIT_REF_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.switch.ref "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "["));
+      EMIT_OPERAND_REG_LIST(value_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "] else "));
+      EMIT_REF_REG_NAME(default_value_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[default_value_reg]);
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Native integer arithmetic
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP_CORE_BINARY_I32(AddI32, "vm.add.i32");
+    DISASM_OP_CORE_BINARY_I32(SubI32, "vm.sub.i32");
+    DISASM_OP_CORE_BINARY_I32(MulI32, "vm.mul.i32");
+    DISASM_OP_CORE_BINARY_I32(DivI32S, "vm.div.i32.s");
+    DISASM_OP_CORE_BINARY_I32(DivI32U, "vm.div.i32.u");
+    DISASM_OP_CORE_BINARY_I32(RemI32S, "vm.rem.i32.s");
+    DISASM_OP_CORE_BINARY_I32(RemI32U, "vm.rem.i32.u");
+    DISASM_OP_CORE_TERNARY_I32(FMAI32, "vm.fma.i32");
+    DISASM_OP_CORE_UNARY_I32(NotI32, "vm.not.i32");
+    DISASM_OP_CORE_BINARY_I32(AndI32, "vm.and.i32");
+    DISASM_OP_CORE_BINARY_I32(OrI32, "vm.or.i32");
+    DISASM_OP_CORE_BINARY_I32(XorI32, "vm.xor.i32");
+
+    //===------------------------------------------------------------------===//
+    // Casting and type conversion/emulation
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP_CORE_UNARY_I32(TruncI32I8, "vm.trunc.i32.i8");
+    DISASM_OP_CORE_UNARY_I32(TruncI32I16, "vm.trunc.i32.i16");
+    DISASM_OP_CORE_UNARY_I32(ExtI8I32S, "vm.ext.i8.i32.s");
+    DISASM_OP_CORE_UNARY_I32(ExtI8I32U, "vm.ext.i8.i32.u");
+    DISASM_OP_CORE_UNARY_I32(ExtI16I32S, "vm.ext.i16.i32.s");
+    DISASM_OP_CORE_UNARY_I32(ExtI16I32U, "vm.ext.i16.i32.u");
+
+    //===------------------------------------------------------------------===//
+    // Native bitwise shifts and rotates
+    //===------------------------------------------------------------------===//
+
+#define DISASM_OP_CORE_SHIFT_I32(op_name, op_mnemonic)                 \
+  DISASM_OP(CORE, op_name) {                                           \
+    uint16_t operand_reg = VM_ParseOperandRegI32("operand");           \
+    uint16_t amount_reg = VM_ParseOperandRegI32("amount");             \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I32_REG_NAME(operand_reg);                                    \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);                   \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I32_REG_NAME(amount_reg);                                     \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[amount_reg]);                    \
+    break;                                                             \
+  }
+
+    DISASM_OP_CORE_SHIFT_I32(ShlI32, "vm.shl.i32");
+    DISASM_OP_CORE_SHIFT_I32(ShrI32S, "vm.shr.i32.s");
+    DISASM_OP_CORE_SHIFT_I32(ShrI32U, "vm.shr.i32.u");
+
+    //===------------------------------------------------------------------===//
+    // Comparison ops
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP_CORE_BINARY_I32(CmpEQI32, "vm.cmp.eq.i32");
+    DISASM_OP_CORE_BINARY_I32(CmpNEI32, "vm.cmp.ne.i32");
+    DISASM_OP_CORE_BINARY_I32(CmpLTI32S, "vm.cmp.lt.i32.s");
+    DISASM_OP_CORE_BINARY_I32(CmpLTI32U, "vm.cmp.lt.i32.u");
+    DISASM_OP_CORE_UNARY_I32(CmpNZI32, "vm.cmp.nz.i32");
+
+    DISASM_OP(CORE, CmpEQRef) {
+      bool lhs_is_move;
+      uint16_t lhs_reg = VM_ParseOperandRegRef("lhs", &lhs_is_move);
+      bool rhs_is_move;
+      uint16_t rhs_reg = VM_ParseOperandRegRef("rhs", &rhs_is_move);
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.eq.ref "));
+      EMIT_REF_REG_NAME(lhs_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[lhs_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(rhs_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[rhs_reg]);
+      break;
+    }
+    DISASM_OP(CORE, CmpNERef) {
+      bool lhs_is_move;
+      uint16_t lhs_reg = VM_ParseOperandRegRef("lhs", &lhs_is_move);
+      bool rhs_is_move;
+      uint16_t rhs_reg = VM_ParseOperandRegRef("rhs", &rhs_is_move);
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.ne.ref "));
+      EMIT_REF_REG_NAME(lhs_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[lhs_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(rhs_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[rhs_reg]);
+      break;
+    }
+    DISASM_OP(CORE, CmpNZRef) {
+      bool operand_is_move;
+      uint16_t operand_reg = VM_ParseOperandRegRef("operand", &operand_is_move);
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.nz.ref "));
+      EMIT_REF_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[operand_reg]);
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Control flow
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, Branch) {
+      int32_t block_pc = VM_ParseBranchTarget("dest");
+      const iree_vm_register_remap_list_t* remap_list =
+          VM_ParseBranchOperands("operands");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.br ^%08X(", block_pc));
+      EMIT_REMAP_LIST(remap_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, CondBranch) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      int32_t true_block_pc = VM_ParseBranchTarget("true_dest");
+      const iree_vm_register_remap_list_t* true_remap_list =
+          VM_ParseBranchOperands("true_operands");
+      int32_t false_block_pc = VM_ParseBranchTarget("false_dest");
+      const iree_vm_register_remap_list_t* false_remap_list =
+          VM_ParseBranchOperands("false_operands");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.cond_br "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", ^%08X(", true_block_pc));
+      EMIT_REMAP_LIST(true_remap_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "), ^%08X(", false_block_pc));
+      EMIT_REMAP_LIST(false_remap_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, Call) {
+      int32_t function_ordinal = VM_ParseFuncAttr("callee");
+      const iree_vm_register_list_t* src_reg_list =
+          VM_ParseVariadicOperands("operands");
+      const iree_vm_register_list_t* dst_reg_list =
+          VM_ParseVariadicResults("results");
+      if (dst_reg_list->size > 0) {
+        EMIT_RESULT_REG_LIST(dst_reg_list);
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " = "));
+      }
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "vm.call @"));
+      int is_import = (function_ordinal & 0x80000000u) != 0;
+      iree_vm_function_t function;
+      if (is_import) {
+        const iree_vm_bytecode_import_t* import =
+            &module_state->import_table[function_ordinal & 0x7FFFFFFFu];
+        function = import->function;
+      } else {
+        function.module = &module->interface;
+        function.linkage = IREE_VM_FUNCTION_LINKAGE_INTERNAL;
+        function.ordinal = function_ordinal;
+      }
+      iree_string_view_t module_name = iree_vm_module_name(function.module);
+      iree_string_view_t func_name = iree_vm_function_name(&function);
+      if (iree_string_view_is_empty(func_name)) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            b, "%.*s:%u", (int)module_name.size, module_name.data,
+            function.ordinal));
+      } else {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            b, "%.*s.%.*s", (int)module_name.size, module_name.data,
+            (int)func_name.size, func_name.data));
+      }
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, CallVariadic) {
+      int32_t function_ordinal = VM_ParseFuncAttr("callee");
+      // TODO(benvanik): print segment sizes.
+      // const iree_vm_register_list_t* segment_size_list =
+      VM_ParseVariadicOperands("segment_sizes");
+      const iree_vm_register_list_t* src_reg_list =
+          VM_ParseVariadicOperands("operands");
+      const iree_vm_register_list_t* dst_reg_list =
+          VM_ParseVariadicResults("results");
+      if (dst_reg_list->size > 0) {
+        EMIT_RESULT_REG_LIST(dst_reg_list);
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " = "));
+      }
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.call.varadic @"));
+      int is_import = (function_ordinal & 0x80000000u) != 0;
+      iree_vm_function_t function;
+      if (is_import) {
+        const iree_vm_bytecode_import_t* import =
+            &module_state->import_table[function_ordinal & 0x7FFFFFFFu];
+        function = import->function;
+      } else {
+        function.module = &module->interface;
+        function.linkage = IREE_VM_FUNCTION_LINKAGE_INTERNAL;
+        function.ordinal = function_ordinal;
+      }
+      iree_string_view_t module_name = iree_vm_module_name(function.module);
+      iree_string_view_t func_name = iree_vm_function_name(&function);
+      if (iree_string_view_is_empty(func_name)) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            b, "%.*s:%u", (int)module_name.size, module_name.data,
+            function.ordinal));
+      } else {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            b, "%.*s.%.*s", (int)module_name.size, module_name.data,
+            (int)func_name.size, func_name.data));
+      }
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "("));
+      EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, Return) {
+      const iree_vm_register_list_t* src_reg_list =
+          VM_ParseVariadicOperands("operands");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "vm.return "));
+      EMIT_OPERAND_REG_LIST(src_reg_list);
+      break;
+    }
+
+    DISASM_OP(CORE, Fail) {
+      uint16_t status_code_reg = VM_ParseOperandRegI32("status");
+      iree_string_view_t message;
+      VM_ParseStrAttr("message", &message);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "vm.fail "));
+      EMIT_I32_REG_NAME(status_code_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[status_code_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, ", \"%.*s\"", (int)message.size, message.data));
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Async/fiber ops
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, Yield) {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.yield (TBD)"));
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Debugging
+    //===------------------------------------------------------------------===//
+
+    DISASM_OP(CORE, Trace) {
+      iree_string_view_t event_name;
+      VM_ParseStrAttr("event_name", &event_name);
+      const iree_vm_register_list_t* src_reg_list =
+          VM_ParseVariadicOperands("operands");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, "vm.trace \"%.*s\"(", (int)event_name.size, event_name.data));
+      EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, Print) {
+      iree_string_view_t event_name;
+      VM_ParseStrAttr("event_name", &event_name);
+      const iree_vm_register_list_t* src_reg_list =
+          VM_ParseVariadicOperands("operands");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, "vm.print \"%.*s\"(", (int)event_name.size, event_name.data));
+      EMIT_OPERAND_REG_LIST(src_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, Break) {
+      int32_t block_pc = VM_DecBranchTarget("dest");
+      const iree_vm_register_remap_list_t* remap_list =
+          VM_ParseBranchOperands("operands");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.break ^%08X(", block_pc));
+      EMIT_REMAP_LIST(remap_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    DISASM_OP(CORE, CondBreak) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      int32_t block_pc = VM_ParseBranchTarget("dest");
+      const iree_vm_register_remap_list_t* remap_list =
+          VM_ParseBranchOperands("operands");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.cond_break "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", ^%08X(", block_pc));
+      EMIT_REMAP_LIST(remap_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ")"));
+      break;
+    }
+
+    //===------------------------------------------------------------------===//
+    // Extension trampolines
+    //===------------------------------------------------------------------===//
+
+#if IREE_VM_EXT_I64_ENABLE
+    BEGIN_DISASM_PREFIX(PrefixExtI64, EXT_I64)
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Globals
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, GlobalLoadI64) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseResultRegI64("value");
+      EMIT_I32_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.global.load.i64 .rwdata[%u]", byte_offset));
+      EMIT_OPTIONAL_VALUE_I64(module_state->rwdata_storage.data[byte_offset]);
+      break;
+    }
+
+    DISASM_OP(EXT_I64, GlobalStoreI64) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseOperandRegI64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.global.store.i64 "));
+      EMIT_I64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", .rwdata[%u]", byte_offset));
+      break;
+    }
+
+    DISASM_OP(EXT_I64, GlobalLoadIndirectI64) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseResultRegI64("value");
+      EMIT_I64_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, " = vm.global.load.indirect.i64 .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      EMIT_OPTIONAL_VALUE_I64(
+          module_state->rwdata_storage.data[regs->i32[byte_offset_reg]]);
+      break;
+    }
+
+    DISASM_OP(EXT_I64, GlobalStoreIndirectI64) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseOperandRegI64("value");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, "vm.global.store.indirect.i64 "));
+      EMIT_I64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Constants
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, ConstI64) {
+      int64_t value = VM_ParseIntAttr64("value");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.const.i64 %" PRId64 "  // 0x%08" PRIX64 "", value, value));
+      break;
+    }
+
+    DISASM_OP(EXT_I64, ConstI64Zero) {
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.const.i64.zero"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Lists
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, ListGetI64) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.get.i64 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_I64, ListSetI64) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t value_reg = VM_ParseOperandRegI64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.set.i64 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[value_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Conditional assignment
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, SelectI64) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      uint16_t true_value_reg = VM_ParseOperandRegI64("true_value");
+      uint16_t false_value_reg = VM_ParseOperandRegI64("false_value");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.select.i64 "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " ? "));
+      EMIT_I64_REG_NAME(true_value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[true_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
+      EMIT_I64_REG_NAME(false_value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[false_value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_I64, SwitchI64) {
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      int64_t default_value = VM_ParseIntAttr64("default_value");
+      const iree_vm_register_list_t* value_reg_list =
+          VM_ParseVariadicOperands("values");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.switch.i64 "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "["));
+      EMIT_OPERAND_REG_LIST(value_reg_list);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, "] else %" PRId64, default_value));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Native integer arithmetic
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP_EXT_I64_BINARY_I64(AddI64, "vm.add.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(SubI64, "vm.sub.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(MulI64, "vm.mul.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(DivI64S, "vm.div.i64.s");
+    DISASM_OP_EXT_I64_BINARY_I64(DivI64U, "vm.div.i64.u");
+    DISASM_OP_EXT_I64_BINARY_I64(RemI64S, "vm.rem.i64.s");
+    DISASM_OP_EXT_I64_BINARY_I64(RemI64U, "vm.rem.i64.u");
+    DISASM_OP_EXT_I64_TERNARY_I64(FMAI64, "vm.fma.i64");
+    DISASM_OP_EXT_I64_UNARY_I64(NotI64, "vm.not.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(AndI64, "vm.and.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(OrI64, "vm.or.i64");
+    DISASM_OP_EXT_I64_BINARY_I64(XorI64, "vm.xor.i64");
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Casting and type conversion/emulation
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, TruncI64I32) {
+      uint16_t operand_reg = VM_ParseOperandRegI64("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.trunc.i64.i32 "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_I64, ExtI32I64S) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.ext.i32.i64.s "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_I64, ExtI32I64U) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.ext.i32.i64.u "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Native bitwise shifts and rotates
+    //===----------------------------------------------------------------===//
+
+#define DISASM_OP_EXT_I64_SHIFT_I64(op_name, op_mnemonic)              \
+  DISASM_OP(EXT_I64, op_name) {                                        \
+    uint16_t operand_reg = VM_ParseOperandRegI64("operand");           \
+    uint16_t amount_reg = VM_ParseOperandRegI32("amount");             \
+    uint16_t result_reg = VM_ParseResultRegI64("result");              \
+    EMIT_I64_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I64_REG_NAME(operand_reg);                                    \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);                   \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I32_REG_NAME(amount_reg);                                     \
+    EMIT_OPTIONAL_VALUE_I32(regs->i32[amount_reg]);                    \
+    break;                                                             \
+  }
+
+    DISASM_OP_EXT_I64_SHIFT_I64(ShlI64, "vm.shl.i64");
+    DISASM_OP_EXT_I64_SHIFT_I64(ShrI64S, "vm.shr.i64.s");
+    DISASM_OP_EXT_I64_SHIFT_I64(ShrI64U, "vm.shr.i64.u");
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Comparison ops
+    //===----------------------------------------------------------------===//
+
+#define DISASM_OP_EXT_I64_CMP_I64(op_name, op_mnemonic)                \
+  DISASM_OP(EXT_I64, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegI64("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegI64("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_I64_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_I64_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_I64(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+    DISASM_OP_EXT_I64_CMP_I64(CmpEQI64, "vm.cmp.eq.i64");
+    DISASM_OP_EXT_I64_CMP_I64(CmpNEI64, "vm.cmp.ne.i64");
+    DISASM_OP_EXT_I64_CMP_I64(CmpLTI64S, "vm.cmp.lt.i64.s");
+    DISASM_OP_EXT_I64_CMP_I64(CmpLTI64U, "vm.cmp.lt.i64.u");
+    DISASM_OP(EXT_I64, CmpNZI64) {
+      uint16_t operand_reg = VM_ParseOperandRegI64("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.nz.i64 "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtI64: Buffers
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_I64, BufferFillI64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t value_reg = VM_ParseOperandRegI64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.i64 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint64_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg] / sizeof(uint64_t));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_I64, BufferLoadI64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.i64 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint64_t));
+      break;
+    }
+
+    DISASM_OP(EXT_I64, BufferStoreI64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegI64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.i64 "));
+      EMIT_I64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint32_t));
+      break;
+    }
+
+    END_DISASM_PREFIX()
+#else
+    UNHANDLED_DISASM_PREFIX(PrefixExtI64, EXT_I64);
+#endif  // IREE_VM_EXT_I64_ENABLE
+
+#if IREE_VM_EXT_F32_ENABLE
+    BEGIN_DISASM_PREFIX(PrefixExtF32, EXT_F32)
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Globals
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, GlobalLoadF32) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseResultRegF32("value");
+      EMIT_F32_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.global.load.f32 .rwdata[%u]", byte_offset));
+      EMIT_OPTIONAL_VALUE_F32(module_state->rwdata_storage.data[byte_offset]);
+      break;
+    }
+
+    DISASM_OP(EXT_F32, GlobalStoreF32) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseOperandRegF32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.global.store.f32 "));
+      EMIT_F32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", .rwdata[%u]", byte_offset));
+      break;
+    }
+
+    DISASM_OP(EXT_F32, GlobalLoadIndirectF32) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseResultRegI32("value");
+      EMIT_F32_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, " = vm.global.load.indirect.f32 .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      EMIT_OPTIONAL_VALUE_F32(
+          module_state->rwdata_storage.data[regs->i32[byte_offset_reg]]);
+      break;
+    }
+
+    DISASM_OP(EXT_F32, GlobalStoreIndirectF32) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseOperandRegF32("value");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, "vm.global.store.indirect.f32 "));
+      EMIT_F32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Constants
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, ConstF32) {
+      float value = VM_ParseFloatAttr32("value");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, " = vm.const.f32 %f", value));
+      break;
+    }
+
+    DISASM_OP(EXT_F32, ConstF32Zero) {
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.const.f32.zero"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Lists
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, ListGetF32) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.get.f32 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F32, ListSetF32) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t raw_value_reg = VM_ParseOperandRegF32("raw_value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.set.f32 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_F32_REG_NAME(raw_value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[raw_value_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Conditional assignment
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, SelectF32) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      uint16_t true_value_reg = VM_ParseOperandRegF32("true_value");
+      uint16_t false_value_reg = VM_ParseOperandRegF32("false_value");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.select.f32 "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " ? "));
+      EMIT_F32_REG_NAME(true_value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[true_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
+      EMIT_F32_REG_NAME(false_value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[false_value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F32, SwitchF32) {
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      float default_value = VM_ParseFloatAttr32("default_value");
+      const iree_vm_register_list_t* value_reg_list =
+          VM_ParseVariadicOperands("values");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.switch.f32 "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "["));
+      EMIT_OPERAND_REG_LIST(value_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "] else %f", default_value));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Native floating-point arithmetic
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP_EXT_F32_BINARY_F32(AddF32, "vm.add.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(SubF32, "vm.sub.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(MulF32, "vm.mul.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(DivF32, "vm.div.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(RemF32, "vm.rem.f32");
+    DISASM_OP_EXT_F32_TERNARY_F32(FMAF32, "vm.fma.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(AbsF32, "vm.abs.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(NegF32, "vm.neg.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(CeilF32, "vm.ceil.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(FloorF32, "vm.floor.f32");
+
+    DISASM_OP_EXT_F32_UNARY_F32(AtanF32, "vm.atan.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(Atan2F32, "vm.atan2.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(CosF32, "vm.cos.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(SinF32, "vm.sin.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(ExpF32, "vm.exp.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(Exp2F32, "vm.exp2.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(ExpM1F32, "vm.expm1.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(LogF32, "vm.log.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(Log10F32, "vm.log10.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(Log1pF32, "vm.log1p.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(Log2F32, "vm.log2.f32");
+    DISASM_OP_EXT_F32_BINARY_F32(PowF32, "vm.pow.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(RsqrtF32, "vm.rsqrt.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(SqrtF32, "vm.sqrt.f32");
+    DISASM_OP_EXT_F32_UNARY_F32(TanhF32, "vm.tanh.f32");
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Casting and type conversion/emulation
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, CastSI32F32) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.si32.f32 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F32, CastUI32F32) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.ui32.f32 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F32, CastF32SI32) {
+      uint16_t operand_reg = VM_ParseOperandRegF32("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f32.sif32 "));
+      EMIT_F32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F32, CastF32UI32) {
+      uint16_t operand_reg = VM_ParseOperandRegF32("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f32.uif32 "));
+      EMIT_F32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F32, BitcastI32F32) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.bitcast.i32.f32 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F32, BitcastF32I32) {
+      uint16_t operand_reg = VM_ParseOperandRegF32("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.bitcast.f32.if32 "));
+      EMIT_F32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Comparison ops
+    //===----------------------------------------------------------------===//
+
+#define DISASM_OP_EXT_F32_CMP_F32(op_name, op_mnemonic)                \
+  DISASM_OP(EXT_F32, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegF32("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegF32("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F32_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F32_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F32(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+    DISASM_OP_EXT_F32_CMP_F32(CmpEQF32O, "vm.cmp.eq.f32.o");
+    DISASM_OP_EXT_F32_CMP_F32(CmpEQF32U, "vm.cmp.eq.f32.u");
+    DISASM_OP_EXT_F32_CMP_F32(CmpNEF32O, "vm.cmp.ne.f32.o");
+    DISASM_OP_EXT_F32_CMP_F32(CmpNEF32U, "vm.cmp.ne.f32.u");
+    DISASM_OP_EXT_F32_CMP_F32(CmpLTF32O, "vm.cmp.lt.f32.o");
+    DISASM_OP_EXT_F32_CMP_F32(CmpLTF32U, "vm.cmp.lt.f32.u");
+    DISASM_OP_EXT_F32_CMP_F32(CmpLTEF32O, "vm.cmp.lte.f32.o");
+    DISASM_OP_EXT_F32_CMP_F32(CmpLTEF32U, "vm.cmp.lte.f32.u");
+    DISASM_OP(EXT_F32, CmpNaNF32) {
+      uint16_t operand_reg = VM_ParseOperandRegF32("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.nan.f32 "));
+      EMIT_F32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF32: Buffers
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F32, BufferFillF32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI32("length");
+      uint16_t value_reg = VM_ParseOperandRegF32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.f32 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(float));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[length_reg] / sizeof(float));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_F32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F32, BufferLoadF32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("source_offset");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.f32 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(float));
+      break;
+    }
+
+    DISASM_OP(EXT_F32, BufferStoreF32) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI32("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegF32("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.f32 "));
+      EMIT_F32_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[offset_reg] / sizeof(uint32_t));
+      break;
+    }
+
+    END_DISASM_PREFIX()
+#else
+    UNHANDLED_DISASM_PREFIX(PrefixExtF32, EXT_F32)
+#endif  // IREE_VM_EXT_F32_ENABLE
+    UNHANDLED_DISASM_PREFIX(PrefixExtF64, EXT_F64)
+
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unhandled core opcode");
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_vm_bytecode_trace_disasm(iree_vm_stack_frame_t* frame,
+                                            iree_vm_source_offset_t pc,
+                                            const iree_vm_registers_t* regs,
+                                            FILE* file) {
+  iree_string_builder_t b;
+  iree_string_builder_initialize(iree_allocator_system(), &b);
+
+  // TODO(benvanik): ensure frame is in-sync before call or restore original.
+  // It's shady to manipulate the frame here but I know we expect the pc to be
+  // valid only on entry/exit from a function.
+  frame->pc = pc;
+
+#if IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE
+  iree_vm_source_location_t source_location;
+  iree_status_t status = iree_vm_module_resolve_source_location(
+      frame->function.module, frame, &source_location);
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_source_location_format(
+        &source_location, IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_SINGLE_LINE, &b);
+  }
+  if (iree_status_is_ok(status)) {
+    // Pad out to keep alignment. This is just guesswork based on my machine.
+    static const iree_host_size_t pad_to = 80;
+    iree_host_size_t col = iree_string_builder_size(&b);
+    if (col < pad_to) {
+      iree_string_builder_append_format(&b, "%*s ", (int)(pad_to - col), "");
+    } else {
+      status = iree_string_builder_append_cstring(&b, " ");
+    }
+  } else {
+    // Ignore failures when no source location is available.
+    if (iree_status_is_unavailable(status)) {
+      status = iree_ok_status();
+    } else {
+      return status;
+    }
+  }
+#else
+  iree_status_t status = iree_ok_status();
+#endif  // IREE_VM_EXECUTION_TRACING_ENABLE
+
+  if (iree_status_is_ok(status)) {
+    iree_string_view_t module_name =
+        iree_vm_module_name(frame->function.module);
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        &b, "[%.*s", (int)module_name.size, module_name.data));
+    iree_string_view_t function_name = iree_vm_function_name(&frame->function);
+    if (iree_string_view_is_empty(function_name)) {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          &b, "@%u", (uint32_t)frame->function.ordinal));
+    } else {
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          &b, ".%.*s", (int)function_name.size, function_name.data));
+    }
+    status = iree_string_builder_append_format(&b, "+%08" PRIX64 "]    ", pc);
+  }
+
+  if (iree_status_is_ok(status)) {
+    status = iree_vm_bytecode_disasm_op(
+        (iree_vm_bytecode_module_t*)frame->function.module,
+        (iree_vm_bytecode_module_state_t*)frame->module_state,
+        frame->function.ordinal, pc, regs,
+        IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES, &b);
+  }
+
+  if (iree_status_is_ok(status)) {
+    fprintf(file, "%.*s\n", (int)iree_string_builder_size(&b),
+            iree_string_builder_buffer(&b));
+  }
+
+  iree_string_builder_deinitialize(&b);
+  return status;
+}

--- a/iree/vm/bytecode_disasm.h
+++ b/iree/vm/bytecode_disasm.h
@@ -1,0 +1,46 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_VM_BYTECODE_DISASM_H_
+#define IREE_VM_BYTECODE_DISASM_H_
+
+#include <stdio.h>
+
+#include "iree/base/string_builder.h"
+#include "iree/vm/bytecode_dispatch_util.h"
+#include "iree/vm/bytecode_module_impl.h"
+#include "iree/vm/stack.h"
+
+// Controls how bytecode disassembly is formatted.
+typedef enum iree_vm_bytecode_disasm_format_e {
+  IREE_VM_BYTECODE_DISASM_FORMAT_DEFAULT = 0,
+  // Includes the input register values inline in the op text.
+  // Example: `%i0 <= ShrI32U %i2(5), %i3(6)`
+  IREE_VM_BYTECODE_DISASM_FORMAT_INLINE_VALUES = 1u << 0,
+} iree_vm_bytecode_disasm_format_t;
+
+// Disassembles the bytecode operation at |pc| using the provided module state.
+// Appends the disasembled op to |string_builder| in a format based on |format|.
+// If |regs| are available then values can be added using the format mode.
+//
+// Example: `%i0 <= ShrI32U %i2, %i3`
+//
+// WARNING: this does not currently perform any verification on the bytecode;
+// it's assumed all bytecode is valid. This is a debug tool: you shouldn't be
+// running this in production on untrusted inputs anyway.
+iree_status_t iree_vm_bytecode_disasm_op(
+    iree_vm_bytecode_module_t* module,
+    iree_vm_bytecode_module_state_t* module_state, uint16_t function_ordinal,
+    iree_vm_source_offset_t pc, const iree_vm_registers_t* regs,
+    iree_vm_bytecode_disasm_format_t format,
+    iree_string_builder_t* string_builder);
+
+iree_status_t iree_vm_bytecode_trace_disasm(iree_vm_stack_frame_t* frame,
+                                            iree_vm_source_offset_t pc,
+                                            const iree_vm_registers_t* regs,
+                                            FILE* file);
+
+#endif  // IREE_VM_BYTECODE_DISASM_H_

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -11,6 +11,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
 #include "iree/vm/api.h"
+#include "iree/vm/bytecode_disasm.h"
 #include "iree/vm/bytecode_dispatch_util.h"
 #include "iree/vm/bytecode_module_impl.h"
 #include "iree/vm/ops.h"
@@ -104,8 +105,6 @@ static iree_status_t iree_vm_bytecode_function_enter(
     iree_vm_stack_t* stack, const iree_vm_function_t function,
     iree_vm_stack_frame_t** out_callee_frame,
     iree_vm_registers_t* out_callee_registers) {
-  IREE_DISPATCH_LOG_CALL(&function);
-
   iree_vm_bytecode_module_t* module =
       (iree_vm_bytecode_module_t*)function.module->self;
   if (IREE_UNLIKELY(function.ordinal >= module->function_descriptor_count)) {
@@ -542,7 +541,6 @@ static iree_status_t iree_vm_bytecode_call_import(
   iree_vm_function_call_t call;
   memset(&call, 0, sizeof(call));
   call.function = import->function;
-  IREE_DISPATCH_LOG_CALL(&call.function);
 
   // Marshal inputs from registers to the ABI arguments buffer.
   call.arguments.data_length = import->argument_buffer_size;
@@ -584,7 +582,6 @@ static iree_status_t iree_vm_bytecode_call_import_variadic(
   iree_vm_function_call_t call;
   memset(&call, 0, sizeof(call));
   call.function = import->function;
-  IREE_DISPATCH_LOG_CALL(&call.function);
 
   // Allocate ABI argument/result storage taking into account the variadic
   // segments.
@@ -742,7 +739,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     });
 
     DISPATCH_OP(CORE, GlobalLoadIndirectRef, {
-      uint32_t global = VM_DecGlobalAttr("global");
+      uint32_t global = VM_DecOperandRegI32("global");
       if (IREE_UNLIKELY(global >= module_state->global_ref_count)) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
@@ -758,7 +755,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     });
 
     DISPATCH_OP(CORE, GlobalStoreIndirectRef, {
-      uint32_t global = VM_DecGlobalAttr("global");
+      uint32_t global = VM_DecOperandRegI32("global");
       if (IREE_UNLIKELY(global >= module_state->global_ref_count)) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,

--- a/iree/vm/bytecode_dispatch_test.cc
+++ b/iree/vm/bytecode_dispatch_test.cc
@@ -81,8 +81,8 @@ class VMBytecodeDispatchTest
 
     std::vector<iree_vm_module_t*> modules = {bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
   }
 
   virtual void TearDown() {
@@ -97,7 +97,7 @@ class VMBytecodeDispatchTest
         bytecode_module_->self, IREE_VM_FUNCTION_LINKAGE_EXPORT,
         iree_make_cstring_view(function_name), &function));
 
-    return iree_vm_invoke(context_, function,
+    return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                           /*policy=*/nullptr, /*inputs=*/nullptr,
                           /*outputs=*/nullptr, iree_allocator_system());
   }

--- a/iree/vm/bytecode_module_benchmark.cc
+++ b/iree/vm/bytecode_module_benchmark.cc
@@ -89,8 +89,8 @@ static iree_status_t RunFunction(benchmark::State& state,
   std::array<iree_vm_module_t*, 2> modules = {import_module, bytecode_module};
   iree_vm_context_t* context = NULL;
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
-      instance, modules.data(), modules.size(), iree_allocator_system(),
-      &context));
+      instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+      iree_allocator_system(), &context));
 
   iree_vm_function_t function;
   IREE_CHECK_OK(
@@ -106,8 +106,9 @@ static iree_status_t RunFunction(benchmark::State& state,
       iree_make_byte_span(iree_alloca(result_count * sizeof(int32_t)),
                           result_count * sizeof(int32_t));
 
-  IREE_VM_INLINE_STACK_INITIALIZE(
-      stack, iree_vm_context_state_resolver(context), iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  iree_vm_context_state_resolver(context),
+                                  iree_allocator_system());
   while (state.KeepRunningBatch(batch_size)) {
     for (iree_host_size_t i = 0; i < i32_args.size(); ++i) {
       reinterpret_cast<int32_t*>(call.arguments.data)[i] = i32_args[i];

--- a/iree/vm/bytecode_module_size_benchmark.cc
+++ b/iree/vm/bytecode_module_size_benchmark.cc
@@ -23,7 +23,8 @@ extern "C" int main(int argc, char** argv) {
       iree_allocator_null(), iree_allocator_system(), &module);
 
   iree_vm_context_t* context = nullptr;
-  iree_vm_context_create_with_modules(instance, &module, /*module_count=*/1,
+  iree_vm_context_create_with_modules(instance, IREE_VM_CONTEXT_FLAG_NONE,
+                                      &module, /*module_count=*/1,
                                       iree_allocator_system(), &context);
 
   iree_vm_function_t function;
@@ -31,7 +32,8 @@ extern "C" int main(int argc, char** argv) {
       module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
       iree_make_cstring_view("empty_func"), &function);
 
-  iree_vm_invoke(context, function, /*policy=*/nullptr, /*inputs=*/nullptr,
+  iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                 /*policy=*/nullptr, /*inputs=*/nullptr,
                  /*outputs=*/nullptr, iree_allocator_system());
 
   iree_vm_module_release(module);

--- a/iree/vm/context.h
+++ b/iree/vm/context.h
@@ -31,11 +31,24 @@ extern "C" {
 // Thread-compatible and must be externally synchronized.
 typedef struct iree_vm_context_t iree_vm_context_t;
 
+enum iree_vm_context_flag_bits_t {
+  IREE_VM_CONTEXT_FLAG_NONE = 0u,
+
+  // Enables tracing of execution to stderr (when available).
+  // See iree/base/config.h for the flags that control whether this
+  // functionality is available; specifically:
+  //   -DIREE_VM_EXECUTION_TRACING_ENABLE=1
+  // All invocations made to this context - including initializers - will be
+  // traced. For fine-grained control use `iree_vm_invocation_flags_t`.
+  IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION = 1u << 0,
+};
+typedef uint32_t iree_vm_context_flags_t;
+
 // Creates a new context that uses the given |instance| for device management.
 // |out_context| must be released by the caller.
-IREE_API_EXPORT iree_status_t
-iree_vm_context_create(iree_vm_instance_t* instance, iree_allocator_t allocator,
-                       iree_vm_context_t** out_context);
+IREE_API_EXPORT iree_status_t iree_vm_context_create(
+    iree_vm_instance_t* instance, iree_vm_context_flags_t flags,
+    iree_allocator_t allocator, iree_vm_context_t** out_context);
 
 // Creates a new context with the given static set of modules.
 // This is equivalent to iree_vm_context_create+iree_vm_context_register_modules
@@ -43,9 +56,9 @@ iree_vm_context_create(iree_vm_instance_t* instance, iree_allocator_t allocator,
 // have additional modules registered after creation.
 // |out_context| must be released by the caller.
 IREE_API_EXPORT iree_status_t iree_vm_context_create_with_modules(
-    iree_vm_instance_t* instance, iree_vm_module_t** modules,
-    iree_host_size_t module_count, iree_allocator_t allocator,
-    iree_vm_context_t** out_context);
+    iree_vm_instance_t* instance, iree_vm_context_flags_t flags,
+    iree_vm_module_t** modules, iree_host_size_t module_count,
+    iree_allocator_t allocator, iree_vm_context_t** out_context);
 
 // Retains the given |context| for the caller.
 IREE_API_EXPORT void iree_vm_context_retain(iree_vm_context_t* context);
@@ -55,6 +68,10 @@ IREE_API_EXPORT void iree_vm_context_release(iree_vm_context_t* context);
 
 // Returns a process-unique ID for the |context|.
 IREE_API_EXPORT intptr_t iree_vm_context_id(const iree_vm_context_t* context);
+
+// Returns |context| flags.
+IREE_API_EXPORT iree_vm_context_flags_t
+iree_vm_context_flags(const iree_vm_context_t* context);
 
 // Registers a list of modules with the context and resolves imports in the
 // order provided.

--- a/iree/vm/invocation.c
+++ b/iree/vm/invocation.c
@@ -201,13 +201,19 @@ static iree_status_t iree_vm_invoke_within(
 
 IREE_API_EXPORT iree_status_t iree_vm_invoke(
     iree_vm_context_t* context, iree_vm_function_t function,
-    const iree_vm_invocation_policy_t* policy, iree_vm_list_t* inputs,
-    iree_vm_list_t* outputs, iree_allocator_t allocator) {
+    iree_vm_invocation_flags_t flags, const iree_vm_invocation_policy_t* policy,
+    iree_vm_list_t* inputs, iree_vm_list_t* outputs,
+    iree_allocator_t allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Force tracing if specified on the context.
+  if (iree_vm_context_flags(context) & IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION) {
+    flags |= IREE_VM_INVOCATION_FLAG_TRACE_EXECUTION;
+  }
 
   // Allocate a VM stack on the host stack and initialize it.
   IREE_VM_INLINE_STACK_INITIALIZE(
-      stack, iree_vm_context_state_resolver(context), allocator);
+      stack, flags, iree_vm_context_state_resolver(context), allocator);
   iree_status_t status =
       iree_vm_invoke_within(context, stack, function, policy, inputs, outputs);
   if (!iree_status_is_ok(status)) {

--- a/iree/vm/invocation.h
+++ b/iree/vm/invocation.h
@@ -36,14 +36,16 @@ typedef struct iree_vm_invocation_policy_t iree_vm_invocation_policy_t;
 // caller.
 IREE_API_EXPORT iree_status_t iree_vm_invoke(
     iree_vm_context_t* context, iree_vm_function_t function,
-    const iree_vm_invocation_policy_t* policy, iree_vm_list_t* inputs,
-    iree_vm_list_t* outputs, iree_allocator_t allocator);
+    iree_vm_invocation_flags_t flags, const iree_vm_invocation_policy_t* policy,
+    iree_vm_list_t* inputs, iree_vm_list_t* outputs,
+    iree_allocator_t allocator);
 
 // TODO(benvanik): document and implement.
 IREE_API_EXPORT iree_status_t iree_vm_invocation_create(
     iree_vm_context_t* context, iree_vm_function_t function,
-    const iree_vm_invocation_policy_t* policy, const iree_vm_list_t* inputs,
-    iree_allocator_t allocator, iree_vm_invocation_t** out_invocation);
+    iree_vm_invocation_flags_t flags, const iree_vm_invocation_policy_t* policy,
+    const iree_vm_list_t* inputs, iree_allocator_t allocator,
+    iree_vm_invocation_t** out_invocation);
 
 // Retains the given |invocation| for the caller.
 IREE_API_EXPORT iree_status_t

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -276,13 +276,14 @@ IREE_API_EXPORT iree_status_t iree_vm_module_resolve_source_location(
 
 IREE_API_EXPORT iree_status_t
 iree_vm_source_location_format(iree_vm_source_location_t* source_location,
+                               iree_vm_source_location_format_flags_t flags,
                                iree_string_builder_t* builder) {
   IREE_ASSERT_ARGUMENT(builder);
   if (!source_location || !source_location->format) {
     return iree_status_from_code(IREE_STATUS_UNAVAILABLE);
   }
   return source_location->format(source_location->self, source_location->data,
-                                 builder);
+                                 flags, builder);
 }
 
 IREE_API_EXPORT iree_string_view_t

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -261,6 +261,15 @@ typedef struct iree_vm_execution_result_t {
   int reserved;
 } iree_vm_execution_result_t;
 
+// Controls how source locations are formatted into strings.
+enum iree_vm_source_location_format_flag_bits_e {
+  IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_NONE = 0u,
+  // Only formats a single line (excluding \n) for the source location, even
+  // if the full location information (such as a backtrace) is available.
+  IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_SINGLE_LINE = 1u << 0,
+};
+typedef uint32_t iree_vm_source_location_format_flags_t;
+
 // Source location interface.
 typedef struct iree_vm_source_location_t {
   IREE_API_UNSTABLE
@@ -269,13 +278,17 @@ typedef struct iree_vm_source_location_t {
   void* self;
   uint64_t data[2];
 
-  iree_status_t(IREE_API_PTR* format)(void* self, uint64_t data[2],
-                                      iree_string_builder_t* builder);
+  iree_status_t(IREE_API_PTR* format)(
+      void* self, uint64_t data[2],
+      iree_vm_source_location_format_flags_t flags,
+      iree_string_builder_t* builder);
 } iree_vm_source_location_t;
 
 // Formats the |source_location| to its canonical string form.
-IREE_API_EXPORT iree_status_t iree_vm_source_location_format(
-    iree_vm_source_location_t* source_location, iree_string_builder_t* builder);
+IREE_API_EXPORT iree_status_t
+iree_vm_source_location_format(iree_vm_source_location_t* source_location,
+                               iree_vm_source_location_format_flags_t flags,
+                               iree_string_builder_t* builder);
 
 // Defines an interface that can be used to reflect and execute functions on a
 // module.

--- a/iree/vm/native_module_test.cc
+++ b/iree/vm/native_module_test.cc
@@ -41,8 +41,8 @@ class VMNativeModuleTest : public ::testing::Test {
     // will be allocated.
     std::vector<iree_vm_module_t*> modules = {module_a, module_b};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
 
     // No longer need the modules as the context retains them.
     iree_vm_module_release(module_a);
@@ -77,10 +77,10 @@ class VMNativeModuleTest : public ::testing::Test {
         /*element_type=*/nullptr, 1, iree_allocator_system(), &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
-    IREE_RETURN_IF_ERROR(iree_vm_invoke(context_, function,
-                                        /*policy=*/nullptr, input_list.get(),
-                                        output_list.get(),
-                                        iree_allocator_system()));
+    IREE_RETURN_IF_ERROR(
+        iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
+                       /*policy=*/nullptr, input_list.get(), output_list.get(),
+                       iree_allocator_system()));
 
     // Load the output result.
     iree_vm_value_t ret0_value;

--- a/iree/vm/stack_test.cc
+++ b/iree/vm/stack_test.cc
@@ -37,8 +37,8 @@ static iree_status_t SentinelStateResolver(
 // Tests simple stack usage, mainly just for demonstration.
 TEST(VMStackTest, Usage) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -74,8 +74,8 @@ TEST(VMStackTest, Usage) {
 // Tests stack cleanup with unpopped frames (like during failure teardown).
 TEST(VMStackTest, DeinitWithRemainingFrames) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
@@ -93,8 +93,8 @@ TEST(VMStackTest, DeinitWithRemainingFrames) {
 // Tests stack overflow detection.
 TEST(VMStackTest, StackOverflow) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -123,8 +123,8 @@ TEST(VMStackTest, StackOverflow) {
 // Tests unbalanced stack popping.
 TEST(VMStackTest, UnbalancedPop) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   iree_status_t status = iree_vm_stack_function_leave(stack);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, status);
@@ -136,8 +136,8 @@ TEST(VMStackTest, UnbalancedPop) {
 // Tests module state reuse and querying.
 TEST(VMStackTest, ModuleStateQueries) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -185,8 +185,8 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
         // NOTE: always failing.
         return iree_make_status(IREE_STATUS_INTERNAL);
       }};
-  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver,
-                                  iree_allocator_system());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
+                                  state_resolver, iree_allocator_system());
 
   // Push should fail if we can't query state, status should propagate.
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -45,6 +45,7 @@ c_embed_data(
         ":global_ops_f32.vmfb",
         ":global_ops_i64.vmfb",
         ":list_ops.vmfb",
+        ":list_ops_i64.vmfb",
         ":list_variant_ops.vmfb",
         ":ref_ops.vmfb",
         ":shift_ops.vmfb",
@@ -166,6 +167,12 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "list_ops",
     src = "list_ops.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "list_ops_i64",
+    src = "list_ops_i64.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_c_embed_data(
     "global_ops_f32.vmfb"
     "global_ops_i64.vmfb"
     "list_ops.vmfb"
+    "list_ops_i64.vmfb"
     "list_variant_ops.vmfb"
     "ref_ops.vmfb"
     "shift_ops.vmfb"
@@ -234,6 +235,16 @@ iree_bytecode_module(
     list_ops
   SRC
     "list_ops.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    list_ops_i64
+  SRC
+    "list_ops_i64.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/conversion_ops.mlir
+++ b/iree/vm/test/conversion_ops.mlir
@@ -24,26 +24,4 @@ vm.module @conversion_ops {
     vm.return
   }
 
-  // 5.5 f32 (0x40b00000 hex) -> 1085276160 int32
-  vm.export @test_bitcast_i32_f32
-  vm.func @test_bitcast_i32_f32() {
-    %c1 = vm.const.i32 1085276160 : i32
-    %c1dno = util.do_not_optimize(%c1) : i32
-    %v = vm.bitcast.i32.f32 %c1dno : i32 -> f32
-    %c2 = vm.const.f32 5.5 : f32
-    vm.check.eq %v, %c2, "bitcast i32 to f32" : f32
-    vm.return
-  }
-
-  // 1085276160 int32 (0x40b00000 hex) -> 5.5 f32
-  vm.export @test_bitcast_f32_i32
-  vm.func @test_bitcast_f32_i32() {
-    %c1 = vm.const.f32 5.5 : f32
-    %c1dno = util.do_not_optimize(%c1) : f32
-    %v = vm.bitcast.f32.i32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 1085276160 : i32
-    vm.check.eq %v, %c2, "bitcast f32 to i32" : i32
-    vm.return
-  }
-
 }

--- a/iree/vm/test/conversion_ops_f32.mlir
+++ b/iree/vm/test/conversion_ops_f32.mlir
@@ -4,6 +4,28 @@ vm.module @conversion_ops_f32 {
   // Casting and type conversion/emulation
   //===----------------------------------------------------------------------===//
 
+  // 5.5 f32 (0x40b00000 hex) -> 1085276160 int32
+  vm.export @test_bitcast_i32_f32
+  vm.func @test_bitcast_i32_f32() {
+    %c1 = vm.const.i32 1085276160 : i32
+    %c1dno = util.do_not_optimize(%c1) : i32
+    %v = vm.bitcast.i32.f32 %c1dno : i32 -> f32
+    %c2 = vm.const.f32 5.5 : f32
+    vm.check.eq %v, %c2, "bitcast i32 to f32" : f32
+    vm.return
+  }
+
+  // 1085276160 int32 (0x40b00000 hex) -> 5.5 f32
+  vm.export @test_bitcast_f32_i32
+  vm.func @test_bitcast_f32_i32() {
+    %c1 = vm.const.f32 5.5 : f32
+    %c1dno = util.do_not_optimize(%c1) : f32
+    %v = vm.bitcast.f32.i32 %c1dno : f32 -> i32
+    %c2 = vm.const.i32 1085276160 : i32
+    vm.check.eq %v, %c2, "bitcast f32 to i32" : i32
+    vm.return
+  }
+
   vm.export @test_cast_si32_f32_int_max
   vm.func @test_cast_si32_f32_int_max() {
     %c1 = vm.const.i32 2147483647 : i32

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -119,8 +119,8 @@ class VMCModuleTest : public ::testing::Test,
 
     std::vector<iree_vm_module_t*> modules = {module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, modules.data(), modules.size(), iree_allocator_system(),
-        &context_));
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        iree_allocator_system(), &context_));
 
     iree_vm_module_release(module_);
   }
@@ -138,7 +138,7 @@ class VMCModuleTest : public ::testing::Test,
         iree_string_view_t{qualified_name.data(), qualified_name.size()},
         &function));
 
-    return iree_vm_invoke(context_, function,
+    return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                           /*policy=*/nullptr, /*inputs=*/nullptr,
                           /*outputs=*/nullptr, iree_allocator_system());
   }

--- a/iree/vm/test/list_ops.mlir
+++ b/iree/vm/test/list_ops.mlir
@@ -53,24 +53,6 @@ vm.module @list_ops {
   }
 
   //===--------------------------------------------------------------------===//
-  // vm.list.* with I64 types
-  //===--------------------------------------------------------------------===//
-
-  vm.export @test_i64
-  vm.func @test_i64() {
-    %capacity = vm.const.i32 42 : i32
-    %index = vm.const.i32 41 : i32
-    %max_int_plus_1 = vm.const.i64 2147483648 : i64
-    %list = vm.list.alloc %capacity : (i32) -> !vm.list<i64>
-    %sz = vm.list.size %list : (!vm.list<i64>) -> i32
-    vm.list.resize %list, %capacity : (!vm.list<i64>, i32)
-    vm.list.set.i64 %list, %index, %max_int_plus_1 : (!vm.list<i64>, i32, i64)
-    %v = vm.list.get.i64 %list, %index : (!vm.list<i64>, i32) -> i64
-    vm.check.eq %v, %max_int_plus_1, "list<i64>.empty.set(41, MAX_INT_PLUS_1).get(41)=MAX_INT_PLUS_1" : i64
-    vm.return
-  }
-
-  //===--------------------------------------------------------------------===//
   // vm.list.* with ref types
   //===--------------------------------------------------------------------===//
 

--- a/iree/vm/test/list_ops_i64.mlir
+++ b/iree/vm/test/list_ops_i64.mlir
@@ -1,0 +1,21 @@
+vm.module @list_ops_i64 {
+
+  //===--------------------------------------------------------------------===//
+  // vm.list.* with I64 types
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_i64
+  vm.func @test_i64() {
+    %capacity = vm.const.i32 42 : i32
+    %index = vm.const.i32 41 : i32
+    %max_int_plus_1 = vm.const.i64 2147483648 : i64
+    %list = vm.list.alloc %capacity : (i32) -> !vm.list<i64>
+    %sz = vm.list.size %list : (!vm.list<i64>) -> i32
+    vm.list.resize %list, %capacity : (!vm.list<i64>, i32)
+    vm.list.set.i64 %list, %index, %max_int_plus_1 : (!vm.list<i64>, i32, i64)
+    %v = vm.list.get.i64 %list, %index : (!vm.list<i64>, i32) -> i64
+    vm.check.eq %v, %max_int_plus_1, "list<i64>.empty.set(41, MAX_INT_PLUS_1).get(41)=MAX_INT_PLUS_1" : i64
+    vm.return
+  }
+
+}


### PR DESCRIPTION
Tracing is enabled by default in debug builds or with `-DIREE_VM_EXECUTION_TRACING_ENABLE=1` for others. A flag can then be passed to `iree_vm_context_t` to enable tracing for all invocations (including initializers) or passed per-invocation to trace only individual calls. `--trace_execution` was added to iree-check-* and iree-run-*, but all other tools/API usage can set `-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1` to force it on.

The plumbing here also sets us up for other per-context and per-invocation flags in the future, even if it's just used for this now.

Source locations can be printed per traced line too, however they are only practically usable with vm source listings as otherwise they are big multiline fused locs or call sites from python. Until some more refinement of location printing can be done they are disabled but can be turned back on with `-DIREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE=1`.

Example output (note the host ptrs, which can be used to directly reference the native types):
```mlir
[module.__init+00000000]    %i0 = vm.const.i32 1  // 0x00000001
[module.__init+00000007]    %i1 = vm.const.i32.zero
[module.__init+0000000A]    %i2 = vm.const.i32 7  // 0x00000007
[module.__init+00000011]    %i3 = vm.const.i32 6  // 0x00000006
[module.__init+00000018]    %r0 = vm.const.ref.zero
[module.__init+0000001B]    %i4 = vm.const.i32 16  // 0x00000010
[module.__init+00000022]    %i5 = vm.const.i32 50  // 0x00000032
[module.__init+00000029]    %i6 = vm.const.i32 15  // 0x0000000F
[module.__init+00000030]    %i7 = vm.const.i32 17  // 0x00000011
[module.__init+00000037]    %i8 = vm.const.i32 1073741824  // 0x40000000
[module.__init+0000003E]    %r1 = vm.call @hal.ex.shared_device()
[module.__init+0000004A]    %r2 = vm.const.ref.rodata 0  // 0x00000269C3CEE8EC 21b
[module.__init+00000051]    %r3 = vm.const.ref.rodata 1  // 0x00000269C3CEE908 19b
[module.__init+00000058]    %i9, %i10 = vm.call @hal.device.query.i32(%r1(!hal.device/0x00000269C36123F0), %r2(!vm.buffer/0x00000269C3CEF820), %r3(!vm.buffer/0x00000269C3CEF848))
[module.__init+0000006C]    %i10 = vm.and.i32 %i10(1), %i0(1)
[module.__init+00000073]    vm.global.store.i32 %i0(1), .rwdata[4]
[module.__init+0000007A]    %i9 = vm.select.i32 %i9(1) ? %i10(1) : %i1(0)
[module.__init+00000083]    vm.global.store.i32 %i9(1), .rwdata[0]
[module.__init+0000008A]    %r2 = vm.call.varadic @hal.descriptor_set_layout.create(%r1(!hal.device/0x00000269C36123F0), %i0(1), %i1(0), %i2(7), %i0(1), %i0(1), %i2(7), %i3(6))
[module.__init+000000AE]    vm.global.store.ref %r2(!hal.descriptor_set_layout/0x00000269C4219A90), .refs[0] : !hal.descriptor_set_layout
[module.__init+000000B9]    %r2 = vm.global.load.ref .refs[0](!hal.descriptor_set_layout/0x00000269C4219A90) : !hal.descriptor_set_layout
[module.__init+000000C4]    %r2 = vm.call.varadic @hal.executable_layout.create(%r1(!hal.device/0x00000269C36123F0), %i1(0), %r2(!hal.descriptor_set_layout/0x00000269C4219A90))
[module.__init+000000DE]    vm.global.store.ref %r2(!hal.executable_layout/0x00000269C4219C40), .refs[1] : !hal.executable_layout
[module.__init+000000E9]    vm.cond_br %i9(1), ^000000F8(), ^00000130()
[module.__init+000000F8]    %r0 = vm.global.load.ref .refs[1](!hal.executable_layout/0x00000269C4219C40) : !hal.executable_layout
[module.__init+00000103]    %r2 = vm.const.ref.rodata 2  // 0x00000269C3CEE970 2312b
[module.__init+0000010A]    %r0 = vm.call.varadic @hal.executable.create(%r1(!hal.device/0x00000269C36123F0), %r3(!vm.buffer/0x00000269C3CEF848), %r2(!vm.buffer/0x00000269C3CEF870), %r0(!hal.executable_layout/0x00000269C4219C40))
[module.__init+00000128]    vm.br ^00000138()
[module.__init+00000138]    vm.global.store.ref %r0(!hal.executable/0x00000269C3F868B0), .refs[2] : !hal.executable
[module.__init+00000143]    %r0 = vm.call @hal.device.allocator(%r1(!hal.device/0x00000269C36123F0))
[module.__init+00000150]    %r0 = vm.call @hal.allocator.allocate(%r0(!hal.allocator/0x00000269C35EADE0), %i5(50), %i6(15), %i4(16))
[module.__init+00000164]    %r2 = vm.call @hal.command_buffer.create(%r1(!hal.device/0x00000269C36123F0), %i7(17), %i0(1))
[module.__init+00000176]    vm.call @hal.command_buffer.begin(%r2(!hal.command_buffer/0x00000269C4278CA0))
[module.__init+00000182]    vm.call @hal.command_buffer.fill_buffer(%r2(!hal.command_buffer/0x00000269C4278CA0), %r0(!hal.buffer/0x00000269C40C04C0), %i1(0), %i4(16), %i8(1073741824))
[module.__init+00000196]    vm.call @hal.command_buffer.end(%r2(!hal.command_buffer/0x00000269C4278CA0))
[module.__init+000001A2]    vm.call @hal.ex.submit_and_wait(%r1(!hal.device/0x00000269C36123F0), %r2(!hal.command_buffer/0x00000269C4278CA0))
[module.__init+000001B0]    vm.global.store.ref %r0(!hal.buffer/0x00000269C40C04C0), .refs[3] : !hal.buffer
[module.__init+000001BB]    %r0 = vm.global.load.ref .refs[3](!hal.buffer/0x00000269C40C04C0) : !hal.buffer
[module.__init+000001C6]    %r0 = vm.call @hal.buffer.subspan(%r0(!hal.buffer/0x00000269C40C04C0), %i1(0), %i4(16))
[module.__init+000001D8]    vm.global.store.ref %r0(!hal.buffer/0x00000269C40C04C0), .refs[4] : !hal.buffer
[module.__init+000001E3]    vm.return 
EXEC @inc
[module.inc+00000000]    %i0 = vm.const.i32 4  // 0x00000004
[module.inc+00000007]    %i1 = vm.const.i32 50  // 0x00000032
[module.inc+0000000E]    %i2 = vm.const.i32 14  // 0x0000000E
[module.inc+00000015]    %i3 = vm.const.i32 17  // 0x00000011
[module.inc+0000001C]    %i4 = vm.const.i32 3  // 0x00000003
[module.inc+00000023]    %i5 = vm.const.i32 1  // 0x00000001
[module.inc+0000002A]    %i6 = vm.const.i32.zero
[module.inc+0000002D]    %i7 = vm.const.i32 20  // 0x00000014
[module.inc+00000034]    %i8 = vm.const.i32 5  // 0x00000005
[module.inc+0000003B]    %i9 = vm.const.i32 50331680  // 0x03000020
[module.inc+00000042]    %i10 = vm.const.i32 2  // 0x00000002
[module.inc+00000049]    %r0 = vm.global.load.ref .refs[4](!hal.buffer/0x00000269C40C04C0) : !hal.buffer
[module.inc+00000054]    %r1 = vm.global.load.ref .refs[1](!hal.executable_layout/0x00000269C4219C40) : !hal.executable_layout
[module.inc+0000005F]    %i11 = vm.global.load.i32 .rwdata[0](1)
[module.inc+00000066]    %r2 = vm.global.load.ref .refs[2](!hal.executable/0x00000269C3F868B0) : !hal.executable
[module.inc+00000071]    %r3 = vm.call @hal.ex.shared_device()
[module.inc+0000007C]    %r4 = vm.call @hal.device.allocator(%r3(!hal.device/0x00000269C36123F0))
[module.inc+0000008A]    %r4 = vm.call @hal.allocator.allocate(%r4(!hal.allocator/0x00000269C35EADE0), %i1(50), %i2(14), %i0(4))
[module.inc+0000009E]    %r5 = vm.call @hal.command_buffer.create(%r3(!hal.device/0x00000269C36123F0), %i3(17), %i4(3))
[module.inc+000000B0]    vm.call @hal.command_buffer.begin(%r5(!hal.command_buffer/0x00000269C4278CA0))
[module.inc+000000BC]    vm.cond_br %i11(1), ^000000CC(), ^00000164()
[module.inc+000000CC]    vm.call.varadic @hal.command_buffer.push_descriptor_set(%r5(!hal.command_buffer/0x00000269C4278CA0), %r1(!hal.executable_layout/0x00000269C4219C40), %i6(0), %i6(0), %r0(!hal.buffer/0x00000269C40C04C0), %i6(0), %i0(4), %i5(1), %r4(!hal.buffer/0x00000269C35EAB20), %i6(0), %i0(4))
[module.inc+000000F6]    vm.call @hal.command_buffer.dispatch(%r5(!hal.command_buffer/0x00000269C4278CA0), %r2(!hal.executable/0x00000269C3F868B0), %i6(0), %i5(1), %i5(1), %i5(1))
[module.inc+0000010C]    vm.call @hal.command_buffer.execution_barrier(%r5(!hal.command_buffer/0x00000269C4278CA0), %i7(20), %i8(5), %i6(0))
[module.inc+0000011E]    vm.call @hal.command_buffer.end(%r5(!hal.command_buffer/0x00000269C4278CA0))
[module.inc+0000012A]    vm.call @hal.ex.submit_and_wait(%r3(!hal.device/0x00000269C36123F0), %r5(!hal.command_buffer/0x00000269C4278CA0))
[module.inc+00000138]    %r0 = vm.call.varadic @hal.buffer_view.create(%r4(!hal.buffer/0x00000269C35EAB20), %i9(50331680), %i5(1))
[module.inc+00000154]    vm.global.store.ref %r4(!hal.buffer/0x00000269C35EAB20), .refs[4] : !hal.buffer
[module.inc+0000015F]    vm.return %r0(!hal.buffer_view/0x00000269C3E537A0)
result[0]: hal.buffer_view
f32=3
```

There are a great many ways to write disassemblers: this is not a particularly good one, but it exists and is easy enough to completely replace with a better solution in the future (single .c file).