### PR TITLE
[NFC] EmitC analysis cleanup

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
@@ -18,6 +18,7 @@ if(${IREE_ENABLE_EMITC})
     SRCS
       "ConvertVMToEmitC.cpp"
       "DropExcludedExports.cpp"
+      "EmitCTypeConverter.cpp"
     DEPS
       MLIREmitC
       MLIRIR

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.h
@@ -15,10 +15,9 @@
 namespace mlir {
 namespace iree_compiler {
 
-void populateVMToEmitCPatterns(MLIRContext *context,
+void populateVMToEmitCPatterns(ConversionTarget &conversionTarget,
                                IREE::VM::EmitCTypeConverter &typeConverter,
-                               OwningRewritePatternList &patterns,
-                               VMAnalysisCache &vmAnalysisCache);
+                               OwningRewritePatternList &patterns);
 
 namespace IREE {
 namespace VM {

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -6,10 +6,60 @@
 
 #include "iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h"
 
+#include <functional>
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
-namespace VM {}  // namespace VM
+namespace VM {
+
+EmitCTypeConverter::EmitCTypeConverter() {
+  // Return the incoming type in the default case.
+  addConversion([](Type type) { return type; });
+
+  addConversion([](emitc::OpaqueType type) { return type; });
+
+  addConversion([](IREE::VM::RefType type) {
+    return emitc::OpaqueType::get(type.getContext(), "iree_vm_ref_t*");
+  });
+
+  // We need a source materialization for refs because after running
+  // `applyFullConversion` there would be references to the original
+  // IREE::VM::Ref values in unused basic block arguments. As these are unused
+  // anyway we create dummy ops which get deleted after the conversion has
+  // finished.
+  addSourceMaterialization([this](OpBuilder &builder, IREE::VM::RefType type,
+                                  ValueRange inputs, Location loc) -> Value {
+    assert(inputs.size() == 1);
+    Value input = inputs[0];
+    assert(input.getType().isa<emitc::OpaqueType>());
+
+    Type objectType = IREE::VM::OpaqueType::get(builder.getContext());
+    Type refType = IREE::VM::RefType::get(objectType);
+
+    auto ctx = builder.getContext();
+    auto op = builder.create<emitc::ConstantOp>(
+        /*location=*/loc,
+        /*resultType=*/refType,
+        /*value=*/emitc::OpaqueAttr::get(ctx, ""));
+
+    sourceMaterializations.insert(op.getOperation());
+
+    return op.getResult();
+  });
+}
+
+FailureOr<std::reference_wrapper<VMAnalysis>>
+EmitCTypeConverter::lookupAnalysis(Operation *op) {
+  auto ptr = analysisCache.find(op);
+  if (ptr == analysisCache.end()) {
+    op->emitError() << "parent func op not found in cache.";
+    return failure();
+  }
+  return std::ref(ptr->second);
+}
+
+}  // namespace VM
 }  // namespace IREE
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -1,0 +1,15 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VM {}  // namespace VM
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -28,6 +28,7 @@ class EmitCTypeConverter : public mlir::TypeConverter {
       IREE::VM::FuncOp &funcOp) {
     return lookupAnalysis(funcOp.getOperation());
   }
+  Optional<Value> materializeRef(Value ref);
 
   SetVector<Operation *> sourceMaterializations;
   VMAnalysisCache analysisCache;

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -19,44 +19,21 @@ namespace VM {
 
 class EmitCTypeConverter : public mlir::TypeConverter {
  public:
-  EmitCTypeConverter() {
-    // Return the incoming type in the default case.
-    addConversion([](Type type) { return type; });
-
-    addConversion([](emitc::OpaqueType type) { return type; });
-
-    addConversion([](IREE::VM::RefType type) {
-      return emitc::OpaqueType::get(type.getContext(), "iree_vm_ref_t*");
-    });
-
-    // We need a source materialization for refs because after running
-    // `applyFullConversion` there would be references to the original
-    // IREE::VM::Ref values in unused basic block arguments. As these are unused
-    // anyway we create dummy ops which get deleted after the conversion has
-    // finished.
-    addSourceMaterialization([this](OpBuilder &builder, IREE::VM::RefType type,
-                                    ValueRange inputs, Location loc) -> Value {
-      assert(inputs.size() == 1);
-      Value input = inputs[0];
-      assert(input.getType().isa<emitc::OpaqueType>());
-
-      Type objectType = IREE::VM::OpaqueType::get(builder.getContext());
-      Type refType = IREE::VM::RefType::get(objectType);
-
-      auto ctx = builder.getContext();
-      auto op = builder.create<emitc::ConstantOp>(
-          /*location=*/loc,
-          /*resultType=*/refType,
-          /*value=*/emitc::OpaqueAttr::get(ctx, ""));
-
-      sourceMaterializations.insert(op.getOperation());
-
-      return op.getResult();
-    });
+  EmitCTypeConverter();
+  FailureOr<std::reference_wrapper<VMAnalysis>> lookupAnalysis(
+      mlir::FuncOp &funcOp) {
+    return lookupAnalysis(funcOp.getOperation());
+  }
+  FailureOr<std::reference_wrapper<VMAnalysis>> lookupAnalysis(
+      IREE::VM::FuncOp &funcOp) {
+    return lookupAnalysis(funcOp.getOperation());
   }
 
   SetVector<Operation *> sourceMaterializations;
   VMAnalysisCache analysisCache;
+
+ private:
+  FailureOr<std::reference_wrapper<VMAnalysis>> lookupAnalysis(Operation *op);
 };
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_
 #define IREE_COMPILER_DIALECT_VM_CONVERSION_VMTOEMITC_EMITCTYPECONVERTER_H_
 
+#include "iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h"
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -55,6 +56,7 @@ class EmitCTypeConverter : public mlir::TypeConverter {
   }
 
   SetVector<Operation *> sourceMaterializations;
+  VMAnalysisCache analysisCache;
 };
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
@@ -17,10 +17,12 @@ namespace iree_compiler {
 
 struct VMAnalysis {
  public:
-  VMAnalysis(RegisterAllocation &&registerAllocation,
-             ValueLiveness &&valueLiveness)
-      : registerAllocation(std::move(registerAllocation)),
-        valueLiveness(std::move(valueLiveness)) {}
+  VMAnalysis() = default;
+  VMAnalysis(IREE::VM::FuncOp &funcOp) {
+    Operation *op = funcOp.getOperation();
+    registerAllocation = RegisterAllocation(op);
+    valueLiveness = ValueLiveness(op);
+  }
 
   VMAnalysis(VMAnalysis &&) = default;
   VMAnalysis &operator=(VMAnalysis &&) = default;


### PR DESCRIPTION
This moves the VM analysis cache into the EmitC type converter in preparation for switching to target materializations.