### PR TITLE
Fixing VM release-before-retain when the source and target alias.

### DIFF
--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -236,11 +236,6 @@ cc_test(
         "bytecode_dispatch_test.cc",
         "bytecode_module_test.cc",
     ],
-    tags = [
-        # TODO(benvanik): Fix type casting errors for --config=android_arm*.
-        "notap",
-        "manual",
-    ],
     deps = [
         ":bytecode_module",
         ":vm",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -206,9 +206,6 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
     iree::vm::test::all_bytecode_modules_c
-  LABELS
-    "notap"
-    "manual"
 )
 
 iree_cc_binary(

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -505,8 +505,12 @@ IREE_API_EXPORT void* iree_vm_list_get_ref_deref(
   return value.ptr;
 }
 
-IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
-    const iree_vm_list_t* list, iree_host_size_t i, iree_vm_ref_t* out_value) {
+// Gets a ref type |list| element at |i| and stores it into |out_value|.
+// If |is_retain|=true then the reference count is incremented and otherwise
+// the ref type is assigned directly (as with iree_vm_ref_assign).
+static iree_status_t iree_vm_list_get_ref_assign_or_retain(
+    const iree_vm_list_t* list, iree_host_size_t i, bool is_retain,
+    iree_vm_ref_t* out_value) {
   if (i >= list->count) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "index %zu out of bounds (%zu)", i, list->count);
@@ -515,7 +519,8 @@ IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
   switch (list->storage_mode) {
     case IREE_VM_LIST_STORAGE_MODE_REF: {
       iree_vm_ref_t* element_ref = (iree_vm_ref_t*)element_ptr;
-      iree_vm_ref_assign(element_ref, out_value);
+      is_retain ? iree_vm_ref_retain(element_ref, out_value)
+                : iree_vm_ref_assign(element_ref, out_value);
       break;
     }
     case IREE_VM_LIST_STORAGE_MODE_VARIANT: {
@@ -523,7 +528,8 @@ IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
       if (!iree_vm_type_def_is_ref(&variant->type)) {
         return iree_make_status(IREE_STATUS_FAILED_PRECONDITION);
       }
-      iree_vm_ref_assign(&variant->ref, out_value);
+      is_retain ? iree_vm_ref_retain(&variant->ref, out_value)
+                : iree_vm_ref_assign(&variant->ref, out_value);
       break;
     }
     default:
@@ -533,11 +539,16 @@ IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
   return iree_ok_status();
 }
 
+IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_assign(
+    const iree_vm_list_t* list, iree_host_size_t i, iree_vm_ref_t* out_value) {
+  return iree_vm_list_get_ref_assign_or_retain(list, i, /*is_retain=*/false,
+                                               out_value);
+}
+
 IREE_API_EXPORT iree_status_t iree_vm_list_get_ref_retain(
     const iree_vm_list_t* list, iree_host_size_t i, iree_vm_ref_t* out_value) {
-  IREE_RETURN_IF_ERROR(iree_vm_list_get_ref_assign(list, i, out_value));
-  iree_vm_ref_retain(out_value, out_value);
-  return iree_ok_status();
+  return iree_vm_list_get_ref_assign_or_retain(list, i, /*is_retain=*/true,
+                                               out_value);
 }
 
 static iree_status_t iree_vm_list_set_ref(iree_vm_list_t* list,

--- a/iree/vm/ref_test.cc
+++ b/iree/vm/ref_test.cc
@@ -176,17 +176,13 @@ TEST(VMRefTest, RetainNull) {
   iree_vm_ref_retain(&null_ref_0, &null_ref_1);
 }
 
-// Tests that retaining into itself only increments the count.
+// Tests that retaining into itself is a no-op.
 TEST(VMRefTest, RetainIntoSelf) {
   iree_vm_ref_t a_ref = MakeRef<A>("AType");
   EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_retain(&a_ref, &a_ref);
-  EXPECT_EQ(2, ReadCounter(&a_ref));
-
-  iree_vm_ref_t last_ref = {0};
-  iree_vm_ref_assign(&a_ref, &last_ref);
+  EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_release(&a_ref);
-  iree_vm_ref_release(&last_ref);
 }
 
 // Tests that retaining into out_ref releases the existing contents.
@@ -250,12 +246,8 @@ TEST(VMRefTest, RetainOrMoveRetainingIntoSelf) {
   iree_vm_ref_t a_ref = MakeRef<A>("AType");
   EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_retain_or_move(/*is_move=*/0, &a_ref, &a_ref);
-  EXPECT_EQ(2, ReadCounter(&a_ref));
-
-  iree_vm_ref_t last_ref = {0};
-  iree_vm_ref_assign(&a_ref, &last_ref);
+  EXPECT_EQ(1, ReadCounter(&a_ref));
   iree_vm_ref_release(&a_ref);
-  iree_vm_ref_release(&last_ref);
 }
 
 // Tests that moving into itself is a no-op.


### PR DESCRIPTION
This reverts commit 567b77785b6d603d866c5dc1496dd367902e830c.
Original PR #7247. Turns out the test was wrong all along.