### PR TITLE
Fixes builds and comments for SingleTilingExpert pipeline.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -174,13 +174,15 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(createLinalgSingleTilingExpertPass(
       static_cast<int64_t>(TilingLevel::L1Tiles), true));
 
-  // Bufferize
-  auto callbacks =
-      std::make_unique<linalg::comprehensive_bufferize::AllocationCallbacks>(
-          cpuComprehensiveBufferizeAllocationFn,
-          cpuComprehensiveBufferizeDeallocationFn,
-          cpuComprehensiveBufferizeCopyFn);
-  addIREEComprehensiveBufferizePasses(passManager, std::move(callbacks));
+  // TODO(ravishankarm): This is commented cause this is WIP, to be enabled
+  // soon.
+  // auto callbacks =
+  //     std::make_unique<linalg::comprehensive_bufferize::AllocationCallbacks>(
+  //         cpuComprehensiveBufferizeAllocationFn,
+  //         cpuComprehensiveBufferizeDeallocationFn,
+  //         cpuComprehensiveBufferizeCopyFn);
+  // addIREEComprehensiveBufferizePasses(passManager, std::move(callbacks));
+  addLinalgBufferizePasses(passManager, cpuAllocationFunction);
 
   // Add the vector lowering expert.
   OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -51,16 +51,6 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
   return entryPointOps;
 }
 
-bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp) {
-  return variantOp.target().getBackend().getValue() == "vmvx";
-}
-
-bool isVMVXBackend(FuncOp entryPointFn) {
-  auto variantOp =
-      entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
-  return isVMVXBackend(variantOp);
-}
-
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -55,6 +55,12 @@ bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp) {
   return variantOp.target().getBackend().getValue() == "vmvx";
 }
 
+bool isVMVXBackend(FuncOp entryPointFn) {
+  auto variantOp =
+      entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  return isVMVXBackend(variantOp);
+}
+
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -33,6 +33,7 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
 IREE::HAL::ExecutableEntryPointOp getEntryPoint(FuncOp funcOp);
 
 bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp);
+bool isVMVXBackend(FuncOp entryPointFn);
 
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -32,8 +32,14 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
 /// Returns the entry point op for the `funcOp`. Returns `nullptr` on failure.
 IREE::HAL::ExecutableEntryPointOp getEntryPoint(FuncOp funcOp);
 
-bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp);
-bool isVMVXBackend(FuncOp entryPointFn);
+inline bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp) {
+  return variantOp.target().getBackend().getValue() == "vmvx";
+}
+inline bool isVMVXBackend(FuncOp entryPointFn) {
+  auto variantOp =
+      entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  return isVMVXBackend(variantOp);
+}
 
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes


### PR DESCRIPTION
The comprehensive bufferization would create alloca ops, so we moved to
use IREE bufferization.

| Model            | Before  | After   |
| ---------------- | ------- | ------- |
| DeepLabV3        | 964 ms  | 954 ms  |
| MobileBertSquad  | 682 ms  | 682 ms  |
| MobileNetV2      | 177 ms  | 176 ms  |
| MobileNetV3Small | 47.6 ms | 47.5 ms |
| MobileSSD        | 365 ms  | 368 ms  |
| PoseNet          | 884 ms  | 884 ms  |

There is a slightly improvement (10ms) in DeepLabV3.