### PR TITLE
Pull in BlockAndValueMapping definition.

### DIFF
--- a/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"


### PR DESCRIPTION
When calling mlir::inlineRegion, g++-10 tries to deduce argument types to
figure out correct inlineRegion version. The g++-10 tries to convert the
fifth arg, which is a ValueRange{}, to BlockAndValueMapping, with conversion
operator 'RangeT()'. This requires full definition of BlockAndValueMapping,
or g++-10 will complain:
    "template argument must be a complete class or an unbounded array"

* Fixes #7451