### PR TITLE
Support global variables with quantized types

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TFL/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:ReconcileUnrealizedCasts",
         "@llvm-project//mlir:Shape",
         "@llvm-project//mlir:ShapeTransforms",
         "@llvm-project//mlir:StandardOps",

--- a/integrations/tensorflow/iree_tf_compiler/TFL/LowerGlobalTensors.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/LowerGlobalTensors.cpp
@@ -14,6 +14,10 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
+#include "third_party/llvm/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinAttributes.h"
+#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinOps.h"
+#include "third_party/tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
 
 namespace mlir {
 namespace iree_integrations {
@@ -24,7 +28,7 @@ class LowerGlobalTensorsPass
     : public LowerGlobalTensorsBase<LowerGlobalTensorsPass> {
  public:
   void getDependentDialects(DialectRegistry& registry) const override {
-    registry.insert<mlir::TFL::TensorFlowLiteDialect,
+    registry.insert<mlir::TFL::TensorFlowLiteDialect, tosa::TosaDialect,
                     iree_compiler::IREE::Util::UtilDialect>();
   }
 
@@ -49,14 +53,29 @@ class LowerGlobalTensorsPass
       // Look through the initialization functions and find the assigned values
       // for each handle, save out the constant value.
       for (auto init : func.getOps<mlir::TFL::CallOnceOp>()) {
-        FuncOp initFunc = symNameToFunction[init.session_init_function()];
+        auto findInitFunc =
+            symNameToFunction.find(init.session_init_function());
+        if (findInitFunc == symNameToFunction.end()) {
+          init.emitError("Unable to find initialization function: " +
+                         init.session_init_function());
+          continue;
+        }
+        FuncOp initFunc = std::get<1>(*findInitFunc);
         for (auto assign : initFunc.getOps<mlir::TFL::AssignVariableOp>()) {
           auto handle = dyn_cast<mlir::TFL::VarHandleOp>(
               assign.resource_id().getDefiningOp());
           if (!handle) continue;
 
           DenseElementsAttr constant;
-          if (!matchPattern(assign.value(), m_Constant(&constant))) continue;
+          if (!matchPattern(assign.value(), m_Constant(&constant))) {
+            // Quantized types we can not use the m_Constant matcher.
+            if (auto constOp = dyn_cast<mlir::TFL::QConstOp>(
+                    assign.value().getDefiningOp())) {
+              constant = constOp.value().cast<DenseElementsAttr>();
+            }
+          }
+          if (!constant) continue;
+
           auto name = handle.shared_name();
           sharedNameToConstant[name] = constant;
           sharedNameToLoc[name] = handle.getLoc();
@@ -131,8 +150,19 @@ class LowerGlobalTensorsPass
       if (!address) continue;
 
       builder.setInsertionPoint(assign);
+      Value value = assign.value();
+      Type storageType = address.getType()
+                             .cast<iree_compiler::IREE::Util::PtrType>()
+                             .getTargetType();
+      if (storageType != value.getType()) {
+        value = builder
+                    .create<UnrealizedConversionCastOp>(assign.getLoc(),
+                                                        storageType, value)
+                    .getResult(0);
+      }
+
       builder.create<iree_compiler::IREE::Util::GlobalStoreIndirectOp>(
-          assign.getLoc(), assign.value(), assign.resource_id());
+          assign.getLoc(), value, assign.resource_id());
       assign.erase();
     }
 
@@ -149,9 +179,15 @@ class LowerGlobalTensorsPass
       auto type = ptrType.getTargetType();
 
       builder.setInsertionPoint(read);
-      auto load =
+      Value load =
           builder.create<iree_compiler::IREE::Util::GlobalLoadIndirectOp>(
               read.getLoc(), type, read.resource_id());
+      if (type != read.getResult().getType()) {
+        load = builder
+                   .create<UnrealizedConversionCastOp>(
+                       read.getLoc(), read.getResult().getType(), load)
+                   .getResult(0);
+      }
       read.getResult().replaceAllUsesWith(load);
       read.erase();
     }

--- a/integrations/tensorflow/iree_tf_compiler/TFL/LowerGlobalTensors.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/LowerGlobalTensors.cpp
@@ -10,14 +10,13 @@
 #include "iree/compiler/Utils/ConversionUtils.h"
 #include "iree_tf_compiler/TFL/PassDetail.h"
 #include "iree_tf_compiler/TFL/Passes.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
-#include "third_party/llvm/llvm-project/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h"
-#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinAttributes.h"
-#include "third_party/llvm/llvm-project/mlir/include/mlir/IR/BuiltinOps.h"
-#include "third_party/tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
 
 namespace mlir {
 namespace iree_integrations {

--- a/integrations/tensorflow/iree_tf_compiler/TFL/Passes.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/Passes.cpp
@@ -7,6 +7,7 @@
 #include "iree_tf_compiler/TFL/Passes.h"
 
 #include "iree/compiler/Dialect/Shape/Transforms/Passes.h"
+#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -56,6 +57,7 @@ void buildTFLImportPassPipeline(OpPassManager &pm) {
   mlir::tosa::createTFTFLtoTOSALegalizationPipeline(pm, tosaOptions);
   pm.nest<FuncOp>().addPass(mlir::tosa::createStripQuantTypesPass());
   pm.addPass(createCanonicalizerPass());
+  pm.addPass(createReconcileUnrealizedCastsPass());
 
   //----------------------------------------------------------------------------
   // Lowering shape-related constructs

--- a/integrations/tensorflow/iree_tf_compiler/TFL/VerifyFullyConverted.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/VerifyFullyConverted.cpp
@@ -28,6 +28,7 @@ class VerifyFullyConvertedPass
     ConversionTarget target(getContext());
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
     target.addIllegalDialect<mlir::TFL::TensorFlowLiteDialect>();
+    target.addIllegalOp<mlir::UnrealizedConversionCastOp>();
     if (failed(
             iree_compiler::verifyAllOperationsAreLegal(getOperation(), target)))
       return signalPassFailure();

--- a/integrations/tensorflow/iree_tf_compiler/TFL/test/lower_global_tensors.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/test/lower_global_tensors.mlir
@@ -1,9 +1,8 @@
 // RUN: iree-opt-tflite -split-input-file -allow-unregistered-dialect -pass-pipeline='iree-tflite-lower-global-tensors' %s | IreeFileCheck %s
 
-// CHECK-LABEL: module {
 module {
   // CHECK: util.global private mutable @__iree_flow_Variable = dense<1.000000e+00> : tensor<16x16xf32>
-  // CHECK: func @state
+  // CHECK-LABEL: func @state
   func @state(%arg0: tensor<16x16xf32>) -> () {
     "tfl.call_once"() {session_init_function = "StateInit"} : () -> ()
     return
@@ -19,11 +18,10 @@ module {
 
 // -----
 
-// CHECK-LABEL: module {
 module {
   // CHECK: util.global private mutable @__iree_flow_Variable = dense<1.000000e+00> : tensor<16x16xf32>
 
-  // CHECK: func @assign
+  // CHECK-LABEL: func @assign
   func @assign(%arg0: tensor<16x16xf32>) -> () {
     "tfl.call_once"() {session_init_function = "AssignInit"} : () -> ()
     // CHECK: %[[ADDR:.+]] = util.global.address @__iree_flow_Variable : !util.ptr<tensor<16x16xf32>>
@@ -44,11 +42,10 @@ module {
 
 // -----
 
-// CHECK-LABEL: module {
 module {
   // CHECK: util.global private mutable @__iree_flow_Variable = dense<1.000000e+00> : tensor<16x16xf32>
 
-  // CHECK: func @read
+  // CHECK-LABEL: func @read
   func @read(%arg0: tensor<16x16xf32>) -> (tensor<16x16xf32>) {
     "tfl.call_once"() {session_init_function = "ReadInit"} : () -> ()
 
@@ -70,11 +67,10 @@ module {
 
 // -----
 
-// CHECK-LABEL: module {
 module {
   // CHECK: util.global private mutable @__iree_flow_Variable = dense<2.000000e+00> : tensor<16x16xf32>
 
-  // func @readAssign
+  // CHECK-LABEL: func @readAssign
   func @readAssign(%arg0: tensor<16x16xf32>) -> (tensor<16x16xf32>) {
     "tfl.call_once"() {session_init_function = "ReadAssignInit"} : () -> ()
     // CHECK: %[[ADDR:.+]] = util.global.address @__iree_flow_Variable : !util.ptr<tensor<16x16xf32>>
@@ -100,12 +96,11 @@ module {
 
 // -----
 
-// CHECK-LABEL: module {
 module {
-  // func @readAssignQuant
+  // CHECK: util.global private mutable @__iree_flow_Variable = dense<42> : tensor<2x3xi8>
+  // CHECK-LABEL: func @readAssignQuant
   func @readAssignQuant(%arg0: tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) -> (tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) {
     "tfl.call_once"() {session_init_function = "ReadAssignInit"} : () -> ()
-  // CHECK: util.global private mutable @__iree_flow_Variable = dense<42> : tensor<2x3xi8>
     %0 = "tfl.var_handle"() {container = "", shared_name = "Variable"} : () -> tensor<*x!tf_type.resource>
 
     // CHECK: %[[ADDR:.+]] = util.global.load.indirect %ptr___iree_flow_Variable : !util.ptr<tensor<2x3xi8>> -> tensor<2x3xi8>


### PR DESCRIPTION
Global tensors assume they contain pure floats / integers. This results in
quantized cases failing to lower. Updated the lowering to support quantized
types during the lowering process.