### PR TITLE
Rework module nesting in VM conversion.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -47,7 +47,7 @@ stream.executable public @add_dispatch_0 {
 //  CHECK-SAME:       interface = @io,
 //  CHECK-SAME:       ordinal = 0 : index
 //  CHECK-SAME:     }
-//       CHECK:     module {
+//       CHECK:     module attributes {vm.toplevel} {
 //  CHECK-NEXT:       vm.module public @module {
 //  CHECK-NEXT:         vm.func private @add_dispatch_0(
 //  CHECK-SAME:             %[[SCRATCHPAD:.+]]: !vm.buffer, %[[CONSTANTS:.+]]: !vm.buffer,

--- a/iree/compiler/Dialect/VM/Conversion/ConversionTarget.h
+++ b/iree/compiler/Dialect/VM/Conversion/ConversionTarget.h
@@ -27,9 +27,13 @@ class VMConversionTarget : public ConversionTarget {
   // Example:
   //  module { func @foo() { ... } }
   // ->
-  //  module { module { func @foo() { ... } } }
+  //  module attributes {vm.toplevel} { module { func @foo() { ... } } }
   static std::pair<mlir::ModuleOp, mlir::ModuleOp> nestModuleForConversion(
       mlir::ModuleOp outerModuleOp);
+
+  // Returns whether this is the outer module as setup via
+  // nestModuleForConversion. Use for patterns which need to distinguish.
+  static bool isTopLevelModule(mlir::ModuleOp moduleOp);
 
   VMConversionTarget(MLIRContext *context);
 };

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.h"
 
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Dialect/VM/Conversion/ConversionTarget.h"
 #include "iree/compiler/Dialect/VM/Conversion/TargetOptions.h"
 #include "iree/compiler/Dialect/VM/Conversion/TypeConverter.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
@@ -32,7 +33,7 @@ class ModuleOpConversion : public OpConversionPattern<ModuleOp> {
       ConversionPatternRewriter &rewriter) const override {
     // Do not attempt to convert the top level module.
     // This mechanism can only support rewriting non top-level modules.
-    if (!srcOp->getParentOp() || !isa<ModuleOp>(srcOp->getParentOp())) {
+    if (VMConversionTarget::isTopLevelModule(srcOp)) {
       return failure();
     }
 

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "control_flow_ops.mlir",
             "conversion_ops.mlir",
             "func_attrs.mlir",
+            "nesting.mlir",
             "structural_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "control_flow_ops.mlir"
     "conversion_ops.mlir"
     "func_attrs.mlir"
+    "nesting.mlir"
     "structural_ops.mlir"
   DATA
     iree::tools::IreeFileCheck

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/nesting.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/nesting.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='builtin.module(test-iree-convert-std-to-vm)' %s | IreeFileCheck %s
+
+// Note that checks are ambiguous between "module" and "vm.module" so we rely
+// on vm.module printing as `vm.module public @foo`
+
+// CHECK-LABEL: module @outerBuiltinModule
+module @outerBuiltinModule {
+  // CHECK-NEXT: module @innerBuiltinModule attributes {vm.toplevel}
+  module @innerBuiltinModule attributes {vm.toplevel} {
+    // CHECK-NEXT: vm.module public @outerVmModule
+    module @outerVmModule {
+      // CHECK-NEXT: vm.module public @deeplyNested
+      module @deeplyNested {
+        // CHECK: vm.func private @foo
+        func @foo() {
+          return
+        }
+      }
+    }
+  }
+}

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/structural_ops.mlir
@@ -40,22 +40,3 @@ module {
 }
 
 }
-
-// -----
-
-// CHECK: module
-module {
-  // CHECK: module
-  module {
-    // CHECK: module
-    module {
-      // CHECK-LABEL: vm.module public @deeplyNested
-      module @deeplyNested {
-        // CHECK: vm.func private @foo
-        func @foo() {
-          return
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
Introduces an explicit `vm.toplevel` attribute when setting up the nesting and then uses this as a signal that a nested module should be considered legal and left alone. The heuristic previously in use was to attempt to infer this based on parents. This turned out to be fragile if nesting a new module in an existing module (i.e. to extract a partial program and compile it without intending to create a layering issue).

I was going to clean the attribute up at the end but opted to leave it there as it was a good debugging aid as I tried to figure out what was going on.

Moved the one nesting test to a new nesting.mlir test case and reworked it to use a non-root based pipeline, which is more realistic for this scenario. Also, verified that what this test was doing was wrong (checks on "module" were inadvertently matching "vm.module", which was not the desired outcome). I believe the current tested behavior is desired.