### PR TITLE
Disable less-used benchmarks

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -192,53 +192,55 @@ iree_benchmark_suite(
     "--task_topology_group_count=1"
 )
 
-iree_benchmark_suite(
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
+# TODO(#7792): Re-enable these when we are able to run different benchmarks
+# depending on use-case (presubmit, postsubmit, nightly, etc.)
+# iree_benchmark_suite(
+#   MODULES
+#     "${DEEPLABV3_FP32_MODULE}"
+#     "${MOBILESSD_FP32_MODULE}"
+#     "${POSENET_FP32_MODULE}"
+#     "${MOBILEBERT_FP32_MODULE}"
+#     "${MOBILENET_V2_MODULE}"
+#     "${MOBILENET_V3SMALL_MODULE}"
 
-  BENCHMARK_MODES
-    "2-thread,big-core,full-inference,default-flags"
-    "2-thread,little-core,full-inference,default-flags"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  TARGET_ARCHITECTURE
-    "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
-  DRIVER
-    "dylib"
-  RUNTIME_FLAGS
-    "--task_topology_group_count=2"
-)
+#   BENCHMARK_MODES
+#     "2-thread,big-core,full-inference,default-flags"
+#     "2-thread,little-core,full-inference,default-flags"
+#   TARGET_BACKEND
+#     "dylib-llvm-aot"
+#   TARGET_ARCHITECTURE
+#     "CPU-ARM64-v8A"
+#   TRANSLATION_FLAGS
+#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   DRIVER
+#     "dylib"
+#   RUNTIME_FLAGS
+#     "--task_topology_group_count=2"
+# )
 
-iree_benchmark_suite(
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
+# iree_benchmark_suite(
+#   MODULES
+#     "${DEEPLABV3_FP32_MODULE}"
+#     "${MOBILESSD_FP32_MODULE}"
+#     "${POSENET_FP32_MODULE}"
+#     "${MOBILEBERT_FP32_MODULE}"
+#     "${MOBILENET_V2_MODULE}"
+#     "${MOBILENET_V3SMALL_MODULE}"
 
-  BENCHMARK_MODES
-    "3-thread,big-core,full-inference,default-flags"
-    "3-thread,little-core,full-inference,default-flags"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  TARGET_ARCHITECTURE
-    "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
-  DRIVER
-    "dylib"
-  RUNTIME_FLAGS
-    "--task_topology_group_count=3"
-)
+#   BENCHMARK_MODES
+#     "3-thread,big-core,full-inference,default-flags"
+#     "3-thread,little-core,full-inference,default-flags"
+#   TARGET_BACKEND
+#     "dylib-llvm-aot"
+#   TARGET_ARCHITECTURE
+#     "CPU-ARM64-v8A"
+#   TRANSLATION_FLAGS
+#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#   DRIVER
+#     "dylib"
+#   RUNTIME_FLAGS
+#     "--task_topology_group_count=3"
+# )
 
 iree_benchmark_suite(
   MODULES
@@ -369,6 +371,9 @@ iree_benchmark_suite(
     "dylib-sync"
 )
 
+# TODO(#7792): Consider re-enabling little-core experimental-flags if we start
+# optimizing for little cores or we can just run them occasionally
+
 # CPU, Dylib, 1 through 4 threads, big/little-core, full-inference.
 iree_benchmark_suite(
   MODULES
@@ -381,7 +386,7 @@ iree_benchmark_suite(
 
   BENCHMARK_MODES
     "1-thread,big-core,full-inference,experimental-flags"
-    "1-thread,little-core,full-inference,experimental-flags"
+    # "1-thread,little-core,full-inference,experimental-flags"
   TARGET_BACKEND
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE
@@ -396,57 +401,59 @@ iree_benchmark_suite(
     "--task_topology_group_count=1"
 )
 
-iree_benchmark_suite(
-  MODULES
-    "${DEEPLABV3_FP32_MODULE}"
-    "${MOBILESSD_FP32_MODULE}"
-    "${POSENET_FP32_MODULE}"
-    "${MOBILEBERT_FP32_MODULE}"
-    "${MOBILENET_V2_MODULE}"
-    "${MOBILENET_V3SMALL_MODULE}"
+# TODO(#7792): Re-enable these when we are able to run different benchmarks
+# depending on use-case (presubmit, postsubmit, nightly, etc.)
+# iree_benchmark_suite(
+#   MODULES
+#     "${DEEPLABV3_FP32_MODULE}"
+#     "${MOBILESSD_FP32_MODULE}"
+#     "${POSENET_FP32_MODULE}"
+#     "${MOBILEBERT_FP32_MODULE}"
+#     "${MOBILENET_V2_MODULE}"
+#     "${MOBILENET_V3SMALL_MODULE}"
 
-  BENCHMARK_MODES
-    "2-thread,big-core,full-inference,experimental-flags"
-    "2-thread,little-core,full-inference,experimental-flags"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  TARGET_ARCHITECTURE
-    "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-llvm-loop-unrolling=true"
-  DRIVER
-    "dylib"
-  RUNTIME_FLAGS
-    "--task_topology_group_count=2"
-)
+#   BENCHMARK_MODES
+#     "2-thread,big-core,full-inference,experimental-flags"
+#     "2-thread,little-core,full-inference,experimental-flags"
+#   TARGET_BACKEND
+#     "dylib-llvm-aot"
+#   TARGET_ARCHITECTURE
+#     "CPU-ARM64-v8A"
+#   TRANSLATION_FLAGS
+#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#     "--iree-flow-inline-constants-max-byte-length=2048"
+#     "--iree-llvm-loop-unrolling=true"
+#   DRIVER
+#     "dylib"
+#   RUNTIME_FLAGS
+#     "--task_topology_group_count=2"
+# )
 
-iree_benchmark_suite(
-  MODULES
-  "${DEEPLABV3_FP32_MODULE}"
-  "${MOBILESSD_FP32_MODULE}"
-  "${POSENET_FP32_MODULE}"
-  "${MOBILEBERT_FP32_MODULE}"
-  "${MOBILENET_V2_MODULE}"
-  "${MOBILENET_V3SMALL_MODULE}"
+# iree_benchmark_suite(
+#   MODULES
+#   "${DEEPLABV3_FP32_MODULE}"
+#   "${MOBILESSD_FP32_MODULE}"
+#   "${POSENET_FP32_MODULE}"
+#   "${MOBILEBERT_FP32_MODULE}"
+#   "${MOBILENET_V2_MODULE}"
+#   "${MOBILENET_V3SMALL_MODULE}"
 
-  BENCHMARK_MODES
-    "3-thread,big-core,full-inference,experimental-flags"
-    "3-thread,little-core,full-inference,experimental-flags"
-  TARGET_BACKEND
-    "dylib-llvm-aot"
-  TARGET_ARCHITECTURE
-    "CPU-ARM64-v8A"
-  TRANSLATION_FLAGS
-    ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-flow-inline-constants-max-byte-length=2048"
-    "--iree-llvm-loop-unrolling=true"
-  DRIVER
-    "dylib"
-  RUNTIME_FLAGS
-    "--task_topology_group_count=3"
-)
+#   BENCHMARK_MODES
+#     "3-thread,big-core,full-inference,experimental-flags"
+#     "3-thread,little-core,full-inference,experimental-flags"
+#   TARGET_BACKEND
+#     "dylib-llvm-aot"
+#   TARGET_ARCHITECTURE
+#     "CPU-ARM64-v8A"
+#   TRANSLATION_FLAGS
+#     ${ANDROID_CPU_TRANSLATION_FLAGS}
+#     "--iree-flow-inline-constants-max-byte-length=2048"
+#     "--iree-llvm-loop-unrolling=true"
+#   DRIVER
+#     "dylib"
+#   RUNTIME_FLAGS
+#     "--task_topology_group_count=3"
+# )
 
 iree_benchmark_suite(
   MODULES
@@ -459,7 +466,7 @@ iree_benchmark_suite(
 
   BENCHMARK_MODES
     "4-thread,big-core,full-inference,experimental-flags"
-    "4-thread,little-core,full-inference,experimental-flags"
+    # "4-thread,little-core,full-inference,experimental-flags"
   TARGET_BACKEND
     "dylib-llvm-aot"
   TARGET_ARCHITECTURE


### PR DESCRIPTION
See discussion at
https://github.com/google/iree/pull/7807#issuecomment-985790882 and
onwards. This disables a number of benchmarks that aren't super useful,
and in particular aren't worth delaying presubmit (and in some cases
per-commit postsubmit) runs.

1. All little-core experimental-flags benchmarks: we are not currently 
   optimizing little-core.
2. 2 and 3 thread CPU benchmarks. 1 and 4 threads give us basically
   everything we need.

Drops benchmarking phone time from
[54 minutes](https://buildkite.com/iree/iree-benchmark/builds/1703)
to [35 minutes](https://buildkite.com/iree/iree-benchmark/builds/1706)