### PR TITLE
Remove "Tests printing and parsing of" comments.

### DIFF
--- a/docs/developers/developing_iree/testing_guide.md
+++ b/docs/developers/developing_iree/testing_guide.md
@@ -105,6 +105,11 @@ iree_cc_test(
 Tests for the IREE compilation pipeline are written as lit tests in the same
 style as MLIR.
 
+By convention, IREE includes tests for printing and parsing of MLIR ops in
+`.../IR/test/{OP_CATEGORY}_ops.mlir` files, tests for folding and
+canonicalization in `.../IR/test/{OP_CATEGORY}_folding.mlir` files, and tests
+for compiler passes and pipelines in other `.../test/*.mlir` files.
+
 ### Running a Test
 
 For the test
@@ -134,7 +139,7 @@ dialects and passes and doesn't register some unnecessary core ones. Instead of
 a shell-script wrapper around FileCheck that passes it a few
 `--do-the-right-thing` flags.
 
-As with all parts of the IREE compiler, these should not have a dependency on
+As with most parts of the IREE compiler, these should not have a dependency on
 the runtime.
 
 ### Configuring the Build System

--- a/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/executable_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of executable/structural ops.
-
 // RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @dispatch_ex

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of tensor ops.
-
 // RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @tensorReshape

--- a/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/experimental_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of experimental ops.
-
 // RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @shared_device

--- a/iree/compiler/Dialect/HAL/IR/test/semaphore_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/semaphore_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of hal.semaphore ops.
-
 // RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @semaphore_create

--- a/iree/compiler/Dialect/VM/IR/test/arithmetic_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/arithmetic_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of arithmetic ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @add_i32

--- a/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of assignment ops.
-
 // RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @select_i32

--- a/iree/compiler/Dialect/VM/IR/test/comparison_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/comparison_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of comparison ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @cmp_eq_i32

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of control flow ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @branch_empty

--- a/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of casting/conversion ops.
-
 // RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @trunc

--- a/iree/compiler/Dialect/VM/IR/test/debug_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/debug_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of debug ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @trace_args

--- a/iree/compiler/Dialect/VM/IR/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/global_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of global ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @global_load_i32

--- a/iree/compiler/Dialect/VM/IR/test/shift_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/shift_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of bitwise shift and rotate ops.
-
 // RUN: iree-opt -split-input-file %s | IreeFileCheck %s
 
 // CHECK-LABEL: @shl_i32

--- a/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
@@ -1,5 +1,3 @@
-// Tests printing and parsing of structural ops.
-
 // RUN: iree-opt -split-input-file %s | iree-opt -split-input-file | IreeFileCheck %s
 
 // CHECK-LABEL: @module_empty


### PR DESCRIPTION
The file path/name conventions already convey this information.

Unrelated, but I also checked for any .mlir files with `// RUN` lines that don't include `| IreeFileCheck` using this regex: `//\srun[^|]+\n`. The only matches either intentionally disable testing or test for expected errors.