### PR TITLE
Fix workgroup count deduction in RemoveTrivialLoops

### DIFF
--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -9,12 +9,12 @@
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "iree-codegen-remove-trivial-loops"
 

--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -14,6 +14,9 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "iree-codegen-remove-trivial-loops"
 
 namespace mlir {
 namespace iree_compiler {
@@ -64,16 +67,27 @@ static Optional<std::pair<AffineExpr, AffineExpr>> getWorkgroupRange(
   return llvm::None;
 }
 
+/// Return true if the given tiled loop is distributed to workgroups.
+static bool isWorkgroupLoop(const LoopTilingAndDistributionInfo &info) {
+  auto forOp = cast<scf::ForOp>(info.loop);
+  Operation *lbOp = forOp.lowerBound().getDefiningOp();
+  if (isa<IREE::HAL::InterfaceWorkgroupIDOp>(lbOp)) return true;
+  auto applyOp = dyn_cast<AffineApplyOp>(lbOp);
+  return applyOp && llvm::any_of(applyOp.getMapOperands(), [](Value operand) {
+           return operand.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>();
+         });
+}
+
 /// Infer the number of workgroups by looking at the tiled loop and the number
 /// of element per workgroups.
 static SmallVector<int64_t> getNumWorkgroup(
     FuncOp funcOp, IREE::HAL::ExecutableEntryPointOp entryPointOp) {
-  SmallVector<LoopTilingAndDistributionInfo> tiledLoopInfo =
-      getTiledAndDistributedLoopInfo(funcOp);
-  SmallVector<int64_t> workloadSize(tiledLoopInfo.size());
-  for (LoopTilingAndDistributionInfo &tileInfo : tiledLoopInfo) {
-    if (tileInfo.processorDistributionDim >= workloadSize.size())
-      return SmallVector<int64_t>();
+  auto allLoops = getTiledAndDistributedLoopInfo(funcOp);
+  auto wgLoops =
+      llvm::to_vector<3>(llvm::make_filter_range(allLoops, isWorkgroupLoop));
+  SmallVector<int64_t> workloadSize(wgLoops.size());
+  for (LoopTilingAndDistributionInfo &tileInfo : wgLoops) {
+    if (tileInfo.processorDistributionDim >= workloadSize.size()) return {};
     if (!tileInfo.untiledLowerBound.is<Attribute>() ||
         !tileInfo.untiledUpperBound.is<Attribute>() ||
         !tileInfo.untiledStep.is<Attribute>()) {

--- a/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -98,3 +98,59 @@ hal.executable private @workgroup_tile_loop_negative  {
     }
   }
 }
+
+// -----
+
+// CHECK-LABEL: func @both_workgroup_and_workitem()
+//   CHECK-NOT:   scf.for
+//       CHECK:   gpu.barrier
+#translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [32, 8, 1]>
+hal.executable private @both_workgroup_and_workitem  {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @both_workgroup_and_workitem attributes {
+      interface = @io, ordinal = 0 : index,
+      translation.info = #translation,
+      workgroup_size = [8: index, 2: index, 1: index]
+    }
+    builtin.module {
+      builtin.func @both_workgroup_and_workitem() {
+        %c8 = arith.constant 8 : index
+        %c32 = arith.constant 32 : index
+        %c112 = arith.constant 112 : index
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c112 step %workgroup_count_z {
+          %4 = affine.apply affine_map<()[s0] -> (s0 * 8)>()[%workgroup_id_y]
+          %5 = affine.apply affine_map<()[s0] -> (s0 * 8)>()[%workgroup_count_y]
+          scf.for %arg1 = %4 to %c112 step %5 {
+            %6 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
+            %7 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
+            scf.for %arg2 = %6 to %c32 step %7 {
+
+              // Additional loops distributed to workitems.
+              %18 = "gpu.thread_id"() {dimension = "y"} : () -> index
+              %19 = "gpu.block_dim"() {dimension = "y"} : () -> index
+              %20 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%18]
+              %21 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%19]
+              scf.for %arg3 = %20 to %c8 step %21 {
+                %22 = "gpu.thread_id"() {dimension = "x"} : () -> index
+                %23 = "gpu.block_dim"() {dimension = "x"} : () -> index
+                %24 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%22]
+                %25 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%23]
+                scf.for %arg4 = %24 to %c32 step %25 {
+                  gpu.barrier
+                }
+              }
+
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
Now we can also recognize tiled loops that are distributed to
workitems, `getTiledAndDistributedLoopInfo` can return loops
distributed both to workgroups and workitems. We need to filter
only those for workgroups in order to deduce workgroup count.