### PR TITLE
Plumb through const-expr hoisting and const-eval pipelines.

### DIFF
--- a/iree/compiler/ConstEval/BUILD
+++ b/iree/compiler/ConstEval/BUILD
@@ -65,6 +65,7 @@ cc_library(
         "//iree/compiler/Dialect/VM/Conversion/StandardToVM",
         "//iree/compiler/Dialect/VM/Target/Bytecode",
         "//iree/compiler/Dialect/VM/Transforms",
+        "//iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",

--- a/iree/compiler/ConstEval/CMakeLists.txt
+++ b/iree/compiler/ConstEval/CMakeLists.txt
@@ -59,6 +59,7 @@ iree_cc_library(
     iree::compiler::Dialect::VM::Conversion::StandardToVM
     iree::compiler::Dialect::VM::Target::Bytecode
     iree::compiler::Dialect::VM::Transforms
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -70,6 +70,40 @@ namespace {
 
 using FunctionLikeNest = MultiOpNest<FuncOp, IREE::Util::InitializerOp>;
 
+// Subset of the overall pass pipeline for optimizing globals and numerics.
+// We may ultimately break this out separately so creating a syntactic
+// distinction to keep that as an option.
+void buildGlobalOptimizationPassPipeline(
+    OpPassManager &mainPassManager, const TransformOptions &transformOptions) {
+  OpPassManager pipeline(ModuleOp::getOperationName());
+
+  FunctionLikeNest(pipeline)
+      // Simplify util.global accesses early on; this can help with dispatch
+      // region formation as redundant store-loads are removed.
+      .addPass(IREE::Util::createSimplifyGlobalAccessesPass);
+
+  // Module level cleanup and canonicalization of util.global (and other util
+  // ops).
+  pipeline.addPass(IREE::Util::createApplyPatternsPass());
+  pipeline.addPass(IREE::Util::createFoldGlobalsPass());
+
+  if (transformOptions.constExprHoisting) {
+    pipeline.addPass(IREE::Util::createHoistIntoGlobalsPass());
+  }
+
+  if (transformOptions.buildConstEvalPassPipeline) {
+    transformOptions.buildConstEvalPassPipeline(pipeline);
+  }
+
+  FunctionLikeNest(pipeline)
+      .addPass(mlir::createCanonicalizerPass)
+      .addPass(mlir::createCSEPass);
+
+  // Add the whole fixed point iterator.
+  mainPassManager.addPass(
+      IREE::Util::createFixedPointIteratorPass(std::move(pipeline)));
+}
+
 }  // namespace
 
 void buildFlowTransformPassPipeline(OpPassManager &passManager,
@@ -87,23 +121,13 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
                          })
 
       // Input should now be legal.
-      .addPass(createVerifyInputLegalityPass)
+      .addPass(createVerifyInputLegalityPass);
 
-      // Simplify util.global accesses early on; this can help with dispatch
-      // region formation as redundant store-loads are removed.
-      .addPass(IREE::Util::createSimplifyGlobalAccessesPass);
-
-  // Module level cleanup and canonicalization of util.global (and other util
-  // ops).
-  passManager.addPass(IREE::Util::createApplyPatternsPass());
-  passManager.addPass(IREE::Util::createFoldGlobalsPass());
+  buildGlobalOptimizationPassPipeline(passManager, transformOptions);
 
   // Perform cleanup after variable simplification as more canonicalizers may be
   // able to kick in.
   FunctionLikeNest(passManager)
-      .addPass(mlir::createCanonicalizerPass)
-      .addPass(mlir::createCSEPass)
-
       // Pad tensors.
       .addPass(createPadTensorToSubTensorInsertPass)
 

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -7,6 +7,8 @@
 #ifndef IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASSES_H_
 #define IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_PASSES_H_
 
+#include <functional>
+
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -23,7 +25,17 @@ namespace Flow {
 // Pipelines
 //===----------------------------------------------------------------------===//
 
-struct TransformOptions : public PassPipelineOptions<TransformOptions> {};
+struct TransformOptions : public PassPipelineOptions<TransformOptions> {
+  // Enables the iree-util-hoist-into-globals pass. This should eventually
+  // become the default.
+  bool constExprHoisting = false;
+
+  // Hook to populate a constant evaluation pass pipeline. If nullptr, then
+  // no passes are added for constant evaluation. This must be injected in
+  // because constant-evaluators can depend on the whole compiler, of which
+  // this is a part, and we maintain strict optionality for this component.
+  std::function<void(OpPassManager &passManager)> buildConstEvalPassPipeline;
+};
 
 // Adds a set of passes to the given pass manager that run the required flow
 // transforms in the canonical order.

--- a/iree/compiler/Dialect/Util/Transforms/BUILD
+++ b/iree/compiler/Dialect/Util/Transforms/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "ApplyPatterns.cpp",
         "CombineInitializers.cpp",
         "DropCompilerHints.cpp",
+        "FixedPointIterator.cpp",
         "FoldGlobals.cpp",
         "FuseGlobals.cpp",
         "HoistIntoGlobals.cpp",

--- a/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     "ApplyPatterns.cpp"
     "CombineInitializers.cpp"
     "DropCompilerHints.cpp"
+    "FixedPointIterator.cpp"
     "FoldGlobals.cpp"
     "FuseGlobals.cpp"
     "HoistIntoGlobals.cpp"

--- a/iree/compiler/Dialect/Util/Transforms/FixedPointIterator.cpp
+++ b/iree/compiler/Dialect/Util/Transforms/FixedPointIterator.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Util {
+namespace {
+
+// Dynamic pass which runs a sub-pipeline to a fixed point or a maximum
+// iteration count.
+//
+// There is no direct coupling between this iterator and the contained passes.
+// Indirectly, at the start of each iteration, this pass will set the
+// "iree.fixedpoint.converged" unit attribute on the root operation. If it is
+// still there when the sub-pipeline is complete, it will be removed and
+// iteration terminates. If a sub-pass removes it, then iteration will
+// continue.
+class FixedPointIteratorPass
+    : public PassWrapper<FixedPointIteratorPass, OperationPass<void>> {
+ public:
+  FixedPointIteratorPass() = default;
+  FixedPointIteratorPass(const FixedPointIteratorPass &other)
+      : PassWrapper(other) {}
+  FixedPointIteratorPass(OpPassManager pipeline);
+
+ private:
+  LogicalResult initializeOptions(StringRef options) override;
+  void getDependentDialects(DialectRegistry &registry) const override;
+  StringRef getArgument() const override {
+    return "iree-util-fixed-point-iterator";
+  }
+  StringRef getDescription() const override {
+    return "Iterates a sub-pipeline to a fixed point";
+  }
+
+  void runOnOperation() override;
+
+  Optional<OpPassManager> pipeline;
+
+  // Serialized form of the body pipeline.
+  Option<std::string> pipelineStr{
+      *this, "pipeline", llvm::cl::desc("Pipeline to run to a fixed point")};
+  Option<int> maxIterations{*this, "max-iterations",
+                            llvm::cl::desc("Maximum number of iterations"),
+                            llvm::cl::init(10)};
+};
+
+FixedPointIteratorPass::FixedPointIteratorPass(OpPassManager pipeline)
+    : pipeline(std::move(pipeline)) {
+  llvm::raw_string_ostream ss(pipelineStr);
+  this->pipeline->printAsTextualPipeline(ss);
+  ss.flush();
+}
+
+LogicalResult FixedPointIteratorPass::initializeOptions(StringRef options) {
+  if (failed(Pass::initializeOptions(options))) return failure();
+  if (pipeline) return success();
+
+  // Pipelines are expected to be of the form `<op-name>(<pipeline>)`.
+  // TODO: This was lifted from the Inliner pass. We should provide a parse
+  // entry point that is the direct inverse of printAsTextualPipeline() and
+  // at least keep this internal to the upstream implementation.
+  // See: https://github.com/llvm/llvm-project/issues/52813
+  StringRef pipelineSr = pipelineStr;
+  size_t pipelineStart = pipelineSr.find_first_of('(');
+  if (pipelineStart == StringRef::npos || !pipelineSr.consume_back(")"))
+    return failure();
+  StringRef opName = pipelineSr.take_front(pipelineStart);
+  OpPassManager pm(opName);
+  if (failed(parsePassPipeline(pipelineSr.drop_front(1 + pipelineStart), pm)))
+    return failure();
+  pipeline = std::move(pm);
+  return success();
+}
+
+void FixedPointIteratorPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  pipeline->getDependentDialects(registry);
+}
+
+void FixedPointIteratorPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  StringAttr markerName = StringAttr::get("iree.fixedpoint.iteration", context);
+  StringAttr modifiedName =
+      StringAttr::get("iree.fixedpoint.modified", context);
+
+  if (getOperation()->hasAttr(markerName)) {
+    emitError(getOperation()->getLoc())
+        << "nested fixed point pipelines not supported";
+    return signalPassFailure();
+  }
+
+  for (int i = 0; i < maxIterations; ++i) {
+    getOperation()->setAttr(markerName,
+                            IntegerAttr::get(IndexType::get(context), i));
+    getOperation()->removeAttr(modifiedName);
+    if (failed(runPipeline(*pipeline, getOperation()))) {
+      return signalPassFailure();
+    }
+
+    if (!getOperation()->hasAttr(modifiedName)) {
+      // Normal exit.
+      getOperation()->removeAttr(markerName);
+      return;
+    }
+  }
+
+  // Abnormal exit - iteration count exceeded.
+  emitError(getOperation()->getLoc())
+      << "maximum iteration count exceeded in fixed point pipeline";
+  return signalPassFailure();
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<void>> createFixedPointIteratorPass(
+    OpPassManager pipeline) {
+  static PassRegistration<FixedPointIteratorPass> pass;
+  return std::make_unique<FixedPointIteratorPass>(std::move(pipeline));
+}
+
+}  // namespace Util
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_DIALECT_IREE_TRANSFORMS_PASSES_H_
 
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -21,11 +22,14 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createFoldGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createFuseGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createHoistIntoGlobalsPass();
 std::unique_ptr<OperationPass<void>> createSimplifyGlobalAccessesPass();
+std::unique_ptr<OperationPass<void>> createFixedPointIteratorPass(
+    OpPassManager pipeline);
 
 // Test passes.
 std::unique_ptr<OperationPass<void>> createTestFloatRangeAnalysis();
 
 // Register all Passes
+// TODO: Switch this directory to declarative registration.
 inline void registerTransformPasses() {
   createApplyPatternsPass();
   createCombineInitializersPass();
@@ -34,6 +38,7 @@ inline void registerTransformPasses() {
   createFuseGlobalsPass();
   createHoistIntoGlobalsPass();
   createSimplifyGlobalAccessesPass();
+  createFixedPointIteratorPass(OpPassManager("dummy_op"));
   createTestFloatRangeAnalysis();
 }
 

--- a/iree/compiler/Translation/BUILD
+++ b/iree/compiler/Translation/BUILD
@@ -19,6 +19,7 @@ cc_library(
     deps = [
         "//iree/compiler/Bindings/Native/Transforms",
         "//iree/compiler/Bindings/TFLite/Transforms",
+        "//iree/compiler/ConstEval",
         "//iree/compiler/Dialect/Flow/IR",
         "//iree/compiler/Dialect/Flow/Transforms",
         "//iree/compiler/Dialect/HAL/Conversion/HALToVM",

--- a/iree/compiler/Translation/CMakeLists.txt
+++ b/iree/compiler/Translation/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     MLIRTranslation
     iree::compiler::Bindings::Native::Transforms
     iree::compiler::Bindings::TFLite::Transforms
+    iree::compiler::ConstEval
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
     iree::compiler::Dialect::HAL::Conversion::HALToVM

--- a/iree/compiler/Translation/IREEVM.h
+++ b/iree/compiler/Translation/IREEVM.h
@@ -56,12 +56,23 @@ struct InputDialectOptions {
   Type type = Type::none;
 };
 
+// Options controlling high level optimizations.
+struct HighLevelOptimizationOptions {
+  // Enables const-expr hoisting into globals.
+  bool constExprHoisting = false;
+
+  // Enables recursive evaluation of immutable globals using the compiler
+  // and runtime.
+  bool constEval = false;
+};
+
 // Builds the translation pipeline with defaults.
 void buildDefaultIREEVMTransformPassPipeline(OpPassManager &passManager);
 
 // Builds the translation pipeline with explicit options.
 void buildIREEVMTransformPassPipeline(
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
+    HighLevelOptimizationOptions highLevelOptimizationOptions,
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions, OpPassManager &passManager);
 

--- a/iree/compiler/Utils/BUILD
+++ b/iree/compiler/Utils/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "ConversionUtils.cpp",
         "FlatbufferUtils.cpp",
         "GraphUtils.cpp",
+        "PassUtils.cpp",
         "TracingUtils.cpp",
     ],
     hdrs = [

--- a/iree/compiler/Utils/CMakeLists.txt
+++ b/iree/compiler/Utils/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "ConversionUtils.cpp"
     "FlatbufferUtils.cpp"
     "GraphUtils.cpp"
+    "PassUtils.cpp"
     "TracingUtils.cpp"
   DEPS
     LLVMSupport

--- a/iree/compiler/Utils/PassUtils.cpp
+++ b/iree/compiler/Utils/PassUtils.cpp
@@ -1,0 +1,29 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Utils/PassUtils.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "iree-utils"
+
+namespace mlir {
+namespace iree_compiler {
+
+void signalFixedPointModified(Operation *rootOp) {
+  MLIRContext *context = rootOp->getContext();
+  if (!rootOp->hasAttr("iree.fixedpoint.iteration")) {
+    LLVM_DEBUG(llvm::dbgs() << "Not signaling fixed-point modification: not "
+                               "running under fixed point iterator");
+    return;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Signalling fixed-point iterator modification");
+  rootOp->setAttr("iree.fixedpoint.modified", UnitAttr::get(context));
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Utils/PassUtils.h
+++ b/iree/compiler/Utils/PassUtils.h
@@ -78,6 +78,10 @@ struct MultiOpNest {
   std::array<OpPassManager *, sizeof...(OpTys)> nestedPassManagers;
 };
 
+// If running under a FixedPointIterator pass, annotate that a modification
+// has been made which requires another iteration. No-op otherwise.
+void signalFixedPointModified(Operation *rootOp);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
+++ b/llvm-external-projects/iree-compiler-api/lib/CAPI/Compiler.cpp
@@ -35,6 +35,7 @@ namespace {
 struct CompilerOptions {
   BindingOptions bindingOptions;
   InputDialectOptions inputDialectOptions;
+  HighLevelOptimizationOptions highLevelOptimizationOptions;
   HALTargetOptions executableOptions;
   VMTargetOptions vmTargetOptions;
   VMBytecodeTargetOptions vmBytecodeTargetOptions;
@@ -95,8 +96,8 @@ void ireeCompilerBuildIREEVMPassPipeline(IreeCompilerOptions options,
   auto *passManagerCpp = unwrap(passManager);
   buildIREEVMTransformPassPipeline(
       optionsCpp->bindingOptions, optionsCpp->inputDialectOptions,
-      optionsCpp->executableOptions, optionsCpp->vmTargetOptions,
-      *passManagerCpp);
+      optionsCpp->highLevelOptimizationOptions, optionsCpp->executableOptions,
+      optionsCpp->vmTargetOptions, *passManagerCpp);
 }
 
 // Translates a module op derived from the ireeCompilerBuildIREEVMPassPipeline


### PR DESCRIPTION
* Adds two new compiler flags: -iree-const-eval and -iree-const-expr-hoisting. The former will be a permanent flag and the latter will be retired once stable and enabled by default.
* Reworks the flow pipeline to have its high level optimizations run through a dynamic fixed-point iteration pass pipeline. The const-eval pass is capable of signalling additional iterations, allowing progressive program simplification. By default, there will only be one cycle.
* Neither of these passes work for a sizable portion of programs, and they represent some fairly extensive compiler fuzzing that I will need to triage to completion before enabling by default.