### PR TITLE
[Cleanup] Delete unused flags.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -41,30 +41,11 @@ static llvm::cl::opt<int> clNumberOfRuntimeThreads(
     llvm::cl::desc("number of threads that are used at runtime"),
     llvm::cl::init(8));
 
-static llvm::cl::opt<int> matmulWorkgroupTileSize(
-    "iree-codegen-llvm-matmul-workgroup-size",
-    llvm::cl::desc(
-        "linalg.matmul tile size for workgroups spliting of M, N dimension"),
-    llvm::cl::init(64));
 static llvm::cl::opt<int> matmulL1TileSize(
     "iree-codegen-llvm-matmul-l1-size",
     llvm::cl::desc(
         "linalg.matmul tile size for L1 spliting of M, N, K dimension"),
     llvm::cl::init(32));
-static llvm::cl::opt<int> matmulVectorSize(
-    "iree-codegen-llvm-matmul-vector-size",
-    llvm::cl::desc("linalg.matmul vector tile size"), llvm::cl::init(4));
-
-static llvm::cl::opt<int> batchMatmulWorkgroupTileSize(
-    "iree-codegen-llvm-batch-matmul-workgroup-size",
-    llvm::cl::desc("linalg.batch_matmul tile size for workgroups spliting of "
-                   "M, N dimension"),
-    llvm::cl::init(32));
-static llvm::cl::opt<int> batchMatmulL1TileSize(
-    "iree-codegen-llvm-batch-matmul-l1-size",
-    llvm::cl::desc("linalg.batch_matmul tile size for L1 spliting of M, N, K "
-                   "dimensions"),
-    llvm::cl::init(16));
 
 static llvm::cl::list<int> mmt4dWorkgroupTileSizes(
     "iree-codegen-llvm-mmt4d-workgroup-tile-sizes",
@@ -249,7 +230,7 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
     }
   } else if (tiledLoops.size() != 2) {
     return contractionOp.emitOpError(
-        "expected op tbe distributed along 2 dimensions");
+        "expected op to be distributed along 2 dimensions");
   }
 
   Type elementType = lhsShapedType.getElementType();
@@ -260,7 +241,7 @@ static LogicalResult setRootConfig(FuncOp entryPointFn,
           getNativeVectorSizeInBytes(entryPointFn)) {
     vectorSize = nativeVectorSizeVal.getValue() / byteWidth;
   } else {
-    vectorSize = matmulVectorSize;
+    vectorSize = clNativeVectorSizeInBytes;
   }
   SmallVector<int64_t> vectorSizeVals(tiledLoops.size(), 1);
   vectorSizeVals.back() = vectorSize;


### PR DESCRIPTION
The matmulVectorSize flag is actually unsued in LLVM CPU codegen because
the native_vector_size attribute will always be set in entry point
function. However, we can not expect every entry point function has the
attribute. Because VMVX backend uses the config and does not have the
attribute. In this case, the PR merges matmulVectorSize into
clNativeVectorSizeInBytes.

Also fixes a typo in error message.