### PR TITLE
Support i1 in hal.command_buffer.fill_buffer.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Utils/TypeUtils.h"
 #include "iree/compiler/Dialect/VM/Conversion/ImportUtils.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -44,9 +45,8 @@ class CommandBufferFillBufferOpConversion
     // command. While the pattern itself will be stored in a 32 bit integer,
     // the fill operation will use this length to slice a potentially smaller
     // range of bits from the full pattern.
-    auto patternLengthBytes = patternBitWidth / 8;
-    // i1 will be promoted to a larger type later, so round up to 1 byte.
-    if (patternLengthBytes < 1) patternLengthBytes = 1;
+    auto patternLengthBytes =
+        IREE::HAL::getRoundedElementByteWidth(originalPatternType);
     auto patternLengthConst = rewriter.createOrFold<mlir::arith::ConstantIntOp>(
         op.getLoc(), patternLengthBytes, 32);
     Value pattern = op.pattern();

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -40,9 +40,15 @@ class CommandBufferFillBufferOpConversion
     // Record the original pattern length then extend it to a 32 bit integer.
     auto originalPatternType = op.pattern().getType();
     auto patternBitWidth = originalPatternType.getIntOrFloatBitWidth();
-    if (patternBitWidth < 8) patternBitWidth = 8;
-    auto patternLength = rewriter.createOrFold<mlir::arith::ConstantIntOp>(
-        op.getLoc(), patternBitWidth / 8, 32);
+    // The pattern length (in bytes) will be used at runtime to issue the fill
+    // command. While the pattern itself will be stored in a 32 bit integer,
+    // the fill operation will use this length to slice a potentially smaller
+    // range of bits from the full pattern.
+    auto patternLengthBytes = patternBitWidth / 8;
+    // i1 will be promoted to a larger type later, so round up to 1 byte.
+    if (patternLengthBytes < 1) patternLengthBytes = 1;
+    auto patternLengthConst = rewriter.createOrFold<mlir::arith::ConstantIntOp>(
+        op.getLoc(), patternLengthBytes, 32);
     Value pattern = op.pattern();
     if (originalPatternType.isF16() || originalPatternType.isF32()) {
       pattern = rewriter.createOrFold<arith::BitcastOp>(
@@ -53,7 +59,7 @@ class CommandBufferFillBufferOpConversion
           op.getLoc(), pattern, rewriter.getIntegerType(32));
     }
     callOperands.push_back(pattern);
-    callOperands.push_back(patternLength);
+    callOperands.push_back(patternLengthConst);
 
     auto callOp = rewriter.replaceOpWithNewOp<IREE::VM::CallOp>(
         op, SymbolRefAttr::get(importOp), importType.getResults(),

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertCommandBufferOps.cpp
@@ -40,6 +40,7 @@ class CommandBufferFillBufferOpConversion
     // Record the original pattern length then extend it to a 32 bit integer.
     auto originalPatternType = op.pattern().getType();
     auto patternBitWidth = originalPatternType.getIntOrFloatBitWidth();
+    if (patternBitWidth < 8) patternBitWidth = 8;
     auto patternLength = rewriter.createOrFold<mlir::arith::ConstantIntOp>(
         op.getLoc(), patternBitWidth / 8, 32);
     Value pattern = op.pattern();

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-convert-hal-to-vm %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-convert-hal-to-vm -canonicalize %s | IreeFileCheck %s
 
 // CHECK-LABEL: @command_buffer_create
 func @command_buffer_create(%arg0: !hal.device) {
@@ -30,6 +30,44 @@ func @command_buffer_execution_barrier(
       source("CommandIssue")
       target("CommandProcess")
       flags("None")
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @command_buffer_fill_buffer_i1
+func @command_buffer_fill_buffer_i1(
+  %arg0: !hal.command_buffer,
+  %arg1: !hal.buffer,
+  %arg2: i1
+) {
+  %c100 = arith.constant 100 : index
+  %c200 = arith.constant 200 : index
+  // CHECK-DAG: %[[C1:.+]] = vm.const.i32 1 : i32
+  // CHECK-DAG: %[[EXTEND:.+]] = vm.and.i32 %arg2, %[[C1]] : i32
+  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[EXTEND]], %[[C1]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
+  hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
+      target(%arg1 : !hal.buffer)[%c100, %c200]
+      pattern(%arg2 : i1)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @command_buffer_fill_buffer_i8
+func @command_buffer_fill_buffer_i8(
+  %arg0: !hal.command_buffer,
+  %arg1: !hal.buffer,
+  %arg2: i8
+) {
+  %c100 = arith.constant 100 : index
+  %c200 = arith.constant 200 : index
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 1 : i32
+  // CHECK-DAG: %[[EXTEND:.+]] = vm.ext.i8.i32.u %arg2 : i32 -> i32
+  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[EXTEND]], %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
+  hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
+      target(%arg1 : !hal.buffer)[%c100, %c200]
+      pattern(%arg2 : i8)
   return
 }
 
@@ -67,6 +105,25 @@ func @command_buffer_fill_buffer_i32(
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
       target(%arg1 : !hal.buffer)[%c100, %c200]
       pattern(%arg2 : i32)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @command_buffer_fill_buffer_f32
+func @command_buffer_fill_buffer_f32(
+  %arg0: !hal.command_buffer,
+  %arg1: !hal.buffer,
+  %arg2: f32
+) {
+  %c100 = arith.constant 100 : index
+  %c200 = arith.constant 200 : index
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 4 : i32
+  // CHECK-DAG: %[[BITCAST:.+]] = vm.bitcast.f32.i32 %arg2 : f32 -> i32
+  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[BITCAST]], %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
+  hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
+      target(%arg1 : !hal.buffer)[%c100, %c200]
+      pattern(%arg2 : f32)
   return
 }
 

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -35,35 +35,38 @@ func @command_buffer_execution_barrier(
 
 // -----
 
-// CHECK-LABEL: @command_buffer_fill_buffer
-func @command_buffer_fill_buffer(
+// CHECK-LABEL: @command_buffer_fill_buffer_i16
+func @command_buffer_fill_buffer_i16(
   %arg0: !hal.command_buffer,
-  %arg1: !hal.buffer
+  %arg1: !hal.buffer,
+  %arg2: i16
 ) {
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
-  %c300 = arith.constant 300 : i32
-  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %c300, %c4) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 2 : i32
+  // CHECK-DAG: %[[EXTEND:.+]] = vm.ext.i16.i32.u %arg2 : i32 -> i32
+  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[EXTEND]], %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
       target(%arg1 : !hal.buffer)[%c100, %c200]
-      pattern(%c300 : i32)
+      pattern(%arg2 : i16)
   return
 }
 
 // -----
 
-// CHECK-LABEL: @command_buffer_fill_buffer_i16
-func @command_buffer_fill_buffer_i16(
+// CHECK-LABEL: @command_buffer_fill_buffer_i32
+func @command_buffer_fill_buffer_i32(
   %arg0: !hal.command_buffer,
-  %arg1: !hal.buffer
+  %arg1: !hal.buffer,
+  %arg2: i32
 ) {
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
-  %cst = arith.constant 1234 : i16
-  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %c1234_0, %c2) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 4 : i32
+  // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %arg2, %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
       target(%arg1 : !hal.buffer)[%c100, %c200]
-      pattern(%cst : i16)
+      pattern(%arg2 : i32)
   return
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1025,7 +1025,7 @@ def HAL_CommandBufferFillBufferOp : HAL_Op<"command_buffer.fill_buffer"> {
     HAL_BufferType:$target_buffer,
     HAL_DeviceSize:$target_offset,
     HAL_DeviceSize:$length,
-    AnyTypeOf<[I8, I16, I32, F16, F32]>:$pattern
+    AnyTypeOf<[I1, I8, I16, I32, F16, F32]>:$pattern
   );
 
   let assemblyFormat = [{


### PR DESCRIPTION
Also added more test cases. I'm still not sure about f16. This is the current behavior, which I could put in a test:

```mlir
vm.func private @command_buffer_fill_buffer_f16(%arg0: !vm.ref<!hal.command_buffer>, %arg1: !vm.ref<!hal.buffer>, %arg2: f32) {
  %c2 = vm.const.i32 2 : i32
  %c200 = vm.const.i32 200 : i32
  %c100 = vm.const.i32 100 : i32
  %0 = vm.bitcast.f32.i32 %arg2 : f32 -> i32
  %1 = vm.ext.i16.i32.u %0 : i32 -> i32
  vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %1, %c2) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
  vm.return
}
```

That sketches me out though, so I could instead disallow f16 for now...