### PR TITLE
Fix or suppress tablegen unused template warnings

### DIFF
--- a/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -184,7 +184,7 @@ def Util_GlobalRefAttr : Confined<FlatSymbolRefAttr, [
 def Util_AnyGlobalPtr : TypeAlias<Util_AnyPtr>;
 // TODO(benvanik): actually implement Util_GlobalPtrOf.
 class Util_GlobalPtrOf<list<Type> types> : TypeAlias<Util_AnyPtr> {
-  // Suppresse
+  // Suppress unused template argument warning.
   int unused = !size(types);
 }
 

--- a/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -183,7 +183,10 @@ def Util_GlobalRefAttr : Confined<FlatSymbolRefAttr, [
 
 def Util_AnyGlobalPtr : TypeAlias<Util_AnyPtr>;
 // TODO(benvanik): actually implement Util_GlobalPtrOf.
-class Util_GlobalPtrOf<list<Type> types> : TypeAlias<Util_AnyPtr>;
+class Util_GlobalPtrOf<list<Type> types> : TypeAlias<Util_AnyPtr> {
+  // Suppresse
+  int unused = !size(types);
+}
 
 //===----------------------------------------------------------------------===//
 // Buffer types

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -552,7 +552,7 @@ class VM_GlobalStoreIndirectPrimitiveOp<Type type, string mnemonic,
   }];
 
   let encoding = [
-    VM_EncOpcode<VM_OPC_GlobalStoreIndirectI64>,
+    VM_EncOpcode<opcode>,
     VM_EncOperand<"global", 0>,
     VM_EncOperand<"value", 1>,
   ];


### PR DESCRIPTION
This was added in https://reviews.llvm.org/D109359 and is showing up as
log spam. Looks like it caught a real bug though!