### PR TITLE
Add benchmarks with default flag configurations

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -91,6 +91,32 @@ iree_benchmark_suite(
     "dylib-sync"
 )
 
+# CPU, Dylib, 1-thread, big/little-core, full-inference. These benchmarks only
+# configure IREE translation and runtime flags for the target architecture and
+# runtime characteristics and do *not* include any non-default flags. No
+# non-default flags should be added here.
+iree_benchmark_suite(
+  MODULES
+    "${DEEPLABV3_FP32_MODULE}"
+    "${MOBILESSD_FP32_MODULE}"
+    "${POSENET_FP32_MODULE}"
+
+  BENCHMARK_MODES
+    "1-thread,big-core,full-inference,default-flags"
+    "1-thread,little-core,full-inference,default-flags"
+  TARGET_BACKEND
+    "dylib-llvm-aot"
+  TARGET_ARCHITECTURE
+    "CPU-ARM64-v8A"
+  TRANSLATION_FLAGS
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+  DRIVER
+    "dylib"
+  RUNTIME_FLAGS
+    "--task_topology_group_count=1"
+)
+
 # CPU, Dylib, 1-thread, big/little-core, full-inference
 iree_benchmark_suite(
   MODULES

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -78,6 +78,8 @@ function(iree_benchmark_suite)
     "BENCHMARK_MODES;MODULES"
   )
 
+  iree_package_name(PACKAGE_NAME)
+
   foreach(_MODULE IN LISTS _RULE_MODULES)
     cmake_parse_arguments(
       _MODULE
@@ -107,7 +109,7 @@ function(iree_benchmark_suite)
       # Update the source file to the downloaded-to place.
       string(REPLACE "/" ";" _SOURCE_URL_SEGMENTS "${_SOURCE_URL}")
       list(POP_BACK _SOURCE_URL_SEGMENTS _LAST_URL_SEGMENT)
-      set(_DOWNLOAD_TARGET "iree-download-benchmark-source-${_LAST_URL_SEGMENT}")
+      set(_DOWNLOAD_TARGET "${PACKAGE_NAME}_iree-download-benchmark-source-${_LAST_URL_SEGMENT}")
 
       # Strip off gzip suffix if present (downloader unzips if necessary)
       string(REGEX REPLACE "\.gz$" "" _SOURCE_FILE_BASENAME "${_LAST_URL_SEGMENT}")
@@ -138,7 +140,7 @@ function(iree_benchmark_suite)
       set(_TFLITE_FILE "${_MODULE_SOURCE}")
       set(_MODULE_SOURCE "${_TFLITE_FILE}.mlir")
       get_filename_component(_TFLITE_FILE_BASENAME "${_TFLITE_FILE}" NAME)
-      set(_TFLITE_IMPORT_TARGET "iree-import-tflite-${_TFLITE_FILE_BASENAME}")
+      set(_TFLITE_IMPORT_TARGET "${PACKAGE_NAME}_iree-import-tflite-${_TFLITE_FILE_BASENAME}")
       if (NOT TARGET "${_TFLITE_IMPORT_TARGET}")
         add_custom_command(
           OUTPUT "${_MODULE_SOURCE}"
@@ -195,7 +197,7 @@ function(iree_benchmark_suite)
       # MLIR source and translation flags.
       set(
         _TRANSLATION_TARGET_NAME
-        "iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME}-${_VMFB_HASH}"
+        "${PACKAGE_NAME}_iree-generate-benchmark-artifact-${_MODULE_SOURCE_BASENAME}-${_VMFB_HASH}"
       )
       if(NOT TARGET "${_TRANSLATION_TARGET_NAME}")
         add_custom_command(
@@ -257,6 +259,7 @@ function(iree_benchmark_suite)
       set(_FLAGFILE_GEN_TARGET_NAME_LIST "iree-generate-benchmark-flagfile")
       list(APPEND _FLAGFILE_GEN_TARGET_NAME_LIST ${_COMMON_NAME_SEGMENTS})
       list(JOIN _FLAGFILE_GEN_TARGET_NAME_LIST "__" _FLAGFILE_GEN_TARGET_NAME)
+      set(_FLAGFILE_GEN_TARGET_NAME "${PACKAGE_NAME}_${_FLAGFILE_GEN_TARGET_NAME}")
 
       add_custom_target("${_FLAGFILE_GEN_TARGET_NAME}"
         DEPENDS "${_FLAG_FILE}"


### PR DESCRIPTION
I'm just doing a couple of these to start. This is going to factor into
the benchmark name, which means it will create new series. I also want
to rename the tuned configurations, but that would turn them to
different series in Dana. I don't see any way to rename series from the
Dana web UI, at least. I think we would have to reupload all the data
under a different name.