### PR TITLE
Enable /std:c11 for MSVC builds.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -128,6 +128,9 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
 
     # Use the modern C preprocessor to more closely match standards/clang/gcc behavior.
     "/Zc:preprocessor"
+
+    # Enable C11 standards conforming mode.
+    "$<$<COMPILE_LANGUAGE:C>:/std:c11>"
 )
 
 # Compiler diagnostics.


### PR DESCRIPTION
There seems to be a version dependency on whether this flag gates all C11 related features, which is causing the CI releases to fail on missing support for _Generic.

Setting this option per the recommendation at https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/ as a first step. That post also indicates a tie-in to a Windows update (??? - really, for a pre-processor change), but starting here.

This will now hard fail on older versions of MSVC (<16.9 iiuc). This is deemed better than soft failures due to unsupported compiler features.