### PR TITLE
IREEComprehensiveBufferize: Use new op interface

### DIFF
--- a/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -67,7 +68,128 @@ static MemRefType getMemrefTypeForTensor(TensorType tensorType,
                          layout, memorySpace);
 }
 
+using linalg::comprehensive_bufferize::BufferizableOpInterface;
+using linalg::comprehensive_bufferize::BufferizationAliasInfo;
+using linalg::comprehensive_bufferize::BufferizationState;
+
+Value getSubspanBuffer(Value tensor, OpBuilder &b, BufferizationState &state) {
+  if (!state.isMapped(tensor)) {
+    OpBuilder::InsertionGuard g(b);
+    auto subspanOp =
+        tensor.getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>();
+    assert(subspanOp && "expected LoadOp/StoreOp source/target is SubspanOp");
+
+    auto shapedType = subspanOp.getResult()
+                          .getType()
+                          .dyn_cast<IREE::Flow::DispatchTensorType>();
+    assert(shapedType && shapedType.hasRank());
+
+    b.setInsertionPoint(subspanOp);
+    // Just change the result type of the InterfaceBindingSubspanOp.
+    auto memRefType = getMemrefTypeForTensor(shapedType);
+    auto baseBuffer = b.create<IREE::HAL::InterfaceBindingSubspanOp>(
+        subspanOp->getLoc(), memRefType, subspanOp.binding(),
+        subspanOp.byte_offset(), subspanOp.byte_length(),
+        subspanOp.dynamic_dims());
+    state.mapValue(subspanOp, baseBuffer);
+    state.aliasInfo.createAliasInfoEntry(subspanOp.result());
+  }
+
+  return state.lookupValue(tensor);
+}
+
 namespace {
+
+struct DispatchTensorLoadOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          DispatchTensorLoadOpInterface, IREE::Flow::DispatchTensorLoadOp> {
+  SmallVector<OpOperand *> getAliasingOpOperand(Operation *op,
+                                                OpResult opResult) const {
+    return {};
+  }
+
+  bool isWritable(Operation *op, Value value) const {
+    auto loadOp = cast<IREE::Flow::DispatchTensorLoadOp>(op);
+    auto shapedType =
+        loadOp.source().getType().dyn_cast<IREE::Flow::DispatchTensorType>();
+    assert(shapedType && "unexpected source type");
+    return shapedType.getAccess() != IREE::Flow::TensorAccess::ReadOnly;
+  }
+
+  LogicalResult bufferize(Operation *op, OpBuilder &b,
+                          BufferizationState &state) const {
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(op);
+    auto loadOp = cast<IREE::Flow::DispatchTensorLoadOp>(op);
+    Value source = getSubspanBuffer(loadOp.source(), b, state);
+
+    // Bufferize to subview.
+    Value subView = b.create<memref::SubViewOp>(
+        loadOp->getLoc(), source, loadOp.getMixedOffsets(),
+        loadOp.getMixedSizes(), loadOp.getMixedStrides());
+    state.mapBuffer(loadOp.result(), subView);
+
+    return success();
+  }
+};
+
+/// Return true if the value of a `storeOp` bufferizes to an equivalent
+/// DispatchTensorLoadOp result that bufferizes inplace.
+static bool isValueEquivalentToAnInplaceTensorLoadOp(
+    const BufferizationAliasInfo &aliasInfo,
+    IREE::Flow::DispatchTensorStoreOp storeOp) {
+  bool foundOp = false;
+  aliasInfo.applyOnEquivalenceClass(storeOp.value(), [&](Value value) {
+    auto loadOp = value.getDefiningOp<IREE::Flow::DispatchTensorLoadOp>();
+    // TODO: Assert that offsets, sizes and strides are the same.
+    if (loadOp &&
+        aliasInfo.areEquivalentBufferizedValues(loadOp.result(),
+                                                storeOp.value()) &&
+        loadOp.source() == storeOp.target()) {
+      foundOp = true;
+    }
+  });
+
+  return foundOp;
+}
+
+struct DispatchTensorStoreOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          DispatchTensorStoreOpInterface, IREE::Flow::DispatchTensorStoreOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand) const {
+    return true;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand) const {
+    return false;
+  }
+
+  OpResult getAliasingOpResult(Operation *op, OpOperand &opOperand) const {
+    return OpResult();
+  }
+
+  LogicalResult bufferize(Operation *op, OpBuilder &b,
+                          BufferizationState &state) const {
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPoint(op);
+    auto storeOp = cast<IREE::Flow::DispatchTensorStoreOp>(op);
+
+    // If everything bufferized inplace, no copy is needed. We wrote to the
+    // target buffer already.
+    if (!isValueEquivalentToAnInplaceTensorLoadOp(state.aliasInfo, storeOp)) {
+      Value target = getSubspanBuffer(storeOp.target(), b, state);
+      Value subView = b.create<memref::SubViewOp>(
+          storeOp->getLoc(), target, storeOp.getMixedOffsets(),
+          storeOp.getMixedSizes(), storeOp.getMixedStrides());
+      Value srcMemref = state.lookupBuffer(storeOp.value());
+      state.allocationFns.memCpyFn(b, storeOp->getLoc(), srcMemref, subView);
+    }
+
+    state.markOpObsolete(storeOp);
+    return success();
+  }
+};
+
 /// Pass to convert from tensor based ops to memref based ops.
 class IREEComprehensiveBufferizePass
     : public IREEComprehensiveBufferizeBase<IREEComprehensiveBufferizePass> {
@@ -85,11 +207,21 @@ class IREEComprehensiveBufferizePass
     registry.insert<arith::ArithmeticDialect, IREE::Util::UtilDialect,
                     linalg::LinalgDialect, memref::MemRefDialect,
                     scf::SCFDialect, StandardOpsDialect, tensor::TensorDialect,
-                    vector::VectorDialect, AffineDialect>();
+                    vector::VectorDialect, AffineDialect,
+                    IREE::Flow::FlowDialect>();
+
+    // TODO: Find a better place to register external models.
+    // Registers operations of other dialects.
     linalg::comprehensive_bufferize::
         registerBufferizableOpInterfaceExternalModels(registry);
     linalg::comprehensive_bufferize::linalg_ext::
         registerBufferizableOpInterfaceExternalModels(registry);
+
+    // Register IREE operations.
+    registry.addOpInterface<IREE::Flow::DispatchTensorLoadOp,
+                            DispatchTensorLoadOpInterface>();
+    registry.addOpInterface<IREE::Flow::DispatchTensorStoreOp,
+                            DispatchTensorStoreOpInterface>();
   }
 
   void runOnOperation() override;
@@ -102,150 +234,15 @@ class IREEComprehensiveBufferizePass
 
 static bool isaTensor(Type t) { return t.isa<TensorType>(); };
 
-/// Stitch comprehensive bufferization inside of IREE by proceeding as follows:
-///   1. a. Bufferizes InterfaceBindingSubspanOp optimistically
-///      b. Insert a memref::TensorLoad to serve as glue between the buffer and
-///         tensor worlds.
-///      c. Record aliasInfo of memref::TensorLoad manually
-///      d. Record inplaceability of memref::TensorLoad manually
-///      e. Record the bufferization of memref::TensorLoad manually
-///   2. Rewrite all Flow::Dispatch::TensorLoad ops as Tensor::ExtractSliceOp
-///      that comprehensive bufferization understands.
-///   3. Specifically select the ops we want to bufferize / skip. In the future,
-///      this may be better specified with a BufferizationOpInterface.
-///   4. Perform analysis and bufferization on the ops.
+/// Run comprehensive bufferize.
 void IREEComprehensiveBufferizePass::runOnOperation() {
   ModuleOp moduleOp = getOperation();
-  MLIRContext *context = &getContext();
 
-  for (auto funcOp : moduleOp.getOps<FuncOp>()) {
-    OpBuilder b(context);
+  linalg::comprehensive_bufferize::BufferizationOptions options;
+  options.testAnalysisOnly = false;
+  // TODO: Use allocationFn.
 
-    LLVM_DEBUG(llvm::dbgs()
-               << "After conversion to destination passing style:\n"
-               << *funcOp << "\n");
-
-    // 1. First go over all hal.interface.binding.subspan ops and create
-    // counterparts working with memrefs.
-    BlockAndValueMapping bvm, tensorLoads;
-    linalg::comprehensive_bufferize::BufferizationAliasInfo aliasInfo(funcOp);
-    // These are used until late, erase on scoped exit.
-    SmallVector<Operation *> toEraseLate;
-    auto scopeGuard = llvm::make_scope_exit([&]() {
-      for (Operation *op : llvm::reverse(toEraseLate)) op->erase();
-    });
-    funcOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp op) {
-      auto shapedType =
-          op.getResult().getType().dyn_cast<IREE::Flow::DispatchTensorType>();
-      if (!shapedType || !shapedType.hasRank()) return;
-      OpBuilder::InsertionGuard g(b);
-      b.setInsertionPoint(op);
-      // 1.a. Just change the result type of the InterfaceBindingSubspanOp to
-      // from the base buffer.
-      auto memRefType = getMemrefTypeForTensor(shapedType);
-      auto baseBuffer = b.create<IREE::HAL::InterfaceBindingSubspanOp>(
-          op->getLoc(), memRefType, op.binding(), op.byte_offset(),
-          op.byte_length(), op.dynamic_dims());
-      bvm.map(op, baseBuffer);
-
-      // This op does not operate on core tensor types and has half-side
-      // effecting semantics. It cannot be added to BufferizationAliasInfo.
-      // Instead:
-      // 1.b. Insert a memref::TensorLoad to serve as glue between the buffer
-      // and tensor worlds.
-      Value tensor = b.create<memref::TensorLoadOp>(op->getLoc(), baseBuffer);
-      // 1.c. Insert a new entry manually into the existing aliasInfo.
-      aliasInfo.createAliasInfoEntry(op.result());
-      aliasInfo.createAliasInfoEntry(tensor);
-      tensorLoads.map(op.result(), tensor);
-      // 1.d. Mark tensors that bufferize to writeable memory as such.
-      if (shapedType.getAccess() != IREE::Flow::TensorAccess::ReadOnly) {
-        aliasInfo.setBufferizesToWritableMemory(tensor);
-      }
-      // 1.e. Save tensor -> baseBuffer into BVM.
-      bvm.map(tensor, baseBuffer);
-
-      // Drop the original op that is now bufferized.
-      toEraseLate.push_back(op);
-    });
-
-    // 2. Rewrite all Flow::Dispatch::TensorLoad ops as Tensor::ExtractSliceOp.
-    funcOp.walk<WalkOrder::PostOrder>([&](IREE::Flow::DispatchTensorLoadOp op) {
-      OpBuilder b(op);
-      Value v = b.create<tensor::ExtractSliceOp>(
-          op->getLoc(), op.result().getType().cast<RankedTensorType>(),
-          tensorLoads.lookup(op.source()), op.getMixedOffsets(),
-          op.getMixedSizes(), op.getMixedStrides());
-      // Insert a new entry manually into the existing aliasInfo.
-      aliasInfo.createAliasInfoEntry(v);
-      op.result().replaceAllUsesWith(v);
-      toEraseLate.push_back(op);
-    });
-    funcOp.walk<WalkOrder::PostOrder>(
-        [&](IREE::Flow::DispatchTensorStoreOp op) {
-          OpBuilder b(op);
-          Value v = b.create<tensor::InsertSliceOp>(
-              op->getLoc(), op.value(), tensorLoads.lookup(op.target()),
-              op.getMixedOffsets(), op.getMixedSizes(), op.getMixedStrides());
-          // Insert a new entry manually into the existing aliasInfo.
-          aliasInfo.createAliasInfoEntry(v);
-          toEraseLate.push_back(op);
-        });
-
-    LLVM_DEBUG(llvm::dbgs() << "After rewriting of Flow ops\n"
-                            << *funcOp << "\n");
-
-    // TODO: Visit all the operations that return `tensor`s that are not handled
-    // by comprehensive bufferize.
-
-    // 3. Specifically select the ops we want to bufferize / skip. In the
-    // future, this may be better specified with a BufferizationOpInterface.
-    DominanceInfo domInfo(funcOp);
-    SmallVector<Operation *> ops;
-    ops.reserve(funcOp.body().front().getOperations().size());
-    WalkResult opsSelected =
-        funcOp.body().walk([&](Operation *op) -> WalkResult {
-          if (isa<IREE::HAL::InterfaceBindingSubspanOp,
-                  IREE::Flow::DispatchTensorLoadOp,
-                  IREE::Flow::DispatchTensorStoreOp>(op)) {
-            return WalkResult::advance();
-          }
-          if (llvm::none_of(op->getOperandTypes(), isaTensor) &&
-              llvm::none_of(op->getResultTypes(), isaTensor)) {
-            return WalkResult::advance();
-          }
-          if (op->getParentOfType<linalg::LinalgOp>())
-            return WalkResult::advance();
-          // TODO: if we want to bufferize function calls, we need FuncOp
-          // and to pass a proper bufferizedFunctionTypes.
-          if (isa<CallOpInterface>(op)) {
-            return static_cast<LogicalResult>(op->emitError(
-                "CallOpInterface bufferization not supported in IREE"));
-          }
-          ops.push_back(op);
-          return WalkResult::advance();
-        });
-
-    // 4. Perform inplaceability analysis of `ops`.
-    if (opsSelected.wasInterrupted() ||
-        failed(linalg::comprehensive_bufferize::inPlaceAnalysis(ops, aliasInfo,
-                                                                domInfo))) {
-      return signalPassFailure();
-    }
-
-    LLVM_DEBUG(llvm::dbgs() << "After inplaceability analysis\n"
-                            << *funcOp << "\n");
-
-    // 5. Perform bufferization.
-    linalg::comprehensive_bufferize::BufferizationState state(aliasInfo,
-                                                              *allocationFn);
-    // Merge `bvm` into `state`.
-    for (auto it : bvm.getValueMap()) state.mapValue(it.first, it.second);
-    for (Operation *op : ops)
-      if (failed(linalg::comprehensive_bufferize::bufferizeOp(
-              op, state, /*bufferizedFunctionTypes=*/nullptr)))
-        return signalPassFailure();
-  }
+  if (failed(runComprehensiveBufferize(moduleOp, options))) signalPassFailure();
 }
 
 // TODO: pass this to comprehensive bufferize.

--- a/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -40,6 +40,7 @@ hal.interface private @io  {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
 //      CHECK: func @matmul()
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.load.constant offset = 0
 //  CHECK-DAG:   %[[N:.+]] = hal.interface.load.constant offset = 1
@@ -64,15 +65,17 @@ hal.interface private @io  {
 //      CHECK:       %[[TILESIZE_X:.+]] = affine.min #[[MAP1]](%[[IV1]])[%[[WG_SIZE_X]], %[[N]]]
 //  CHECK-DAG:       %[[LHS_TILE:.+]] = memref.subview %[[LHS]][%[[IV0]], 0] [%[[TILESIZE_Y]], %[[K]]]
 //  CHECK-DAG:       %[[RHS_TILE:.+]] = memref.subview %[[RHS]][0, %[[IV1]]] [%[[K]], %[[TILESIZE_X]]]
-//  CHECK-DAG:       %[[ALLOC:.+]] = memref.alloc(%[[TILESIZE_Y]], %[[TILESIZE_X]]) {alignment = 128 : i64}
 //  CHECK-DAG:       %[[INIT_TILE:.+]] = memref.subview %[[INIT]][%[[IV0]], %[[IV1]]] [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
-//      CHECK:       memref.copy %[[INIT_TILE]], %[[ALLOC]]
+//  CHECK-DAG:       %[[ALLOC:.+]] = memref.alloc(%[[TILESIZE_Y]], %[[TILESIZE_X]]) {alignment = 128 : i64}
+//      CHECK:       %[[ALLOC_CASTED:.+]] = memref.cast %[[ALLOC]] : memref<?x?xf32> to memref<?x?xf32, #[[MAP2]]>
+//      CHECK:       memref.copy %[[INIT_TILE]], %[[ALLOC_CASTED]]
 //      CHECK:       linalg.matmul
 // CHECK-SAME:           ins(%[[LHS_TILE]], %[[RHS_TILE]]
 // CHECK-SAME:           outs(%[[ALLOC]]
 //      CHECK:       %[[RESULT_TILE:.+]] = memref.subview %[[RESULT]][%[[IV0]], %[[IV1]]] [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
-//      CHECK:       memref.copy %[[ALLOC]], %[[RESULT_TILE]]
+//      CHECK:       memref.copy %[[ALLOC_CASTED]], %[[RESULT_TILE]]
 //      CHECK:       memref.dealloc %[[ALLOC]]
+
 
 // -----
 
@@ -148,3 +151,4 @@ hal.interface private @io  {
 //  CHECK-DAG:       %[[RESULT_TILE:.+]] = memref.subview %[[RESULT]][%[[IV0]], %[[IV1]]] [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
 //      CHECK:       memref.copy %[[ALLOC]], %[[RESULT_TILE]]
 //      CHECK:       memref.dealloc %[[ALLOC]]
+


### PR DESCRIPTION
Implement `BufferiableOpInterface` on `DispatchTensorLoadOp` and
`DispatchTensorStoreOp`, so that these ops can be bufferized directly. Configure and run Comprehensive Bufferize via `runComprehensiveBufferize` without leaking internals of the bufferization.

Note: This change is dependent on MLIR D113723 and D113726.