### PR TITLE
Plumb through spirv serialization options in WebGPUTarget.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
@@ -33,7 +33,7 @@ WebGPUTargetOptions getWebGPUTargetOptionsFromFlags() {
       "iree-webgpu-debug-symbols",
       llvm::cl::desc(
           "Include debug information like variable names in outputs"),
-      llvm::cl::init(false));
+      llvm::cl::init(true));
 
   static llvm::cl::opt<bool> clWebGPUKeepShaderModules(
       "iree-webgpu-keep-shader-modules",
@@ -130,7 +130,12 @@ class WebGPUTargetBackend : public TargetBackend {
 
     // Serialize the spirv::ModuleOp into binary format.
     SmallVector<uint32_t, 0> spvBinary;
-    if (failed(spirv::serialize(spvModuleOp, spvBinary)) || spvBinary.empty()) {
+    spirv::SerializationOptions serializationOptions;
+    serializationOptions.emitSymbolName = options_.debugSymbols;
+    serializationOptions.emitDebugInfo = options_.debugSymbols;
+    if (failed(
+            spirv::serialize(spvModuleOp, spvBinary, serializationOptions)) ||
+        spvBinary.empty()) {
       return variantOp.emitError() << "failed to serialize spv.module";
     }
     if (options_.keepShaderModules) {


### PR DESCRIPTION
(forgot about this when merging the initial implementation of WebGPUTarget)

This now uses the new serialization control provided by https://reviews.llvm.org/D115531. I didn't see much of an effect on simple_abs, but this may do more for complex programs.