### PR TITLE
Mark f16 vulkan tests as manual

### DIFF
--- a/iree/test/e2e/xla_ops/partial/BUILD
+++ b/iree/test/e2e/xla_ops/partial/BUILD
@@ -35,6 +35,7 @@ iree_check_single_backend_test_suite(
     ],
     driver = "vulkan",
     tags = [
+        "manual",
         "notap",
         "vulkan_uses_vk_khr_shader_float16_int8",
     ],

--- a/iree/test/e2e/xla_ops/partial/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/partial/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_check_single_backend_test_suite(
     "-iree-input-type=mhlo"
     "-iree-vulkan-target-triple=valhall-unknown-android11"
   LABELS
+    "manual"
     "notap"
     "vulkan_uses_vk_khr_shader_float16_int8"
 )


### PR DESCRIPTION
These tests aren't supported on many platforms (in particular,
swiftshader) and it's nice for wildcard runs to succeed.
