### PR TITLE
Turning on streams by default.

### DIFF
--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -35,7 +35,7 @@ static bool getExperimentalStreamsModeFromFlags() {
   static llvm::cl::opt<bool> *enableFlag = new llvm::cl::opt<bool>{
       "iree-experimental-streams",
       llvm::cl::desc("Enables experimental stream dialect pipelines."),
-      llvm::cl::init(false),
+      llvm::cl::init(true),
   };
   return *enableFlag;
 }


### PR DESCRIPTION
The majority of the previous regressions are fixed with #7716 - mostly looking like aliasing of mutable bindings disabling vectorization.