### PR TITLE
Enable tiling of linalg.pad_tensor operations.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -300,7 +300,7 @@ static bool hasNonScfForControlFlow(
   return dispatchOp
       .walk([&](Operation *op) {
         if (isa<BranchOpInterface>(op) || isa<RegionBranchOpInterface>(op)) {
-          if (!isa<scf::ForOp>(op) &&
+          if (!isa<scf::ForOp, scf::IfOp>(op) &&
               !isa<IREE::Flow::DispatchWorkgroupsOp>(op))
             return WalkResult::interrupt();
         }

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1125,3 +1125,21 @@ func @extract_slice(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index,
 // CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>
 //      CHECK:   %[[SLICE:.+]] = flow.dispatch.tensor.load %[[INPUT]]
 //      CHECK:   flow.dispatch.tensor.store %[[SLICE]], %[[OUTPUT]]
+
+// -----
+
+func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index,
+    %arg3 : index, %arg4 : index, %arg5 : f32) -> tensor<?x?xf32> {
+  %0 = linalg.pad_tensor %arg0 low[%arg1, %arg2] high[%arg3, %arg4] {
+    ^bb0(%arg6 : index, %arg7 : index):
+      linalg.yield %arg5 : f32
+  } :  tensor<?x?xf32> to tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: flow.dispatch.workgroups
+// CHECK-NEXT:   %[[ARG6:.+]]: !flow.dispatch.tensor<readonly:?x?xf32>
+// CHECK-SAME:   %[[ARG12:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>
+//      CHECK:   scf.for
+//      CHECK:     scf.for
+//      CHECK:       flow.dispatch.tensor.load %[[ARG6]]
+//      CHECK:       flow.dispatch.tensor.store %{{.+}}, %[[ARG12]]

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
@@ -267,12 +267,15 @@ struct ForwardToTilingInterface
                                     SmallVectorImpl<Value> &results) const {
     Operation *tiledOp =
         cast<OpTy>(op).getTiledImplementation(b, dest, offsets, sizes);
-    Location loc = op->getLoc();
-    if (op->getNumResults() != dest.size()) {
-      op->emitOpError(
+    if (!tiledOp) {
+      return op->emitOpError("failed to tile operation");
+    }
+    if (tiledOp->getNumResults() != dest.size()) {
+      return op->emitOpError(
           "mismatch in the number of results of the tiled operation and the "
           "number of results expected");
     }
+    Location loc = op->getLoc();
     auto oneAttr = b.getI64IntegerAttr(1);
     SmallVector<OpFoldResult> strides(offsets.size(), oneAttr);
     for (auto result : llvm::enumerate(tiledOp->getResults())) {

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
@@ -268,12 +268,14 @@ struct ForwardToTilingInterface
     Operation *tiledOp =
         cast<OpTy>(op).getTiledImplementation(b, dest, offsets, sizes);
     if (!tiledOp) {
-      return op->emitOpError("failed to tile operation");
+      op->emitOpError("failed to tile operation");
+      return nullptr;
     }
     if (tiledOp->getNumResults() != dest.size()) {
-      return op->emitOpError(
+      op->emitOpError(
           "mismatch in the number of results of the tiled operation and the "
           "number of results expected");
+      return nullptr;
     }
     Location loc = op->getLoc();
     auto oneAttr = b.getI64IntegerAttr(1);

--- a/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
+++ b/iree/compiler/Dialect/LinalgExt/IR/TiledOpInterface.cpp
@@ -238,6 +238,59 @@ struct InsertSliceTiledOpInterface
     return extractSliceOp;
   }
 };
+
+/// Forwards the implementation of `TiledOpInterface` to upstream
+/// `TilingInterface`. Note that this forwarding is only valid when the
+/// iteration space is same as the data space of the result(s). This is due to
+/// the difference in the tiling algorithm being developed around
+/// `TilingInterface` and that used with `TiledOpInterface`. The difference
+/// comes down to the former only needing the tiled operation, and not the value
+/// of the whole tensor.
+template <typename OpTy>
+struct ForwardToTilingInterface
+    : public TiledOpInterface::ExternalModel<ForwardToTilingInterface<OpTy>,
+                                             OpTy> {
+  SmallVector<Value> getDestinationOperands(Operation *op, OpBuilder &b) const {
+    return cast<OpTy>(op).getDestinationOperands(b);
+  }
+
+  SmallVector<StringRef> getLoopIteratorTypes(Operation *op) const {
+    return cast<OpTy>(op).getLoopIteratorTypes();
+  }
+  SmallVector<Range> getLoopBounds(Operation *op, OpBuilder &b) const {
+    return cast<OpTy>(op).getLoopBounds(b);
+  }
+  Operation *getTiledImplementation(Operation *op, OpBuilder &b,
+                                    ValueRange dest,
+                                    ArrayRef<OpFoldResult> offsets,
+                                    ArrayRef<OpFoldResult> sizes,
+                                    SmallVectorImpl<Value> &results) const {
+    Operation *tiledOp =
+        cast<OpTy>(op).getTiledImplementation(b, dest, offsets, sizes);
+    Location loc = op->getLoc();
+    if (op->getNumResults() != dest.size()) {
+      op->emitOpError(
+          "mismatch in the number of results of the tiled operation and the "
+          "number of results expected");
+    }
+    auto oneAttr = b.getI64IntegerAttr(1);
+    SmallVector<OpFoldResult> strides(offsets.size(), oneAttr);
+    for (auto result : llvm::enumerate(tiledOp->getResults())) {
+      // Assume that the shape of the result is same as the loop bounds of the
+      // op. This implies the result can be inserted into the `dest` at
+      // `offsets` and `sizes`. This would be illegal if that is not the
+      // case. This is a point of difference between the `TiledOpInterface` in
+      // IREE and `TilingInterface` in MLIR, since the latter sees fusion and
+      // tiling as the same things. So it returns just the tiled op, and not the
+      // result of the full tensor as the current tiling algorithm expects.
+      auto tiledInsertOp = b.create<tensor::InsertSliceOp>(
+          loc, result.value(), dest[result.index()], offsets, sizes, strides);
+      results.push_back(tiledInsertOp);
+    }
+    return tiledOp;
+  }
+};
+
 }  // namespace
 
 void registerTiledOpInterfaceExternalModels(DialectRegistry &registry) {
@@ -246,6 +299,8 @@ void registerTiledOpInterfaceExternalModels(DialectRegistry &registry) {
   registry
       .addOpInterface<tensor::ExtractSliceOp, ExtractSliceTiledOpInterface>();
   registry.addOpInterface<tensor::InsertSliceOp, InsertSliceTiledOpInterface>();
+  registry.addOpInterface<linalg::PadTensorOp,
+                          ForwardToTilingInterface<linalg::PadTensorOp>>();
 }
 
 }  // namespace linalg_ext

--- a/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1167,3 +1167,42 @@ func @extract_slice_reduced_rank_two_dims_4(%arg0 : tensor<?x?x?x?xf32>, %arg1 :
 //      CHECK:     scf.yield %[[YIELD]]
 //      CHECK:   }
 //      CHECK:   return %[[RESULT]]
+
+// -----
+
+func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index,
+    %arg3 : index, %arg4 : index, %arg5 : f32) -> tensor<?x?xf32> {
+  %0 = linalg.pad_tensor %arg0 low[%arg1, %arg2] high[%arg3, %arg4] {
+    ^bb0(%arg6 : index, %arg7 : index):
+      linalg.yield %arg5 : f32
+  } {__internal_linalg_transform__ = "tiling_input"}
+      :  tensor<?x?xf32> to tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2] -> (s2 + s0 + s1)>
+//      CHECK: func @pad_tensor
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:   %[[ARG3:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:   %[[ARG4:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:   %[[ARG5:[a-zA-Z0-9]+]]: f32
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[C10:.+]] = arith.constant 10 : index
+//  CHECK-DAG:   %[[C20:.+]] = arith.constant 20 : index
+//  CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor
+//      CHECK:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//      CHECK:   %[[UBY:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]], %[[ARG3]], %[[D0]]]
+//      CHECK:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[UBX:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]], %[[ARG4]], %[[D1]]]
+//      CHECK:   %[[RESULT:.+]] = scf.for %[[IV0:[a-zA-Z0-9]+]] = %[[C0]] to %[[UBY]] step %[[C10]]
+// CHECK-SAME:       iter_args(%[[ARG7:.+]] = %[[INIT]])
+//      CHECK:     %[[YIELD:.+]] = scf.for %[[IV1:[a-zA-Z0-9]+]] = %[[C0]] to %[[UBX]] step %[[C20]]
+// CHECK-SAME:         iter_args(%[[ARG9:.+]] = %[[ARG7]])
+//      CHECK:       %[[PAD_TILE:.+]] = scf.if
+//      CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[PAD_TILE]] into %[[ARG9]]
+// CHECK-SAME:           [%[[IV0]], %[[IV1]]]
+//      CHECK:       scf.yield %[[INSERT]]
+//      CHECK:     scf.yield %[[YIELD]]
+//      CHECK:   return %[[RESULT]]


### PR DESCRIPTION
Forwarding the implementation of `TiledOpInterface` to methods in
`linalg.pad_tensor` that implement the `TilingInterface` in MLIR
allows IREE to pick up the tiling transformations that exist on this
operation. This PR just checks that the pad tensor operation is tiled
during dispatch region formation. It isnt connected end-to-end yet
till the effects downstream can be evaluated.