### PR TITLE
Fixing dispatch region outlining with tied operands with dynamic shapes.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -91,7 +91,9 @@ static LogicalResult convertToDispatchOp(DispatchWorkgroupsOp regionOp,
       auto dynamicDims = Shape::buildOrFindDynamicDimsForValue(
           regionOp.getLoc(), result, builder);
       resultDynamicDims.append(dynamicDims);
-      newOperands.append(dynamicDims);
+      if (!regionOp.getTiedResultOperand(result)) {
+        newOperands.append(dynamicDims);
+      }
     }
   }
 

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -94,7 +94,7 @@ def InterchangeGenericOps :
 }
 
 def OutlineDispatchRegions :
-    Pass<"iree-flow-outline-dispatch-regions2", "mlir::ModuleOp"> {
+    Pass<"iree-flow-outline-dispatch-regions", "mlir::ModuleOp"> {
   let summary = "Outlines dispatch regions into executables";
   let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineDispatchRegionsPass()";
 }

--- a/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-flow-outline-dispatch-regions2 %s | IreeFileCheck %s
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -iree-flow-outline-dispatch-regions %s | IreeFileCheck %s
 
 //      CHECK: flow.executable private @staticShapeDispatch_dispatch_0
 // CHECK-NEXT:   flow.dispatch.entry public @staticShapeDispatch_dispatch_0 attributes {


### PR DESCRIPTION
This was always adding on some extra operands before that were harmless,
however in the streams world we actually optimize things and need the
interfaces to match on both sides.

(also dropped the 2 in the pass name)