### PR TITLE
Removing linkage name from iree_vm_module_lookup_function_by_ordinal.

### DIFF
--- a/bindings/python/iree/runtime/vm.cc
+++ b/bindings/python/iree/runtime/vm.cc
@@ -701,10 +701,8 @@ void SetupVmBindings(pybind11::module m) {
         for (size_t ordinal = 0; ordinal < sig.export_function_count;
              ++ordinal) {
           iree_vm_function_t f;
-          iree_string_view_t linkage_name;
           auto status = iree_vm_module_lookup_function_by_ordinal(
-              self.raw_ptr(), IREE_VM_FUNCTION_LINKAGE_EXPORT, ordinal, &f,
-              &linkage_name);
+              self.raw_ptr(), IREE_VM_FUNCTION_LINKAGE_EXPORT, ordinal, &f);
           if (iree_status_is_not_found(status)) {
             iree_status_ignore(status);
             break;

--- a/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/iree/hal/local/loaders/vmvx_module_loader.c
@@ -105,7 +105,7 @@ static iree_status_t iree_hal_vmvx_executable_create(
     for (iree_host_size_t i = 0; i < executable->entry_fn_count; ++i) {
       status = iree_vm_module_lookup_function_by_ordinal(
           bytecode_module, IREE_VM_FUNCTION_LINKAGE_EXPORT, i,
-          &executable->entry_fns[i], NULL);
+          &executable->entry_fns[i]);
       if (!iree_status_is_ok(status)) break;
       status = iree_hal_vmvx_executable_verify_entry_point(
           &executable->entry_fns[i]);

--- a/iree/samples/vulkan/vulkan_inference_gui.cc
+++ b/iree/samples/vulkan/vulkan_inference_gui.cc
@@ -241,11 +241,11 @@ extern "C" int iree_main(int argc, char** argv) {
                  << bytecode_module_signature.export_function_count
                  << "> exported functions:";
   for (int i = 0; i < bytecode_module_signature.export_function_count; ++i) {
-    iree_string_view_t function_name;
-    iree_vm_function_signature_t function_signature;
-    IREE_CHECK_OK(bytecode_module->get_function(
-        bytecode_module->self, IREE_VM_FUNCTION_LINKAGE_EXPORT, i,
-        /*out_function=*/nullptr, &function_name, &function_signature));
+    iree_vm_function_t function;
+    IREE_CHECK_OK(iree_vm_module_lookup_function_by_ordinal(
+        bytecode_module, IREE_VM_FUNCTION_LINKAGE_EXPORT, i, &function));
+    auto function_name = iree_vm_function_name(&function);
+    auto function_signature = iree_vm_function_signature(&function);
     IREE_LOG(INFO) << "  " << i << ": '"
                    << std::string(function_name.data, function_name.size)
                    << "' with calling convention '"

--- a/iree/vm/bytecode_dispatch_test.cc
+++ b/iree/vm/bytecode_dispatch_test.cc
@@ -52,11 +52,12 @@ std::vector<TestParams> GetModuleTestParams() {
     iree_vm_module_signature_t signature = module->signature(module->self);
     test_params.reserve(test_params.size() + signature.export_function_count);
     for (int i = 0; i < signature.export_function_count; ++i) {
-      iree_string_view_t name;
-      IREE_CHECK_OK(module->get_function(module->self,
-                                         IREE_VM_FUNCTION_LINKAGE_EXPORT, i,
-                                         nullptr, &name, nullptr));
-      test_params.push_back({module_file, std::string(name.data, name.size)});
+      iree_vm_function_t function;
+      IREE_CHECK_OK(iree_vm_module_lookup_function_by_ordinal(
+          module, IREE_VM_FUNCTION_LINKAGE_EXPORT, i, &function));
+      iree_string_view_t function_name = iree_vm_function_name(&function);
+      test_params.push_back(
+          {module_file, std::string(function_name.data, function_name.size)});
     }
     iree_vm_module_release(module);
   }

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -253,10 +253,9 @@ IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_name(
 
 IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_ordinal(
     const iree_vm_module_t* module, iree_vm_function_linkage_t linkage,
-    iree_host_size_t ordinal, iree_vm_function_t* out_function,
-    iree_string_view_t* linkage_name) {
+    iree_host_size_t ordinal, iree_vm_function_t* out_function) {
   return module->get_function(module->self, linkage, ordinal, out_function,
-                              /*out_name=*/linkage_name,
+                              /*out_name=*/NULL,
                               /*out_signature=*/NULL);
 }
 

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -392,16 +392,9 @@ IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_name(
     iree_string_view_t name, iree_vm_function_t* out_function);
 
 // Looks up a function with the given ordinal and linkage in the |module|.
-// If |linkage_name| is not null, then it will be populated with the name
-// of the linkage record (i.e. the actual exported name vs the internal
-// name which would be returned in a subsequent call to iree_vm_function_name).
-// TODO(laurenzo): Remove out_linkage_name in favore of a LINKAGE_PUBLIC (with
-// the name that you'd get from a function_name call on that being the public
-// name).
 IREE_API_EXPORT iree_status_t iree_vm_module_lookup_function_by_ordinal(
     const iree_vm_module_t* module, iree_vm_function_linkage_t linkage,
-    iree_host_size_t ordinal, iree_vm_function_t* out_function,
-    iree_string_view_t* out_linkage_name);
+    iree_host_size_t ordinal, iree_vm_function_t* out_function);
 
 // Resolves a stack |frame| from the module to a |out_source_location|, if
 // debug information is available.


### PR DESCRIPTION
Internal names are no longer returned so the normal iree_vm_function_name
call can get the same value without as much out-ptr magic.

This also let me clean up some sites directly touching module impls.