### PR TITLE
Fix CMakeList files caused by the most recent integrate

### DIFF
--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     MLIRArithBufferizableOpInterfaceImpl
     MLIRArithmetic
     MLIRBufferizableOpInterface
+    MLIRBufferizationDialect
     MLIRComprehensiveBufferize
     MLIRGPUOps
     MLIRIR

--- a/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     MLIRArithmetic
     MLIRArithmeticToSPIRV
     MLIRArithmeticTransforms
+    MLIRBufferizationDialect
     MLIRGPUOps
     MLIRGPUToSPIRV
     MLIRGPUTransforms

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRAffineToStandard
+    MLIRBufferizationDialect
     MLIRIR
     MLIRPass
     MLIRStandard

--- a/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
+++ b/iree/compiler/Dialect/Shape/IR/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     MLIRSideEffectInterfaces
     MLIRStandard
     MLIRSupport
+    MLIRTensor
     MLIRTransforms
     MLIRViewLikeInterface
     iree::compiler::Dialect::Util::IR

--- a/iree/compiler/Dialect/VM/Conversion/MemRefToVM/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/MemRefToVM/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
   DEPS
     MLIRAffine
     MLIRArithmetic
+    MLIRBufferizationDialect
     MLIRIR
     MLIRMemRef
     MLIRPass


### PR DESCRIPTION
LLVM integration caused some failures for our OSS builds. Fixed the CMake files to correct.