### PR TITLE
Remove system linker hacks to see what breaks.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
@@ -122,12 +122,7 @@ class AndroidLinkerTool : public LinkerTool {
 
         // Statically link all dependencies so we don't have any runtime deps.
         // We cannot have any imports in the module we produce.
-        // "-static",
-
-        // HACK: we insert mallocs and junk. This is *not good*.
-        // We should be statically linking and not require anything from libc.
-        "-shared",
-        "-lc",
+        "-static",
 
         // Currently we are emitting calls to libm (expf, cosf, etc). We ideally
         // should not be doing this - those functions are all generally terrible

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/RiscvLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/RiscvLinkerTool.cpp
@@ -71,13 +71,7 @@ class RiscvLinkerTool : public LinkerTool {
 
     // Statically link all dependencies so we don't have any runtime deps.
     // We cannot have any imports in the module we produce.
-    // flags.push_back("-static");
-
-    // HACK: we insert mallocs and libm calls. This is *not good*.
-    // We need hermetic binaries that pull in no imports; the MLIR LLVM
-    // lowering paths introduce a bunch, though, so this is what we are
-    // stuck with.
-    flags.push_back("-shared");
+    flags.push_back("-static");
 
     // Strip debug information (only, no relocations) when not requested.
     if (!targetOptions.debugSymbols) {

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -65,11 +65,6 @@ class UnixLinkerTool : public LinkerTool {
       flags.push_back(
           "-L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib "
           "-lSystem");
-
-      // HACK: we insert libm calls. This is *not good*.
-      // Until the MLIR LLVM lowering paths no longer introduce these,
-      // we are stuck with this.
-      flags.push_back("-undefined suppress");
     } else {
       // Avoids including any libc/startup files that initialize the CRT as
       // we don't use any of that. Our shared libraries must be freestanding.
@@ -77,14 +72,7 @@ class UnixLinkerTool : public LinkerTool {
 
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
-      // flags.push_back("-static");
-
-      // HACK: we insert mallocs and libm calls. This is *not good*.
-      // We need hermetic binaries that pull in no imports; the MLIR LLVM
-      // lowering paths introduce a bunch, though, so this is what we are
-      // stuck with.
-      flags.push_back("-shared");
-      flags.push_back("-undefined suppress");
+      flags.push_back("-static");
     }
 
     // Strip debug information (only, no relocations) when not requested.

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -82,10 +82,6 @@ class WasmLinkerTool : public LinkerTool {
         // entry symbol not defined (pass --no-entry to suppress): _start
         "--no-entry",
 
-        // Allow undefined symbols, provided by the runtime environment (?)
-        // TODO(scotttodd): figure out how to avoid this.
-        "--allow-undefined",
-
         // Treat warnings as errors.
         "--fatal-warnings",
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
@@ -113,7 +113,7 @@ class WindowsLinkerTool : public LinkerTool {
         // Builds a DLL and exports functions with the dllexport storage class.
         "/dll",
 
-        // Forces a fixed timestamp to ensure files are reproducable across
+        // Forces a fixed timestamp to ensure files are reproducible across
         // builds. Undocumented but accepted by both link and lld-link.
         // https://blog.conan.io/2019/09/02/Deterministic-builds-with-C-C++.html
         "/Brepro",


### PR DESCRIPTION
Another piece of https://github.com/google/iree/issues/4717 (that may be harder to fix after embedded linking is used by default: https://github.com/google/iree/pull/7372)