### PR TITLE
Stop benchmarking on Galaxy S20

### DIFF
--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -63,26 +63,6 @@ steps:
       - "trace-captures-galaxy-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz"
     timeout_in_minutes: "60"
 
-  - label: "Benchmark on Galaxy S20 (exynos-990, mali-g77)"
-    commands:
-      - "git clean -fdx"
-      - "buildkite-agent artifact download --step Build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "buildkite-agent artifact download --step Build iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "wget https://storage.googleapis.com/iree-shared-files/tracy-capture-058e8901.tgz"
-      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "tar -xzvf tracy-capture-058e8901.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --normal_benchmark_tool=build-android/iree/tools/iree-benchmark-module --traced_benchmark_tool=build-android-trace/iree/tools/iree-benchmark-module --trace_capture_tool=tracy-capture -o benchmark-results-galaxy-s20-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-galaxy-s20-${BUILDKITE_BUILD_NUMBER}.tgz --verbose build-host/"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
-    agents:
-      - "android-soc=exynos-990"
-      - "android-version=11"
-      - "queue=benchmark-android"
-    artifact_paths:
-      - "benchmark-results-galaxy-s20-${BUILDKITE_BUILD_NUMBER}.json"
-      - "trace-captures-galaxy-s20-${BUILDKITE_BUILD_NUMBER}.tgz"
-    timeout_in_minutes: "60"
-
   - wait
 
   - label: "Comment benchmark results on pull request"


### PR DESCRIPTION
We cannot pin down GPU frequency on these phones reliably, even
with rooting. The numbers reported by these phones fluctuate to
a greate extent, rendering them basically unless. Having them
is brininging more confusion than help now given we can use
Pixel 6 Pro for Mali GPU benchmarking.