### PR TITLE
Inlining set/binding ordinals onto hal.interface.binding.subspan.

### DIFF
--- a/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
+++ b/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
@@ -32,7 +32,7 @@ namespace {
 ///
 /// For example, this matches the following pattern:
 ///
-///   %subspan = hal.interface.binding.subspan @... :
+///   %subspan = hal.interface.binding.subspan ... :
 ///       !flow.dispatch.tensor<readonly:3x3x1x96xf32>
 ///   %tensor = flow.dispatch.tensor.load %subspan :
 ///       !flow.dispatch.tensor<readonly:3x3x1x96xf32> -> tensor<3x3x1x96xf32>
@@ -42,7 +42,7 @@ namespace {
 ///
 /// And turns it into:
 ///
-///   %subspan = hal.interface.binding.subspan @... :
+///   %subspan = hal.interface.binding.subspan ... :
 ///       !flow.dispatch.tensor<readonly:864xf32>
 ///   %0 = flow.dispatch.tensor.load %subspan :
 ///       !flow.dispatch.tensor<readonly:864xf32> -> tensor<864xf32>
@@ -83,9 +83,9 @@ struct FoldReshapeIntoInterfaceTensorLoad : OpRewritePattern<TensorReshapeOp> {
         tensorAccess, reshapeOp.getResultType());
 
     Value newSubspanOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp.getLoc(), newSubspanType, subspanOp.binding(),
-        subspanOp.byte_offset(), subspanOp.byte_length(),
-        subspanOp.dynamic_dims(), subspanOp.alignmentAttr());
+        subspanOp.getLoc(), newSubspanType, subspanOp.type(), subspanOp.set(),
+        subspanOp.binding(), subspanOp.byte_offset(), subspanOp.dynamic_dims(),
+        subspanOp.alignmentAttr());
 
     rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorLoadOp>(
         reshapeOp, reshapeOp.getResultType(), newSubspanOp,

--- a/iree/compiler/Codegen/Common/test/canonicalize_interface_load_store.mlir
+++ b/iree/compiler/Codegen/Common/test/canonicalize_interface_load_store.mlir
@@ -2,12 +2,11 @@
 
 // CHECK-LABEL: func @fold_reshape()
 func @fold_reshape() {
-  // CHECK: %[[C0:.+]] = arith.constant 0 : index
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK: %[[ARG:.+]] = hal.interface.binding.subspan @interface_io::@arg0[%[[C0]]] : !flow.dispatch.tensor<readonly:3x3x96xf32>
-  %1 = hal.interface.binding.subspan @interface_io::@arg0[%c0] : !flow.dispatch.tensor<readonly:3x3x1x96xf32>
-  %2 = hal.interface.binding.subspan @interface_io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x3x96xf32>
+  // CHECK: %[[ARG:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:3x3x96xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:3x3x1x96xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<writeonly:3x3x96xf32>
   // CHECK: %[[LOAD:.+]] = flow.dispatch.tensor.load %[[ARG]], {{.*}} : !flow.dispatch.tensor<readonly:3x3x96xf32> -> tensor<3x3x96xf32>
   %3 = flow.dispatch.tensor.load %1, offsets=[], sizes =[], strides=[] : !flow.dispatch.tensor<readonly:3x3x1x96xf32> -> tensor<3x3x1x96xf32>
   %4 = tensor.collapse_shape %3 [[0, 1, 2, 3]] : tensor<3x3x1x96xf32> into tensor<864xf32>
@@ -17,12 +16,6 @@ func @fold_reshape() {
   return
 }
 
-hal.interface private @interface_io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer"
-}
-
-
 // -----
 
 // CHECK-LABEL: func @dont_fold_reshape_with_not_full_load()
@@ -31,8 +24,8 @@ func @dont_fold_reshape_with_not_full_load() {
   %c1 = arith.constant 1 : index
   %c3 = arith.constant 3 : index
   %c96 = arith.constant 96 : index
-  %1 = hal.interface.binding.subspan @interface_io::@arg0[%c0] : !flow.dispatch.tensor<readonly:6x3x1x96xf32>
-  %2 = hal.interface.binding.subspan @interface_io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x3x96xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:6x3x1x96xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<writeonly:3x3x96xf32>
   %3 = flow.dispatch.tensor.load %1, offsets = [%c3, %c0, %c0, %c0], sizes = [%c3, %c3, %c1, %c96], strides = [%c1, %c1, %c1, %c1] : !flow.dispatch.tensor<readonly:6x3x1x96xf32> -> tensor<3x3x1x96xf32>
   // CHECK: tensor.collapse_shape
   // CHECK: tensor.expand_shape
@@ -40,11 +33,6 @@ func @dont_fold_reshape_with_not_full_load() {
   %5 = tensor.expand_shape %4 [[0, 1, 2]] : tensor<864xf32> into tensor<3x3x96xf32>
   flow.dispatch.tensor.store %5, %2, offsets = [%c0, %c0, %c0], sizes = [%c1, %c1, %c1], strides = [%c1, %c1, %c1] : tensor<3x3x96xf32> -> !flow.dispatch.tensor<writeonly:3x3x96xf32>
   return
-}
-
-hal.interface private @interface_io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer"
 }
 
 // -----
@@ -56,8 +44,8 @@ func @dont_fold_dynamic_reshape() {
   %dim0 = hal.interface.load.constant offset = 0 : index
   %dim1 = hal.interface.load.constant offset = 1 : index
   %dim2 = hal.interface.load.constant offset = 2 : index
-  %1 = hal.interface.binding.subspan @interface_io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?x96xf32>{%dim0, %dim1}
-  %2 = hal.interface.binding.subspan @interface_io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x12x8xf32>{%dim2}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?x96xf32>{%dim0, %dim1}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<writeonly:?x12x8xf32>{%dim2}
   %3 = flow.dispatch.tensor.load %1, offsets=[], sizes =[], strides=[] : !flow.dispatch.tensor<readonly:?x?x96xf32> -> tensor<?x?x96xf32>
   // CHECK: tensor.collapse_shape
   // CHECK: tensor.expand_shape

--- a/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
+++ b/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
@@ -1,13 +1,9 @@
 // RUN: iree-opt -split-input-file -iree-codegen-flatten-memref-subspan -canonicalize %s | IreeFileCheck %s
 
 func @load_subspan_with_offset(%offset : index, %i0: index, %i1: index, %i2: index) -> f32 {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<6x7x8xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<6x7x8xf32>
   %val = memref.load %subspan[%i0, %i1, %i2] : memref<6x7x8xf32>
   return %val: f32
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 * 56 + s1 * 8 + s2 + s3 floordiv 4)>
@@ -15,7 +11,7 @@ hal.interface private @io  {
 // CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index, %[[I2:.+]]: index)
 //  CHECK-DAG:   %[[ZERO:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C336:.+]] = arith.constant 336 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_constant[%[[ZERO]]] : memref<?xf32>{%[[C336]]}
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[ZERO]]) : memref<?xf32>{%[[C336]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[OFFSET]]]
 //      CHECK:   %[[LOAD:.+]] = memref.load %[[SUBSPAN]][%[[INDEX]]]
 //      CHECK:   return %[[LOAD]]
@@ -23,13 +19,9 @@ hal.interface private @io  {
 // -----
 
 func @store_subspan_with_offset(%value: f32, %offset : index, %i0: index, %i1: index, %i2: index) {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_xw_external[%offset] : memref<2x3x4xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<2x3x4xf32>
   memref.store %value, %subspan[%i0, %i1, %i2] : memref<2x3x4xf32>
   return
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_xw_external, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 * 12 + s1 * 4 + s2 + s3 floordiv 4)>
@@ -37,20 +29,16 @@ hal.interface private @io  {
 // CHECK-SAME: (%[[VALUE:.+]]: f32, %[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index, %[[I2:.+]]: index)
 //  CHECK-DAG:   %[[ZERO:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C24:.+]] = arith.constant 24 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan @io::@s0b0_xw_external[%[[ZERO]]] : memref<?xf32>{%[[C24]]}
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[ZERO]]) : memref<?xf32>{%[[C24]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[OFFSET]]]
 //      CHECK:   memref.store %[[VALUE]], %[[SUBSPAN]][%[[INDEX]]] : memref<?xf32>
 
 // -----
 
 func @load_subspan_with_vector_element(%offset : index, %i0: index, %i1: index, %i2: index) -> vector<4xf32> {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<6x7x8xvector<4xf32>>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<6x7x8xvector<4xf32>>
   %val = memref.load %subspan[%i0, %i1, %i2] : memref<6x7x8xvector<4xf32>>
   return %val: vector<4xf32>
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 * 56 + s1 * 8 + s2 + s3 floordiv 16)>
@@ -60,13 +48,9 @@ hal.interface private @io  {
 // -----
 
 func @load_subspan_with_16bit_element(%offset : index, %i0: index, %i1: index, %i2: index) -> f16 {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<6x7x8xf16>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<6x7x8xf16>
   %val = memref.load %subspan[%i0, %i1, %i2] : memref<6x7x8xf16>
   return %val: f16
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 * 56 + s1 * 8 + s2 + s3 floordiv 2)>
@@ -77,13 +61,9 @@ hal.interface private @io  {
 
 func @store_subspan_with_leading_dynamic_dim(%value: f32, %offset : index, %i0: index, %i1: index, %i2: index) {
   %dim = hal.interface.load.constant offset = 0 : index
-  %subspan = hal.interface.binding.subspan @io::@s0b0_xw_external[%offset] : memref<?x3x4xf32>{%dim}
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<?x3x4xf32>{%dim}
   memref.store %value, %subspan[%i0, %i1, %i2] : memref<?x3x4xf32>
   return
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_xw_external, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[SIZE_MAP:.+]] = affine_map<()[s0] -> (s0 * 12)
@@ -93,7 +73,7 @@ hal.interface private @io  {
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   %[[DIM:.+]] = hal.interface.load.constant offset = 0 : index
 //      CHECK:   %[[SIZE:.+]] = affine.apply #[[SIZE_MAP]]()[%[[DIM]]]
-//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b0_xw_external[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[OFFSET_MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[OFFSET]]]
 //      CHECK:   memref.store %[[VALUE]], %[[DST]][%[[INDEX]]] : memref<?xf32>
 
@@ -104,13 +84,9 @@ func @store_subspan_with_all_dynamic_dim(%value: f32, %offset : index, %i0: inde
   %dim1 = hal.interface.load.constant offset = 1 : index
   %dim2 = hal.interface.load.constant offset = 2 : index
   %dim3 = hal.interface.load.constant offset = 3 : index
-  %subspan = hal.interface.binding.subspan @io::@s0b0_xw_external[%offset] : memref<?x?x?x?xf32>{%dim0, %dim1, %dim2, %dim3}
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<?x?x?x?xf32>{%dim0, %dim1, %dim2, %dim3}
   memref.store %value, %subspan[%i0, %i1, %i2, %i3] : memref<?x?x?x?xf32>
   return
-}
-
-hal.interface @io attributes {sym_visibility = "private"} {
-  hal.interface.binding @s0b0_xw_external, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[SIZE_MAP:.+]] = affine_map<()[s0, s1, s2, s3] -> (((s0 * s1) * s2) * s3)>
@@ -123,7 +99,7 @@ hal.interface @io attributes {sym_visibility = "private"} {
 //      CHECK:   %[[DIM2:.+]] = hal.interface.load.constant offset = 2 : index
 //      CHECK:   %[[DIM3:.+]] = hal.interface.load.constant offset = 3 : index
 //      CHECK:   %[[SIZE:.+]] = affine.apply #[[SIZE_MAP]]()[%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]]
-//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b0_xw_external[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[OFFSET_MAP]]()[%[[DIM3]], %[[I3]], %[[DIM2]], %[[I2]], %[[I0]], %[[DIM1]], %[[I1]], %[[OFFSET]]]
 //      CHECK:   memref.store %[[VALUE]], %[[DST]][%[[INDEX]]]
 
@@ -132,13 +108,9 @@ hal.interface @io attributes {sym_visibility = "private"} {
 func @store_subspan_with_mixed_dynamic_dim(%value: f32, %offset : index, %i0: index, %i1: index, %i2: index, %i3: index) {
   %dim0 = hal.interface.load.constant offset = 0 : index
   %dim1 = hal.interface.load.constant offset = 1 : index
-  %subspan = hal.interface.binding.subspan @io::@s0b0_xw_external[%offset] : memref<?x4x?x8xf32>{%dim0, %dim1}
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<?x4x?x8xf32>{%dim0, %dim1}
   memref.store %value, %subspan[%i0, %i1, %i2, %i3] : memref<?x4x?x8xf32>
   return
-}
-
-hal.interface @io attributes {sym_visibility = "private"} {
-  hal.interface.binding @s0b0_xw_external, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[SIZE_MAP:.+]] = affine_map<()[s0, s1] -> ((s0 * s1) * 32)>
@@ -149,7 +121,7 @@ hal.interface @io attributes {sym_visibility = "private"} {
 //      CHECK:   %[[DIM0:.+]] = hal.interface.load.constant offset = 0 : index
 //      CHECK:   %[[DIM2:.+]] = hal.interface.load.constant offset = 1 : index
 //      CHECK:   %[[SIZE:.+]] = affine.apply #[[SIZE_MAP]]()[%[[DIM0]], %[[DIM2]]]
-//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b0_xw_external[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[OFFSET_MAP]]()[%[[I3]], %[[DIM2]], %[[I2]], %[[I0]], %[[I1]], %[[OFFSET]]]
 //      CHECK:   memref.store %[[VALUE]], %[[DST]][%[[INDEX]]]
 
@@ -157,15 +129,11 @@ hal.interface @io attributes {sym_visibility = "private"} {
 
 func @store_subspan_with_flow_control(%value: f32, %offset : index, %i0: index, %i1: index, %i2: index) {
   %dim = hal.interface.load.constant offset = 0 : index
-  %subspan = hal.interface.binding.subspan @io::@s0b0_xw_external[%offset] : memref<?x3x4xf32>{%dim}
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<?x3x4xf32>{%dim}
   scf.for %i = %i0 to %i1 step %i2 {
     memref.store %value, %subspan[%i0, %i1, %i2] : memref<?x3x4xf32>
   }
   return
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_xw_external, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[SIZE_MAP:.+]] = affine_map<()[s0] -> (s0 * 12)
@@ -175,7 +143,7 @@ hal.interface private @io  {
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   %[[DIM:.+]] = hal.interface.load.constant offset = 0 : index
 //      CHECK:   %[[SIZE:.+]] = affine.apply #[[SIZE_MAP]]()[%[[DIM]]]
-//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b0_xw_external[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK: scf.for
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[OFFSET_MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[OFFSET]]]
 //      CHECK:   memref.store %[[VALUE]], %[[DST]][%[[INDEX]]] : memref<?xf32>
@@ -224,21 +192,17 @@ func @load_store_alloca_dynamic(%value : f32, %dim0 : index, %dim1: index, %dim2
 // -----
 
 func @use_subspan_with_unrealized_conversion_cast(%offset : index, %i: index) -> f32 {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<6x7x8xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<6x7x8xf32>
   %use = builtin.unrealized_conversion_cast %subspan : memref<6x7x8xf32> to memref<?xf32>
   %val = memref.load %use[%i] : memref<?xf32>
   return %val: f32
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1 floordiv 4)>
 //      CHECK: func @use_subspan_with_unrealized_conversion_cast
 // CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I:.+]]: index)
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_constant[%[[C0]]] : memref<?xf32>
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I]], %[[OFFSET]]]
 //      CHECK:   memref.load %[[SUBSPAN]][%[[INDEX]]]
 
@@ -264,21 +228,19 @@ func @load_global_with_offset(%i0: index, %i1: index, %i2: index, %i3: index) ->
 
 func @transfer_read_subspan_with_offset(
     %arg0 : index, %arg1: index, %arg2: index, %arg3: index) -> vector<4xf32> {
-  %subspan = hal.interface.binding.subspan @io::@ro[%arg0] : memref<6x7x8xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%arg0) : memref<6x7x8xf32>
   %cst = arith.constant 0.0 : f32
   %val = vector.transfer_read %subspan[%arg1, %arg2, %arg3], %cst {in_bounds = [true]} : memref<6x7x8xf32>, vector<4xf32>
   return %val: vector<4xf32>
 }
-hal.interface private @io  {
-  hal.interface.binding @ro, set=0, binding=0, type="StorageBuffer"
-}
+
 //      CHECK: #[[MAP:.+]] =  affine_map<()[s0, s1, s2] -> (s0 * 56 + s1 * 8 + s2)>
 //      CHECK: func @transfer_read_subspan_with_offset
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: index
-//      CHECK:   %[[MEMREF:.+]] = hal.interface.binding.subspan @io::@ro[%[[ARG0]]] : memref<?xf32>
+//      CHECK:   %[[MEMREF:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[ARG0]]) : memref<?xf32>
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //      CHECK:   %[[VEC:.+]] = vector.transfer_read %[[MEMREF]][%[[INDEX]]]
 //      CHECK:   return %[[VEC]]
@@ -287,13 +249,11 @@ hal.interface private @io  {
 
 func @transfer_write_subspan_with_offset(
     %arg0 : index, %arg1: index, %arg2: index, %arg3: index, %arg4 : vector<4xf32>) {
-  %subspan = hal.interface.binding.subspan @io::@ro[%arg0] : memref<6x7x8xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%arg0) : memref<6x7x8xf32>
   vector.transfer_write %arg4, %subspan[%arg1, %arg2, %arg3] {in_bounds = [true]} :  vector<4xf32>, memref<6x7x8xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @ro, set=0, binding=0, type="StorageBuffer"
-}
+
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 * 56 + s1 * 8 + s2)>
 //      CHECK: func @transfer_write_subspan_with_offset
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: index
@@ -301,23 +261,18 @@ hal.interface private @io  {
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG4:[a-zA-Z0-9_]+]]: vector<4xf32>
-//      CHECK:   %[[MEMREF:.+]] = hal.interface.binding.subspan @io::@ro[%[[ARG0]]] : memref<?xf32>
+//      CHECK:   %[[MEMREF:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[ARG0]]) : memref<?xf32>
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[ARG1]], %[[ARG2]], %[[ARG3]]]
 //      CHECK:   vector.transfer_write %[[ARG4]], %[[MEMREF]][%[[INDEX]]]
 
 // -----
 
 func @load_store_rank_zero_subspan_with_offset(%offset : index) {
-  %subspan0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<f32>
-  %subspan1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%offset] : memref<f32>
+  %subspan0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<f32>
+  %subspan1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) offset(%offset) : memref<f32>
   %val = memref.load %subspan0[] : memref<f32>
   memref.store %val, %subspan1[] : memref<f32>
   return
-}
-
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 floordiv 4)>
@@ -325,8 +280,8 @@ hal.interface private @io  {
 // CHECK-SAME: (%[[OFFSET:.+]]: index)
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//      CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_constant[%[[C0]]] : memref<?xf32>{%[[C1]]}
-//      CHECK:   %[[SPAN1:.+]] = hal.interface.binding.subspan @io::@s0b1_xw_external[%[[C0]]] : memref<?xf32>{%[[C1]]}
+//      CHECK:   %[[SPAN0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[C1]]}
+//      CHECK:   %[[SPAN1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) offset(%[[C0]]) : memref<?xf32>{%[[C1]]}
 //      CHECK:   %[[INDEX0:.+]] = affine.apply #[[MAP]]()[%[[OFFSET]]]
 //      CHECK:   %[[LOAD:.+]] = memref.load %[[SPAN0]][%[[INDEX0]]] : memref<?xf32>
 //      CHECK:   %[[INDEX1:.+]] = affine.apply #[[MAP]]()[%[[OFFSET]]]
@@ -335,14 +290,10 @@ hal.interface private @io  {
 // -----
 
 func @collapse_shape(%offset : index, %i0 : index, %i1 : index) -> f32 {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<4x5x6x7xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<4x5x6x7xf32>
   %collapse = memref.collapse_shape %subspan[[0, 1], [2, 3]] : memref<4x5x6x7xf32> into memref<20x42xf32>
   %value = memref.load %collapse[%i0, %i1] : memref<20x42xf32>
   return %value : f32
-}
-
-hal.interface @io attributes {sym_visibility = "private"} {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 * 42 + s1 + s2 floordiv 4)>
@@ -350,21 +301,17 @@ hal.interface @io attributes {sym_visibility = "private"} {
 // CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index)
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   %[[SIZE:.+]] = arith.constant 840 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_constant[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]], %[[OFFSET]]]
 //      CHECK:   memref.load %[[SUBSPAN]][%[[INDEX]]]
 
 // -----
 
 func @expand_shape(%offset : index, %i0: index, %i1: index, %i2: index, %i3: index) -> f32 {
-  %subspan = hal.interface.binding.subspan @io::@s0b0_ro_constant[%offset] : memref<20x42xf32>
+  %subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%offset) : memref<20x42xf32>
   %expand = memref.expand_shape %subspan[[0, 1], [2, 3]] : memref<20x42xf32> into memref<4x5x6x7xf32>
   %value = memref.load %expand[%i0, %i1, %i2, %i3] : memref<4x5x6x7xf32>
   return %value : f32
-}
-
-hal.interface @io attributes {sym_visibility = "private"} {
-  hal.interface.binding @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
 }
 
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2, s3, s4] -> (s0 * 210 + s1 * 42 + s2 * 7 + s3 + s4 floordiv 4)>
@@ -372,6 +319,6 @@ hal.interface @io attributes {sym_visibility = "private"} {
 // CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index, %[[I2:.+]]: index, %[[I3:.+]]: index)
 //      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   %[[SIZE:.+]] = arith.constant 840 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_constant[%[[C0]]] : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
 //      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[I3]], %[[OFFSET]]]
 //      CHECK:   memref.load %[[SUBSPAN]][%[[INDEX]]]

--- a/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -5,10 +5,10 @@ func @matmul() {
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %init = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %n}
-  %result = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+  %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %init = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %n}
+  %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
   %wg_id_y = hal.interface.workgroup.id[1] : index
   %wg_count_y = hal.interface.workgroup.count[1] : index
   %wg_size_y = hal.interface.workgroup.size[1] : index
@@ -32,12 +32,7 @@ func @matmul() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>
@@ -45,10 +40,10 @@ hal.interface private @io  {
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.load.constant offset = 0
 //  CHECK-DAG:   %[[N:.+]] = hal.interface.load.constant offset = 1
 //  CHECK-DAG:   %[[K:.+]] = hal.interface.load.constant offset = 2
-//  CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0
-//  CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1
-//  CHECK-DAG:   %[[INIT:.+]] = hal.interface.binding.subspan @io::@arg2
-//  CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@ret0
+//  CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//  CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//  CHECK-DAG:   %[[INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//  CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //  CHECK-DAG:   %[[WG_ID_Y:.+]] = hal.interface.workgroup.id[1]
 //  CHECK-DAG:   %[[WG_COUNT_Y:.+]] = hal.interface.workgroup.count[1]
 //  CHECK-DAG:   %[[WG_SIZE_Y:.+]] = hal.interface.workgroup.size[1]
@@ -84,9 +79,9 @@ func @matmul_fill() {
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %result = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%m, %n}
+  %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%m, %n}
   %wg_id_y = hal.interface.workgroup.id[1] : index
   %wg_count_y = hal.interface.workgroup.count[1] : index
   %wg_size_y = hal.interface.workgroup.size[1] : index
@@ -111,11 +106,7 @@ func @matmul_fill() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-}
+
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
 //      CHECK: func @matmul_fill()
@@ -123,9 +114,9 @@ hal.interface private @io  {
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.load.constant offset = 0
 //  CHECK-DAG:   %[[N:.+]] = hal.interface.load.constant offset = 1
 //  CHECK-DAG:   %[[K:.+]] = hal.interface.load.constant offset = 2
-//  CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0
-//  CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1
-//  CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@ret0
+//  CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//  CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//  CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //  CHECK-DAG:   %[[WG_ID_Y:.+]] = hal.interface.workgroup.id[1]
 //  CHECK-DAG:   %[[WG_COUNT_Y:.+]] = hal.interface.workgroup.count[1]
 //  CHECK-DAG:   %[[WG_SIZE_Y:.+]] = hal.interface.workgroup.size[1]
@@ -148,4 +139,3 @@ hal.interface private @io  {
 //      CHECK:       linalg.matmul
 // CHECK-SAME:           ins(%[[LHS_TILE]], %[[RHS_TILE]]
 // CHECK-SAME:           outs(%[[RESULT_TILE]]
-

--- a/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
+++ b/iree/compiler/Codegen/Common/test/linalg_bufferize.mlir
@@ -9,10 +9,10 @@ func @tile_from_tensor_load() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] {alignment = 32 : index}: !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) alignment(32) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -27,18 +27,12 @@ func @tile_from_tensor_load() {
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
 // CHECK-LABEL: func @tile_from_tensor_load()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
 //   CHECK-DAG:   memref.assume_alignment %[[TENSOR_LHS]], 32 : memref<?x?xf32>
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -61,9 +55,9 @@ func @tile_from_tensor_load_inplace() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -78,15 +72,10 @@ func @tile_from_tensor_load_inplace() {
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-}
 // CHECK-LABEL: func @tile_from_tensor_load_inplace()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -107,10 +96,10 @@ func @tile_from_tensor_load_inplace_and_copy() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -126,17 +115,11 @@ func @tile_from_tensor_load_inplace_and_copy() {
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
 // CHECK-LABEL: func @tile_from_tensor_load_inplace_and_copy()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[RETURN1:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
-//   CHECK-DAG:   %[[RETURN2:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RETURN1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RETURN2:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -160,10 +143,10 @@ func @tile_from_pointwise_lhs() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -183,18 +166,13 @@ func @tile_from_pointwise_lhs() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tile_from_pointwise_lhs()
 //       CHECK:       %[[ALLOC:.+]] = memref.alloc() : memref<1x3xf32>
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -221,9 +199,9 @@ func @tile_from_pointwise_lhs_inplace() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -244,16 +222,11 @@ func @tile_from_pointwise_lhs_inplace() {
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-}
 // CHECK-LABEL: func @tile_from_pointwise_lhs_inplace()
 //       CHECK:       %[[ALLOC:.+]] = memref.alloc() : memref<1x3xf32>
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -278,10 +251,10 @@ func @tile_from_pointwise_outs() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -301,17 +274,12 @@ func @tile_from_pointwise_outs() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tile_from_pointwise_outs()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[RESULT:.+]] = memref.subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
@@ -337,9 +305,9 @@ func @tile_from_pointwise_outs_inplace() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -359,15 +327,11 @@ func @tile_from_pointwise_outs_inplace() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tile_from_pointwise_outs_inplace()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[RESULT:.+]] = memref.subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
@@ -391,10 +355,10 @@ func @tile_from_matmul_outs() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %N}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -410,17 +374,12 @@ func @tile_from_matmul_outs() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tile_from_matmul_outs()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[TENSOR_INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS:.+]] = memref.subview %[[TENSOR_LHS]][%[[IV0]], 0] [1, 3] [1, 1]
@@ -445,9 +404,9 @@ func @tile_from_matmul_outs_inplace() {
   %M = hal.interface.load.constant offset = 0 : index
   %N = hal.interface.load.constant offset = 1 : index
   %K = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@TENSOR_LHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
-  %1 = hal.interface.binding.subspan @io::@TENSOR_RHS[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
-  %2 = hal.interface.binding.subspan @io::@TENSOR_INIT[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%M, %K}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%K, %N}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%M, %N}
   %4 = hal.interface.workgroup.id[0] : index
   %5 = hal.interface.workgroup.id[1] : index
   scf.for %arg0 = %5 to %c2 step %c2 {
@@ -462,15 +421,11 @@ func @tile_from_matmul_outs_inplace() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @TENSOR_LHS, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @TENSOR_RHS, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @TENSOR_INIT, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tile_from_matmul_outs_inplace()
-//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_LHS
-//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan @io::@TENSOR_RHS
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@TENSOR_INIT
+//   CHECK-DAG:   %[[TENSOR_LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[TENSOR_RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[RESULT:.+]] = memref.subview %[[RETURN]][%[[IV0]], %[[IV1]]] [1, 1] [1, 1]
@@ -495,10 +450,10 @@ func @bufferize_dynamic() {
   %9 = hal.interface.load.constant offset = 5 : index
   %10 = hal.interface.load.constant offset = 6 : index
   %11 = hal.interface.load.constant offset = 7 : index
-  %LHS = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%4, %5}
-  %RHS = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%6, %7}
-  %INIT = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%8, %9}
-  %RET = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%10, %11}
+  %LHS = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%4, %5}
+  %RHS = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%6, %7}
+  %INIT = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%8, %9}
+  %RET = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%10, %11}
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_size_y = hal.interface.workgroup.size[1] : index
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -524,12 +479,7 @@ func @bufferize_dynamic() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>
 //   CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
 //       CHECK: func @bufferize_dynamic()
@@ -541,10 +491,10 @@ hal.interface private @io  {
 //       CHECK:   %[[DIM5:.+]] = hal.interface.load.constant offset = 5 : index
 //       CHECK:   %[[DIM6:.+]] = hal.interface.load.constant offset = 6 : index
 //       CHECK:   %[[DIM7:.+]] = hal.interface.load.constant offset = 7 : index
-//       CHECK:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0[%{{.+}}] : memref<?x?xf32>{%[[DIM0]], %[[DIM1]]}
-//       CHECK:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1[%{{.+}}] : memref<?x?xf32>{%[[DIM2]], %[[DIM3]]}
-//       CHECK:   %[[INIT:.+]] = hal.interface.binding.subspan @io::@arg2[%{{.+}}] : memref<?x?xf32>{%[[DIM4]], %[[DIM5]]}
-//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@ret0[%{{.+}}] : memref<?x?xf32>{%[[DIM6]], %[[DIM7]]}
+//       CHECK:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>{%[[DIM0]], %[[DIM1]]}
+//       CHECK:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>{%[[DIM2]], %[[DIM3]]}
+//       CHECK:   %[[INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xf32>{%[[DIM4]], %[[DIM5]]}
+//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<?x?xf32>{%[[DIM6]], %[[DIM7]]}
 //   CHECK-DAG:   %[[WGSIZE_X:.+]] = hal.interface.workgroup.size[0]
 //   CHECK-DAG:   %[[WGSIZE_Y:.+]] = hal.interface.workgroup.size[1]
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
@@ -573,9 +523,9 @@ func @bufferize_dynamic_inplace() {
   %7 = hal.interface.load.constant offset = 3 : index
   %8 = hal.interface.load.constant offset = 4 : index
   %9 = hal.interface.load.constant offset = 5 : index
-  %LHS = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%4, %5}
-  %RHS = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%6, %7}
-  %OUT = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readwrite:?x?xf32>{%8, %9}
+  %LHS = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%4, %5}
+  %RHS = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%6, %7}
+  %OUT = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:?x?xf32>{%8, %9}
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_size_y = hal.interface.workgroup.size[1] : index
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -601,11 +551,7 @@ func @bufferize_dynamic_inplace() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-}
+
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0, s1] -> (s1, -d0 + s0)>
 //   CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
 //       CHECK: func @bufferize_dynamic_inplace()
@@ -615,9 +561,9 @@ hal.interface private @io  {
 //       CHECK:   %[[DIM3:.+]] = hal.interface.load.constant offset = 3 : index
 //       CHECK:   %[[DIM4:.+]] = hal.interface.load.constant offset = 4 : index
 //       CHECK:   %[[DIM5:.+]] = hal.interface.load.constant offset = 5 : index
-//       CHECK:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0[%{{.+}}] : memref<?x?xf32>{%[[DIM0]], %[[DIM1]]}
-//       CHECK:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1[%{{.+}}] : memref<?x?xf32>{%[[DIM2]], %[[DIM3]]}
-//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@arg2[%{{.+}}] : memref<?x?xf32>{%[[DIM4]], %[[DIM5]]}
+//       CHECK:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>{%[[DIM0]], %[[DIM1]]}
+//       CHECK:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>{%[[DIM2]], %[[DIM3]]}
+//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xf32>{%[[DIM4]], %[[DIM5]]}
 //   CHECK-DAG:   %[[WGSIZE_X:.+]] = hal.interface.workgroup.size[0]
 //   CHECK-DAG:   %[[WGSIZE_Y:.+]] = hal.interface.workgroup.size[1]
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
@@ -641,20 +587,17 @@ func @reshape_simple() {
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
   %c12 = arith.constant 12 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:12xi32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x4xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:12xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:3x4xi32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:12xi32> -> tensor<12xi32>
   %3 = tensor.expand_shape %2 [[0, 1]] : tensor<12xi32> into tensor<3x4xi32>
   flow.dispatch.tensor.store %3, %1, offsets = [], sizes = [], strides = [] : tensor<3x4xi32> -> !flow.dispatch.tensor<writeonly:3x4xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 //       CHECK: func @reshape_simple()
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   %[[RESHAPE:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]]
 //       CHECK:   linalg.copy(%[[RESHAPE]], %[[RET0]])
 
@@ -666,8 +609,8 @@ func @reshape_fused_source() {
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
   %c12 = arith.constant 12 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:12xi32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x4xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:12xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:3x4xi32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:12xi32> -> tensor<12xi32>
   %3 = tensor.expand_shape %2 [[0, 1]] : tensor<12xi32> into tensor<3x4xi32>
   %4 = linalg.init_tensor [3, 4] : tensor<3x4xi32>
@@ -682,14 +625,10 @@ func @reshape_fused_source() {
   flow.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<3x4xi32> -> !flow.dispatch.tensor<writeonly:3x4xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 //       CHECK: func @reshape_fused_source()
-//       CHECK:   %[[C0:.+]] = arith.constant 0
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0[%[[C0]]] : memref<12xi32>
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0[%[[C0]]] : memref<3x4xi32>
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<12xi32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x4xi32>
 //       CHECK:   %[[RESHAPE:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[RESHAPE]] : memref<3x4xi32>)
@@ -703,9 +642,9 @@ func @reshape_fused_source_and_copyout() {
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
   %c12 = arith.constant 12 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:12xi32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x4xi32>
-  %2 = hal.interface.binding.subspan @io::@ret1[%c0] : !flow.dispatch.tensor<writeonly:3x4xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:12xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:3x4xi32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:3x4xi32>
   %3 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:12xi32> -> tensor<12xi32>
   %4 = tensor.expand_shape %3 [[0, 1]] : tensor<12xi32> into tensor<3x4xi32>
   %5 = linalg.init_tensor [3, 4] : tensor<3x4xi32>
@@ -721,16 +660,11 @@ func @reshape_fused_source_and_copyout() {
   flow.dispatch.tensor.store %4, %2, offsets = [], sizes = [], strides = [] : tensor<3x4xi32> -> !flow.dispatch.tensor<writeonly:3x4xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret1, set=0, binding=2, type="StorageBuffer"
-}
+
 //       CHECK: func @reshape_fused_source_and_copyout()
-//       CHECK:   %[[C0:.+]] = arith.constant 0
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0[%[[C0]]] : memref<12xi32>
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0[%[[C0]]] : memref<3x4xi32>
-//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@ret1[%[[C0]]] : memref<3x4xi32>
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<12xi32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x4xi32>
+//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<3x4xi32>
 //       CHECK:   %[[RESHAPE:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[RESHAPE]] : memref<3x4xi32>)
@@ -745,8 +679,8 @@ func @reshape_fused_target() {
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
   %c12 = arith.constant 12 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:3x4xi32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:12xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:3x4xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:12xi32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:3x4xi32> -> tensor<3x4xi32>
   %3 = linalg.init_tensor [3, 4] : tensor<3x4xi32>
   %4 = linalg.generic {
@@ -761,14 +695,10 @@ func @reshape_fused_target() {
   flow.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<12xi32> -> !flow.dispatch.tensor<writeonly:12xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 //       CHECK: func @reshape_fused_target()
-//       CHECK:   %[[C0:.+]] = arith.constant 0
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0[%[[C0]]] : memref<3x4xi32>
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0[%[[C0]]] : memref<12xi32>
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<3x4xi32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<12xi32>
 //       CHECK:   %[[RESHAPE:.+]] = memref.expand_shape %[[RET0]] {{\[}}[0, 1]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[ARG0]] : memref<3x4xi32>)
@@ -782,9 +712,9 @@ func @dot_general_lowering() {
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x1x2xf32>
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:2x3xf32>
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:1x3xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x1x2xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:2x3xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x3xf32>
   %3 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:1x1x2xf32> -> tensor<1x1x2xf32>
   %4 = tensor.collapse_shape %3 [[0, 1], [2]] : tensor<1x1x2xf32> into tensor<1x2xf32>
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
@@ -811,16 +741,12 @@ func @dot_general_lowering() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @dot_general_lowering()
-//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1
+//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //   CHECK-DAG:   %[[RESHAPE_LHS:.+]] = memref.collapse_shape %[[LHS]]
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   scf.for %[[IV0:.+]] = {{.+}} {
 //       CHECK:     scf.for %[[IV1:.+]] = {{.+}} {
 //   CHECK-DAG:       %[[LHS_TILE:.+]] = memref.subview %[[RESHAPE_LHS]][%[[IV0]], 0]
@@ -839,20 +765,17 @@ func @slice() {
   %3 = hal.interface.load.constant offset = 1 : index
   %4 = hal.interface.load.constant offset = 2 : index
   %5 = hal.interface.load.constant offset = 3 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%2, %3}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%4, %5}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%2, %3}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>{%4, %5}
   %6 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
   %7 = tensor.extract_slice %6[%2, %3] [%4, %5] [1, 1] : tensor<?x?xi32> to tensor<?x?xi32>
   flow.dispatch.tensor.store %7, %1, offsets = [], sizes = [], strides = [] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @slice()
-//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG: %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG: %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK: %[[SUBVIEW:.+]] = memref.subview %[[ARG]]
 //       CHECK: linalg.copy(%[[SUBVIEW]], %[[RETURN]])
 
@@ -865,20 +788,17 @@ func @slice_rank_reducing() {
   %4 = hal.interface.load.constant offset = 2 : index
   %5 = hal.interface.load.constant offset = 3 : index
   %8 = hal.interface.load.constant offset = 4 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?x?xi32>{%8, %8, %8}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%4, %5}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?x?xi32>{%8, %8, %8}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>{%4, %5}
   %6 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?x?xi32> -> tensor<?x?x?xi32>
   %7 = tensor.extract_slice %6[%2, %2, %3] [%4, 1, %5] [1, 1, 1] : tensor<?x?x?xi32> to tensor<?x?xi32>
   flow.dispatch.tensor.store %7, %1, offsets = [], sizes = [], strides = [] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @slice_rank_reducing()
-//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG: %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG: %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK: %[[SUBVIEW:.+]] = memref.subview %[[ARG]]
 //       CHECK: linalg.copy(%[[SUBVIEW]], %[[RETURN]])
 
@@ -893,9 +813,9 @@ func @slice_multiple_copy() {
   %7 = hal.interface.load.constant offset = 4 : index
   %8 = hal.interface.load.constant offset = 5 : index
   %12 = hal.interface.load.constant offset = 6 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?x?xi32>{%12, %12, %12}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?x?xi32>{%6, %7, %8}
-  %2 = hal.interface.binding.subspan @io::@ret1[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%6, %8}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?x?xi32>{%12, %12, %12}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?x?xi32>{%6, %7, %8}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xi32>{%6, %8}
   %9 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?x?xi32> -> tensor<?x?x?xi32>
   %10 = tensor.extract_slice %9[%3, %4, %5] [%6, %7, %8] [1, 1, 1] : tensor<?x?x?xi32> to tensor<?x?x?xi32>
   %11 = tensor.extract_slice %9[%3, %4, %5] [%6, 1, %8] [1, 1, 1] : tensor<?x?x?xi32> to tensor<?x?xi32>
@@ -903,15 +823,11 @@ func @slice_multiple_copy() {
   flow.dispatch.tensor.store %11, %2, offsets = [%3, %5], sizes = [%6, %8], strides = [1, 1] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret1, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @slice_multiple_copy()
-//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG: %[[RETURN1:.+]] = hal.interface.binding.subspan @io::@ret0
-//   CHECK-DAG: %[[RETURN2:.+]] = hal.interface.binding.subspan @io::@ret1
+//   CHECK-DAG: %[[ARG:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG: %[[RETURN1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG: %[[RETURN2:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //   CHECK-DAG: %[[SIZE1:.+]] = hal.interface.load.constant offset = 3 : index
 //   CHECK-DAG: %[[SIZE2:.+]] = hal.interface.load.constant offset = 4 : index
 //   CHECK-DAG: %[[SIZE3:.+]] = hal.interface.load.constant offset = 5 : index
@@ -927,14 +843,12 @@ func @slice_in_place() {
   %c0 = arith.constant 0 : index
   %2 = hal.interface.load.constant offset = 0 : index
   %3 = hal.interface.load.constant offset = 1 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readwrite:?x?xi32>{%2, %3}
   %6 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:?x?xi32> -> tensor<?x?xi32>
   flow.dispatch.tensor.store %6, %0, offsets = [], sizes = [], strides = [] : tensor<?x?xi32> -> !flow.dispatch.tensor<readwrite:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @slice_in_place()
 //   CHECK-NOT:   linalg.copy
 
@@ -947,20 +861,17 @@ func @slice_whole_stride_dispatch_0() {
   %dim1 = hal.interface.load.constant offset = 1 : index
   %dim2 = hal.interface.load.constant offset = 2 : index
   %dim3 = hal.interface.load.constant offset = 3 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%dim2, %dim3}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>{%dim2, %dim3}
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
   %3 = tensor.extract_slice %2[1, 0] [1, 4] [1, 1] : tensor<?x?xi32> to tensor<1x4xi32>
   flow.dispatch.tensor.store %3, %1, offsets = [], sizes = [], strides = [] : tensor<1x4xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @slice_whole_stride_dispatch_0()
-//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[INPUT]]
 //       CHECK:   linalg.copy(%[[SUBVIEW]], %[[OUTPUT]])
 
@@ -975,9 +886,9 @@ func @subtensor_insert() {
   %dim3 = hal.interface.load.constant offset = 3 : index
   %dim4 = hal.interface.load.constant offset = 4 : index
   %dim5 = hal.interface.load.constant offset = 5 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%dim2, %dim3}
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%dim4, %dim5}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xi32>{%dim2, %dim3}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xi32>{%dim4, %dim5}
   %3 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
   %4 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xi32> -> tensor<?x?xi32>
   %5 = tensor.dim %3, %c0 : tensor<?x?xi32>
@@ -986,16 +897,11 @@ func @subtensor_insert() {
   flow.dispatch.tensor.store %7, %2, offsets = [], sizes = [], strides = [] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:?x?xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @subtensor_insert()
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //   CHECK-DAG:   %[[D0:.+]] = hal.interface.load.constant offset = 0 : index
 //   CHECK-DAG:   %[[D1:.+]] = hal.interface.load.constant offset = 1 : index
 //       CHECK:   linalg.copy(%[[ARG1]], %[[RET0]])
@@ -1006,8 +912,8 @@ hal.interface private @io  {
 
 func @tensor_extract() {
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:i32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x9xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:i32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:3x9xi32>
   %2 = linalg.init_tensor [3, 9] : tensor<3x9xi32>
   %3 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = []  : !flow.dispatch.tensor<readonly:i32> -> tensor<i32>
   %4 = tensor.extract %3[] : tensor<i32>
@@ -1015,13 +921,10 @@ func @tensor_extract() {
   flow.dispatch.tensor.store %5, %1, offsets = [], sizes = [], strides = [] : tensor<3x9xi32> -> !flow.dispatch.tensor<writeonly:3x9xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @tensor_extract()
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   %[[LOAD:.+]] = memref.load %[[ARG0]]
 //       CHECK:   linalg.fill(%[[LOAD]], %[[RET0]])
 
@@ -1029,21 +932,16 @@ hal.interface private @io  {
 
 func @load_to_store() {
   %c0 = arith.constant 0 : index
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:3x4xi32>
-  %2 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:3x4xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<writeonly:3x4xi32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x4xi32>
   %3 = flow.dispatch.tensor.load %2, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:3x4xi32> -> tensor<3x4xi32>
   flow.dispatch.tensor.store %3, %1, offsets = [], sizes = [], strides = [] : tensor<3x4xi32> -> !flow.dispatch.tensor<writeonly:3x4xi32>
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
-
 // CHECK-LABEL: func @load_to_store()
-//       CHECK:   %[[OUT:.+]] = hal.interface.binding.subspan @io::@ret0[%c0] : memref<3x4xi32>
-//       CHECK:   %[[IN:.+]] = hal.interface.binding.subspan @io::@arg0[%c0] : memref<3x4xi32>
+//       CHECK:   %[[OUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<3x4xi32>
+//       CHECK:   %[[IN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x4xi32>
 //       CHECK:   linalg.copy(%[[IN]], %[[OUT]]) : memref<3x4xi32>, memref<3x4xi32>
 
 // -----
@@ -1051,14 +949,15 @@ hal.interface private @io  {
 func @constant() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant dense<[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]> : tensor<2x2x3xi32>
-  %0 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:2x2x3xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<writeonly:2x2x3xi32>
   flow.dispatch.tensor.store %cst, %0, offsets = [], sizes = [], strides = [] : tensor<2x2x3xi32> -> !flow.dispatch.tensor<writeonly:2x2x3xi32>
   return
 }
+
 // CHECK-LABEL: func @constant()
 //       CHECK:   %[[CST:.+]] = arith.constant {{.+}} : tensor<2x2x3xi32>
 //       CHECK:   %[[MEMREF:.+]] = bufferization.to_memref %[[CST]] : memref<2x2x3xi32>
-//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@ret0
+//       CHECK:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
 //       CHECK:   linalg.copy(%[[MEMREF]], %[[RESULT]])
 
 // -----
@@ -1069,8 +968,8 @@ func @rhs_non_splat_constant() {
   %cst_0 = arith.constant 0.000000e+00 : f32
   %c5 = arith.constant 5 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x5x3x1xf32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:5x5xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x5x3x1xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:5x5xf32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:1x5x3x1xf32> -> tensor<1x5x3x1xf32>
   %3 = tensor.collapse_shape %2 [[0, 1], [2, 3]] : tensor<1x5x3x1xf32> into tensor<5x3xf32>
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
@@ -1097,15 +996,12 @@ func @rhs_non_splat_constant() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @rhs_non_splat_constant
 //   CHECK-DAG:   %[[CONSTANT:.+]] = arith.constant {{.+}} : tensor<3x5xf32>
 //   CHECK-DAG:   %[[RHS:.+]] = bufferization.to_memref %[[CONSTANT]]
-//   CHECK-DAG:   %[[LHS_INPUT:.+]] = hal.interface.binding.subspan @io::@arg0[%{{.+}}] : memref<1x5x3x1xf32>
-//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan @io::@ret0[%{{.+}}] : memref<5x5xf32>
+//   CHECK-DAG:   %[[LHS_INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<1x5x3x1xf32>
+//   CHECK-DAG:   %[[RETURN:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<5x5xf32>
 //       CHECK:   %[[LHS:.+]] = memref.collapse_shape %[[LHS_INPUT]]
 //       CHECK:   scf.for %[[IV0:.+]] =
 //       CHECK:     scf.for %[[IV1:.+]] =
@@ -1127,9 +1023,9 @@ func @gather() {
   %dim2 = hal.interface.load.constant offset = 2 : index
   %dim3 = hal.interface.load.constant offset = 3 : index
   %dim4 = hal.interface.load.constant offset = 4 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?xi32>{%dim2}
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim3, %dim4}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?xi32>{%dim2}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim3, %dim4}
   %4 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = []: !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
   %5 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?xi32> -> tensor<?xi32>
   %d0 = tensor.dim %5, %c0 : tensor<?xi32>
@@ -1145,15 +1041,11 @@ func @gather() {
   flow.dispatch.tensor.store %7, %2, offsets = [], sizes = [], strides = [] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @gather()
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK:   linalg.generic
 //       CHECK:     %[[VAL:.+]] = memref.load %[[ARG0]]
 //       CHECK:     linalg.yield %[[VAL]]
@@ -1164,9 +1056,9 @@ func @pooling_nhwc_sum() {
   %c2 = arith.constant 2 : index
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:f32>
-  %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:1x4x6x1xf32>
-  %2 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:1x2x2x1xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:f32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1x4x6x1xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x2x2x1xf32>
   %3 = linalg.init_tensor [2, 3] : tensor<2x3xf32>
   %4 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:f32> -> tensor<f32>
   %5 = tensor.extract %4[] : tensor<f32>
@@ -1181,16 +1073,12 @@ func @pooling_nhwc_sum() {
   flow.dispatch.tensor.store %9, %2, offsets = [], sizes = [], strides = [] : tensor<1x2x2x1xf32> -> !flow.dispatch.tensor<writeonly:1x2x2x1xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @pooling_nhwc_sum
 //       CHECK:   %[[WINDOW:.+]] = memref.alloc() : memref<2x3xf32>
-//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan @io::@ro1[%c0] : memref<1x4x6x1xf32>
-//   CHECK-DAG:   %[[INIT:.+]] = hal.interface.binding.subspan @io::@ro0[%c0] : memref<f32>
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@wo2[%c0] : memref<1x2x2x1xf32>
+//   CHECK-DAG:   %[[INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<f32>
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<1x4x6x1xf32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<1x2x2x1xf32>
 //       CHECK:   %[[INIT_VAL:.+]] = memref.load %[[INIT]][] : memref<f32>
 //       CHECK:   linalg.fill(%[[INIT_VAL]], %[[RET0]]) : f32, memref<1x2x2x1xf32>
 //       CHECK:   linalg.pooling_nhwc_sum
@@ -1210,10 +1098,10 @@ func @read_only_subtensor() {
   %pc3 = hal.interface.load.constant offset = 3 : index
   %pc4 = hal.interface.load.constant offset = 4 : index
   %pc5 = hal.interface.load.constant offset = 5 : index
-  %0 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%pc0, %pc1}
-  %1 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%pc2, %pc3}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xf32>{%pc0, %pc1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%pc2, %pc3}
   %2 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
-  %3 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%pc4, %pc5}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%pc4, %pc5}
   %4 = flow.dispatch.tensor.load %3, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_size_y = hal.interface.workgroup.size[1] : index
@@ -1256,15 +1144,12 @@ func @read_only_subtensor() {
     }
   }
   return
-}hal.interface private @io  {
-  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
 }
+
 // CHECK-LABEL: func @read_only_subtensor
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@ro0[%c0] : memref<?x?xf32>
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@ro1[%c0] : memref<?x?xf32>
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@wo2[%c0] : memref<?x?xf32>
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xf32>
 //       CHECK:   scf.for
 //       CHECK:     scf.for
 //   CHECK-DAG:       %[[SV1:.+]] = memref.subview %[[ARG0]]
@@ -1281,8 +1166,8 @@ func @reshape_read_only() {
   %dim0 = hal.interface.load.constant offset = 0 : index
   %dim1 = hal.interface.load.constant offset = 1 : index
   %dim2 = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@wo0[%c0] : !flow.dispatch.tensor<writeonly:?xf32>{%dim2}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?xf32>{%dim2}
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
   %3 = tensor.collapse_shape %2 [[0, 1]]
       : tensor<?x?xf32> into tensor<?xf32>
@@ -1299,9 +1184,10 @@ func @reshape_read_only() {
   flow.dispatch.tensor.store %6, %1, offsets = [], sizes = [], strides = []: tensor<?xf32> -> !flow.dispatch.tensor<writeonly:?xf32>
   return
 }
+
 // CHECK-LABEL: func @reshape_read_only
-//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan @io::@ro0
-//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan @io::@wo0
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   %[[RESHAPE:.+]] = memref.collapse_shape %[[INPUT]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[RESHAPE]] : memref<?xf32>)
@@ -1312,10 +1198,10 @@ func @reshape_read_only() {
 func @use_buffer_for_operand_when_output_tensor_not_used() {
   %c0 = arith.constant 0 : index
 
-  %input_subspan = hal.interface.binding.subspan @interface_io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1x225x225x16xf32>
-  %filter_subspan = hal.interface.binding.subspan @interface_io::@ro1[%c0] : !flow.dispatch.tensor<readonly:3x3x16x32xf32>
-  %offset_subspan = hal.interface.binding.subspan @interface_io::@ro2[%c0] : !flow.dispatch.tensor<readonly:32xf32>
-  %output_subspan = hal.interface.binding.subspan @interface_io::@wo3[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+  %input_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x16xf32>
+  %filter_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x16x32xf32>
+  %offset_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:32xf32>
+  %output_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
 
   %input = flow.dispatch.tensor.load %input_subspan, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:1x225x225x16xf32> -> tensor<1x225x225x16xf32>
   %filter = flow.dispatch.tensor.load %filter_subspan, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:3x3x16x32xf32> -> tensor<3x3x16x32xf32>
@@ -1345,17 +1231,10 @@ func @use_buffer_for_operand_when_output_tensor_not_used() {
   return
 }
 
-hal.interface private @interface_io  {
-  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ro2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @wo3, set=0, binding=3, type="StorageBuffer"
-}
-
 // CHECK: func @use_buffer_for_operand_when_output_tensor_not_used()
 
 //  CHECK-NOT: memref.alloc
-//      CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan @interface_io::@wo3
+//      CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //      CHECK: linalg.fill(%{{.+}}, %[[OUTPUT]])
 // CHECK-NEXT: linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:   outs(%[[OUTPUT]] : memref<1x112x112x32xf32>)
@@ -1368,10 +1247,10 @@ hal.interface private @interface_io  {
 func @dont_use_buffer_for_operand_when_output_tensor_used() {
   %c0 = arith.constant 0 : index
 
-  %input_subspan = hal.interface.binding.subspan @interface_io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1x225x225x16xf32>
-  %filter_subspan = hal.interface.binding.subspan @interface_io::@ro1[%c0] : !flow.dispatch.tensor<readonly:3x3x16x32xf32>
-  %offset_subspan = hal.interface.binding.subspan @interface_io::@ro2[%c0] : !flow.dispatch.tensor<readonly:32xf32>
-  %output_subspan = hal.interface.binding.subspan @interface_io::@wo3[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+  %input_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x16xf32>
+  %filter_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x16x32xf32>
+  %offset_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:32xf32>
+  %output_subspan = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
 
   %input = flow.dispatch.tensor.load %input_subspan, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:1x225x225x16xf32> -> tensor<1x225x225x16xf32>
   %filter = flow.dispatch.tensor.load %filter_subspan, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:3x3x16x32xf32> -> tensor<3x3x16x32xf32>
@@ -1406,7 +1285,7 @@ func @dont_use_buffer_for_operand_when_output_tensor_used() {
 
 // CHECK-LABEL: func @dont_use_buffer_for_operand_when_output_tensor_used()
 //      CHECK: %[[ALLOC:.+]] = memref.alloc
-//      CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan @interface_io::@wo3
+//      CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //      CHECK: linalg.fill(%{{.+}}, %[[ALLOC]])
 // CHECK-NEXT: linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:   outs(%[[ALLOC]] : memref<1x112x112x32xf32>)
@@ -1422,8 +1301,8 @@ func @bufferize_cst_output_tensor() {
   %cst1 = arith.constant dense<-2147483648> : tensor<i32>
   %zero = arith.constant 0.000000e+00 : f32
   %cst5 = arith.constant dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
-  %input = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:5xf32>
-  %output = hal.interface.binding.subspan @io::@wo1[%c0] : !flow.dispatch.tensor<writeonly:i32>
+  %input = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:5xf32>
+  %output = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:i32>
   %1 = flow.dispatch.tensor.load %input, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:5xf32> -> tensor<5xf32>
   %2 = linalg.generic {
          indexing_maps = [affine_map<(d0) -> (-d0 + 4)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
@@ -1442,19 +1321,14 @@ func @bufferize_cst_output_tensor() {
   return
 }
 
-hal.interface private @interface_io  {
-  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @wo1, set=0, binding=1, type="StorageBuffer"
-}
-
 // CHECK-LABEL: func @bufferize_cst_output_tensor()
 
 //       CHECK-DAG: %[[CST1:.+]] = arith.constant dense<-2147483648> : tensor<i32>
 //       CHECK-DAG: %[[CST5:.+]] = arith.constant dense<[1, 2, 3, 4, 5]> : tensor<5xi32>
 //       CHECK: %[[CAST1:.+]] = bufferization.to_memref %[[CST1]] : memref<i32>
 //       CHECK: %[[CAST5:.+]] = bufferization.to_memref %[[CST5]] : memref<5xi32>
-//       CHECK: %[[INPUT:.+]] = hal.interface.binding.subspan @io::@ro0[%c0] : memref<5xf32>
-//       CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan @io::@wo1[%c0] : memref<i32>
+//       CHECK: %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<5xf32>
+//       CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<i32>
 //       CHECK: linalg.copy(%[[CAST1]], %[[OUTPUT]])
 //       CHECK: linalg.generic
 //  CHECK-SAME:   ins(%[[INPUT]], %[[CAST5]] : memref<5xf32>, memref<5xi32>)
@@ -1469,9 +1343,9 @@ func @cast_follwed_by_store() {
   %c64 = arith.constant 64 : index
   %c1 = arith.constant 1 : index
   %c32 = arith.constant 32 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x32x1024xf32>
-  %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x1024x64xf32>
-  %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4x32x64xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x32x1024xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x1024x64xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x32x64xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -1500,9 +1374,9 @@ func @cast_follwed_by_store() {
 
 // CHECK-LABEL: func @cast_follwed_by_store()
 //   CHECK-DAG: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-//   CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<4x32x1024xf32>
-//   CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<4x1024x64xf32>
-//   CHECK-DAG: %[[RESULT:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : memref<4x32x64xf32>
+//   CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x32x1024xf32>
+//   CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4x1024x64xf32>
+//   CHECK-DAG: %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x32x64xf32>
 //       CHECK: %[[LHSV:.+]] = memref.subview %[[LHS]]
 //       CHECK: %[[RHSV:.+]] = memref.subview %[[RHS]]
 //       CHECK: %[[RESULTV:.+]] = memref.subview %[[RESULT]]
@@ -1520,8 +1394,8 @@ func @rank_reduced_subtensor_insert() {
   %dim2 = hal.interface.load.constant offset = 2 : index
   %dim3 = hal.interface.load.constant offset = 3 : index
   %dim4 = hal.interface.load.constant offset = 4 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<readwrite:?x?x?xf32>{%dim2, %dim3, %dim4}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readwrite:?x?x?xf32>{%dim2, %dim3, %dim4}
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:?x?xf32> -> tensor<?x?xf32>
   %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:?x?x?xf32> -> tensor<?x?x?xf32>
   %4 = tensor.dim %3, %c1 : tensor<?x?x?xf32>
@@ -1530,13 +1404,10 @@ func @rank_reduced_subtensor_insert() {
   flow.dispatch.tensor.store %6, %1, offsets = [], sizes = [], strides = [] : tensor<?x?x?xf32> -> !flow.dispatch.tensor<readwrite:?x?x?xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @rank_reduced_subtensor_insert()
-//   CHECK-DAG:   %[[ARG:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[RET:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[ARG:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[RET:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[RET]]
 //       CHECK:   linalg.copy(%[[ARG]], %[[SUBVIEW]])
 
@@ -1551,10 +1422,10 @@ func @bufferize_transfer_op() {
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:2x3xf32>
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:3x4xf32>
-  %2 = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:2x4xf32>
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:2x4xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:2x3xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x4xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:2x4xf32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:2x4xf32>
   %4 = flow.dispatch.tensor.load %0, offsets = [%c0, %c0], sizes = [%c1, %c3], strides = [%c1, %c1] : !flow.dispatch.tensor<readonly:2x3xf32> -> tensor<2x3xf32>
   %5 = flow.dispatch.tensor.load %1, offsets = [%c0, %c0], sizes = [%c3, %c1], strides = [%c1, %c1] : !flow.dispatch.tensor<readonly:3x4xf32> -> tensor<3x1xf32>
   %6 = flow.dispatch.tensor.load %2, offsets = [%c0, %c0], sizes = [%c1, %c1], strides = [%c1, %c1] : !flow.dispatch.tensor<readonly:2x4xf32> -> tensor<2x1xf32>
@@ -1580,17 +1451,12 @@ func @bufferize_transfer_op() {
   flow.dispatch.tensor.store %25, %3, offsets = [%c0, %c0], sizes = [%c1, %c1], strides = [%c1, %c1] : tensor<2x1xf32> -> !flow.dispatch.tensor<writeonly:2x4xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 //   CHECK-LABEL: func @bufferize_transfer_op()
-//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//     CHECK-DAG:   %[[ARG2:.+]] = hal.interface.binding.subspan @io::@arg2
-//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//     CHECK-DAG:   %[[ARG2:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //     CHECK-DAG:   %[[ARG0V:.+]] = memref.subview %[[ARG0]]
 //     CHECK-DAG:   %[[ARG1V:.+]] = memref.subview %[[ARG1]]
 //     CHECK-DAG:   %[[ARG2V:.+]] = memref.subview %[[ARG2]]
@@ -1613,9 +1479,9 @@ func @bufferize_transfer_op_inplace() {
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:2x3xf32>
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:3x4xf32>
-  %3 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<readwrite:2x4xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:2x3xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x4xf32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:2x4xf32>
   %4 = flow.dispatch.tensor.load %0, offsets = [%c0, %c0], sizes = [%c1, %c3], strides = [%c1, %c1] : !flow.dispatch.tensor<readonly:2x3xf32> -> tensor<2x3xf32>
   %5 = flow.dispatch.tensor.load %1, offsets = [%c0, %c0], sizes = [%c3, %c1], strides = [%c1, %c1] : !flow.dispatch.tensor<readonly:3x4xf32> -> tensor<3x1xf32>
   %6 = flow.dispatch.tensor.load %3, offsets = [%c0, %c0], sizes = [%c1, %c1], strides = [%c1, %c1] : !flow.dispatch.tensor<readwrite:2x4xf32> -> tensor<2x1xf32>
@@ -1641,15 +1507,11 @@ func @bufferize_transfer_op_inplace() {
   flow.dispatch.tensor.store %25, %3, offsets = [%c0, %c0], sizes = [%c1, %c1], strides = [%c1, %c1] : tensor<2x1xf32> -> !flow.dispatch.tensor<readwrite:2x4xf32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer"
-}
+
 //   CHECK-LABEL: func @bufferize_transfer_op_inplace()
-//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //     CHECK-DAG:   %[[ARG0V:.+]] = memref.subview %[[ARG0]]
 //     CHECK-DAG:   %[[ARG1V:.+]] = memref.subview %[[ARG1]]
 //     CHECK-DAG:   %[[RET0V:.+]] = memref.subview %[[RET0]]
@@ -1677,10 +1539,10 @@ func @multi_result() {
   %dim5 = hal.interface.load.constant offset = 5 : index
   %dim6 = hal.interface.load.constant offset = 6 : index
   %dim7 = hal.interface.load.constant offset = 7 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%dim2, %dim3}
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim4, %dim5}
-  %3 = hal.interface.binding.subspan @io::@ret1[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim6, %dim7}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%dim2, %dim3}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim4, %dim5}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%dim6, %dim7}
   %4 = hal.interface.load.constant offset = 8 : index
   %5 = hal.interface.load.constant offset = 9 : index
   %6 = hal.interface.load.constant offset = 10 : index
@@ -1716,17 +1578,12 @@ func @multi_result() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret1, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @multi_result()
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
-//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@ret1
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //   CHECK-DAG:   %[[ARG0V:.+]] = memref.subview %[[ARG0]]
 //   CHECK-DAG:   %[[ARG1V:.+]] = memref.subview %[[ARG1]]
 //   CHECK-DAG:   %[[RET0V:.+]] = memref.subview %[[RET0]]
@@ -1739,54 +1596,52 @@ hal.interface private @io  {
 
 #map0 = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<()[s0] -> (s0 * 16)>
-module  {
-  func @padded_matmul() {
-    %c0 = arith.constant 0 : index
-    %c12544 = arith.constant 12544 : index
-    %c64 = arith.constant 64 : index
-    %c16 = arith.constant 16 : index
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:12544x27xf32>
-    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:27x16xf32>
-    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:12544x16xf32>
-    %workgroup_id_x = hal.interface.workgroup.id[0] : index
-    %workgroup_count_x = hal.interface.workgroup.count[0] : index
-    %workgroup_id_y = hal.interface.workgroup.id[1] : index
-    %workgroup_count_y = hal.interface.workgroup.count[1] : index
-    %3 = affine.apply #map0()[%workgroup_id_y]
-    %4 = affine.apply #map0()[%workgroup_count_y]
-    scf.for %arg0 = %3 to %c12544 step %4 {
-      %5 = affine.apply #map1()[%workgroup_id_x]
-      %6 = affine.apply #map1()[%workgroup_count_x]
-      scf.for %arg1 = %5 to %c16 step %6 {
-        %7 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 27], strides = [1, 1] : !flow.dispatch.tensor<readonly:12544x27xf32> -> tensor<64x27xf32>
-        %8 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [27, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:27x16xf32> -> tensor<27x16xf32>
-        %9 = linalg.init_tensor [64, 16] : tensor<64x16xf32>
-        %10 = linalg.fill(%cst, %9) {__internal_linalg_transform__ = "workgroup"} : f32, tensor<64x16xf32> -> tensor<64x16xf32>
-        %11 = linalg.pad_tensor %7 low[0, 0] high[0, 5]  {
-        ^bb0(%arg2: index, %arg3: index):  // no predecessors
-          linalg.yield %cst : f32
-        } : tensor<64x27xf32> to tensor<64x32xf32>
-        %12 = linalg.pad_tensor %8 low[0, 0] high[5, 0]  {
-        ^bb0(%arg2: index, %arg3: index):  // no predecessors
-          linalg.yield %cst : f32
-        } : tensor<27x16xf32> to tensor<32x16xf32>
-        %13 = linalg.matmul ins(%11, %12 : tensor<64x32xf32>, tensor<32x16xf32>) outs(%10 : tensor<64x16xf32>) -> tensor<64x16xf32>
-        %14 = tensor.cast %13 : tensor<64x16xf32> to tensor<?x?xf32>
-        flow.dispatch.tensor.store %14, %2, offsets = [%arg0, %arg1], sizes = [%c64, %c16], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:12544x16xf32>
-      }
+func @padded_matmul() {
+  %c0 = arith.constant 0 : index
+  %c12544 = arith.constant 12544 : index
+  %c64 = arith.constant 64 : index
+  %c16 = arith.constant 16 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:12544x27xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:27x16xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:12544x16xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %3 = affine.apply #map0()[%workgroup_id_y]
+  %4 = affine.apply #map0()[%workgroup_count_y]
+  scf.for %arg0 = %3 to %c12544 step %4 {
+    %5 = affine.apply #map1()[%workgroup_id_x]
+    %6 = affine.apply #map1()[%workgroup_count_x]
+    scf.for %arg1 = %5 to %c16 step %6 {
+      %7 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 27], strides = [1, 1] : !flow.dispatch.tensor<readonly:12544x27xf32> -> tensor<64x27xf32>
+      %8 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [27, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:27x16xf32> -> tensor<27x16xf32>
+      %9 = linalg.init_tensor [64, 16] : tensor<64x16xf32>
+      %10 = linalg.fill(%cst, %9) {__internal_linalg_transform__ = "workgroup"} : f32, tensor<64x16xf32> -> tensor<64x16xf32>
+      %11 = linalg.pad_tensor %7 low[0, 0] high[0, 5]  {
+      ^bb0(%arg2: index, %arg3: index):  // no predecessors
+        linalg.yield %cst : f32
+      } : tensor<64x27xf32> to tensor<64x32xf32>
+      %12 = linalg.pad_tensor %8 low[0, 0] high[5, 0]  {
+      ^bb0(%arg2: index, %arg3: index):  // no predecessors
+        linalg.yield %cst : f32
+      } : tensor<27x16xf32> to tensor<32x16xf32>
+      %13 = linalg.matmul ins(%11, %12 : tensor<64x32xf32>, tensor<32x16xf32>) outs(%10 : tensor<64x16xf32>) -> tensor<64x16xf32>
+      %14 = tensor.cast %13 : tensor<64x16xf32> to tensor<?x?xf32>
+      flow.dispatch.tensor.store %14, %2, offsets = [%arg0, %arg1], sizes = [%c64, %c16], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:12544x16xf32>
     }
-    return
   }
+  return
 }
 
 // CHECK-LABEL: func @padded_matmul()
 // CHECK-DAG: %[[LHS_PADDED:.+]] = memref.alloc() : memref<64x32xf32>
 // CHECK-DAG: %[[RHS_PADDED:.+]] = memref.alloc() : memref<32x16xf32>
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<12544x27xf32>
-// CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<27x16xf32>
-// CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : memref<12544x16xf32>
+// CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<12544x27xf32>
+// CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<27x16xf32>
+// CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<12544x16xf32>
 // CHECK-DAG: %[[LHS_V:.+]] = memref.subview %[[LHS]][%{{.*}}, 0] [64, 27] [1, 1]
 // CHECK-DAG: %[[RHS_V:.+]] = memref.subview %[[RHS]][0, %{{.*}}] [27, 16] [1, 1]
 // CHECK-DAG: %[[DST_V:.+]] = memref.subview %[[DST]][%{{.*}}, %{{.*}}] [64, 16] [1, 1]
@@ -1809,9 +1664,9 @@ func @dot_general_padded() {
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -1845,19 +1700,15 @@ func @dot_general_padded() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-}
+
 //      CHECK: #[[MAP1:.+]] = affine_map<(d0)[s0] -> (4, -d0 + s0)>
 //      CHECK: func @dot_general_padded
 //   CHECK-DAG:      %[[ALLOC_RET0:.+]] = memref.alloc
 //   CHECK-DAG:      %[[ALLOC_ARG1:.+]] = memref.alloc
 //   CHECK-DAG:      %[[ALLOC_ARG0:.+]] = memref.alloc
-//   CHECK-DAG:  %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0[{{.*}}] : memref<?x?xf32>
-//   CHECK-DAG:  %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1[{{.*}}] : memref<?x?xf32>
-//   CHECK-DAG:  %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0[{{.*}}] : memref<?x?xf32>
+//   CHECK-DAG:  %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>
+//   CHECK-DAG:  %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>
+//   CHECK-DAG:  %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xf32>
 //   CHECK-DAG:  %[[M:.+]] = hal.interface.load.constant offset = 0
 //   CHECK-DAG:  %[[N:.+]] = hal.interface.load.constant offset = 1
 //       CHECK:  scf.for %[[IV0:.+]] = %{{.+}} to %[[M]]
@@ -1888,9 +1739,9 @@ func @im2col() {
   %c32 = arith.constant 32 : index
   %c16 = arith.constant 16 : index
   %c4 = arith.constant 4 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x225x225x8xf32>
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:3x3x8x32xf32>
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x8xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x8x32xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -1931,15 +1782,11 @@ func @im2col() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @im2col
-//   CHECK-DAG:  %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:  %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:  %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:  %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:  %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:  %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //   CHECK-DAG:  %[[ALLOC_ARG0:.+]] = memref.alloc() : memref<1x16x16x3x3x8xf32>
 //   CHECK-DAG:  %[[ALLOC_ARG1:.+]] = memref.alloc() : memref<3x3x8x4xf32>
 //   CHECK-DAG:  %[[ALLOC_RET0:.+]] = memref.alloc() : memref<1x16x16x4xf32>
@@ -1972,10 +1819,10 @@ func @multi_result_reduce() {
   %d0 = hal.interface.load.constant offset = 0 : index
   %d1 = hal.interface.load.constant offset = 1 : index
   %d2 = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
-  %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
-  %2 = hal.interface.binding.subspan @io::@wo0[%c0] : !flow.dispatch.tensor<writeonly:?xi32>{%d2}
-  %3 = hal.interface.binding.subspan @io::@wo1[%c0] : !flow.dispatch.tensor<writeonly:?xi32>{%d2}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?xi32>{%d2}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?xi32>{%d2}
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
@@ -2003,17 +1850,12 @@ func @multi_result_reduce() {
   }
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @wo0, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @wo1, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @multi_result_reduce
-//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@ro0
-//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@ro1
-//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@wo0
-//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan @io::@wo1
+//   CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RET1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for
 //   CHECK-DAG:     %[[ARG0_SV:.+]] = memref.subview %[[ARG0]]
 //   CHECK-DAG:     %[[ARG1_SV:.+]] = memref.subview %[[ARG1]]
@@ -2036,67 +1878,59 @@ hal.interface private @io  {
 #map4 = affine_map<(d0) -> (24, -d0 + 144)>
 #map5 = affine_map<(d0) -> (32, -d0 + 370)>
 #map6 = affine_map<(d0, d1) -> (32, d0 - d1)>
-module  {
-  func @l1_tiled_matmul_no_fill() {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c32 = arith.constant 32 : index
-    %c24 = arith.constant 24 : index
-    %c144 = arith.constant 144 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c250 = arith.constant 250 : index
-    %c370 = arith.constant 370 : index
-    %0 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:250x144xf32>
-    %1 = hal.interface.binding.subspan @io::@ro2[%c0] : !flow.dispatch.tensor<readonly:144x370xf32>
-    %init = hal.interface.binding.subspan @io::@ro3[%c0] : !flow.dispatch.tensor<readonly:250x370xf32>
-    %2 = hal.interface.binding.subspan @io::@wo[%c0] : !flow.dispatch.tensor<writeonly:250x370xf32>
-    %workgroup_id_x = hal.interface.workgroup.id[0] : index
-    %workgroup_count_x = hal.interface.workgroup.count[0] : index
-    %workgroup_id_y = hal.interface.workgroup.id[1] : index
-    %workgroup_count_y = hal.interface.workgroup.count[1] : index
-    %3 = affine.apply #map0()[%workgroup_id_y]
-    %4 = affine.apply #map0()[%workgroup_count_y]
-    scf.for %arg0 = %3 to %c250 step %4 {
-      %5 = affine.apply #map0()[%workgroup_id_x]
-      %6 = affine.apply #map0()[%workgroup_count_x]
-      scf.for %arg1 = %5 to %c370 step %6 {
-        %7 = affine.min #map1(%arg0)
-        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
-        %9 = affine.min #map2(%arg1)
-        %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
-        %11 = flow.dispatch.tensor.load %init, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x370xf32> -> tensor<?x?xf32>
-        %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %11) -> (tensor<?x?xf32>) {
-          %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
-            %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
-              %16 = affine.min #map3(%arg2)
-              %17 = affine.min #map4(%arg6)
-              %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
-              %19 = affine.min #map5(%arg4)
-              %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
-              %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
-              %22 = affine.min #map6(%21, %arg2)
-              %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
-              %24 = affine.min #map6(%23, %arg4)
-              %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-              %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
-              %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
-              scf.yield %27 : tensor<?x?xf32>
-            }
-            scf.yield %15 : tensor<?x?xf32>
+func @l1_tiled_matmul_no_fill() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c32 = arith.constant 32 : index
+  %c24 = arith.constant 24 : index
+  %c144 = arith.constant 144 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c250 = arith.constant 250 : index
+  %c370 = arith.constant 370 : index
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:250x144xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:144x370xf32>
+  %init = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:250x370xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:250x370xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %3 = affine.apply #map0()[%workgroup_id_y]
+  %4 = affine.apply #map0()[%workgroup_count_y]
+  scf.for %arg0 = %3 to %c250 step %4 {
+    %5 = affine.apply #map0()[%workgroup_id_x]
+    %6 = affine.apply #map0()[%workgroup_count_x]
+    scf.for %arg1 = %5 to %c370 step %6 {
+      %7 = affine.min #map1(%arg0)
+      %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
+      %9 = affine.min #map2(%arg1)
+      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
+      %11 = flow.dispatch.tensor.load %init, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x370xf32> -> tensor<?x?xf32>
+      %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %11) -> (tensor<?x?xf32>) {
+        %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
+          %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
+            %16 = affine.min #map3(%arg2)
+            %17 = affine.min #map4(%arg6)
+            %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
+            %19 = affine.min #map5(%arg4)
+            %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
+            %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
+            %22 = affine.min #map6(%21, %arg2)
+            %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
+            %24 = affine.min #map6(%23, %arg4)
+            %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
+            scf.yield %27 : tensor<?x?xf32>
           }
-          scf.yield %14 : tensor<?x?xf32>
+          scf.yield %15 : tensor<?x?xf32>
         }
-        flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:250x370xf32>
+        scf.yield %14 : tensor<?x?xf32>
       }
+      flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:250x370xf32>
     }
-    return
   }
-  hal.interface private @io  {
-    hal.interface.binding @ro1, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @ro2, set=0, binding=1, type="StorageBuffer"
-    hal.interface.binding @ro3, set=0, binding=2, type="StorageBuffer"
-    hal.interface.binding @wo, set=0, binding=3, type="StorageBuffer"
-  }
+  return
 }
 
 // CHECK-LABEL: l1_tiled_matmul_no_fill
@@ -2105,10 +1939,10 @@ module  {
 //    CHECK-DAG: %[[K:.+]] = arith.constant 144 : index
 //    CHECK-DAG: %[[L1_MN_SIZE:.+]] = arith.constant 32 : index
 //    CHECK-DAG: %[[L1_K_SIZE:.+]] = arith.constant 24 : index
-//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@ro1[%{{.*}}] : memref<250x144xf32>
-//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@ro2[%{{.*}}] : memref<144x370xf32>
-//    CHECK-DAG: %[[INIT:.+]] = hal.interface.binding.subspan @io::@ro3[%{{.*}}] : memref<250x370xf32>
-//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan @io::@wo[%{{.*}}] : memref<250x370xf32>
+//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<250x144xf32>
+//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<144x370xf32>
+//    CHECK-DAG: %[[INIT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<250x370xf32>
+//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<250x370xf32>
 //        CHECK: scf.for %[[WORKGROUP_I:.+]] = %{{.*}} to %[[M]] step %{{.*}} {
 //        CHECK:    scf.for %[[WORKGROUP_J:.+]] = %{{.*}} to %[[N]] step %{{.*}} {
 //    CHECK-DAG:        %[[WORKGROUP_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I]])
@@ -2142,65 +1976,58 @@ module  {
 #map4 = affine_map<(d0) -> (24, -d0 + 144)>
 #map5 = affine_map<(d0) -> (32, -d0 + 370)>
 #map6 = affine_map<(d0, d1) -> (32, d0 - d1)>
-module  {
-  func @l1_tiled_matmul_no_fill_readwrite() {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c32 = arith.constant 32 : index
-    %c24 = arith.constant 24 : index
-    %c144 = arith.constant 144 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c250 = arith.constant 250 : index
-    %c370 = arith.constant 370 : index
-    %0 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:250x144xf32>
-    %1 = hal.interface.binding.subspan @io::@ro2[%c0] : !flow.dispatch.tensor<readonly:144x370xf32>
-    %2 = hal.interface.binding.subspan @io::@wo[%c0] : !flow.dispatch.tensor<readwrite:250x370xf32>
-    %workgroup_id_x = hal.interface.workgroup.id[0] : index
-    %workgroup_count_x = hal.interface.workgroup.count[0] : index
-    %workgroup_id_y = hal.interface.workgroup.id[1] : index
-    %workgroup_count_y = hal.interface.workgroup.count[1] : index
-    %3 = affine.apply #map0()[%workgroup_id_y]
-    %4 = affine.apply #map0()[%workgroup_count_y]
-    scf.for %arg0 = %3 to %c250 step %4 {
-      %5 = affine.apply #map0()[%workgroup_id_x]
-      %6 = affine.apply #map0()[%workgroup_count_x]
-      scf.for %arg1 = %5 to %c370 step %6 {
-        %7 = affine.min #map1(%arg0)
-        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
-        %9 = affine.min #map2(%arg1)
-        %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
-        %11 = flow.dispatch.tensor.load %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : !flow.dispatch.tensor<readwrite:250x370xf32> -> tensor<?x?xf32>
-        %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %11) -> (tensor<?x?xf32>) {
-          %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
-            %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
-              %16 = affine.min #map3(%arg2)
-              %17 = affine.min #map4(%arg6)
-              %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
-              %19 = affine.min #map5(%arg4)
-              %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
-              %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
-              %22 = affine.min #map6(%21, %arg2)
-              %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
-              %24 = affine.min #map6(%23, %arg4)
-              %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-              %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
-              %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
-              scf.yield %27 : tensor<?x?xf32>
-            }
-            scf.yield %15 : tensor<?x?xf32>
+func @l1_tiled_matmul_no_fill_readwrite() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c32 = arith.constant 32 : index
+  %c24 = arith.constant 24 : index
+  %c144 = arith.constant 144 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c250 = arith.constant 250 : index
+  %c370 = arith.constant 370 : index
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:250x144xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:144x370xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:250x370xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %3 = affine.apply #map0()[%workgroup_id_y]
+  %4 = affine.apply #map0()[%workgroup_count_y]
+  scf.for %arg0 = %3 to %c250 step %4 {
+    %5 = affine.apply #map0()[%workgroup_id_x]
+    %6 = affine.apply #map0()[%workgroup_count_x]
+    scf.for %arg1 = %5 to %c370 step %6 {
+      %7 = affine.min #map1(%arg0)
+      %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
+      %9 = affine.min #map2(%arg1)
+      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
+      %11 = flow.dispatch.tensor.load %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : !flow.dispatch.tensor<readwrite:250x370xf32> -> tensor<?x?xf32>
+      %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %11) -> (tensor<?x?xf32>) {
+        %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
+          %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
+            %16 = affine.min #map3(%arg2)
+            %17 = affine.min #map4(%arg6)
+            %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
+            %19 = affine.min #map5(%arg4)
+            %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
+            %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
+            %22 = affine.min #map6(%21, %arg2)
+            %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
+            %24 = affine.min #map6(%23, %arg4)
+            %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
+            scf.yield %27 : tensor<?x?xf32>
           }
-          scf.yield %14 : tensor<?x?xf32>
+          scf.yield %15 : tensor<?x?xf32>
         }
-        flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<readwrite:250x370xf32>
+        scf.yield %14 : tensor<?x?xf32>
       }
+      flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<readwrite:250x370xf32>
     }
-    return
   }
-  hal.interface private @io  {
-    hal.interface.binding @ro1, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @ro2, set=0, binding=1, type="StorageBuffer"
-    hal.interface.binding @wo, set=0, binding=2, type="StorageBuffer"
-  }
+  return
 }
 
 // CHECK-LABEL: l1_tiled_matmul_no_fill_readwrite
@@ -2209,9 +2036,9 @@ module  {
 //    CHECK-DAG: %[[K:.+]] = arith.constant 144 : index
 //    CHECK-DAG: %[[L1_MN_SIZE:.+]] = arith.constant 32 : index
 //    CHECK-DAG: %[[L1_K_SIZE:.+]] = arith.constant 24 : index
-//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@ro1[%{{.*}}] : memref<250x144xf32>
-//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@ro2[%{{.*}}] : memref<144x370xf32>
-//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan @io::@wo[%{{.*}}] : memref<250x370xf32>
+//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<250x144xf32>
+//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<144x370xf32>
+//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<250x370xf32>
 //        CHECK: scf.for %[[WORKGROUP_I:.+]] = %{{.*}} to %[[M]] step %{{.*}} {
 //        CHECK:    scf.for %[[WORKGROUP_J:.+]] = %{{.*}} to %[[N]] step %{{.*}} {
 //    CHECK-DAG:        %[[WORKGROUP_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I]])
@@ -2242,66 +2069,59 @@ module  {
 #map4 = affine_map<(d0) -> (24, -d0 + 144)>
 #map5 = affine_map<(d0) -> (32, -d0 + 370)>
 #map6 = affine_map<(d0, d1) -> (32, d0 - d1)>
-module  {
-  func @l1_tiled_matmul() {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c32 = arith.constant 32 : index
-    %c24 = arith.constant 24 : index
-    %c144 = arith.constant 144 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c250 = arith.constant 250 : index
-    %c370 = arith.constant 370 : index
-    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:250x144xf32>
-    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:144x370xf32>
-    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:250x370xf32>
-    %workgroup_id_x = hal.interface.workgroup.id[0] : index
-    %workgroup_count_x = hal.interface.workgroup.count[0] : index
-    %workgroup_id_y = hal.interface.workgroup.id[1] : index
-    %workgroup_count_y = hal.interface.workgroup.count[1] : index
-    %3 = affine.apply #map0()[%workgroup_id_y]
-    %4 = affine.apply #map0()[%workgroup_count_y]
-    scf.for %arg0 = %3 to %c250 step %4 {
-      %5 = affine.apply #map0()[%workgroup_id_x]
-      %6 = affine.apply #map0()[%workgroup_count_x]
-      scf.for %arg1 = %5 to %c370 step %6 {
-        %7 = affine.min #map1(%arg0)
-        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
-        %9 = affine.min #map2(%arg1)
-        %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
-        %11 = linalg.init_tensor [%7, %9] : tensor<?x?xf32>
-        %12 = linalg.fill(%cst, %11) {__internal_linalg_transform__ = "workgroup", lowering.config = #config0} : f32, tensor<?x?xf32> -> tensor<?x?xf32>
-        %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %12) -> (tensor<?x?xf32>) {
-          %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
-            %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
-              %16 = affine.min #map3(%arg2)
-              %17 = affine.min #map4(%arg6)
-              %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
-              %19 = affine.min #map5(%arg4)
-              %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
-              %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
-              %22 = affine.min #map6(%21, %arg2)
-              %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
-              %24 = affine.min #map6(%23, %arg4)
-              %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
-              %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
-              %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
-              scf.yield %27 : tensor<?x?xf32>
-            }
-            scf.yield %15 : tensor<?x?xf32>
+func @l1_tiled_matmul() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c32 = arith.constant 32 : index
+  %c24 = arith.constant 24 : index
+  %c144 = arith.constant 144 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c250 = arith.constant 250 : index
+  %c370 = arith.constant 370 : index
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:250x144xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:144x370xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:250x370xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %3 = affine.apply #map0()[%workgroup_id_y]
+  %4 = affine.apply #map0()[%workgroup_count_y]
+  scf.for %arg0 = %3 to %c250 step %4 {
+    %5 = affine.apply #map0()[%workgroup_id_x]
+    %6 = affine.apply #map0()[%workgroup_count_x]
+    scf.for %arg1 = %5 to %c370 step %6 {
+      %7 = affine.min #map1(%arg0)
+      %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [%7, 144], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x144xf32> -> tensor<?x144xf32>
+      %9 = affine.min #map2(%arg1)
+      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [144, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:144x370xf32> -> tensor<144x?xf32>
+      %11 = linalg.init_tensor [%7, %9] : tensor<?x?xf32>
+      %12 = linalg.fill(%cst, %11) {__internal_linalg_transform__ = "workgroup", lowering.config = #config0} : f32, tensor<?x?xf32> -> tensor<?x?xf32>
+      %13 = scf.for %arg2 = %c0 to %c250 step %c32 iter_args(%arg3 = %12) -> (tensor<?x?xf32>) {
+        %14 = scf.for %arg4 = %c0 to %c370 step %c32 iter_args(%arg5 = %arg3) -> (tensor<?x?xf32>) {
+          %15 = scf.for %arg6 = %c0 to %c144 step %c24 iter_args(%arg7 = %arg5) -> (tensor<?x?xf32>) {
+            %16 = affine.min #map3(%arg2)
+            %17 = affine.min #map4(%arg6)
+            %18 = tensor.extract_slice %8[%arg2, %arg6] [%16, %17] [1, 1] : tensor<?x144xf32> to tensor<?x?xf32>
+            %19 = affine.min #map5(%arg4)
+            %20 = tensor.extract_slice %10[%arg6, %arg4] [%17, %19] [1, 1] : tensor<144x?xf32> to tensor<?x?xf32>
+            %21 = tensor.dim %arg7, %c0 : tensor<?x?xf32>
+            %22 = affine.min #map6(%21, %arg2)
+            %23 = tensor.dim %arg7, %c1 : tensor<?x?xf32>
+            %24 = affine.min #map6(%23, %arg4)
+            %25 = tensor.extract_slice %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+            %26 = linalg.matmul {__internal_linalg_transform__ = "workgroup_l1_tile", lowering.config = #config1} ins(%18, %20 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%25 : tensor<?x?xf32>) -> tensor<?x?xf32>
+            %27 = tensor.insert_slice %26 into %arg7[%arg2, %arg4] [%22, %24] [1, 1] : tensor<?x?xf32> into tensor<?x?xf32>
+            scf.yield %27 : tensor<?x?xf32>
           }
-          scf.yield %14 : tensor<?x?xf32>
+          scf.yield %15 : tensor<?x?xf32>
         }
-        flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:250x370xf32>
+        scf.yield %14 : tensor<?x?xf32>
       }
+      flow.dispatch.tensor.store %13, %2, offsets = [%arg0, %arg1], sizes = [%7, %9], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:250x370xf32>
     }
-    return
   }
-  hal.interface private @io  {
-    hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-    hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
-  }
+  return
 }
 
 // CHECK-LABEL: l1_tiled_matmul
@@ -2310,9 +2130,9 @@ module  {
 //    CHECK-DAG: %[[K:.+]] = arith.constant 144 : index
 //    CHECK-DAG: %[[L1_MN_SIZE:.+]] = arith.constant 32 : index
 //    CHECK-DAG: %[[L1_K_SIZE:.+]] = arith.constant 24 : index
-//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%{{.*}}] : memref<250x144xf32>
-//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%{{.*}}] : memref<144x370xf32>
-//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%{{.*}}] : memref<250x370xf32>
+//    CHECK-DAG: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<250x144xf32>
+//    CHECK-DAG: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<144x370xf32>
+//    CHECK-DAG: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<250x370xf32>
 //        CHECK: scf.for %[[WORKGROUP_I:.+]] = %{{.*}} to %[[M]] step %{{.*}} {
 //        CHECK:    scf.for %[[WORKGROUP_J:.+]] = %{{.*}} to %[[N]] step %{{.*}} {
 //    CHECK-DAG:        %[[WORKGROUP_I_SIZE:.+]] = affine.min #{{.*}}(%[[WORKGROUP_I]])
@@ -2339,8 +2159,8 @@ func @sort1D() {
   %c3 = arith.constant 3 : index
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@ro[%c0] : !flow.dispatch.tensor<readonly:4xi32>
-  %1 = hal.interface.binding.subspan @io::@wo[%c0] : !flow.dispatch.tensor<writeonly:4xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:4xi32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:4xi32> -> tensor<4xi32>
   %3 = scf.for %arg0 = %c0 to %c4 step %c1 iter_args(%arg1 = %2) -> (tensor<4xi32>) {
     %4 = scf.for %arg2 = %c0 to %c3 step %c1 iter_args(%arg3 = %arg1) -> (tensor<4xi32>) {
@@ -2362,13 +2182,10 @@ func @sort1D() {
   flow.dispatch.tensor.store %3, %1, offsets = [], sizes = [], strides = [] : tensor<4xi32> -> !flow.dispatch.tensor<writeonly:4xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @ro, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @wo, set=0, binding=1, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @sort1D()
-//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan @io::@ro
-//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan @io::@wo
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK:   linalg.copy(%[[INPUT]], %[[OUTPUT]])
 //       CHECK:   scf.for %[[ARG0:.+]] =
 //       CHECK:     scf.for %[[ARG1:.+]] =
@@ -2379,7 +2196,6 @@ hal.interface private @io  {
 //   CHECK-DAG:         memref.store %[[V1]], %[[OUTPUT]][%[[P1]]]
 //   CHECK-DAG:         memref.store %[[V2]], %[[OUTPUT]][%[[ARG1]]]
 
-
 // -----
 
 func @sort1D_inplace() {
@@ -2387,7 +2203,7 @@ func @sort1D_inplace() {
   %c3 = arith.constant 3 : index
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %0 = hal.interface.binding.subspan @io::@rw[%c0] : !flow.dispatch.tensor<readwrite:4xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readwrite:4xi32>
   %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:4xi32> -> tensor<4xi32>
   %3 = scf.for %arg0 = %c0 to %c4 step %c1 iter_args(%arg1 = %2) -> (tensor<4xi32>) {
     %4 = scf.for %arg2 = %c0 to %c3 step %c1 iter_args(%arg3 = %arg1) -> (tensor<4xi32>) {
@@ -2409,11 +2225,9 @@ func @sort1D_inplace() {
   flow.dispatch.tensor.store %3, %0, offsets = [], sizes = [], strides = [] : tensor<4xi32> -> !flow.dispatch.tensor<readwrite:4xi32>
   return
 }
-hal.interface private @io  {
-  hal.interface.binding @rw, set=0, binding=0, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @sort1D_inplace()
-//   CHECK-DAG:   %[[INOUT:.+]] = hal.interface.binding.subspan @io::@rw
+//   CHECK-DAG:   %[[INOUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
 //       CHECK:   scf.for %[[ARG0:.+]] =
 //       CHECK:     scf.for %[[ARG1:.+]] =
 //   CHECK-DAG:       %[[P1:.+]] = arith.addi %[[ARG1]]
@@ -2425,9 +2239,9 @@ hal.interface private @io  {
 
 // -----
 
-func @iree_linalg_ext.sort_1d() {
+func @iree_linalg_ext_sort_1d() {
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@rw[%c0] : !flow.dispatch.tensor<readwrite:128xi32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readwrite:128xi32>
   %1 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:128xi32> -> tensor<128xi32>
   %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<128xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -2437,8 +2251,9 @@ func @iree_linalg_ext.sort_1d() {
   flow.dispatch.tensor.store %2, %0, offsets = [], sizes = [], strides = [] : tensor<128xi32> -> !flow.dispatch.tensor<readwrite:128xi32>
   return
 }
-// CHECK-LABEL: func @iree_linalg_ext.sort_1d()
-//   CHECK-DAG:   %[[INOUT:.+]] = hal.interface.binding.subspan @io::@rw
+
+// CHECK-LABEL: func @iree_linalg_ext_sort_1d()
+//   CHECK-DAG:   %[[INOUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
 //       CHECK:   iree_linalg_ext.sort
 //  CHECK-SAME:     dimension(0)
 //  CHECK-SAME:     outs(%[[INOUT]] : memref<128xi32>)
@@ -2453,8 +2268,8 @@ builtin.func @tensor_insert_slice() {
   %d1 = hal.interface.load.constant offset = 3 : index
   %d2 = hal.interface.load.constant offset = 4 : index
   %d3 = hal.interface.load.constant offset = 5 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
-  %3 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%d2, %d3}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%d0, %d1}
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>{%d2, %d3}
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_size_y = hal.interface.workgroup.size[1] : index
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -2477,14 +2292,11 @@ builtin.func @tensor_insert_slice() {
   }
   return
 }
-hal.interface @io attributes {push_constants = 2 : index, sym_visibility = "private"} {
-  hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-}
+
 //       CHECK: #[[MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
 //       CHECK: func @tensor_insert_slice()
-//   CHECK-DAG:   %[[SRC:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%{{.+}}] : memref<?x?xi32>
-//   CHECK-DAG:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b1_xw_external[%{{.+}}] : memref<?x?xi32>
+//   CHECK-DAG:   %[[SRC:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xi32>
+//   CHECK-DAG:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xi32>
 //   CHECK-DAG:   %[[OFFSET_Y:.+]] = hal.interface.load.constant offset = 0
 //   CHECK-DAG:   %[[OFFSET_X:.+]] = hal.interface.load.constant offset = 1
 //       CHECK:   scf.for %[[IV0:.+]] =
@@ -2504,9 +2316,9 @@ builtin.func @dynamic_update_slice() {
   %c0_i32 = arith.constant 0 : i32
   %d0 = hal.interface.load.constant offset = 0 : index
   %d1 = hal.interface.load.constant offset = 1 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?xi32>{%d0}
-  %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:i32>
-  %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%d1, %d0}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?xi32>{%d0}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:i32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:?x?xi32>{%d1, %d0}
   %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i32> -> tensor<i32>
   %4 = tensor.extract %3[] : tensor<i32>
   %5 = arith.cmpi slt, %4, %c0_i32 : i32
@@ -2526,14 +2338,10 @@ builtin.func @dynamic_update_slice() {
   }
   return
 }
-hal.interface @io attributes {sym_visibility = "private"} {
-  hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @dynamic_update_slice()
-//   CHECK-DAG:   %[[SRC:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%{{.+}}] : memref<?xi32>
-//   CHECK-DAG:   %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%{{.+}}] : memref<?x?xi32>
+//   CHECK-DAG:   %[[SRC:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?xi32>
+//   CHECK-DAG:   %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xi32>
 //   CHECK-DAG:   %[[OFFSET_Y:.+]] = hal.interface.load.constant offset = 0
 //   CHECK-DAG:   %[[OFFSET_X:.+]] = hal.interface.load.constant offset = 1
 //       CHECK:   scf.for %[[IV0:.+]] =
@@ -2554,10 +2362,10 @@ func @multi_level_tile_fuse() {
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %2 = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:f32>
-  %3 = hal.interface.binding.subspan @io::@arg3[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:f32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
   %4 = flow.dispatch.tensor.load %2, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:f32> -> tensor<f32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -2613,21 +2421,16 @@ func @multi_level_tile_fuse() {
   }
   return
 }
-hal.interface private @io {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @arg3, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @multi_level_tile_fuse()
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[M:.+]] = hal.interface.load.constant offset = 0
 //   CHECK-DAG:   %[[N:.+]] = hal.interface.load.constant offset = 1
 //   CHECK-DAG:   %[[K:.+]] = hal.interface.load.constant offset = 2
-//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0[%[[C0]]] : memref<?x?xf32>{%[[M]], %[[K]]}
-//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1[%[[C0]]] : memref<?x?xf32>{%[[K]], %[[N]]}
-//   CHECK-DAG:   %[[SCALAR:.+]] = hal.interface.binding.subspan @io::@arg2[%[[C0]]] : memref<f32>
-//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan @io::@arg3[%[[C0]]] : memref<?x?xf32>{%[[M]], %[[N]]}
+//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>{%[[M]], %[[K]]}
+//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>{%[[K]], %[[N]]}
+//   CHECK-DAG:   %[[SCALAR:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<f32>
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<?x?xf32>{%[[M]], %[[N]]}
 //       CHECK:   scf.for
 //       CHECK:     scf.for
 //   CHECK-DAG:       %[[LHS_SUBVIEW1:.+]] = memref.subview %[[LHS]]
@@ -2660,10 +2463,10 @@ func @operand_fusion() {
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %2 = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:f32>
-  %3 = hal.interface.binding.subspan @io::@arg3[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:f32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
   %4 = flow.dispatch.tensor.load %2, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:f32> -> tensor<f32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -2697,21 +2500,15 @@ func @operand_fusion() {
   }
   return
 }
-hal.interface private @io {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
-  hal.interface.binding @arg3, set=0, binding=3, type="StorageBuffer"
-}
+
 // CHECK-LABEL: func @operand_fusion()
-//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[M:.+]] = hal.interface.load.constant offset = 0
 //   CHECK-DAG:   %[[N:.+]] = hal.interface.load.constant offset = 1
 //   CHECK-DAG:   %[[K:.+]] = hal.interface.load.constant offset = 2
-//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0[%[[C0]]] : memref<?x?xf32>{%[[M]], %[[K]]}
-//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1[%[[C0]]] : memref<?x?xf32>{%[[K]], %[[N]]}
-//   CHECK-DAG:   %[[SCALAR:.+]] = hal.interface.binding.subspan @io::@arg2[%[[C0]]] : memref<f32>
-//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan @io::@arg3[%[[C0]]] : memref<?x?xf32>{%[[M]], %[[N]]}
+//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>{%[[M]], %[[K]]}
+//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>{%[[K]], %[[N]]}
+//   CHECK-DAG:   %[[SCALAR:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<f32>
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<?x?xf32>{%[[M]], %[[N]]}
 //       CHECK:   scf.for
 //       CHECK:     scf.for
 //   CHECK-DAG:       %[[LHS_SUBVIEW1:.+]] = memref.subview %[[LHS]]
@@ -2730,8 +2527,7 @@ hal.interface private @io {
 #map_dist = affine_map<()[s0, s1] -> (s0 * s1)>
 #map_min = affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>
 #map_indexing = affine_map<(d0, d1) -> (d0, d1)>
-func @two_level_tile_and_fuse()
-{
+func @two_level_tile_and_fuse() {
   %c0 = arith.constant 0 : index
   %c8 = arith.constant 8 : index
   %c16 = arith.constant 16 : index
@@ -2739,10 +2535,10 @@ func @two_level_tile_and_fuse()
   %m = hal.interface.load.constant offset = 0 : index
   %n = hal.interface.load.constant offset = 1 : index
   %k = hal.interface.load.constant offset = 2 : index
-  %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
-  %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
-  %bias = hal.interface.binding.subspan @io::@arg2[%c0] : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %n}
-  %result = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
+  %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %k}
+  %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:?x?xf32>{%k, %n}
+  %bias = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:?x?xf32>{%m, %n}
+  %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:?x?xf32>{%m, %n}
   %id_x = hal.interface.workgroup.id[0] : index
   %count_x = hal.interface.workgroup.count[0] : index
   %size_x = hal.interface.workgroup.size[0] : index
@@ -2793,11 +2589,12 @@ func @two_level_tile_and_fuse()
   }
   return
 }
+
 // CHECK-LABEL: func @two_level_tile_and_fuse()
-//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan @io::@arg0
-//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan @io::@arg1
-//   CHECK-DAG:   %[[BIAS:.+]] = hal.interface.binding.subspan @io::@arg2
-//   CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan @io::@ret0
+//   CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//   CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//   CHECK-DAG:   %[[BIAS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//   CHECK-DAG:   %[[RESULT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3)
 //       CHECK:   scf.for %[[IV0:[a-zA-Z0-9]+]] =
 //       CHECK:     scf.for %[[IV1:[a-zA-Z0-9]+]] =
 //   CHECK-DAG:       %[[LHS_TILE:.+]] = memref.subview %[[LHS]][%[[IV0]], 0]

--- a/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -4,10 +4,9 @@
 // CHECK-LABEL: func @dispatch_0()
 hal.executable private @dispatch_0  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dispatch_0 attributes {
-      interface = @io,
-      ordinal = 0 : index,
-      workgroup_size = [64: index, 1: index, 1:index]}
+    hal.executable.entry_point @dispatch_0 interface(@io) {
+      workgroup_size = [64: index, 1: index, 1:index]
+    }
     builtin.module {
       builtin.func @dispatch_0() {
         %c2 = arith.constant 2 : index
@@ -45,9 +44,7 @@ hal.executable private @dispatch_0  {
 #translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [32]>
 hal.executable private @workgroup_tile_loop  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop attributes {
-      interface = @io,
-      ordinal = 0 : index,
+    hal.executable.entry_point @workgroup_tile_loop interface(@io) {
       translation.info = #translation
     }
     builtin.module {
@@ -75,9 +72,7 @@ hal.executable private @workgroup_tile_loop  {
 #translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [16]>
 hal.executable private @workgroup_tile_loop_negative  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop_negative attributes {
-      interface = @io,
-      ordinal = 0 : index,
+    hal.executable.entry_point @workgroup_tile_loop_negative interface(@io) {
       translation.info = #translation
     }
     builtin.module {
@@ -107,8 +102,7 @@ hal.executable private @workgroup_tile_loop_negative  {
 #translation = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [32, 8, 1]>
 hal.executable private @both_workgroup_and_workitem  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @both_workgroup_and_workitem attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @both_workgroup_and_workitem interface(@io) {
       translation.info = #translation,
       workgroup_size = [8: index, 2: index, 1: index]
     }

--- a/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -81,9 +81,9 @@ static Value getSubspanBuffer(Value tensor, OpBuilder &b,
     // Just change the result type of the InterfaceBindingSubspanOp.
     auto memRefType = getMemrefTypeForTensor(shapedType);
     Value baseBuffer = b.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        subspanOp->getLoc(), memRefType, subspanOp.binding(),
-        subspanOp.byte_offset(), subspanOp.byte_length(),
-        subspanOp.dynamic_dims(), subspanOp.alignmentAttr());
+        subspanOp->getLoc(), memRefType, subspanOp.type(), subspanOp.set(),
+        subspanOp.binding(), subspanOp.byte_offset(), subspanOp.dynamic_dims(),
+        subspanOp.alignmentAttr());
     flowState.subspan_to_buffer[tensor] = baseBuffer;
   }
 

--- a/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
@@ -9,11 +9,11 @@ func @binding_ptrs() {
 
   // CHECK: %[[STATE:.+]] = llvm.load %arg0 : !llvm.ptr<struct<[[DISPATCH_STATE_TYPE:.+]]>>
   // CHECK: %[[PC:.+]] = llvm.extractvalue %[[STATE]][3] : !llvm.struct<[[DISPATCH_STATE_TYPE]]>
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK: %[[DIM_PTR:.+]] = llvm.getelementptr %[[PC]][%[[C0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : i64) : i64
+  // CHECK: %[[DIM_PTR:.+]] = llvm.getelementptr %[[PC]][%[[C2]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
   // CHECK: %[[DIM_I32:.+]] = llvm.load %[[DIM_PTR]] : !llvm.ptr<i32>
   // CHECK: %[[DIM:.+]] = llvm.zext %[[DIM_I32]] : i32 to i64
-  %dim = hal.interface.load.constant offset = 0 : index
+  %dim = hal.interface.load.constant offset = 2 : index
 
   // CHECK: %[[STATE:.+]] = llvm.load %arg0 : !llvm.ptr<struct<[[DISPATCH_STATE_TYPE]]>>
   // CHECK: %[[BINDING_PTRS:.+]] = llvm.extractvalue %[[STATE]][5] : !llvm.struct<[[DISPATCH_STATE_TYPE]]>
@@ -36,7 +36,7 @@ func @binding_ptrs() {
   // CHECK: %[[DIM1:.+]] = llvm.extractvalue %[[DESC_G]][3, 1]
   // CHECK: %[[STRIDE0:.+]] = llvm.mul %[[STRIDE1]], %[[DIM1]]  : i64
   // CHECK: %[[DESC_H:.+]] = llvm.insertvalue %[[STRIDE0]], %[[DESC_G]][4, 0]
-  %memref = hal.interface.binding.subspan @io::@ret0[%c72] : memref<?x2xf32>{%dim}
+  %memref = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) offset(%c72) : memref<?x2xf32>{%dim}
 
   // CHECK: %[[VAL:.+]] = llvm.load
   %c0 = arith.constant 0 : index
@@ -45,8 +45,4 @@ func @binding_ptrs() {
   // CHECK: llvm.call @sink(%[[VAL]])
   llvm.call @sink(%val) : (f32) -> ()
   return
-}
-hal.interface private @io attributes {push_constants = 2 : index} {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
 }

--- a/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -9,10 +9,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -40,10 +38,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -71,10 +67,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -102,10 +96,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -133,10 +125,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {
@@ -164,10 +154,8 @@ hal.executable private @matmul_tensors  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.entry_point @illegal attributes {
-      translation.info = #translation,
-      interface = @io,
-      ordinal = 0 : index
+    hal.executable.entry_point @illegal interface(@io) {
+      translation.info = #translation
     }
     builtin.module {
       func @illegal() {

--- a/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -17,9 +17,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{expected 2 entries for workload_per_wg, but got 0}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
@@ -48,9 +48,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{invalid to use 0 in workload_per_wg}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
@@ -79,9 +79,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{workload_per_wg size should be less than 3}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
@@ -110,9 +110,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{expected three levels of tile sizes for CPUTensorToVectors, got 0}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
@@ -141,9 +141,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{mismatch in distributed tile size value 4 at position 0 and workload_per_wg value 6}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
@@ -172,9 +172,9 @@ hal.executable private @matmul_tensors  {
     builtin.module {
       func @illegal() {
         %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan @io::@arg1[%c0] : memref<8x16xf32>
-        %result = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x16xf32>
+        %lhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<4x16xf32>
         // expected-error @+1 {{native_vector_size must be same as the last level of tiling}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)

--- a/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/materialize_launch_configuration.mlir
@@ -11,10 +11,7 @@ hal.executable private @matmul_tensors  {
        native_vector_size = 16 : index,
        target_triple = "aarch64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point @matmul_tensors attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
+    hal.executable.entry_point @matmul_tensors interface(@io)
     builtin.module {
       func @matmul_tensors() {
         %c0 = arith.constant 0 : index
@@ -81,11 +78,8 @@ hal.executable private @add_no_config  {
        native_vector_size = 16 : index,
        target_triple = "x86_64-unknown-linux-gnu"
     }> {
-    hal.executable.entry_point @add_no_config attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    builtin.module  {
+    hal.executable.entry_point @add_no_config interface(@io)
+    builtin.module {
       func @add_no_config() {
         %c0 = arith.constant 0 : index
         %dim0 = hal.interface.load.constant offset = 0 : index
@@ -139,10 +133,8 @@ hal.executable private @add4D  {
        native_vector_size = 16 : index,
        target_triple = "x86_64-unknown-linux-gnu"
     }> {
-    hal.executable.entry_point @add4D attributes {
-      interface = @io, ordinal = 0 : index
-    }
-    builtin.module  {
+    hal.executable.entry_point @add4D interface(@io)
+    builtin.module {
       func @add4D() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.load.constant offset = 0 : index
@@ -220,11 +212,8 @@ hal.executable private @batch_matmul_tensors {
        native_vector_size = 16 : index,
        target_triple = "aarch64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point @batch_matmul_tensors attributes {
-      interface = @io,
-      ordinal = 0 : index
-    }
-    builtin.module  {
+    hal.executable.entry_point @batch_matmul_tensors interface(@io)
+    builtin.module {
       func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
@@ -297,8 +286,8 @@ hal.executable private @batch_matmul_tensors {
     workgroup_size = []>
 hal.executable private @preset_config_matmul_tensors  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @preset_config attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @preset_config interface(@io)
+    builtin.module {
       builtin.func @preset_config() {
         %c0 = arith.constant 0 : index
         %c512 = arith.constant 512 : index
@@ -375,8 +364,8 @@ hal.executable private @preset_config_matmul_tensors  {
 
 hal.executable @tensor_insert {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @tensor_insert_slice attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @tensor_insert_slice interface(@io)
+    builtin.module {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>
@@ -430,7 +419,7 @@ hal.executable private @static_1d_fft_stage2  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_1d_fft_stage2 interface(@io)
     builtin.module {
       builtin.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -473,7 +462,7 @@ hal.executable private @static_3d_fft_stage3  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_3d_fft_stage3 interface(@io)
     builtin.module {
       builtin.func @static_3d_fft_stage3() {
         %c0 = arith.constant 0 : index
@@ -545,7 +534,7 @@ hal.executable private @outs_fusion {
     hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.entry_point @outs_fusion_fn attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @outs_fusion_fn interface(@io)
     builtin.module {
       builtin.func @outs_fusion_fn() {
         %c0 = arith.constant 0 : index
@@ -609,8 +598,8 @@ hal.executable private @outs_fusion {
 
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-linux-gnu"}> {
-    hal.executable.entry_point public @conv attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv interface(@io)
+    builtin.module {
       func @conv() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.load.constant offset = 0 : index
@@ -668,7 +657,7 @@ hal.executable private @conv {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64, 64]>
-//      CHECK: hal.executable.entry_point public @conv attributes
+//      CHECK: hal.executable.entry_point public @conv
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
 //  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]
@@ -682,8 +671,8 @@ hal.executable private @conv {
 
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-pc-linux-gnu"}> {
-    hal.executable.entry_point public @conv_static attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv_static interface(@io)
+    builtin.module {
       func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
         %c80 = arith.constant 80 : index
@@ -740,7 +729,7 @@ hal.executable private @conv_static {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 64, 32]>
-//      CHECK: hal.executable.entry_point public @conv_static attributes
+//      CHECK: hal.executable.entry_point public @conv_static
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
 //  CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]
@@ -754,8 +743,8 @@ hal.executable private @conv_static {
 
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-pc-linux-gnu"}> {
-    hal.executable.entry_point public @generic_static attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @generic_static interface(@io)
+    builtin.module {
       func @generic_static() {
         %c16 = arith.constant 16 : index
         %c96 = arith.constant 96 : index
@@ -796,7 +785,7 @@ hal.executable private @generic_static {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [32, 8]>
-//      CHECK: hal.executable.entry_point public @generic_static attributes
+//      CHECK: hal.executable.entry_point public @generic_static
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -810,8 +799,8 @@ hal.executable private @generic_static {
 
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @matmul_static attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_static interface(@io)
+    builtin.module {
       func @matmul_static() {
         %cst = arith.constant 0.000000e+00 : f32
         %c196 = arith.constant 196 : index
@@ -854,7 +843,7 @@ hal.executable private @matmul_static {
 //   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 28)>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUTileFuseAndVectorize", workload_per_wg = [8, 28]>
-//       CHECK: hal.executable.entry_point public @matmul_static attributes
+//       CHECK: hal.executable.entry_point public @matmul_static
 //  CHECK-SAME:     translation.info = #[[TRANSLATION]]
 //  CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
 //   CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -868,8 +857,8 @@ hal.executable private @matmul_static {
 
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @restrict_num_workgroups attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @restrict_num_workgroups interface(@io)
+    builtin.module {
       func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
         %c7 = arith.constant 7 : index
@@ -923,7 +912,7 @@ hal.executable private @restrict_num_workgroups {
 //   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
 //   CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64, 8, 4]>
-//       CHECK: hal.executable.entry_point public @restrict_num_workgroups attributes
+//       CHECK: hal.executable.entry_point public @restrict_num_workgroups
 //  CHECK-SAME:     translation.info = #[[TRANSLATION]]
 //  CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index, %[[ARG1:[a-zA-Z0-9]+]]: index, %[[ARG2:[a-zA-Z0-9]+]]: index)
 //   CHECK-DAG:     %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
@@ -935,8 +924,8 @@ hal.executable private @restrict_num_workgroups {
 
 hal.executable private @test_exp_0 {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @test_exp_0 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @test_exp_0 interface(@io)
+    builtin.module {
       func @test_exp_0() {
         %c0 = arith.constant 0 : index
         %size = hal.interface.workgroup.size[0] : index
@@ -961,7 +950,7 @@ hal.executable private @test_exp_0 {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
-//      CHECK: hal.executable.entry_point public @test_exp_0 attributes
+//      CHECK: hal.executable.entry_point public @test_exp_0
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -972,8 +961,8 @@ hal.executable private @test_exp_0 {
 
 hal.executable private @test_exp_1 {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @test_exp_1 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @test_exp_1 interface(@io)
+    builtin.module {
       func @test_exp_1() {
         %c0 = arith.constant 0 : index
         %size = hal.interface.workgroup.size[0] : index
@@ -998,7 +987,7 @@ hal.executable private @test_exp_1 {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECk-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
-//      CHECK: hal.executable.entry_point public @test_exp_1 attributes
+//      CHECK: hal.executable.entry_point public @test_exp_1
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -1009,8 +998,8 @@ hal.executable private @test_exp_1 {
 
 hal.executable private @test_exp_2 {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @test_exp_3 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @test_exp_3 interface(@io)
+    builtin.module {
       func @test_exp_3() {
         %c0 = arith.constant 0 : index
         %size = hal.interface.workgroup.size[0] : index
@@ -1035,7 +1024,7 @@ hal.executable private @test_exp_2 {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
-//      CHECK: hal.executable.entry_point public @test_exp_3 attributes
+//      CHECK: hal.executable.entry_point public @test_exp_3
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -1046,8 +1035,8 @@ hal.executable private @test_exp_2 {
 
 hal.executable private @test_exp_3 {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @test_exp_4 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @test_exp_4 interface(@io)
+    builtin.module {
       func @test_exp_4() {
         %c0 = arith.constant 0 : index
         %size = hal.interface.workgroup.size[0] : index
@@ -1072,7 +1061,7 @@ hal.executable private @test_exp_3 {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
-//      CHECK: hal.executable.entry_point public @test_exp_4 attributes
+//      CHECK: hal.executable.entry_point public @test_exp_4
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -1083,8 +1072,8 @@ hal.executable private @test_exp_3 {
 
 hal.executable private @test_exp_4 {
   hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}> {
-    hal.executable.entry_point public @test_exp_5 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @test_exp_5 interface(@io)
+    builtin.module {
       func @test_exp_5() {
         %c0 = arith.constant 0 : index
         %size = hal.interface.workgroup.size[0] : index
@@ -1109,7 +1098,7 @@ hal.executable private @test_exp_4 {
 
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"CPUDefault", workload_per_wg = [64]>
-//      CHECK: hal.executable.entry_point public @test_exp_5 attributes
+//      CHECK: hal.executable.entry_point public @test_exp_5
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
@@ -1126,8 +1115,8 @@ hal.executable private @matmul_x86  {
           native_vector_size = 16 : index,
           target_triple = "x86_64-unknown-unknown-eabi-elf"
     }> {
-    hal.executable.entry_point public @matmul_x86 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_x86 interface(@io)
+    builtin.module {
       func @matmul_x86() {
         %c128 = arith.constant 128 : index
         %c384 = arith.constant 384 : index

--- a/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
@@ -11,7 +11,7 @@ hal.executable private @mmt4d_384x384x512_4x1x4_dispatch_0 {
       hal.interface.binding public @s0b2_rw_external, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant public @embedded_elf_arm_64, target = #executable_target_embedded_elf_arm_64_ {
-      hal.executable.entry_point public @mmt4d_384x384x512_4x1x4_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+      hal.executable.entry_point public @mmt4d_384x384x512_4x1x4_dispatch_0 interface(@io)
       builtin.module  {
         func @mmt4d_384x384x512_4x1x4_dispatch_0() {
           %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
@@ -17,9 +17,9 @@ hal.executable private @mmt4d_384x384x512_4x1x4_dispatch_0 {
           %c0 = arith.constant 0 : index
           %c96 = arith.constant 96 : index
           %c128 = arith.constant 128 : index
-          %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:96x384x4x1xf32>
-          %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:128x384x4x1xf32>
-          %2 = hal.interface.binding.subspan @io::@s0b2_rw_external[%c0] : !flow.dispatch.tensor<readwrite:96x128x4x4xf32>
+          %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:96x384x4x1xf32>
+          %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:128x384x4x1xf32>
+          %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readwrite:96x128x4x4xf32>
           %workgroup_size_x = hal.interface.workgroup.size[0] : index
           %workgroup_size_y = hal.interface.workgroup.size[1] : index
           %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -42,11 +42,6 @@ hal.executable private @mmt4d_384x384x512_4x1x4_dispatch_0 {
             }
           }
           return
-        }
-        hal.interface private @io {
-          hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-          hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-          hal.interface.binding public @s0b2_rw_external, set=0, binding=2, type="StorageBuffer"
         }
       }
     }

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_and_vectorize.mlir
@@ -13,9 +13,9 @@ module  {
     %c513 = arith.constant 513 : index
     %c383 = arith.constant 383 : index
     %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x383xf32>
-    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x513xf32>
-    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:383x513xf32>
+    %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:383x383xf32>
+    %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:383x513xf32>
+    %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:383x513xf32>
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %workgroup_count_x = hal.interface.workgroup.count[0] : index
     %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -40,12 +40,8 @@ module  {
     }
     return
   }
-  hal.interface private @io  {
-    hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-    hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
-  }
 }
+
 //      CHECK: #[[MAP1:.+]] = affine_map<(d0) -> (64, -d0 + 383)>
 //      CHECK: #[[MAP2:.+]] = affine_map<(d0) -> (64, -d0 + 513)>
 //      CHECK: #[[MAP5:.+]] = affine_map<(d0, d1) -> (32, -d0 + d1)>
@@ -57,9 +53,9 @@ module  {
 //  CHECK-DAG: %[[C383:.+]] = arith.constant 383 : index
 //  CHECK-DAG: %[[C513:.+]] = arith.constant 513 : index
 //  CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
-//      CHECK: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x383xf32>
-//      CHECK: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:383x513xf32>
-//      CHECK: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:383x513xf32>
+//      CHECK: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:383x383xf32>
+//      CHECK: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:383x513xf32>
+//      CHECK: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:383x513xf32>
 //      CHECK: scf.for %[[I_WG_IDX:.+]] = {{.*}} to %c383
 //      CHECK: scf.for %[[J_WG_IDX:.+]] = {{.*}} to %c513
 //      CHECK: %[[LHS_WG_TILE_DIM0:.+]] = affine.min #[[MAP1]](%[[I_WG_IDX]])

--- a/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/tile_fuse_and_vectorize.mlir
@@ -10,9 +10,9 @@ module  {
     %cst = arith.constant 0.000000e+00 : f32
     %c384 = arith.constant 384 : index
     %c128 = arith.constant 128 : index
-    %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:384x512xf32>
-    %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x128xf32>
-    %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:384x128xf32>
+    %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:384x512xf32>
+    %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:512x128xf32>
+    %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:384x128xf32>
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %workgroup_count_x = hal.interface.workgroup.count[0] : index
     %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -38,12 +38,8 @@ module  {
     }
     return
   }
-  hal.interface private @io {
-    hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-    hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
-  }
 }
+
 //      CHECK: #[[MAP:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //      CHECK: func @dot_384x512x128_dispatch_0() {
 //  CHECK-DAG: %[[CST:.+]] = arith.constant 0.000000e+00 : f32
@@ -55,9 +51,9 @@ module  {
 //  CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
 //  CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
 //  CHECK-DAG: %[[C64:.+]] = arith.constant 64 : index
-//      CHECK: %[[LHS:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:384x512xf32>
-//      CHECK: %[[RHS:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x128xf32>
-//      CHECK: %[[DST:.+]] = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:384x128xf32>
+//      CHECK: %[[LHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:384x512xf32>
+//      CHECK: %[[RHS:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:512x128xf32>
+//      CHECK: %[[DST:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:384x128xf32>
 //      CHECK: %[[DST_TILE_INIT:.+]] = linalg.init_tensor
 //      CHECK: scf.for %[[I_IDX:.+]] = {{.*}} to %[[C384]] step %{{[0-9]*}} {
 //      CHECK:   %[[LHS_TILE:.+]] = flow.dispatch.tensor.load %[[LHS]], {{.*}} -> tensor<64x512xf32>
@@ -90,12 +86,12 @@ func @matmul_gather() {
   %c1835008 = arith.constant 1835008 : index
   %c0 = arith.constant 0 : index
   %c64 = arith.constant 64 : index
-  %0 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:384xi32>
-  %1 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:384x512xf32>
-  %2 = hal.interface.binding.subspan @io::@s0b3_ro_external[%c0] : !flow.dispatch.tensor<readonly:384x384xf32>
-  %3 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:384x512xf32>
-  %4 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c1835008] : !flow.dispatch.tensor<readonly:2x512xf32>
-  %5 = hal.interface.binding.subspan @io::@s0b4_xw_external[%c0] : !flow.dispatch.tensor<writeonly:384x512xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:384xi32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:384x512xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:384x384xf32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<readonly:384x512xf32>
+  %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) offset(%c1835008) : !flow.dispatch.tensor<readonly:2x512xf32>
+  %5 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(5) : !flow.dispatch.tensor<writeonly:384x512xf32>
   %6 = flow.dispatch.tensor.load %4, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:2x512xf32> -> tensor<2x512xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -157,13 +153,13 @@ func @nonvectorizable_matmul_and_vectorizable_generic() {
   %c0 = arith.constant 0 : index
   %c49 = arith.constant 49 : index
   %c16 = arith.constant 16 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c768] : !flow.dispatch.tensor<readonly:96xf32>
-  %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:96xf32>
-  %2 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c1152] : !flow.dispatch.tensor<readonly:96xf32>
-  %3 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c384] : !flow.dispatch.tensor<readonly:96xf32>
-  %4 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:784x24xf32>
-  %5 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:24x96xf32>
-  %6 = hal.interface.binding.subspan @io::@s0b3_xw_external[%c0] : !flow.dispatch.tensor<writeonly:784x96xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c768) : !flow.dispatch.tensor<readonly:96xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c0) : !flow.dispatch.tensor<readonly:96xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c1152) : !flow.dispatch.tensor<readonly:96xf32>
+  %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c384) : !flow.dispatch.tensor<readonly:96xf32>
+  %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:784x24xf32>
+  %5 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:24x96xf32>
+  %6 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:784x96xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -3,9 +3,9 @@
 // Test that that standard and GPU ops are converted to LLVM and NVVM.
 func @abs_ex_dispatch_0() {
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<16xf32>
-  %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<16xf32>
-  %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<16xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<16xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<16xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<16xf32>
   %3 = "gpu.block_id"() {dimension = "x"} : () -> index
   %4 = "gpu.block_dim"() {dimension = "x"} : () -> index
   %5 = "gpu.thread_id"() {dimension = "x"} : () -> index
@@ -16,11 +16,6 @@ func @abs_ex_dispatch_0() {
   %11 = arith.addf %9, %10 : f32
   memref.store %11, %0[%7] : memref<16xf32>
   return
-}
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
 }
 
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0

--- a/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -10,11 +10,10 @@
 #map4 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 hal.executable private @dot_dispatch_0  {
 hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-  hal.executable.entry_point @dot_dispatch_0 attributes {
-    interface = @legacy_io,
-    ordinal = 0 : index,
+  hal.executable.entry_point @dot_dispatch_0 interface(@io) {
     translation.info = #translation,
-    workgroup_size = [64 : index, 1 : index, 1 : index]}
+    workgroup_size = [64 : index, 1 : index, 1 : index]
+  }
   builtin.module {
     builtin.func @dot_dispatch_0() {
       %cst = arith.constant 0.000000e+00 : f32
@@ -85,11 +84,10 @@ hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
 // Pure reducion case, skip tiling.
 hal.executable @reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @predict_dispatch_153 attributes {
-      interface = @io,
-      ordinal = 0 : index,
+    hal.executable.entry_point @predict_dispatch_153 interface(@io) {
       translation.info = #translation,
-      workgroup_size = [1: index, 1: index, 1: index]}
+      workgroup_size = [1: index, 1: index, 1: index]
+    }
     builtin.module  {
       builtin.func @predict_dispatch_153() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -15,14 +15,14 @@ hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
     ordinal = 0 : index,
     translation.info = #translation,
     workgroup_size = [64 : index, 1 : index, 1 : index]}
-  builtin.module  {
+  builtin.module {
     builtin.func @dot_dispatch_0() {
       %cst = arith.constant 0.000000e+00 : f32
       %c0 = arith.constant 0 : index
       %c1024 = arith.constant 1024 : index
-      %0 = hal.interface.binding.subspan @legacy_io::@ro0[%c0] : memref<1024x1024xf32>
-      %1 = hal.interface.binding.subspan @legacy_io::@ro1[%c0] : memref<1024x1024xf32>
-      %2 = hal.interface.binding.subspan @legacy_io::@wo2[%c0] : memref<1024x1024xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<1024x1024xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<1024x1024xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<1024x1024xf32>
       %workgroup_size_x = hal.interface.workgroup.size[0] : index
       %workgroup_size_y = hal.interface.workgroup.size[1] : index
       %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -49,11 +49,6 @@ hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
         }
       }
       return
-    }
-    hal.interface private @legacy_io  {
-      hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-      hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-      hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
     }
   }
 }
@@ -100,8 +95,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0x7FC00000 : f32
         %cst_0 = arith.constant 0xFF800000 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<1000xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<f32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<1000xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<f32>
         linalg.fill(%cst_0, %1) {lowering.config = #config}  : f32, memref<f32>
         linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%0 : memref<1000xf32>) outs(%1 : memref<f32>) attrs = {lowering.config = #config} {
         ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
@@ -113,13 +108,10 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
         }
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-      }
     }
   }
 }
+
 //      CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[]{{\]}}, native_vector_size = []>
 //      CHECK: hal.executable public @reduction_dispatch
 //      CHECK: linalg.fill

--- a/iree/compiler/Codegen/LLVMGPU/test/distribute_wg_copy.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/distribute_wg_copy.mlir
@@ -9,10 +9,9 @@
 
 hal.executable private @shared_mem_cpy  {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @shared_mem_cpy attributes {
-      interface = @io,
-      ordinal = 0 : index,
-      workgroup_size = [32: index, 4: index, 1:index]}
+    hal.executable.entry_point @shared_mem_cpy interface(@io) {
+      workgroup_size = [32: index, 4: index, 1:index]
+    }
     builtin.module  {
       memref.global "private" @__shared_memory___1 : memref<3x512xf32, 3>
       memref.global "private" @__shared_memory___0 : memref<256x4xf32, 3>

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -10,9 +10,9 @@ hal.executable @add_dispatch_0 {
   builtin.module  {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:16384xf32>
-      %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:16384xf32>
-      %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:16384xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16384xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:16384xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:16384xf32>
       %3 = linalg.init_tensor [16384] : tensor<16384xf32>
       %4 = flow.dispatch.tensor.load %0, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16384xf32> -> tensor<16384xf32>
       %5 = flow.dispatch.tensor.load %1, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16384xf32> -> tensor<16384xf32>
@@ -23,11 +23,6 @@ hal.executable @add_dispatch_0 {
         } -> tensor<16384xf32>
         flow.dispatch.tensor.store %6, %2, offsets=[], sizes=[], strides=[] : tensor<16384xf32> -> !flow.dispatch.tensor<writeonly:16384xf32>
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -58,9 +53,9 @@ hal.executable private @dot_dispatch_1  {
         %c4 = arith.constant 4 : index
         %c2 = arith.constant 2 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : memref<2x3xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : memref<3x4xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : memref<2x4xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<2x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x4xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<2x4xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -84,14 +79,10 @@ hal.executable private @dot_dispatch_1  {
         }
         return
       }
-      hal.interface private @legacy_io  {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
+
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[4, 2, 4]{{\]}}, native_vector_size = []>
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 2)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
@@ -122,8 +113,8 @@ hal.executable @reduction_dispatch {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0x7FC00000 : f32
         %cst_0 = arith.constant 0xFF800000 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<1000xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<f32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<1000xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<f32>
         linalg.fill(%cst_0, %1) : f32, memref<f32>
         linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>], iterator_types = ["reduction"]} ins(%0 : memref<1000xf32>) outs(%1 : memref<f32>) {
         ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
@@ -134,10 +125,6 @@ hal.executable @reduction_dispatch {
           linalg.yield %5 : f32
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
       }
     }
   }
@@ -164,10 +151,10 @@ hal.executable @tensor_insert {
     builtin.module  {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>
         %1 = hal.interface.load.constant offset = 0 : index
         %2 = hal.interface.load.constant offset = 1 : index
-        %3 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -192,13 +179,10 @@ hal.executable @tensor_insert {
         }
         return
       }
-      hal.interface @io attributes {push_constants = 2 : index, sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-      }
     }
   }
 }
+
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUDistribute", workload_per_wg = [128, 1]>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
@@ -219,8 +203,8 @@ hal.executable @tensor_insert {
         %c0 = arith.constant 0 : index
         %d0 = hal.interface.load.constant offset = 0 : index
         %d1 = hal.interface.load.constant offset = 1 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<?x?xi32>{%d0, %d1}
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<?x?xi32>{%d0, %d1}
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xi32>{%d0, %d1}
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xi32>{%d0, %d1}
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -247,6 +231,7 @@ hal.executable @tensor_insert {
     }
   }
 }
+
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[1, 256]{{\]}}, native_vector_size = []>
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 256)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUVectorize", workload_per_wg = [256, 1]>
@@ -275,8 +260,8 @@ hal.executable private @static_1d_fft_stage2  {
         %c2 = arith.constant 2 : index
         %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
         %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
-        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readwrite:32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readwrite:32xf32>
         %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
         %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
         %4:2 = iree_linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
@@ -324,8 +309,8 @@ hal.executable private @static_3d_fft_stage3  {
         %cst_0 = arith.constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
         %0 = bufferization.to_memref %cst_0 : memref<4xf32>
         %1 = bufferization.to_memref %cst : memref<4xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<64x128x32xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<64x128x32xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<64x128x32xf32>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -382,9 +367,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
       %c128 = arith.constant 128 : index
       %c1024 = arith.constant 1024 : index
       %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:128x256xf32>
-      %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf32>
-      %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:128x1024xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:128x256xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:256x1024xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:128x1024xf32>
       %workgroup_size_x = hal.interface.workgroup.size[0] : index
       %workgroup_size_y = hal.interface.workgroup.size[1] : index
       %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -412,11 +397,6 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
         }
       }
       return
-    }
-    hal.interface private @io {
-      hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-      hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-      hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
     }
   }
 }
@@ -449,10 +429,10 @@ hal.executable private @sort_op {
         %c1 = arith.constant 1 : index
         %c0 = arith.constant 0 : index
         %c2304000 = arith.constant 2304000 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0[%c0] {alignment = 32 : index} : !flow.dispatch.tensor<readonly:1x576000xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1[%c0] {alignment = 32 : index} : !flow.dispatch.tensor<readonly:1x576000xi32>
-        %2 = hal.interface.binding.subspan @io::@s0b2[%c0] {alignment = 32 : index} : !flow.dispatch.tensor<writeonly:1x576000xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b3[%c2304000] {alignment = 32 : index} : !flow.dispatch.tensor<writeonly:1x576000xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) alignment(32) : !flow.dispatch.tensor<readonly:1x576000xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) alignment(32) : !flow.dispatch.tensor<readonly:1x576000xi32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) alignment(32) : !flow.dispatch.tensor<writeonly:1x576000xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) offset(%c2304000) alignment(32) : !flow.dispatch.tensor<writeonly:1x576000xi32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -471,12 +451,6 @@ hal.executable private @sort_op {
           flow.dispatch.tensor.store %9#1, %3, offsets = [%arg0, 0], sizes = [%6, 576000], strides = [1, 1] : tensor<?x576000xi32> -> !flow.dispatch.tensor<writeonly:1x576000xi32>
         }
         return
-      }
-      hal.interface private @io attributes {push_constants = 0 : index} {
-        hal.interface.binding public @s0b0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding public @s0b3, set=0, binding=3, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -6,8 +6,8 @@ hal.executable @add_dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @add_dispatch_0 interface(@io)
+  builtin.module {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
       %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16384xf32>
@@ -46,8 +46,8 @@ hal.executable @add_dispatch_0 {
 
 hal.executable private @dot_dispatch_1  {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_1 attributes {interface = @legacy_io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @dot_dispatch_1 interface(@io)
+    builtin.module {
       func @dot_dispatch_1() {
         %c0 = arith.constant 0 : index
         %c4 = arith.constant 4 : index
@@ -105,10 +105,8 @@ hal.executable private @dot_dispatch_1  {
 
 hal.executable @reduction_dispatch {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @predict_dispatch_153 attributes {
-      interface = @io,
-      ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @predict_dispatch_153 interface(@io)
+    builtin.module {
       func @predict_dispatch_153() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0x7FC00000 : f32
@@ -147,8 +145,8 @@ hal.executable @reduction_dispatch {
 
 hal.executable @tensor_insert {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @tensor_insert_slice attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @tensor_insert_slice interface(@io)
+    builtin.module {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>
@@ -197,8 +195,8 @@ hal.executable @tensor_insert {
 
 hal.executable @tensor_insert {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @tensor_insert_slice attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @tensor_insert_slice interface(@io)
+    builtin.module {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
         %d0 = hal.interface.load.constant offset = 0 : index
@@ -253,7 +251,7 @@ hal.executable private @static_1d_fft_stage2  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_1d_fft_stage2 interface(@io)
     builtin.module {
       builtin.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -297,7 +295,7 @@ hal.executable private @static_3d_fft_stage3  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_3d_fft_stage3 interface(@io)
     builtin.module {
       builtin.func @static_3d_fft_stage3() {
         %c0 = arith.constant 0 : index
@@ -360,8 +358,8 @@ hal.executable private @static_3d_fft_stage3  {
     workgroup_size = [16, 8, 1]>
 hal.executable @user_config {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point public @_lowering_config_test_dispatch_1 attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point public @_lowering_config_test_dispatch_1 interface(@io)
+  builtin.module {
     func @_lowering_config_test_dispatch_1() {
       %cst = arith.constant 0.000000e+00 : f32
       %c128 = arith.constant 128 : index
@@ -423,8 +421,8 @@ hal.executable private @sort_op {
     hal.interface.binding public @s0b3, set=0, binding=3, type="StorageBuffer"
   }
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
-    hal.executable.entry_point public @sort_op attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @sort_op interface(@io)
+    builtin.module {
       func @sort_op() {
         %c1 = arith.constant 1 : index
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -6,16 +6,17 @@
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.interface @io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
   builtin.module  {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:16xf32>
-      %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:16xf32>
-      %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:16xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:16xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:16xf32>
       %3 = linalg.init_tensor [16] : tensor<16xf32>
       %4 = flow.dispatch.tensor.load %0, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
       %5 = flow.dispatch.tensor.load %1, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
@@ -26,11 +27,6 @@ hal.executable @simpleMath_ex_dispatch_0 {
         } -> tensor<16xf32>
         flow.dispatch.tensor.store %6, %2, offsets=[], sizes=[], strides=[] : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:16xf32>
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -59,9 +55,9 @@ hal.executable @dot_dispatch_0 {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c1 = arith.constant 1 : index
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:1024x1024xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x1024xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -89,11 +85,6 @@ hal.executable @dot_dispatch_0 {
           }
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -147,9 +138,9 @@ hal.executable @dot_dispatch_0 {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c1 = arith.constant 1 : index
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:1024x1024xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x1024xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -183,11 +174,6 @@ hal.executable @dot_dispatch_0 {
         }
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
@@ -216,9 +202,9 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
       %c2 = arith.constant 2 : index
       %c3 = arith.constant 3 : index
       %c1 = arith.constant 1 : index
-      %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x4x4x2xf32>
-      %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x2x2x1xf32>
-      %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x2x3x1xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x4x4x2xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x2x2x1xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x2x3x1xf32>
       %workgroup_size_x = hal.interface.workgroup.size[0] : index
       %workgroup_size_y = hal.interface.workgroup.size[1] : index
       %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -257,11 +243,6 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
       }
       return
     }
-    hal.interface private @io  {
-      hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-      hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-      hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
-    }
   }
 }
 }
@@ -285,8 +266,8 @@ hal.executable @simpleMath_ex_dispatch_0 {
   builtin.module  {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:16xf32>
-      %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:16xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:16xf32>
       %3 = linalg.init_tensor [16] : tensor<16xf32>
       %4 = flow.dispatch.tensor.load %0, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
       %5 = arith.constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
@@ -297,10 +278,6 @@ hal.executable @simpleMath_ex_dispatch_0 {
         } -> tensor<16xf32>
         flow.dispatch.tensor.store %6, %2, offsets=[], sizes=[], strides=[] : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:16xf32>
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
       }
     }
   }
@@ -321,8 +298,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
       %c0 = arith.constant 0 : index
       %cst = arith.constant 0.000000e+00 : f32
       %c96 = arith.constant 96 : index
-      %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:14x14x96xf32>
-      %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:96xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:14x14x96xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:96xf32>
       %workgroup_size_x = hal.interface.workgroup.size[0] : index
       %workgroup_id_x = hal.interface.workgroup.id[0] : index
       %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -344,10 +321,6 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
       }
       return
     }
-    hal.interface private @io  {
-      hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-      hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-    }
   }
 }
 }
@@ -365,9 +338,9 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
     builtin.func @vector_add_dispatch() {
       %c0 = arith.constant 0 : index
       %c16384 = arith.constant 16384 : index
-      %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:16384xf32>
-      %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:16384xf32>
-      %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:16384xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16384xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:16384xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:16384xf32>
       %workgroup_size_x = hal.interface.workgroup.size[0] : index
       %workgroup_id_x = hal.interface.workgroup.id[0] : index
       %workgroup_count_x = hal.interface.workgroup.count[0] : index
@@ -388,11 +361,6 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
         flow.dispatch.tensor.store %11, %2, offsets = [%arg0], sizes = [%9], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:16384xf32>
       }
       return
-    }
-    hal.interface private @io  {
-      hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-      hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-       hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
     }
   }
 }
@@ -416,38 +384,34 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.entry_point @vector_reduction_dispatch attributes {interface = @io, ordinal = 0 : index}
   builtin.module  {
     builtin.func @vector_reduction_dispatch() {
-          %c0 = arith.constant 0 : index
-          %c16384 = arith.constant 16384 : index
-          %cst = arith.constant 1.000000e+00 : f32
-          %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x16384xf32>
-          %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:16384xf32>
-          %workgroup_size_x = hal.interface.workgroup.size[0] : index
-          %workgroup_id_x = hal.interface.workgroup.id[0] : index
-          %workgroup_count_x = hal.interface.workgroup.count[0] : index
-          %2 = affine.apply #map0()[%workgroup_id_x, %workgroup_size_x]
-          %3 = affine.apply #map0()[%workgroup_count_x, %workgroup_size_x]
-          scf.for %arg0 = %2 to %c16384 step %3 {
-            %4 = affine.min #map1(%arg0)[%workgroup_size_x]
-            %5 = flow.dispatch.tensor.load %0, offsets = [0, %arg0], sizes = [512, %4], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x16384xf32> -> tensor<512x?xf32>
-            %6 = affine.min #map1(%arg0)[%workgroup_size_x]
-            %7 = affine.min #map2(%arg0)[%workgroup_size_x]
-            %8 = linalg.init_tensor [%7] : tensor<?xf32>
-            %9 = linalg.fill(%cst, %8) : f32, tensor<?xf32> -> tensor<?xf32>
-            %10 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]} ins(%5 : tensor<512x?xf32>) outs(%9 : tensor<?xf32>) {
-            ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
-              %11 = arith.addf %arg1, %arg2 : f32
-              linalg.yield %11 : f32
-            } -> tensor<?xf32>
-            flow.dispatch.tensor.store %10, %1, offsets = [%arg0], sizes = [%6], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:16384xf32>
-          }
-          return
-        }
-        hal.interface private @io  {
-          hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-          hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-        }
+      %c0 = arith.constant 0 : index
+      %c16384 = arith.constant 16384 : index
+      %cst = arith.constant 1.000000e+00 : f32
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:512x16384xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:16384xf32>
+      %workgroup_size_x = hal.interface.workgroup.size[0] : index
+      %workgroup_id_x = hal.interface.workgroup.id[0] : index
+      %workgroup_count_x = hal.interface.workgroup.count[0] : index
+      %2 = affine.apply #map0()[%workgroup_id_x, %workgroup_size_x]
+      %3 = affine.apply #map0()[%workgroup_count_x, %workgroup_size_x]
+      scf.for %arg0 = %2 to %c16384 step %3 {
+        %4 = affine.min #map1(%arg0)[%workgroup_size_x]
+        %5 = flow.dispatch.tensor.load %0, offsets = [0, %arg0], sizes = [512, %4], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x16384xf32> -> tensor<512x?xf32>
+        %6 = affine.min #map1(%arg0)[%workgroup_size_x]
+        %7 = affine.min #map2(%arg0)[%workgroup_size_x]
+        %8 = linalg.init_tensor [%7] : tensor<?xf32>
+        %9 = linalg.fill(%cst, %8) : f32, tensor<?xf32> -> tensor<?xf32>
+        %10 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]} ins(%5 : tensor<512x?xf32>) outs(%9 : tensor<?xf32>) {
+        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+          %11 = arith.addf %arg1, %arg2 : f32
+          linalg.yield %11 : f32
+        } -> tensor<?xf32>
+        flow.dispatch.tensor.store %10, %1, offsets = [%arg0], sizes = [%6], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:16384xf32>
+      }
+      return
     }
   }
+}
 }
 
 //   CHECK-LABEL: hal.executable public @vector_reduction_dispatch
@@ -474,9 +438,9 @@ hal.executable @mma_fused {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c1 = arith.constant 1 : index
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:1024x1024xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x1024xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -510,11 +474,6 @@ hal.executable @mma_fused {
           }
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -10,8 +10,8 @@ hal.executable @simpleMath_ex_dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @add_dispatch_0 interface(@io)
+  builtin.module {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
       %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
@@ -48,8 +48,8 @@ hal.executable @dot_dispatch_0 {
     hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @dot_dispatch_0 interface(@io)
+    builtin.module {
       func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
@@ -131,8 +131,8 @@ hal.executable @dot_dispatch_0 {
     hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @dot_dispatch_0 interface(@io)
+    builtin.module {
       func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
@@ -194,8 +194,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
     hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
     hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
   }
-  hal.executable.entry_point @conv2d_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @conv2d_dispatch_0 interface(@io)
+  builtin.module {
     func @conv2d_dispatch_0() {
       %c0 = arith.constant 0 : index
       %cst = arith.constant 0.000000e+00 : f32
@@ -262,8 +262,8 @@ hal.executable @simpleMath_ex_dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @add_dispatch_0 interface(@io)
+  builtin.module {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
       %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
@@ -292,8 +292,8 @@ hal.executable @simpleMath_ex_dispatch_0 {
 
 hal.executable @reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @reduction attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @reduction interface(@io)
+  builtin.module {
     func @reduction() {
       %c0 = arith.constant 0 : index
       %cst = arith.constant 0.000000e+00 : f32
@@ -333,8 +333,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 
 hal.executable @vector_add_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @vector_add_dispatch attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @vector_add_dispatch interface(@io)
+  builtin.module {
     builtin.func @vector_add_dispatch() {
       %c0 = arith.constant 0 : index
       %c16384 = arith.constant 16384 : index
@@ -381,8 +381,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 
 hal.executable @vector_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.entry_point @vector_reduction_dispatch attributes {interface = @io, ordinal = 0 : index}
-  builtin.module  {
+  hal.executable.entry_point @vector_reduction_dispatch interface(@io)
+  builtin.module {
     builtin.func @vector_reduction_dispatch() {
       %c0 = arith.constant 0 : index
       %c16384 = arith.constant 16384 : index
@@ -431,8 +431,8 @@ hal.executable @mma_fused {
     hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-    hal.executable.entry_point @mma_fused attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @mma_fused interface(@io)
+    builtin.module {
       func @mma_fused() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -10,8 +10,8 @@ hal.executable @simpleMath_ex_dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-  hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index, signature = (!flow.dispatch.tensor<readonly:16xf32>, !flow.dispatch.tensor<readonly:16xf32>, !flow.dispatch.tensor<writeonly:16xf32>) -> ()}
-  builtin.module  {
+  hal.executable.entry_point @add_dispatch_0 interface(@io)
+  builtin.module {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
       %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
@@ -48,8 +48,8 @@ hal.executable @dot_dispatch_0 {
     hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-    hal.executable.entry_point @dot_dispatch_0 attributes {interface = @io, ordinal = 0 : index, signature = (!flow.dispatch.tensor<readonly:1024x1024xf32>, !flow.dispatch.tensor<readonly:1024x1024xf32>, !flow.dispatch.tensor<writeonly:1024x1024xf32>) -> ()}
-    builtin.module  {
+    hal.executable.entry_point @dot_dispatch_0 interface(@io)
+    builtin.module {
       func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -6,16 +6,17 @@
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.interface @io {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
   hal.executable.entry_point @add_dispatch_0 attributes {interface = @io, ordinal = 0 : index, signature = (!flow.dispatch.tensor<readonly:16xf32>, !flow.dispatch.tensor<readonly:16xf32>, !flow.dispatch.tensor<writeonly:16xf32>) -> ()}
   builtin.module  {
     func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
-      %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:16xf32>
-      %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:16xf32>
-      %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:16xf32>
+      %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:16xf32>
+      %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:16xf32>
+      %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:16xf32>
       %3 = linalg.init_tensor [16] : tensor<16xf32>
       %4 = flow.dispatch.tensor.load %0, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
       %5 = flow.dispatch.tensor.load %1, offsets=[], sizes=[], strides=[] : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
@@ -26,11 +27,6 @@ hal.executable @simpleMath_ex_dispatch_0 {
         } -> tensor<16xf32>
         flow.dispatch.tensor.store %6, %2, offsets=[], sizes=[], strides=[] : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:16xf32>
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -59,9 +55,9 @@ hal.executable @dot_dispatch_0 {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c1 = arith.constant 1 : index
-        %0 = hal.interface.binding.subspan @io::@ro0[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %1 = hal.interface.binding.subspan @io::@ro1[%c0] : !flow.dispatch.tensor<readonly:1024x1024xf32>
-        %2 = hal.interface.binding.subspan @io::@wo2[%c0] : !flow.dispatch.tensor<writeonly:1024x1024xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1024x1024xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x1024xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -89,11 +85,6 @@ hal.executable @dot_dispatch_0 {
           }
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @ro0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @ro1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @wo2, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/LLVMGPU/test/tensorcore_vectorization.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/tensorcore_vectorization.mlir
@@ -5,9 +5,9 @@ func @dot() {
   %c1024 = arith.constant 1024 : index
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<2048x1024xf32>
-  %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<1024x512xf32>
-  %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : memref<2048x512xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<2048x1024xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<1024x512xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<2048x512xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index
   %3 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]

--- a/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -80,10 +80,9 @@ spirv::GlobalVariableOp createResourceVariable(Location loc, Type type,
 }
 
 /// Returns the (set, binding) pair for the given interface op.
-std::pair<int32_t, int32_t> getInterfaceSetAndBinding(Operation *op) {
-  IREE::HAL::InterfaceBindingOp bindingOp =
-      cast<IREE::HAL::InterfaceBindingSubspanOp>(op).queryBindingOp();
-  return {bindingOp.set().getSExtValue(), bindingOp.binding().getSExtValue()};
+std::pair<int32_t, int32_t> getInterfaceSetAndBinding(
+    IREE::HAL::InterfaceBindingSubspanOp op) {
+  return {op.set().getSExtValue(), op.binding().getSExtValue()};
 }
 
 /// Scans all hal.interface.binding.subspan ops in `module`, creates their
@@ -97,7 +96,7 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
   for (FuncOp func : llvm::reverse(fns)) {
     // Collect all interface ops and their (set, binding) pairs in this
     // function. Use SmallVector here for a deterministic order.
-    SmallVector<IREE::HAL::InterfaceBindingSubspanOp, 8> interfaceOps;
+    SmallVector<IREE::HAL::InterfaceBindingSubspanOp, 8> subspanOps;
     SmallVector<std::pair<uint32_t, uint32_t>, 8> setBindings;
 
     // Use a map to see if we have different types for one (set, binding) pair,
@@ -106,11 +105,11 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
         setBindingTypes;
 
     func.walk([&](Operation *op) {
-      auto interfaceOp = dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(op);
-      if (!interfaceOp || interfaceOp.use_empty()) return;
-      interfaceOps.emplace_back(interfaceOp);
-      setBindings.emplace_back(getInterfaceSetAndBinding(interfaceOp));
-      setBindingTypes[setBindings.back()].insert(interfaceOp.getType());
+      auto subspanOp = dyn_cast<IREE::HAL::InterfaceBindingSubspanOp>(op);
+      if (!subspanOp || subspanOp.use_empty()) return;
+      subspanOps.emplace_back(subspanOp);
+      setBindings.emplace_back(getInterfaceSetAndBinding(subspanOp));
+      setBindingTypes[setBindings.back()].insert(subspanOp.getType());
     });
 
     // Keep track of created SPIR-V global variables. This allows us to
@@ -119,12 +118,12 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
                    spirv::GlobalVariableOp>
         resourceVars;
 
-    for (int i = interfaceOps.size() - 1; i >= 0; --i) {
-      auto interfaceOp = interfaceOps[i];
+    for (int i = subspanOps.size() - 1; i >= 0; --i) {
+      auto subspanOp = subspanOps[i];
       const auto &setBinding = setBindings[i];
 
       auto key = std::make_tuple(setBinding.first, setBinding.second,
-                                 interfaceOp.getType());
+                                 subspanOp.getType());
       auto var = resourceVars.lookup(key);
       if (!var) {
         // If we have multiple SPIR-V global variables bound to the same (set,
@@ -135,13 +134,13 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
         // We are using the interface op's type for creating the global
         // variable. It's fine. The correctness boundary is the pass.
         // We will fix it up during conversion so it won't leak.
-        var = createResourceVariable(
-            interfaceOp.getLoc(), interfaceOp.getType(), setBinding.first,
-            setBinding.second, alias, module, &symbolTable);
+        var = createResourceVariable(subspanOp.getLoc(), subspanOp.getType(),
+                                     setBinding.first, setBinding.second, alias,
+                                     module, &symbolTable);
         resourceVars[key] = var;
       }
 
-      interfaceToResourceVars[interfaceOp] = var;
+      interfaceToResourceVars[subspanOp] = var;
     }
   }
 
@@ -166,9 +165,9 @@ struct HALInterfaceLoadConstantConverter final
       ConversionPatternRewriter &rewriter) const override {
     // TODO(#1519): hal.interface.load.constant should point to the
     // hal.interface op.
-    auto moduleOp = loadOp->getParentOfType<ModuleOp>();
+    auto executableOp = loadOp->getParentOfType<IREE::HAL::ExecutableOp>();
     auto halInterfaceOps =
-        llvm::to_vector<1>(moduleOp.getOps<IREE::HAL::InterfaceOp>());
+        llvm::to_vector<1>(executableOp.getOps<IREE::HAL::InterfaceOp>());
     assert(halInterfaceOps.size() == 1);
     assert(halInterfaceOps.front().push_constants().hasValue());
 
@@ -220,25 +219,25 @@ struct HALInterfaceBindingSubspanConverter final
         interfaceToResourceVars(interfaceToResourceVars) {}
 
   LogicalResult matchAndRewrite(
-      IREE::HAL::InterfaceBindingSubspanOp interfaceOp, OpAdaptor adaptor,
+      IREE::HAL::InterfaceBindingSubspanOp subspanOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (interfaceOp.use_empty()) {
-      rewriter.eraseOp(interfaceOp);
+    if (subspanOp.use_empty()) {
+      rewriter.eraseOp(subspanOp);
       return success();
     }
 
-    Type resultType = interfaceOp.getOperation()->getResult(0).getType();
+    Type resultType = subspanOp.getOperation()->getResult(0).getType();
     Type convertedType = this->getTypeConverter()->convertType(resultType);
     if (!convertedType) {
-      return interfaceOp.emitError()
+      return subspanOp.emitError()
              << "failed to convert SPIR-V type: " << resultType;
     }
 
-    auto varOp = interfaceToResourceVars.lookup(interfaceOp);
+    auto varOp = interfaceToResourceVars.lookup(subspanOp);
     // Fix up the variable's type.
     varOp.typeAttr(TypeAttr::get(convertedType));
 
-    rewriter.replaceOpWithNewOp<spirv::AddressOfOp>(interfaceOp, varOp);
+    rewriter.replaceOpWithNewOp<spirv::AddressOfOp>(subspanOp, varOp);
 
     return success();
   }

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -360,30 +360,30 @@ class ProcessAlloc final : public MemRefConversionPattern<memref::AllocOp> {
   }
 };
 
-class ProcessInterfaceBinding final
+class ProcessInterfaceBindingSubspan final
     : public MemRefConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
  public:
   using MemRefConversionPattern::MemRefConversionPattern;
 
   LogicalResult matchAndRewrite(
-      IREE::HAL::InterfaceBindingSubspanOp bindingOp, OpAdaptor adaptor,
+      IREE::HAL::InterfaceBindingSubspanOp subspanOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    auto memrefType = bindingOp.getType().dyn_cast<MemRefType>();
+    auto memrefType = subspanOp.getType().dyn_cast<MemRefType>();
     if (!memrefType) return failure();
 
     // This should be guaranteed by the analysis step. But just double check.
     assert(memrefType.getRank() > 0 &&
            !ShapedType::isDynamic(memrefType.getShape().back()));
 
-    auto vecMemRef = getVectorizedMemRefType(rewriter, bindingOp.result());
+    auto vecMemRef = getVectorizedMemRefType(rewriter, subspanOp.result());
     if (!vecMemRef) {
-      return rewriter.notifyMatchFailure(bindingOp,
+      return rewriter.notifyMatchFailure(subspanOp,
                                          "cannot get vectorized memref type");
     }
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
-        bindingOp, *vecMemRef, bindingOp.binding(), bindingOp.byte_offset(),
-        bindingOp.byte_length(), bindingOp.dynamic_dims(),
-        bindingOp.alignmentAttr());
+        subspanOp, *vecMemRef, subspanOp.type(), subspanOp.set(),
+        subspanOp.binding(), subspanOp.byte_offset(), subspanOp.dynamic_dims(),
+        subspanOp.alignmentAttr());
     return success();
   }
 };
@@ -521,8 +521,8 @@ void SPIRVVectorizeLoadStorePass::runOnOperation() {
   RewritePatternSet conversionPatterns(context);
   conversionPatterns
       .add<ProcessFunctionArgument, ProcessTransferRead, ProcessTransferWrite,
-           ProcessAlloc, ProcessInterfaceBinding>(context,
-                                                  *memrefUsageAnalysis);
+           ProcessAlloc, ProcessInterfaceBindingSubspan>(context,
+                                                         *memrefUsageAnalysis);
   conversionPatterns.add<PassThroughConversion<memref::DeallocOp>,
                          PassThroughConversion<memref::AssumeAlignmentOp>>(
       context);

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -22,9 +22,9 @@ hal.executable @conv_112x112x512 {
         %c512 = arith.constant 512 : index
         %c112 = arith.constant 112 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x512xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x512xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x512xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x512xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -64,11 +64,6 @@ hal.executable @conv_112x112x512 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -114,9 +109,9 @@ hal.executable @conv_112x112x32 {
         %c32 = arith.constant 32 : index
         %c112 = arith.constant 112 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -207,9 +202,9 @@ hal.executable @conv_16x16x16 {
         %c0 = arith.constant 0 : index
         %c16 = arith.constant 16 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x33x33x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x16xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x16x16x16xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x33x33x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x16xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x16x16x16xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -249,11 +244,6 @@ hal.executable @conv_16x16x16 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -300,9 +290,9 @@ hal.executable @dwconv_28x28x144 {
         %c144 = arith.constant 144 : index
         %c28 = arith.constant 28 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x57x57x144xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x144xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x28x28x144xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x57x57x144xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x144xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x28x28x144xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -343,11 +333,6 @@ hal.executable @dwconv_28x28x144 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -394,9 +379,9 @@ hal.executable @dwconv_4x4x8 {
         %c8 = arith.constant 8 : index
         %c4 = arith.constant 4 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x9x9x8xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x8xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x4x4x8xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x9x9x8xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x8xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x4x4x8xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -437,11 +422,6 @@ hal.executable @dwconv_4x4x8 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -15,7 +15,7 @@ hal.executable @conv_112x112x512 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x512 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @conv_112x112x512 interface(@io)
     builtin.module  {
       func @conv_112x112x512() {
         %c0 = arith.constant 0 : index
@@ -102,7 +102,7 @@ hal.executable @conv_112x112x32 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x32 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @conv_112x112x32 interface(@io)
     builtin.module  {
       func @conv_112x112x32() {
         %c0 = arith.constant 0 : index
@@ -196,7 +196,7 @@ hal.executable @conv_16x16x16 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @conv_16x16x16 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @conv_16x16x16 interface(@io)
     builtin.module  {
       func @conv_16x16x16() {
         %c0 = arith.constant 0 : index
@@ -283,7 +283,7 @@ hal.executable @dwconv_28x28x144 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_28x28x144 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @dwconv_28x28x144 interface(@io)
     builtin.module  {
       func @dwconv_28x28x144() {
         %c0 = arith.constant 0 : index
@@ -372,7 +372,7 @@ hal.executable @dwconv_4x4x8 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_4x4x8 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @dwconv_4x4x8 interface(@io)
     builtin.module  {
       func @dwconv_4x4x8() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -22,9 +22,9 @@ hal.executable @matmul_1024x2048x512 {
         %c2048 = arith.constant 2048 : index
         %c1024 = arith.constant 1024 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1024x512xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x2048xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1024x2048xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x512xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:512x2048xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x2048xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -52,11 +52,6 @@ hal.executable @matmul_1024x2048x512 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -103,9 +98,9 @@ hal.executable @matmul_3136x24x96 {
         %c24 = arith.constant 24 : index
         %c3136 = arith.constant 3136 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:3136x96xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:96x24xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:3136x24xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:3136x96xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:96x24xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:3136x24xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -133,11 +128,6 @@ hal.executable @matmul_3136x24x96 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -184,9 +174,9 @@ hal.executable @matmul_196x64x192 {
         %c64 = arith.constant 64 : index
         %c196 = arith.constant 196 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:196x192xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:192x64xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:196x64xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:196x192xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:192x64xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:196x64xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -214,11 +204,6 @@ hal.executable @matmul_196x64x192 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -265,9 +250,9 @@ hal.executable @matmul_12544x96x16 {
         %c96 = arith.constant 96 : index
         %c12544 = arith.constant 12544 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<12544x16xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<16x96xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : memref<12544x96xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<12544x16xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<16x96xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<12544x96xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -290,11 +275,6 @@ hal.executable @matmul_12544x96x16 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -341,9 +321,9 @@ hal.executable @matmul_49x160x576 {
         %c160 = arith.constant 160 : index
         %c49 = arith.constant 49 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:49x576xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:576x160xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:49x160xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:49x576xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:576x160xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:49x160xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -371,11 +351,6 @@ hal.executable @matmul_49x160x576 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -422,9 +397,9 @@ hal.executable @batch_matmul_4x384x384 {
         %c384 = arith.constant 384 : index
         %c4 = arith.constant 4 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x384x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x32x384xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4x384x384xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x384x32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x32x384xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x384x384xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -463,11 +438,6 @@ hal.executable @batch_matmul_4x384x384 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -513,9 +483,9 @@ hal.executable @batch_matmul_4x8x8 {
         %c8 = arith.constant 8 : index
         %c4 = arith.constant 4 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x8x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x32x8xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4x8x8xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x8x32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x32x8xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x8x8xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -554,11 +524,6 @@ hal.executable @batch_matmul_4x8x8 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -15,8 +15,8 @@ hal.executable @matmul_1024x2048x512 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_1024x2048x512 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_1024x2048x512 interface(@io)
+    builtin.module {
       func @matmul_1024x2048x512() {
         %c0 = arith.constant 0 : index
         %c2048 = arith.constant 2048 : index
@@ -91,8 +91,8 @@ hal.executable @matmul_3136x24x96 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_3136x24x96 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_3136x24x96 interface(@io)
+    builtin.module {
       func @matmul_3136x24x96() {
         %c0 = arith.constant 0 : index
         %c24 = arith.constant 24 : index
@@ -167,8 +167,8 @@ hal.executable @matmul_196x64x192 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_196x64x192 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_196x64x192 interface(@io)
+    builtin.module {
       func @matmul_196x64x192() {
         %c0 = arith.constant 0 : index
         %c64 = arith.constant 64 : index
@@ -243,8 +243,8 @@ hal.executable @matmul_12544x96x16 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_12544x96x16 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_12544x96x16 interface(@io)
+    builtin.module {
       func @matmul_12544x96x16() {
         %c0 = arith.constant 0 : index
         %c96 = arith.constant 96 : index
@@ -314,8 +314,8 @@ hal.executable @matmul_49x160x576 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @matmul_49x160x576 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_49x160x576 interface(@io)
+    builtin.module {
       func @matmul_49x160x576() {
         %c0 = arith.constant 0 : index
         %c160 = arith.constant 160 : index
@@ -390,8 +390,8 @@ hal.executable @batch_matmul_4x384x384 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x384x384 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @batch_matmul_4x384x384 interface(@io)
+    builtin.module {
       func @batch_matmul_4x384x384() {
         %c0 = arith.constant 0 : index
         %c384 = arith.constant 384 : index
@@ -476,8 +476,8 @@ hal.executable @batch_matmul_4x8x8 {
         max_compute_workgroup_size = dense<[1024, 1024, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x8x8 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @batch_matmul_4x8x8 interface(@io)
+    builtin.module {
       func @batch_matmul_4x8x8() {
         %c0 = arith.constant 0 : index
         %c8 = arith.constant 8 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -32,10 +32,10 @@ hal.executable private @conv_pointwise_112x112x32 {
         %cst = arith.constant 0.000000e+00 : f32
         %c112 = arith.constant 112 : index
         %c32 = arith.constant 32 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x112x112x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b3_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x112x112x32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -81,12 +81,6 @@ hal.executable private @conv_pointwise_112x112x32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_ro_external, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding public @s0b3_xw_external, set=0, binding=3, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -25,8 +25,8 @@ hal.executable private @conv_pointwise_112x112x32 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @conv_pointwise_112x112x32 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv_pointwise_112x112x32 interface(@io)
+    builtin.module {
       func @conv_pointwise_112x112x32() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f32

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -14,7 +14,7 @@ hal.executable private @static_1d_sort  {
     builtin.module {
       builtin.func @static_1d_sort() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:1000xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readwrite:1000xi32>
         %1 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:1000xi32> -> tensor<1000xi32>
         %2 = iree_linalg_ext.sort dimension(0) {__internal_linalg_transform__ = "workgroup"} outs(%1 : tensor<1000xi32>)  {
         ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -23,9 +23,6 @@ hal.executable private @static_1d_sort  {
         } -> tensor<1000xi32>
         flow.dispatch.tensor.store %2, %0, offsets = [], sizes = [], strides = [] : tensor<1000xi32> -> !flow.dispatch.tensor<readwrite:1000xi32>
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_rw_external, set=0, binding=0, type="StorageBuffer"
       }
     }
   }
@@ -66,8 +63,8 @@ hal.executable private @static_3d_sort  {
         %c64 = arith.constant 64 : index
         %c128 = arith.constant 128 : index
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<64x32x128xi32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<64x32x128xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<64x32x128xi32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<64x32x128xi32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -135,8 +132,8 @@ hal.executable private @static_1d_fft_stage2  {
         %c2 = arith.constant 2 : index
         %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
         %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
-        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : !flow.dispatch.tensor<readwrite:32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readwrite:32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readwrite:32xf32>
         %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
         %3 = flow.dispatch.tensor.load %1, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readwrite:32xf32> -> tensor<32xf32>
         %4:2 = iree_linalg_ext.fft {__internal_linalg_transform__ = "workgroup"} ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
@@ -190,8 +187,8 @@ hal.executable private @static_3d_fft_stage3  {
         %cst_0 = arith.constant dense<[-0.000000e+00, -0.707106769, -1.000000e+00, -0.707106769]> : tensor<4xf32>
         %0 = bufferization.to_memref %cst_0 : memref<4xf32>
         %1 = bufferization.to_memref %cst : memref<4xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<64x128x32xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b1_rw_external[%c0] : memref<64x128x32xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<64x128x32xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<64x128x32xf32>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -10,7 +10,7 @@ hal.executable private @static_1d_sort  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_1d_sort attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_1d_sort interface(@io)
     builtin.module {
       builtin.func @static_1d_sort() {
         %c0 = arith.constant 0 : index
@@ -57,7 +57,7 @@ hal.executable private @static_3d_sort  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_3d_sort attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_3d_sort interface(@io)
     builtin.module {
       builtin.func @static_3d_sort() {
         %c64 = arith.constant 64 : index
@@ -125,7 +125,7 @@ hal.executable private @static_1d_fft_stage2  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_1d_fft_stage2 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_1d_fft_stage2 interface(@io)
     builtin.module {
       builtin.func @static_1d_fft_stage2() {
         %c0 = arith.constant 0 : index
@@ -175,7 +175,7 @@ hal.executable private @static_3d_fft_stage3  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @static_3d_fft_stage3 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @static_3d_fft_stage3 interface(@io)
     builtin.module {
       builtin.func @static_3d_fft_stage3() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -14,8 +14,8 @@ hal.executable @tensor_insert {
         %c0 = arith.constant 0 : index
         %1 = hal.interface.load.constant offset = 0 : index
         %2 = hal.interface.load.constant offset = 1 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:?x?xi32>{%1, %2}
-        %3 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:?x?xi32>{%1, %2}
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:?x?xi32>{%1, %2}
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:?x?xi32>{%1, %2}
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -39,10 +39,6 @@ hal.executable @tensor_insert {
           }
         }
         return
-      }
-      hal.interface @io attributes {push_constants = 2 : index, sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
       }
     }
   }
@@ -69,8 +65,8 @@ hal.executable @tensor_insert {
         %c0 = arith.constant 0 : index
         %d0 = hal.interface.load.constant offset = 0 : index
         %d1 = hal.interface.load.constant offset = 1 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<?x?xi32>{%d0, %d1}
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<?x?xi32>{%d0, %d1}
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xi32>{%d0, %d1}
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xi32>{%d0, %d1}
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -127,8 +123,8 @@ hal.executable @tensor_insert {
         %c0 = arith.constant 0 : index
         %c224 = arith.constant 224 : index
         %c3 = arith.constant 3 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_rw_external[%c0] : memref<1x225x225x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<1x224x224x3xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<1x225x225x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<1x224x224x3xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -157,10 +153,6 @@ hal.executable @tensor_insert {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
       }
     }
   }
@@ -211,8 +203,8 @@ hal.executable @avg_pool {
         %cst = arith.constant 0.000000e+00 : f32
         %c2 = arith.constant 2 : index
         %c8 = arith.constant 8 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x24x24x8xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x2x2x8xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x24x24x8xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<writeonly:1x2x2x8xf32>
         %2 = linalg.init_tensor [12, 12] : tensor<12x12xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
@@ -251,10 +243,6 @@ hal.executable @avg_pool {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
       }
     }
   }
@@ -297,9 +285,9 @@ hal.executable @elementwise {
         %c0 = arith.constant 0 : index
         %c1 = arith.constant 1 : index
         %c10 = arith.constant 10 : index
-        %0 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x10xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:10xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:10xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x10xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:10xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:10xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -332,11 +320,6 @@ hal.executable @elementwise {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -8,8 +8,8 @@ hal.executable @tensor_insert {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @tensor_insert_slice attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @tensor_insert_slice interface(@io)
+    builtin.module {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
         %1 = hal.interface.load.constant offset = 0 : index
@@ -59,8 +59,8 @@ hal.executable @tensor_insert {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @tensor_insert_slice attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @tensor_insert_slice interface(@io)
+    builtin.module {
       builtin.func @tensor_insert_slice() {
         %c0 = arith.constant 0 : index
         %d0 = hal.interface.load.constant offset = 0 : index
@@ -117,8 +117,8 @@ hal.executable @tensor_insert {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point @copy attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @copy interface(@io)
+    builtin.module {
       builtin.func @copy() {
         %c0 = arith.constant 0 : index
         %c224 = arith.constant 224 : index
@@ -196,8 +196,8 @@ hal.executable @avg_pool {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @avg_pool attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @avg_pool interface(@io)
+    builtin.module {
       func @avg_pool() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f32
@@ -279,8 +279,8 @@ hal.executable @elementwise {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @elementwise attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @elementwise interface(@io)
+    builtin.module {
       func @elementwise() {
         %c0 = arith.constant 0 : index
         %c1 = arith.constant 1 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -23,9 +23,9 @@ hal.executable @batch_matmul_1x3x32 {
         %c3 = arith.constant 3 : index
         %c1 = arith.constant 1 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x3x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:1x3x32xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x3x32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x3x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1x3x32xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x3x32xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -64,11 +64,6 @@ hal.executable @batch_matmul_1x3x32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -112,9 +107,9 @@ hal.executable private @matmul_64x16 {
         %c16 = arith.constant 16 : index
         %c64 = arith.constant 64 : index
         %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:64x32xi8>
-        %1 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:32x16xi8>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:64x16xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:64x32xi8>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:32x16xi8>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:64x16xi32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -142,11 +137,6 @@ hal.executable private @matmul_64x16 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -194,10 +184,10 @@ hal.executable @matmul_400x273 {
         %cst = arith.constant 0.000000e+00 : f32
         %c400 = arith.constant 400 : index
         %c273 = arith.constant 273 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c11775744] : !flow.dispatch.tensor<readonly:273xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:400x576xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:576x273xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:400x273xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c11775744) : !flow.dispatch.tensor<readonly:273xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:400x576xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:576x273xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:400x273xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -278,10 +268,10 @@ hal.executable @matmul_25x546 {
         %cst = arith.constant 0.000000e+00 : f32
         %c25 = arith.constant 25 : index
         %c546 = arith.constant 546 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c15842560] : !flow.dispatch.tensor<readonly:546xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:25x512xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b0_ro_constant[%c0] : !flow.dispatch.tensor<readonly:512x546xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:25x546xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c15842560) : !flow.dispatch.tensor<readonly:546xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:25x512xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:512x546xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:25x546xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -314,11 +304,6 @@ hal.executable @matmul_25x546 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_constant, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -374,11 +359,11 @@ hal.executable private @matmul_pointwise_256x1024 {
         %cst = arith.constant 0.000000e+00 : f16
         %c256 = arith.constant 256 : index
         %c1024 = arith.constant 1024 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x128xf16>
-        %3 = hal.interface.binding.subspan @io::@s0b3_ro_external[%c0] : !flow.dispatch.tensor<readonly:128x1024xf16>
-        %4 = hal.interface.binding.subspan @io::@s0b4_xw_external[%c0] : !flow.dispatch.tensor<writeonly:256x1024xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:256x128xf16>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<readonly:128x1024xf16>
+        %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) : !flow.dispatch.tensor<writeonly:256x1024xf16>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -413,13 +398,6 @@ hal.executable private @matmul_pointwise_256x1024 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_ro_external, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding public @s0b3_ro_external, set=0, binding=3, type="StorageBuffer"
-        hal.interface.binding public @s0b4_xw_external, set=0, binding=4, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -15,8 +15,8 @@ hal.executable @batch_matmul_1x3x32 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @batch_matmul_1x3x32 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @batch_matmul_1x3x32 interface(@io)
+    builtin.module {
       func @batch_matmul_1x3x32() {
         %c0 = arith.constant 0 : index
         %c32 = arith.constant 32 : index
@@ -100,8 +100,8 @@ hal.executable private @matmul_64x16 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
   }> {
-    hal.executable.entry_point public @matmul_64x16 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_64x16 interface(@io)
+    builtin.module {
       func @matmul_64x16() {
         %c0 = arith.constant 0 : index
         %c16 = arith.constant 16 : index
@@ -176,8 +176,8 @@ hal.executable @matmul_400x273 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
     }> {
-    hal.executable.entry_point public @matmul_400x273 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_400x273 interface(@io)
+    builtin.module {
       func @matmul_400x273() {
         %c0 = arith.constant 0 : index
         %c11775744 = arith.constant 11775744 : index
@@ -260,8 +260,8 @@ hal.executable @matmul_25x546 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 64 : i32}>
   }> {
-    hal.executable.entry_point public @matmul_25x546 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_25x546 interface(@io)
+    builtin.module {
       func @matmul_25x546() {
         %c0 = arith.constant 0 : index
         %c15842560 = arith.constant 15842560 : index
@@ -352,8 +352,8 @@ hal.executable private @matmul_pointwise_256x1024 {
         max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>,
         subgroup_size = 32 : i32}>
     }> {
-    hal.executable.entry_point public @matmul_pointwise_256x1024 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @matmul_pointwise_256x1024 interface(@io)
+    builtin.module {
       func @matmul_pointwise_256x1024() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f16

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -22,9 +22,9 @@ hal.executable @conv_112x112x512 {
         %c512 = arith.constant 512 : index
         %c112 = arith.constant 112 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x512xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x512xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x512xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x512xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -64,11 +64,6 @@ hal.executable @conv_112x112x512 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -114,9 +109,9 @@ hal.executable @conv_112x112x32 {
         %c32 = arith.constant 32 : index
         %c112 = arith.constant 112 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -156,11 +151,6 @@ hal.executable @conv_112x112x32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -205,9 +195,9 @@ hal.executable @conv_16x16x16 {
         %c0 = arith.constant 0 : index
         %c16 = arith.constant 16 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x33x33x3xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x3x16xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x16x16x16xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x33x33x3xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x3x16xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x16x16x16xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -247,11 +237,6 @@ hal.executable @conv_16x16x16 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -298,9 +283,9 @@ hal.executable @dwconv_28x28x144 {
         %c144 = arith.constant 144 : index
         %c28 = arith.constant 28 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x57x57x144xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x144xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x28x28x144xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x57x57x144xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x144xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x28x28x144xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -341,11 +326,6 @@ hal.executable @dwconv_28x28x144 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -393,9 +373,9 @@ hal.executable @dwconv_1x2x8 {
         %c2 = arith.constant 2 : index
         %c1 = arith.constant 1 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1x3x5x8xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:3x3x8xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1x1x2x8xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x3x5x8xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x8xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x1x2x8xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -436,11 +416,6 @@ hal.executable @dwconv_1x2x8 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -15,8 +15,8 @@ hal.executable @conv_112x112x512 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x512 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv_112x112x512 interface(@io)
+    builtin.module {
       func @conv_112x112x512() {
         %c0 = arith.constant 0 : index
         %c512 = arith.constant 512 : index
@@ -102,8 +102,8 @@ hal.executable @conv_112x112x32 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_112x112x32 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv_112x112x32 interface(@io)
+    builtin.module {
       func @conv_112x112x32() {
         %c0 = arith.constant 0 : index
         %c32 = arith.constant 32 : index
@@ -189,8 +189,8 @@ hal.executable @conv_16x16x16 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @conv_16x16x16 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @conv_16x16x16 interface(@io)
+    builtin.module {
       func @conv_16x16x16() {
         %c0 = arith.constant 0 : index
         %c16 = arith.constant 16 : index
@@ -276,8 +276,8 @@ hal.executable @dwconv_28x28x144 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_28x28x144 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @dwconv_28x28x144 interface(@io)
+    builtin.module {
       func @dwconv_28x28x144() {
         %c0 = arith.constant 0 : index
         %c144 = arith.constant 144 : index
@@ -365,8 +365,8 @@ hal.executable @dwconv_1x2x8 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point public @dwconv_1x2x8 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point public @dwconv_1x2x8 interface(@io)
+    builtin.module {
       func @dwconv_1x2x8() {
         %c0 = arith.constant 0 : index
         %c8 = arith.constant 8 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -22,9 +22,9 @@ hal.executable @matmul_1024x2048x512 {
         %c2048 = arith.constant 2048 : index
         %c1024 = arith.constant 1024 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1024x512xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x2048xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1024x2048xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x512xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:512x2048xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1024x2048xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -52,11 +52,6 @@ hal.executable @matmul_1024x2048x512 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -103,9 +98,9 @@ hal.executable @matmul_3136x24x96 {
         %c24 = arith.constant 24 : index
         %c3136 = arith.constant 3136 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:3136x96xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:96x24xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:3136x24xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:3136x96xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:96x24xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:3136x24xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -133,11 +128,6 @@ hal.executable @matmul_3136x24x96 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -184,9 +174,9 @@ hal.executable @matmul_196x64x192 {
         %c64 = arith.constant 64 : index
         %c196 = arith.constant 196 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:196x192xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:192x64xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:196x64xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:196x192xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:192x64xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:196x64xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -214,11 +204,6 @@ hal.executable @matmul_196x64x192 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -265,9 +250,9 @@ hal.executable @matmul_12544x96x16 {
         %c96 = arith.constant 96 : index
         %c12544 = arith.constant 12544 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<12544x16xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<16x96xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : memref<12544x96xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<12544x16xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<16x96xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<12544x96xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -290,11 +275,6 @@ hal.executable @matmul_12544x96x16 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -341,9 +321,9 @@ hal.executable @matmul_49x160x576 {
         %c160 = arith.constant 160 : index
         %c49 = arith.constant 49 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:49x576xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:576x160xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:49x160xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:49x576xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:576x160xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:49x160xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -371,11 +351,6 @@ hal.executable @matmul_49x160x576 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -420,9 +395,9 @@ hal.executable @batch_matmul_4x384x384 {
         %c384 = arith.constant 384 : index
         %c4 = arith.constant 4 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x384x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x32x384xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4x384x384xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x384x32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x32x384xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x384x384xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -461,11 +436,6 @@ hal.executable @batch_matmul_4x384x384 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -512,9 +482,9 @@ hal.executable @batch_matmul_4x2x8 {
         %c2 = arith.constant 2 : index
         %c4 = arith.constant 4 : index
         %cst = arith.constant 0.000000e+00 : f32
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x2x32xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x32x8xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4x2x8xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x2x32xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x32x8xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x2x8xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -553,11 +523,6 @@ hal.executable @batch_matmul_4x2x8 {
           }
         }
         return
-      }
-      hal.interface @io attributes {sym_visibility = "private"} {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -15,8 +15,8 @@ hal.executable @matmul_1024x2048x512 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_1024x2048x512 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_1024x2048x512 interface(@io)
+    builtin.module {
       func @matmul_1024x2048x512() {
         %c0 = arith.constant 0 : index
         %c2048 = arith.constant 2048 : index
@@ -91,8 +91,8 @@ hal.executable @matmul_3136x24x96 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_3136x24x96 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_3136x24x96 interface(@io)
+    builtin.module {
       func @matmul_3136x24x96() {
         %c0 = arith.constant 0 : index
         %c24 = arith.constant 24 : index
@@ -167,8 +167,8 @@ hal.executable @matmul_196x64x192 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_196x64x192 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_196x64x192 interface(@io)
+    builtin.module {
       func @matmul_196x64x192() {
         %c0 = arith.constant 0 : index
         %c64 = arith.constant 64 : index
@@ -243,8 +243,8 @@ hal.executable @matmul_12544x96x16 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_12544x96x16 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_12544x96x16 interface(@io)
+    builtin.module {
       func @matmul_12544x96x16() {
         %c0 = arith.constant 0 : index
         %c96 = arith.constant 96 : index
@@ -314,8 +314,8 @@ hal.executable @matmul_49x160x576 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @matmul_49x160x576 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @matmul_49x160x576 interface(@io)
+    builtin.module {
       func @matmul_49x160x576() {
         %c0 = arith.constant 0 : index
         %c160 = arith.constant 160 : index
@@ -388,8 +388,8 @@ hal.executable @batch_matmul_4x384x384 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x384x384 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @batch_matmul_4x384x384 interface(@io)
+    builtin.module {
       func @batch_matmul_4x384x384() {
         %c0 = arith.constant 0 : index
         %c384 = arith.constant 384 : index
@@ -474,8 +474,8 @@ hal.executable @batch_matmul_4x2x8 {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @batch_matmul_4x2x8 attributes {interface = @io, ordinal = 0 : index}
-    builtin.module  {
+    hal.executable.entry_point @batch_matmul_4x2x8 interface(@io)
+    builtin.module {
       func @batch_matmul_4x2x8() {
         %c0 = arith.constant 0 : index
         %c8 = arith.constant 8 : index

--- a/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -40,11 +40,11 @@ hal.executable public @matmul_256x1024x128_div_sub {
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
         %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x128xf16>
-        %3 = hal.interface.binding.subspan @io::@s0b3_ro_external[%c0] : !flow.dispatch.tensor<readonly:128x1024xf16>
-        %4 = hal.interface.binding.subspan @io::@s0b4_xw_external[%c0] : !flow.dispatch.tensor<writeonly:256x1024xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:256x128xf16>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<readonly:128x1024xf16>
+        %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) : !flow.dispatch.tensor<writeonly:256x1024xf16>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -88,13 +88,6 @@ hal.executable public @matmul_256x1024x128_div_sub {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_ro_external, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding public @s0b3_ro_external, set=0, binding=3, type="StorageBuffer"
-        hal.interface.binding public @s0b4_xw_external, set=0, binding=4, type="StorageBuffer"
       }
     }
   }
@@ -157,9 +150,9 @@ hal.executable public @matmul_256x1024x8 {
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
         %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x8xf16>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:8x1024xf16>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:256x1024xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:256x8xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:8x1024xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:256x1024xf16>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -187,11 +180,6 @@ hal.executable public @matmul_256x1024x8 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -33,7 +33,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @matmul_256x1024x128_div_sub interface(@io)
     builtin.module  {
       func @matmul_256x1024x128_div_sub() {
         %c0 = arith.constant 0 : index
@@ -143,7 +143,7 @@ hal.executable public @matmul_256x1024x8 {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x8 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @matmul_256x1024x8 interface(@io)
     builtin.module  {
       func @matmul_256x1024x8() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -7,8 +7,7 @@ hal.executable private @push_constant  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @push_constant attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @push_constant interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -43,8 +42,7 @@ hal.executable private @resource_bindings_in_same_func  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @resource_bindings_in_same_func attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @resource_bindings_in_same_func interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -95,12 +93,10 @@ hal.executable private @resource_bindings_in_multi_entry_func  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @resource_bindings_in_entry_func1 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @resource_bindings_in_entry_func1 interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    hal.executable.entry_point @resource_bindings_in_entry_func2 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @resource_bindings_in_entry_func2 interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -151,8 +147,7 @@ hal.executable private @interface_binding  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_binding attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @interface_binding interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -193,8 +188,7 @@ hal.executable private @interface_wg_id  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_wg_id attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @interface_wg_id interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -227,8 +221,7 @@ hal.executable private @interface_wg_count  {
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, {}>}> {
-    hal.executable.entry_point @interface_wg_count attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @interface_wg_count interface(@io) {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {

--- a/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -60,17 +60,17 @@ hal.executable private @resource_bindings_in_same_func  {
         // Same type
         // CHECK: spv.mlir.addressof @[[ARG0]]
         // CHECK: spv.mlir.addressof @[[ARG0]]
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
-        %1 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) : memref<4x4xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) : memref<4x4xf32>
 
         // Different type
         // CHECK: spv.mlir.addressof @[[ARG1_0]]
         // CHECK: spv.mlir.addressof @[[ARG1_1]]
-        %2 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<4x4xf32>
-        %3 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<4xvector<4xf32>>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(3) : memref<4x4xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(3) : memref<4xvector<4xf32>>
 
         // CHECK: spv.mlir.addressof @[[RET0]]
-        %4 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32>
+        %4 = hal.interface.binding.subspan type(StorageBuffer) set(3) binding(4) : memref<4x4xf32>
 
         %5 = memref.load %0[%c0, %c0] : memref<4x4xf32>
         %6 = memref.load %1[%c0, %c0] : memref<4x4xf32>
@@ -81,12 +81,6 @@ hal.executable private @resource_bindings_in_same_func  {
         %9 = memref.load %4[%c0, %c0] : memref<4x4xf32>
 
         return
-      }
-
-      hal.interface private @io attributes {push_constants = 5 : index} {
-        hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-        hal.interface.binding @arg1, set=1, binding=3, type="StorageBuffer"
-        hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
       }
     }
   }
@@ -121,8 +115,8 @@ hal.executable private @resource_bindings_in_multi_entry_func  {
         // CHECK: spv.mlir.addressof @[[FUNC1_ARG]]
         // CHECK: spv.mlir.addressof @[[FUNC1_RET]]
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32>
-        %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4xvector<4xf32>>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) : memref<4x4xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(3) binding(4) : memref<4xvector<4xf32>>
 
         %2 = memref.load %0[%c0, %c0] : memref<4x4xf32>
         %3 = memref.load %1[%c0] : memref<4xvector<4xf32>>
@@ -135,18 +129,13 @@ hal.executable private @resource_bindings_in_multi_entry_func  {
         // CHECK: spv.mlir.addressof @[[FUNC2_ARG]]
         // CHECK: spv.mlir.addressof @[[FUNC2_RET]]
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x4xf32> // Same type as previous function
-        %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x4xf32> // Different type as previous function
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) : memref<4x4xf32> // Same type as previous function
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(3) binding(4) : memref<4x4xf32> // Different type as previous function
 
         %2 = memref.load %0[%c0, %c0] : memref<4x4xf32>
         %3 = memref.load %1[%c0, %c0] : memref<4x4xf32>
 
         return
-      }
-
-      hal.interface private @io attributes {push_constants = 5 : index} {
-        hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-        hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
       }
     }
   }
@@ -169,20 +158,15 @@ hal.executable private @interface_binding  {
     builtin.module {
       func @interface_binding() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<8x5xf32>
-        %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<5xf32>
-        %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<8x5xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<8x5xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<5xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<8x5xf32>
 
         %3 = memref.load %0[%c0, %c0] : memref<8x5xf32>
         %4 = memref.load %1[%c0] : memref<5xf32>
         %5 = memref.load %2[%c0, %c0] : memref<8x5xf32>
 
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -219,11 +203,6 @@ hal.executable private @interface_wg_id  {
         %1 = hal.interface.workgroup.id[1] : index
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
@@ -257,11 +236,6 @@ hal.executable private @interface_wg_count  {
         %0 = hal.interface.workgroup.count[0] : index
         %1 = hal.interface.workgroup.count[1] : index
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -40,11 +40,11 @@ hal.executable public @matmul_256x1024x128_div_sub {
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
         %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x1024xf16>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:256x128xf16>
-        %3 = hal.interface.binding.subspan @io::@s0b3_ro_external[%c0] : !flow.dispatch.tensor<readonly:128x1024xf16>
-        %4 = hal.interface.binding.subspan @io::@s0b4_xw_external[%c0] : !flow.dispatch.tensor<writeonly:256x1024xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:256x1024xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:256x128xf16>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<readonly:128x1024xf16>
+        %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) : !flow.dispatch.tensor<writeonly:256x1024xf16>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -87,13 +87,6 @@ hal.executable public @matmul_256x1024x128_div_sub {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @s0b2_ro_external, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding public @s0b3_ro_external, set=0, binding=3, type="StorageBuffer"
-        hal.interface.binding public @s0b4_xw_external, set=0, binding=4, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -33,7 +33,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point public @matmul_256x1024x128_div_sub interface(@io)
     builtin.module  {
       func @matmul_256x1024x128_div_sub() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -13,7 +13,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @fuse_and_vectorize_fill_matmul attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @fuse_and_vectorize_fill_matmul interface(@io)
     builtin.module {
       func @fuse_and_vectorize_fill_matmul() {
         %c0 = arith.constant 0 : index
@@ -77,7 +77,7 @@ hal.executable private @fuse_and_vectorize_matmul_add  {
         max_compute_workgroup_size = dense<512> : vector<3xi32>,
        subgroup_size = 16 : i32}>
     }> {
-    hal.executable.entry_point @fuse_and_vectorize_matmul_add attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @fuse_and_vectorize_matmul_add interface(@io)
     builtin.module {
       func @fuse_and_vectorize_matmul_add() {
         %c0 = arith.constant 0 : index

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -19,9 +19,9 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f32
         %c4096 = arith.constant 4096 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:4096x4096xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4096x4096xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4096x4096xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4096x4096xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -49,11 +49,6 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
           }
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -89,10 +84,10 @@ hal.executable private @fuse_and_vectorize_matmul_add  {
         %cst = arith.constant 0.000000e+00 : f32
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:1024x256xf32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:1024x512xf32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : !flow.dispatch.tensor<readonly:512x256xf32>
-        %3 = hal.interface.binding.subspan @io::@s0b3_xw_external[%c0] : !flow.dispatch.tensor<writeonly:1024x256xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1024x256xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:1024x512xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<readonly:512x256xf32>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : !flow.dispatch.tensor<writeonly:1024x256xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -129,12 +124,6 @@ hal.executable private @fuse_and_vectorize_matmul_add  {
           }
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_ro_external, set=0, binding=2, type="StorageBuffer"
-        hal.interface.binding @s0b3_xw_external, set=0, binding=3, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/promote_workgroup_memory.mlir
@@ -8,8 +8,7 @@ hal.executable private @matmul_promote_workgroup_memory  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_promote_workgroup_memory attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @matmul_promote_workgroup_memory interface(@io) {
       workgroup_size = [16: index, 8: index, 1: index]
     }
     builtin.module {
@@ -82,8 +81,7 @@ hal.executable private @conv_promote_workgroup_memory  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_promote_workgroup_memory attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @conv_promote_workgroup_memory interface(@io) {
       workgroup_size = [32: index, 4: index, 1: index]
     }
     builtin.module {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -18,8 +18,7 @@ hal.executable private @matmul  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @matmul interface(@io) {
       workgroup_size = [16: index, 8: index, 1: index],
       translation.info = #translation
     }
@@ -63,6 +62,7 @@ hal.executable private @matmul  {
     }
   }
 }
+
 // CHECK-LABEL: func @matmul
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -86,8 +86,7 @@ hal.executable private @conv_1d  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_1d attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @conv_1d interface(@io) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = #translation
     }
@@ -165,8 +164,7 @@ hal.executable private @conv_2d  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_2d attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @conv_2d interface(@io) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = #translation
     }
@@ -279,8 +277,7 @@ hal.executable private @conv_3d  {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_3d attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @conv_3d interface(@io) {
       workgroup_size = [32: index, 4: index, 1: index],
       translation.info = #translation
     }
@@ -349,8 +346,7 @@ module  {
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-      hal.executable.entry_point @pooling_nhwc_max attributes {
-        interface = @io, ordinal = 0 : index,
+      hal.executable.entry_point @pooling_nhwc_max interface(@io) {
         workgroup_size = [32: index, 4: index, 1: index],
         translation.info = #translation
       }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -29,9 +29,9 @@ hal.executable private @matmul  {
         %M = hal.interface.load.constant offset = 0 : index
         %N = hal.interface.load.constant offset = 1 : index
         %K = hal.interface.load.constant offset = 2 : index
-        %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?xf32>{%M, %K}
-        %arg1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<?x?xf32>{%K, %N}
-        %arg2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x?xf32>{%M, %N}
+        %arg0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?xf32>{%M, %K}
+        %arg1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?xf32>{%K, %N}
+        %arg2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?xf32>{%M, %N}
         %c4 = arith.constant 4 : index
         %c1 = arith.constant 1 : index
         %0 = memref.dim %arg0, %c1 : memref<?x?xf32>
@@ -59,11 +59,6 @@ hal.executable private @matmul  {
             outs(%18 : memref<?x?xf32, #map3>)
         }
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -100,9 +95,9 @@ hal.executable private @conv_1d  {
       func @conv_1d() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<3x6x1xf32>
-        %1 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<3x8x1xf32>
-        %2 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<3x1x1xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<3x6x1xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<3x8x1xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x1x1xf32>
         %3 = "gpu.block_id"() {dimension = "x"} : () -> index
         %4 = "gpu.block_id"() {dimension = "y"} : () -> index
         %5 = "gpu.block_id"() {dimension = "z"} : () -> index
@@ -123,23 +118,17 @@ hal.executable private @conv_1d  {
           outs(%16 : memref<1x?x?xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 6 + s0 + d1 + d2)>>)
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
 
 // CHECK-LABEL: func @conv_1d
-//       CHECK: %[[C0:.+]] = arith.constant 0 : index
-//       CHECK: %[[RET:.+]] = hal.interface.binding.subspan @io::@ret0
-//       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//       CHECK: %[[ARG0SV1:.+]] = memref.subview %[[ARG0]]
-//       CHECK: %[[ARG1SV1:.+]] = memref.subview %[[ARG1]]
-//       CHECK: %[[RETSV1:.+]] = memref.subview %[[RET]]
+//       CHECK-DAG: %[[RET:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//       CHECK-DAG: %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//       CHECK-DAG: %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//       CHECK-DAG: %[[ARG0SV1:.+]] = memref.subview %[[ARG0]]
+//       CHECK-DAG: %[[ARG1SV1:.+]] = memref.subview %[[ARG1]]
+//       CHECK-DAG: %[[RETSV1:.+]] = memref.subview %[[RET]]
 //       CHECK: %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"}
 //       CHECK: %[[BDIMX:.+]] = "gpu.block_dim"() {dimension = "x"}
 //       CHECK: %[[TIDY:.+]] = "gpu.thread_id"() {dimension = "y"}
@@ -155,7 +144,6 @@ hal.executable private @conv_1d  {
 //       CHECK:       linalg.conv_1d_nwc_wcf
 //  CHECK-SAME:         ins(%[[ARG0SV2]], %[[ARG1SV2]]
 //  CHECK-SAME:         outs(%[[RETSV2]]
-
 
 // -----
 
@@ -194,9 +182,9 @@ hal.executable private @conv_2d  {
         %ic = hal.interface.load.constant offset = 6 : index
         %fh = hal.interface.load.constant offset = 7 : index
         %fw = hal.interface.load.constant offset = 8 : index
-        %arg0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x?x?x?xf32>{%n, %ih, %iw, %ic}
-        %arg1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<?x?x?x?xf32>{%fh, %fw, %ic, %oc}
-        %arg2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x?x?x?xf32>{%n, %oh, %ow, %oc}
+        %arg0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x?x?x?xf32>{%n, %ih, %iw, %ic}
+        %arg1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x?x?x?xf32>{%fh, %fw, %ic, %oc}
+        %arg2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<?x?x?x?xf32>{%n, %oh, %ow, %oc}
         %c2 = arith.constant 2 : index
         %c3 = arith.constant 3 : index
         %c1 = arith.constant 1 : index
@@ -244,20 +232,17 @@ hal.executable private @conv_2d  {
         }
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
+
 //     CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 4)>
 //     CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //         CHECK: func @conv_2d
-//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
+//     CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //     CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //     CHECK-DAG:   %[[C4:.+]] = arith.constant 4
 //         CHECK:   %[[INPUT_BLOCK:.+]] = memref.subview %[[ARG1]]
@@ -303,9 +288,9 @@ hal.executable private @conv_3d  {
       func @conv_3d() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<2x7x7x7x2xf32>
-        %1 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<2x8x8x8x3xf32>
-        %2 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<2x2x2x3x2xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<2x7x7x7x2xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<2x8x8x8x3xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<2x2x2x3x2xf32>
         %3 = "gpu.block_id"() {dimension = "x"} : () -> index
         %4 = "gpu.block_id"() {dimension = "y"} : () -> index
         %5 = "gpu.block_id"() {dimension = "z"} : () -> index
@@ -324,11 +309,6 @@ hal.executable private @conv_3d  {
           ins(%10, %2 : memref<1x?x?x8x3xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 1536 + s0 + d1 * 192 + d2 * 24 + d3 * 3 + d4)>>, memref<2x2x2x3x2xf32>)
           outs(%15 : memref<1x?x?x7x2xf32, affine_map<(d0, d1, d2, d3, d4)[s0] -> (d0 * 686 + s0 + d1 * 98 + d2 * 14 + d3 * 2 + d4)>>)
         return
-      }
-      hal.interface private @io  {
-        hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -377,9 +357,9 @@ module  {
       builtin.module {
         func @pooling_nhwc_max() {
           %c0 = arith.constant 0 : index
-          %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<2x16x16x6xf32>
-          %1 = hal.interface.binding.subspan @io::@arg1[%c0] : memref<3x4xf32>
-          %2 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<2x14x13x6xf32>
+          %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<2x16x16x6xf32>
+          %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<3x4xf32>
+          %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<2x14x13x6xf32>
           %3 = "gpu.block_id"() {dimension = "x"} : () -> index
           %4 = "gpu.block_id"() {dimension = "y"} : () -> index
           %5 = affine.apply #map0()[%4]
@@ -395,11 +375,6 @@ module  {
             outs(%12 : memref<2x?x?x6xf32, #map7>)
           return
         }
-        hal.interface private @io  {
-          hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-          hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer"
-          hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
-        }
       }
     }
   }
@@ -408,9 +383,9 @@ module  {
 //     CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 4)>
 //     CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //         CHECK: func @pooling_nhwc_max
-//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan @io::@arg0
-//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan @io::@arg1
-//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan @io::@ret0
+//     CHECK-DAG:   %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//     CHECK-DAG:   %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//     CHECK-DAG:   %[[RET0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //         CHECK:   %[[SV1:.+]] = memref.subview %[[ARG0]]
 //         CHECK:   %[[SV2:.+]] = memref.subview %[[RET0]]
 //     CHECK-DAG:   %[[TIDX:.+]] = "gpu.thread_id"() {dimension = "x"}

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -21,9 +21,9 @@ hal.executable private @static_scatter_update_slice  {
         %c40 = arith.constant 40 : index
         %c500 = arith.constant 500 : index
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<40x500xi32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<40x1xi32>
-        %2 = hal.interface.binding.subspan @io::@s0b2_rw_external[%c0] : memref<100x500xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<40x500xi32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<40x1xi32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<100x500xi32>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -46,19 +46,14 @@ hal.executable private @static_scatter_update_slice  {
         }
         return
       }
-      hal.interface private @io  {
-        hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding @s0b1_ro_external, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding @s0b2_rw_external, set=0, binding=2, type="StorageBuffer"
-      }
     }
   }
 }
 
 // CHECK-LABEL: func @static_scatter_update_slice()
-//       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external
-//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external
-//       CHECK: %[[ARG2:.+]] = hal.interface.binding.subspan @io::@s0b2_rw_external
+//       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
+//       CHECK: %[[ARG2:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2)
 //       CHECK: scf.for
 //       CHECK:   scf.for
 //       CHECK:     %[[WG_UPDATE:.+]] = memref.subview %[[ARG0]]

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -10,12 +10,10 @@ hal.executable private @static_scatter_update_slice  {
   }
 
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_scatter_update_slice attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @static_scatter_update_slice interface(@io) {
       translation.info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }
-
     builtin.module {
       builtin.func @static_scatter_update_slice() {
         %c40 = arith.constant 40 : index

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -8,8 +8,7 @@ hal.executable private @static_3d_sort  {
     hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @static_3d_sort attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @static_3d_sort interface(@io) {
       translation.info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -18,8 +18,8 @@ hal.executable private @static_3d_sort  {
         %c64 = arith.constant 64 : index
         %c128 = arith.constant 128 : index
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<64x32x128xi32>
-        %1 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<64x32x128xi32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<64x32x128xi32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<64x32x128xi32>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -47,8 +47,8 @@ hal.executable private @static_3d_sort  {
 }
 
 // CHECK-LABEL: func @static_3d_sort()
-//       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external
-//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan @io::@s0b1_xw_external
+//       CHECK: %[[ARG0:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0)
+//       CHECK: %[[ARG1:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1)
 //       CHECK: scf.for
 //       CHECK:   scf.for
 //       CHECK:     %[[WG_INPUT:.+]] = memref.subview %[[ARG0]]

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -21,9 +21,9 @@ hal.executable private @fused_fill_batch_matmul {
         %cst = arith.constant 0.000000e+00 : f32
         %c4 = arith.constant 4 : index
         %c1024 = arith.constant 1024 : index
-        %0 = hal.interface.binding.subspan @io::@in0[%c0] : !flow.dispatch.tensor<readonly:4x1024x1024xf32>
-        %1 = hal.interface.binding.subspan @io::@in1[%c0] : !flow.dispatch.tensor<readonly:4x1024x1024xf32>
-        %2 = hal.interface.binding.subspan @io::@out0[%c0] : !flow.dispatch.tensor<writeonly:4x1024x1024xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4x1024x1024xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x1024x1024xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4x1024x1024xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -58,11 +58,6 @@ hal.executable private @fused_fill_batch_matmul {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @in0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @in1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @out1, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -10,8 +10,7 @@ hal.executable private @fused_fill_batch_matmul {
     hal.interface.binding public @out0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @fused_fill_batch_matmul attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @fused_fill_batch_matmul interface(@io) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = #translation
     }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -10,8 +10,7 @@ hal.executable private @conv_static_shape_f32 {
     hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @conv_static_shape_f32 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @conv_static_shape_f32 interface(@io) {
       workgroup_size = [4: index, 4: index, 1: index],
       translation.info = #translation
     }
@@ -101,8 +100,7 @@ hal.executable private @depthwise_conv_static_shape_f32 {
     hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @depthwise_conv_static_shape_f32 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @depthwise_conv_static_shape_f32 interface(@io) {
       workgroup_size = [4: index, 4: index, 4: index],
       translation.info = #translation
     }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -21,9 +21,9 @@ hal.executable private @conv_static_shape_f32 {
         %cst = arith.constant 0.000000e+00 : f32
         %c112 = arith.constant 112 : index
         %c16 = arith.constant 16 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x225x225x8xf32>
-        %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:3x3x8x16xf32>
-        %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:1x112x112x16xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x225x225x8xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x8x16xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x112x112x16xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -64,11 +64,6 @@ hal.executable private @conv_static_shape_f32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -117,9 +112,9 @@ hal.executable private @depthwise_conv_static_shape_f32 {
         %cst = arith.constant 0.000000e+00 : f32
         %c56 = arith.constant 56 : index
         %c96 = arith.constant 96 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:1x113x113x96xf32>
-        %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:3x3x96xf32>
-        %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:1x56x56x96xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:1x113x113x96xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:3x3x96xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:1x56x56x96xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
@@ -160,11 +155,6 @@ hal.executable private @depthwise_conv_static_shape_f32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -19,9 +19,9 @@ hal.executable private @matmul_static_shape_f16 {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f16
         %c4096 = arith.constant 4096 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf16>
-        %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf16>
-        %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:4096x4096xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4096x4096xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4096x4096xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4096x4096xf16>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -47,11 +47,6 @@ hal.executable private @matmul_static_shape_f16 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }
@@ -88,9 +83,9 @@ hal.executable private @matmul_static_shape_f32 {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f32
         %c4096 = arith.constant 4096 : index
-        %0 = hal.interface.binding.subspan @io::@arg0[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf32>
-        %1 = hal.interface.binding.subspan @io::@arg1[%c0] : !flow.dispatch.tensor<readonly:4096x4096xf32>
-        %2 = hal.interface.binding.subspan @io::@ret0[%c0] : !flow.dispatch.tensor<writeonly:4096x4096xf32>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:4096x4096xf32>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4096x4096xf32>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:4096x4096xf32>
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
@@ -116,11 +111,6 @@ hal.executable private @matmul_static_shape_f32 {
           }
         }
         return
-      }
-      hal.interface private @io {
-        hal.interface.binding public @arg0, set=0, binding=0, type="StorageBuffer"
-        hal.interface.binding public @arg1, set=0, binding=1, type="StorageBuffer"
-        hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
       }
     }
   }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -9,8 +9,7 @@ hal.executable private @matmul_static_shape_f16 {
     hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape_f16 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @matmul_static_shape_f16 interface(@io) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = #translation
     }
@@ -73,8 +72,7 @@ hal.executable private @matmul_static_shape_f32 {
     hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.entry_point @matmul_static_shape_f32 attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point @matmul_static_shape_f32 interface(@io) {
       workgroup_size = [16: index, 1: index, 1: index],
       translation.info = #translation
     }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -45,11 +45,11 @@ hal.executable public @matmul_256x1024x128_div_sub {
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
         %cst = arith.constant 0.000000e+00 : f16
-        %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<256x1024xf16>
-        %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : memref<256x1024xf16>
-        %2 = hal.interface.binding.subspan @io::@s0b2_ro_external[%c0] : memref<256x128xf16>
-        %3 = hal.interface.binding.subspan @io::@s0b3_ro_external[%c0] : memref<128x1024xf16>
-        %4 = hal.interface.binding.subspan @io::@s0b4_xw_external[%c0] : memref<256x1024xf16>
+        %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<256x1024xf16>
+        %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<256x1024xf16>
+        %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<256x128xf16>
+        %3 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<128x1024xf16>
+        %4 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) : memref<256x1024xf16>
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_count_x = hal.interface.workgroup.count[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
@@ -103,11 +103,11 @@ hal.executable public @matmul_256x1024x128_div_sub {
 // CHECK-DAG: %[[C96:.+]] = arith.constant 96 : index
 // CHECK-DAG: %[[C112:.+]] = arith.constant 112 : index
 
-// CHECK: %[[DIV_BUFFER:.+]] = hal.interface.binding.subspan @io::@s0b0_ro_external[%[[C0]]] : memref<256x1024xf16>
-// CHECK: %[[SUB_BUFFER:.+]] = hal.interface.binding.subspan @io::@s0b1_ro_external[%[[C0]]] : memref<256x1024xf16>
-// CHECK: %[[LHS_BUFFER:.+]] = hal.interface.binding.subspan @io::@s0b2_ro_external[%[[C0]]] : memref<256x128xf16>
-// CHECK: %[[RHS_BUFFER:.+]] = hal.interface.binding.subspan @io::@s0b3_ro_external[%[[C0]]] : memref<128x1024xf16>
-// CHECK: %[[ACC_BUFFER:.+]] = hal.interface.binding.subspan @io::@s0b4_xw_external[%[[C0]]] : memref<256x1024xf16>
+// CHECK: %[[DIV_BUFFER:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<256x1024xf16>
+// CHECK: %[[SUB_BUFFER:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<256x1024xf16>
+// CHECK: %[[LHS_BUFFER:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : memref<256x128xf16>
+// CHECK: %[[RHS_BUFFER:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(3) : memref<128x1024xf16>
+// CHECK: %[[ACC_BUFFER:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(4) : memref<256x1024xf16>
 
 // CHECK: scf.for %[[IV_Y:.+]] =
 // CHECK:   %[[LHS_TILE:.+]] = memref.subview %[[LHS_BUFFER]][%[[IV_Y]], 0] [16, 128] [1, 1]

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -28,8 +28,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
            max_compute_workgroup_invocations = 1024 : i32,
            max_compute_workgroup_size = dense<[2147483647, 65535, 65535]> : vector<3xi32>,
            subgroup_size = 32 : i32}>}> {
-    hal.executable.entry_point public @matmul_256x1024x128_div_sub attributes {
-      interface = @io, ordinal = 0 : index,
+    hal.executable.entry_point public @matmul_256x1024x128_div_sub interface(@io) {
       translation.info = #translation,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     } {

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -38,8 +38,8 @@ func @alloc_copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
 // -----
 
 // CHECK-LABEL: func @resource_copy
-//     CHECK: %[[A:.+]] = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x1024xvector<4xf32>>
-//     CHECK: %[[B:.+]] = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x1024xvector<4xf32>>
+//     CHECK: %[[A:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x1024xvector<4xf32>>
+//     CHECK: %[[B:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x1024xvector<4xf32>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf32>>
 //     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf32>>, vector<32x8xf32>
@@ -47,8 +47,8 @@ func @alloc_copy(%arg0: memref<4096x4096xf32>, %x: index, %y: index) {
 func @resource_copy() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x4096xf32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x4096xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x4096xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x4096xf32>
   %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<1x4xf32>
   vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x4096xf32>
   %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
@@ -56,16 +56,11 @@ func @resource_copy() {
   return
 }
 
-hal.interface private @io attributes {push_constants = 5 : index} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
-}
-
 // -----
 
 // CHECK-LABEL: func @resource_copy_f16
-//     CHECK: %[[A:.+]] = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x1024xvector<4xf16>>
-//     CHECK: %[[B:.+]] = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x1024xvector<4xf16>>
+//     CHECK: %[[A:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x1024xvector<4xf16>>
+//     CHECK: %[[B:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x1024xvector<4xf16>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf16>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x1024xvector<4xf16>>
 //     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x1024xvector<4xf16>>, vector<32x8xf16>
@@ -73,8 +68,8 @@ hal.interface private @io attributes {push_constants = 5 : index} {
 func @resource_copy_f16() {
   %cst = arith.constant 0.000000e+00 : f16
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x4096xf16>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x4096xf16>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x4096xf16>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x4096xf16>
   %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<1x4xf16>
   vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf16>, memref<4096x4096xf16>
   %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<32x8xf16>
@@ -82,16 +77,11 @@ func @resource_copy_f16() {
   return
 }
 
-hal.interface private @io attributes {push_constants = 5 : index} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
-}
-
 // -----
 
 // CHECK-LABEL: func @resource_copy_8xf16
-//     CHECK: %[[A:.+]] = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x512xvector<4xf32>>
-//     CHECK: %[[B:.+]] = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x512xvector<4xf32>>
+//     CHECK: %[[A:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x512xvector<4xf32>>
+//     CHECK: %[[B:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x512xvector<4xf32>>
 //     CHECK: %[[V:.+]] = memref.load %[[A]][%{{.*}}, %{{.*}}] : memref<4096x512xvector<4xf32>>
 //     CHECK: memref.store %[[V]], %[[B]][%{{.*}}, %{{.*}}] : memref<4096x512xvector<4xf32>>
 //     CHECK: %[[MAT:.+]] = vector.transfer_read %[[A]][%{{.*}}, %{{.*}}], %{{.*}} : memref<4096x512xvector<4xf32>>, vector<32x8xf16>
@@ -99,18 +89,13 @@ hal.interface private @io attributes {push_constants = 5 : index} {
 func @resource_copy_8xf16() {
   %cst = arith.constant 0.000000e+00 : f16
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x4096xf16>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x4096xf16>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x4096xf16>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x4096xf16>
   %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<1x8xf16>
   vector.transfer_write %v, %1[%c0, %c0] : vector<1x8xf16>, memref<4096x4096xf16>
   %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf16>, vector<32x8xf16>
   vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf16>, memref<4096x4096xf16>
   return
-}
-
-hal.interface private @io attributes {push_constants = 5 : index} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
 }
 
 // -----
@@ -124,10 +109,10 @@ func @resource_copy_dynamic_shape() {
   %dim0 = hal.interface.load.constant offset = 0 : index
   %dim1 = hal.interface.load.constant offset = 1 : index
 
-  // CHECK: %[[INPUT:.+]] = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x8x?x32xvector<4xf32>>{%[[DIM0]], %[[DIM1]]}
-  // CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x8x?x32xvector<4xf32>>{%[[DIM0]], %[[DIM1]]}
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<?x8x?x128xf32>{%dim0, %dim1}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<?x8x?x128xf32>{%dim0, %dim1}
+  // CHECK: %[[INPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x8x?x32xvector<4xf32>>{%[[DIM0]], %[[DIM1]]}
+  // CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x8x?x32xvector<4xf32>>{%[[DIM0]], %[[DIM1]]}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<?x8x?x128xf32>{%dim0, %dim1}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<?x8x?x128xf32>{%dim0, %dim1}
 
   // CHECK: %[[VAL1:.+]] = memref.load %[[INPUT]]
   // CHECK: memref.store %[[VAL1]], %[[OUTPUT]]
@@ -141,11 +126,6 @@ func @resource_copy_dynamic_shape() {
   return
 }
 
-hal.interface @io attributes {push_constants = 5 : index, sym_visibility = "private"} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
-}
-
 // -----
 
 // CHECK-LABEL: func @resource_copy_dynamic_last_dim()
@@ -153,18 +133,13 @@ func @resource_copy_dynamic_last_dim() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
   %dim = hal.interface.load.constant offset = 0 : index
-  // CHECK: hal.interface.binding.subspan @io::@arg0[{{.+}}] : memref<4096x?xf32>
-  // CHECK: hal.interface.binding.subspan @io::@ret0[{{.+}}] : memref<4096x?xf32>
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x?xf32>{%dim}
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x?xf32>{%dim}
+  // CHECK: hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x?xf32>
+  // CHECK: hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x?xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x?xf32>{%dim}
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x?xf32>{%dim}
   %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x?xf32>, vector<1x4xf32>
   vector.transfer_write %v, %1[%c0, %c0] : vector<1x4xf32>, memref<4096x?xf32>
   return
-}
-
-hal.interface @io attributes {push_constants = 5 : index, sym_visibility = "private"} {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
 }
 
 // -----
@@ -175,18 +150,13 @@ func @do_not_vectorize_odd_vector_size() {
   %c0 = arith.constant 0 : index
   // CHECK: hal.interface.binding.subspan
   // CHECK-SAME: memref<4x3xf32>
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4x3xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4x3xf32>
   // CHECK: hal.interface.binding.subspan
   // CHECK-SAME: memref<4x3xf32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4x3xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4x3xf32>
   %v = vector.transfer_read %0[%c0, %c0], %cst : memref<4x3xf32>, vector<3xf32>
   vector.transfer_write %v, %1[%c0, %c0] : vector<3xf32>, memref<4x3xf32>
   return
-}
-
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=1, binding=2, type="StorageBuffer"
-  hal.interface.binding @ret0, set=3, binding=4, type="StorageBuffer"
 }
 
 // -----
@@ -194,21 +164,15 @@ hal.interface private @io  {
 func @vectorize_binding_subspan() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  // CHECK: hal.interface.binding.subspan @io::@arg0[%c0]
-  // CHECK-SAME: memref<4096x1024xvector<4xf32>>
-  // CHECK: hal.interface.binding.subspan @io::@ret0[%c0]
-  // CHECK-SAME: memref<4096x1024xvector<4xf32>>
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<4096x4096xf32>
-  %1 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<4096x4096xf32>
+  // CHECK: hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x1024xvector<4xf32>>
+  // CHECK: hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x1024xvector<4xf32>>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<4096x4096xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<4096x4096xf32>
   %mat = vector.transfer_read %0[%c0, %c0], %cst : memref<4096x4096xf32>, vector<32x8xf32>
   vector.transfer_write %mat, %1[%c0, %c0] : vector<32x8xf32>, memref<4096x4096xf32>
   return
 }
 
-hal.interface private @io  {
-  hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer"
-}
 
 // -----
 
@@ -217,8 +181,8 @@ func @scalarize_vector_transfer_op(%arg: vector<3xf32>) -> (vector<3xf32>) {
   %c0 = arith.constant 0: index
   %c3 = arith.constant 3: index
   %f0 = arith.constant 0.0 : f32
-  %0 = hal.interface.binding.subspan @io::@arg0[%c0] : memref<20xf32>
-  %2 = hal.interface.binding.subspan @io::@ret1[%c0] : memref<20xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<20xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<20xf32>
   // CHECK-DAG: %[[INDEX0:.+]] = arith.constant 3 : index
   // CHECK-DAG: %[[INDEX1:.+]] = arith.constant 4 : index
   // CHECK-DAG: %[[INDEX2:.+]] = arith.constant 5 : index

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_matmul.mlir
@@ -9,9 +9,9 @@ func @matmul_2x128x4() {
   %c2 = arith.constant 2 : index
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : !flow.dispatch.tensor<readonly:2x4xf32>
-  %1 = hal.interface.binding.subspan @io::@s0b1_ro_external[%c0] : !flow.dispatch.tensor<readonly:4x128xf32>
-  %2 = hal.interface.binding.subspan @io::@s0b2_xw_external[%c0] : !flow.dispatch.tensor<writeonly:2x128xf32>
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : !flow.dispatch.tensor<readonly:2x4xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : !flow.dispatch.tensor<readonly:4x128xf32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(2) : !flow.dispatch.tensor<writeonly:2x128xf32>
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index
   %workgroup_id_y = hal.interface.workgroup.id[1] : index

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -951,11 +951,6 @@ static LogicalResult verifyInterfaceBindingSubspanOp(
   return success();
 }
 
-InterfaceBindingOp InterfaceBindingSubspanOp::queryBindingOp() {
-  return dyn_cast_or_null<InterfaceBindingOp>(
-      SymbolTable::lookupNearestSymbolFrom(getOperation(), binding()));
-}
-
 // TODO(benvanik): share with align op folder and analysis.
 // May need an interface for querying the alignment from ops that can carry it.
 
@@ -995,6 +990,10 @@ llvm::Align InterfaceBindingSubspanOp::calculateAlignment() {
   if (!bindingAlignmentInt) return naturalAlignment;
   auto bindingAlignment =
       llvm::Align(bindingAlignmentInt.getValue().getZExtValue());
+
+  // If there's no offset specified then we can use the binding alignment
+  // directly.
+  if (!byte_offset()) return bindingAlignment;
 
   // Try to get the alignment of the byte offset. If it's a constant then we can
   // find a common alignment between it and the base and otherwise we need to

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -698,12 +698,19 @@ static ParseResult parseExecutableEntryPointOp(OpAsmParser &parser,
   }
 
   StringAttr nameAttr;
+  SymbolRefAttr interfaceAttr;
   if (failed(parser.parseSymbolName(nameAttr,
                                     mlir::SymbolTable::getSymbolAttrName(),
                                     result->attributes)) ||
-      failed(parser.parseOptionalAttrDictWithKeyword(result->attributes))) {
+      failed(parser.parseKeyword("interface")) ||
+      failed(parser.parseLParen()) ||
+      failed(parser.parseAttribute(interfaceAttr)) ||
+      failed(parser.parseRParen()) ||
+      failed(parser.parseOptionalAttrDict(result->attributes))) {
     return failure();
   }
+  result->addAttribute("interface", interfaceAttr);
+
   // For now assume that the workload is at max 3D. So arguments to the region
   // are workload along x, y and z.
   std::unique_ptr<Region> region;
@@ -714,6 +721,7 @@ static ParseResult parseExecutableEntryPointOp(OpAsmParser &parser,
   if (!parseResult.hasValue()) return success();
   if (failed(*parseResult)) return failure();
   result->addRegion(std::move(region));
+
   return success();
 }
 
@@ -723,8 +731,11 @@ static void printExecutableEntryPointOp(OpAsmPrinter &p,
   printSymbolVisibility(p, op, op->getAttrOfType<StringAttr>("sym_visibility"));
   p << ' ';
   p.printSymbolName(op.sym_name());
-  p.printOptionalAttrDictWithKeyword(op->getAttrs(),
-                                     /*elidedAttrs=*/{"sym_name"});
+  p << " interface(";
+  p.printAttributeWithoutType(op.interfaceAttr());
+  p << ")";
+  p.printOptionalAttrDict(op->getAttrs(),
+                          /*elidedAttrs=*/{"sym_name", "interface"});
   if (op.workgroup_count_region().empty()) return;
   p.printRegion(op.workgroup_count_region().front());
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1951,7 +1951,8 @@ def HAL_InterfaceLoadConstantOp : HAL_PureOp<"interface.load.constant"> {
 }
 
 def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
-    AttrSizedOperandSegments, MemoryEffects<[MemAlloc]>,
+    AttrSizedOperandSegments,
+    MemoryEffects<[MemAlloc]>,
     Util_ShapeAwareOp,
   ]> {
   let summary = [{returns an alias to a subspan of interface binding data}];
@@ -1966,9 +1967,10 @@ def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
   }];
 
   let arguments = (ins
-    SymbolRefAttr:$binding,
-    HAL_DeviceSize:$byte_offset,
-    Optional<HAL_DeviceSize>:$byte_length,
+    HAL_DescriptorTypeAttr:$type,
+    IndexAttr:$set,
+    IndexAttr:$binding,
+    Optional<HAL_DeviceSize>:$byte_offset,
     HAL_ShapeDynamicDims:$dynamic_dims,
     OptionalAttr<IndexAttr>:$alignment
   );
@@ -1977,7 +1979,11 @@ def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
   );
 
   let assemblyFormat = [{
-    $binding `[` $byte_offset ( `,` $byte_length^ )? `]`
+    `type` `(` $type `)`
+    `set` `(` $set `)`
+    `binding` `(` $binding `)`
+    (`offset` `(` $byte_offset^ `)`)?
+    (`alignment` `(` $alignment^ `)`)?
     attr-dict `:` type($result) (`{` $dynamic_dims^ `}`)?
   }];
 
@@ -1986,10 +1992,6 @@ def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
   let extraClassDeclaration = [{
     ValueRange getOperandDynamicDims(unsigned idx) { return ValueRange{}; }
     ValueRange getResultDynamicDims(unsigned idx) { return dynamic_dims(); }
-
-    /// Returns the hal.interface.binding op associated with this op.
-    /// Returns null op if not found.
-    IREE::HAL::InterfaceBindingOp queryBindingOp();
 
     // Attempts to calculate an alignment of the final subspan offset in the
     // parent storage buffer. This is a combination of both the binding

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1478,7 +1478,7 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
     SymbolNameAttr:$sym_name,
-    HAL_OrdinalAttr:$ordinal,
+    OptionalAttr<HAL_OrdinalAttr>:$ordinal,
     FlatSymbolRefAttr:$interface,
     OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size,
     OptionalAttr<IndexAttr>:$workgroup_local_memory
@@ -1487,16 +1487,6 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
   let regions = (region VariadicRegion<SizedRegion<1>>:$workgroup_count_region);
 
   let builders = [
-    OpBuilder<(ins
-      "::llvm::StringRef":$sym_name,
-      "::llvm::APInt":$ordinal,
-      "::llvm::StringRef":$interface,
-      "::mlir::ArrayAttr":$workgroup_size,
-      "::mlir::IntegerAttr":$workgroup_local_memory
-    ), [{
-      build($_builder, $_state, nullptr, sym_name, ordinal, interface,
-            workgroup_size, workgroup_local_memory, 0);
-    }]>,
     OpBuilder<(ins
       "::mlir::StringAttr":$sym_name,
       "::mlir::IntegerAttr":$ordinal,

--- a/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -135,8 +135,7 @@ func @command_buffer_bind_descriptor_set(
 
 hal.executable @ex {
   hal.executable.variant @backend, target = <"backend", "format"> {
-    hal.executable.entry_point @entry0 attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry0 interface(@interface) {
       ordinal = 0 : index
     }
   }
@@ -164,8 +163,7 @@ func @command_buffer_dispatch(
 
 hal.executable @ex {
   hal.executable.variant @backend, target = <"backend", "format"> {
-    hal.executable.entry_point @entry0 attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry0 interface(@interface) {
       ordinal = 0 : index
     }
   }

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -6,12 +6,10 @@
 hal.executable @ex {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.entry_point public @entry0 attributes {
-    // CHECK-SAME:     interface = @interface
+    // CHECK-DAG: hal.executable.entry_point public @entry0 interface(@interface) {
     // CHECK-SAME:     ordinal = 0 : index
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.entry_point @entry0 attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry0 interface(@interface) {
       ordinal = 0 : index,
       workgroup_size = [4 : index, 1 : index, 1 : index]
     }
@@ -40,12 +38,10 @@ hal.executable @ex {
 hal.executable @ex_with_workgroup_count_region {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.entry_point public @entry0 attributes {
-    // CHECK-SAME:     interface = @interface
+    // CHECK-DAG: hal.executable.entry_point public @entry0 interface(@interface) {
     // CHECK-SAME:     ordinal = 0 : index
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.entry_point @entry0 attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry0 interface(@interface) {
       ordinal = 0 : index,
       workgroup_size = [4 : index, 1 : index, 1 : index]
     } {

--- a/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
@@ -17,13 +17,12 @@ func @interface_workgroup_info() {
 //  CHECK-SAME: (%[[DIM0:.+]]: index, %[[DIM2:.+]]: index)
 func @interface_io_subspan(%dim0: index, %dim2: index) {
   %c8 = arith.constant 8 : index
-  %c16 = arith.constant 16 : index
 
-  // CHECK: = hal.interface.binding.subspan @interface::@s0b0[%c8] : memref<?x4x?x16xi8>{%[[DIM0]], %[[DIM2]]}
-  %0 = hal.interface.binding.subspan @interface::@s0b0[%c8] : memref<?x4x?x16xi8>{%dim0, %dim2}
+  // CHECK: = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c8) : memref<?x4x?x16xi8>{%[[DIM0]], %[[DIM2]]}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c8) : memref<?x4x?x16xi8>{%dim0, %dim2}
 
-  // CHECK: = hal.interface.binding.subspan @interface::@s0b0[%c8, %c16] : memref<16xi8>
-  %1 = hal.interface.binding.subspan @interface::@s0b0[%c8, %c16] : memref<16xi8>
+  // CHECK: = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) alignment(16) : memref<16xi8>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(1) binding(2) alignment(16) : memref<16xi8>
 
   return
 }
@@ -34,7 +33,7 @@ func @interface_io_subspan_wrong_dynamic_dim(%dim: index) {
   %c8 = arith.constant 8 : index
 
   // expected-error @+1{{result type 'memref<?x4x?x16xi8>' has 2 dynamic dimensions but 1 associated dimension SSA values}}
-  %0 = hal.interface.binding.subspan @interface::@s0b0[%c8] : memref<?x4x?x16xi8>{%dim}
+  %0 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) offset(%c8) : memref<?x4x?x16xi8>{%dim}
 
   return
 }

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -136,8 +136,7 @@ class TargetBackend {
   //       hal.interface.binding @arg1, set=0, binding=1, ...
   //     }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.entry_point @main attributes {
-  //         interface = @main_io,
+  //       hal.executable.entry_point @main interface(@main_io) {
   //         ordinal = 0 : index
   //       }
   //       module { ... }

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -9,7 +9,7 @@ hal.executable private @dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_0 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.func @dispatch_0() {
@@ -27,7 +27,7 @@ hal.executable private @dispatch_1 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_1 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.func @dispatch_1() {
@@ -46,7 +46,7 @@ hal.executable private @dispatch_2 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_2 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_2 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.func @dispatch_2() {
@@ -94,9 +94,9 @@ util.initializer {
 // CHECK-NEXT:      hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hal.executable.variant public @vmvx_bytecode_fb, target = #executable_target_vmvx_bytecode_fb {
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_0 attributes {interface = @io_0, ordinal = 0 : index}
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_1 attributes {interface = @io_0, ordinal = 1 : index}
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_2 attributes {interface = @io_1, ordinal = 2 : index}
+// CHECK-NEXT:      hal.executable.entry_point public @dispatch_0 interface(@io_0) {ordinal = 0 : index}
+// CHECK-NEXT:      hal.executable.entry_point public @dispatch_1 interface(@io_0) {ordinal = 1 : index}
+// CHECK-NEXT:      hal.executable.entry_point public @dispatch_2 interface(@io_1) {ordinal = 2 : index}
 // CHECK-NEXT:      module {
 // CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.func @dispatch_0() {
@@ -141,7 +141,7 @@ hal.executable private @dispatch_0 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_0 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.func @dispatch_0() {
@@ -162,7 +162,7 @@ hal.executable private @dispatch_1 {
     hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_1 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.func @dispatch_1() {
@@ -209,8 +209,8 @@ func @other_targets() -> () {
 // CHECK-NEXT:      hal.interface.binding public @ret0, set=0, binding=2, type="StorageBuffer"
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hal.executable.variant public @vmvx_bytecode_fb, target = #executable_target_vmvx_bytecode_fb {
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_0 attributes {interface = @io_0, ordinal = 0 : index}
-// CHECK-NEXT:      hal.executable.entry_point public @dispatch_1 attributes {interface = @io_1, ordinal = 1 : index}
+// CHECK-NEXT:      hal.executable.entry_point public @dispatch_0 interface(@io_0) {ordinal = 0 : index}
+// CHECK-NEXT:      hal.executable.entry_point public @dispatch_1 interface(@io_1) {ordinal = 1 : index}
 // CHECK-NEXT:      module {
 // CHECK-NEXT:        vm.module public @linked_module {
 // CHECK-NEXT:          vm.func @dispatch_0() {
@@ -263,7 +263,7 @@ module {
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant @vmvx, target = #vmvx_target {
-      hal.executable.entry_point @dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+      hal.executable.entry_point @dispatch_0 interface(@io) {ordinal = 0 : index}
       builtin.module {
         vm.module @module {}
       }
@@ -276,7 +276,7 @@ module {
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant @vmvx, target = #vmvx_target {
-      hal.executable.entry_point @dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+      hal.executable.entry_point @dispatch_1 interface(@io) {ordinal = 0 : index}
       builtin.module {
         vm.module @module {}
       }
@@ -289,7 +289,7 @@ module {
       hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant @vmvx, target = #vmvx_target {
-      hal.executable.entry_point @dispatch_2 attributes {interface = @io, ordinal = 0 : index}
+      hal.executable.entry_point @dispatch_2 interface(@io) {ordinal = 0 : index}
       builtin.module {
         vm.module @module {}
       }
@@ -320,7 +320,7 @@ module {
 hal.executable private @dispatch_0 {
   hal.interface @io {}
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_0 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         vm.rodata public @rodata_a dense<[0]> : tensor<1xi32>
@@ -343,7 +343,7 @@ hal.executable private @dispatch_0 {
 hal.executable private @dispatch_1 {
   hal.interface @io {}
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.entry_point @dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @dispatch_1 interface(@io) {ordinal = 0 : index}
     builtin.module {
       vm.module @module {
         // Conflict with a public symbol, this should be renamed when linked.

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -43,8 +43,7 @@ stream.executable public @add_dispatch_0 {
 //  CHECK-NEXT:    hal.interface.binding public @s0b2, set=0, binding=2, type="StorageBuffer"
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   hal.executable.variant public @vmvx_bytecode_fb, target = #executable_target_vmvx_bytecode_fb {
-//  CHECK-NEXT:     hal.executable.entry_point public @add_dispatch_0 attributes {
-//  CHECK-SAME:       interface = @io,
+//  CHECK-NEXT:     hal.executable.entry_point public @add_dispatch_0 interface(@io) {
 //  CHECK-SAME:       ordinal = 0 : index
 //  CHECK-SAME:     }
 //       CHECK:     module attributes {vm.toplevel} {

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
@@ -11,7 +11,7 @@ hal.executable private @call_dispatch_0  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_0 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @call_dispatch_0 interface(@io) {ordinal = 0 : index}
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_0() "None" {
@@ -34,7 +34,7 @@ hal.executable private @call_dispatch_1  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_1 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @call_dispatch_1 interface(@io) {ordinal = 0 : index}
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_1() "None" {
@@ -57,7 +57,7 @@ hal.executable private @call_dispatch_2  {
     hal.interface.binding @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_2 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @call_dispatch_2 interface(@io) {ordinal = 0 : index}
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_2() "None" {
@@ -80,7 +80,7 @@ hal.executable private @call_dispatch_3  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_3 attributes {interface = @io, ordinal = 0 : index} {
+    hal.executable.entry_point @call_dispatch_3 interface(@io) {ordinal = 0 : index} {
     ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
       %c1 = arith.constant 1 : index
       %c56 = arith.constant 56 : index
@@ -110,7 +110,7 @@ hal.executable private @call_dispatch_4  {
     hal.interface.binding @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.entry_point @call_dispatch_4 attributes {interface = @io, ordinal = 0 : index}
+    hal.executable.entry_point @call_dispatch_4 interface(@io) {ordinal = 0 : index}
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_4() "None" {
@@ -137,9 +137,9 @@ hal.executable private @call_dispatch_4  {
 // CHECK-NEXT:     hal.interface.binding public @s0b2_xw_external, set=0, binding=2, type="StorageBuffer"
 // CHECK-NEXT:   }
 // CHECK-NEXT:   hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_1 attributes {interface = @io_0, ordinal = 0 : index}
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_3 attributes {interface = @io_0, ordinal = 1 : index}
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_4 attributes {interface = @io_0, ordinal = 2 : index}
+// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_1 interface(@io_0) {ordinal = 0 : index}
+// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_3 interface(@io_0) {ordinal = 1 : index}
+// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_4 interface(@io_0) {ordinal = 2 : index}
 // CHECK-NEXT:     module  {
 // CHECK-NEXT:       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
 // CHECK-NEXT:         spv.func @call_dispatch_1() "None" {
@@ -168,8 +168,8 @@ hal.executable private @call_dispatch_4  {
 // CHECK-NEXT:     hal.interface.binding public @s0b1_rw_external, set=0, binding=1, type="StorageBuffer"
 // CHECK-NEXT:   }
 // CHECK-NEXT:   hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_0 attributes {interface = @io_0, ordinal = 0 : index}
-// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_2 attributes {interface = @io_0, ordinal = 1 : index}
+// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_0 interface(@io_0) {ordinal = 0 : index}
+// CHECK-NEXT:     hal.executable.entry_point public @call_dispatch_2 interface(@io_0) {ordinal = 1 : index}
 // CHECK-NEXT:     module  {
 // CHECK-NEXT:       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
 // CHECK-NEXT:         spv.func @call_dispatch_0() "None" {

--- a/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -21,8 +21,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       hal.interface.binding public @s0b2_wo, set=0, binding=2, type="StorageBuffer"
     }
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.entry_point public @dispatch attributes {
-        interface = @io,
+      hal.executable.entry_point public @dispatch interface(@io) {
         ordinal = 0 : index,
         translation.info = #translation
       } {

--- a/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -117,18 +117,15 @@ hal.executable @exe {
     hal.interface.binding @s0b2, set=0, binding=2, type="StorageBuffer"
   }
   hal.executable.variant @vmvx, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry0 attributes {
-      interface = @interface0,
+    hal.executable.entry_point @entry0 interface(@interface0) {
       ordinal = 0 : index,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.entry_point @entry0_alias attributes {
-      interface = @interface0,
+    hal.executable.entry_point @entry0_alias interface(@interface0) {
       ordinal = 0 : index,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.entry_point @entry1 attributes {
-      interface = @interface1,
+    hal.executable.entry_point @entry1 interface(@interface1) {
       ordinal = 1 : index,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }

--- a/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/resolve_entry_point_ordinals.mlir
@@ -6,8 +6,7 @@ hal.executable @exe {
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @target, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry interface(@interface) {
       ordinal = 0 : index,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
@@ -62,8 +61,7 @@ hal.executable @exe {
     hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer"
   }
   hal.executable.variant @target, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.entry_point @entry attributes {
-      interface = @interface,
+    hal.executable.entry_point @entry interface(@interface) {
       ordinal = 0 : index,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }

--- a/iree/compiler/Dialect/Modules/VMVX/Conversion/HALToVMVX/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/Modules/VMVX/Conversion/HALToVMVX/test/interface_ops.mlir
@@ -1,10 +1,5 @@
 // RUN: iree-opt -split-input-file -iree-vmvx-conversion -canonicalize %s | IreeFileCheck %s
 
-hal.interface private @io  {
-  hal.interface.binding @s0b0_ro_external, set=0, binding=0, type="StorageBuffer"
-  hal.interface.binding @s0b1_xw_external, set=0, binding=1, type="StorageBuffer"
-}
-
 // CHECK: memref.global "private" constant @__constant_5xi32 : memref<5xi32> = dense<[1, 2, 3, 4, 5]>
 memref.global "private" constant @__constant_5xi32 : memref<5xi32> = dense<[1, 2, 3, 4, 5]>
 
@@ -29,10 +24,10 @@ func @entry() {
   %0 = memref.get_global @__constant_5xi32 : memref<5xi32>
   //      CHECK: %[[BINDING0_RAW:.+]] = util.list.get %[[BINDINGS]][%c0] : !util.list<memref<?xi8>>
   // CHECK-NEXT: %[[BINDING0:.+]] = builtin.unrealized_conversion_cast %[[BINDING0_RAW]] : memref<?xi8> to memref<5xf32>
-  %1 = hal.interface.binding.subspan @io::@s0b0_ro_external[%c0] : memref<5xf32>
+  %1 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(0) : memref<5xf32>
   //      CHECK: %[[BINDING1_RAW:.+]] = util.list.get %[[BINDINGS]][%c1] : !util.list<memref<?xi8>>
   // CHECK-NEXT: %[[BINDING1:.+]] = builtin.unrealized_conversion_cast %[[BINDING1_RAW]] : memref<?xi8> to memref<5xi32>
-  %2 = hal.interface.binding.subspan @io::@s0b1_xw_external[%c0] : memref<5xi32>
+  %2 = hal.interface.binding.subspan type(StorageBuffer) set(0) binding(1) : memref<5xi32>
   %workgroup_size_x = hal.interface.workgroup.size[0] : index
   %workgroup_id_x = hal.interface.workgroup.id[0] : index
   %workgroup_count_x = hal.interface.workgroup.count[0] : index


### PR DESCRIPTION
Now with most of the optimizations that reorder/fuse/etc bindings
happening in the stream dialect and the binding analysis happening
only during materialization we don't need the flexibility of the symbols
within the executable bodies. This removes the need for the inlined
hal.interface to make symbol resolution happy.

Future changes will clean things up more - this is just the first step
enabling `hal.interface` to change without impacting codegen.