### PR TITLE
Prevent partitioning from moving ops across side-effecting ops.

### DIFF
--- a/iree/compiler/Dialect/Stream/Analysis/Partitioning.cpp
+++ b/iree/compiler/Dialect/Stream/Analysis/Partitioning.cpp
@@ -30,7 +30,7 @@ void dumpPartition(Partition &partition, AsmState &state) {
     out.printAsOperand(llvm::dbgs(), state);
   });
   llvm::dbgs() << "\n OPS:\n";
-  for (auto *op : partition.ops) {
+  for (auto *op : llvm::reverse(partition.ops)) {
     llvm::dbgs() << "  ";
     op->print(llvm::dbgs(), state);
     llvm::dbgs() << "\n";

--- a/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -51,16 +51,14 @@ struct ExecutePartitionBuilder {
     auto fusedLoc = FusedLoc::get(context, locs);
 
     // Find the insertion point in the parent block.
-    // This is at the last op defining an input as all inputs must be available.
+    // This is at the last op in the partition.
     Operation *insertionPt = nullptr;
-    for (auto in : partition->ins) {
-      auto *definingOp = in.getDefiningOp();
-      if (!definingOp) continue;
-      if (definingOp->getBlock() != parentBlock) continue;
+    for (auto *op : partition->ops) {
+      if (op->getBlock() != parentBlock) continue;
       if (!insertionPt) {
-        insertionPt = definingOp;  // first defining op
-      } else if (insertionPt->isBeforeInBlock(definingOp)) {
-        insertionPt = definingOp;  // moving insertion point down
+        insertionPt = op;  // first defining op
+      } else if (insertionPt->isBeforeInBlock(op)) {
+        insertionPt = op;  // moving insertion point down
       }
     }
     OpBuilder parentBuilder(context);


### PR DESCRIPTION
This is conservative and uses any side-effecting non-streamable op
as a barrier. We could use memory effects to do better things but
this at least should keep us correct. It's assumed that asserts should
be hoisted higher up in the IR during canonicalization.