### PR TITLE
Remove mhlo control flow to SCF.

### DIFF
--- a/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -86,9 +86,7 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
 }
 
 void buildXLACleanupPassPipeline(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(mhlo::createControlFlowToScfPass());
   passManager.addNestedPass<FuncOp>(mhlo::createLegalizeControlFlowPass());
-  passManager.addNestedPass<FuncOp>(mlir::createLowerToCFGPass());
   passManager.addPass(createFlattenTuplesInCFGPass());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
 }


### PR DESCRIPTION
This pass is horribly broken, and LegalizeControlFlow actual does a reasonable job of lowering to CFG.

Will follow up to delete the pass upstream.