### PR TITLE
Fix use-after-free of ostream in the passManager dtor

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
@@ -120,11 +120,11 @@ LogicalResult runEmitObjFilePasses(llvm::TargetMachine *machine,
                                    std::string *objData) {
   llvm::SmallVector<char, 0> stream_buffer;
   {
+    llvm::raw_svector_ostream ostream(stream_buffer);
     // TODO(ataei): Use non legacy pass mamanger for this.
     llvm::legacy::PassManager passManager;
     passManager.add(
         new llvm::TargetLibraryInfoWrapperPass(machine->getTargetTriple()));
-    llvm::raw_svector_ostream ostream(stream_buffer);
     if (machine->addPassesToEmitFile(passManager, ostream,
                                      /*DwoOut=*/nullptr, fileType)) {
       return failure();


### PR DESCRIPTION
Local variables are constructed in their order of declaration and destructed in the reverse order at end of scope. As `passManager` references `ostream`, it should be constructed after it so it gets destructed before it.

ASan report:

```
==1714714==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fff59769760 at pc 0x0000097d0cbb bp 0x7fff59769490 sp 0x7fff59769488
READ of size 8 at 0x7fff59769760 thread T0
    #0 0x97d0cba in llvm::formatted_raw_ostream::releaseStream() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/Support/FormattedStream.h
    #1 0x1159f056 in llvm::formatted_raw_ostream::~formatted_raw_ostream() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/Support/FormattedStream.h:116:5
    #2 0x1159f056 in llvm::formatted_raw_ostream::~formatted_raw_ostream() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/Support/FormattedStream.h:114:37
    #3 0xe510075 in std::default_delete<llvm::formatted_raw_ostream>::operator()(llvm::formatted_raw_ostream*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:85:2
    #4 0xe510075 in std::unique_ptr<llvm::formatted_raw_ostream, std::default_delete<llvm::formatted_raw_ostream> >::~unique_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:361:4
    #5 0xe510075 in (anonymous namespace)::MCAsmStreamer::~MCAsmStreamer() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/MC/MCAsmStreamer.cpp:46:7
    #6 0xe510108 in (anonymous namespace)::MCAsmStreamer::~MCAsmStreamer() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/MC/MCAsmStreamer.cpp:46:7
    #7 0x7a75047 in std::default_delete<llvm::MCStreamer>::operator()(llvm::MCStreamer*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:85:2
    #8 0x7a75047 in std::unique_ptr<llvm::MCStreamer, std::default_delete<llvm::MCStreamer> >::~unique_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/unique_ptr.h:361:4
    #9 0x7a75047 in llvm::AsmPrinter::~AsmPrinter() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp:212:1
    #10 0x514d9ca in (anonymous namespace)::AArch64AsmPrinter::~AArch64AsmPrinter() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp:71:7
    #11 0x514d9ca in (anonymous namespace)::AArch64AsmPrinter::~AArch64AsmPrinter() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp:71:7
    #12 0x10ae4691 in llvm::PMDataManager::~PMDataManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:1309:5
    #13 0x10ae4691 in llvm::FPPassManager::~FPPassManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/IR/LegacyPassManagers.h:460:7
    #14 0x10ae4691 in llvm::FPPassManager::~FPPassManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/IR/LegacyPassManagers.h:460:7
    #15 0x10ae88c6 in llvm::PMDataManager::~PMDataManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:1309:5
    #16 0x10ae88c6 in (anonymous namespace)::MPPassManager::~MPPassManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:399:3
    #17 0x10ae9c3f in (anonymous namespace)::MPPassManager::~MPPassManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:394:29
    #18 0x10ae9c3f in non-virtual thunk to (anonymous namespace)::MPPassManager::~MPPassManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp
    #19 0x10ad85b1 in llvm::PMTopLevelManager::~PMTopLevelManager() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:868:5
    #20 0x10ae5c87 in llvm::legacy::PassManagerImpl::~PassManagerImpl() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:474:7
    #21 0x10ae5c87 in llvm::legacy::PassManagerImpl::~PassManagerImpl() /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/lib/IR/LegacyPassManager.cpp:474:7
    #22 0x5068b82 in mlir::iree_compiler::IREE::HAL::runEmitObjFilePasses(llvm::TargetMachine*, llvm::Module*, llvm::CodeGenFileType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /usr/local/google/home/benoitjacob/iree/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp:133:3
    #23 0x504a493 in mlir::iree_compiler::IREE::HAL::LLVMAOTTargetBackend::serializeExecutable(mlir::iree_compiler::IREE::HAL::ExecutableVariantOp, mlir::OpBuilder&) /usr/local/google/home/benoitjacob/iree/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp:413:18
    #24 0xb94a04d in mlir::iree_compiler::IREE::HAL::SerializeTargetExecutablesPass::runOnOperation() /usr/local/google/home/benoitjacob/iree/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp:69:33
    #25 0x10f23a72 in mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:392:11
    #26 0x10f24bf8 in mlir::detail::OpToOpPassAdaptor::runPipeline(llvm::iterator_range<llvm::pointee_iterator<std::unique_ptr<mlir::Pass, std::default_delete<mlir::Pass> >*, mlir::Pass> >, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:452:16
    #27 0x10f3085c in mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_2::operator()(mlir::OpPassManager&, mlir::Operation*) const /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:378:12
    #28 0x10f3085c in mlir::LogicalResult llvm::function_ref<mlir::LogicalResult (mlir::OpPassManager&, mlir::Operation*)>::callback_fn<mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_2>(long, mlir::OpPassManager&, mlir::Operation*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/ADT/STLExtras.h:177:12
    #29 0xb94c0e4 in llvm::function_ref<mlir::LogicalResult (mlir::OpPassManager&, mlir::Operation*)>::operator()(mlir::OpPassManager&, mlir::Operation*) const /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/llvm/include/llvm/ADT/STLExtras.h:200:12
    #30 0xb94c0e4 in mlir::Pass::runPipeline(mlir::OpPassManager&, mlir::Operation*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/include/mlir/Pass/Pass.h:191:12
    #31 0xb94c0e4 in mlir::iree_compiler::IREE::HAL::SerializeExecutablesPass::runOnOperation() /usr/local/google/home/benoitjacob/iree/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp:116:16
    #32 0x10f23a72 in mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:392:11
    #33 0x10f24bf8 in mlir::detail::OpToOpPassAdaptor::runPipeline(llvm::iterator_range<llvm::pointee_iterator<std::unique_ptr<mlir::Pass, std::default_delete<mlir::Pass> >*, mlir::Pass> >, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:452:16
    #34 0x10f28108 in mlir::detail::OpToOpPassAdaptor::runOnOperationImpl(bool) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:548:20
    #35 0x10f23aee in mlir::detail::OpToOpPassAdaptor::runOnOperation(bool) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:529:5
    #36 0x10f23aee in mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:390:14
    #37 0x10f2af16 in mlir::detail::OpToOpPassAdaptor::runPipeline(llvm::iterator_range<llvm::pointee_iterator<std::unique_ptr<mlir::Pass, std::default_delete<mlir::Pass> >*, mlir::Pass> >, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:452:16
    #38 0x10f2af16 in mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:696:10
    #39 0x10f2a945 in mlir::PassManager::run(mlir::Operation*) /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Pass/Pass.cpp:676:60
    #40 0xb8739db in mlir::iree_compiler::translateFromMLIRToVM(mlir::ModuleOp, mlir::iree_compiler::BindingOptions, mlir::iree_compiler::InputDialectOptions, mlir::iree_compiler::IREE::HAL::TargetOptions, mlir::iree_compiler::IREE::VM::TargetOptions) /usr/local/google/home/benoitjacob/iree/iree/compiler/Translation/IREEVM.cpp:139:26
    #41 0xb872e38 in mlir::iree_compiler::translateFromMLIRToVMBytecodeModuleWithFlags(mlir::ModuleOp, llvm::raw_ostream&) /usr/local/google/home/benoitjacob/iree/iree/compiler/Translation/IREEVM.cpp:160:17
    #42 0xb8b1581 in std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)>::operator()(mlir::ModuleOp, llvm::raw_ostream&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_function.h:622:14
    #43 0xb8b1581 in mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1::operator()(llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*) const /usr/local/google/home/benoitjacob/iree/third_party/llvm-project/mlir/lib/Translation/Translation.cpp:107:12
    #44 0xb8b1581 in mlir::LogicalResult std::__invoke_impl<mlir::LogicalResult, mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*>(std::__invoke_other, mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:60:14
    #45 0xb8b1581 in std::enable_if<__and_<std::__not_<std::is_void<mlir::LogicalResult> >, std::is_convertible<std::__invoke_result<mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*>::type, mlir::LogicalResult> >::value, mlir::LogicalResult>::type std::__invoke_r<mlir::LogicalResult, mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*>(mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/invoke.h:141:14
    #46 0xb8b1581 in std::_Function_handler<mlir::LogicalResult (llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*), mlir::TranslateFromMLIRRegistration::TranslateFromMLIRRegistration(llvm::StringRef, std::function<mlir::LogicalResult (mlir::ModuleOp, llvm::raw_ostream&)> const&, std::function<void (mlir::DialectRegistry&)>)::$_1>::_M_invoke(std::_Any_data const&, llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_function.h:291:9
    #47 0x4ec4ffa in std::function<mlir::LogicalResult (llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*)>::operator()(llvm::SourceMgr&, llvm::raw_ostream&, mlir::MLIRContext*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/std_function.h:622:14
    #48 0x4ec4ffa in mlir::iree_compiler::runIreeTranslateMain(int, char**)::$_0::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >, llvm::raw_ostream&) const /usr/local/google/home/benoitjacob/iree/iree/tools/iree_translate_lib.cc:112:12
    #49 0x4ec3c2a in mlir::iree_compiler::runIreeTranslateMain(int, char**) /usr/local/google/home/benoitjacob/iree/iree/tools/iree_translate_lib.cc:120:16
    #50 0x7f2841830e49 in __libc_start_main csu/../csu/libc-start.c:314:16
    #51 0x4e160f9 in _start (/usr/local/google/home/benoitjacob/iree-build-linux/iree/tools/iree-translate+0x4e160f9)

Address 0x7fff59769760 is located in stack of thread T0 at offset 192 in frame
    #0 0x506884f in mlir::iree_compiler::IREE::HAL::runEmitObjFilePasses(llvm::TargetMachine*, llvm::Module*, llvm::CodeGenFileType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /usr/local/google/home/benoitjacob/iree/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp:120

  This frame has 5 object(s):
    [32, 40) '__dnew.i.i.i.i'
    [64, 88) 'stream_buffer' (line 121)
    [128, 144) 'passManager' (line 124)
    [160, 232) 'ostream' (line 127) <== Memory access at offset 192 is inside this variable
    [272, 304) 'ref.tmp' (line 136)
```