### PR TITLE
Hook vector unrolling in LLVMTileFuseAndVectorizePass.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -39,12 +39,6 @@ static llvm::cl::opt<int> clNumberOfRuntimeThreads(
     llvm::cl::desc("number of threads that are used at runtime"),
     llvm::cl::init(8));
 
-static llvm::cl::opt<int> matmulL1TileSize(
-    "iree-codegen-llvm-matmul-l1-size",
-    llvm::cl::desc(
-        "linalg.matmul tile size for L1 spliting of M, N, K dimension"),
-    llvm::cl::init(32));
-
 static llvm::cl::list<int> mmt4dWorkgroupTileSizes(
     "iree-codegen-llvm-mmt4d-workgroup-tile-sizes",
     llvm::cl::desc("linalg.mmt4d workgroup tile size"), llvm::cl::ZeroOrMore,
@@ -68,7 +62,7 @@ static llvm::cl::opt<int> defaultWorkgroupTileSize(
 
 using IREE::Codegen::DispatchLoweringPassPipeline;
 
-static Optional<std::string> getTargetTriple(FuncOp entryPointFn) {
+static Optional<llvm::TargetTriple> getTargetTriple(FuncOp entryPointFn) {
   auto variantOp =
       entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
   IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.target();
@@ -77,15 +71,15 @@ static Optional<std::string> getTargetTriple(FuncOp entryPointFn) {
   if (!config) return llvm::None;
   auto triple = config.getAs<StringAttr>("target_triple");
   if (!triple) return llvm::None;
-  return triple.getValue().str();
+  return llvm::TargetTriple(triple.getValue().str());
 }
 
 static DispatchLoweringPassPipeline getDispatchLoweringPassPipeline(
     FuncOp entryPointFn, Operation *op) {
   return TypeSwitch<Operation *, DispatchLoweringPassPipeline>(op)
       .Case<linalg::ContractionOpInterface>([&](auto op) {
-        Optional<std::string> triple = getTargetTriple(entryPointFn);
-        if (triple && triple.getValue().find("x86_64") != std::string::npos) {
+        Optional<std::TargetTriple> triple = getTargetTriple(entryPointFn);
+        if (triple && triple.getValue().isX86()) {
           return DispatchLoweringPassPipeline::CPUTileFuseAndVectorize;
         } else {
           return DispatchLoweringPassPipeline::CPUTensorToVectors;
@@ -320,6 +314,9 @@ static LogicalResult setRootConfig(
       getDispatchLoweringPassPipeline(entryPointFn, contractionOp),
       workloadPerWorkgroup,
       /*workgroupSize =*/ArrayRef<int64_t>{});
+
+  Optional<llvm::TargetTriple> triple = getTargetTriple(entryPointFn);
+  int64_t matmulL1TileSize = (triple && triple.getValue().isX86()) ? 16 : 32;
 
   SmallVector<int64_t, 4> l1TileSizes, vectorTileSizes;
   if (isBatchMatmul) {

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
@@ -99,14 +99,16 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
     }
   });
 
-  auto tileAndFuseLinalgOps = [&](TilingLevel level) {
+  // Tile and fuse Linalg ops.
+  {
     OpBuilder builder(funcOp.getContext());
     SmallVector<Operation *> computeOps;
     SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
       return signalPassFailure();
     }
-    auto tileSizes = config.getTileSizeVals(static_cast<unsigned>(level));
+    auto tileSizes =
+        config.getTileSizeVals(static_cast<unsigned>(TilingLevel::L1Tiles));
     linalg::LinalgOp consumerOp;
     for (auto iter : llvm::reverse(computeOps)) {
       if (auto op = dyn_cast<linalg::LinalgOp>(iter)) {
@@ -135,15 +137,12 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
-  };
-
-  tileAndFuseLinalgOps(TilingLevel::L1Tiles);
+  }
 
   // Tile and fuse for vector sizes, then tile reduction loops. We don't rely on
   // unroll vector pass because it could introduce register pressure.
   bool hasMatmulAndIsVectorizable = true;
   {
-    tileAndFuseLinalgOps(TilingLevel::VectorTiles);
     OwningRewritePatternList tileReductionPatterns(&getContext());
 
     funcOp.walk([&](linalg::ContractionOpInterface op) {
@@ -177,7 +176,7 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
                Operation *operation) -> SmallVector<Value, 4> {
               auto tiles =
                   getTileSizes(builder, operation,
-                               static_cast<unsigned>(TilingLevel::VectorTiles));
+                               static_cast<unsigned>(TilingLevel::L1Tiles));
               auto numParallelLoops =
                   dyn_cast<linalg::LinalgOp>(operation).getNumParallelLoops();
               auto zeroTileVal = builder.create<arith::ConstantIndexOp>(
@@ -250,6 +249,25 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
       llvm::dbgs()
           << "\n--- After folding consumer add ops into contraction op "
              "iteself ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+  }
+
+  // Apply vector unroll
+  {
+    RewritePatternSet vectorUnrollPatterns(context);
+    // TODO(hanchung): Set different vector sizes for different operations. Also
+    // it seems that `{16, 16, 16}` is not a good config. We should tune it.
+    vector::populateVectorUnrollPatterns(
+        vectorUnrollPatterns, vector::UnrollVectorOptions().setNativeShape(
+                                  config.getNativeVectorSizeVals()));
+    if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                            std::move(vectorUnrollPatterns)))) {
+      return signalPassFailure();
+    }
+    DEBUG_WITH_TYPE(DEBUG_TYPE, {
+      llvm::dbgs() << "\n--- After vector unrolling ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s -iree-llvmcpu-tile-fuse-and-vectorize -cse -canonicalize -split-input-file | IreeFileCheck %s
 
-#config = #iree_codegen.lowering.config<tile_sizes = [[], [32, 32, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>
+#config = #iree_codegen.lowering.config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>
 #map0 = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 module  {
@@ -26,7 +26,7 @@ module  {
         %7 = linalg.init_tensor [64, 64] : tensor<64x64xf32>
         %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:384x512xf32> -> tensor<64x512xf32>
         %9 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [512, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x128xf32> -> tensor<512x64xf32>
-        %10 = linalg.fill(%cst, %7) : f32, tensor<64x64xf32> -> tensor<64x64xf32> 
+        %10 = linalg.fill(%cst, %7) : f32, tensor<64x64xf32> -> tensor<64x64xf32>
         %11 = linalg.matmul {lowering.config = #config} ins(%8, %9 : tensor<64x512xf32>, tensor<512x64xf32>) outs(%10 : tensor<64x64xf32>) -> tensor<64x64xf32>
         %12 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%11 : tensor<64x64xf32>) outs(%7 : tensor<64x64xf32>) {
         ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
@@ -63,23 +63,19 @@ module  {
 //      CHECK:   %[[LHS_TILE:.+]] = flow.dispatch.tensor.load %[[LHS]], {{.*}} -> tensor<64x512xf32>
 //      CHECK:   scf.for %[[J_IDX:.+]] = {{.*}} to %[[C128]] step %{{[0-9]*}} {
 //      CHECK:     %[[RHS_TILE:.+]] = flow.dispatch.tensor.load %[[RHS]], {{.*}} -> tensor<512x64xf32>
-//      CHECK:     {{.*}} = scf.for %[[L1_I:.+]] = %[[C0]] to %[[C64]] step %[[C32]]
+//      CHECK:     {{.*}} = scf.for %[[L1_I:.+]] = %[[C0]] to %[[C64]] step %[[C16]]
 // CHECK-SAME:       iter_args(%[[ITER0:.+]] = %[[DST_TILE_INIT]]) -> (tensor<64x64xf32>)
-//      CHECK:       {{.*}} = scf.for %[[L1_J:.+]] = %[[C0]] to %[[C64]] step %[[C32]]
+//      CHECK:       {{.*}} = scf.for %[[L1_J:.+]] = %[[C0]] to %[[C64]] step %[[C16]]
 // CHECK-SAME:         iter_args(%[[ITER1:.+]] = %[[ITER0]]) -> (tensor<64x64xf32>)
-//      CHECK:         %[[SLICE1:.+]] = tensor.extract_slice %[[ITER1]][%[[L1_I]], %[[L1_J]]] [32, 32] [1, 1] : tensor<64x64xf32> to tensor<32x32xf32>
-//      CHECK:         {{.*}} = scf.for %[[VEC_I:.+]] = %[[C0]] to %[[C32]] step %[[C16]]
-// CHECK-SAME:           iter_args(%[[ITER2:.+]] = %[[SLICE1]]) -> (tensor<32x32xf32>)
-//      CHECK:           {{.*}} = scf.for %[[VEC_J:.+]] = %[[C0]] to %[[C32]] step %[[C16]]
-// CHECK-SAME:             iter_args(%[[ITER3:.+]] = %[[ITER2]]) -> (tensor<32x32xf32>)
-//      CHECK:         %[[MATMUL_RES:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C512]] step %[[C16]]
+//      CHECK:         %[[MATMUL_RES:.+]] = scf.for %[[L1_K:.+]] = %[[C0]] to %[[C512]] step %[[C32]]
 // CHECK-SAME:           iter_args(%[[ITER2:.+]] = %[[CST_VECTOR]]) -> (vector<16x16xf32>)
 //      CHECK:           {{.*}} = vector.transfer_read %[[LHS_TILE]]
 //      CHECK:           {{.*}} = vector.transfer_read %[[RHS_TILE]]
 // CHECK-COUNT-16:       vector.outerproduct
+// CHECK-COUNT-16:       vector.outerproduct
 //      CHECK:           scf.yield %{{.*}} : vector<16x16xf32>
 //      CHECK:         %[[EXP:.+]] = math.exp %[[MATMUL_RES]] : vector<16x16xf32>
-//      CHECK:         %[[RES:.+]] = vector.transfer_write %[[EXP]], %[[ITER3]][%[[VEC_I]], %[[VEC_J]]] {{.*}} : vector<16x16xf32>, tensor<32x32xf32>
+//      CHECK:         %[[RES:.+]] = vector.transfer_write %[[EXP]], %[[ITER1]][%[[L1_I]], %[[L1_J]]] {{.*}} : vector<16x16xf32>, tensor<64x64xf32>
 //      CHECK:         scf.yield %[[RES]]
 
 // -----


### PR DESCRIPTION
This PR enables tiling reduction loop in L1 tiling, and unrolls the
loops with native vector sizes.

Vector unrolling could introduce register pressure issue. To prevent
regression at this moment, we explicitly set default L1 tile sizes to
16,16,16 for x86. Vector unrolling does nothing in this case. I tested
with different tile sizes (e.g.,16,16,32), there were differences. As
mentioned. we use 16,16,16 as default to prevent big regressions.

The next steps is to figure out different configurations between sandbox
and IREE. Might have to set up different vector.contract lowering
strategies, and tune with different tile sizes.

Before unrolling:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           2.82 ms         2.83 ms          252
BM_dot_384x128x128/process_time/real_time          0.152 ms        0.152 ms         4595
BM_dot_384x128x512/process_time/real_time          0.631 ms        0.633 ms         1153
BM_dot_384x512x128/process_time/real_time          0.653 ms        0.654 ms          858
BM_dot_384x512x2/process_time/real_time            0.535 ms        0.537 ms         1328
BM_dot_384x384x32/process_time/real_time           0.151 ms        0.151 ms         4666
BM_dot_384x384x512_exp/process_time/real_time       2.89 ms         2.90 ms          246
BM_dot_384x128x128_exp/process_time/real_time      0.167 ms        0.168 ms         4222
BM_dot_384x128x512_exp/process_time/real_time      0.666 ms        0.668 ms         1082
BM_dot_384x512x128_exp/process_time/real_time      0.650 ms        0.652 ms         1078
BM_dot_384x512x2_exp/process_time/real_time        0.550 ms        0.551 ms         1276
BM_dot_384x384x32_exp/process_time/real_time       0.157 ms        0.157 ms         4462
```

After unrolling:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           2.78 ms         2.79 ms          249
BM_dot_384x128x128/process_time/real_time          0.153 ms        0.153 ms         4561
BM_dot_384x128x512/process_time/real_time          0.596 ms        0.598 ms         1183
BM_dot_384x512x128/process_time/real_time          0.707 ms        0.708 ms         1096
BM_dot_384x512x2/process_time/real_time            0.528 ms        0.529 ms         1309
BM_dot_384x384x32/process_time/real_time           0.151 ms        0.151 ms         4533
BM_dot_384x384x512_exp/process_time/real_time       2.91 ms         2.92 ms          242
BM_dot_384x128x128_exp/process_time/real_time      0.166 ms        0.166 ms         4225
BM_dot_384x128x512_exp/process_time/real_time      0.649 ms        0.651 ms         1058
BM_dot_384x512x128_exp/process_time/real_time      0.650 ms        0.651 ms         1075
BM_dot_384x512x2_exp/process_time/real_time        0.539 ms        0.540 ms         1302
BM_dot_384x384x32_exp/process_time/real_time       0.157 ms        0.158 ms         4404
```