### PR TITLE
Fixes for CModuleTarget after LLVM update.

### DIFF
--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -264,20 +264,18 @@ static LogicalResult canonicalizeModule(
 
   // Add all VM canonicalization patterns and mark pseudo-ops illegal.
   auto *context = moduleOp.getContext();
-  for (auto *op : context->getRegisteredOperations()) {
+  for (auto op : context->getRegisteredOperations()) {
     // Non-serializable ops must be removed prior to serialization.
-    if (op->hasTrait<OpTrait::IREE::VM::PseudoOp>()) {
-      op->getCanonicalizationPatterns(patterns, context);
-      target.setOpAction(OperationName(op->name, context),
-                         ConversionTarget::LegalizationAction::Illegal);
+    if (op.hasTrait<OpTrait::IREE::VM::PseudoOp>()) {
+      op.getCanonicalizationPatterns(patterns, context);
+      target.setOpAction(op, ConversionTarget::LegalizationAction::Illegal);
     }
 
     // Debug ops must not be present when stripping.
     // TODO(benvanik): add RemoveDisabledDebugOp pattern.
-    if (op->hasTrait<OpTrait::IREE::VM::DebugOnly>() &&
+    if (op.hasTrait<OpTrait::IREE::VM::DebugOnly>() &&
         targetOptions.stripDebugOps) {
-      target.setOpAction(OperationName(op->name, context),
-                         ConversionTarget::LegalizationAction::Illegal);
+      target.setOpAction(op, ConversionTarget::LegalizationAction::Illegal);
     }
   }
 


### PR DESCRIPTION
Missed by https://github.com/google/iree/commit/ee91353ec3089ea793b90d8203572aea471fb5f2 since this isn't building with Bazel yet.