### PR TITLE
Rework global hoisting to be policy based.

### DIFF
--- a/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -64,10 +64,9 @@ module @hoist_tree_const_expr {
 
   // CHECK: func @main
   builtin.func @main() -> (i32, i32, i32) {
-    // CHECK: %[[LOAD_HOISTED_1:.*]] = util.global.load @[[HOISTED_1]] : i32
-    // CHECK: %[[RESULT:.*]] = "iree_unregistered.var_expr"(%[[LOAD_HOISTED_1]])
     // CHECK-DAG: %[[LOAD_HOISTED_0:.*]] = util.global.load @[[HOISTED_0]] : i32
     // CHECK-DAG: %[[LOAD_HOISTED_1:.*]] = util.global.load @[[HOISTED_1]] : i32
+    // CHECK-DAG: %[[RESULT:.*]] = "iree_unregistered.var_expr"(%[[LOAD_HOISTED_1]])
     // CHECK: return %[[LOAD_HOISTED_0]], %[[LOAD_HOISTED_1]], %[[RESULT]]
     %0 = arith.constant 0 : i32
     %1 = arith.constant 1 : i32


### PR DESCRIPTION
* Adds a policy/decision layer on top of the analysis.
* Reworks the transformation to be based purely on the policy with no inline decisions.
* Tightens up the policy a bit to better handle:
  * Never hoisting a standalone init_tensor
  * Working properly with a chain of non-hoistable leaves (i.e. several broadcast or metadata ops which should not hoist)