### PR TITLE
Enable command buffer validation and provide a way to disable it.

### DIFF
--- a/experimental/rocm/direct_command_buffer.c
+++ b/experimental/rocm/direct_command_buffer.c
@@ -94,6 +94,21 @@ static void iree_hal_rocm_direct_command_buffer_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_rocm_direct_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer) {
+  return iree_hal_command_buffer_dyn_cast(
+      command_buffer, &iree_hal_rocm_direct_command_buffer_vtable);
+}
+
+static void* iree_hal_rocm_direct_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
+  if (vtable == &iree_hal_rocm_direct_command_buffer_vtable) {
+    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
+    return command_buffer;
+  }
+  return NULL;
+}
+
 static iree_hal_command_buffer_mode_t iree_hal_rocm_direct_command_buffer_mode(
     const iree_hal_command_buffer_t* base_command_buffer) {
   const iree_hal_rocm_direct_command_buffer_t* command_buffer =
@@ -359,6 +374,7 @@ static iree_status_t iree_hal_rocm_direct_command_buffer_dispatch_indirect(
 const iree_hal_command_buffer_vtable_t
     iree_hal_rocm_direct_command_buffer_vtable = {
         .destroy = iree_hal_rocm_direct_command_buffer_destroy,
+        .dyn_cast = iree_hal_rocm_direct_command_buffer_dyn_cast,
         .mode = iree_hal_rocm_direct_command_buffer_mode,
         .allowed_categories =
             iree_hal_rocm_direct_command_buffer_allowed_categories,

--- a/experimental/rocm/direct_command_buffer.h
+++ b/experimental/rocm/direct_command_buffer.h
@@ -37,6 +37,10 @@ iree_status_t iree_hal_rocm_direct_command_buffer_create(
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_command_buffer_t** out_command_buffer);
 
+// Returns true if |command_buffer| is a ROCM command buffer.
+bool iree_hal_rocm_direct_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -23,6 +23,8 @@ cc_library(
         "allocator.h",
         "api.c",
         "assert.h",
+        "bitfield.c",
+        "bitfield.h",
         "status.c",
         "status.h",
         "string_builder.c",
@@ -53,6 +55,16 @@ cc_library(
         ":base",
         ":core_headers",
         ":logging",
+    ],
+)
+
+cc_test(
+    name = "bitfield_test",
+    srcs = ["bitfield_test.cc"],
+    deps = [
+        ":base",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
     ],
 )
 

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -16,6 +16,8 @@ iree_cc_library(
     "allocator.h"
     "api.c"
     "assert.h"
+    "bitfield.c"
+    "bitfield.h"
     "status.c"
     "status.h"
     "string_builder.c"
@@ -42,6 +44,17 @@ iree_cc_library(
     ::core_headers
     ::logging
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    bitfield_test
+  SRCS
+    "bitfield_test.cc"
+  DEPS
+    ::base
+    iree::testing::gtest
+    iree::testing::gtest_main
 )
 
 iree_cc_test(

--- a/iree/base/allocator.h
+++ b/iree/base/allocator.h
@@ -37,11 +37,6 @@ extern "C" {
 #define iree_min(lhs, rhs) ((lhs) <= (rhs) ? (lhs) : (rhs))
 #define iree_max(lhs, rhs) ((lhs) <= (rhs) ? (rhs) : (lhs))
 
-// Returns true if any bit from |rhs| is set in |lhs|.
-#define iree_any_bit_set(lhs, rhs) (((lhs) & (rhs)) != 0)
-// Returns true iff all bits from |rhs| are set in |lhs|.
-#define iree_all_bits_set(lhs, rhs) (((lhs) & (rhs)) == (rhs))
-
 #if IREE_STATISTICS_ENABLE
 // Evalutes the expression code only if statistics are enabled.
 //

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -95,6 +95,7 @@
 #include "iree/base/allocator.h"       // IWYU pragma: export
 #include "iree/base/assert.h"          // IWYU pragma: export
 #include "iree/base/attributes.h"      // IWYU pragma: export
+#include "iree/base/bitfield.h"        // IWYU pragma: export
 #include "iree/base/config.h"          // IWYU pragma: export
 #include "iree/base/status.h"          // IWYU pragma: export
 #include "iree/base/string_builder.h"  // IWYU pragma: export

--- a/iree/base/bitfield.c
+++ b/iree/base/bitfield.c
@@ -1,0 +1,55 @@
+// Copyright 2019 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/bitfield.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+IREE_API_EXPORT iree_status_t iree_bitfield_format(
+    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
+    iree_host_size_t mapping_count, iree_string_builder_t* string_builder) {
+  uint32_t remaining_bits = value;
+  int i = 0;
+  for (iree_host_size_t mapping_index = 0; mapping_index < mapping_count;
+       ++mapping_index) {
+    const iree_bitfield_string_mapping_t mapping = mappings[mapping_index];
+    if ((remaining_bits & mapping.bits) == mapping.bits) {
+      if (i > 0) {
+        IREE_RETURN_IF_ERROR(
+            iree_string_builder_append_string(string_builder, IREE_SV("|")));
+      }
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_string(string_builder, mapping.string));
+      remaining_bits &= ~mapping.bits;
+      ++i;
+    }
+  }
+  if (remaining_bits != 0u) {
+    if (i > 0) {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_string(string_builder, IREE_SV("|")));
+    }
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        string_builder, "%Xh", remaining_bits));
+  }
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_string_view_t iree_bitfield_format_inline(
+    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
+    iree_host_size_t mapping_count, iree_bitfield_string_temp_t* out_temp) {
+  iree_string_builder_t string_builder;
+  iree_string_builder_initialize_with_storage(
+      out_temp->buffer, IREE_ARRAYSIZE(out_temp->buffer), &string_builder);
+  iree_status_t status =
+      iree_bitfield_format(value, mappings, mapping_count, &string_builder);
+  if (iree_status_is_ok(status)) {
+    return iree_string_builder_view(&string_builder);
+  }
+  iree_status_ignore(status);
+  return IREE_SV("(error)");
+}

--- a/iree/base/bitfield.h
+++ b/iree/base/bitfield.h
@@ -1,0 +1,85 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_BITFIELD_H_
+#define IREE_BASE_BITFIELD_H_
+
+#include "iree/base/attributes.h"
+#include "iree/base/string_builder.h"
+#include "iree/base/string_view.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Bitfield utilities
+//===----------------------------------------------------------------------===//
+
+// Returns true if any bit from |rhs| is set in |lhs|.
+#define iree_any_bit_set(lhs, rhs) (((lhs) & (rhs)) != 0)
+// Returns true iff all bits from |rhs| are set in |lhs|.
+#define iree_all_bits_set(lhs, rhs) (((lhs) & (rhs)) == (rhs))
+
+// Maps bits within a bitfield to a string literal.
+typedef struct iree_bitfield_string_mapping_t {
+  uint32_t bits;
+  iree_string_view_t string;
+} iree_bitfield_string_mapping_t;
+
+// Appends the formatted contents of the given bitfield value.
+// Processes values in the order of the mapping table provided and will only
+// use each bit once. Use this to prioritize combined flags over split ones.
+//
+// Usage:
+//  // Static mapping table:
+//  static const iree_bitfield_string_mapping_t my_bitfield_mappings[] = {
+//    {MY_BITFIELD_ALL, IREE_SVL("ALL")},  // combined flags first
+//    {MY_BITFIELD_A,   IREE_SVL("A")},
+//    {MY_BITFIELD_B,   IREE_SVL("B")},
+//    {MY_BITFIELD_C,   IREE_SVL("C")},
+//  };
+//
+//  // Produces the string "A|B":
+//  IREE_RETURN_IF_ERROR(iree_bitfield_format(
+//      MY_BITFIELD_A | MY_BITFIELD_B,
+//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      &string_builder));
+//
+//  // Produces the string "ALL":
+//  IREE_RETURN_IF_ERROR(iree_bitfield_format(
+//      MY_BITFIELD_A | MY_BITFIELD_B | MY_BITFIELD_C,
+//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      &string_builder));
+IREE_API_EXPORT iree_status_t iree_bitfield_format(
+    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
+    iree_host_size_t mapping_count, iree_string_builder_t* string_builder);
+
+// Stack storage for iree_bitfield_format_inline temporary strings.
+typedef struct iree_bitfield_string_temp_t {
+  char buffer[128];
+} iree_bitfield_string_temp_t;
+
+// Appends the formatted contents of the given bitfield value.
+// As with iree_bitfield_format only the storage for the formatted string is
+// allocated inline on the stack.
+//
+// Usage:
+//  // Produces the string "A|B":
+//  iree_bitfield_string_temp_t temp;
+//  iree_string_view_t my_str = iree_bitfield_format_inline(
+//      MY_BITFIELD_A | MY_BITFIELD_B,
+//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      &temp);
+IREE_API_EXPORT iree_string_view_t iree_bitfield_format_inline(
+    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
+    iree_host_size_t mapping_count, iree_bitfield_string_temp_t* out_temp);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_BITFIELD_H_

--- a/iree/base/bitfield_test.cc
+++ b/iree/base/bitfield_test.cc
@@ -1,0 +1,83 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <string>
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace {
+
+enum my_bitfield_e {
+  MY_BITFIELD_NONE = 0,
+  MY_BITFIELD_A = 1 << 0,
+  MY_BITFIELD_B = 1 << 1,
+  MY_BITFIELD_ALL = MY_BITFIELD_A | MY_BITFIELD_B,
+};
+typedef uint32_t my_bitfield_t;
+
+template <size_t mapping_count>
+std::string FormatBitfieldValue(
+    uint32_t value,
+    const iree_bitfield_string_mapping_t (&mappings)[mapping_count]) {
+  iree_bitfield_string_temp_t temp;
+  auto sv = iree_bitfield_format_inline(value, mappings, mapping_count, &temp);
+  return std::string(sv.data, sv.size);
+}
+
+// Tests general usage.
+TEST(BitfieldTest, FormatBitfieldValue) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      {MY_BITFIELD_A, IREE_SV("A")},
+      {MY_BITFIELD_B, IREE_SV("B")},
+  };
+  EXPECT_EQ("", FormatBitfieldValue(MY_BITFIELD_NONE, mappings));
+  EXPECT_EQ("A", FormatBitfieldValue(MY_BITFIELD_A, mappings));
+  EXPECT_EQ("A|B",
+            FormatBitfieldValue(MY_BITFIELD_A | MY_BITFIELD_B, mappings));
+}
+
+// Tests that empty mapping tables are fine.
+TEST(BitfieldTest, FormatBitfieldValueEmpty) {
+  static const iree_bitfield_string_mapping_t mappings[1] = {
+      {0, IREE_SV("UNUSED")},
+  };
+  iree_bitfield_string_temp_t temp;
+  auto sv = iree_bitfield_format_inline(MY_BITFIELD_NONE, mappings, 0, &temp);
+  EXPECT_TRUE(iree_string_view_is_empty(sv));
+}
+
+// Tests that values not found in the mappings are still displayed.
+TEST(BitfieldTest, FormatBitfieldValueUnhandledValues) {
+  EXPECT_EQ("A|2h", FormatBitfieldValue(MY_BITFIELD_A | MY_BITFIELD_B,
+                                        {
+                                            {MY_BITFIELD_A, IREE_SV("A")},
+                                        }));
+}
+
+// Tests priority order in the mapping table.
+TEST(BitfieldTest, FormatBitfieldValuePriority) {
+  // No priority, will do separate.
+  EXPECT_EQ("A|B", FormatBitfieldValue(MY_BITFIELD_A | MY_BITFIELD_B,
+                                       {
+                                           {MY_BITFIELD_A, IREE_SV("A")},
+                                           {MY_BITFIELD_B, IREE_SV("B")},
+                                           {MY_BITFIELD_ALL, IREE_SV("ALL")},
+                                       }));
+
+  // Priority on the combined flag, use that instead.
+  EXPECT_EQ("ALL", FormatBitfieldValue(MY_BITFIELD_A | MY_BITFIELD_B,
+                                       {
+                                           {MY_BITFIELD_ALL, IREE_SV("ALL")},
+                                           {MY_BITFIELD_A, IREE_SV("A")},
+                                           {MY_BITFIELD_B, IREE_SV("B")},
+                                       }));
+}
+
+}  // namespace
+}  // namespace iree

--- a/iree/base/config.h
+++ b/iree/base/config.h
@@ -155,6 +155,14 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 // Enables optional HAL features. Each of these may add several KB to the final
 // binary when linked dynamically.
 
+#if !defined(IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE)
+// Enables additional validation of commands issued against command buffers.
+// This adds small amounts of per-command overhead but in all but the most
+// constrained environments it's recommended to keep it enabled in order to get
+// the really nice error messages.
+#define IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE 1
+#endif  // IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE
+
 #if !defined(IREE_HAL_MODULE_STRING_UTIL_ENABLE)
 // Enables HAL module methods that perform string printing/parsing.
 // This functionality pulls in a large amount of string manipulation code that

--- a/iree/base/string_builder.c
+++ b/iree/base/string_builder.c
@@ -17,6 +17,14 @@ IREE_API_EXPORT void iree_string_builder_initialize(
   out_builder->allocator = allocator;
 }
 
+IREE_API_EXPORT void iree_string_builder_initialize_with_storage(
+    char* buffer, iree_host_size_t buffer_capacity,
+    iree_string_builder_t* out_builder) {
+  iree_string_builder_initialize(iree_allocator_null(), out_builder);
+  out_builder->buffer = buffer;
+  out_builder->capacity = buffer_capacity;
+}
+
 IREE_API_EXPORT void iree_string_builder_deinitialize(
     iree_string_builder_t* builder) {
   if (builder->buffer != NULL) {

--- a/iree/base/string_builder.h
+++ b/iree/base/string_builder.h
@@ -55,6 +55,12 @@ typedef struct iree_string_builder_t {
 IREE_API_EXPORT void iree_string_builder_initialize(
     iree_allocator_t allocator, iree_string_builder_t* out_builder);
 
+// Initializes a string builder in |out_builder| using the given storage.
+// Once the capacity is reached further appending will fail.
+IREE_API_EXPORT void iree_string_builder_initialize_with_storage(
+    char* buffer, iree_host_size_t buffer_capacity,
+    iree_string_builder_t* out_builder);
+
 // Deinitializes |builder| and releases allocated storage.
 IREE_API_EXPORT void iree_string_builder_deinitialize(
     iree_string_builder_t* builder);

--- a/iree/base/string_view.h
+++ b/iree/base/string_view.h
@@ -56,6 +56,9 @@ static inline iree_string_view_t iree_make_cstring_view(const char* str) {
 // Returns a string view initialized with the given cstring.
 #define IREE_SV(cstr) iree_make_cstring_view(cstr)
 
+// Returns a string view initialized with the given string literal.
+#define IREE_SVL(cstr) iree_string_view_literal(cstr)
+
 // Returns true if the two strings are equal (compare == 0).
 IREE_API_EXPORT bool iree_string_view_equal(iree_string_view_t lhs,
                                             iree_string_view_t rhs);

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -183,34 +183,20 @@ typedef struct iree_hal_buffer_mapping_t {
   uint64_t reserved[4];
 } iree_hal_buffer_mapping_t;
 
-// TODO(benvanik): replace with tables for iree_string_builder_*.
-#define iree_hal_memory_type_string(...) "TODO"
-//     // Combined:
-//     {IREE_HAL_MEMORY_TYPE_HOST_LOCAL, "HOST_LOCAL"},
-//     {IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL, "DEVICE_LOCAL"},
-//     // Separate:
-//     {IREE_HAL_MEMORY_TYPE_TRANSIENT, "TRANSIENT"},
-//     {IREE_HAL_MEMORY_TYPE_HOST_VISIBLE, "HOST_VISIBLE"},
-//     {IREE_HAL_MEMORY_TYPE_HOST_COHERENT, "HOST_COHERENT"},
-//     {IREE_HAL_MEMORY_TYPE_HOST_CACHED, "HOST_CACHED"},
-//     {IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, "DEVICE_VISIBLE"},
-#define iree_hal_memory_access_string(...) "TODO"
-//     // Combined:
-//     {IREE_HAL_MEMORY_ACCESS_ALL, "ALL"},
-//     {IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE, "DISCARD_WRITE"},
-//     // Separate:
-//     {IREE_HAL_MEMORY_ACCESS_READ, "READ"},
-//     {IREE_HAL_MEMORY_ACCESS_WRITE, "WRITE"},
-//     {IREE_HAL_MEMORY_ACCESS_DISCARD, "DISCARD"},
-//     {IREE_HAL_MEMORY_ACCESS_MAY_ALIAS, "MAY_ALIAS"},
-#define iree_hal_buffer_usage_string(...) "TODO"
-//     // Combined:
-//     {IREE_HAL_BUFFER_USAGE_ALL, "ALL"},
-//     // Separate:
-//     {IREE_HAL_BUFFER_USAGE_CONSTANT, "CONSTANT"},
-//     {IREE_HAL_BUFFER_USAGE_TRANSFER, "TRANSFER"},
-//     {IREE_HAL_BUFFER_USAGE_MAPPING, "MAPPING"},
-//     {IREE_HAL_BUFFER_USAGE_DISPATCH, "DISPATCH"},
+// Formats a memory type bitfield as a string.
+// See iree_bitfield_format for usage.
+IREE_API_EXPORT iree_string_view_t iree_hal_memory_type_format(
+    iree_hal_memory_type_t value, iree_bitfield_string_temp_t* out_temp);
+
+// Formats a memory access bitfield as a string.
+// See iree_bitfield_format for usage.
+IREE_API_EXPORT iree_string_view_t iree_hal_memory_access_format(
+    iree_hal_memory_access_t value, iree_bitfield_string_temp_t* out_temp);
+
+// Formats a buffer usage bitfield as a string.
+// See iree_bitfield_format for usage.
+IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
+    iree_hal_buffer_usage_t value, iree_bitfield_string_temp_t* out_temp);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_buffer_t

--- a/iree/hal/command_buffer.c
+++ b/iree/hal/command_buffer.c
@@ -57,6 +57,13 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(
   return status;
 }
 
+IREE_API_EXPORT void* iree_hal_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
+  IREE_ASSERT_ARGUMENT(command_buffer);
+  if (iree_hal_resource_is(command_buffer, vtable)) return command_buffer;
+  return _VTABLE_DISPATCH(command_buffer, dyn_cast)(command_buffer, vtable);
+}
+
 IREE_API_EXPORT iree_hal_command_buffer_mode_t
 iree_hal_command_buffer_mode(const iree_hal_command_buffer_t* command_buffer) {
   IREE_ASSERT_ARGUMENT(command_buffer);

--- a/iree/hal/command_buffer.c
+++ b/iree/hal/command_buffer.c
@@ -43,6 +43,16 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(
       IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device, create_command_buffer)(
           device, mode, command_categories, queue_affinity, out_command_buffer);
 
+#if IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE
+  // Wrap the command buffer with the validation layer if enabled in the build.
+  // It may be disabled to save code size and per-command overhead (only when
+  // inputs are trusted!).
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_command_buffer_wrap_validation(
+        device, *out_command_buffer, out_command_buffer);
+  }
+#endif  // IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE
+
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/iree/hal/command_buffer.c
+++ b/iree/hal/command_buffer.c
@@ -17,6 +17,39 @@
 #define _VTABLE_DISPATCH(command_buffer, method_name) \
   IREE_HAL_VTABLE_DISPATCH(command_buffer, iree_hal_command_buffer, method_name)
 
+//===----------------------------------------------------------------------===//
+// String utils
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_string_view_t
+iree_hal_command_buffer_mode_format(iree_hal_command_buffer_mode_t value,
+                                    iree_bitfield_string_temp_t* out_temp) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      {IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT, IREE_SVL("ONE_SHOT")},
+      {IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
+       IREE_SVL("ALLOW_INLINE_EXECUTION")},
+  };
+  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+                                     out_temp);
+}
+
+IREE_API_EXPORT iree_string_view_t iree_hal_command_category_format(
+    iree_hal_command_category_t value, iree_bitfield_string_temp_t* out_temp) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      // Combined:
+      {IREE_HAL_COMMAND_CATEGORY_ANY, IREE_SVL("ANY")},
+      // Separate:
+      {IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_SVL("TRANSFER")},
+      {IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_SVL("DISPATCH")},
+  };
+  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+                                     out_temp);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_command_buffer_t
+//===----------------------------------------------------------------------===//
+
 IREE_HAL_API_RETAIN_RELEASE(command_buffer);
 
 IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(

--- a/iree/hal/command_buffer.h
+++ b/iree/hal/command_buffer.h
@@ -202,12 +202,16 @@ static inline iree_hal_label_color_t iree_hal_label_color_unspecified() {
   return color;
 }
 
-// TODO(benvanik): replace with tables for iree_string_builder_*.
-#define iree_hal_command_buffer_mode_string(...) "TODO"
-//    {IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT, "ONE_SHOT"},
-#define iree_hal_command_category_string(...) "TODO"
-//    {IREE_HAL_COMMAND_CATEGORY_TRANSFER, "TRANSFER"},
-//    {IREE_HAL_COMMAND_CATEGORY_DISPATCH, "DISPATCH"},
+// Formats a command buffer mode bitfield as a string.
+// See iree_bitfield_format for usage.
+IREE_API_EXPORT iree_string_view_t
+iree_hal_command_buffer_mode_format(iree_hal_command_buffer_mode_t value,
+                                    iree_bitfield_string_temp_t* out_temp);
+
+// Formats a command category bitfield as a string.
+// See iree_bitfield_format for usage.
+IREE_API_EXPORT iree_string_view_t iree_hal_command_category_format(
+    iree_hal_command_category_t value, iree_bitfield_string_temp_t* out_temp);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_command_buffer_t

--- a/iree/hal/command_buffer.h
+++ b/iree/hal/command_buffer.h
@@ -261,6 +261,9 @@ IREE_API_EXPORT void iree_hal_command_buffer_retain(
 IREE_API_EXPORT void iree_hal_command_buffer_release(
     iree_hal_command_buffer_t* command_buffer);
 
+IREE_API_EXPORT void* iree_hal_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable);
+
 // Returns a bitmask indicating the behavior of the command buffer.
 IREE_API_EXPORT iree_hal_command_buffer_mode_t
 iree_hal_command_buffer_mode(const iree_hal_command_buffer_t* command_buffer);
@@ -498,6 +501,9 @@ typedef struct iree_hal_command_buffer_vtable_t {
   IREE_API_UNSTABLE
 
   void(IREE_API_PTR* destroy)(iree_hal_command_buffer_t* command_buffer);
+
+  void*(IREE_API_PTR* dyn_cast)(iree_hal_command_buffer_t* command_buffer,
+                                const void* vtable);
 
   iree_hal_command_buffer_mode_t(IREE_API_PTR* mode)(
       const iree_hal_command_buffer_t* command_buffer);

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -25,15 +25,30 @@ typedef struct iree_hal_validating_command_buffer_t {
   iree_hal_resource_t resource;
   iree_hal_device_t* device;
   iree_hal_command_buffer_t* target_command_buffer;
+  iree_hal_command_buffer_mode_t mode;
   iree_hal_command_category_t allowed_categories;
 
   bool is_recording;
+  int32_t debug_group_depth;
   // TODO(benvanik): current executable layout/descriptor set layout info.
   // TODO(benvanik): valid push constant bit ranges.
 } iree_hal_validating_command_buffer_t;
 
 static const iree_hal_command_buffer_vtable_t
     iree_hal_validating_command_buffer_vtable;
+
+static iree_hal_validating_command_buffer_t*
+iree_hal_validating_command_buffer_cast(iree_hal_command_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_validating_command_buffer_vtable);
+  return (iree_hal_validating_command_buffer_t*)base_value;
+}
+
+static const iree_hal_validating_command_buffer_t*
+iree_hal_validating_command_buffer_const_cast(
+    const iree_hal_command_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_validating_command_buffer_vtable);
+  return (const iree_hal_validating_command_buffer_t*)base_value;
+}
 
 // Returns success iff the queue supports the given command categories.
 static iree_status_t iree_hal_command_buffer_validate_categories(
@@ -104,6 +119,8 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_wrap_validation(
     iree_hal_device_retain(command_buffer->device);
     command_buffer->target_command_buffer = target_command_buffer;
     iree_hal_command_buffer_retain(command_buffer->target_command_buffer);
+    command_buffer->mode =
+        iree_hal_command_buffer_mode(command_buffer->target_command_buffer);
     command_buffer->allowed_categories =
         iree_hal_command_buffer_allowed_categories(
             command_buffer->target_command_buffer);
@@ -120,7 +137,7 @@ static void iree_hal_validating_command_buffer_destroy(
     iree_hal_command_buffer_t* base_command_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
   iree_allocator_t host_allocator =
       iree_hal_device_host_allocator(command_buffer->device);
   iree_hal_command_buffer_release(command_buffer->target_command_buffer);
@@ -129,18 +146,37 @@ static void iree_hal_validating_command_buffer_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static void* iree_hal_validating_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* base_command_buffer, const void* vtable) {
+  if (vtable == &iree_hal_validating_command_buffer_vtable) {
+    IREE_HAL_ASSERT_TYPE(base_command_buffer, vtable);
+    return base_command_buffer;
+  }
+  iree_hal_validating_command_buffer_t* command_buffer =
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
+  return iree_hal_command_buffer_dyn_cast(command_buffer->target_command_buffer,
+                                          vtable);
+}
+
+static iree_hal_command_buffer_mode_t iree_hal_validating_command_buffer_mode(
+    const iree_hal_command_buffer_t* base_command_buffer) {
+  const iree_hal_validating_command_buffer_t* command_buffer =
+      iree_hal_validating_command_buffer_const_cast(base_command_buffer);
+  return command_buffer->mode;
+}
+
 static iree_hal_command_category_t
 iree_hal_validating_command_buffer_allowed_categories(
     const iree_hal_command_buffer_t* base_command_buffer) {
-  iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+  const iree_hal_validating_command_buffer_t* command_buffer =
+      iree_hal_validating_command_buffer_const_cast(base_command_buffer);
   return command_buffer->allowed_categories;
 }
 
 static iree_status_t iree_hal_validating_command_buffer_begin(
     iree_hal_command_buffer_t* base_command_buffer) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   if (command_buffer->is_recording) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
@@ -154,8 +190,13 @@ static iree_status_t iree_hal_validating_command_buffer_begin(
 static iree_status_t iree_hal_validating_command_buffer_end(
     iree_hal_command_buffer_t* base_command_buffer) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
+  if (command_buffer->debug_group_depth != 0) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "unbalanced debug group depth (expected 0, is %d)",
+                            command_buffer->debug_group_depth);
+  }
   if (!command_buffer->is_recording) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "command buffer is not in a recording state");
@@ -163,6 +204,25 @@ static iree_status_t iree_hal_validating_command_buffer_end(
   command_buffer->is_recording = false;
 
   return iree_hal_command_buffer_end(command_buffer->target_command_buffer);
+}
+
+static void iree_hal_validating_command_buffer_begin_debug_group(
+    iree_hal_command_buffer_t* base_command_buffer, iree_string_view_t label,
+    iree_hal_label_color_t label_color,
+    const iree_hal_label_location_t* location) {
+  iree_hal_validating_command_buffer_t* command_buffer =
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
+  iree_hal_command_buffer_begin_debug_group(
+      command_buffer->target_command_buffer, label, label_color, location);
+}
+
+static void iree_hal_validating_command_buffer_end_debug_group(
+    iree_hal_command_buffer_t* base_command_buffer) {
+  iree_hal_validating_command_buffer_t* command_buffer =
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
+  --command_buffer->debug_group_depth;
+  iree_hal_command_buffer_end_debug_group(
+      command_buffer->target_command_buffer);
 }
 
 static iree_status_t iree_hal_validating_command_buffer_execution_barrier(
@@ -175,7 +235,7 @@ static iree_status_t iree_hal_validating_command_buffer_execution_barrier(
     iree_host_size_t buffer_barrier_count,
     const iree_hal_buffer_barrier_t* buffer_barriers) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_ANY));
@@ -192,7 +252,7 @@ static iree_status_t iree_hal_validating_command_buffer_signal_event(
     iree_hal_command_buffer_t* base_command_buffer, iree_hal_event_t* event,
     iree_hal_execution_stage_t source_stage_mask) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -207,7 +267,7 @@ static iree_status_t iree_hal_validating_command_buffer_reset_event(
     iree_hal_command_buffer_t* base_command_buffer, iree_hal_event_t* event,
     iree_hal_execution_stage_t source_stage_mask) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -228,7 +288,7 @@ static iree_status_t iree_hal_validating_command_buffer_wait_events(
     iree_host_size_t buffer_barrier_count,
     const iree_hal_buffer_barrier_t* buffer_barriers) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -244,7 +304,7 @@ static iree_status_t iree_hal_validating_command_buffer_wait_events(
 static iree_status_t iree_hal_validating_command_buffer_discard_buffer(
     iree_hal_command_buffer_t* base_command_buffer, iree_hal_buffer_t* buffer) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_TRANSFER));
@@ -263,7 +323,7 @@ static iree_status_t iree_hal_validating_command_buffer_fill_buffer(
     iree_device_size_t length, const void* pattern,
     iree_host_size_t pattern_length) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_TRANSFER));
@@ -312,7 +372,7 @@ static iree_status_t iree_hal_validating_command_buffer_update_buffer(
     iree_host_size_t source_offset, iree_hal_buffer_t* target_buffer,
     iree_device_size_t target_offset, iree_device_size_t length) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_TRANSFER));
@@ -344,7 +404,7 @@ static iree_status_t iree_hal_validating_command_buffer_copy_buffer(
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_TRANSFER));
@@ -410,7 +470,7 @@ static iree_status_t iree_hal_validating_command_buffer_push_constants(
     iree_hal_executable_layout_t* executable_layout, iree_host_size_t offset,
     const void* values, iree_host_size_t values_length) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -434,7 +494,7 @@ static iree_status_t iree_hal_validating_command_buffer_push_descriptor_set(
     iree_host_size_t binding_count,
     const iree_hal_descriptor_set_binding_t* bindings) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -455,7 +515,7 @@ static iree_status_t iree_hal_validating_command_buffer_bind_descriptor_set(
     iree_host_size_t dynamic_offset_count,
     const iree_device_size_t* dynamic_offsets) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -473,7 +533,7 @@ static iree_status_t iree_hal_validating_command_buffer_dispatch(
     iree_hal_executable_t* executable, int32_t entry_point,
     uint32_t workgroup_x, uint32_t workgroup_y, uint32_t workgroup_z) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -491,7 +551,7 @@ static iree_status_t iree_hal_validating_command_buffer_dispatch_indirect(
     iree_hal_buffer_t* workgroups_buffer,
     iree_device_size_t workgroups_offset) {
   iree_hal_validating_command_buffer_t* command_buffer =
-      (iree_hal_validating_command_buffer_t*)base_command_buffer;
+      iree_hal_validating_command_buffer_cast(base_command_buffer);
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_categories(
       command_buffer, IREE_HAL_COMMAND_CATEGORY_DISPATCH));
@@ -523,10 +583,15 @@ static iree_status_t iree_hal_validating_command_buffer_dispatch_indirect(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_validating_command_buffer_vtable = {
         .destroy = iree_hal_validating_command_buffer_destroy,
+        .dyn_cast = iree_hal_validating_command_buffer_dyn_cast,
+        .mode = iree_hal_validating_command_buffer_mode,
         .allowed_categories =
             iree_hal_validating_command_buffer_allowed_categories,
         .begin = iree_hal_validating_command_buffer_begin,
         .end = iree_hal_validating_command_buffer_end,
+        .begin_debug_group =
+            iree_hal_validating_command_buffer_begin_debug_group,
+        .end_debug_group = iree_hal_validating_command_buffer_end_debug_group,
         .execution_barrier =
             iree_hal_validating_command_buffer_execution_barrier,
         .signal_event = iree_hal_validating_command_buffer_signal_event,

--- a/iree/hal/cuda/api.h
+++ b/iree/hal/cuda/api.h
@@ -16,6 +16,14 @@
 extern "C" {
 #endif  // __cplusplus
 
+// Defines how command buffers are recorded and executed.
+typedef enum iree_hal_cuda_command_buffer_mode_e {
+  // Command buffers are recorded into CUDA graphs.
+  IREE_HAL_CUDA_COMMAND_BUFFER_MODE_GRAPH = 0,
+  // Command buffers are directly issued against a CUDA stream.
+  IREE_HAL_CUDA_COMMAND_BUFFER_MODE_STREAM = 1,
+} iree_hal_cuda_command_buffer_mode_t;
+
 // Parameters configuring an iree_hal_cuda_device_t.
 // Must be initialized with iree_hal_cuda_device_params_initialize prior to use.
 typedef struct iree_hal_cuda_device_params_t {
@@ -29,8 +37,8 @@ typedef struct iree_hal_cuda_device_params_t {
   // transient allocations while also increasing memory consumption.
   iree_host_size_t arena_block_size;
 
-  // Switch for using deferred command buffer or default graph command buffer
-  bool use_deferred_submission;
+  // Specifies how command buffers are recorded and executed.
+  iree_hal_cuda_command_buffer_mode_t command_buffer_mode;
 } iree_hal_cuda_device_params_t;
 
 // Initializes |out_params| to default values.

--- a/iree/hal/cuda/graph_command_buffer.h
+++ b/iree/hal/cuda/graph_command_buffer.h
@@ -25,9 +25,13 @@ iree_status_t iree_hal_cuda_graph_command_buffer_create(
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_command_buffer_t** out_command_buffer);
 
+// Returns true if |command_buffer| is a CUDA graph-based command buffer.
+bool iree_hal_cuda_graph_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 // Returns the native cuda graph associated to the command buffer.
 CUgraphExec iree_hal_cuda_graph_command_buffer_exec(
-    const iree_hal_command_buffer_t* command_buffer);
+    iree_hal_command_buffer_t* command_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/hal/cuda/registration/driver_module.c
+++ b/iree/hal/cuda/registration/driver_module.c
@@ -41,15 +41,14 @@ static iree_status_t iree_hal_cuda_driver_factory_try_create(
                             driver_id);
   }
   IREE_TRACE_ZONE_BEGIN(z0);
+
   iree_hal_cuda_device_params_t default_params;
   iree_hal_cuda_device_params_initialize(&default_params);
-  // TODO(jinchen62): set up default_params.use_deferred_submission by flag
-  // When we expose more than one driver (different cuda versions, etc) we
-  // can name them here:
-  iree_string_view_t identifier = iree_make_cstring_view("cuda");
 
   iree_hal_cuda_driver_options_t driver_options;
   iree_hal_cuda_driver_options_initialize(&driver_options);
+
+  iree_string_view_t identifier = iree_make_cstring_view("cuda");
   iree_status_t status = iree_hal_cuda_driver_create(
       identifier, &default_params, &driver_options, allocator, out_driver);
   IREE_TRACE_ZONE_END(z0);

--- a/iree/hal/cuda/stream_command_buffer.c
+++ b/iree/hal/cuda/stream_command_buffer.c
@@ -83,6 +83,21 @@ static void iree_hal_cuda_stream_command_buffer_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_cuda_stream_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer) {
+  return iree_hal_command_buffer_dyn_cast(
+      command_buffer, &iree_hal_cuda_stream_command_buffer_vtable);
+}
+
+static void* iree_hal_cuda_stream_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
+  if (vtable == &iree_hal_cuda_stream_command_buffer_vtable) {
+    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
+    return command_buffer;
+  }
+  return NULL;
+}
+
 static iree_hal_command_buffer_mode_t iree_hal_cuda_stream_command_buffer_mode(
     const iree_hal_command_buffer_t* base_command_buffer) {
   const iree_hal_cuda_stream_command_buffer_t* command_buffer =
@@ -328,6 +343,7 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_dispatch_indirect(
 const iree_hal_command_buffer_vtable_t
     iree_hal_cuda_stream_command_buffer_vtable = {
         .destroy = iree_hal_cuda_stream_command_buffer_destroy,
+        .dyn_cast = iree_hal_cuda_stream_command_buffer_dyn_cast,
         .mode = iree_hal_cuda_stream_command_buffer_mode,
         .allowed_categories =
             iree_hal_cuda_stream_command_buffer_allowed_categories,

--- a/iree/hal/cuda/stream_command_buffer.h
+++ b/iree/hal/cuda/stream_command_buffer.h
@@ -28,6 +28,10 @@ iree_status_t iree_hal_cuda_stream_command_buffer_create(
     iree_hal_command_category_t command_categories, CUstream stream,
     iree_hal_command_buffer_t **out_command_buffer);
 
+// Returns true if |command_buffer| is a CUDA stream-based command buffer.
+bool iree_hal_cuda_stream_command_buffer_isa(
+    iree_hal_command_buffer_t *command_buffer);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/local/inline_command_buffer.c
+++ b/iree/hal/local/inline_command_buffer.c
@@ -137,6 +137,21 @@ static void iree_hal_inline_command_buffer_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_inline_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer) {
+  return iree_hal_command_buffer_dyn_cast(
+      command_buffer, &iree_hal_inline_command_buffer_vtable);
+}
+
+static void* iree_hal_inline_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
+  if (vtable == &iree_hal_inline_command_buffer_vtable) {
+    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
+    return command_buffer;
+  }
+  return NULL;
+}
+
 static iree_hal_command_buffer_mode_t iree_hal_inline_command_buffer_mode(
     const iree_hal_command_buffer_t* base_command_buffer) {
   return ((const iree_hal_inline_command_buffer_t*)base_command_buffer)->mode;
@@ -502,6 +517,7 @@ static iree_status_t iree_hal_inline_command_buffer_dispatch_indirect(
 static const iree_hal_command_buffer_vtable_t
     iree_hal_inline_command_buffer_vtable = {
         .destroy = iree_hal_inline_command_buffer_destroy,
+        .dyn_cast = iree_hal_inline_command_buffer_dyn_cast,
         .mode = iree_hal_inline_command_buffer_mode,
         .allowed_categories = iree_hal_inline_command_buffer_allowed_categories,
         .begin = iree_hal_inline_command_buffer_begin,

--- a/iree/hal/local/inline_command_buffer.h
+++ b/iree/hal/local/inline_command_buffer.h
@@ -29,6 +29,10 @@ iree_status_t iree_hal_inline_command_buffer_create(
     iree_hal_queue_affinity_t queue_affinity, iree_allocator_t host_allocator,
     iree_hal_command_buffer_t** out_command_buffer);
 
+// Returns true if |command_buffer| is an inline command buffer.
+bool iree_hal_inline_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/local/task_command_buffer.h
+++ b/iree/hal/local/task_command_buffer.h
@@ -25,6 +25,10 @@ iree_status_t iree_hal_task_command_buffer_create(
     iree_arena_block_pool_t* block_pool, iree_allocator_t host_allocator,
     iree_hal_command_buffer_t** out_command_buffer);
 
+// Returns true if |command_buffer| is a task system command buffer.
+bool iree_hal_task_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 // Issues a recorded command buffer using the serial |queue_state|.
 // |queue_state| is used to track the synchronization scope of the queue from
 // prior commands such as signaled events and will be mutated as events are

--- a/iree/hal/local/task_queue.c
+++ b/iree/hal/local/task_queue.c
@@ -200,9 +200,15 @@ static iree_status_t iree_hal_task_queue_issue_cmd(
   // submission was purely for synchronization.
   if (cmd->command_buffer_count > 0) {
     for (iree_host_size_t i = 0; i < cmd->command_buffer_count; ++i) {
-      status = iree_hal_task_command_buffer_issue(
-          cmd->command_buffers[i], &cmd->queue->state,
-          cmd->task.header.completion_task, cmd->arena, pending_submission);
+      if (iree_hal_task_command_buffer_isa(cmd->command_buffers[i])) {
+        status = iree_hal_task_command_buffer_issue(
+            cmd->command_buffers[i], &cmd->queue->state,
+            cmd->task.header.completion_task, cmd->arena, pending_submission);
+      } else {
+        status = iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "unsupported command buffer type for task queue submission");
+      }
       if (IREE_UNLIKELY(!iree_status_is_ok(status))) break;
     }
   }

--- a/iree/hal/vulkan/direct_command_buffer.cc
+++ b/iree/hal/vulkan/direct_command_buffer.cc
@@ -137,6 +137,21 @@ static void iree_hal_vulkan_direct_command_buffer_reset(
   IREE_IGNORE_ERROR(command_buffer->descriptor_set_group.Reset());
 }
 
+bool iree_hal_vulkan_direct_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer) {
+  return iree_hal_command_buffer_dyn_cast(
+      command_buffer, &iree_hal_vulkan_direct_command_buffer_vtable);
+}
+
+static void* iree_hal_vulkan_direct_command_buffer_dyn_cast(
+    iree_hal_command_buffer_t* command_buffer, const void* vtable) {
+  if (vtable == &iree_hal_vulkan_direct_command_buffer_vtable) {
+    IREE_HAL_ASSERT_TYPE(command_buffer, vtable);
+    return command_buffer;
+  }
+  return NULL;
+}
+
 static void iree_hal_vulkan_direct_command_buffer_destroy(
     iree_hal_command_buffer_t* base_command_buffer) {
   iree_hal_vulkan_direct_command_buffer_t* command_buffer =
@@ -159,7 +174,10 @@ static void iree_hal_vulkan_direct_command_buffer_destroy(
 VkCommandBuffer iree_hal_vulkan_direct_command_buffer_handle(
     iree_hal_command_buffer_t* base_command_buffer) {
   iree_hal_vulkan_direct_command_buffer_t* command_buffer =
-      iree_hal_vulkan_direct_command_buffer_cast(base_command_buffer);
+      (iree_hal_vulkan_direct_command_buffer_t*)
+          iree_hal_command_buffer_dyn_cast(
+              base_command_buffer,
+              &iree_hal_vulkan_direct_command_buffer_vtable);
   return command_buffer->handle;
 }
 
@@ -770,6 +788,7 @@ static iree_status_t iree_hal_vulkan_direct_command_buffer_dispatch_indirect(
 const iree_hal_command_buffer_vtable_t
     iree_hal_vulkan_direct_command_buffer_vtable = {
         /*.destroy=*/iree_hal_vulkan_direct_command_buffer_destroy,
+        /*.dyn_cast=*/iree_hal_vulkan_direct_command_buffer_dyn_cast,
         /*.mode=*/
         iree_hal_vulkan_direct_command_buffer_mode,
         /*.allowed_categories=*/

--- a/iree/hal/vulkan/direct_command_buffer.h
+++ b/iree/hal/vulkan/direct_command_buffer.h
@@ -34,6 +34,10 @@ iree_status_t iree_hal_vulkan_direct_command_buffer_allocate(
 VkCommandBuffer iree_hal_vulkan_direct_command_buffer_handle(
     iree_hal_command_buffer_t* command_buffer);
 
+// Returns true if |command_buffer| is a Vulkan command buffer.
+bool iree_hal_vulkan_direct_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/task/worker.c
+++ b/iree/task/worker.c
@@ -264,6 +264,9 @@ static bool iree_task_worker_pump_once(
   // in one doesn't bring down the whole system we pretend we executed
   // something here by falling through.
   IREE_ASSERT_TRUE(iree_status_is_ok(status));
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+  }
   iree_status_ignore(status);
 
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
It's almost always worth having on but size constrained configs can disable it in release builds/etc.
To support this command buffers gain a dyn_cast that allows for shimming them at runtime.
Future changes will enable this for iree_hal_allocator_t as well and then we can decide if we want
to do it for everything (could be used for statistics/reporting on executables, buffers, etc).

We may want to eventually inline the validation and always run it - it does add code size and overhead
that we may not always want to include in tiny/static builds. There are ways to mitigate that but for
now the flexibility at the cost of an extra function pointer and easily predicted indirection is a good
tradeoff for the quality of life improvement the validation error messages give.

Fixes #7463.