### PR TITLE
Fixing ordering of ops in execution regions after partitioning.

### DIFF
--- a/iree/compiler/Utils/GraphUtils.cpp
+++ b/iree/compiler/Utils/GraphUtils.cpp
@@ -48,5 +48,14 @@ std::vector<Operation *> sortOpsTopologically(
   return sortedOps;
 }
 
+void sortBlockTopologically(Block *block) {
+  SetVector<Operation *> unsortedOps;
+  for (auto &op : *block) unsortedOps.insert(&op);
+  auto sortedOps = sortOpsTopologically(unsortedOps);
+  for (auto *op : llvm::reverse(sortedOps)) {
+    op->moveBefore(block, block->begin());
+  }
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/iree/compiler/Utils/GraphUtils.h
+++ b/iree/compiler/Utils/GraphUtils.h
@@ -32,6 +32,9 @@ SmallVector<Operation *, N> sortOpsTopologically(
   return SmallVector<Operation *, N>(result.begin(), result.end());
 }
 
+// Sorts all of the ops within |block| into an arbitrary topological order.
+void sortBlockTopologically(Block *block);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 


### PR DESCRIPTION
The partitioning algorithm is allowed to reorder ops but the fixup that
was happening was not very good (or correct).

Progress on #7750.