### PR TITLE
Fixing iree-util-fold-globals to materialize custom constants.

### DIFF
--- a/iree/compiler/Dialect/Stream/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Stream/Transforms/test/BUILD
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "convert_to_stream.mlir",
             "elide_async_copies.mlir",
             "encode_tensors.mlir",
+            "fold_globals.mlir",
             "fold_uniform_operands.mlir",
             "fuse_dispatch_bindings.mlir",
             "fuse_dispatch_bindings_noalias.mlir",

--- a/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "convert_to_stream.mlir"
     "elide_async_copies.mlir"
     "encode_tensors.mlir"
+    "fold_globals.mlir"
     "fold_uniform_operands.mlir"
     "fuse_dispatch_bindings.mlir"
     "fuse_dispatch_bindings_noalias.mlir"

--- a/iree/compiler/Dialect/Stream/Transforms/test/fold_globals.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/fold_globals.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt -split-input-file -iree-util-fold-globals %s | IreeFileCheck %s
+
+// NOTE: this file is only testing that the iree-util-fold-globals pass works
+// with stream types - the rest of the testing for that pass lives in
+// iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+
+// CHECK: util.global public mutable @uniformConstants = #stream.timepoint<immediate>
+util.global public mutable @uniformConstants : !stream.timepoint
+builtin.func @foo() {
+  %timepoint = stream.timepoint.immediate => !stream.timepoint
+  // CHECK-NOT: util.global.store
+  util.global.store %timepoint, @uniformConstants : !stream.timepoint
+  return
+}
+builtin.func @bar() {
+  %timepoint = stream.timepoint.immediate => !stream.timepoint
+  // CHECK-NOT: util.global.store
+  util.global.store %timepoint, @uniformConstants : !stream.timepoint
+  return
+}
+
+// -----
+
+// CHECK-NOT: @immutable
+util.global private @immutable = #stream.timepoint<immediate> : !stream.timepoint
+builtin.func @foo() -> !stream.timepoint {
+  // CHECK-NOT: util.global.load @immutable
+  // CHECK: %[[IMMEDIATE:.+]] = stream.timepoint.immediate => !stream.timepoint
+  %0 = util.global.load @immutable : !stream.timepoint
+  // CHECK: return %[[IMMEDIATE]]
+  return %0 : !stream.timepoint
+}


### PR DESCRIPTION
When the folded constant global is not buildable with arith/std.constant
the dialect owning the attribute will be asked to materialize it.
If it's not possible then we bail gracefully and don't try to inline
the global.

Fixes #7808.