### PR TITLE
Adds a new pad-contraction-to-block-size pass.

### DIFF
--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -124,7 +124,7 @@ cc_library(
     deps = [
         ":IREEInputIncGen",
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:Arithmetic",
+        "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -124,6 +124,7 @@ cc_library(
     deps = [
         ":IREEInputIncGen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Arithmetic",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputOps.td
@@ -628,4 +628,43 @@ def IREEInput_DispatchWorkgroupSizeOp : IREEInput_PureOp<"dispatch.workgroup.siz
   let assemblyFormat = "`[` $dimension `]` attr-dict `:` type($result)";
 }
 
+//===----------------------------------------------------------------------===//
+// Utilities
+// Various utility ops needed for program completeness. These arguably should
+// not be exclusive to IREE.
+//===----------------------------------------------------------------------===//
+
+def IREEInput_AlignOp : IREEInput_PureOp<"align", [
+  SameOperandsAndResultType
+  ]> {
+  let summary = "Aligns up to a power-of-two alignment if required";
+  let description = [{
+     Aligns |value| up to the given power-of-two |alignment| if required.
+  }];
+
+  let arguments = (ins
+    SignlessIntegerLike:$value,
+    SignlessIntegerLike:$alignment
+  );
+
+  let results = (outs
+    SignlessIntegerLike:$result
+  );
+
+  let assemblyFormat = [{
+    $value `,` $alignment attr-dict `:` type($result)
+  }];
+
+  let builders = [
+    OpBuilder<(ins
+      "Value":$value,
+      "int64_t":$alignment
+    ),
+    [{
+      build($_builder, $_state, value.getType(), value,
+       $_builder.createOrFold<arith::ConstantIndexOp>($_state.location, alignment));
+    }]>,
+  ];
+}
+
 #endif // IREE_DIALECTS_DIALECT_INPUT_OPS_TD

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.h
@@ -18,6 +18,8 @@ std::unique_ptr<OperationPass<FuncOp>> createTiledOpInterfaceTilingPass();
 
 std::unique_ptr<OperationPass<FuncOp>> createLinalgExtToLoopsPass();
 
+std::unique_ptr<OperationPass<>> createPadContractionToBlockSizePass();
+
 void registerPasses();
 
 }  // namespace LinalgExt

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.td
@@ -21,4 +21,27 @@ def TiledOpInterfaceTiling :
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createTiledOpInterfaceTilingPass()";
 }
 
+def PadContractionToBlockSize :
+    Pass<"iree-linalg-pad-contraction-to-block-size", ""> {
+  let summary = "Pads contraction (matmul) ops to next multiple of block size";
+  let description = [{
+    This pass will apply padding to any supported linalg contractions:
+      * Row-major matmul:
+          Padded to <rowAlignment x columnAlignment>
+
+    Both rowAlignment and columnAlignment must be power-of-two values. If an
+    op is already statically padded properly, no change will be made. However,
+    if dynamic dimensions exist, padding will be applied regardless. Because
+    of the dynamic case, applying this pass multiple times can result in
+    mutation on each run.
+  }];
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::createPadContractionToBlockSizePass()";
+  let options = [
+    Option<"rowAlignment", "rowAlignment", "int", /*default=*/"16",
+           "The row-wise output block size">,
+    Option<"columnAlignment", "columnAlignment", "int", /*default=*/"16",
+           "The column-wise output block size">,
+  ];
+}
+
 #endif  // IREE_DIALECT_LINALGEXT_PASSES

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_library(IREEInputDialect
   IREEInputIncGen
 
   LINK_LIBS PUBLIC
+  MLIRArithmetic
   MLIRIR
   MLIRSideEffectInterfaces
 )

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -7,6 +7,7 @@
 #include "iree-dialects/Dialect/Input/InputOps.h"
 
 #include "iree-dialects/Dialect/Input/InputDialect.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(IREELinalgExtPasses
   ConvertToLoops.cpp
+  PadContractionToBlockSize.cpp
   Passes.cpp
   Tiling.cpp
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
@@ -1,0 +1,143 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/Input/InputDialect.h"
+#include "iree-dialects/Dialect/Input/InputOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Passes.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+namespace IREE = mlir::iree_compiler::IREE;
+using namespace IREE::LinalgExt;
+
+static bool isPowerOfTwo(int x) { return (x & (x - 1)) == 0; }
+
+static Operation *sliceTensor(Location loc, Value expanded, Value original,
+                              OpBuilder &builder) {
+  auto originalType = original.getType().cast<RankedTensorType>();
+  auto rank = originalType.getRank();
+  SmallVector<OpFoldResult> offsets(rank, builder.getI64IntegerAttr(0));
+  SmallVector<OpFoldResult> strides(rank, builder.getI64IntegerAttr(1));
+  SmallVector<OpFoldResult> sizes(rank);
+  for (int i = 0, e = rank; i < e; ++i) {
+    if (!originalType.isDynamicDim(i)) {
+      sizes[i] = builder.getI64IntegerAttr(originalType.getDimSize(i));
+    } else {
+      sizes[i] = builder.create<tensor::DimOp>(loc, original, i).getResult();
+    }
+  }
+
+  return builder.create<tensor::ExtractSliceOp>(loc, expanded, offsets, sizes,
+                                                strides);
+}
+
+static bool padTensor(Location loc, OpOperand *operand,
+                      ArrayRef<int64_t> alignments, OpBuilder &builder) {
+  Value original = operand->get();
+  auto type = original.getType().cast<RankedTensorType>();
+  ArrayRef<int64_t> shape = type.getShape();
+  assert(shape.size() == alignments.size() &&
+         "expected shape and alignments to match");
+
+  // New dimensions.
+  SmallVector<int64_t> newStaticDims;
+  newStaticDims.resize(shape.size(), -1);
+  SmallVector<OpFoldResult> newPaddingSizes(shape.size(),
+                                            builder.getI64IntegerAttr(0));
+
+  // Compute padded dims.
+  bool needsPad = false;
+  for (int i = 0, e = shape.size(); i < e; ++i) {
+    auto inputDim = shape[i];
+    auto alignment = alignments[i];
+    if (inputDim >= 0) {
+      // Static dim.
+      if ((inputDim % alignment) == 0) {
+        newStaticDims[i] = inputDim;
+        continue;
+      }
+      int64_t alignedDim = (inputDim + (alignment - 1)) & ~(alignment - 1);
+      newStaticDims[i] = alignedDim;
+      newPaddingSizes[i] = builder.getI64IntegerAttr(alignedDim - inputDim);
+      needsPad = true;
+    } else {
+      // Dynamic dim.
+      Value inputDimValue = builder.create<tensor::DimOp>(loc, original, i);
+      Value alignedDim =
+          builder.create<IREE::Input::AlignOp>(loc, inputDimValue, alignment);
+      newPaddingSizes[i] = alignedDim;
+      needsPad = true;
+    }
+  }
+  if (!needsPad) return false;
+
+  auto resultType = RankedTensorType::get(newStaticDims, type.getElementType());
+  Value zeroConstant = builder.create<arith::ConstantOp>(
+      loc, builder.getZeroAttr(type.getElementType()));
+  SmallVector<OpFoldResult> zeroStaticLow(shape.size(),
+                                          builder.getI64IntegerAttr(0));
+  SmallVector<Value> nullLow;
+  Value padded = linalg::PadTensorOp::createPadScalarOp(
+      resultType, operand->get(), zeroConstant, zeroStaticLow, newPaddingSizes,
+      false, loc, builder);
+  operand->set(padded);
+  return true;
+}
+
+namespace {
+
+struct PadContractionToBlockSizePass
+    : public PadContractionToBlockSizeBase<PadContractionToBlockSizePass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Input::IREEInputDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    getOperation()->walk([&](linalg::ContractionOpInterface op) {
+      auto linalgOp = llvm::cast<linalg::LinalgOp>(op.getOperation());
+      Location loc = op.getLoc();
+      OpOperand *lhs = linalgOp.getInputOperand(0);
+      OpOperand *rhs = linalgOp.getInputOperand(1);
+      OpOperand *output = linalgOp.getOutputOperand(0);
+      Value origOutput = output->get();
+      OpResult result = op.getOperation()->getResult(0);
+
+      bool insertSlice = false;
+      OpBuilder builder(op.getOperation());
+      if (op.isRowMajorMatmul()) {
+        padTensor(loc, lhs, {rowAlignment, rowAlignment}, builder);
+        padTensor(loc, rhs, {rowAlignment, columnAlignment}, builder);
+        if (padTensor(loc, output, {rowAlignment, columnAlignment}, builder)) {
+          result.setType(output->get().getType());
+          insertSlice = true;
+        }
+      }
+
+      // Insert an appropriate extract.
+      if (insertSlice) {
+        builder.setInsertionPointAfter(op.getOperation());
+        Operation *slicedResult = sliceTensor(loc, result, origOutput, builder);
+        result.replaceAllUsesExcept(slicedResult->getResult(0), slicedResult);
+      }
+
+      return WalkResult::advance();
+    });
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<>>
+IREE::LinalgExt::createPadContractionToBlockSizePass() {
+  return std::make_unique<PadContractionToBlockSizePass>();
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
@@ -19,8 +19,6 @@ using namespace mlir;
 namespace IREE = mlir::iree_compiler::IREE;
 using namespace IREE::LinalgExt;
 
-static bool isPowerOfTwo(int x) { return (x & (x - 1)) == 0; }
-
 static Operation *sliceTensor(Location loc, Value expanded, Value original,
                               OpBuilder &builder) {
   auto originalType = original.getType().cast<RankedTensorType>();
@@ -102,8 +100,6 @@ struct PadContractionToBlockSizePass
   }
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
-
     getOperation()->walk([&](linalg::ContractionOpInterface op) {
       auto linalgOp = llvm::cast<linalg::LinalgOp>(op.getOperation());
       Location loc = op.getLoc();

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/pad_contraction_to_block_size.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/pad_contraction_to_block_size.mlir
@@ -1,0 +1,92 @@
+// RUN: iree-dialects-opt -pass-pipeline='iree-linalg-pad-contraction-to-block-size{rowAlignment=16 columnAlignment=32}' -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @pad_matmul_static
+// Full verification is done on this case. Others use reduced checks.
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_4:.*]] = linalg.pad_tensor %arg0 low[0, 0] high[6, 12]  {
+// CHECK:           ^bb0(%[[VAL_5:.*]]: index, %[[VAL_6:.*]]: index):
+// CHECK:             linalg.yield %[[VAL_3]] : f32
+// CHECK:           } : tensor<250x500xf32> to tensor<256x512xf32>
+// CHECK:           %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_8:.*]] = linalg.pad_tensor %arg1 low[0, 0] high[12, 4]  {
+// CHECK:           ^bb0(%[[VAL_9:.*]]: index, %[[VAL_10:.*]]: index):
+// CHECK:             linalg.yield %[[VAL_7]] : f32
+// CHECK:           } : tensor<500x1020xf32> to tensor<512x1024xf32>
+// CHECK:           %[[VAL_11:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_12:.*]] = linalg.pad_tensor %arg2 low[0, 0] high[6, 4]  {
+// CHECK:           ^bb0(%[[VAL_13:.*]]: index, %[[VAL_14:.*]]: index):
+// CHECK:             linalg.yield %[[VAL_11]] : f32
+// CHECK:           } : tensor<250x1020xf32> to tensor<256x1024xf32>
+// CHECK:           %[[VAL_15:.*]] = linalg.matmul ins(%[[VAL_16:.*]], %[[VAL_17:.*]] : tensor<256x512xf32>, tensor<512x1024xf32>) outs(%[[VAL_18:.*]] : tensor<256x1024xf32>) -> tensor<256x1024xf32>
+// CHECK:           %[[VAL_19:.*]] = tensor.extract_slice %[[VAL_15]][0, 0] [250, 1020] [1, 1] : tensor<256x1024xf32> to tensor<250x1020xf32>
+// CHECK:           return %[[VAL_19]] : tensor<250x1020xf32>
+func @pad_matmul_static(%arg0 : tensor<250x500xf32>, %arg1 : tensor<500x1020xf32>,
+        %arg2 : tensor<250x1020xf32>) -> tensor<250x1020xf32> {
+  %matmul = linalg.matmul
+      ins(%arg0, %arg1 : tensor<250x500xf32>, tensor<500x1020xf32>)
+      outs(%arg2 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+  return %matmul : tensor<250x1020xf32>
+}
+
+// -----
+// CHECK-LABEL: @pad_matmul_noop
+// CHECK-NOT: pad_tensor
+// CHECK-NOT: extract_slice
+func @pad_matmul_noop(%arg0 : tensor<256x512xf32>, %arg1 : tensor<512x1024xf32>,
+        %arg2 : tensor<256x1024xf32>) -> tensor<256x1024xf32> {
+  %matmul = linalg.matmul
+      ins(%arg0, %arg1 : tensor<256x512xf32>, tensor<512x1024xf32>)
+      outs(%arg2 : tensor<256x1024xf32>) -> tensor<256x1024xf32>
+  return %matmul : tensor<256x1024xf32>
+}
+
+// -----
+// CHECK-LABEL: @pad_matmul_dynamic_row
+// Should trigger row alignment (16).
+// Pad LHS:
+// CHECK:           %[[LHS_DIM0:.*]] = arith.constant 0 : index
+// CHECK:           %[[LHS_DIM:.*]] = tensor.dim %arg0, %[[LHS_DIM0]] : tensor<?x512xf32>
+// CHECK:           %[[LHS_ALIGN:.*]] = arith.constant 16 : index
+// CHECK:           %[[LHS_DIM_ALIGNED:.*]] = iree_input.align %[[LHS_DIM]], %[[LHS_ALIGN]] : index
+// CHECK:           %[[LHS_ZERO:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[LHS_PADDED:.*]] = linalg.pad_tensor %arg0 low[0, 0] high{{\[}}%[[LHS_DIM_ALIGNED]], 0]   {
+// CHECK:           } : tensor<?x512xf32> to tensor<?x512xf32>
+// Pad Output:
+// CHECK:           %[[OUTPUT_PADDED:.*]] = linalg.pad_tensor %arg2 low[0, 0] high{{\[}}{{.*}}, 0]  {
+// CHECK:           } : tensor<?x1024xf32> to tensor<?x1024xf32>
+// Matmul:
+// CHECK:           %[[PADDED_RESULT:.*]] = linalg.matmul ins(%[[LHS_PADDED]], %arg1 : tensor<?x512xf32>, tensor<512x1024xf32>) outs(%[[OUTPUT_PADDED]] : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+// CHECK:           %[[DIM0:.*]] = arith.constant 0 : index
+// CHECK:           %[[ORIG_DIM_VALUE:.*]] = tensor.dim %arg2, %[[DIM0]]
+// CHECK:           %[[RETURN:.*]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0] {{\[}}%[[ORIG_DIM_VALUE]], 1024] [1, 1] : tensor<?x1024xf32> to tensor<?x1024xf32>
+// CHECK:           return %[[RETURN]] : tensor<?x1024xf32>
+func @pad_matmul_dynamic_row(%arg0 : tensor<?x512xf32>, %arg1 : tensor<512x1024xf32>,
+        %arg2 : tensor<?x1024xf32>) -> tensor<?x1024xf32> {
+  %matmul = linalg.matmul
+      ins(%arg0, %arg1 : tensor<?x512xf32>, tensor<512x1024xf32>)
+      outs(%arg2 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+  return %matmul : tensor<?x1024xf32>
+}
+
+// -----
+// CHECK-LABEL: @pad_matmul_dynamic_col
+// Should trigger column alignment (32).
+// Pad RHS:
+// CHECK:           %[[RHS_ALIGNMENT:.*]] = arith.constant 32 : index
+// CHECK:           %[[RHS_ALIGNED_DIM:.*]] = iree_input.align %{{.*}}, %[[RHS_ALIGNMENT]] : index
+// CHECK:           %[[RHS_PADDED:.*]] = linalg.pad_tensor %arg1 low[0, 0] high[0, %[[RHS_ALIGNED_DIM]]]  {
+// CHECK:           } : tensor<512x?xf32> to tensor<512x?xf32>
+// Pad Output:
+// CHECK:           %[[OUTPUT_ALIGNMENT:.*]] = arith.constant 32 : index
+// CHECK:           %[[OUTPUT_ALIGNED_DIM:.*]] = iree_input.align %{{.*}}, %[[OUTPUT_ALIGNMENT]] : index
+// CHECK:           %[[OUTPUT_PADDED:.*]] = linalg.pad_tensor %arg2 low[0, 0] high[0, %[[OUTPUT_ALIGNED_DIM]]]  {
+// CHECK:           } : tensor<256x?xf32> to tensor<256x?xf32>
+// Matmul:
+// CHECK:           %{{.*}} = linalg.matmul ins(%arg0, %[[RHS_PADDED]] : tensor<256x512xf32>, tensor<512x?xf32>) outs(%[[OUTPUT_PADDED]] : tensor<256x?xf32>) -> tensor<256x?xf32>
+func @pad_matmul_dynamic_col(%arg0 : tensor<256x512xf32>, %arg1 : tensor<512x?xf32>,
+        %arg2 : tensor<256x?xf32>) -> tensor<256x?xf32> {
+  %matmul = linalg.matmul
+      ins(%arg0, %arg1 : tensor<256x512xf32>, tensor<512x?xf32>)
+      outs(%arg2 : tensor<256x?xf32>) -> tensor<256x?xf32>
+  return %matmul : tensor<256x?xf32>
+}


### PR DESCRIPTION
* Unlike the existing POC pass in the flow dialect, this handles both static and dynamic shapes. It also uses walk vs a pattern so as to better control once-only rewriting in the dynamic case.
* Only pads row major matmul right now but should be extensible to other contractions relatively easily.
* Will be followed by a pass to propagate padding.