### PR TITLE
Teach the MHLO->Linalg conversion how to handle functions, blocks and CFG.

### DIFF
--- a/iree/compiler/InputConversion/MHLO/test/BUILD
+++ b/iree/compiler/InputConversion/MHLO/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "broadcasting.mlir",
             "convert_mhlo_to_linalg_ext.mlir",
             "convert_complex_to_real.mlir",
+            "convert_structural_types.mlir",
             "dynamic_shape.mlir",
             "fft.mlir",
             "legalize_input_types.mlir",

--- a/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "broadcasting.mlir"
     "convert_complex_to_real.mlir"
     "convert_mhlo_to_linalg_ext.mlir"
+    "convert_structural_types.mlir"
     "dynamic_shape.mlir"
     "fft.mlir"
     "legalize_input_types.mlir"

--- a/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
@@ -411,7 +411,6 @@ func @PolygammaWithoutBroadcast(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>)
 // -----
 // CHECK-LABEL: @fallbackDynamicReshape
 func @fallbackDynamicReshape(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tensor<5xindex>) -> tensor<12x?x?x1x?xui32> {
-  // CHECK: %[[INPUT:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<4x?x3x?xui32> to tensor<4x?x3x?xi32>
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[RESULT_D1:.*]] = tensor.extract %arg1[%[[C1]]] : tensor<5xindex>
   // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
@@ -419,12 +418,11 @@ func @fallbackDynamicReshape(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tensor<5xinde
   // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
   // CHECK-DAG: %[[RESULT_D4:.*]] = tensor.extract %arg1[%[[C4]]] : tensor<5xindex>
   // CHECK-DAG: %[[INDEX1:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %[[INPUT]], %[[INDEX1]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %arg0, %[[INDEX1]] : tensor<4x?x3x?xi32>
   // CHECK-DAG: %[[INDEX3:.*]] = arith.constant 3 : index
-  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %[[INPUT]], %[[INDEX3]] : tensor<4x?x3x?xi32>
-  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %[[INPUT]] : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
+  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %arg0, %[[INDEX3]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
   %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<4x?x3x?xui32>, tensor<5xindex>) -> tensor<12x?x?x1x?xui32>
-  // CHECK: %[[UNCONVERTED_RESULT:.*]] = builtin.unrealized_conversion_cast %[[RESULT]] : tensor<12x?x?x1x?xi32> to tensor<12x?x?x1x?xui32>
-  // CHECK: return %[[UNCONVERTED_RESULT]]
+  // CHECK: return %[[RESULT]]
   return %0 : tensor<12x?x?x1x?xui32>
 }

--- a/iree/compiler/InputConversion/MHLO/test/convert_structural_types.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/convert_structural_types.mlir
@@ -1,0 +1,25 @@
+// RUN: iree-opt -split-input-file --iree-mhlo-to-linalg-on-tensors %s | IreeFileCheck %s
+
+// CHECK-LABEL: @func_cfg_conversion
+module @func_cfg_conversion {
+  // CHECK: func @caller(%arg0: tensor<2xi32>, %arg1: i1) -> tensor<2xi32>
+  func @caller(%arg0: tensor<2xui32>, %arg1 : i1) -> tensor<2xui32> {
+    // CHECK: %[[RESULT:.*]] = call @callee(%arg0, %arg1) : (tensor<2xi32>, i1) -> tensor<2xi32>
+    %1 = call @callee(%arg0, %arg1) : (tensor<2xui32>, i1) -> tensor<2xui32>
+    // CHECK: return %[[RESULT]] : tensor<2xi32>
+    return %1 : tensor<2xui32>
+  }
+
+  // CHECK: func @callee(%arg0: tensor<2xi32>, %arg1: i1) -> tensor<2xi32>
+  func @callee(%arg0: tensor<2xui32>, %arg1: i1) -> tensor<2xui32> {
+    // CHECK: cond_br %arg1, ^bb1(%arg0 : tensor<2xi32>), ^bb2(%arg0 : tensor<2xi32>)
+    cond_br %arg1, ^bb1(%arg0 : tensor<2xui32>), ^bb2(%arg0 : tensor<2xui32>)
+  // CHECK: ^bb1(%[[BB1_PHI:.*]]: tensor<2xi32>)
+  ^bb1(%phi0 : tensor<2xui32>) :
+    // CHECK: br ^bb2(%[[BB1_PHI]] : tensor<2xi32>)
+    br ^bb2(%phi0 : tensor<2xui32>)
+  // CHECK: ^bb2(%[[BB2_PHI:.*]]: tensor<2xi32>)
+  ^bb2(%phi1 : tensor<2xui32>):
+    return %phi1 : tensor<2xui32>
+  }
+}


### PR DESCRIPTION
* This allows us to to type conversion for unsigned types (among other things) at the boundaries.
* I may break this out to a separate pass a bit later when I attempt to collapse the XLA-unweirding into the core pipeline.
* Mostly copy and paste from the global input conversion.
* Fixes #7708