### PR TITLE
Use `sync_driver` instead of `task_driver`

### DIFF
--- a/iree/samples/static_library/CMakeLists.txt
+++ b/iree/samples/static_library/CMakeLists.txt
@@ -76,7 +76,7 @@ DEPS
   ::simple_mul_c
   iree::runtime
   iree::hal::local::loaders::static_library_loader
-  iree::hal::local::task_driver
+  iree::hal::local::sync_driver
   iree::task::api
   simple_mul
 )

--- a/iree/samples/static_library/README.md
+++ b/iree/samples/static_library/README.md
@@ -42,7 +42,7 @@ for general instructions on building using CMake):
   cmake -B ../iree-build/
     -DIREE_BUILD_SAMPLES=ON \
     -DIREE_TARGET_BACKENDS_TO_BUILD=DYLIB-LLVM-AOT \
-    -DIREE_HAL_DRIVERS_TO_BUILD=DYLIB \
+    -DIREE_HAL_DRIVERS_TO_BUILD=Dylib_Sync \
     -DIREE_BUILD_COMPILER=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo .
   ```


### PR DESCRIPTION
Switches over to use the synchronous local CPU driver instead of using
the asynchronous task driver.