### PR TITLE
[spirv] Remove createStdExpandOpsPass in pass pipelines

### DIFF
--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -118,7 +118,6 @@ static void addLowerToSPIRVPasses(OpPassManager &pm) {
   // subview ops.
   pm.addPass(memref::createFoldSubViewOpsPass());
   pm.addNestedPass<FuncOp>(Shape::createFoldDimOverShapeCarryingOpPass());
-  pm.addNestedPass<FuncOp>(createStdExpandOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 


### PR DESCRIPTION
We can lower standard max/min ops directly with
https://reviews.llvm.org/D111143; no need to emulate
them.