### PR TITLE
NFC: improve naming and doc for tiled and distributed loop info

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -263,7 +263,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     if (!entryPointOp) continue;
     if (getTranslationInfo(entryPointOp)) continue;
     SmallVector<Operation *> computeOps;
-    SmallVector<TiledLoopInfo> tiledLoops;
+    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
       return funcOp.emitOpError("failed to get compute ops");
     }

--- a/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVRemoveOneTripTiledLoops.cpp
@@ -103,7 +103,7 @@ class SPIRVRemoveOneTripTiledLoopPass
     // This pass seems to be only needed for the convolution vectorization. So
     // filter out the necessary conv ops.
     SmallVector<Operation *> rootOp;
-    SmallVector<TiledLoopInfo> tiledLoops;
+    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
     auto isConvOp = [](Operation *op) {
       return isa<linalg::DepthwiseConv2DNhwOp, linalg::Conv2DNhwcHwcfOp>(op);
     };


### PR DESCRIPTION
The logic behind rediscovering the loop tiling and distribution
information is quite dense. This makes at least the API clearer.