### PR TITLE
Exposes control over the partitioning favor mode on the command line.

### DIFF
--- a/docs/website/docs/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/deployment-configurations/bare-metal.md
@@ -30,6 +30,7 @@ build directory
 ``` shell hl_lines="3 4 5"
 iree/tools/iree-translate \
     -iree-mlir-to-vm-bytecode-module \
+    -iree-stream-partitioning-favor=min-peak-memory \
     -iree-hal-target-backends=dylib-llvm-aot \
     -iree-llvm-target-triple=x86_64-pc-linux-elf \
     -iree-llvm-debug-symbols=false \
@@ -40,6 +41,9 @@ iree/tools/iree-translate \
 
 In which
 
+* `-iree-stream-partitioning-favor=min-peak-memory`: Optimize for minimum peak
+memory usage at the cost of concurrency - include when targeting single-threaded
+execution to reduce memory consumption.
 * `iree-hal-target-backends=dylib-llvm-aot`: Build the model for the dynamic
 library CPU HAL driver
 * `iree-llvm-target-triple`: Use the `<arch>-pc-linux-elf` LLVM target triple so

--- a/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -218,8 +218,7 @@ PartitionSet partitionRegionConcurrencyReference(
     IREE::Stream::PartitioningConfigAttr config, Block *block) {
   PartitionSet waveSet;
 
-  auto favor = config ? config.getFavor().getValue()
-                      : IREE::Stream::Favor::MinPeakMemory;
+  auto favor = config.getFavor().getValue();
   if (favor == IREE::Stream::Favor::Debug) {
     // Disable partitioning when favoring debugability.
     return waveSet;
@@ -298,7 +297,7 @@ PartitionSet partitionRegionConcurrencyReference(
     opInfo.membership.resize(builders.size(), /*t=*/false);
 
     // No consumers - if there's any candidate then we'll go into that.
-    int firstCandidateOrdinal = favor == IREE::Stream::Favor::MinPeakMemory
+    int firstCandidateOrdinal = favor == IREE::Stream::Favor::MaxConcurrency
                                     ? candidates.find_first()
                                     : candidates.find_last();
     if (firstCandidateOrdinal != -1) {

--- a/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -173,13 +173,13 @@ def Stream_AffinityAttr : AttrDef<Stream_Dialect, "Affinity", []> {
 }
 
 def Stream_Favor_Debug : I32EnumAttrCase<"Debug", 0, "debug">;
-def Stream_Favor_Concurrency : I32EnumAttrCase<"Concurrency", 1, "concurrency">;
-def Stream_Favor_MinPeakMemory : I32EnumAttrCase<"MinPeakMemory", 2, "min-peak-memory">;
+def Stream_Favor_MinPeakMemory : I32EnumAttrCase<"MinPeakMemory", 1, "min-peak-memory">;
+def Stream_Favor_MaxConcurrency : I32EnumAttrCase<"MaxConcurrency", 2, "max-concurrency">;
 def Stream_FavorAttr :
     I32EnumAttr<"Favor", "IREE partitioning bias", [
       Stream_Favor_Debug,
-      Stream_Favor_Concurrency,
       Stream_Favor_MinPeakMemory,
+      Stream_Favor_MaxConcurrency,
     ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Stream";
 }

--- a/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
@@ -1,8 +1,61 @@
 // RUN: iree-opt -split-input-file -pass-pipeline="builtin.func(iree-stream-schedule-concurrency)" %s | IreeFileCheck %s
 
-// CHECK-LABEL: @partitioning
+// Tests that when favor=min-peak-memory we assume ops are in an order that
+// reduces live memory ranges and only optimistically put them in concurrency
+// regions when it wouldn't increase the ranges.
+
+// CHECK-LABEL: @partitioningForMinPeakMemory
 // CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>, %[[ARG1:.+]]: !stream.resource<external>)
-func @partitioning(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>) -> !stream.resource<external> {
+func @partitioningForMinPeakMemory(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>) -> !stream.resource<external>
+    attributes {stream.partitioning = #stream.partitioning_config<"min-peak-memory">} {
+  %c1 = arith.constant 1 : index
+  %c20 = arith.constant 20 : index
+  %c80 = arith.constant 80 : index
+  %c1280 = arith.constant 1280 : index
+  %cst = arith.constant 0x7F800000 : f32
+  // CHECK: stream.async.execute
+  %results, %result_timepoint = stream.async.execute
+      // CHECK-SAME: with(%[[ARG1]] as %[[ARG1_CAPTURE:.+]]: !stream.resource<external>{%c80},
+      // CHECK-SAME:      %[[ARG0]] as %[[ARG0_CAPTURE:.+]]: !stream.resource<external>{%c20})
+      with(%arg1 as %arg2: !stream.resource<external>{%c80},
+           %arg0 as %arg3: !stream.resource<external>{%c20})
+      -> !stream.resource<external>{%c20} {
+
+    // CHECK: %[[SPLAT0:.+]] = stream.async.splat %cst : f32 -> !stream.resource<transient>{%c1280}
+    %1 = stream.async.splat %cst : f32 -> !stream.resource<transient>{%c1280}
+
+    // CHECK: %[[CON0:.+]]:2 = stream.async.concurrent
+    // CHECK-SAME: with(%[[SPLAT0]] as %[[SPLAT0_CAPTURE:.+]]: !stream.resource<transient>{%c1280},
+    // CHECK-SAME:      %[[ARG1_CAPTURE]] as %[[ARG1_CON0_CAPTURE:.+]]: !stream.resource<external>{%c80})
+    // CHECK-SAME: -> (!stream.resource<transient>{%c1280}, !stream.resource<transient>{%c20}) {
+    // CHECK-NEXT: %[[DISPATCH0:.+]] = stream.async.dispatch @ex::@dispatch_0[%c1, %c1, %c1](%[[SPLAT0_CAPTURE]], %[[ARG1_CON0_CAPTURE]])
+    %2 = stream.async.dispatch @ex::@dispatch_0[%c1, %c1, %c1](%1, %arg2) : (!stream.resource<transient>{%c1280}, !stream.resource<external>{%c80}) -> %1{%c1280}
+    // CHECK-NEXT: %[[SPLAT1:.+]] = stream.async.splat %cst : f32 -> !stream.resource<transient>{%c20}
+    %3 = stream.async.splat %cst : f32 -> !stream.resource<transient>{%c20}
+    // CHECK-NEXT: stream.yield %[[DISPATCH0]], %[[SPLAT1]] : !stream.resource<transient>{%c1280}, !stream.resource<transient>{%c20}
+
+    // CHECK: %[[DISPATCH1:.+]] = stream.async.dispatch @ex::@dispatch_1[%c1, %c1, %c1](%[[ARG0_CAPTURE]], %[[CON0]]#1)
+    %4 = stream.async.dispatch @ex::@dispatch_1[%c1, %c1, %c1](%arg3, %3) : (!stream.resource<external>{%c20}, !stream.resource<transient>{%c20}) -> %3{%c20}
+
+    // CHECK: %[[DISPATCH2:.+]] = stream.async.dispatch @ex::@dispatch_2[%c1, %c1, %c1](%[[CON0]]#0, %[[DISPATCH1]])
+    %5 = stream.async.dispatch @ex::@dispatch_2[%c1, %c1, %c1](%2, %4) : (!stream.resource<transient>{%c1280}, !stream.resource<transient>{%c20}) -> !stream.resource<external>{%c20}
+
+    // CHECK-NEXT: stream.yield %[[DISPATCH2]]
+    stream.yield %5 : !stream.resource<external>{%c20}
+  } => !stream.timepoint
+  %0 = stream.timepoint.await %result_timepoint => %results : !stream.resource<external>{%c20}
+  return %0 : !stream.resource<external>
+}
+
+// -----
+
+// Tests that when favor=max-concurrency we reorder ops aggressively to maximize
+// the amount of work scheduled concurrently.
+
+// CHECK-LABEL: @partitioningForMaxConcurrency
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>, %[[ARG1:.+]]: !stream.resource<external>)
+func @partitioningForMaxConcurrency(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>) -> !stream.resource<external>
+    attributes {stream.partitioning = #stream.partitioning_config<"max-concurrency">} {
   %c1 = arith.constant 1 : index
   %c20 = arith.constant 20 : index
   %c80 = arith.constant 80 : index


### PR DESCRIPTION
The `#stream.partitioning_config` attribute can be added to the module/functions/etc to control this explicitly and otherwise the `-iree-stream-partitioning-favor=` flag will be used as a default.

- `debug` disables all partitioning for concurrency (and in the future when partitioning command buffers for concurrency).
- `min-peak-memory` attempts to preserve the debug-level memory consumption by only optimistically scheduling work concurrently.
- `max-concurrency` reorders ops to try to extract the maximum amount of concurrency allowed by the program - it's not a fantastic algorithm and in the future we can reduce the memory consumption with better clustering/SCC.

Models primarily designed for single-threaded execution should favor `min-peak-memory` while those for multithreaded/GPU should favor `max-concurrency`. We can extend these modes in the future and make them smarter: for example, min-peak-memory should perform reordering to minimize live ranges.

Examples from the JAX mnist_train model:
`-iree-stream-partitioning-favor=debug`: 12MB transients, 0 concurrent dispatches
`-iree-stream-partitioning-favor=min-peak-memory`: 12MB transients, ~80 concurrent dispatches
`-iree-stream-partitioning-favor=max-concurrency`: 22MB transients, ~350 concurrent dispatches

For now we are defaulting to `max-concurrency` but can change that as we get better benchmarking infra and more devices/backends (CUDA/etc) running. I added a note to the bare-metal docs (where min-peak-memory is most interesting today).