### PR TITLE
Remove lldDriver dependency

### DIFF
--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/CMakeLists.txt
@@ -23,7 +23,6 @@ add_mlir_public_c_api_library(IREECompilerAPICompilerCAPI
     # LLD.
     lldCommon
     lldCOFF
-    lldDriver
     lldELF
     lldMachO
     lldMinGW


### PR DESCRIPTION
After
https://github.com/llvm/llvm-project/commit/9e3552523ebd3385487e01e3e7af37b8c0efaf57
this dependency no longer exists.