### PR TITLE
Adding some of the new size-optimized flags to the config.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -331,25 +331,15 @@ endif()
 # Size-optimized build flags
 #-------------------------------------------------------------------------------
 
-  # TODO(#898): add a dedicated size-constrained configuration.
+# TODO(#898): add a dedicated size-constrained configuration.
 if(${IREE_SIZE_OPTIMIZED})
   iree_select_compiler_opts(IREE_SIZE_OPTIMIZED_DEFAULT_COPTS
-    CLANG_OR_GCC
-      "-DIREE_STATUS_MODE=0"
-      "-DIREE_HAL_MODULE_STRING_UTIL_ENABLE=0"
-      "-DIREE_VM_EXT_I64_ENABLE=0"
-      "-DIREE_VM_EXT_F32_ENABLE=0"
     MSVC_OR_CLANG_CL
       "/GS-"
       "/GL"
       "/Gw"
       "/Gy"
       "/DNDEBUG"
-      "/DIREE_STATUS_MODE=0"
-      "/DIREE_FLAGS_ENABLE_CLI=0"
-      "/DIREE_HAL_MODULE_STRING_UTIL_ENABLE=0"
-      "/DIREE_VM_EXT_I64_ENABLE=0"
-      "/DIREE_VM_EXT_F32_ENABLE=0"
       "/Os"
       "/Oy"
       "/Zi"
@@ -362,12 +352,23 @@ if(${IREE_SIZE_OPTIMIZED})
       "-opt:ref,icf"
   )
   # TODO(#898): make this only impact the runtime (IREE_RUNTIME_DEFAULT_...).
+  # These flags come from iree/base/config.h:
   set(IREE_DEFAULT_COPTS
       "${IREE_DEFAULT_COPTS}"
-      "${IREE_SIZE_OPTIMIZED_DEFAULT_COPTS}")
+      "${IREE_SIZE_OPTIMIZED_DEFAULT_COPTS}"
+      "-DIREE_STATUS_MODE=0"
+      "-DIREE_STATISTICS_ENABLE=0"
+      "-DIREE_HAL_MODULE_STRING_UTIL_ENABLE=0"
+      "-DIREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE=0"
+      "-DIREE_VM_BACKTRACE_ENABLE=0"
+      "-DIREE_VM_EXT_I64_ENABLE=0"
+      "-DIREE_VM_EXT_F32_ENABLE=0"
+      "-DIREE_VM_EXT_F64_ENABLE=0"
+  )
   set(IREE_DEFAULT_LINKOPTS
       "${IREE_DEFAULT_LINKOPTS}"
-      "${IREE_SIZE_OPTIMIZED_DEFAULT_LINKOPTS}")
+      "${IREE_SIZE_OPTIMIZED_DEFAULT_LINKOPTS}"
+  )
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Adding `-DIREE_SIZE_OPTIMIZED=1` should now turn off most extra features.