### PR TITLE
Allow to turn of error on uninitialized submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,9 +330,11 @@ endif()
 # This will only run if python3 is available.
 #-------------------------------------------------------------------------------
 
+option(IREE_ERROR_ON_MISSING_SUBMODULES "Error if submodules have not been initialized." ON)
+
 find_package(Python3 COMPONENTS Interpreter QUIET)
 find_package(Git)
-if(Python3_FOUND AND Git_FOUND)
+if(IREE_ERROR_ON_MISSING_SUBMODULES AND Python3_FOUND AND Git_FOUND)
   # Only check submodule status when the git commit changes.
   execute_process(
     COMMAND git rev-parse --short HEAD


### PR DESCRIPTION
Makes the error on uninitialized submodules optional. With this,
external projects that use IREE are no longer forced to initialize all
submodules. E.g. if a project only uses the runtime and does not reply
on the TensorFlow integration, these submodules don't have to be cloned
at all. This is especially convenient in CI pipelines.