### PR TITLE
Raise xargs limits

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-swiftshader/build.sh
@@ -35,8 +35,12 @@ echo "Initializing submodules"
 pushd integrations/tensorflow
 BAZEL_CMD=(bazel --noworkspace_rc --bazelrc=build_tools/bazel/iree-tf.bazelrc)
 BAZEL_BINDIR="$(${BAZEL_CMD[@]?} info bazel-bin)"
+# xargs is set to high arg limits to avoid multiple Bazel invocations and will
+# hard fail if the limits are exceeded.
+# See https://github.com/bazelbuild/bazel/issues/12479
 "${BAZEL_CMD[@]?}" query //iree_tf_compiler/... | \
-   xargs "${BAZEL_CMD[@]?}" test \
+   xargs --max-args 1000000 --max-chars 1000000 --exit \
+    "${BAZEL_CMD[@]?}" test \
       --config=remote_cache_tf_integrations \
       --config=generic_clang \
       --test_tag_filters="-nokokoro" \

--- a/build_tools/pytype/check_diff.sh
+++ b/build_tools/pytype/check_diff.sh
@@ -46,8 +46,12 @@ function check_files() {
 
   # We disable import-error because pytype doesn't have access to bazel.
   # We disable pyi-error because of the way the bindings imports work.
+  # xargs is set to high arg limits to avoid multiple Bazel invocations and will
+  # hard fail if the limits are exceeded.
+  # See https://github.com/bazelbuild/bazel/issues/12479
   echo "${@:2}" | \
-    xargs python3 -m pytype --disable=import-error,pyi-error -j $(nproc)
+    xargs --max-args 1000000 --max-chars 1000000 --exit \
+      python3 -m pytype --disable=import-error,pyi-error -j $(nproc)
   EXIT_CODE="$?"
   echo
   if [[ "${EXIT_CODE?}" -gt "${1?}" ]]; then


### PR DESCRIPTION
xargs will partition the args it passes through based on some limit.
The default limit configured in xargs is generally much much lower than
the actual upper limits for the system. For instance, on my system:

```shell
$ xargs --show-limits
Your environment variables take up 4819 bytes
POSIX upper limit on argument length (this system): 2090285
POSIX smallest allowable upper limit on argument length (all systems): 4096
Maximum length of command we could actually use: 2085466
Size of command buffer we are actually using: 131072
Maximum parallelism (--max-procs must be no greater): 2147483647
```

(system limit is 16x configured limit). We don't want multiple Bazel
invocations because a) it's unnecessarily slow, and b) a `bazel test`
invocation that doesn't contain any test targets will fail, whereas a
mix of test and non-test targets will build all the targets and run the
tests, which is what we want.

So setting this to some arbitrarily large limit. Also making it hard
fail in the case where the limit is exceeded, so that we get a clear
error message.