### PR TITLE
[CUDA] Fill out push constant kernel arguments at dispatch time

### DIFF
--- a/iree/hal/cuda/executable_layout.c
+++ b/iree/hal/cuda/executable_layout.c
@@ -55,6 +55,14 @@ iree_status_t iree_hal_cuda_executable_layout_create(
   IREE_ASSERT_ARGUMENT(out_executable_layout);
   *out_executable_layout = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (push_constant_count > IREE_HAL_CUDA_MAX_PUSH_CONSTANT_COUNT) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "push constant count %zu over the limit of %d",
+                            push_constant_count,
+                            IREE_HAL_CUDA_MAX_PUSH_CONSTANT_COUNT);
+  }
+
   // Currently the executable layout doesn't do anything.
   // TODO: Handle creating the argument layout at that time hadling both push
   // constant and buffers.

--- a/iree/hal/cuda/executable_layout.c
+++ b/iree/hal/cuda/executable_layout.c
@@ -16,6 +16,7 @@ typedef struct iree_hal_cuda_executable_layout_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
   iree_host_size_t push_constant_base_index;
+  iree_host_size_t push_constant_count;
   iree_host_size_t set_layout_count;
   iree_hal_descriptor_set_layout_t* set_layouts[];
 } iree_hal_cuda_executable_layout_t;
@@ -76,6 +77,7 @@ iree_status_t iree_hal_cuda_executable_layout_create(
           iree_hal_cuda_descriptor_set_layout_binding_count(set_layouts[i]);
     }
     executable_layout->push_constant_base_index = binding_number;
+    executable_layout->push_constant_count = push_constant_count;
     *out_executable_layout = (iree_hal_executable_layout_t*)executable_layout;
   }
   IREE_TRACE_ZONE_END(z0);
@@ -101,6 +103,13 @@ iree_host_size_t iree_hal_cuda_push_constant_index(
   iree_hal_cuda_executable_layout_t* executable_layout =
       iree_hal_cuda_executable_layout_cast(base_executable_layout);
   return executable_layout->push_constant_base_index;
+}
+
+iree_host_size_t iree_hal_cuda_executable_layout_num_constants(
+    iree_hal_executable_layout_t* base_executable_layout) {
+  iree_hal_cuda_executable_layout_t* executable_layout =
+      iree_hal_cuda_executable_layout_cast(base_executable_layout);
+  return executable_layout->push_constant_count;
 }
 
 const iree_hal_executable_layout_vtable_t

--- a/iree/hal/cuda/executable_layout.h
+++ b/iree/hal/cuda/executable_layout.h
@@ -30,6 +30,10 @@ iree_host_size_t iree_hal_cuda_base_binding_index(
 iree_host_size_t iree_hal_cuda_push_constant_index(
     iree_hal_executable_layout_t* base_executable_layout);
 
+// Return the number of constants in the executable layout.
+iree_host_size_t iree_hal_cuda_executable_layout_num_constants(
+    iree_hal_executable_layout_t* base_executable_layout);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/cuda/executable_layout.h
+++ b/iree/hal/cuda/executable_layout.h
@@ -15,6 +15,8 @@
 extern "C" {
 #endif  // __cplusplus
 
+#define IREE_HAL_CUDA_MAX_PUSH_CONSTANT_COUNT 64
+
 // Creates the kernel arguments.
 iree_status_t iree_hal_cuda_executable_layout_create(
     iree_hal_cuda_context_wrapper_t* context, iree_host_size_t set_layout_count,

--- a/iree/hal/cuda/graph_command_buffer.c
+++ b/iree/hal/cuda/graph_command_buffer.c
@@ -18,6 +18,11 @@
 #include "iree/hal/cuda/native_executable.h"
 #include "iree/hal/cuda/status_util.h"
 
+#define IREE_HAL_CUDA_MAX_PUSH_CONSTANT 64
+#define IREE_HAL_CUDA_MAX_BINDING_COUNT 64
+// Kernel arguments contains binding and push constants.
+#define IREE_HAL_CUDA_MAX_KERNEL_ARG 128
+
 // Command buffer implementation that directly maps to cuda graph.
 // This records the commands on the calling thread without additional threading
 // indirection.
@@ -32,13 +37,10 @@ typedef struct iree_hal_cuda_graph_command_buffer_t {
   // Keep track of the last node added to the command buffer as we are currently
   // serializing all the nodes (each node depends on the previous one).
   CUgraphNode last_node;
+  int32_t push_constant[IREE_HAL_CUDA_MAX_PUSH_CONSTANT];
   // Keep track of the current set of kernel arguments.
   void* current_descriptor[];
 } iree_hal_cuda_graph_command_buffer_t;
-
-#define IREE_HAL_CUDA_MAX_BINDING_COUNT 64
-// Kernel arguments contains binding and push constants.
-#define IREE_HAL_CUDA_MAX_KERNEL_ARG 128
 
 extern const iree_hal_command_buffer_vtable_t
     iree_hal_cuda_graph_command_buffer_vtable;
@@ -349,11 +351,9 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_push_constants(
     const void* values, iree_host_size_t values_length) {
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
-  iree_host_size_t constant_base_index =
-      iree_hal_cuda_push_constant_index(executable_layout) +
-      offset / sizeof(int32_t);
+  iree_host_size_t constant_base_index = offset / sizeof(int32_t);
   for (iree_host_size_t i = 0; i < values_length / sizeof(int32_t); i++) {
-    *((uint32_t*)command_buffer->current_descriptor[i + constant_base_index]) =
+    command_buffer->push_constant[i + constant_base_index] =
         ((uint32_t*)values)[i];
   }
   return iree_ok_status();
@@ -425,7 +425,17 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_dispatch(
     uint32_t workgroup_x, uint32_t workgroup_y, uint32_t workgroup_z) {
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
-
+  iree_hal_executable_layout_t* layout =
+      iree_hal_cuda_executable_get_layout(executable, entry_point);
+  iree_host_size_t num_constants =
+      iree_hal_cuda_executable_layout_num_constants(layout);
+  iree_host_size_t constant_base_index =
+      iree_hal_cuda_push_constant_index(layout);
+  // Patch the push constants in the kernel arguments.
+  for (iree_host_size_t i = 0; i < num_constants; i++) {
+    *((uint32_t*)command_buffer->current_descriptor[i + constant_base_index]) =
+        command_buffer->push_constant[i];
+  }
   int32_t block_size_x, block_size_y, block_size_z;
   IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_block_size(
       executable, entry_point, &block_size_x, &block_size_y, &block_size_z));

--- a/iree/hal/cuda/graph_command_buffer.c
+++ b/iree/hal/cuda/graph_command_buffer.c
@@ -18,7 +18,6 @@
 #include "iree/hal/cuda/native_executable.h"
 #include "iree/hal/cuda/status_util.h"
 
-#define IREE_HAL_CUDA_MAX_PUSH_CONSTANT 64
 #define IREE_HAL_CUDA_MAX_BINDING_COUNT 64
 // Kernel arguments contains binding and push constants.
 #define IREE_HAL_CUDA_MAX_KERNEL_ARG 128
@@ -37,7 +36,7 @@ typedef struct iree_hal_cuda_graph_command_buffer_t {
   // Keep track of the last node added to the command buffer as we are currently
   // serializing all the nodes (each node depends on the previous one).
   CUgraphNode last_node;
-  int32_t push_constant[IREE_HAL_CUDA_MAX_PUSH_CONSTANT];
+  int32_t push_constant[IREE_HAL_CUDA_MAX_PUSH_CONSTANT_COUNT];
   // Keep track of the current set of kernel arguments.
   void* current_descriptor[];
 } iree_hal_cuda_graph_command_buffer_t;

--- a/iree/hal/cuda/native_executable.c
+++ b/iree/hal/cuda/native_executable.c
@@ -11,6 +11,7 @@
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/cuda/dynamic_symbols.h"
+#include "iree/hal/cuda/executable_layout.h"
 #include "iree/hal/cuda/status_util.h"
 
 // flatcc schemas:
@@ -28,6 +29,7 @@ typedef struct iree_hal_cuda_native_executable_function_t {
 typedef struct iree_hal_cuda_native_executable_t {
   iree_hal_resource_t resource;
   iree_hal_cuda_context_wrapper_t* context;
+  iree_hal_executable_layout_t** executable_layouts;
   iree_host_size_t entry_count;
   CUmodule module;
   iree_hal_cuda_native_executable_function_t entry_functions[];
@@ -68,9 +70,13 @@ iree_status_t iree_hal_cuda_native_executable_create(
   iree_host_size_t entry_count = flatbuffers_string_vec_len(entry_points_vec);
   iree_host_size_t total_size =
       sizeof(*executable) +
-      entry_count * sizeof(iree_hal_cuda_native_executable_function_t);
+      entry_count * sizeof(iree_hal_cuda_native_executable_function_t) +
+      entry_count * sizeof(iree_hal_executable_layout_t*);
   iree_status_t status = iree_allocator_malloc(context->host_allocator,
                                                total_size, (void**)&executable);
+  executable->executable_layouts =
+      (void*)((char*)executable + sizeof(*executable) +
+              entry_count * sizeof(iree_hal_cuda_native_executable_function_t));
   CUmodule module = NULL;
   CUDA_RETURN_IF_ERROR(context->syms,
                        cuModuleLoadDataEx(&module, ptx_image, 0, NULL, NULL),
@@ -86,6 +92,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
     executable->entry_functions[i].block_size_x = block_sizes_vec[i].x;
     executable->entry_functions[i].block_size_y = block_sizes_vec[i].y;
     executable->entry_functions[i].block_size_z = block_sizes_vec[i].z;
+    executable->executable_layouts[i] = executable_spec->executable_layouts[i];
   }
 
   iree_hal_resource_initialize(&iree_hal_cuda_native_executable_vtable,
@@ -113,6 +120,13 @@ iree_status_t iree_hal_cuda_native_executable_block_size(
   *y = executable->entry_functions[entry_point].block_size_y;
   *z = executable->entry_functions[entry_point].block_size_z;
   return iree_ok_status();
+}
+
+iree_hal_executable_layout_t* iree_hal_cuda_executable_get_layout(
+    iree_hal_executable_t* base_executable, int32_t entry_point) {
+  iree_hal_cuda_native_executable_t* executable =
+      iree_hal_cuda_native_executable_cast(base_executable);
+  return executable->executable_layouts[entry_point];
 }
 
 static void iree_hal_cuda_native_executable_destroy(

--- a/iree/hal/cuda/native_executable.c
+++ b/iree/hal/cuda/native_executable.c
@@ -93,6 +93,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
     executable->entry_functions[i].block_size_y = block_sizes_vec[i].y;
     executable->entry_functions[i].block_size_z = block_sizes_vec[i].z;
     executable->executable_layouts[i] = executable_spec->executable_layouts[i];
+    iree_hal_executable_layout_retain(executable_spec->executable_layouts[i]);
   }
 
   iree_hal_resource_initialize(&iree_hal_cuda_native_executable_vtable,
@@ -136,6 +137,9 @@ static void iree_hal_cuda_native_executable_destroy(
   iree_allocator_t host_allocator = executable->context->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  for (iree_host_size_t i = 0; i < executable->entry_count; ++i) {
+    iree_hal_executable_layout_release(executable->executable_layouts[i]);
+  }
   iree_allocator_free(host_allocator, executable);
 
   IREE_TRACE_ZONE_END(z0);

--- a/iree/hal/cuda/native_executable.h
+++ b/iree/hal/cuda/native_executable.h
@@ -33,6 +33,10 @@ iree_status_t iree_hal_cuda_native_executable_block_size(
     iree_hal_executable_t* executable, int32_t entry_point, uint32_t* x,
     uint32_t* y, uint32_t* z);
 
+/// Return the layout associated with the entry point.
+iree_hal_executable_layout_t* iree_hal_cuda_executable_get_layout(
+    iree_hal_executable_t* executable, int32_t entry_point);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
This is needed as push constant command may not be sent again