### PR TITLE
Adding -iree-stream-propagate-timepoints pass.

### DIFF
--- a/iree/compiler/Dialect/Stream/Transforms/BUILD
+++ b/iree/compiler/Dialect/Stream/Transforms/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "OutlineConstants.cpp",
         "PassDetail.h",
         "Passes.cpp",
+        "PropagateTimepoints.cpp",
         "RefineUsage.cpp",
         "ScheduleConcurrency.cpp",
         "ScheduleExecution.cpp",

--- a/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     "OutlineConstants.cpp"
     "PassDetail.h"
     "Passes.cpp"
+    "PropagateTimepoints.cpp"
     "RefineUsage.cpp"
     "ScheduleConcurrency.cpp"
     "ScheduleExecution.cpp"

--- a/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -147,6 +147,17 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
       IREE::Stream::createScheduleConcurrencyPass());
   passManager.addNestedPass<mlir::FuncOp>(
       IREE::Stream::createScheduleConcurrencyPass());
+
+  // Materialize timepoints across the entire module. This simplifies scheduling
+  // of the timeline as we can shake the IR and see what timepoints we still
+  // have left.
+  passManager.addPass(IREE::Stream::createPropagateTimepointsPass());
+  addCleanupPatterns(passManager);
+
+  // TODO(benvanik): remove covered timepoints in awaits (dominance).
+
+  // Everything must now be in stream.async.* form.
+  passManager.addPass(IREE::Stream::createVerifyLoweringToAsyncPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Stream/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Stream/Transforms/Passes.h
@@ -95,6 +95,8 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createRefineUsagePass();
 std::unique_ptr<OperationPass<>> createScheduleExecutionPass();
 std::unique_ptr<OperationPass<>> createScheduleConcurrencyPass();
 
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateTimepointsPass();
+
 //===----------------------------------------------------------------------===//
 // Diagnostics
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -89,6 +89,14 @@ def ScheduleConcurrency :
   }];
 }
 
+def PropagateTimepoints :
+    Pass<"iree-stream-propagate-timepoints", "mlir::ModuleOp"> {
+  let summary = "Materializes timepoints and sinks them to consumers throughout the whole program.";
+  let constructor = [{
+    mlir::iree_compiler::IREE::Stream::createPropagateTimepointsPass()
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Diagnostics
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -1,0 +1,604 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <utility>
+
+#include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/Transforms/Patterns.h"
+#include "llvm/ADT/BreadthFirstIterator.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Pass/Pass.h"
+
+#define DEBUG_TYPE "iree-stream-propagate-timepoints"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Stream {
+namespace {
+
+// TODO(benvanik): factor out into a generic util pass base that lets us share
+// with other expanded type propagation passes. The walking of
+// functions/blocks/globals/etc are the same across all of them and only the
+// exact type expansion and consumption/query ops differ.
+
+//===----------------------------------------------------------------------===//
+// Global handling
+//===----------------------------------------------------------------------===//
+
+struct ExpandedGlobal {
+  IREE::Util::GlobalOp resourceOp;
+  IREE::Util::GlobalOp timepointOp;
+};
+using ExpandedGlobalMap = DenseMap<StringRef, ExpandedGlobal>;
+
+// Expands each !stream.resource global in |rootOp| to have a matching
+// timepoint. Does not behave optimally if there already exist timepoint globals
+// as duplicates will get added and we'll need to rely on global fusion to
+// get rid of them. Note that this only expands globals and does not yet update
+// use sites - we just need the ops to reference while doing so.
+static ExpandedGlobalMap expandResourceGlobals(Operation *rootOp) {
+  ExpandedGlobalMap expandedGlobals;
+
+  // Gather all of the resource globals in the root.
+  for (auto &region : rootOp->getRegions()) {
+    for (auto globalOp : region.getOps<IREE::Util::GlobalOp>()) {
+      if (!globalOp.type().isa<IREE::Stream::ResourceType>()) continue;
+      expandedGlobals[globalOp.getName()].resourceOp = globalOp;
+    }
+  }
+
+  // Expand each global by adding the timepoint right next to it.
+  SymbolTable symbolTable(rootOp);
+  auto timepointType = IREE::Stream::TimepointType::get(rootOp->getContext());
+  auto immediateAttr =
+      IREE::Stream::TimepointAttr::get(rootOp->getContext(), timepointType);
+  for (auto &it : expandedGlobals) {
+    auto resourceOp = it.second.resourceOp;
+    OpBuilder builder(resourceOp);
+    auto timepointName = (resourceOp.getName() + "__timepoint").str();
+    auto timepointOp = builder.create<IREE::Util::GlobalOp>(
+        resourceOp.getLoc(), timepointName,
+        /*isMutable=*/true, timepointType, immediateAttr);
+    timepointOp.setVisibility(resourceOp.getVisibility());
+    symbolTable.insert(timepointOp);
+    it.second.timepointOp = timepointOp;
+  }
+
+  return expandedGlobals;
+}
+
+//===----------------------------------------------------------------------===//
+// Structural IR rewriting patterns
+//===----------------------------------------------------------------------===//
+
+static bool isResourceType(Type type) {
+  return type.isa<IREE::Stream::ResourceType>();
+}
+
+// Returns true if an operands or results of |op| use !stream.resources.
+static bool usesResources(Operation *op) {
+  return llvm::any_of(op->getOperandTypes(), isResourceType) ||
+         llvm::any_of(op->getResultTypes(), isResourceType);
+}
+
+// Expands resources in the given |types| list to (timepoint, resource).
+// This could be changed to some iterator magic to avoid the alloc.
+static SmallVector<Type> expandTypes(TypeRange types) {
+  if (types.empty()) return {};
+  auto timepointType =
+      IREE::Stream::TimepointType::get(types.front().getContext());
+  SmallVector<Type> newTypes;
+  newTypes.reserve(types.size() * 2);
+  for (auto type : types) {
+    if (isResourceType(type)) {
+      newTypes.push_back(timepointType);
+    }
+    newTypes.push_back(type);
+  }
+  return newTypes;
+}
+
+// Attempts to find and consume the timepoint associated with |value|.
+// Returns a (timepoint, resource) pair where the timepoint indicates when the
+// resource - which may differ from the provided |value| - is ready. In cases
+// where no associated timepoint was found the timepoint will be immediate.
+static std::pair<Value, Value> consumeTimepoint(
+    Location loc, Value value, BlockAndValueMapping &resourceTimepointMap,
+    OpBuilder &builder) {
+  // TODO(benvanik): follow ties on value to try to consume there; there are a
+  // few other ops we could look through as well (such as select, where we could
+  // join). For now we just look at immediate defining ops.
+  auto timepoint = resourceTimepointMap.lookupOrNull(value);
+  if (timepoint) {
+    return std::make_pair(timepoint, value);
+  }
+
+  if (auto awaitOp = dyn_cast_or_null<IREE::Stream::TimepointAwaitOp>(
+          value.getDefiningOp())) {
+    return std::make_pair(awaitOp.timepoint(),
+                          awaitOp.getTiedResultOperand(value));
+  } else if (auto executeOp = dyn_cast_or_null<IREE::Stream::AsyncExecuteOp>(
+                 value.getDefiningOp())) {
+    return std::make_pair(executeOp.result_timepoint(), value);
+  } else {
+    return std::make_pair(
+        builder.create<IREE::Stream::TimepointImmediateOp>(loc).getResult(),
+        value);
+  }
+}
+
+// Expands resources in |operands| into (timepoint, resource) pairs.
+static SmallVector<Value> expandOperands(
+    Location loc, ValueRange operands,
+    BlockAndValueMapping &resourceTimepointMap, OpBuilder &builder) {
+  SmallVector<Value> result;
+  result.reserve(operands.size() * 2);
+  for (auto operand : operands) {
+    if (isResourceType(operand.getType())) {
+      auto timepointOperand =
+          consumeTimepoint(loc, operand, resourceTimepointMap, builder);
+      result.push_back(timepointOperand.first);
+      result.push_back(timepointOperand.second);
+    } else {
+      result.push_back(operand);
+    }
+  }
+  return result;
+}
+
+static void expandTimepoints(Operation *op, ExpandedGlobalMap &globalMap,
+                             BlockAndValueMapping &resourceTimepointMap);
+
+// Finds the size of a block argument resource or materializes a size if needed.
+// The returned SSA value will be valid at the insertion point (by way of clones
+// or other trickery required to make it so).
+static Value makeBlockArgResourceSize(Location loc, Value resourceValue,
+                                      OpBuilder &builder) {
+  // We can take any implicitly captured SSA values.
+  if (auto sizeAwareOp = dyn_cast_or_null<IREE::Util::SizeAwareOpInterface>(
+          resourceValue.getDefiningOp())) {
+    auto sizeValue = sizeAwareOp.getResultSizeFromValue(resourceValue);
+    if (sizeValue) return sizeValue;
+  }
+
+  // Try first to scan uses in the IR. Since we carry the shape in most ops we
+  // are likely to find at least some SSA value we can inspect.
+  for (auto &use : resourceValue.getUses()) {
+    auto sizeAwareOp =
+        dyn_cast<IREE::Util::SizeAwareOpInterface>(use.getOwner());
+    if (!sizeAwareOp) continue;
+    auto sizeValue = sizeAwareOp.getOperandSize(use.getOperandNumber());
+    if (!sizeValue) continue;
+    if (sizeValue.getParentRegion()->isProperAncestor(
+            builder.getInsertionBlock()->getParent())) {
+      // Size value found and implicitly captured; we can reuse (could be
+      // a parent block argument, a constant, computed, etc).
+      return sizeValue;
+    } else if (auto blockArg = sizeValue.dyn_cast<BlockArgument>()) {
+      if (blockArg.getParentBlock()->isEntryBlock()) {
+        // Dynamic dimension passed in to the entry block; safe to use.
+        return sizeValue;
+      }
+    } else if (sizeValue.getDefiningOp() &&
+               sizeValue.getDefiningOp()->hasTrait<OpTrait::ConstantLike>()) {
+      // Constant op - duplicate at the builder location so we don't have to
+      // worry about SSA dominance issues. CSE will clean up the dupes later.
+      return builder.clone(*sizeValue.getDefiningOp())->getResult(0);
+    }
+    // Uninspectable value.
+  }
+
+  // If we couldn't find anything we could use we'll insert the size query. The
+  // hope is that more program analysis could take care of this for us.
+  return builder.create<IREE::Stream::ResourceSizeOp>(loc, resourceValue);
+}
+
+// Recursively expands resources into (timepoint, resource) pairs within the
+// given |region|. All branches, ops, and nested regions will be processed.
+static void expandRegion(Region &region, ExpandedGlobalMap &globalMap,
+                         BlockAndValueMapping resourceTimepointMap) {
+  // Update all block arguments.
+  auto timepointType = IREE::Stream::TimepointType::get(region.getContext());
+  for (auto &block : region.getBlocks()) {
+    if (!llvm::any_of(block.getArgumentTypes(), isResourceType)) continue;
+
+    // Insert and build a list of expanded (timepoint, resource) pairs.
+    SmallVector<std::pair<Value, Value>> expansions;
+    for (int i = block.getNumArguments() - 1; i >= 0; --i) {
+      auto resourceArg = block.getArgument(i);
+      if (!isResourceType(resourceArg.getType())) continue;
+      auto timepointArg = block.insertArgument(i, timepointType);
+      expansions.push_back(std::make_pair(timepointArg, resourceArg));
+      resourceTimepointMap.map(resourceArg, timepointArg);
+    }
+
+    // Insert awaits that we've sunk from callers.
+    auto builder = OpBuilder::atBlockBegin(&block);
+    for (auto expansion : expansions) {
+      // If we can look down the chain and see the size then we can use that.
+      // If it's a constant we can't use it as it may be defined anywhere in the
+      // region. Dynamic dimensions usually come from outside or entry arguments
+      // though and those are available.
+      auto timepoint = expansion.first;
+      auto resource = expansion.second;
+      auto resourceSize =
+          makeBlockArgResourceSize(region.getLoc(), resource, builder);
+      auto awaitOp = builder.create<IREE::Stream::TimepointAwaitOp>(
+          region.getLoc(), resource, resourceSize, timepoint);
+      resource.replaceAllUsesExcept(awaitOp.results().front(), awaitOp);
+    }
+  }
+
+  // Walk blocks forward in domination order so that we add dominating values to
+  // the timepoint map. Note that DominanceInfo is just determined not to be
+  // cool about things when there's only one block so we have to special case.
+  if (region.hasOneBlock()) {
+    for (auto &op :
+         llvm::make_early_inc_range(region.front().getOperations())) {
+      expandTimepoints(&op, globalMap, resourceTimepointMap);
+    }
+  } else {
+    DominanceInfo domInfo(region.getParentOp());
+    for (auto *blockInfo : llvm::breadth_first(domInfo.getRootNode(&region))) {
+      auto *block = blockInfo->getBlock();
+      for (auto &op : llvm::make_early_inc_range(block->getOperations())) {
+        expandTimepoints(&op, globalMap, resourceTimepointMap);
+      }
+    }
+  }
+}
+
+// Moves awaits from global stores to loads.
+// Requires that the ExpandGlobalStoreOp pattern elides the await.
+//
+// Example:
+//  %0 = util.global.load @foo : !stream.resource
+//  ->
+//  %t = util.global.load @foo : !stream.timepoint
+//  %0 = util.global.load @foo : !stream.resource
+//  %1 = stream.timepoint.await %t, %0
+static void expandGlobalLoadOp(IREE::Util::GlobalLoadOp op,
+                               ExpandedGlobalMap &globalMap,
+                               BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+  OpBuilder builder(op);
+  auto &expandedGlobal = globalMap[op.global()];
+  auto timepoint =
+      builder
+          .create<IREE::Util::GlobalLoadOp>(
+              op.getLoc(), IREE::Stream::TimepointType::get(op.getContext()),
+              expandedGlobal.timepointOp.getName())
+          .result();
+  resourceTimepointMap.map(op.result(), timepoint);
+
+  // HACK: queryValueSize may insert other ops that we don't want to replace.
+  // TODO(benvanik): carry the size so we don't need to guess here.
+  SmallPtrSet<Operation *, 2> replacementExceptions;
+  builder.setInsertionPointAfter(op);
+  auto resultSize = IREE::Util::SizeAwareTypeInterface::queryValueSize(
+      op.getLoc(), op.result(), builder);
+  if (!resultSize) {
+    auto sizeOp =
+        builder.create<IREE::Stream::ResourceSizeOp>(op.getLoc(), op.result());
+    replacementExceptions.insert(sizeOp);
+    resultSize = sizeOp.result();
+  }
+  assert(resultSize && "need to be able to get a size");
+
+  auto awaitOp = builder.create<IREE::Stream::TimepointAwaitOp>(
+      op.getLoc(), op.result(), resultSize, timepoint);
+  replacementExceptions.insert(awaitOp);
+
+  op.result().replaceAllUsesExcept(awaitOp.results().front(),
+                                   replacementExceptions);
+}
+
+// Moves awaits from global stores to loads.
+// Requires that the ExpandGlobalLoadOp pattern inserts the await.
+//
+// Example:
+//  %1 = stream.timepoint.await %t, %0
+//  util.global.store %1, @foo : !stream.resource
+//  ->
+//  util.global.store %t, @foo_timepoint : !stream.timepoint
+//  util.global.store %0, @foo : !stream.resource
+static void expandGlobalStoreOp(IREE::Util::GlobalStoreOp op,
+                                ExpandedGlobalMap &globalMap,
+                                BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+  OpBuilder builder(op);
+  auto timepointOperand =
+      consumeTimepoint(op.getLoc(), op.value(), resourceTimepointMap, builder);
+  auto &expandedGlobal = globalMap[op.global()];
+  builder.create<IREE::Util::GlobalStoreOp>(
+      op.getLoc(), timepointOperand.first,
+      expandedGlobal.timepointOp.getName());
+  op.valueMutable().assign(timepointOperand.second);
+}
+
+static void expandInitializerOp(IREE::Util::InitializerOp op,
+                                ExpandedGlobalMap &globalMap,
+                                BlockAndValueMapping &resourceTimepointMap) {
+  expandRegion(op.getRegion(), globalMap, resourceTimepointMap);
+}
+
+// Inserts awaits on resource arguments.
+// Requires that the ExpandCallOp/ExpandReturnOp patterns handle migrating the
+// await.
+//
+// NOTE: this needs IPO to remove redundant waits in cases where the call sites
+// don't need a wait.
+//
+// Example:
+//  func @foo(%0: !stream.resource)
+//  ->
+//  func @foo(%t: !stream.timepoint, %0: !stream.resource) {
+//    %1 = stream.timepoint.await %t, %0
+static void expandFuncOp(mlir::FuncOp op, ExpandedGlobalMap &globalMap,
+                         BlockAndValueMapping &resourceTimepointMap) {
+  auto oldType = op.getType();
+  auto inputTypes = expandTypes(oldType.getInputs());
+  auto resultTypes = expandTypes(oldType.getResults());
+  auto newType = FunctionType::get(op.getContext(), inputTypes, resultTypes);
+  if (newType != oldType) {
+    op.setType(newType);
+  }
+  expandRegion(op.getRegion(), globalMap, resourceTimepointMap);
+}
+
+// Splits resource operands and results into (timepoint, resource).
+// Requires that the ExpandFuncOp/ExpandReturnOp patterns handle migrating the
+// await.
+//
+// NOTE: this needs IPO to remove redundant waits in cases where the call sites
+// don't need a wait.
+//
+// Example:
+//  %1 = stream.timepoint.await %t, %0
+//  %r = call @foo(%1)
+//  ->
+//  %rt, %r = call @foo(%t, %0)
+//  stream.timepoint.await %rt, %t
+static void expandCallOp(mlir::CallOp op,
+                         BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+
+  // Build the new call op with expanded operands and results.
+  OpBuilder builder(op);
+  auto operands =
+      expandOperands(op.getLoc(), op.operands(), resourceTimepointMap, builder);
+  auto resultTypes = expandTypes(op.getResultTypes());
+  auto newOp = builder.create<mlir::CallOp>(op.getLoc(), op.callee(),
+                                            resultTypes, operands);
+
+  // Insert awaits on results that we are sinking across the call edge.
+  // The hope is that by moving the awaits here we can fold with uses inside
+  // of this function.
+  builder.setInsertionPointAfter(newOp);
+  unsigned newIdx = 0;
+  for (unsigned oldIdx = 0; oldIdx < op.getNumResults(); ++oldIdx) {
+    auto oldResult = op.getResult(oldIdx);
+    if (!isResourceType(oldResult.getType())) {
+      auto newResult = newOp.getResult(newIdx++);
+      oldResult.replaceAllUsesWith(newResult);
+      continue;
+    }
+    auto newTimepoint = newOp.getResult(newIdx++);
+    auto newResult = newOp.getResult(newIdx++);
+    resourceTimepointMap.map(newResult, newTimepoint);
+    auto newResultSize =
+        builder.create<IREE::Stream::ResourceSizeOp>(op.getLoc(), newResult)
+            .result();
+    auto awaitOp = builder.create<IREE::Stream::TimepointAwaitOp>(
+        op.getLoc(), newResult, newResultSize, newTimepoint);
+    oldResult.replaceAllUsesWith(awaitOp.results().front());
+  }
+
+  op.erase();
+}
+
+// Moves awaits to callers upon return.
+// Requires that the ExpandFuncOp/ExpandCallOp patterns handle migrating the
+// await.
+//
+// Example:
+//  %1 = stream.timepoint.await %t, %0
+//  return %1
+//  ->
+//  return %t, %0
+static void expandReturnOp(mlir::ReturnOp op,
+                           BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+  OpBuilder builder(op);
+  auto operands =
+      expandOperands(op.getLoc(), op.operands(), resourceTimepointMap, builder);
+  builder.create<mlir::ReturnOp>(op.getLoc(), operands);
+  op.erase();
+}
+
+// Moves awaits across branches.
+// Requires that the ExpandFuncOp pattern handles modifying the block args.
+//
+// Example:
+//    %1 = stream.timepoint.await %t, %0
+//    br ^bb1(%1)
+//  ^bb1(%b):
+//  ->
+//    br ^bb1(%t, %0)
+//  ^bb1(%a, %b):
+//    %1 = stream.timepoint.await %a, %b
+static void expandBranchOp(mlir::BranchOp op,
+                           BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+  OpBuilder builder(op);
+  auto operands = expandOperands(op.getLoc(), op.destOperands(),
+                                 resourceTimepointMap, builder);
+  builder.create<mlir::BranchOp>(op.getLoc(), op.dest(), operands);
+  op.erase();
+}
+
+static void expandCondBranchOp(mlir::CondBranchOp op,
+                               BlockAndValueMapping &resourceTimepointMap) {
+  if (!usesResources(op)) return;
+  OpBuilder builder(op);
+  builder.create<mlir::CondBranchOp>(
+      op.getLoc(), op.condition(), op.trueDest(),
+      expandOperands(op.getLoc(), op.trueDestOperands(), resourceTimepointMap,
+                     builder),
+      op.falseDest(),
+      expandOperands(op.getLoc(), op.falseDestOperands(), resourceTimepointMap,
+                     builder));
+  op.erase();
+}
+
+// Tracks timepoints associated with resources based on awaits.
+// By nature of SSA we will encounter these and setup the mapping before any
+// user of the resulting resource performs a lookup, avoiding the need to
+// perform an initial scan to populate the mapping.
+static void expandAwaitOp(IREE::Stream::TimepointAwaitOp op,
+                          BlockAndValueMapping &resourceTimepointMap) {
+  for (auto result : op.results()) {
+    resourceTimepointMap.map(op.getTiedResultOperand(result), op.timepoint());
+  }
+}
+
+// Expands resource operands captured by a stream.async.execute |op| to await
+// on the timepoints of those resources. In the case of back-to-back execution
+// regions this performs the chaining of unreadied results to awaited operands.
+static void expandAsyncExecuteOp(IREE::Stream::AsyncExecuteOp op,
+                                 BlockAndValueMapping &resourceTimepointMap) {
+  OpBuilder builder(op);
+  SetVector<Value> newTimepoints;
+  SmallVector<Value> newOperands;
+  SmallVector<Value> newOperandSizes;
+  if (op.await_timepoint()) {
+    newTimepoints.insert(op.await_timepoint());
+  }
+  for (auto it : llvm::zip(op.operands(), op.operand_sizes())) {
+    auto operand = std::get<0>(it);
+    auto operandSize = std::get<1>(it);
+    auto timepointOperand =
+        consumeTimepoint(op.getLoc(), operand, resourceTimepointMap, builder);
+    if (newTimepoints.insert(timepointOperand.first)) {
+      // Not yet covered; need to add the timepoint.
+      newOperands.push_back(timepointOperand.second);
+      newOperandSizes.push_back(operandSize);
+    } else {
+      // Already covered in the timepoints set on this op, we can go right to
+      // the source.
+      newOperands.push_back(timepointOperand.second);
+      newOperandSizes.push_back(operandSize);
+    }
+  }
+  if (newTimepoints.empty()) {
+    op.await_timepointMutable().clear();
+  } else {
+    Value newTimepoint = builder.createOrFold<IREE::Stream::TimepointJoinOp>(
+        op.getLoc(), builder.getType<IREE::Stream::TimepointType>(),
+        newTimepoints.takeVector());
+    op.await_timepointMutable().assign(newTimepoint);
+  }
+  op.operandsMutable().assign(newOperands);
+  op.operand_sizesMutable().assign(newOperandSizes);
+  for (auto result : op.results()) {
+    resourceTimepointMap.map(result, op.result_timepoint());
+  }
+}
+
+// Recursively expands resources into (timepoint, resource) in |op|.
+// Resource timepoint chains are established when possible by looking through
+// awaits.
+static void expandTimepoints(Operation *op, ExpandedGlobalMap &globalMap,
+                             BlockAndValueMapping &resourceTimepointMap) {
+  if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOp>(op)) {
+    expandGlobalLoadOp(loadOp, globalMap, resourceTimepointMap);
+  } else if (auto storeOp = dyn_cast<IREE::Util::GlobalStoreOp>(op)) {
+    expandGlobalStoreOp(storeOp, globalMap, resourceTimepointMap);
+  } else if (auto initializerOp = dyn_cast<IREE::Util::InitializerOp>(op)) {
+    expandInitializerOp(initializerOp, globalMap, resourceTimepointMap);
+  } else if (auto funcOp = dyn_cast<mlir::FuncOp>(op)) {
+    expandFuncOp(funcOp, globalMap, resourceTimepointMap);
+  } else if (auto callOp = dyn_cast<mlir::CallOp>(op)) {
+    expandCallOp(callOp, resourceTimepointMap);
+  } else if (auto returnOp = dyn_cast<mlir::ReturnOp>(op)) {
+    expandReturnOp(returnOp, resourceTimepointMap);
+  } else if (auto branchOp = dyn_cast<mlir::BranchOp>(op)) {
+    expandBranchOp(branchOp, resourceTimepointMap);
+  } else if (auto condBranchOp = dyn_cast<mlir::CondBranchOp>(op)) {
+    expandCondBranchOp(condBranchOp, resourceTimepointMap);
+  } else if (auto awaitOp = dyn_cast<IREE::Stream::TimepointAwaitOp>(op)) {
+    expandAwaitOp(awaitOp, resourceTimepointMap);
+  } else if (auto executeOp = dyn_cast<IREE::Stream::AsyncExecuteOp>(op)) {
+    expandAsyncExecuteOp(executeOp, resourceTimepointMap);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// -iree-stream-propagate-timepoints
+//===----------------------------------------------------------------------===//
+
+// This does a relatively mechanical transformation of a module to expand all
+// resource values (and globals) into a (timepoint, resource) pair. Ops that
+// consume resources and timepoints attempt to dereference those expanded
+// timepoints and bypass waits, effectively chaining execution across
+// asynchronous ops.
+//
+// This is designed to be composed with generic optimization passes like global
+// fusion/folding and IPO and as such performs all transformations locally. For
+// example, calls are always updated to take/return timepoints and results are
+// always awaited, with the elision/deduplication/etc left until cleanup.
+class PropagateTimepointsPass
+    : public PropagateTimepointsBase<PropagateTimepointsPass> {
+ public:
+  PropagateTimepointsPass() = default;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::StandardOpsDialect>();
+    registry.insert<IREE::Stream::StreamDialect>();
+    registry.insert<IREE::Util::UtilDialect>();
+  }
+
+  void runOnOperation() override {
+    auto rootOp = getOperation();
+
+    // Expand all util.global ops holding resources into (timepoint, resource).
+    auto globalMap = expandResourceGlobals(rootOp);
+
+    // Walk the entire IR tree and expand the globals.
+    // We could do this via pattern application but that gets much trickier to
+    // manage with the expansion as we'd need to prevent ourselves from
+    // expanding multiple times.
+    for (auto callableOp : rootOp.getOps<mlir::CallableOpInterface>()) {
+      BlockAndValueMapping resourceTimepointMap;
+      expandTimepoints(callableOp, globalMap, resourceTimepointMap);
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateTimepointsPass() {
+  return std::make_unique<PropagateTimepointsPass>();
+}
+
+}  // namespace Stream
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Stream/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Stream/Transforms/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "encode_tensors.mlir",
             "materialize_copy_on_write.mlir",
             "outline_constants.mlir",
+            "propagate_timepoints.mlir",
             "refine_usage.mlir",
             "schedule_concurrency.mlir",
             "schedule_execution.mlir",

--- a/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "encode_tensors.mlir"
     "materialize_copy_on_write.mlir"
     "outline_constants.mlir"
+    "propagate_timepoints.mlir"
     "refine_usage.mlir"
     "schedule_concurrency.mlir"
     "schedule_execution.mlir"

--- a/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
@@ -1,0 +1,3 @@
+// RUN: iree-opt -split-input-file -iree-stream-propagate-timepoints %s | IreeFileCheck %s
+
+// CHECK: DO NOT SUBMIT

--- a/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
@@ -1,3 +1,188 @@
 // RUN: iree-opt -split-input-file -iree-stream-propagate-timepoints %s | IreeFileCheck %s
 
-// CHECK: DO NOT SUBMIT
+// Tests that resource global loads pull an unready resource and provide an
+// await with the associated timepoint.
+//
+// This rotates waits through stores and into loads.
+
+// CHECK: util.global private mutable @constantGlobal__timepoint = #stream.timepoint<immediate>
+// CHECK-NEXT: util.global private mutable @constantGlobal : !stream.resource<constant>
+util.global private mutable @constantGlobal : !stream.resource<constant>
+
+// CHECK-LABEL: @globalLoad
+func @globalLoad() {
+  // CHECK-NEXT: %[[TIMEPOINT:.+]] = util.global.load @constantGlobal__timepoint : !stream.timepoint
+  // CHECK-NEXT: %[[UNREADY:.+]] = util.global.load @constantGlobal : !stream.resource<constant>
+  // CHECK-NEXT: %[[SIZE:.+]] = stream.resource.size %[[UNREADY]]
+  // CHECK-NEXT: %[[VALUE:.+]] = stream.timepoint.await %[[TIMEPOINT]] => %[[UNREADY]] : !stream.resource<constant>{%[[SIZE]]}
+  %0 = util.global.load @constantGlobal : !stream.resource<constant>
+  // CHECK-NEXT: util.do_not_optimize(%[[VALUE]])
+  util.do_not_optimize(%0) : !stream.resource<constant>
+  return
+}
+
+// -----
+
+// Tests that resource global stores consume their incoming timepoints.
+// Here the function gets a timepoint + unready resource and we forward that
+// directly into an expanded (timepoint, resource) global.
+//
+// This rotates waits through stores and into loads.
+
+// CHECK: util.global private mutable @mutableGlobal__timepoint = #stream.timepoint<immediate>
+// CHECK-NEXT: util.global private mutable @mutableGlobal : !stream.resource<variable>
+util.global private mutable @mutableGlobal : !stream.resource<variable>
+
+// CHECK-LABEL: @globalStore
+// CHECK-SAME: (%[[TIMEPOINT:.+]]: !stream.timepoint, %[[UNREADY:.+]]: !stream.resource<variable>)
+func @globalStore(%arg0: !stream.resource<variable>) {
+  //      CHECK: util.global.store %[[TIMEPOINT]], @mutableGlobal__timepoint : !stream.timepoint
+  // CHECK-NEXT: util.global.store %[[UNREADY]], @mutableGlobal : !stream.resource<variable>
+  util.global.store %arg0, @mutableGlobal : !stream.resource<variable>
+  return
+}
+
+// -----
+
+// Tests that function arguments are expanded into (timepoint, resource) and
+// an await is inserted to tie them together.
+//
+// This rotates waits from callers into callees.
+
+// CHECK-LABEL: @funcArgs
+// CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
+func @funcArgs(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+  // CHECK-NEXT: %[[SIZE0:.+]] = stream.resource.size %[[UNREADY0]] : !stream.resource<external>
+  // CHECK-NEXT: %[[READY0:.+]] = stream.timepoint.await %[[TIMEPOINT0]] => %[[UNREADY0]] : !stream.resource<external>{%[[SIZE0]]}
+  // CHECK-NEXT: %[[SIZE1:.+]] = stream.resource.size %[[UNREADY1]] : !stream.resource<transient>
+  // CHECK-NEXT: %[[READY1:.+]] = stream.timepoint.await %[[TIMEPOINT1]] => %[[UNREADY1]] : !stream.resource<transient>{%[[SIZE1]]}
+
+  // CHECK-NEXT: util.do_not_optimize(%[[READY0]])
+  util.do_not_optimize(%arg0) : !stream.resource<external>
+  // CHECK-NEXT: util.do_not_optimize(%[[READY1]])
+  util.do_not_optimize(%arg1) : !stream.resource<transient>
+  return
+}
+
+// -----
+
+// Tests that function results are expanded into (timepoint, resource) and
+// awaits are consumed.
+//
+// This rotates waits from callees into callers.
+
+// CHECK-LABEL: @funcResults
+// CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
+func @funcResults(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
+  // NOTE: there will be extra stuff here from the arg insertion. Since the
+  // return should consume the await that was inserted we expect to directly use
+  // the function arguments.
+
+  // CHECK: return %[[TIMEPOINT0]], %[[UNREADY0]], %[[TIMEPOINT1]], %[[UNREADY1]]
+  return %arg0, %arg1 : !stream.resource<external>, !stream.resource<transient>
+}
+
+// -----
+
+// Tests that function calls have their args and results expanded into
+// (timepoint, resource) and awaits are consumed on the arguments. Results will
+// have awaits inserted.
+//
+// This rotates waits on args from callers to callees and waits on results from
+// callees to callers.
+
+// CHECK-LABEL: @caller
+// CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
+func @caller(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+  // NOTE: there will be extra stuff here from the arg insertion. The call
+  // consumes the unready resources and we expect the args to be passed directly
+  // to the call.
+
+  // CHECK: %[[RET:.+]]:4 = call @callee(%[[TIMEPOINT0]], %[[UNREADY0]], %[[TIMEPOINT1]], %[[UNREADY1]])
+  // CHECK-SAME: : (!stream.timepoint, !stream.resource<external>, !stream.timepoint, !stream.resource<transient>) -> (!stream.timepoint, !stream.resource<external>, !stream.timepoint, !stream.resource<transient>)
+  %0:2 = call @callee(%arg0, %arg1) : (!stream.resource<external>, !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>)
+  // CHECK-NEXT: %[[RET_SIZE0:.+]] = stream.resource.size %[[RET]]#1 : !stream.resource<external>
+  // CHECK-NEXT: %[[RET_READY0:.+]] = stream.timepoint.await %[[RET]]#0 => %[[RET]]#1 : !stream.resource<external>{%[[RET_SIZE0]]}
+  // CHECK-NEXT: %[[RET_SIZE1:.+]] = stream.resource.size %[[RET]]#3 : !stream.resource<transient>
+  // CHECK-NEXT: %[[RET_READY1:.+]] = stream.timepoint.await %[[RET]]#2 => %[[RET]]#3 : !stream.resource<transient>{%[[RET_SIZE1]]}
+
+  // CHECK-NEXT: util.do_not_optimize(%[[RET_READY0]]) : !stream.resource<external>
+  util.do_not_optimize(%0#0) : !stream.resource<external>
+  // CHECK-NEXT: util.do_not_optimize(%[[RET_READY1]]) : !stream.resource<transient>
+  util.do_not_optimize(%0#1) : !stream.resource<transient>
+
+  return
+}
+
+func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>)
+
+// -----
+
+// Tests that branch args are expanded into (timepoint, resource) and that
+// branch operands are properly expanded.
+//
+// This rotates waits on branch operands into successors.
+
+// CHECK-LABEL: @br
+// CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
+func @br(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+  // NOTE: there will be extra stuff here from the arg insertion. The branch
+  // consumes the unready resources and we expect the args to be passed directly
+  // to the br.
+
+  // CHECK: br ^bb1(%[[TIMEPOINT0]], %[[UNREADY0]], %[[TIMEPOINT1]], %[[UNREADY1]]
+  br ^bb1(%arg0, %arg1 : !stream.resource<external>, !stream.resource<transient>)
+
+// CHECK-NEXT: ^bb1(%[[BB1_TIMEPOINT0:.+]]: !stream.timepoint, %[[BB1_UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:      %[[BB1_TIMEPOINT1:.+]]: !stream.timepoint, %[[BB1_UNREADY1:.+]]: !stream.resource<transient>):
+^bb1(%bb1_arg0: !stream.resource<external>, %bb1_arg1: !stream.resource<transient>):
+  // CHECK-NEXT: %[[SIZE0:.+]] = stream.resource.size %[[BB1_UNREADY0]] : !stream.resource<external>
+  // CHECK-NEXT: %[[READY0:.+]] = stream.timepoint.await %[[BB1_TIMEPOINT0]] => %[[BB1_UNREADY0]] : !stream.resource<external>{%8}
+  // CHECK-NEXT: %[[SIZE1:.+]] = stream.resource.size %[[BB1_UNREADY1]] : !stream.resource<transient>
+  // CHECK-NEXT: %[[READY1:.+]] = stream.timepoint.await %[[BB1_TIMEPOINT1]] => %[[BB1_UNREADY1]] : !stream.resource<transient>{%10}
+
+  // CHECK-NEXT: util.do_not_optimize(%[[READY0]])
+  util.do_not_optimize(%bb1_arg0) : !stream.resource<external>
+  // CHECK-NEXT: util.do_not_optimize(%[[READY1]])
+  util.do_not_optimize(%bb1_arg1) : !stream.resource<transient>
+  return
+}
+
+// -----
+
+// Tests that stream.async.execute consumes incoming timepoints.
+// If multiple timepoints are required for the captures then a
+// stream.timepoint.join should be emitted.
+//
+// This rotates waits on producers to waits on consumers.
+
+// CHECK-LABEL: @asyncExecuteConsume
+// CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
+// CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
+func @asyncExecuteConsume(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+  // NOTE: there will be extra stuff here from the arg insertion. The execution
+  // region consumes the unready resources and we expect the args to be captured
+  // directly.
+
+  %arg0_size = stream.resource.size %arg0 : !stream.resource<external>
+  %arg1_size = stream.resource.size %arg1 : !stream.resource<transient>
+
+  // CHECK: %[[JOIN:.+]] = stream.timepoint.join max(%[[TIMEPOINT0]], %[[TIMEPOINT1]]) => !stream.timepoint
+  // CHECK: = stream.async.execute await(%[[JOIN]])
+  // CHECK-SAME: with(%[[UNREADY0]] as %{{.+}}: !stream.resource<external>{%{{[a-z0-9]+}}},
+  // CHECK-SAME:      %[[UNREADY1]] as %{{.+}}: !stream.resource<transient>{%{{.+}}})
+  %results:2, %results_timepoint = stream.async.execute
+      with(%arg0 as %arg0_capture: !stream.resource<external>{%arg0_size},
+           %arg1 as %arg1_capture: !stream.resource<transient>{%arg1_size})
+      -> (!stream.resource<external>{%arg0_size}, !stream.resource<transient>{%arg1_size}) {
+    stream.yield %arg0_capture, %arg1_capture : !stream.resource<external>{%arg0_size}, !stream.resource<transient>{%arg1_size}
+  } => !stream.timepoint
+  %ready_results:2 = stream.timepoint.await %results_timepoint => %results#0, %results#1 : !stream.resource<external>{%arg0_size}, !stream.resource<transient>{%arg1_size}
+  util.do_not_optimize(%ready_results#0) : !stream.resource<external>
+  util.do_not_optimize(%ready_results#1) : !stream.resource<transient>
+  return
+}


### PR DESCRIPTION
This does a relatively mechanical transformation of a module to expand all `!stream.resource` values (and globals) into a (`!stream.timepoint`, `!stream.resource`) pair. Ops that consume resources and timepoints attempt to dereference those expanded timepoints and bypass waits, effectively chaining execution across asynchronous ops.