### PR TITLE
Implementation of Util::AlignOp with tests and integration into compiler passes

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/test/pack_allocations.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/pack_allocations.mlir
@@ -56,22 +56,16 @@ func @packDynamic(%allocator: !hal.allocator, %size_a: index, %size_b: index) ->
   // Right now this is too verbose to really test against with anything but
   // a change detector like this.
 
+  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %c0 = arith.constant 0 : index
-  // CHECK-DAG: %c-16 = arith.constant -16 : index
-  // CHECK-DAG: %c15 = arith.constant 15 : index
-  // CHECK-DAG: %0 = arith.addi %arg1, %c15 : index
-  // CHECK-DAG: %1 = arith.andi %0, %c-16 : index
-  // CHECK-DAG: %2 = arith.addi %1, %c15 : index
-  // CHECK-DAG: %3 = arith.andi %2, %c-16 : index
-  // CHECK-DAG: %4 = arith.addi %arg2, %c15 : index
-  // CHECK-DAG: %5 = arith.andi %4, %c-16 : index
-  // CHECK-DAG: %6 = arith.addi %3, %5 : index
-  // CHECK-DAG: %7 = arith.addi %6, %c15 : index
-  // CHECK-DAG: %8 = arith.andi %7, %c-16 : index
-  // CHECK-DAG: %9 = arith.addi %8, %c15 : index
-  // CHECK-DAG: %10 = arith.andi %9, %c-16 : index
+  // CHECK-DAG: %0 = util.align %arg1, %c16 : index
+  // CHECK-DAG: %1 = util.align %0, %c16 : index
+  // CHECK-DAG: %2 = util.align %arg2, %c16 : index
+  // CHECK-DAG: %3 = arith.addi %1, %2 : index
+  // CHECK-DAG: %4 = util.align %3, %c16 : index
+  // CHECK-DAG: %5 = util.align %4, %c16 : index
 
-  // CHECK-DAG: return %10, %c0, %3, %c0
+  // CHECK-DAG: return %5, %c0, %1, %c0
   return %t#0, %t#1, %t#2, %t#3 : index, index, index, index
 }
 
@@ -106,23 +100,18 @@ func @packMixedStaticDynamic(%allocator: !hal.allocator, %size_a: index, %size_b
   // Right now this is too verbose to really test against with anything but
   // a change detector like this.
 
-  // CHECK-DAG: %c0 = arith.constant 0 : index
+  // CHECK-DAG: %c16 = arith.constant 16 : index
   // CHECK-DAG: %c208 = arith.constant 208 : index
-  // CHECK-DAG: %c-16 = arith.constant -16 : index
-  // CHECK-DAG: %c15 = arith.constant 15 : index
-  // CHECK-DAG: %0 = arith.addi %arg1, %c15 : index
-  // CHECK-DAG: %1 = arith.andi %0, %c-16 : index
-  // CHECK-DAG: %2 = arith.addi %1, %c223 : index
-  // CHECK-DAG: %3 = arith.andi %2, %c-16 : index
-  // CHECK-DAG: %4 = arith.addi %arg2, %c15 : index
-  // CHECK-DAG: %5 = arith.andi %4, %c-16 : index
-  // CHECK-DAG: %6 = arith.addi %3, %5 : index
-  // CHECK-DAG: %7 = arith.addi %6, %c15 : index
-  // CHECK-DAG: %8 = arith.andi %7, %c-16 : index
-  // CHECK-DAG: %9 = arith.addi %8, %c15 : index
-  // CHECK-DAG: %10 = arith.andi %9, %c-16 : index
+  // CHECK-DAG: %c0 = arith.constant 0 : index
+  // CHECK-DAG: %0 = util.align %arg1, %c16 : index
+  // CHECK-DAG: %1 = arith.addi %0, %c208 : index
+  // CHECK-DAG: %2 = util.align %1, %c16 : index
+  // CHECK-DAG: %3 = util.align %arg2, %c16 : index
+  // CHECK-DAG: %4 = arith.addi %2, %3 : index
+  // CHECK-DAG: %5 = util.align %4, %c16 : index
+  // CHECK-DAG: %6 = util.align %5, %c16 : index
 
-  // CHECK-DAG: return %10, %c0, %c208, %3, %c0
+  // CHECK-DAG: return %6, %c0, %c208, %2, %c0
   return %t#0, %t#1, %t#2, %t#3, %t#4 : index, index, index, index, index
 }
 

--- a/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -177,6 +177,47 @@ def Util_RangeExtentsOp : Util_PureOp<"range.extents", [
 }
 
 //===----------------------------------------------------------------------===//
+// Alignment Arithmetic
+//===----------------------------------------------------------------------===//
+
+def Util_AlignOp : Util_PureOp<"align", [
+  SameOperandsAndResultType
+  ]> {
+  let summary = "Aligns up to a power-of-two alignment if required";
+  let description = [{
+     Aligns |value| up to the given power-of-two |alignment| if required.
+  }];
+
+  let arguments = (ins
+    SignlessIntegerLike:$value,
+    SignlessIntegerLike:$alignment
+  );
+
+  let results = (outs
+    SignlessIntegerLike:$result
+  );
+
+  let assemblyFormat = [{
+    $value `,` $alignment attr-dict `:` type($result)
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "Value":$value,
+      "int64_t":$alignment
+    ),
+    [{
+      build($_builder, $_state, value.getType(), value,
+       $_builder.createOrFold<arith::ConstantIndexOp>($_state.location, alignment));
+    }]>,
+  ];
+
+  //TODO(#5405): add canonicalizers/folders to simplify cases with constnat
+  // alignment values with in a certain range (not zero) as well as duplicate
+  // alignments (EX: util.align 16 -> util.align 4)
+}
+
+//===----------------------------------------------------------------------===//
 // Compiler hints
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -457,22 +457,6 @@ Optional<ValueRange> findDynamicDims(Value shapedValue, Block *block,
 }
 
 //===----------------------------------------------------------------------===//
-// Utilities
-//===----------------------------------------------------------------------===//
-
-// TODO(benvanik): emit a util.align op that we can use to carry the semantics
-// of the alignment and elide redundant aligns.
-Value align(Location loc, Value value, int64_t alignment, OpBuilder &builder) {
-  // (value + (alignment - 1)) & ~(alignment - 1)
-  return builder.createOrFold<arith::AndIOp>(
-      loc,
-      builder.createOrFold<arith::AddIOp>(
-          loc, value,
-          builder.createOrFold<arith::ConstantIndexOp>(loc, alignment - 1)),
-      builder.createOrFold<arith::ConstantIndexOp>(loc, ~(alignment - 1)));
-}
-
-//===----------------------------------------------------------------------===//
 // IREE::Util::UtilDialect
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -187,9 +187,6 @@ static inline uint64_t align(uint64_t value, const APInt &alignment) {
   return align(value, alignment.getZExtValue());
 }
 
-// Aligns |value| to |alignment|, rounding up if needed.
-Value align(Location loc, Value value, int64_t alignment, OpBuilder &builder);
-
 }  // namespace Util
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Util/IR/test/BUILD
+++ b/iree/compiler/Dialect/Util/IR/test/BUILD
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "alignment_ops.mlir",
             "attributes.mlir",
             "byte_buffer_ops.mlir",
             "global_folding.mlir",

--- a/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Util/IR/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "alignment_ops.mlir"
     "attributes.mlir"
     "byte_buffer_ops.mlir"
     "global_folding.mlir"

--- a/iree/compiler/Dialect/Util/IR/test/alignment_ops.mlir
+++ b/iree/compiler/Dialect/Util/IR/test/alignment_ops.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt -split-input-file %s | IreeFileCheck %s
+
+// CHECK-LABEL: @utilAlign
+func @utilAlign(%arg0 : index, %arg1: index) {
+  // CHECK: = util.align %arg0, %arg1 : index
+  %result = util.align %arg0, %arg1 : index
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @utilAlignInt
+func @utilAlignInt(%arg0 : i32, %arg1: i32) {
+  // CHECK: = util.align %arg0, %arg1 : i32
+  %result = util.align %arg0, %arg1 : i32
+  return
+}

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD
@@ -13,6 +13,7 @@ package(
 cc_library(
     name = "UtilToVM",
     srcs = [
+        "ConvertAlignmentOps.cpp",
         "ConvertGlobalOps.cpp",
         "ConvertListOps.cpp",
         "ConvertStatusOps.cpp",

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "ConvertUtilToVM.h"
   SRCS
+    "ConvertAlignmentOps.cpp"
     "ConvertGlobalOps.cpp"
     "ConvertListOps.cpp"
     "ConvertStatusOps.cpp"

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertAlignmentOps.cpp
@@ -1,0 +1,83 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
+#include "iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.h"
+#include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+template <typename CONST_OP, typename SUB_OP, typename ADD_OP, typename NOT_OP,
+          typename AND_OP>
+void insertAlignOps(IREE::Util::AlignOp srcOp,
+                    ConversionPatternRewriter &rewriter,
+                    IREE::Util::AlignOpAdaptor operands,
+                    IntegerType integerType) {
+  // Aligns |value| up to the given power-of-two |alignment| if required.
+  // (value + (alignment - 1)) & ~(alignment - 1)
+  // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+  auto oneConstant = rewriter.createOrFold<CONST_OP>(srcOp.getLoc(), 1);
+  // (alignment - 1)
+  auto alignmentValue = rewriter.createOrFold<SUB_OP>(
+      srcOp.getLoc(), integerType, operands.alignment(), oneConstant);
+  // value + (alignment - 1)
+  auto valueAddedValue = rewriter.createOrFold<ADD_OP>(
+      srcOp.getLoc(), integerType, operands.value(), alignmentValue);
+  // ~(alignment - 1)
+  auto notAlignmentValue = rewriter.createOrFold<NOT_OP>(
+      srcOp.getLoc(), integerType, alignmentValue);
+
+  rewriter.replaceOpWithNewOp<AND_OP>(srcOp, integerType, valueAddedValue,
+                                      notAlignmentValue);
+}
+
+class UtilAlignOpConversion : public OpConversionPattern<IREE::Util::AlignOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      IREE::Util::AlignOp srcOp, IREE::Util::AlignOpAdaptor operands,
+      ConversionPatternRewriter &rewriter) const override {
+    Type valueType = operands.value().getType();
+
+    if (valueType.isInteger(32)) {
+      insertAlignOps<IREE::VM::ConstI32Op, IREE::VM::SubI32Op,
+                     IREE::VM::AddI32Op, IREE::VM::NotI32Op,
+                     IREE::VM::AndI32Op>(srcOp, rewriter, operands,
+                                         rewriter.getI32Type());
+    } else if (valueType.isInteger(64)) {
+      insertAlignOps<IREE::VM::ConstI64Op, IREE::VM::SubI64Op,
+                     IREE::VM::AddI64Op, IREE::VM::NotI64Op,
+                     IREE::VM::AndI64Op>(srcOp, rewriter, operands,
+                                         rewriter.getI64Type());
+    } else {
+      return srcOp.emitError()
+             << "unsupported value type for util.align: " << valueType;
+    }
+    return success();
+  }
+};
+
+}  // namespace
+
+void populateUtilAlignmentToVMPatterns(MLIRContext *context,
+                                       ConversionTarget &conversionTarget,
+                                       TypeConverter &typeConverter,
+                                       OwningRewritePatternList &patterns) {
+  conversionTarget.addIllegalOp<IREE::Util::AlignOp>();
+
+  patterns.insert<UtilAlignOpConversion>(typeConverter, context);
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/ConvertUtilToVM.cpp
@@ -32,6 +32,10 @@ void populateUtilStatusToVMPatterns(MLIRContext *context,
                                     ConversionTarget &conversionTarget,
                                     TypeConverter &typeConverter,
                                     OwningRewritePatternList &patterns);
+void populateUtilAlignmentToVMPatterns(MLIRContext *context,
+                                       ConversionTarget &conversionTarget,
+                                       TypeConverter &typeConverter,
+                                       OwningRewritePatternList &patterns);
 
 namespace {
 
@@ -136,6 +140,8 @@ void populateUtilToVMPatterns(MLIRContext *context,
                                patterns);
   populateUtilStatusToVMPatterns(context, conversionTarget, typeConverter,
                                  patterns);
+  populateUtilAlignmentToVMPatterns(context, conversionTarget, typeConverter,
+                                    patterns);
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "alignment_ops.mlir",
             "byte_buffer_ops.mlir",
             "global_ops.mlir",
             "hint_ops.mlir",

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "alignment_ops.mlir"
     "byte_buffer_ops.mlir"
     "global_ops.mlir"
     "hint_ops.mlir"

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/alignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/alignment_ops.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt -split-input-file -iree-vm-conversion -cse -iree-vm-target-extension-i64 %s | IreeFileCheck %s
+
+// CHECK-LABEL: @utilAlign
+func @utilAlign(%arg0 : index, %arg1: index) ->  (index) {
+  %result = util.align %arg0, %arg1 : index
+  //CHECK-DAG: %c1 = vm.const.i32 1 : i32
+  //CHECK-DAG: %0 = vm.sub.i32 %arg1, %c1 : i32
+  //CHECK-DAG: %1 = vm.add.i32 %arg0, %0 : i32
+  //CHECK-DAG: %2 = vm.not.i32 %0 : i32
+  //CHECK-DAG: %3 = vm.and.i32 %1, %2 : i32
+
+  //CHECK-DAG: vm.return %3 : i32
+  return %result : index
+}
+
+// -----
+
+// CHECK-LABEL: @utilAlignInt32
+func @utilAlignInt32(%arg0 : i32, %arg1: i32) ->  (i32) {
+  %result = util.align %arg0, %arg1 : i32
+  //CHECK-DAG: %c1 = vm.const.i32 1 : i32
+  //CHECK-DAG: %0 = vm.sub.i32 %arg1, %c1 : i32
+  //CHECK-DAG: %1 = vm.add.i32 %arg0, %0 : i32
+  //CHECK-DAG: %2 = vm.not.i32 %0 : i32
+  //CHECK-DAG: %3 = vm.and.i32 %1, %2 : i32
+
+  //CHECK-DAG: vm.return %3 : i32
+  return %result : i32
+}
+
+// -----
+
+// CHECK-LABEL: @utilAlignInt64
+func @utilAlignInt64(%arg0 : i64, %arg1: i64) ->  (i64) {
+  %result = util.align %arg0, %arg1 : i64
+  //CHECK-DAG: %c1 = vm.const.i64 1 : i64
+  //CHECK-DAG: %0 = vm.sub.i64 %arg1, %c1 : i64
+  //CHECK-DAG: %1 = vm.add.i64 %arg0, %0 : i64
+  //CHECK-DAG: %2 = vm.not.i64 %0 : i64
+  //CHECK-DAG: %3 = vm.and.i64 %1, %2 : i64
+
+  //CHECK-DAG: vm.return %3 : i64
+  return %result : i64
+}


### PR DESCRIPTION
Adds a Util.Align op to `UtilOps.td`. Align accepts two arguments, the value to align and the alignment to return the newly aligned value. 

`--iree-hal-pack-allocations` pass produces `Util::Align` ops instead of arithmetic ops for the alignment. The `--iree-vm-conversion` pass concerts the alignment ops directly to VM arithmetic/const ops (bypassing the arithmetic ops altogether). 

#5405