### PR TITLE
Truely apply vector unrolling in TileFuseAndVectorize pipeline.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileFuseAndVectorizeLinalgTensorOps.cpp
@@ -260,8 +260,10 @@ void LLVMCPUTileFuseAndVectorizePass::runOnOperation() {
     // TODO(hanchung): Set different vector sizes for different operations. Also
     // it seems that `{16, 16, 16}` is not a good config. We should tune it.
     vector::populateVectorUnrollPatterns(
-        vectorUnrollPatterns, vector::UnrollVectorOptions().setNativeShape(
-                                  config.getNativeVectorSizeVals()));
+        vectorUnrollPatterns,
+        vector::UnrollVectorOptions().setNativeShape(config.getTileSizeVals(
+            static_cast<unsigned>(TilingLevel::VectorTiles))));
+
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(vectorUnrollPatterns)))) {
       return signalPassFailure();

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -1351,4 +1351,6 @@ hal.executable private @matmul_x86  {
     }
   }
 }
-//  CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering.config<tile_sizes = [{{\[}}], [8, 32, 32], [1, 16, 16]], native_vector_size = [1, 16, 16]>
+//  CHECK:       linalg.matmul {lowering.config = #[[CONFIG]]}


### PR DESCRIPTION
It speeds up matmul perf 10% ~ 20% on x86. This also splits x86 and ARM
configurations into two methods to have better structure.

The tile sizes for x86 are not well-tuned. This is a demonstration that
how vector unrolling helps performance in IREE.

Before:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           2.78 ms         2.79 ms          249
BM_dot_384x128x128/process_time/real_time          0.153 ms        0.153 ms         4561
BM_dot_384x128x512/process_time/real_time          0.596 ms        0.598 ms         1183
BM_dot_384x512x128/process_time/real_time          0.707 ms        0.708 ms         1096
BM_dot_384x512x2/process_time/real_time            0.528 ms        0.529 ms         1309
BM_dot_384x384x32/process_time/real_time           0.151 ms        0.151 ms         4533
BM_dot_384x384x512_exp/process_time/real_time       2.91 ms         2.92 ms          242
BM_dot_384x128x128_exp/process_time/real_time      0.166 ms        0.166 ms         4225
BM_dot_384x128x512_exp/process_time/real_time      0.649 ms        0.651 ms         1058
BM_dot_384x512x128_exp/process_time/real_time      0.650 ms        0.651 ms         1075
BM_dot_384x512x2_exp/process_time/real_time        0.539 ms        0.540 ms         1302
BM_dot_384x384x32_exp/process_time/real_time       0.157 ms        0.158 ms         4404
```

After:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           2.62 ms         2.62 ms          248
BM_dot_384x128x128/process_time/real_time          0.122 ms        0.122 ms         5588
BM_dot_384x128x512/process_time/real_time          0.484 ms        0.486 ms         1469
BM_dot_384x512x128/process_time/real_time          0.457 ms        0.459 ms         1509
BM_dot_384x512x2/process_time/real_time            0.491 ms        0.492 ms         1509
BM_dot_384x384x32/process_time/real_time           0.131 ms        0.131 ms         5393
BM_dot_384x384x512_exp/process_time/real_time       2.54 ms         2.54 ms          287
BM_dot_384x128x128_exp/process_time/real_time      0.133 ms        0.134 ms         5340
BM_dot_384x128x512_exp/process_time/real_time      0.523 ms        0.524 ms         1322
BM_dot_384x512x128_exp/process_time/real_time      0.469 ms        0.470 ms         1500
BM_dot_384x512x2_exp/process_time/real_time        0.503 ms        0.504 ms         1000
BM_dot_384x384x32_exp/process_time/real_time       0.133 ms        0.133 ms         5208
```