### PR TITLE
Roll forward "Don't outline splat constants."

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -769,15 +769,6 @@ void TensorSplatOp::getCanonicalizationPatterns(
   results.insert<FoldSplatReshapeIntoSplat>(context);
 }
 
-OpFoldResult TensorSplatOp::fold(ArrayRef<Attribute> operands) {
-  if (operands.size() == 1 && operands.front()) {
-    // Splat value is constant and we can fold the operation.
-    return SplatElementsAttr::get(result().getType().cast<ShapedType>(),
-                                  operands[0]);
-  }
-  return {};
-}
-
 OpFoldResult TensorCloneOp::fold(ArrayRef<Attribute> operands) {
   if (operands[0]) {
     // Constants always fold.

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -839,7 +839,6 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
   }];
 
   let hasCanonicalizer = 1;
-  let hasFolder = 1;
 }
 
 def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -154,28 +154,6 @@ func @storeConstScalar() -> tensor<i32> {
 
 // -----
 
-// CHECK-LABEL: @splatConst
-func @splatConst() -> tensor<4xi32> {
-  %0 = arith.constant 4 : i32
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<4> : tensor<4xi32>
-  %1 = flow.tensor.splat %0 : tensor<4xi32>
-  // CHECK-NEXT: return %[[C]]
-  return %1 : tensor<4xi32>
-}
-
-// -----
-
-// CHECK-LABEL: @splatConstScalar
-func @splatConstScalar() -> tensor<i32> {
-  %0 = arith.constant 4 : i32
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<4> : tensor<i32>
-  %1 = flow.tensor.splat %0 : tensor<i32>
-  // CHECK-NEXT: return %[[C]]
-  return %1 : tensor<i32>
-}
-
-// -----
-
 // CHECK-LABEL: @splatDynamicShape
 //  CHECK-SAME: (%[[DIM0:.+]]: index, %[[DIM1:.+]]: index)
 func @splatDynamicShape(%dim0: index, %dim1: index) -> tensor<?x?xi32> {

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -131,12 +131,8 @@ createPadLinalgOpsToIntegerMultiplePass(int paddingSize = 4);
 //===----------------------------------------------------------------------===//
 
 // Outlines large tensor constants into util.globals at the module level.
-//
-// TODO(#5493): implement the support for inlining constants into the command
-// buffer and raise this value to one that is measured to be good.
-static constexpr size_t kMinLargeConstantSize = 1;
-std::unique_ptr<OperationPass<mlir::ModuleOp>> createOutlineLargeConstantsPass(
-    size_t minLargeConstantSize = kMinLargeConstantSize);
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createOutlineLargeConstantsPass();
 
 // Deduplicates equivalent executables.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -102,8 +102,12 @@ def OutlineDispatchRegions :
 def OutlineLargeConstants :
     Pass<"iree-flow-outline-large-constants", "mlir::ModuleOp"> {
   let summary = "Outlines large tensor constants into util.globals at the module level.";
-  // TODO(#5493): add a flag for this.
-  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineLargeConstantsPass(25)";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineLargeConstantsPass()";
+  let options = [
+    Option<"minStorageSize", "min-storage-size",
+           "int64_t", /*default=*/"64",
+           "Outlines constants with storage sizes > than this byte size.">
+  ];
 }
 
 def PadLinalgOps :

--- a/iree/compiler/Dialect/Flow/Transforms/test/outline_large_constants.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/outline_large_constants.mlir
@@ -1,10 +1,12 @@
-// RUN: iree-opt -split-input-file -iree-flow-outline-large-constants %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-flow-outline-large-constants='min-storage-size=9' %s | IreeFileCheck %s
 
-// CHECK: util.global private @[[LARGE_VARIABLE:.+]] {noinline} = dense<1.200000e+00> : tensor<512x128xf32>
-func @fn1() -> (tensor<2xf32>, tensor<512x128xf32>) {
+// CHECK: util.global private @[[LARGE_VARIABLE:.+]] {noinline} = dense<{{.+}}> : tensor<8xf32>
+func @fn1() -> (tensor<2xf32>, tensor<512x128xf32>, tensor<8xf32>) {
   // CHECK-DAG: %[[SMALL_VALUE:.+]] = arith.constant dense<{{.+}}> : tensor<2xf32>
   %cst_0 = arith.constant dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
-  // CHECK-DAG: %[[LARGE_VALUE:.+]] = util.global.load @[[LARGE_VARIABLE]] : tensor<512x128xf32>
+  // CHECK-DAG: %[[SPLATG_VALUE:.+]] = arith.constant dense<{{.+}}> : tensor<512x128xf32>
   %cst_1 = arith.constant dense<1.2> : tensor<512x128xf32>
-  return %cst_0, %cst_1 : tensor<2xf32>, tensor<512x128xf32>
+  // CHECK-DAG: %[[LARGE_VALUE:.+]] = util.global.load @[[LARGE_VARIABLE]] : tensor<8xf32>
+  %cst_2 = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]> : tensor<8xf32>
+  return %cst_0, %cst_1, %cst_2 : tensor<2xf32>, tensor<512x128xf32>, tensor<8xf32>
 }


### PR DESCRIPTION
This reverts commit c4e0f3b01a874e1bb0b3d3b71d54d5b70f3129e6 to roll forward https://github.com/google/iree/pull/6816, now that https://github.com/google/iree/pull/7370 has landed and unaligned buffer fills are supported by the compiler and runtime.

I tested this sequence of changes with the person_detect program mentioned at https://github.com/google/iree/pull/7370#issuecomment-952379671 and https://github.com/google/iree/pull/7462#issuecomment-952332376, but we don't yet have complete test coverage in the main IREE repo.