### PR TITLE
Implement all feasible types in JitGlobals.

### DIFF
--- a/iree/compiler/ConstEval/Runtime.h
+++ b/iree/compiler/ConstEval/Runtime.h
@@ -34,7 +34,10 @@ class CompiledBinary {
 
   // Invokes a nullary function and returns its (presumed single) single result
   // as an Attribute.
-  Attribute invokeNullaryAsElements(Location loc, StringRef name);
+  Attribute invokeNullaryAsAttribute(Location loc, StringRef name);
+
+  // Whether the given type is supported in *AsAttribute methods.
+  static bool isSupportedResultType(Type type);
 
  protected:
   CompiledBinary();

--- a/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -40,62 +40,184 @@ module @linalg_tensor_jit {
   }
 }
 
-// TODO: Crashes compiler.
-// COM-CHECK-LABEL: @eval_f16_tensor
-// module @eval_f16_tensor {
-//   util.global private @hoisted : tensor<5x6xf16>
-//   func @main() -> tensor<5x6xf16> {
-//     %hoisted = util.global.load @hoisted : tensor<5x6xf16>
-//     return %hoisted : tensor<5x6xf16>
-//   }
-//   util.initializer {
-//     %cst = arith.constant dense<2.0e+2> : tensor<5x6xf16>
-//     util.global.store %cst, @hoisted : tensor<5x6xf16>
-//     util.initializer.return
-//   }
-// }
+// -----
+// CHECK-LABEL: @eval_splat_detection
+// CHECK: util.global private @{{.*}} = dense<2> : tensor<2xi32>
+module @eval_splat_detection {
+  util.global private @hoisted : tensor<2xi32>
+  func @main() -> tensor<2xi32> {
+    %hoisted = util.global.load @hoisted : tensor<2xi32>
+    return %hoisted : tensor<2xi32>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2, 2]> : tensor<2xi32>
+    util.global.store %cst, @hoisted : tensor<2xi32>
+    util.initializer.return
+  }
+}
 
-// TODO: Error on 'hal.command_buffer.fill_buffer'
-// COM-CHECK-LABEL: @eval_f16_tensor
-// module @eval_bf16_tensor {
-//   util.global private @hoisted : tensor<5x6xbf16>
-//   func @main() -> tensor<5x6xbf16> {
-//     %hoisted = util.global.load @hoisted : tensor<5x6xbf16>
-//     return %hoisted : tensor<5x6xbf16>
-//   }
-//   util.initializer {
-//     %cst = arith.constant dense<2.0e+2> : tensor<5x6xbf16>
-//     util.global.store %cst, @hoisted : tensor<5x6xbf16>
-//     util.initializer.return
-//   }
-// }
 
-// TODO: Error on 'hal.command_buffer.fill_buffer'
-// COM-CHECK-LABEL: @eval_i4_tensor
-// module @eval_i4_tensor {
-//   util.global private @hoisted : tensor<5x6xi4>
-//   func @main() -> tensor<5x6xi4> {
-//     %hoisted = util.global.load @hoisted : tensor<5x6xi4>
-//     return %hoisted : tensor<5x6xi4>
-//   }
-//   util.initializer {
-//     %cst = arith.constant dense<3> : tensor<5x6xi4>
-//     util.global.store %cst, @hoisted : tensor<5x6xi4>
-//     util.initializer.return
-//   }
-// }
+// -----
+// CHECK-LABEL: @eval_f16_tensor
+// Not currently supported (initializer should remain)
+// CHECK: util.initializer
+module @eval_f16_tensor {
+  util.global private @hoisted : tensor<5x6xf16>
+  func @main() -> tensor<5x6xf16> {
+    %hoisted = util.global.load @hoisted : tensor<5x6xf16>
+    return %hoisted : tensor<5x6xf16>
+  }
+  util.initializer {
+    %cst = arith.constant dense<2.0e+2> : tensor<5x6xf16>
+    util.global.store %cst, @hoisted : tensor<5x6xf16>
+    util.initializer.return
+  }
+}
 
-// TODO: Error: mapped memory region was not valid for constructing tensor of type 'tensor<5x6xi1>' (length=30)
-// COM-CHECK-LABEL: @eval_i1_tensor
-// module @eval_i1_tensor {
-//   util.global private @hoisted : tensor<5x6xi1>
-//   func @main() -> tensor<5x6xi1> {
-//     %hoisted = util.global.load @hoisted : tensor<5x6xi1>
-//     return %hoisted : tensor<5x6xi1>
-//   }
-//   util.initializer {
-//     %cst = arith.constant dense<1> : tensor<5x6xi1>
-//     util.global.store %cst, @hoisted : tensor<5x6xi1>
-//     util.initializer.return
-//   }
-// }
+// -----
+// CHECK-LABEL: @eval_bf16_tensor
+// Not currently supported (initializer should remain)
+// CHECK: util.initializer
+module @eval_bf16_tensor {
+  util.global private @hoisted : tensor<5x6xbf16>
+  func @main() -> tensor<5x6xbf16> {
+    %hoisted = util.global.load @hoisted : tensor<5x6xbf16>
+    return %hoisted : tensor<5x6xbf16>
+  }
+  util.initializer {
+    %cst = arith.constant dense<2.0e+2> : tensor<5x6xbf16>
+    util.global.store %cst, @hoisted : tensor<5x6xbf16>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_f32_tensor
+// CHECK: util.global private @{{.*}} = dense<[2.000000e+02, 3.200000e+03]> : tensor<2xf32>
+module @eval_f32_tensor {
+  util.global private @hoisted : tensor<2xf32>
+  func @main() -> tensor<2xf32> {
+    %hoisted = util.global.load @hoisted : tensor<2xf32>
+    return %hoisted : tensor<2xf32>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2.0e+2, 3.2e+3]> : tensor<2xf32>
+    util.global.store %cst, @hoisted : tensor<2xf32>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_f64_tensor
+// CHECK: util.global private @{{.*}} = dense<[2.000000e+02, 3.200000e+03]> : tensor<2xf64>
+module @eval_f64_tensor {
+  util.global private @hoisted : tensor<2xf64>
+  func @main() -> tensor<2xf64> {
+    %hoisted = util.global.load @hoisted : tensor<2xf64>
+    return %hoisted : tensor<2xf64>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2.0e+2, 3.2e+3]> : tensor<2xf64>
+    util.global.store %cst, @hoisted : tensor<2xf64>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i1_tensor
+// CHECK: util.global private @{{.*}} = dense<[false, true, false, true, true, false]> : tensor<6xi1>
+module @eval_i1_tensor {
+  util.global private @hoisted : tensor<6xi1>
+  func @main() -> tensor<6xi1> {
+    %hoisted = util.global.load @hoisted : tensor<6xi1>
+    return %hoisted : tensor<6xi1>
+  }
+  util.initializer {
+    // Note that the level we are testing at is a bit odd in the way i1 vs
+    // i8 are handled.
+    %cst = arith.constant dense<[0, 1, 0, 1, 1, 0]> : tensor<6xi8>
+    %casted = arith.trunci %cst : tensor<6xi8> to tensor<6xi1>
+    util.global.store %casted, @hoisted : tensor<6xi1>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i4_tensor
+// CHECK: util.initializer
+module @eval_i4_tensor {
+  util.global private @hoisted : tensor<5x6xi4>
+  func @main() -> tensor<5x6xi4> {
+    %hoisted = util.global.load @hoisted : tensor<5x6xi4>
+    return %hoisted : tensor<5x6xi4>
+  }
+  util.initializer {
+    %cst = arith.constant dense<3> : tensor<5x6xi4>
+    util.global.store %cst, @hoisted : tensor<5x6xi4>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i8_tensor
+// CHECK: util.global private @{{.*}} = dense<[2, 3]> : tensor<2xi8>
+module @eval_i8_tensor {
+  util.global private @hoisted : tensor<2xi8>
+  func @main() -> tensor<2xi8> {
+    %hoisted = util.global.load @hoisted : tensor<2xi8>
+    return %hoisted : tensor<2xi8>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2, 3]> : tensor<2xi8>
+    util.global.store %cst, @hoisted : tensor<2xi8>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i16_tensor
+// CHECK: util.global private @{{.*}} = dense<[2, 3]> : tensor<2xi16>
+module @eval_i16_tensor {
+  util.global private @hoisted : tensor<2xi16>
+  func @main() -> tensor<2xi16> {
+    %hoisted = util.global.load @hoisted : tensor<2xi16>
+    return %hoisted : tensor<2xi16>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2, 3]> : tensor<2xi16>
+    util.global.store %cst, @hoisted : tensor<2xi16>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i32_tensor
+// CHECK: util.global private @{{.*}} = dense<[2, 3]> : tensor<2xi32>
+module @eval_i32_tensor {
+  util.global private @hoisted : tensor<2xi32>
+  func @main() -> tensor<2xi32> {
+    %hoisted = util.global.load @hoisted : tensor<2xi32>
+    return %hoisted : tensor<2xi32>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2, 3]> : tensor<2xi32>
+    util.global.store %cst, @hoisted : tensor<2xi32>
+    util.initializer.return
+  }
+}
+
+// -----
+// CHECK-LABEL: @eval_i64_tensor
+// CHECK: util.global private @{{.*}} = dense<[2, 3]> : tensor<2xi64>
+module @eval_i64_tensor {
+  util.global private @hoisted : tensor<2xi64>
+  func @main() -> tensor<2xi64> {
+    %hoisted = util.global.load @hoisted : tensor<2xi64>
+    return %hoisted : tensor<2xi64>
+  }
+  util.initializer {
+    %cst = arith.constant dense<[2, 3]> : tensor<2xi64>
+    util.global.store %cst, @hoisted : tensor<2xi64>
+    util.initializer.return
+  }
+}

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -245,6 +245,7 @@ static LogicalResult translateFromMLIRToVMCModuleWithFlags(
 void registerIREEVMTranslationFlags() {
   getBindingOptionsFromFlags();
   getInputDialectOptionsFromFlags();
+  getHighLevelOptimizationOptionsFromFlags();
 }
 
 void registerIREEVMTranslation() {


### PR DESCRIPTION
Supported: i8/16/32/64, f32/f64, i1
Unsupported: Non byte-aligned integer, f16, bf16

There are still some VM bugs with i1 which I will need to address separately. Also sub-byte aligned still seems to need a fair bit of work in the system so just punting on that for now.