### PR TITLE
Update RISC-V crosscompile instructions

### DIFF
--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -38,6 +38,8 @@ fi
 # Configure, build, install.
 "${CMAKE_BIN?}" -G Ninja -B "${BUILD_HOST_DIR?}" \
   -DCMAKE_INSTALL_PREFIX="${BUILD_HOST_DIR?}/install" \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF \

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -56,6 +56,8 @@ Build and install on your host machine:
 
 ``` shell
 cmake -GNinja -B ../iree-build/ \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_INSTALL_PREFIX=../iree-build/install \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   .


### PR DESCRIPTION
Set the host build compiler to clang. It should be a no-op for CI since
the docker image already set the {CC, CXX} environment variables to clang.