### PR TITLE
Add WebGPU dependencies and refactor *_TO_BUILD CMake options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ option(IREE_BUILD_TENSORFLOW_COMPILER "Builds TensorFlow compiler frontend." "${
 option(IREE_BUILD_TFLITE_COMPILER "Builds the TFLite compiler frontend." "${IREE_BUILD_TENSORFLOW_ALL}")
 option(IREE_BUILD_XLA_COMPILER "Builds TensorFlow XLA compiler frontend." "${IREE_BUILD_TENSORFLOW_ALL}")
 
-set(IREE_HAL_DRIVERS_TO_BUILD "all"
-  CACHE STRING "Semicolon-separated list of HAL drivers to build, or \"all\".")
-set(IREE_TARGET_BACKENDS_TO_BUILD "all"
-  CACHE STRING "Semicolon-separated list of target backends to build, or \"all\".")
+set(IREE_HAL_DRIVERS_TO_BUILD "default"
+  CACHE STRING "Semicolon-separated list of HAL drivers to build, or \"default\"")
+set(IREE_TARGET_BACKENDS_TO_BUILD "default"
+  CACHE STRING "Semicolon-separated list of target backends to build, or \"default\"")
 
 # Properties controlling version and naming of release artifacts.
 set(IREE_RELEASE_PACKAGE_SUFFIX "-dev" CACHE STRING "Suffix to append to distributed package names")
@@ -66,7 +66,6 @@ if(${IREE_BUILD_TENSORFLOW_ALL} OR
   set(IREE_ENABLE_TENSORFLOW ON)
 endif()
 
-
 option(IREE_BUILD_BINDINGS_TFLITE "Builds the IREE TFLite C API compatibility shim" ON)
 option(IREE_BUILD_BINDINGS_TFLITE_JAVA "Builds the IREE TFLite Java bindings with the C API compatibility shim" ON)
 
@@ -78,7 +77,7 @@ option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" "${IREE_ENAB
 #-------------------------------------------------------------------------------
 
 option(IREE_BUILD_EXPERIMENTAL_REMOTING "Builds experimental remoting support." OFF)
-option(IREE_BUILD_EXPERIMENTAL_ROCM "Builds the experimental ROCM Backend." OFF)
+option(IREE_BUILD_EXPERIMENTAL_ROCM "Builds the experimental ROCm Backend." OFF)
 option(IREE_ENABLE_NEW_INTEGRATION_TESTS "Enables new integration tests and disables old." OFF)
 
 #-------------------------------------------------------------------------------
@@ -91,59 +90,59 @@ option(IREE_ENABLE_EMITC "Enables MLIR EmitC dependencies." ${IREE_BUILD_COMPILE
 # Target and backend configuration
 #-------------------------------------------------------------------------------
 
-# List of all HAL drivers to be built by default:
+# List of all runtime HAL drivers included in the project:
 set(IREE_ALL_HAL_DRIVERS
-  Cuda
-  DyLib
+  CUDA
+  Dylib
   Dylib_Sync
   VMVX
   VMVX_Sync
   Vulkan
 )
 
-if(IREE_HAL_DRIVERS_TO_BUILD STREQUAL "all")
+if(IREE_HAL_DRIVERS_TO_BUILD STREQUAL "default")
   set(IREE_HAL_DRIVERS_TO_BUILD ${IREE_ALL_HAL_DRIVERS})
 
-  # For Apple platforms we need to use Metal instead of Vulkan.
+  # Vulkan is not natively supported on Apple platforms.
+  # Metal should generally be used instead, though MoltenVK may also work.
   if(APPLE)
     list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD Vulkan)
   endif()
-  # Remove Cuda from Android and Apple platforms.
+
+  # CUDA is not natively supported on Android or Apple platforms.
   if(ANDROID OR APPLE)
-    list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD Cuda)
+    list(REMOVE_ITEM IREE_HAL_DRIVERS_TO_BUILD CUDA)
   endif()
 endif()
-message(STATUS "Building HAL drivers: ${IREE_HAL_DRIVERS_TO_BUILD}")
+message(STATUS "Building runtime HAL drivers: ${IREE_HAL_DRIVERS_TO_BUILD}")
 
-# Default every IREE_HAL_DRIVER_* to OFF
+# Start each IREE_HAL_DRIVER_* OFF, then enable from IREE_HAL_DRIVERS_TO_BUILD.
 foreach(_backend ${IREE_ALL_HAL_DRIVERS})
   string(TOUPPER "${_backend}" uppercase_backend)
   set(IREE_HAL_DRIVER_${uppercase_backend} OFF CACHE BOOL "" FORCE)
 endforeach()
-
-# Set IREE_HAL_DRIVER_* based on configuration
 foreach(_backend ${IREE_HAL_DRIVERS_TO_BUILD})
   string(TOUPPER "${_backend}" uppercase_backend)
   string(REPLACE "\"" "" uppercase_backend ${uppercase_backend})
   set(IREE_HAL_DRIVER_${uppercase_backend} ON CACHE BOOL "" FORCE)
 endforeach()
 
-# List of all target backends to be built by default:
+# List of all compiler target backends included in the project:
 set(IREE_ALL_TARGET_BACKENDS
   CUDA
-  DYLIB-LLVM-AOT
+  Dylib-LLVM-AOT
   WASM-LLVM-AOT
   Metal-SPIRV
-  ROCM
+  ROCm
   Vulkan-SPIRV
   VMVX
 )
 
 if(${IREE_BUILD_COMPILER})
-  if(IREE_TARGET_BACKENDS_TO_BUILD STREQUAL "all")
+  if(IREE_TARGET_BACKENDS_TO_BUILD STREQUAL "default")
     set(IREE_TARGET_BACKENDS_TO_BUILD ${IREE_ALL_TARGET_BACKENDS})
   endif()
-  message(STATUS "Building target backends: ${IREE_TARGET_BACKENDS_TO_BUILD}")
+  message(STATUS "Building compiler target backends: ${IREE_TARGET_BACKENDS_TO_BUILD}")
 else()
   set(IREE_TARGET_BACKENDS_TO_BUILD "" CACHE STRING "" FORCE)
   message(STATUS "Compiler is disabled, building no target backends")
@@ -421,7 +420,7 @@ else()
 endif()
 
 #-------------------------------------------------------------------------------
-# Other dependencies.
+# Other dependencies
 #-------------------------------------------------------------------------------
 
 include(external_cc_library)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,16 @@ set(IREE_ALL_TARGET_BACKENDS
   ROCm
   Vulkan-SPIRV
   VMVX
+  WebGPU
 )
 
 if(${IREE_BUILD_COMPILER})
   if(IREE_TARGET_BACKENDS_TO_BUILD STREQUAL "default")
     set(IREE_TARGET_BACKENDS_TO_BUILD ${IREE_ALL_TARGET_BACKENDS})
+
+    # Disable the WebGPU backend by default, as it has complex dependencies and
+    # is still early in its development.
+    list(REMOVE_ITEM IREE_TARGET_BACKENDS_TO_BUILD WebGPU)
   endif()
   message(STATUS "Building compiler target backends: ${IREE_TARGET_BACKENDS_TO_BUILD}")
 else()
@@ -475,6 +480,15 @@ if(IREE_TARGET_BACKEND_METAL-SPIRV)
   iree_set_spirv_cross_cmake_options()
   # SPIRV-Cross is needed to cross compile SPIR-V into MSL source code.
   add_subdirectory(third_party/spirv_cross EXCLUDE_FROM_ALL)
+endif()
+
+if(IREE_TARGET_BACKEND_WEBGPU)
+  # Tint is needed to compile SPIR-V into WGSL source code.
+  # Tint also requires SPIRV-Tools, which requires SPIRV-Headers.
+  iree_set_spirv_headers_cmake_options()
+  add_subdirectory(third_party/spirv_headers EXCLUDE_FROM_ALL)
+  add_subdirectory(build_tools/third_party/spirv-tools EXCLUDE_FROM_ALL)
+  add_subdirectory(build_tools/third_party/tint EXCLUDE_FROM_ALL)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_third_party_cmake_options.cmake
+++ b/build_tools/cmake/iree_third_party_cmake_options.cmake
@@ -48,6 +48,11 @@ macro(iree_add_llvm_external_project name identifier location)
   set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
 endmacro()
 
+macro(iree_set_spirv_headers_cmake_options)
+  set(SPIRV_HEADERS_SKIP_EXAMPLES ON CACHE BOOL "" FORCE)
+  set(SPIRV_HEADERS_SKIP_INSTALL ON CACHE BOOL "" FORCE)
+endmacro()
+
 macro(iree_set_spirv_cross_cmake_options)
   set(SPIRV_CROSS_ENABLE_MSL ON CACHE BOOL "" FORCE)
   set(SPIRV_CROSS_ENABLE_GLSL ON CACHE BOOL "" FORCE) # Required to enable MSL

--- a/build_tools/third_party/spirv-tools/CMakeLists.txt
+++ b/build_tools/third_party/spirv-tools/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(FetchContent)
+
+FetchContent_Declare(
+  spirv-tools
+  GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Tools.git
+  GIT_TAG ff07cfd86fa229525659f6b81058b3171a67bef1 # 2021-12-10
+)
+
+set(SKIP_SPIRV_TOOLS_INSTALL OFF CACHE BOOL "" FORCE)
+set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "" FORCE)
+set(SPIRV_SKIP_TESTS ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(spirv-tools)
+FetchContent_GetProperties(spirv-tools SOURCE_DIR SPIRV_TOOLS_SOURCE)

--- a/build_tools/third_party/tint/CMakeLists.txt
+++ b/build_tools/third_party/tint/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(FetchContent)
+
+FetchContent_Declare(
+  tint
+  GIT_REPOSITORY https://dawn.googlesource.com/tint
+  GIT_TAG 188b1fb8f5be52299fb7fbc6db17dbb0c07dbb7e # 2021-12-16
+)
+
+set(TINT_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
+set(TINT_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+
+# Our usage at compile time primarily needs the SPIR-V reader and WGSL writer,
+# but usage at runtime through Dawn needs a broader set.
+
+set(TINT_BUILD_SPV_READER ON CACHE BOOL "" FORCE)
+set(TINT_BUILD_WGSL_READER ON CACHE BOOL "" FORCE)
+
+set(TINT_BUILD_GLSL_WRITER OFF CACHE BOOL "" FORCE)
+set(TINT_BUILD_HLSL_WRITER ON CACHE BOOL "" FORCE)
+set(TINT_BUILD_MSL_WRITER ON CACHE BOOL "" FORCE)
+set(TINT_BUILD_SPV_WRITER ON CACHE BOOL "" FORCE)
+set(TINT_BUILD_WGSL_WRITER ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(tint)
+FetchContent_GetProperties(tint SOURCE_DIR TINT_SOURCE)

--- a/iree/tools/utils/BUILD
+++ b/iree/tools/utils/BUILD
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
@@ -48,6 +50,13 @@ cc_library(
     ],
 )
 
+iree_cmake_extra_content(
+    content = """
+if(${IREE_HAL_DRIVER_VMVX})
+""",
+    inline = True,
+)
+
 cc_test(
     name = "vm_util_test",
     srcs = ["vm_util_test.cc"],
@@ -62,6 +71,13 @@ cc_test(
         "//iree/vm",
         "//iree/vm:cc",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )
 
 cc_library(

--- a/iree/tools/utils/CMakeLists.txt
+++ b/iree/tools/utils/CMakeLists.txt
@@ -53,6 +53,8 @@ iree_cc_library(
   PUBLIC
 )
 
+if(${IREE_HAL_DRIVER_VMVX})
+
 iree_cc_test(
   NAME
     vm_util_test
@@ -69,6 +71,8 @@ iree_cc_test(
     iree::vm
     iree::vm::cc
 )
+
+endif()
 
 iree_cc_library(
   NAME


### PR DESCRIPTION
Part of https://github.com/google/iree/issues/7840

`IREE_HAL_DRIVERS_TO_BUILD` and `IREE_TARGET_BACKENDS_TO_BUILD` now use "default" instead of "all".

The new WebGPU compiler target is included in the list of all targets but is _not_ enabled by default, and the Metal+CUDA targets similarly disable themselves on incompatible platforms. Developers must explicitly opt in to building the WebGPU compiler target or the Metal/CUDA targets in unsupported configurations. I'm using `-DIREE_TARGET_BACKENDS_TO_BUILD=CUDA;Dylib-LLVM-AOT;WASM-LLVM-AOT;Vulkan-SPIRV;VMVX;WebGPU`, for example.

Thanks to being conditionally enabled, we can also use CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) instead of git submodules for some dependencies, which will _hopefully_ keep the rest of IREE's CMake and git infrastructure simple for most users while only adding costs for those us of working on or using these optional components.