### PR TITLE
Fixing partitioning when ops are cloned across partitions in various orders.

### DIFF
--- a/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
+++ b/iree/compiler/Dialect/Stream/IR/StreamDialect.cpp
@@ -60,6 +60,10 @@ struct StreamFolderInterface : public DialectFoldInterface {
 // Tries to fold away unrealized_conversion_cast ops if the downstream consumers
 // don't need the extra information. These are inserted during conversion or
 // transforms that may interop with external dialects.
+//
+// Specifically matches:
+//   %0 = builtin.unrealized_conversion_cast %arg0, %arg1 :
+//        !stream.resource<transient>, index to !stream.resource<transient>
 struct StripResourceConversionCastPattern
     : public OpRewritePattern<UnrealizedConversionCastOp> {
   using OpRewritePattern::OpRewritePattern;

--- a/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -141,3 +141,41 @@ func @dontHoistPastAsserts(%arg0: !stream.resource<external>, %arg1: !stream.res
 
   return %6 : !stream.resource<external>
 }
+
+// -----
+
+// Tests that cloning across partition boundaries inserts the cloned op into the
+// correct partitions.
+
+// CHECK-LABEL: @cloneAcrossPartitions
+func @cloneAcrossPartitions(%cond: i1) -> (!stream.resource<external>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c123_i8 = arith.constant 123 : i8
+
+  // CHECK: stream.async.execute
+  // CHECK-NEXT: stream.async.splat
+  %splat = stream.async.splat %c123_i8 : i8 -> !stream.resource<transient>{%c1}
+  // CHECK-NEXT: stream.async.dispatch
+  %dispatch0 = stream.async.dispatch @ex::@dispatch0[%c1, %c1, %c1](%splat) : (!stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  // CHECK-NEXT: stream.async.transfer
+  %download = stream.async.transfer %dispatch0 : !stream.resource<transient>{%c1} -> !stream.resource<staging>{%c1}
+  // CHECK: stream.timepoint.await
+
+  // CHECK: stream.async.load
+  %load = stream.async.load %download[%c0] : !stream.resource<staging>{%c1} -> i8
+  // CHECK: stream.async.store
+  %updated = stream.async.store %load, %download[%c0] : i8 -> !stream.resource<staging>{%c1}
+
+  // CHECK: stream.async.execute
+  // CHECK-NEXT: stream.async.splat
+  // CHECK-NEXT: stream.async.transfer
+  %upload = stream.async.transfer %updated : !stream.resource<staging>{%c1} -> !stream.resource<transient>{%c1}
+  // CHECK-NEXT: stream.async.dispatch
+  %dispatch1 = stream.async.dispatch @ex::@dispatch1[%c1, %c1, %c1](%upload, %splat) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  // CHECK-NEXT: stream.async.transfer
+  %result = stream.async.transfer %dispatch1 : !stream.resource<transient>{%c1} -> !stream.resource<external>{%c1}
+
+  // CHECK: return
+  return %result : !stream.resource<external>
+}

--- a/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -179,3 +179,35 @@ func @cloneAcrossPartitions(%cond: i1) -> (!stream.resource<external>) {
   // CHECK: return
   return %result : !stream.resource<external>
 }
+
+// -----
+
+// Tests multiple partitions with dependencies that cross both host and
+// device boundaries. Here %1 is used in both partitions and indirectly through
+// the select op that executes on the host. In the scheduling code this requires
+// tracking both the host and device hazards correctly.
+
+// CHECK-LABEL: @deviceHostDeviceCrossing
+func @deviceHostDeviceCrossing(%arg0: i1) -> !stream.resource<transient> {
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %cst = arith.constant 0xFF800000 : f32
+
+  // CHECK: stream.async.execute
+  // CHECK-NEXT: stream.async.splat
+  %0 = stream.async.splat %cst : f32 -> !stream.resource<transient>{%c128}
+  // CHECK-NEXT: stream.async.dispatch @ex::@dispatch0
+  %1 = stream.async.dispatch @ex::@dispatch0[%c1, %c1, %c1](%0) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  // CHECK-NEXT: stream.async.dispatch @ex::@dispatch1
+  %2 = stream.async.dispatch @ex::@dispatch1[%c1, %c1, %c1](%1) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: select
+  %3 = select %arg0, %1, %2 : !stream.resource<transient>
+
+  // CHECK: stream.async.execute
+  // CHECK-NEXT: stream.async.dispatch @ex::@dispatch2
+  %4 = stream.async.dispatch @ex::@dispatch2[%c1, %c1, %c1](%1, %3) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: return
+  return %4 : !stream.resource<transient>
+}


### PR DESCRIPTION
Fixes #7813. The issue reported was an overaggressive verification but immediately behind that was a real issue.