### PR TITLE
[spirv] Perform bufferization after vectorization

### DIFF
--- a/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
@@ -1378,7 +1378,10 @@ static LogicalResult convertVectorTransferWriteOp(OpBuilder &b,
   if (!resultType) return success();
   Value resultBuffer = bvm.lookup(result);
 
-  if (!plan.isEquivalent(op.source(), result)) {
+  if (!plan.isEquivalent(op.source(), result) &&
+      // If the source is linalg.init_tensor, then we don't care about the
+      // initial value and can avoid the copy.
+      !op.source().getDefiningOp<linalg::InitTensorOp>()) {
     Value destBuffer = bvm.lookup(op.source());
     b.create<linalg::CopyOp>(loc, destBuffer, resultBuffer);
   }

--- a/iree/compiler/Codegen/SPIRV/BUILD
+++ b/iree/compiler/Codegen/SPIRV/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "//iree/compiler/Codegen/Transforms",
         "//iree/compiler/Codegen/Utils",
         "//iree/compiler/Dialect/Flow/IR",
+        "//iree/compiler/Dialect/Flow/Transforms",
         "//iree/compiler/Dialect/HAL/IR",
         "//iree/compiler/Dialect/HAL/IR:HALDialect",
         "//iree/compiler/Dialect/LinalgExt/IR",

--- a/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -75,6 +75,7 @@ iree_cc_library(
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::LinalgExt::IR

--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -543,15 +543,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
       // indicator of that. Need a better way of information flow from flow
       // dialect to hal.
       if (!tiledLoops.empty()) {
-        const int64_t subgroupSize =
-            limits.subgroup_size().getValue().getSExtValue();
-        std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
-        SmallVector<int64_t> workloadPerWorkgroup(tiledLoops.size(), 1);
-        workloadPerWorkgroup.front() = subgroupSize * 4;
-        setTranslationInfo(
-            funcOp,
-            IREE::Codegen::DispatchLoweringPassPipeline::SPIRVDistribute,
-            workloadPerWorkgroup, workgroupSize);
+        // XXX: HACK to enable bufferization after vectorization.
         return success();
       }
       return funcOp.emitError("contains no root Linalg operation");

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -133,6 +133,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
+    linalg::hoistRedundantVectorTransfersOnTensor(funcOp);
     linalg::hoistRedundantVectorTransfers(funcOp);
 
     LLVM_DEBUG({

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
@@ -12,10 +12,10 @@ hal.executable @tensor_insert {
     builtin.module  {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
         %1 = hal.interface.load.constant offset = 0 : index
         %2 = hal.interface.load.constant offset = 1 : index
-        %3 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>
+        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%1, %2}
+        %3 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%1, %2}
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -47,8 +47,8 @@ hal.executable @tensor_insert {
     }
   }
 }
-//  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [64, 1]>
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"SPIRVDistribute", workload_per_wg = [16, 1]>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
 // CHECK-SAME:   translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -182,6 +182,34 @@ void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, ArrayRef<Type>(), value, target, ArrayRef<Value>(),
         ArrayRef<Value>(), ArrayRef<Value>(), builder.getI64ArrayAttr({}),
         builder.getI64ArrayAttr({}), builder.getI64ArrayAttr({}));
+  state.addAttributes(attributes);
+}
+
+void DispatchTensorStoreOp::build(OpBuilder &builder, OperationState &state,
+                                  Value value, Value target,
+                                  ArrayRef<OpFoldResult> mixedOffsets,
+                                  ArrayRef<OpFoldResult> mixedSizes,
+                                  ArrayRef<OpFoldResult> mixedStrides,
+                                  ArrayRef<NamedAttribute> attributes) {
+  SmallVector<Value> offsets;
+  SmallVector<Value> sizes;
+  SmallVector<Value> strides;
+  SmallVector<int64_t> staticOffsets;
+  SmallVector<int64_t> staticSizes;
+  SmallVector<int64_t> staticStrides;
+
+  processMixedOperands(mixedOffsets, offsets, staticOffsets,
+                       ShapedType::kDynamicStrideOrOffset);
+  processMixedOperands(mixedSizes, sizes, staticSizes,
+                       ShapedType::kDynamicSize);
+  processMixedOperands(mixedStrides, strides, staticStrides,
+                       ShapedType::kDynamicStrideOrOffset);
+
+  build(builder, state, ArrayRef<Type>(), value, target, offsets, sizes,
+        strides, builder.getI64ArrayAttr(staticOffsets),
+        builder.getI64ArrayAttr(staticSizes),
+        builder.getI64ArrayAttr(staticStrides));
+  state.addAttributes(attributes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -417,6 +417,10 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     // This is used to store an entire tensor.
     OpBuilder<(ins "Value":$value, "Value":$target,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+    OpBuilder<(ins "Value":$value, "Value":$target,
+      "ArrayRef<OpFoldResult>":$offsets, "ArrayRef<OpFoldResult>":$sizes,
+      "ArrayRef<OpFoldResult>":$strides,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
   ];
 
   let extraClassDeclaration = [{

--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.h
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.h
@@ -85,8 +85,7 @@ namespace Flow {
 //     tensor<...> -> !flow.dispatch.tensor<writeonly:...>
 // ```
 // is elided.
-LogicalResult rewriteLinalgDestructiveUpdates(
-    IREE::Flow::DispatchWorkgroupsOp dispatchOp);
+LogicalResult rewriteLinalgDestructiveUpdates(Operation *regionOp);
 
 }  // namespace Flow
 }  // namespace IREE


### PR DESCRIPTION
This commit moves bufferization to be after vectorization in the
main SPIRVTileAndVectorizePassPipeline. With previous changes and
fixes, this is mostly reordering passes, pulling in corresponding
patterns with tensor semantics, and adding various canonicalization
patterns.

One noticable thing is to pull in `rewriteLinalgDestructiveUpdates`
to handle distributing to workitems to bridge semantic gap. This is
just to make forward progress with minimal and non-intrusive change:

There is no readily avaiable good solution for handling distribution
with tensor semantics right now. Also the distribution issue is
tangled together with trip-one loop removal and vectorization
optimization pattern expectations. It could take a while to develop
the full/best solution for all the above issues.

OTOH, we already have a way to bridge such semantic gap when
performing tiling and distributing to workgroups, because in IREE
we have tight control over the full flow and such assuptions.
They are structually similar and handles the same issue, so it's
natural to extend it a bit to support tiling to workitems. We can
replace them both once we have a better solution. So this should
be minimal, well-isolated, and non-intrusive.