### PR TITLE
Add verification hooks for lowering configuration.

### DIFF
--- a/iree/compiler/Codegen/BUILD
+++ b/iree/compiler/Codegen/BUILD
@@ -34,7 +34,7 @@ cc_library(
     ],
     deps = [
         ":PassesIncGen",
-        "//iree/compiler/Codegen/Dialect:IREECodegenDialect"
+        "//iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//iree/compiler/Dialect/HAL/IR",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/Codegen/BUILD
+++ b/iree/compiler/Codegen/BUILD
@@ -50,6 +50,7 @@ cc_library(
         ":PassHeaders",
         ":PassesIncGen",
         "//iree/compiler/Codegen/Common",
+        "//iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//iree/compiler/Codegen/LLVMCPU",
         "//iree/compiler/Codegen/LLVMGPU",
         "//iree/compiler/Codegen/SPIRV",

--- a/iree/compiler/Codegen/BUILD
+++ b/iree/compiler/Codegen/BUILD
@@ -34,6 +34,7 @@ cc_library(
     ],
     deps = [
         ":PassesIncGen",
+        "//iree/compiler/Codegen/Dialect:IREECodegenDialect"
         "//iree/compiler/Dialect/HAL/IR",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/Codegen/CMakeLists.txt
+++ b/iree/compiler/Codegen/CMakeLists.txt
@@ -31,7 +31,8 @@ iree_cc_library(
     MLIRLinalgTransforms
     MLIRPass
     MLIRTransforms
-    iree::compiler::Codegen::Dialect::IREECodegenDialect::::iree::compiler::Dialect::HAL::IR
+    iree::compiler::Codegen::Dialect::IREECodegenDialect
+    iree::compiler::Dialect::HAL::IR
   PUBLIC
 )
 

--- a/iree/compiler/Codegen/CMakeLists.txt
+++ b/iree/compiler/Codegen/CMakeLists.txt
@@ -31,7 +31,7 @@ iree_cc_library(
     MLIRLinalgTransforms
     MLIRPass
     MLIRTransforms
-    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Codegen::Dialect::IREECodegenDialect::::iree::compiler::Dialect::HAL::IR
   PUBLIC
 )
 

--- a/iree/compiler/Codegen/CMakeLists.txt
+++ b/iree/compiler/Codegen/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     ::PassHeaders
     ::PassesIncGen
     iree::compiler::Codegen::Common
+    iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::LLVMCPU
     iree::compiler::Codegen::LLVMGPU
     iree::compiler::Codegen::SPIRV

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -304,6 +304,9 @@ static LogicalResult setRootConfig(
         lb.getInt(), ub.getInt(),
         workloadPerWorkgroup[tiledLoops.size() - 1 - i], vectorSizeVals[i]);
   }
+  if (isBatchMatmul) {
+    workloadPerWorkgroup.push_back(1);
+  }
   setTranslationInfo(
       entryPointFn,
       clUseTileFuseAndVectorize

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -189,7 +189,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors:
             addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors);
             break;
-          case IREE::Codegen::DispatchLoweringPassPipeline::CPUTileFuseAndVectorize:
+          case IREE::Codegen::DispatchLoweringPassPipeline::
+              CPUTileFuseAndVectorize:
             addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors,
                                            /*useTileAndVectorizeV2=*/true);
             break;

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -92,6 +92,21 @@ static StringRef sanitizePipelineString(StringRef input) {
   return input;
 }
 
+/// Verify that valid configuration is set for all ops within the compiled
+/// module.
+template <typename F>
+static LogicalResult verifyLoweringConfiguration(
+    ModuleOp module, IREE::Codegen::TranslationInfoAttr translationInfo,
+    F verificationFn) {
+  auto walkResult = module.walk([&](Operation *op) -> WalkResult {
+    IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+    if (!loweringConfig) return WalkResult::advance();
+    return verificationFn(op, loweringConfig, translationInfo,
+                          ArrayRef<int64_t>{});
+  });
+  return failure(walkResult.wasInterrupted());
+}
+
 void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   IREE::HAL::ExecutableVariantOp variantOp = getOperation();
   ModuleOp moduleOp = variantOp.getInnerModule();
@@ -118,55 +133,69 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     }
 
     // There might be multiple entry points in the module. Currently, all of
-    // them need to have the same pipeline.
+    // them need to have the same translation info.
     // TODO(ravishankarm): This is strange that this is not enforced
-    // structurally, but something to address later on. For now this restriction
+    // structurally, but something to address later on. The main issue is how
+    // to invoke separate dynamic pass pipelines on  entry point functions, when
+    // the passes might have module level changes. For now this restriction
     // is fine.
     llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> entryPoints =
         getAllEntryPoints(moduleOp);
-    Optional<IREE::Codegen::DispatchLoweringPassPipeline> passPipeline;
+    Optional<IREE::Codegen::TranslationInfoAttr> translationInfo;
     for (auto &it : entryPoints) {
       auto entryPointOp = it.second;
-      if (IREE::Codegen::TranslationInfoAttr translationInfo =
+      if (IREE::Codegen::TranslationInfoAttr currTranslationInfo =
               getTranslationInfo(entryPointOp)) {
-        IREE::Codegen::DispatchLoweringPassPipeline currPipeline =
-            translationInfo.getDispatchLoweringPassPipeline();
-        if (passPipeline) {
-          if (currPipeline != passPipeline.getValue()) {
-            moduleOp.emitError(
-                "unhandled compilation of entry point function with different "
-                "pass pipelines within a module");
-            return signalPassFailure();
+        if (translationInfo) {
+          if (currTranslationInfo != translationInfo.getValue()) {
+            moduleOp.emitOpError(
+                "unhandled compilation of entry point functions with different "
+                "translation info");
           }
-          continue;
+        } else {
+          translationInfo = currTranslationInfo;
         }
-        passPipeline = currPipeline;
       }
     }
 
-    executableLoweringPipeline.addPass(createSetNumWorkgroupsPass());
-    executableLoweringPipeline.addPass(createCanonicalizerPass());
-    if (!testLoweringConfiguration && passPipeline.hasValue()) {
-      OpPassManager &nestedModulePM =
-          executableLoweringPipeline.nest<ModuleOp>();
-      switch (passPipeline.getValue()) {
-        case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
-        case IREE::Codegen::DispatchLoweringPassPipeline::None:
-          addCPUDefaultPassPipeline(nestedModulePM);
-          break;
-        case IREE::Codegen::DispatchLoweringPassPipeline::CPUVectorization:
-          addCPUVectorizationPassPipeline(nestedModulePM, lowerToVectors);
-          break;
+    // Verify the configuration.
+    if (translationInfo.hasValue()) {
+      LogicalResult verificationStatus = success();
+      switch (translationInfo.getValue().getDispatchLoweringPassPipeline()) {
         case IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors:
-          addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors);
+          verificationStatus = verifyLoweringConfiguration(
+              moduleOp, translationInfo.getValue(),
+              verifyTensorToVectorsPassPipelineConfig);
           break;
-        case IREE::Codegen::DispatchLoweringPassPipeline::
-            CPUTileFuseAndVectorize:
-          addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors,
-                                         /*useTileAndVectorizeV2=*/true);
-          break;
-        default:
-          llvm_unreachable("Unsupported pipeline on CPU target.");
+        default:;
+      }
+      if (failed(verificationStatus)) {
+        return signalPassFailure();
+      }
+
+      executableLoweringPipeline.addPass(createSetNumWorkgroupsPass());
+      executableLoweringPipeline.addPass(createCanonicalizerPass());
+      if (!testLoweringConfiguration) {
+        OpPassManager &nestedModulePM =
+            executableLoweringPipeline.nest<ModuleOp>();
+        switch (translationInfo.getValue().getDispatchLoweringPassPipeline()) {
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
+          case IREE::Codegen::DispatchLoweringPassPipeline::None:
+            addCPUDefaultPassPipeline(nestedModulePM);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUVectorization:
+            addCPUVectorizationPassPipeline(nestedModulePM, lowerToVectors);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors:
+            addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUTileFuseAndVectorize:
+            addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors,
+                                           /*useTileAndVectorizeV2=*/true);
+            break;
+          default:
+            llvm_unreachable("Unsupported pipeline on CPU target.");
+        }
       }
     }
   }

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -48,6 +48,87 @@ void addCPUVectorizationPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
 }
 
+LogicalResult verifyTensorToVectorsPassPipelineConfig(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize) {
+  // Expected CPU side to have empty workgroup size.
+  if (!workgroupSize.empty()) {
+    return op->emitOpError(
+        "expected workgroup size to be empty for CPU pipelines");
+  }
+  // Verify that the translation info is using the right pipeline.
+  auto pipeline =
+      IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors;
+  StringRef pipelineName = stringifyEnum(pipeline);
+  if (translationInfo.getDispatchLoweringPassPipeline() != pipeline) {
+    return op->emitOpError("expected pipeline in translation.info to be ")
+           << pipelineName;
+  }
+
+  // Verify that the workload per workgroup is set and is non-zero.
+  SmallVector<int64_t> workloadPerWorkgroup =
+      translationInfo.getWorkloadPerWorkgroupVals();
+  SmallVector<unsigned> partitionedLoops = getPartitionedLoops(op);
+  if (workloadPerWorkgroup.size() != partitionedLoops.size()) {
+    return op->emitOpError("expected ")
+           << partitionedLoops.size()
+           << " entries for workload_per_wg, but got "
+           << workloadPerWorkgroup.size();
+  }
+  if (llvm::any_of(workloadPerWorkgroup,
+                   [](int64_t val) { return val == 0; })) {
+    return op->emitOpError("invalid to use 0 in workload_per_wg");
+  }
+
+  if (loweringConfig.getTileSizes().size() != 3) {
+    return op->emitOpError("expected three levels of tile sizes for ")
+           << pipelineName << ", got " << loweringConfig.getTileSizes().size();
+  }
+  SmallVector<int64_t> firstLevelTileSizes = loweringConfig.getTileSizeVals(0);
+  if (!firstLevelTileSizes.empty()) {
+    // Verify that if the first-level tile sizes are set, they are the same as
+    // workload_per_wg for the partitioned loops.
+    size_t minElements =
+        (partitionedLoops.empty() ? 0 : partitionedLoops.back() + 1);
+    if (firstLevelTileSizes.size() < minElements) {
+      return op->emitOpError("expected at least ")
+             << minElements
+             << " size for first level tiling to get the distribution fully "
+                "specified.";
+    }
+    llvm::SmallDenseSet<unsigned> partitionedLoopsSet;
+    partitionedLoopsSet.insert(partitionedLoops.begin(),
+                               partitionedLoops.end());
+    SmallVector<int64_t> partitionedTileSizes;
+    for (auto tileSize : llvm::enumerate(firstLevelTileSizes)) {
+      if (!partitionedLoopsSet.count(tileSize.index())) {
+        continue;
+      }
+      partitionedTileSizes.push_back(tileSize.value());
+    }
+    for (auto val : llvm::enumerate(llvm::reverse(workloadPerWorkgroup))) {
+      if (val.value() != partitionedTileSizes[val.index()]) {
+        return op->emitOpError("mismatch in distributed tile size value ")
+               << partitionedTileSizes[val.index()] << " at position "
+               << val.index() << " and workload_per_wg value " << val.value();
+      }
+    }
+  }
+
+  // Verify that native vector size is either empty, or if set is same as the
+  // last level of tiling
+  SmallVector<int64_t> nativeVectorSize =
+      loweringConfig.getNativeVectorSizeVals();
+  if (!nativeVectorSize.empty()) {
+    if (nativeVectorSize != loweringConfig.getTileSizeVals(2)) {
+      return op->emitOpError(
+          "native_vector_size must be same as the last level of tiling");
+    }
+  }
+  return success();
+}
+
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors,
                                     bool useTileAndVectorizeV2) {

--- a/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "hal_interface_bindings.mlir",
             "hal_interface_constants.mlir",
             "hal_interface_workgroup_info.mlir",
+            "illegal_configuration.mlir",
             "materialize_launch_configuration.mlir",
             "matmul_vectorization.mlir",
             "synchronize_symbol_visibility.mlir",

--- a/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "hal_interface_bindings.mlir"
     "hal_interface_constants.mlir"
     "hal_interface_workgroup_info.mlir"
+    "illegal_configuration.mlir"
     "materialize_launch_configuration.mlir"
     "matmul_vectorization.mlir"
     "synchronize_symbol_visibility.mlir"

--- a/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -1,0 +1,154 @@
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target{test-lowering-configuration=true}))' -verify-diagnostics -split-input-file %s 
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = []>
+hal.executable private @matmul_tensors  {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+    hal.executable.entry_point @illegal attributes {
+      translation.info = #translation,
+      interface = @io,
+      ordinal = 0 : index
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
+        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        // expected-error @+1 {{expected 2 entries for workload_per_wg, but got 0}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [1, 0]>
+hal.executable private @matmul_tensors  {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+    hal.executable.entry_point @illegal attributes {
+      translation.info = #translation,
+      interface = @io,
+      ordinal = 0 : index
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
+        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        // expected-error @+1 {{invalid to use 0 in workload_per_wg}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [1, 1]>
+hal.executable private @matmul_tensors  {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+    hal.executable.entry_point @illegal attributes {
+      translation.info = #translation,
+      interface = @io,
+      ordinal = 0 : index
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
+        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        // expected-error @+1 {{expected three levels of tile sizes for CPUTensorToVectors, got 0}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[4, 8], [], []], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [8, 6]>
+hal.executable private @matmul_tensors  {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+    hal.executable.entry_point @illegal attributes {
+      translation.info = #translation,
+      interface = @io,
+      ordinal = 0 : index
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
+        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        // expected-error @+1 {{mismatch in distributed tile size value 4 at position 0 and workload_per_wg value 6}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[], [], [8, 8, 8]], native_vector_size = [4, 4, 4]>
+#translation = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [8, 4]>
+hal.executable private @matmul_tensors  {
+  hal.interface @io {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+    hal.executable.entry_point @illegal attributes {
+      translation.info = #translation,
+      interface = @io,
+      ordinal = 0 : index
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
+        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        // expected-error @+1 {{native_vector_size must be same as the last level of tiling}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -382,15 +382,14 @@ hal.executable private @batch_matmul_tensors  {
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [1, 32, 32, 32], [1, 4, 4, 4]{{\]}}, native_vector_size = [1, 4, 4, 4]>
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [64, 64, 1]>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
 // CHECK-NEXT: (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:  %[[ARG2:[a-zA-Z0-9]+]]: index)
-//  CHECK-DAG:  %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:  %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
 //  CHECK-DAG:  %[[D1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//      CHECK:  hal.return %[[D0]], %[[D1]], %[[C1]]
+//      CHECK:  hal.return %[[D0]], %[[D1]], %[[ARG2]]
 //      CHECK:  linalg.batch_matmul
 // CHECK-SAME:    lowering.config = #[[CONFIG]]
 

--- a/iree/compiler/Codegen/Passes.cpp
+++ b/iree/compiler/Codegen/Passes.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Codegen/Passes.h"
 
+#include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
+
 namespace mlir {
 namespace iree_compiler {
 
@@ -46,6 +48,22 @@ void registerCodegenPasses() {
       [](OpPassManager &passManager) {
         buildSPIRVCodegenPassPipeline(passManager);
       });
+}
+
+/// Hook to verify the lowering configuration and translation info for an
+/// operation.
+LogicalResult verifyLoweringConfiguration(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize) {
+  switch (translationInfo.getDispatchLoweringPassPipeline()) {
+    case IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors:
+      return verifyTensorToVectorsPassPipelineConfig(op, loweringConfig,
+                                                     translationInfo);
+    default:
+      break;
+  }
+  return success();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/ComprehensiveBufferize/ComprehensiveBufferize.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -19,8 +20,14 @@
 namespace mlir {
 namespace iree_compiler {
 
-// Registers all conversion passes in this directory.
+/// Registers all conversion passes in this directory.
 void registerCodegenPasses();
+
+/// Verify that the configuration used for compilation is valid.
+LogicalResult verifyLoweringConfiguration(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize = {});
 
 //------------------------------------------------------------------------------
 // Misc/common conversions
@@ -191,6 +198,10 @@ void addCPUVectorizationPassPipeline(OpPassManager &passManager,
 
 /// Populates the passes needed to multi level tile and lowering of linalg ops
 /// on tensors to vectors operations.
+LogicalResult verifyTensorToVectorsPassPipelineConfig(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize = {});
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true,
                                     bool useTileAndVectorizeV2 = false);


### PR DESCRIPTION
This PR allows for checking if the `#iree_codegen.translation.info`
and `#iree_codegen.lowering.config` on an operation are valid for a
given pipeline. Apart from verifying existing configurations, it also
allows a search to prune out illegal configurations.