### PR TITLE
Align Vulkan allocs to 4 bytes, fixing unaligned fill edge cases.

### DIFF
--- a/iree/hal/cts/command_buffer_test.cc
+++ b/iree/hal/cts/command_buffer_test.cc
@@ -254,7 +254,32 @@ TEST_P(CommandBufferTest, CopySubBuffer) {
   iree_hal_buffer_release(host_buffer);
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length1) {
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size1_offset0_length1) {
+  iree_device_size_t buffer_size = 1;
+  iree_device_size_t target_offset = 0;
+  iree_device_size_t fill_length = 1;
+  uint8_t pattern = 0x07;
+  std::vector<uint8_t> reference_buffer{0x07};
+  std::vector<uint8_t> actual_buffer =
+      RunFillBufferTest(buffer_size, target_offset, fill_length,
+                        (void*)&pattern, sizeof(pattern));
+  EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
+}
+
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size5_offset0_length5) {
+  iree_device_size_t buffer_size = 5;
+  iree_device_size_t target_offset = 0;
+  iree_device_size_t fill_length = 5;
+  uint8_t pattern = 0x07;
+  std::vector<uint8_t> reference_buffer{0x07, 0x07, 0x07, 0x07,  //
+                                        0x07};
+  std::vector<uint8_t> actual_buffer =
+      RunFillBufferTest(buffer_size, target_offset, fill_length,
+                        (void*)&pattern, sizeof(pattern));
+  EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
+}
+
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size16_offset0_length1) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 1;
@@ -269,7 +294,7 @@ TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length1) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length3) {
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size16_offset0_length3) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 3;
@@ -284,7 +309,7 @@ TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length3) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length8) {
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size16_offset0_length8) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 8;
@@ -299,7 +324,7 @@ TEST_P(CommandBufferTest, FillBuffer_pattern1_offset0_length8) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern1_offset2_length8) {
+TEST_P(CommandBufferTest, FillBuffer_pattern1_size16_offset2_length8) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 2;
   iree_device_size_t fill_length = 8;
@@ -314,7 +339,19 @@ TEST_P(CommandBufferTest, FillBuffer_pattern1_offset2_length8) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern2_offset0_length8) {
+TEST_P(CommandBufferTest, FillBuffer_pattern2_size2_offset0_length2) {
+  iree_device_size_t buffer_size = 2;
+  iree_device_size_t target_offset = 0;
+  iree_device_size_t fill_length = 2;
+  uint16_t pattern = 0xAB23;
+  std::vector<uint8_t> reference_buffer{0x23, 0xAB};
+  std::vector<uint8_t> actual_buffer =
+      RunFillBufferTest(buffer_size, target_offset, fill_length,
+                        (void*)&pattern, sizeof(pattern));
+  EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
+}
+
+TEST_P(CommandBufferTest, FillBuffer_pattern2_size16_offset0_length8) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 8;
@@ -329,7 +366,7 @@ TEST_P(CommandBufferTest, FillBuffer_pattern2_offset0_length8) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern2_offset0_length10) {
+TEST_P(CommandBufferTest, FillBuffer_pattern2_size16_offset0_length10) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 10;
@@ -344,7 +381,7 @@ TEST_P(CommandBufferTest, FillBuffer_pattern2_offset0_length10) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern2_offset2_length8) {
+TEST_P(CommandBufferTest, FillBuffer_pattern2_size16_offset2_length8) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 2;
   iree_device_size_t fill_length = 8;
@@ -359,7 +396,19 @@ TEST_P(CommandBufferTest, FillBuffer_pattern2_offset2_length8) {
   EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
 }
 
-TEST_P(CommandBufferTest, FillBuffer_pattern4_offset0_length8) {
+TEST_P(CommandBufferTest, FillBuffer_pattern4_size4_offset0_length4) {
+  iree_device_size_t buffer_size = 4;
+  iree_device_size_t target_offset = 0;
+  iree_device_size_t fill_length = 4;
+  uint32_t pattern = 0xAB23CD45;
+  std::vector<uint8_t> reference_buffer{0x45, 0xCD, 0x23, 0xAB};
+  std::vector<uint8_t> actual_buffer =
+      RunFillBufferTest(buffer_size, target_offset, fill_length,
+                        (void*)&pattern, sizeof(pattern));
+  EXPECT_THAT(actual_buffer, ContainerEq(reference_buffer));
+}
+
+TEST_P(CommandBufferTest, FillBuffer_pattern4_size16_offset0_length8) {
   iree_device_size_t buffer_size = 16;
   iree_device_size_t target_offset = 0;
   iree_device_size_t fill_length = 8;

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -236,12 +236,15 @@ static iree_status_t iree_hal_vulkan_vma_allocator_make_compatible(
 static iree_status_t iree_hal_vulkan_vma_allocator_allocate_internal(
     iree_hal_vulkan_vma_allocator_t* allocator,
     iree_hal_memory_type_t memory_type, iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_memory_access_t allowed_access, size_t allocation_size,
+    iree_hal_memory_access_t allowed_access, iree_host_size_t allocation_size,
     VmaAllocationCreateFlags flags, iree_hal_buffer_t** out_buffer) {
   // Guard against the corner case where the requested buffer size is 0. The
   // application is unlikely to do anything when requesting a 0-byte buffer; but
   // it can happen in real world use cases. So we should at least not crash.
   if (allocation_size == 0) allocation_size = 4;
+  // Align allocation sizes to 4 bytes so shaders operating on 32 bit types can
+  // act safely even on buffer ranges that are not naturally aligned.
+  allocation_size = iree_host_align(allocation_size, 4);
 
   VkBufferCreateInfo buffer_create_info;
   buffer_create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;


### PR DESCRIPTION
I'm not sure if there is a better way to handle this, but I was observing that a 1 byte buffer would fail all writes in the polyfilled shader (even hardcoding a write into `output_elements[0]` would do nothing). `vkCmdFillBuffer`, however, _did_ correctly write into buffers of that size. By aligning the underlying buffer allocations to 4 bytes, the polyfilled shader can now write into the only byte in a 1 byte buffer, the trailing byte in a 5 byte buffer, etc.

I missed this edge case when working on https://github.com/google/iree/issues/7228.
This fixes the issues I noticed on https://github.com/google/iree/pull/7370#discussion_r732949146.