### PR TITLE
Avoid using Bazel in the Buildkite Android pipeline

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -7,7 +7,8 @@
 steps:
   - label: "build"
     commands:
-      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/android@sha256:58adb4131cfc7b08cd5767c577420f3479ca2f46bb67d9fac6c0797984627758 build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh arm64-v8a"
+      - "./scripts/git/submodule_versions.py init"
+      - "docker run --user=$(id -u):$(id -g) --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/android@sha256:58adb4131cfc7b08cd5767c577420f3479ca2f46bb67d9fac6c0797984627758 build_tools/cmake/build_android.sh arm64-v8a"
       - "tar --exclude='*.o' --exclude='*.a' -czvf build-artifacts.tgz build-android"
     agents:
       - "queue=build"

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2020 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -20,30 +20,18 @@ fi
 
 ANDROID_ABI=$1
 
-CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+ROOT_DIR=$(git rev-parse --show-toplevel)
 
+CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
 "${CMAKE_BIN}" --version
 "${CC}" --version
 "${CXX}" --version
 ninja --version
-echo "Android NDK path: ${ANDROID_NDK}"
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
-cd ${ROOT_DIR}
-
-# BUILD the iree-import-tflite binary for importing models to benchmark from
-# TFLite flatbuffers.
-cd "${ROOT_DIR}/integrations/tensorflow"
-BAZEL_CMD=(bazel --noworkspace_rc --bazelrc=build_tools/bazel/iree-tf.bazelrc)
-BAZEL_BINDIR="$(${BAZEL_CMD[@]} info bazel-bin)"
-"${BAZEL_CMD[@]}" build //iree_tf_compiler:iree-import-tflite \
-      --config=generic_clang \
-      --config=remote_cache_tf_integrations
+cd "${ROOT_DIR}"
 
 # --------------------------------------------------------------------------- #
 # Build for the host.
-
-cd "${ROOT_DIR}"
 
 if [ -d "build-host" ]
 then
@@ -61,17 +49,16 @@ cd build-host
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_BENCHMARKS=ON \
-  -DIREE_BUILD_TFLITE_COMPILER=ON \
   -DIREE_BUILD_SAMPLES=OFF
 "${CMAKE_BIN}" --build . --target install
 # Also make sure that we can generate artifacts for benchmarking on Android.
 "${CMAKE_BIN}" --build . --target iree-benchmark-suites
 # --------------------------------------------------------------------------- #
 
+cd "${ROOT_DIR}"
+
 # --------------------------------------------------------------------------- #
 # Build for the target (Android).
-
-cd ${ROOT_DIR}
 
 if [ -d "build-android" ]
 then

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -22,7 +22,7 @@ ANDROID_ABI=$1
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
 "${CMAKE_BIN}" --version
 "${CC}" --version
 "${CXX}" --version

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -49,11 +49,9 @@ cd build-host
   -DIREE_ENABLE_ASSERTIONS=ON \
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
-  -DIREE_BUILD_BENCHMARKS=ON \
+  -DIREE_BUILD_BENCHMARKS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
 "${CMAKE_BIN}" --build . --target install
-# Also make sure that we can generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build . --target iree-benchmark-suites
 # --------------------------------------------------------------------------- #
 
 cd "${ROOT_DIR}"

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -22,9 +22,9 @@ ANDROID_ABI="$1"
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
 
 # Check these exist and print the versions for later debugging
 "${CMAKE_BIN}" --version
@@ -38,7 +38,7 @@ echo "Android NDK path: $ANDROID_NDK"
 echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init
 
-cd ${ROOT_DIR}
+cd "${ROOT_DIR}"
 
 # BUILD the iree-import-tflite binary for importing models to benchmark from
 # TFLite flatbuffers.
@@ -80,7 +80,7 @@ cd build-host
 # --------------------------------------------------------------------------- #
 # Build for the target (Android).
 
-cd ${ROOT_DIR}
+cd "${ROOT_DIR}"
 
 if [ -d "build-android" ]
 then

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -6,31 +6,99 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Cross-compile the project towards Android with CMake using Kokoro.
+# Cross-compile the project towards Android with CMake using Kokoro. First
+# builds the TFLite import binary with Bazel to allow testing the build of
+# benchmarks for Android.
 
-set -e
-set -x
+set -xeuo pipefail
 
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <android-abi>"
   exit 1
 fi
 
-ANDROID_ABI="${1?}"
+ANDROID_ABI="$1"
 
 # Print the UTC time when set -x is on
 export PS4='[$(date -u "+%T %Z")] '
 
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
+
 # Check these exist and print the versions for later debugging
-export CMAKE_BIN="$(which cmake)"
-"${CMAKE_BIN?}" --version
+"${CMAKE_BIN}" --version
+bazel --version
 "${CC?}" --version
 "${CXX?}" --version
 python3 --version
+ninja --version
 echo "Android NDK path: $ANDROID_NDK"
 
 echo "Initializing submodules"
 ./scripts/git/submodule_versions.py init
 
-echo "Cross-compiling with cmake"
-./build_tools/cmake/build_android.sh $ANDROID_ABI
+cd ${ROOT_DIR}
+
+# BUILD the iree-import-tflite binary for importing models to benchmark from
+# TFLite flatbuffers.
+cd "${ROOT_DIR}/integrations/tensorflow"
+BAZEL_CMD=(bazel --noworkspace_rc --bazelrc=build_tools/bazel/iree-tf.bazelrc)
+BAZEL_BINDIR="$(${BAZEL_CMD[@]} info bazel-bin)"
+"${BAZEL_CMD[@]}" build //iree_tf_compiler:iree-import-tflite \
+      --config=generic_clang # \
+      # --config=remote_cache_tf_integrations
+
+# --------------------------------------------------------------------------- #
+# Build for the host.
+
+cd "${ROOT_DIR}"
+
+if [ -d "build-host" ]
+then
+  echo "build-host directory already exists. Will use cached results there."
+else
+  echo "build-host directory does not already exist. Creating a new one."
+  mkdir build-host
+fi
+cd build-host
+
+# Configure, build, install.
+"${CMAKE_BIN}" -G Ninja .. \
+  -DCMAKE_INSTALL_PREFIX=./install \
+  -DIREE_ENABLE_ASSERTIONS=ON \
+  -DIREE_BUILD_COMPILER=ON \
+  -DIREE_BUILD_TESTS=OFF \
+  -DIREE_BUILD_BENCHMARKS=ON \
+  -DIREE_BUILD_TFLITE_COMPILER=ON \
+  -DIREE_BUILD_SAMPLES=OFF
+"${CMAKE_BIN}" --build . --target install
+# Also make sure that we can generate artifacts for benchmarking on Android.
+"${CMAKE_BIN}" --build . --target iree-benchmark-suites
+# --------------------------------------------------------------------------- #
+
+# --------------------------------------------------------------------------- #
+# Build for the target (Android).
+
+cd ${ROOT_DIR}
+
+if [ -d "build-android" ]
+then
+  echo "build-android directory already exists. Will use cached results there."
+else
+  echo "build-android directory does not already exist. Creating a new one."
+  mkdir build-android
+fi
+cd build-android
+
+# Configure towards 64-bit Android 10, then build.
+"${CMAKE_BIN}" -G Ninja .. \
+  -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
+  -DANDROID_ABI="${ANDROID_ABI}" \
+  -DANDROID_PLATFORM=android-29 \
+  -DIREE_HOST_BINARY_ROOT="${PWD}/../build-host/install" \
+  -DIREE_ENABLE_ASSERTIONS=ON \
+  -DIREE_BUILD_COMPILER=OFF \
+  -DIREE_BUILD_TESTS=ON \
+  -DIREE_BUILD_SAMPLES=OFF
+"${CMAKE_BIN}" --build .


### PR DESCRIPTION
Turns out the Buildkite Android build was using a script under the
Kokoro directory. https://github.com/google/iree/pull/7494 switched
that script to build the TFLite importer with Bazel to allow verifying
that we can build benchmark artifacts for Android (the least-bad option
available at the moment, see
https://github.com/google/iree/pull/7494#issuecomment-959710770). We
don't want to be doing that as part of the Buildkite pipeline though.
So we pull the Bazel stuff into the Kokoro script and make the
Buildkite pipeline not use it.