### PR TITLE
Treat nested implicit captures as producers for const-expr analysis.

### DIFF
--- a/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -99,7 +99,7 @@ class ConstExprAnalysis {
     SmallPtrSet<Value, 4> roots;
 
     // Direct producers that feed into this constant value.
-    SmallVector<ConstValueInfo *> producers;
+    SmallPtrSet<ConstValueInfo *, 8> producers;
 
     // Whether this is a root.
     bool isRoot = false;


### PR DESCRIPTION
* Also reworks the hoisting transformation to consider the producer tree from the analysis authoritative vs relying on creating a backward slice.
* This is needed to handle implicit captures correctly and has the byproduct of making a more precise clone (the prior version would sometimes materialize extra dead ops for odd const-expr tree shapes).