### PR TITLE
Switch matmul default CPU codegen to use TileFuseAndVectorize pipeline.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -188,7 +188,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUTileFuseAndVectorize:
-            addTileFuseAndVectorizePassPipeline(nestedModulePM);
+            addTileFuseAndVectorizePassPipeline(nestedModulePM, lowerToVectors);
             break;
           default:
             llvm_unreachable("Unsupported pipeline on CPU target.");

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -167,11 +167,13 @@ void addTensorToVectorsPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
 }
 
-void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager) {
+void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
+                                         bool lowerToVectors) {
   passManager.addPass(createCanonicalizerPass());
 
   // Tile and vectorize linalg ops on tensors.
-  passManager.addNestedPass<FuncOp>(createLLVMCPUTileFuseAndVectorizePass());
+  passManager.addNestedPass<FuncOp>(
+      createLLVMCPUTileFuseAndVectorizePass(lowerToVectors));
   passManager.addNestedPass<FuncOp>(createCSEPass());
   passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
 

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -53,8 +53,8 @@ hal.executable private @matmul_tensors  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [32, 32, 32], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [64, 64]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [16, 4, 64], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64]>
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.entry_point public @matmul_tensors
 // CHECK-SAME:   translation.info = #[[TRANSLATION]]
@@ -378,9 +378,9 @@ hal.executable private @batch_matmul_tensors  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [1, 32, 32, 32], [1, 4, 4, 4]{{\]}}, native_vector_size = [1, 4, 4, 4]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [1, 16, 4, 64], [1, 4, 4, 4]{{\]}}, native_vector_size = [1, 4, 4, 4]>
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [64, 64, 1]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [64, 64, 1]>
 //      CHECK: hal.executable.entry_point public @batch_matmul_tensors
 // CHECK-NEXT: (%[[ARG0:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:  %[[ARG1:[a-zA-Z0-9]+]]: index
@@ -972,10 +972,10 @@ hal.executable private @matmul_static {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [28, 8, 24], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[], [4, 4, 60], [4, 4, 4]{{\]}}, native_vector_size = [4, 4, 4]>
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTensorToVectors", workload_per_wg = [8, 28]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [8, 28]>
 //       CHECK: hal.executable.entry_point public @matmul_static attributes
 //  CHECK-SAME:     translation.info = #[[TRANSLATION]]
 //  CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
@@ -205,7 +205,6 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
   return
 }
 
-
 // CHECK: func @nonvectorizable_matmul_and_vectorizable_generic
 // Verify that both matmul and generic ops are not vectorized.
 // CHECK:   linalg.matmul

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
@@ -155,7 +155,7 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
   %c1152 = arith.constant 1152 : index
   %c768 = arith.constant 768 : index
   %c0 = arith.constant 0 : index
-  %c48 = arith.constant 48 : index
+  %c49 = arith.constant 49 : index
   %c16 = arith.constant 16 : index
   %0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c768] : !flow.dispatch.tensor<readonly:96xf32>
   %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:96xf32>
@@ -171,20 +171,20 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
   %7 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_id_y]
   %8 = affine.apply affine_map<()[s0] -> (s0 * 16)>()[%workgroup_count_y]
   scf.for %arg0 = %7 to %c784 step %8 {
-    %9 = affine.apply affine_map<()[s0] -> (s0 * 48)>()[%workgroup_id_x]
-    %10 = affine.apply affine_map<()[s0] -> (s0 * 48)>()[%workgroup_count_x]
+    %9 = affine.apply affine_map<()[s0] -> (s0 * 49)>()[%workgroup_id_x]
+    %10 = affine.apply affine_map<()[s0] -> (s0 * 49)>()[%workgroup_count_x]
     scf.for %arg1 = %9 to %c96 step %10 {
-      %11 = flow.dispatch.tensor.load %0, offsets = [%arg1], sizes = [48], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<48xf32>
-      %12 = flow.dispatch.tensor.load %1, offsets = [%arg1], sizes = [48], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<48xf32>
-      %13 = flow.dispatch.tensor.load %2, offsets = [%arg1], sizes = [48], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<48xf32>
-      %14 = flow.dispatch.tensor.load %3, offsets = [%arg1], sizes = [48], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<48xf32>
-      %15 = linalg.init_tensor [16, 48] : tensor<16x48xf32>
+      %11 = flow.dispatch.tensor.load %0, offsets = [%arg1], sizes = [49], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<49xf32>
+      %12 = flow.dispatch.tensor.load %1, offsets = [%arg1], sizes = [49], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<49xf32>
+      %13 = flow.dispatch.tensor.load %2, offsets = [%arg1], sizes = [49], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<49xf32>
+      %14 = flow.dispatch.tensor.load %3, offsets = [%arg1], sizes = [49], strides = [1] : !flow.dispatch.tensor<readonly:96xf32> -> tensor<49xf32>
+      %15 = linalg.init_tensor [16, 49] : tensor<16x49xf32>
       %16 = flow.dispatch.tensor.load %4, offsets = [%arg0, 0], sizes = [16, 24], strides = [1, 1] : !flow.dispatch.tensor<readonly:784x24xf32> -> tensor<16x24xf32>
-      %17 = flow.dispatch.tensor.load %5, offsets = [0, %arg1], sizes = [24, 48], strides = [1, 1] : !flow.dispatch.tensor<readonly:24x96xf32> -> tensor<24x48xf32>
-      %18 = linalg.init_tensor [16, 48] : tensor<16x48xf32>
-      %19 = linalg.fill(%cst, %18) : f32, tensor<16x48xf32> -> tensor<16x48xf32>
-      %20 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%16, %17 : tensor<16x24xf32>, tensor<24x48xf32>) outs(%19 : tensor<16x48xf32>) -> tensor<16x48xf32>
-      %21 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%20, %11, %12, %13, %14 : tensor<16x48xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>, tensor<48xf32>) outs(%15 : tensor<16x48xf32>) {
+      %17 = flow.dispatch.tensor.load %5, offsets = [0, %arg1], sizes = [24, 49], strides = [1, 1] : !flow.dispatch.tensor<readonly:24x96xf32> -> tensor<24x49xf32>
+      %18 = linalg.init_tensor [16, 49] : tensor<16x49xf32>
+      %19 = linalg.fill(%cst, %18) : f32, tensor<16x49xf32> -> tensor<16x49xf32>
+      %20 = linalg.matmul {lowering.config = #iree_codegen.lowering.config<tile_sizes = [[], [16, 16, 32], [16, 16, 16]], native_vector_size = [16, 16, 16]>} ins(%16, %17 : tensor<16x24xf32>, tensor<24x49xf32>) outs(%19 : tensor<16x49xf32>) -> tensor<16x49xf32>
+      %21 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%20, %11, %12, %13, %14 : tensor<16x49xf32>, tensor<49xf32>, tensor<49xf32>, tensor<49xf32>, tensor<49xf32>) outs(%15 : tensor<16x49xf32>) {
       ^bb0(%arg2: f32, %arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32, %arg7: f32):  // no predecessors
         %22 = arith.addf %arg5, %cst_0 : f32
         %23 = math.sqrt %22 : f32
@@ -198,8 +198,8 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
         %31 = arith.mulf %30, %cst_3 : f32
         %32 = arith.mulf %31, %27 : f32
         linalg.yield %32 : f32
-      } -> tensor<16x48xf32>
-      flow.dispatch.tensor.store %21, %6, offsets = [%arg0, %arg1], sizes = [%c16, %c48], strides = [1, 1] : tensor<16x48xf32> -> !flow.dispatch.tensor<writeonly:784x96xf32>
+      } -> tensor<16x49xf32>
+      flow.dispatch.tensor.store %21, %6, offsets = [%arg0, %arg1], sizes = [%c16, %c49], strides = [1, 1] : tensor<16x49xf32> -> !flow.dispatch.tensor<writeonly:784x96xf32>
     }
   }
   return
@@ -207,5 +207,14 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
 
 // CHECK: func @nonvectorizable_matmul_and_vectorizable_generic
 // Verify that both matmul and generic ops are not vectorized.
-// CHECK:   linalg.matmul
-// CHECK:   linalg.generic
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[C49:.+]] = arith.constant 49 : index
+// CHECK:     scf.for
+// CHECK:       scf.for
+// CHECK:         %{{.+}} = scf.for %{{.*}} = %[[C0]] to %[[C49]] step %[[C16]]
+// CHECK:           %{{.+}} = linalg.fill
+// CHECK:           %{{.+}} = scf.for
+// CHECK:             %{{.+}} = scf.for
+// CHECK:               linalg.matmul
+// CHECK:           linalg.generic

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -157,7 +157,8 @@ std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUTileAndVectorizePass(
     bool lowerToVectors = true);
 
 /// Multi-level tiling, fusing and vectorization of linalg ops on tensors.
-std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUTileFuseAndVectorizePass();
+std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUTileFuseAndVectorizePass(
+    bool lowerToVectors = true);
 
 /// Vectorizes linalg ops executed in the same hal.interface.workgroup.
 std::unique_ptr<OperationPass<FuncOp>> createLLVMCPUVectorizationPass(
@@ -202,7 +203,8 @@ void addTensorToVectorsPassPipeline(OpPassManager &passManager,
 
 /// Populates the passes needed to multi level tile, fuse and vectorize lowering
 /// of linalg ops on tensors to vectors operations.
-void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager);
+void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
+                                         bool lowerToVectors = true);
 
 //----------------------------------------------------------------------------//
 // LLVMCPU Pass Pipelines for lowering to LLVM dialect.


### PR DESCRIPTION
- Add an option to not vectorize in TileFuseAndVectorizeLinalgTensorOps,
  which is required by VMVX backend.
- Tile reduction loops if the tile size is greater than dim size.
- Add another level of tiling when ops are not vectorizable.

# Benchmarks
Configurations: taskset 80 + dylib-sync on local Pixel 4

## Model perfs

| Model            | Before  | After   |
| ---------------- | ------- | ------- |
| DeepLabV3        | 956 ms  | 955 ms  |
| MobileBertSquad  | 682 ms  | 679 ms  |
| MobileNetV2      | 173 ms  | 173 ms  |
| MobileNetV3Small | 44.8 ms | 47.3 ms |
| MobileSSD        | 365 ms  | 375 ms  |
| PoseNet          | 873 ms  | 884 ms  |

## Matmul perfs

Before:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           7.32 ms         7.13 ms           92
BM_dot_384x128x128/process_time/real_time          0.502 ms        0.490 ms         1330
BM_dot_384x128x512/process_time/real_time           2.45 ms         2.39 ms          285
BM_dot_384x512x128/process_time/real_time           1.87 ms         1.82 ms          375
BM_dot_384x512x2/process_time/real_time            0.719 ms        0.702 ms          976
BM_dot_384x384x32/process_time/real_time           0.458 ms        0.446 ms         1530
BM_dot_384x384x512_exp/process_time/real_time       7.89 ms         7.68 ms           88
BM_dot_384x128x128_exp/process_time/real_time      0.589 ms        0.575 ms         1189
BM_dot_384x128x512_exp/process_time/real_time       2.80 ms         2.73 ms          250
BM_dot_384x512x128_exp/process_time/real_time       1.93 ms         1.88 ms          362
BM_dot_384x512x2_exp/process_time/real_time        0.748 ms        0.730 ms          936
BM_dot_384x384x32_exp/process_time/real_time       0.483 ms        0.471 ms         1446
```

After:

```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_dot_384x384x512/process_time/real_time           7.28 ms         7.09 ms           90
BM_dot_384x128x128/process_time/real_time          0.496 ms        0.484 ms         1342
BM_dot_384x128x512/process_time/real_time           1.94 ms         1.89 ms          359
BM_dot_384x512x128/process_time/real_time           1.72 ms         1.68 ms          407
BM_dot_384x512x2/process_time/real_time            0.737 ms        0.719 ms          950
BM_dot_384x384x32/process_time/real_time           0.414 ms        0.403 ms         1692
BM_dot_384x384x512_exp/process_time/real_time       7.51 ms         7.32 ms           93
BM_dot_384x128x128_exp/process_time/real_time      0.628 ms        0.613 ms         1119
BM_dot_384x128x512_exp/process_time/real_time       2.47 ms         2.41 ms          282
BM_dot_384x512x128_exp/process_time/real_time       1.81 ms         1.77 ms          385
BM_dot_384x512x2_exp/process_time/real_time        0.664 ms        0.648 ms         1058
BM_dot_384x384x32_exp/process_time/real_time       0.435 ms        0.423 ms         1607
```

## Observations

Some matmul are faster and some are slower. We don't see significant
regressions in end-to-end models.

There are slight regressions on MobileSSD and PoseNet. Looking into
tracy dumps, some of them are introduced by conv/depthwise_conv ops.
There are actually no changes for these dispatches.

My guess is that some mamtul is slightly slower, which triggered bad CPU
scheduling for later conv launches.

In this case, we can switch to use the new pipeline and tune better
params later.