### PR TITLE
Expand embedded linker discovery and improve error messages.

### DIFF
--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -15,12 +15,12 @@ compilers:
 
 === "Linux and macOS"
 
-    1. Install a compiler/linker (typically "clang" and "lld" package).
+    1. Install a compiler/linker (typically "clang" and "lld" package)
 
-    2. Install [CMake](https://cmake.org/download/) (typically "cmake" package).
+    2. Install [CMake](https://cmake.org/download/) (typically "cmake" package)
 
     3. Install [Ninja](https://ninja-build.org/) (typically "ninja-build"
-       package).
+       package)
 
     On a relatively recent Debian/Ubuntu:
 
@@ -37,7 +37,7 @@ compilers:
        [official downloads page](https://cmake.org/download/)
 
     3. Install Ninja either from the
-       [official site](https://ninja-build.org/).
+       [official site](https://ninja-build.org/)
 
     !!! note
         You will need to initialize MSVC by running `vcvarsall.bat` to use it

--- a/docs/website/docs/deployment-configurations/cpu-dylib.md
+++ b/docs/website/docs/deployment-configurations/cpu-dylib.md
@@ -73,9 +73,6 @@ If you want to explicitly specify HAL drivers to support, you will need to add
 `DYLIB-LLVM-AOT` to the `IREE_TARGET_BACKENDS_TO_BUILD` CMake list variable when
 configuring (for host).
 
-The LLVM-based compiler also needs the `lld` linker, which can be built from
-source or [installed along with LLVM](https://releases.llvm.org/download.html).
-
 ## Compile and run the model
 
 With the compiler and runtime for dynamic libraries, we can now compile a model

--- a/docs/website/docs/deployment-configurations/cpu-dylib.md
+++ b/docs/website/docs/deployment-configurations/cpu-dylib.md
@@ -28,9 +28,10 @@ CPU instructions.
 #### Build runtime from source
 
 Please make sure you have followed the [Getting started][get-started] page
-to build IREE for Linux/Windows and the [Android cross-compilation][android-cc]
-page for Android. The dylib HAL driver is compiled in by default on all
-platforms.
+to build IREE for your host platform and the
+[Android cross-compilation][android-cc]
+page if you are cross compiling for Android. The dylib HAL driver is compiled
+in by default on all platforms.
 
 <!-- TODO(??): a way to verify dylib is compiled in and supported -->
 
@@ -63,13 +64,17 @@ python -m pip install iree-compiler-snapshot \
 #### Build compiler from source
 
 Please make sure you have followed the [Getting started][get-started] page
-to build IREE for Linux/Windows and the [Android cross-compilation][android-cc]
-page for Android. The dylib compiler backend is compiled in by default on all
-platforms.
+to build IREE for your host platform and the
+[Android cross-compilation][android-cc]
+page if you are cross compiling for Android. The dylib compiler backend is
+compiled in by default on all platforms.
 
 If you want to explicitly specify HAL drivers to support, you will need to add
 `DYLIB-LLVM-AOT` to the `IREE_TARGET_BACKENDS_TO_BUILD` CMake list variable when
 configuring (for host).
+
+The LLVM-based compiler also needs the `lld` linker, which can be built from
+source or [installed along with LLVM](https://releases.llvm.org/download.html).
 
 ## Compile and run the model
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -383,9 +383,8 @@ class LLVMAOTTargetBackend final : public TargetBackend {
         linkerTool->linkDynamicLibrary(libraryName, objectFiles);
     if (!linkArtifactsOr.hasValue()) {
       return mlir::emitError(variantOp.getLoc())
-             << "failed to link executable and generate target dylib using "
-                "linker toolchain "
-             << linkerTool->getSystemToolPath();
+             << "failed to link executable and generate target dylib (check "
+                "above for more specific error messages)";
     }
     auto &linkArtifacts = linkArtifactsOr.getValue();
     if (options_.keepLinkerArtifacts) {

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
@@ -144,6 +144,7 @@ static std::string normalizeToolNameForPlatform(const std::string &toolName) {
 
 static std::string findToolAtPath(
     SmallVector<std::string, 4> normalizedToolNames, const Twine &path) {
+  LLVM_DEBUG(llvm::dbgs() << "Searching for tool at path '" << path << "'\n");
   for (auto toolName : normalizedToolNames) {
     SmallString<256> pathStorage;
     llvm::sys::path::append(pathStorage, path, toolName);
@@ -176,6 +177,9 @@ std::string LinkerTool::findToolInEnvironment(
   for (auto toolName : toolNames) {
     normalizedToolNames.push_back(normalizeToolNameForPlatform(toolName));
   }
+  LLVM_DEBUG(llvm::dbgs() << "Searching environment for one of these tools: [";
+             llvm::interleaveComma(normalizedToolNames, llvm::dbgs());
+             llvm::dbgs() << "]\n");
 
   std::string mainExecutablePath =
       llvm::sys::fs::getMainExecutable(nullptr, nullptr);

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
@@ -142,6 +142,22 @@ static std::string normalizeToolNameForPlatform(const std::string &toolName) {
 #endif
 }
 
+static std::string findToolAtPath(
+    SmallVector<std::string, 4> normalizedToolNames, const Twine &path) {
+  for (auto toolName : normalizedToolNames) {
+    SmallString<256> pathStorage;
+    llvm::sys::path::append(pathStorage, path, toolName);
+
+    if (llvm::sys::fs::exists(pathStorage)) {
+      llvm::sys::fs::make_absolute(pathStorage);
+      (void)llvm::sys::path::remove_dots(pathStorage, /*remove_dot_dot=*/true);
+      return escapeCommandLineComponent(std::string(pathStorage));
+    }
+  }
+
+  return "";
+}
+
 LogicalResult LinkerTool::runLinkCommand(const std::string &commandLine) {
   LLVM_DEBUG(llvm::dbgs() << "Running linker command:\n" << commandLine);
   auto escapedCommandLine = escapeCommandLineComponent(commandLine);
@@ -155,42 +171,41 @@ LogicalResult LinkerTool::runLinkCommand(const std::string &commandLine) {
 
 std::string LinkerTool::findToolInEnvironment(
     SmallVector<std::string, 4> toolNames) const {
-  // First search the current directory.
+  SmallVector<std::string, 4> normalizedToolNames;
+  normalizedToolNames.reserve(toolNames.size());
   for (auto toolName : toolNames) {
-    toolName = normalizeToolNameForPlatform(toolName);
-    if (llvm::sys::fs::exists(toolName)) {
-      llvm::SmallString<256> absolutePath(toolName);
-      llvm::sys::fs::make_absolute(absolutePath);
-      return escapeCommandLineComponent(std::string(absolutePath));
-    }
+    normalizedToolNames.push_back(normalizeToolNameForPlatform(toolName));
   }
 
-  // Then search the build tree.
-  SmallString<256> mainExecutable =
+  std::string mainExecutablePath =
       llvm::sys::fs::getMainExecutable(nullptr, nullptr);
-  if (!mainExecutable.empty()) {
-    llvm::sys::path::remove_filename(mainExecutable);
+  SmallString<256> mainExecutableDir(mainExecutablePath);
+  llvm::sys::path::remove_filename(mainExecutableDir);
 
-    for (auto toolName : toolNames) {
-      std::string normalizedToolName = normalizeToolNameForPlatform(toolName);
-
-      SmallString<256> pathStorage;
-      llvm::sys::path::append(pathStorage, std::string(mainExecutable),
-                              "../../third_party/llvm-project/llvm/bin/",
-                              normalizedToolName);
-
-      if (llvm::sys::fs::exists(std::string(pathStorage))) {
-        llvm::SmallString<256> absolutePath(pathStorage);
-        llvm::sys::fs::make_absolute(absolutePath);
-        return escapeCommandLineComponent(std::string(absolutePath));
-      }
-    }
+  // First search the current executable's directory. This should find tools
+  // within the install directory (through CMake or binary distributions).
+  std::string toolPath = findToolAtPath(normalizedToolNames, mainExecutableDir);
+  if (!toolPath.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "Found tool in executable's directory at path "
+                            << toolPath << "\n");
+    return toolPath;
   }
 
-  // Next search the environment path.
-  for (auto toolName : toolNames) {
-    toolName = normalizeToolNameForPlatform(toolName);
+  // Next search around in the CMake build tree.
+  toolPath = findToolAtPath(
+      normalizedToolNames,
+      mainExecutableDir + "/../../third_party/llvm-project/llvm/bin/");
+  if (!toolPath.empty()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Found tool in build tree at path " << toolPath << "\n");
+    return toolPath;
+  }
+
+  // Finally search the environment path.
+  for (auto toolName : normalizedToolNames) {
     if (auto result = llvm::sys::Process::FindInEnvPath("PATH", toolName)) {
+      LLVM_DEBUG(llvm::dbgs() << "Found tool on environment PATH at path "
+                              << toolPath << "\n");
       return escapeCommandLineComponent(std::string(*result));
     }
   }

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -105,7 +105,8 @@ class LinkerTool {
   // Runs the given command line on the shell, logging failures.
   LogicalResult runLinkCommand(const std::string& commandLine);
 
-  // Returns the path to the first tool in |toolNames| found in the environment.
+  // Returns the path to the first tool in |toolNames| found in the environment,
+  // or empty string if no tool was found.
   std::string findToolInEnvironment(
       SmallVector<std::string, 4> toolNames) const;
 

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -58,9 +58,11 @@ class EmbeddedLinkerTool : public LinkerTool {
         findToolInEnvironment({"iree-lld", "lld", "ld.lld", "lld-link"});
     if (!environmentPath.empty()) return environmentPath;
 
-    llvm::errs() << "LLD (ld.lld) not found on path; specify with the "
-                    "IREE_LLVMAOT_EMBEDDED_LINKER_PATH environment variable or "
-                    "-iree-llvm-embedded-linker-path=\n";
+    llvm::errs() << "error: embedded linker tool (typically `lld`) not found; "
+                    "either (1) install lld and place it on your PATH, (2) set "
+                    "the IREE_LLVMAOT_EMBEDDED_LINKER_PATH environment "
+                    "variable or (3) set the -iree-llvm-embedded-linker-path= "
+                    "flag\n";
     return "";
   }
 


### PR DESCRIPTION
This path didn't _quite_ work out of the box for development builds. This expands the search space to make automatic discovery more likely.

The LLVM backend's embedded linker requires `lld` to be discoverable and we make an attempt to build it from source:
https://github.com/google/iree/blob/222828129144c8bfb603b4647aa969afb64a5a45/iree/tools/CMakeLists.txt#L395-L401

However, the `lld` binary ends up in `iree-build\third_party\llvm-project\llvm\bin` for builds (`install` does put `lld` next to the other IREE tools). This now searches that path in the build tree and includes more information in error messages:
```
Searching environment for one of these tools: [iree-lld.exe, lld.exe, ld.lld.exe, lld-link.exe]
Searching for tool at path 'D:\dev\projects\iree\..\iree-build\iree\tools'
Searching for tool at path 'D:\dev\projects\iree\..\iree-build\iree\tools/../../third_party/llvm-project/llvm/bin/'

(success)
Found tool in build tree at path "D:\dev\projects\iree-build\third_party\llvm-project\llvm\bin\lld.exe"

(failure)
error: embedded linker tool (typically `lld`) not found after searching:
  * -iree-llvm-embedded-linker-path= flag
  * IREE_LLVMAOT_EMBEDDED_LINKER_PATH environment variable
  * common locations at relative file paths
  * system PATH
Run with -debug-only=llvmaot-linker for search details
```

We do also have `iree-lld` now, but that lives in [llvm-external-projects/iree-compiler-api/python/](https://github.com/google/iree/blob/main/llvm-external-projects/iree-compiler-api/python/), not [iree/tools/](https://github.com/google/iree/tree/main/iree/tools/).

A workaround we _don't_ want to encourage is to install `lld` directly at the system level. Using the built-from-source binary has less risk of compatibility issues.