### PR TITLE
Fixing VK descriptor pool initialization for push descriptor fallback.

### DIFF
--- a/iree/hal/vulkan/descriptor_pool_cache.cc
+++ b/iree/hal/vulkan/descriptor_pool_cache.cc
@@ -60,13 +60,12 @@ iree_status_t DescriptorPoolCache::AcquireDescriptorPool(
   create_info.maxSets = kMaxDescriptorSets;
   std::array<VkDescriptorPoolSize, 1> pool_sizes;
   pool_sizes[0].type = descriptor_type;
-  pool_sizes[0].descriptorCount = max_descriptor_count;
+  pool_sizes[0].descriptorCount = max_descriptor_count * create_info.maxSets;
   create_info.poolSizeCount = static_cast<uint32_t>(pool_sizes.size());
   create_info.pPoolSizes = pool_sizes.data();
 
   DescriptorPool descriptor_pool;
   descriptor_pool.descriptor_type = descriptor_type;
-  descriptor_pool.max_descriptor_count = max_descriptor_count;
   descriptor_pool.handle = VK_NULL_HANDLE;
 
   VK_RETURN_IF_ERROR(syms().vkCreateDescriptorPool(

--- a/iree/hal/vulkan/descriptor_pool_cache.h
+++ b/iree/hal/vulkan/descriptor_pool_cache.h
@@ -28,8 +28,6 @@ class DescriptorPoolCache;
 struct DescriptorPool {
   // Type of the descriptor in the set.
   VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
-  // Maximum number of descriptors of the given type per allocation.
-  int max_descriptor_count = 0;
   // Pool handle.
   VkDescriptorPool handle = VK_NULL_HANDLE;
 };


### PR DESCRIPTION
The descriptor count is not per descriptor set but a sum of all available
in the entire pool - whoops. Most drivers seem to ignore the specific
typed pool sizes and just use the maxSets but Mali drivers do not and
this was causing the pool to run out of memory after nearly every single
use.

Before:
![image](https://user-images.githubusercontent.com/75337/142775131-4177628f-5ddb-407f-ad49-5f6dafccb020.png)
![image](https://user-images.githubusercontent.com/75337/142775154-85dbffe5-3cad-44ab-a018-ca01db59b71b.png)

After:
![image](https://user-images.githubusercontent.com/75337/142775142-e7b5d2d3-7b3e-4b78-884a-8f37a7b4d917.png)
![image](https://user-images.githubusercontent.com/75337/142775161-b001df5a-455b-4455-b55c-bdfd36bff0e4.png)
