### PR TITLE
[CUDA HAL] Use CUDA streams by default

### DIFF
--- a/iree/hal/cuda/registration/driver_module.c
+++ b/iree/hal/cuda/registration/driver_module.c
@@ -16,7 +16,9 @@
 
 #define IREE_HAL_CUDA_DRIVER_ID 0x43554441u  // CUDA
 
-IREE_FLAG(bool, cuda_use_streams, false, "Force to use cuda streams");
+// Force using CUDA streams until we support command buffer caching to avoid the
+// overhead of graph creation.
+IREE_FLAG(bool, cuda_use_streams, true, "Force to use cuda streams");
 
 static iree_status_t iree_hal_cuda_driver_factory_enumerate(
     void* self, const iree_hal_driver_info_t** out_driver_infos,

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -20,7 +20,7 @@ package(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_cuda",
+    name = "check_cuda_graph",
     srcs = enforce_glob(
         # keep sorted
         [
@@ -87,6 +87,7 @@ iree_check_single_backend_test_suite(
     ),
     compiler_flags = ["-iree-input-type=mhlo"],
     driver = "cuda",
+    runner_args = ["--cuda_use_streams=false"],
     tags = [
         # CUDA cuInit fails with sanitizer on.
         "noasan",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -12,7 +12,7 @@ iree_add_all_subdirs()
 
 iree_check_single_backend_test_suite(
   NAME
-    check_cuda
+    check_cuda_graph
   SRCS
     "abs.mlir"
     "add.mlir"
@@ -75,6 +75,8 @@ iree_check_single_backend_test_suite(
     "cuda"
   COMPILER_FLAGS
     "-iree-input-type=mhlo"
+  RUNNER_ARGS
+    "--cuda_use_streams=false"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
As we currently don't support command buffer caching using CUDA streams
allows us to avoid runtime overhead related to graph creation. We will
pick based on the command buffers once we support caching.