### PR TITLE
Fixing a case of stream/tensor interop.

### DIFF
--- a/iree/compiler/Dialect/Stream/Transforms/BUILD
+++ b/iree/compiler/Dialect/Stream/Transforms/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "//iree/compiler/Dialect/Shape/Transforms",
         "//iree/compiler/Dialect/Shape/Utils:TypeConversion",
         "//iree/compiler/Dialect/Stream/Analysis",
+        "//iree/compiler/Dialect/Stream/Conversion",
         "//iree/compiler/Dialect/Stream/Conversion/FlowToStream",
         "//iree/compiler/Dialect/Stream/Conversion/StandardToStream",
         "//iree/compiler/Dialect/Stream/Conversion/UtilToStream",

--- a/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     iree::compiler::Dialect::Shape::Transforms
     iree::compiler::Dialect::Shape::Utils::TypeConversion
     iree::compiler::Dialect::Stream::Analysis
+    iree::compiler::Dialect::Stream::Conversion
     iree::compiler::Dialect::Stream::Conversion::FlowToStream
     iree::compiler::Dialect::Stream::Conversion::StandardToStream
     iree::compiler::Dialect::Stream::Conversion::UtilToStream

--- a/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/Shape/IR/ShapeDialect.h"
 #include "iree/compiler/Dialect/Shape/IR/ShapeOps.h"
 #include "iree/compiler/Dialect/Stream/Conversion/FlowToStream/ConvertFlowToStream.h"
+#include "iree/compiler/Dialect/Stream/Conversion/PatternUtils.h"
 #include "iree/compiler/Dialect/Stream/Conversion/StandardToStream/ConvertStandardToStream.h"
 #include "iree/compiler/Dialect/Stream/Conversion/UtilToStream/ConvertUtilToStream.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
@@ -57,8 +58,8 @@ static Value buildTensorImportOp(Location loc, Value sourceTensor,
   // Associate the external SSA value, encoding, and shape information with the
   // stream resource. When lowering we'll then have all the metadata required
   // even after erasing it all on the resource.
-  auto externalType = IREE::Stream::ResourceType::get(
-      builder.getContext(), IREE::Stream::Lifetime::External);
+  auto externalType = builder.getType<IREE::Stream::ResourceType>(
+      IREE::Stream::Lifetime::External);
   auto importOp = builder.create<IREE::Stream::TensorImportOp>(
       loc, externalType, sourceTensor, encodingAttr, dynamicDims, resultSize,
       /*affinity=*/nullptr);
@@ -79,28 +80,26 @@ static Value buildTensorImportOp(Location loc, Value sourceTensor,
 
 // Builds a stream.tensor.export op that exports a stream resource into an
 // external tensor value.
-static Value buildTensorExportOp(Location loc, Value sourceResource,
+static Value buildTensorExportOp(Location loc, Value sourceValue,
                                  TensorType targetType, ValueRange dynamicDims,
                                  OpBuilder &builder) {
-  // Query the size of the resource - which may differ from the target external
-  // value if we changed the encoding.
-  auto sourceSize = builder.createOrFold<IREE::Stream::ResourceSizeOp>(
-      loc, builder.getIndexType(), sourceResource);
+  auto source = consumeTensorOperand(loc, sourceValue, builder);
 
   // If needed insert a transfer to external resource lifetime.
-  auto externalType = IREE::Stream::ResourceType::get(
-      builder.getContext(), IREE::Stream::Lifetime::External);
-  if (sourceResource.getType() != externalType) {
-    sourceResource = builder.create<IREE::Stream::AsyncTransferOp>(
-        loc, externalType, sourceResource, sourceSize, sourceSize,
+  auto externalType = builder.getType<IREE::Stream::ResourceType>(
+      IREE::Stream::Lifetime::External);
+  if (source.resource.getType() != externalType) {
+    source.resource = builder.create<IREE::Stream::AsyncTransferOp>(
+        loc, externalType, source.resource, source.resourceSize,
+        source.resourceSize,
         /*source_affinity=*/nullptr,
         /*result_affinity=*/nullptr);
   }
 
   // Associate the stream resource and external encoding and shape information.
   auto newOp = builder.create<IREE::Stream::TensorExportOp>(
-      loc, targetType, sourceResource, TypeAttr::get(targetType), dynamicDims,
-      sourceSize,
+      loc, targetType, source.resource, TypeAttr::get(targetType), dynamicDims,
+      source.resourceSize,
       /*affinity=*/nullptr);
   return newOp.result();
 }
@@ -139,7 +138,8 @@ struct GenericResourcePattern : public ConversionPattern {
     for (auto it : llvm::zip(op->getOperands(), operands)) {
       auto oldOperand = std::get<0>(it);
       auto newOperand = std::get<1>(it);
-      if (!newOperand.getType().isa<IREE::Stream::ResourceType>()) {
+      if (!newOperand.getType().isa<IREE::Stream::ResourceType>() &&
+          !newOperand.getType().isa<TensorType>()) {
         newOperands.push_back(newOperand);
         continue;
       }
@@ -162,7 +162,7 @@ struct GenericResourcePattern : public ConversionPattern {
       auto dynamicDims =
           Shape::buildOrFindDynamicDimsForValue(op->getLoc(), result, rewriter);
       auto importedValue = buildTensorImportOp(
-          op->getLoc(), result, IREE::Stream::ResourceType::get(getContext()),
+          op->getLoc(), result, rewriter.getType<IREE::Stream::ResourceType>(),
           rewriter);
       result.replaceAllUsesExcept(importedValue, importedValue.getDefiningOp());
     }

--- a/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -48,3 +48,104 @@ func @simple_mul(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.a
   // CHECK: return %[[RET0_EXPORT]] : !hal.buffer_view
   return %2 : !hal.buffer_view
 }
+
+// -----
+
+// This is the while test, which exercises flow control and readbacks but is
+// still simple enough to reason about: iree/test/e2e/tosa_ops/while.mlir
+// This test is also nice because it contains a check test op, which requires
+// stream/tensor interop.
+
+// CHECK: stream.executable private @while_test_dispatch_0
+flow.executable private @while_test_dispatch_0 {
+  // CHECK: stream.executable.export public @dispatch
+  flow.dispatch.entry public @dispatch attributes {workgroup_rank = 3 : index}
+  // CHECK: builtin.module
+  builtin.module {
+    // CHECK: func @dispatch(%[[BINDING0:.+]]: !stream.binding, %[[BINDING1:.+]]: !stream.binding)
+    func @dispatch(%arg0: !flow.dispatch.tensor<readonly:i32>, %arg1: !flow.dispatch.tensor<writeonly:i1>) {
+      %c3_i32 = arith.constant 3 : i32
+      // CHECK: %[[ARG0:.+]] = stream.binding.subspan %[[BINDING0]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:i32>
+      // CHECK: %[[ARG1:.+]] = stream.binding.subspan %[[BINDING1]][%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:i1>
+      // CHECK: = flow.dispatch.tensor.load %[[ARG0]], offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i32> -> tensor<i32>
+      %0 = flow.dispatch.tensor.load %arg0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i32> -> tensor<i32>
+      %1 = linalg.init_tensor [] : tensor<i1>
+      // CHECK: linalg.generic
+      %2 = linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%0 : tensor<i32>) outs(%1 : tensor<i1>) {
+      ^bb0(%arg2: i32, %arg3: i1):
+        %3 = arith.cmpi sge, %c3_i32, %arg2 : i32
+        linalg.yield %3 : i1
+      } -> tensor<i1>
+      // CHECK: flow.dispatch.tensor.store %{{.+}}, %[[ARG1]], offsets = [], sizes = [], strides = [] : tensor<i1> -> !flow.dispatch.tensor<writeonly:i1>
+      flow.dispatch.tensor.store %2, %arg1, offsets = [], sizes = [], strides = [] : tensor<i1> -> !flow.dispatch.tensor<writeonly:i1>
+      return
+    }
+  }
+}
+
+// CHECK: stream.executable private @while_test_dispatch_1
+flow.executable private @while_test_dispatch_1 {
+  flow.dispatch.entry public @dispatch attributes {workgroup_rank = 3 : index}
+  builtin.module  {
+    func @dispatch(%arg0: !flow.dispatch.tensor<readonly:i32>, %arg1: !flow.dispatch.tensor<writeonly:i32>) {
+      %c2_i32 = arith.constant 2 : i32
+      %0 = flow.dispatch.tensor.load %arg0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i32> -> tensor<i32>
+      %1 = linalg.init_tensor [] : tensor<i32>
+      %2 = linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%0 : tensor<i32>) outs(%1 : tensor<i32>) {
+      ^bb0(%arg2: i32, %arg3: i32):
+        %3 = arith.addi %arg2, %c2_i32 : i32
+        linalg.yield %3 : i32
+      } -> tensor<i32>
+      flow.dispatch.tensor.store %2, %arg1, offsets = [], sizes = [], strides = [] : tensor<i32> -> !flow.dispatch.tensor<writeonly:i32>
+      return
+    }
+  }
+}
+
+// CHECK-LABEL: func @while_test
+func @while_test() {
+  %c1 = arith.constant 1 : index
+
+  // CHECK: %[[CONSTANT:.+]] = stream.tensor.constant : tensor<i32> in !stream.resource<constant> = dense<4> : tensor<i32>
+  // CHECK: %[[CONSTANT_SIZE:.+]] = stream.resource.size %[[CONSTANT]] : !stream.resource<constant>
+  // CHECK: %[[INITIAL:.+]] = stream.async.transfer %[[CONSTANT]] : !stream.resource<constant>{%[[CONSTANT_SIZE]]} -> !stream.resource<*>{%[[CONSTANT_SIZE]]}
+  %cst = arith.constant dense<4> : tensor<i32>
+  // CHECK: %[[INITIAL_DNO:.+]] = util.do_not_optimize(%[[INITIAL]]) : !stream.resource<*>
+  %0 = util.do_not_optimize(%cst) : tensor<i32>
+
+  // CHECK: %[[VAR_SIZE:.+]] = stream.resource.size %[[INITIAL_DNO]] : !stream.resource<*>
+  // CHECK: br ^bb1(%[[INITIAL_DNO]], %[[VAR_SIZE]] : !stream.resource<*>, index)
+  br ^bb1(%0 : tensor<i32>)
+
+// CHECK: ^bb1(%[[BB1_ARG:.+]]: !stream.resource<*>, %[[BB1_ARG_SIZE:.+]]: index):
+^bb1(%1: tensor<i32>):
+  // CHECK: %[[COND_SIZE:.+]] = stream.tensor.sizeof tensor<i1> : index
+  // CHECK: %[[COND_RESOURCE:.+]] = stream.async.dispatch @while_test_dispatch_0::@dispatch[%c1, %c1, %c1](%[[BB1_ARG]]) : (!stream.resource<*>{%[[BB1_ARG_SIZE]]}) -> !stream.resource<*>{%[[COND_SIZE]]}
+  %2 = flow.dispatch @while_test_dispatch_0::@dispatch[%c1, %c1, %c1](%1) : (tensor<i32>) -> tensor<i1>
+
+  // CHECK: %[[READBACK:.+]] = stream.async.transfer %[[COND_RESOURCE]] : !stream.resource<*>{%[[COND_SIZE]]} -> !stream.resource<staging>{%[[COND_SIZE]]}
+  // CHECK: %[[COND:.+]] = stream.tensor.load %[[READBACK]] : tensor<i1> in !stream.resource<staging>{%[[COND_SIZE]]} -> i1
+  %3 = flow.tensor.load %2 : tensor<i1>
+
+  // CHECK: cond_br %[[COND]], ^bb2, ^bb3
+  cond_br %3, ^bb2, ^bb3
+
+// CHECK: ^bb2:
+^bb2:
+  // CHECK: %[[BB2_VAR_SIZE:.+]] = stream.tensor.sizeof tensor<i32> : index
+  // CHECK: %[[BB2_VAR:.+]] = stream.async.dispatch @while_test_dispatch_1::@dispatch[%c1, %c1, %c1](%[[BB1_ARG]]) : (!stream.resource<*>{%[[BB1_ARG_SIZE]]}) -> !stream.resource<*>{%[[BB2_VAR_SIZE]]}
+  %4 = flow.dispatch @while_test_dispatch_1::@dispatch[%c1, %c1, %c1](%1) : (tensor<i32>) -> tensor<i32>
+
+  // CHECK: br ^bb1(%[[BB2_VAR]], %[[BB2_VAR_SIZE]] : !stream.resource<*>, index)
+  br ^bb1(%4 : tensor<i32>)
+
+// CHECK: ^bb3:
+^bb3:
+  // CHECK: %[[EXTERNAL_RESULT:.+]] = stream.async.transfer %[[BB1_ARG]] : !stream.resource<*>{%[[BB1_ARG_SIZE]]} -> !stream.resource<external>{%[[BB1_ARG_SIZE]]}
+  // CHECK: %[[TENSOR_RESULT:.+]] = stream.tensor.export %[[EXTERNAL_RESULT]] : tensor<i32> in !stream.resource<external>{%[[BB1_ARG_SIZE]]} -> tensor<i32>
+  // CHECK: %[[EXTERNAL_CONSTANT:.+]] = stream.async.transfer %[[INITIAL]] : !stream.resource<*>{%[[CONSTANT_SIZE]]} -> !stream.resource<external>{%[[CONSTANT_SIZE]]}
+  // CHECK: %[[TENSOR_CONSTANT:.+]] = stream.tensor.export %[[EXTERNAL_CONSTANT]] : tensor<i32> in !stream.resource<external>{%[[CONSTANT_SIZE]]} -> tensor<i32>
+  // CHECK: check.expect_eq(%[[TENSOR_RESULT]], %[[TENSOR_CONSTANT]]) : tensor<i32>
+  check.expect_eq(%1, %cst) : tensor<i32>
+  return
+}

--- a/iree/test/e2e/tosa_ops/while.mlir
+++ b/iree/test/e2e/tosa_ops/while.mlir
@@ -24,56 +24,56 @@ func @while_test_iter0() {
   return
 }
 
-// // i = 2, n = 2
-// func @while_test_iter1() {
-//   %0 = util.unfoldable_constant dense<2> : tensor<i32>
-//   %1 = "tosa.while_loop"(%0) ( {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-//     "tosa.yield"(%3) : (tensor<i1>) -> ()
-//   },  {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-//     "tosa.yield"(%3) : (tensor<i32>) -> ()
-//   }) : (tensor<i32>) -> (tensor<i32>)
-//   check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
-//   return
-// }
+// i = 2, n = 2
+func @while_test_iter1() {
+  %0 = util.unfoldable_constant dense<2> : tensor<i32>
+  %1 = "tosa.while_loop"(%0) ( {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "tosa.yield"(%3) : (tensor<i1>) -> ()
+  },  {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    "tosa.yield"(%3) : (tensor<i32>) -> ()
+  }) : (tensor<i32>) -> (tensor<i32>)
+  check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
+  return
+}
 
-// // i = 0, n = 2
-// func @while_test_iter2() {
-//   %0 = util.unfoldable_constant dense<0> : tensor<i32>
-//   %1 = "tosa.while_loop"(%0) ( {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-//     "tosa.yield"(%3) : (tensor<i1>) -> ()
-//   },  {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-//     "tosa.yield"(%3) : (tensor<i32>) -> ()
-//   }) : (tensor<i32>) -> (tensor<i32>)
-//   check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
-//   return
-// }
+// i = 0, n = 2
+func @while_test_iter2() {
+  %0 = util.unfoldable_constant dense<0> : tensor<i32>
+  %1 = "tosa.while_loop"(%0) ( {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "tosa.yield"(%3) : (tensor<i1>) -> ()
+  },  {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    "tosa.yield"(%3) : (tensor<i32>) -> ()
+  }) : (tensor<i32>) -> (tensor<i32>)
+  check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
+  return
+}
 
-// // i = 0, n = 1
-// func @while_test_iter4() {
-//   %0 = util.unfoldable_constant dense<0> : tensor<i32>
-//   %1 = "tosa.while_loop"(%0) ( {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-//     "tosa.yield"(%3) : (tensor<i1>) -> ()
-//   },  {
-//   ^bb0(%arg0: tensor<i32>):
-//     %2 = "tosa.const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
-//     %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-//     "tosa.yield"(%3) : (tensor<i32>) -> ()
-//   }) : (tensor<i32>) -> (tensor<i32>)
-//   check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
-//   return
-// }
+// i = 0, n = 1
+func @while_test_iter4() {
+  %0 = util.unfoldable_constant dense<0> : tensor<i32>
+  %1 = "tosa.while_loop"(%0) ( {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.greater_equal"(%2, %arg0) : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    "tosa.yield"(%3) : (tensor<i1>) -> ()
+  },  {
+  ^bb0(%arg0: tensor<i32>):
+    %2 = "tosa.const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+    %3 = "tosa.add"(%arg0, %2) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+    "tosa.yield"(%3) : (tensor<i32>) -> ()
+  }) : (tensor<i32>) -> (tensor<i32>)
+  check.expect_eq_const(%1, dense<4> : tensor<i32>) : tensor<i32>
+  return
+}


### PR DESCRIPTION
This would be triggered only if the tensor used by the external dialect
was directly captured from a block argument. I added a more complete
test for the convert to stream pass taken from the tosa while.mlir that
covers this and more.