### PR TITLE
Cleanup unrealized_conversion_casts that survive stream conversion.

### DIFF
--- a/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -57,6 +57,34 @@ struct StreamFolderInterface : public DialectFoldInterface {
   }
 };
 
+// Tries to fold away unrealized_conversion_cast ops if the downstream consumers
+// don't need the extra information. These are inserted during conversion or
+// transforms that may interop with external dialects.
+struct StripResourceConversionCastPattern
+    : public OpRewritePattern<UnrealizedConversionCastOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(UnrealizedConversionCastOp castOp,
+                                PatternRewriter &rewriter) const override {
+    auto result = castOp.getResult(0);
+    if (!result.getType().isa<IREE::Stream::ResourceType>()) return failure();
+    assert(castOp.getNumOperands() == 2 &&
+           "expect resource, index -> resource");
+    auto resourceValue = castOp.getOperand(0);
+    auto sizeValue = castOp.getOperand(1);
+    for (auto &use : llvm::make_early_inc_range(result.getUses())) {
+      if (auto sizeOp =
+              dyn_cast<IREE::Stream::ResourceSizeOp>(use.getOwner())) {
+        sizeOp.getResult().replaceAllUsesWith(sizeValue);
+        rewriter.eraseOp(sizeOp);
+      } else {
+        use.set(resourceValue);
+      }
+    }
+    rewriter.eraseOp(castOp);
+    return success();
+  }
+};
+
 }  // namespace
 
 StreamDialect::StreamDialect(MLIRContext *context)
@@ -69,6 +97,11 @@ StreamDialect::StreamDialect(MLIRContext *context)
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.cpp.inc"
       >();
   addInterfaces<StreamInlinerInterface, StreamFolderInterface>();
+}
+
+void StreamDialect::getCanonicalizationPatterns(
+    RewritePatternSet &results) const {
+  results.insert<StripResourceConversionCastPattern>(getContext());
 }
 
 Operation *StreamDialect::materializeConstant(OpBuilder &builder,

--- a/iree/compiler/Dialect/Stream/IR/StreamDialect.h
+++ b/iree/compiler/Dialect/Stream/IR/StreamDialect.h
@@ -21,6 +21,8 @@ class StreamDialect : public Dialect {
   explicit StreamDialect(MLIRContext *context);
   static StringRef getDialectNamespace() { return "stream"; }
 
+  void getCanonicalizationPatterns(RewritePatternSet &results) const override;
+
   Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
                                  Location loc) override;
 
@@ -29,11 +31,6 @@ class StreamDialect : public Dialect {
 
   Type parseType(DialectAsmParser &parser) const override;
   void printType(Type type, DialectAsmPrinter &p) const override;
-
-  static bool isDialectOp(Operation *op) {
-    return op && op->getDialect() &&
-           op->getDialect()->getNamespace() == getDialectNamespace();
-  }
 
  private:
   void registerAttributes();

--- a/iree/compiler/Dialect/Stream/IR/test/resource_folding.mlir
+++ b/iree/compiler/Dialect/Stream/IR/test/resource_folding.mlir
@@ -177,3 +177,16 @@ func @FoldResourceSubviewOps(%arg0: !stream.resource<*>, %arg1: index) -> !strea
   // CHECK-NEXT: return %[[RET]]
   return %2 : !stream.resource<*>
 }
+
+// -----
+
+// Tests that unrealized_conversion_casts on resources are properly cleaned up.
+
+// CHECK-LABEL: unrealizedCastCleanup
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<transient>, %[[ARG1:.+]]: index)
+func @unrealizedCastCleanup(%arg0: !stream.resource<transient>, %arg1: index) -> (!stream.resource<transient>, index) {
+  %0 = builtin.unrealized_conversion_cast %arg0, %arg1 : !stream.resource<transient>, index to !stream.resource<transient>
+  %1 = stream.resource.size %0 : !stream.resource<transient>
+  // CHECK-NEXT: return %[[ARG0]], %[[ARG1]]
+  return %0, %1 : !stream.resource<transient>, index
+}


### PR DESCRIPTION
Most are pruned by construction as the conversion consumes the original
values but any op that is handled generically may leave them around
(such as selects).