### PR TITLE
Revert "Add Pixel 6 for Mali GPU benchmarking (#7914)"

### DIFF
--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -559,7 +559,7 @@ def set_cpu_frequency_scaling_governor(governor: str):
 def set_gpu_frequency_scaling_policy(policy: str):
   git_root = execute_cmd_and_get_output(["git", "rev-parse", "--show-toplevel"])
   device_model = get_android_device_model()
-  if device_model == "Pixel-6" or device_model == "Pixel-6-Pro":
+  if device_model == "Pixel-6":
     gpu_script = os.path.join(
         git_root, "build_tools/benchmarks/set_pixel6_gpu_scaling_policy.sh")
   else:

--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -43,26 +43,6 @@ steps:
       - "trace-captures-pixel-4-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
-  - label: "Benchmark on Pixel 6 Pro (google-tensor, mali-g78)"
-    commands:
-      - "git clean -fdx"
-      - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "buildkite-agent artifact download --step Build iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "wget https://storage.googleapis.com/iree-shared-files/tracy-capture-058e8901.tgz"
-      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "tar -xzvf tracy-capture-058e8901.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool=build-android/iree/tools/iree-benchmark-module --traced_benchmark_tool=build-android-trace/iree/tools/iree-benchmark-module --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz --verbose build-host/"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
-    agents:
-      - "android-soc=google-tensor"
-      - "android-version=12"
-      - "queue=benchmark-android"
-    artifact_paths:
-      - "benchmark-results-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.json"
-      - "trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz"
-    timeout_in_minutes: "60"
-
   - label: "Benchmark on Galaxy S20 (exynos-990, mali-g77)"
     commands:
       - "git clean -fdx"


### PR DESCRIPTION
Somehow the lab phones are having permissions issues. We'll need
physical access to authorize adb:

```
* daemon not running; starting now at tcp:5037
--
  | * daemon started successfully
  | error: device unauthorized.
  | This adb server's $ADB_VENDOR_KEYS is not set
  | Try 'adb kill-server' if that seems wrong.
  | Otherwise check for a confirmation dialog on your device.

``` 

https://buildkite.com/iree/iree-benchmark/builds/1726#65075289-5235-48a6-80e3-74bed97477ad

Reverts google/iree#7914