### PR TITLE
Add braces to `if`s where it helps readability and/or debugging.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
@@ -391,8 +391,9 @@ struct StructureLevel {
 
   StructureLevel *allocateChild(Location loc, int childIndex,
                                 bool asTuple = false) {
-    if (type == LevelType::None)
+    if (type == LevelType::None) {
       type = asTuple ? LevelType::Tuple : LevelType::List;
+    }
     if (type != LevelType::List && type != LevelType::Tuple) {
       emitError(loc) << "structure path mismatch: dereference a non-sequence "
                      << "with a sequence key " << childIndex;

--- a/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -58,20 +58,23 @@ struct CanonicalizeForOpInductionVarShape final
                      Operation* ivDef) const {
     if (auto shapeCast = dyn_cast<vector::ShapeCastOp>(ivUser)) {
       if (auto souceOp = dyn_cast<vector::ShapeCastOp>(ivDef)) {
-        if (shapeCast.getType() == souceOp.source().getType())
+        if (shapeCast.getType() == souceOp.source().getType()) {
           return souceOp.source();
+        }
       }
     } else if (auto extractOp = dyn_cast<vector::ExtractOp>(ivUser)) {
       if (auto broadcastOp = dyn_cast<vector::BroadcastOp>(ivDef)) {
-        if (extractOp.getType() == broadcastOp.getSourceType())
+        if (extractOp.getType() == broadcastOp.getSourceType()) {
           return broadcastOp.source();
+        }
       }
     } else if (auto targetOp = dyn_cast<UnrealizedConversionCastOp>(ivUser)) {
       if (auto sourceOp = dyn_cast<UnrealizedConversionCastOp>(ivDef)) {
         if (sourceOp->getNumOperands() == 1 && targetOp->getNumResults() == 1 &&
             sourceOp->getOperandTypes().front() ==
-                targetOp.getResultTypes().front())
+                targetOp.getResultTypes().front()) {
           return sourceOp.inputs().front();
+        }
       }
     }
     return Value();
@@ -97,8 +100,9 @@ struct CanonicalizeForOpInductionVarShape final
       if (!it.value().hasOneUse()) continue;
       Operation* op = it.value().use_begin()->getOwner();
       if (!isa<vector::ShapeCastOp, vector::ExtractOp,
-               UnrealizedConversionCastOp>(op))
+               UnrealizedConversionCastOp>(op)) {
         continue;
+      }
       Operation* returnValDef = returnValues[it.index()].getDefiningOp();
       Value newReturn = FoldCarryDep(forOp, op, returnValDef);
       if (!newReturn) continue;

--- a/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -80,8 +80,9 @@ static void loopInvariantCodeMotion(FuncOp funcOp) {
   // way, we first LICM from the inner loop, and place the ops in
   // the outer loop, which in turn can be further LICM'ed.
   funcOp.walk([&](LoopLikeOpInterface loopLike) {
-    if (failed(moveLoopInvariantCode(loopLike)))
+    if (failed(moveLoopInvariantCode(loopLike))) {
       llvm_unreachable("Unexpected failure to move invariant code out of loop");
+    }
   });
 }
 

--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -109,8 +109,9 @@ static SmallVector<int64_t> getNumWorkgroup(
 
   SmallVector<int64_t> workloadPerWorkgroup =
       translationInfo.getWorkloadPerWorkgroupVals();
-  if (workloadSize.size() != workloadPerWorkgroup.size())
+  if (workloadSize.size() != workloadPerWorkgroup.size()) {
     return SmallVector<int64_t>();
+  }
   SmallVector<int64_t> numWorkgroups;
   for (auto pair : llvm::zip(workloadSize, workloadPerWorkgroup)) {
     auto workload = std::get<0>(pair);

--- a/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
+++ b/iree/compiler/Codegen/Common/VectorizeMMT4d.cpp
@@ -57,8 +57,9 @@ struct VectorizeMMT4DOp : public OpRewritePattern<linalg::Mmt4DOp> {
     // to specialized code paths where these inner dimensions become static
     // (M1xK1x?x? --> M1xK1xM0xK0)
     if (!lhsType || !rhsType || !lhsType.hasStaticShape() ||
-        !rhsType.hasStaticShape())
+        !rhsType.hasStaticShape()) {
       return failure();
+    }
 
     // We expect the incoming mmt4d to already have been maximally tiled, so
     // that the outer dimensions are equal to 1.

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -598,10 +598,11 @@ class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
     IREE::HAL::InterfaceBindingSubspanOpAdaptor newOperands(
         operands, op->getAttrDictionary());
     MemRefType memRefType = op->getResult(0).getType().dyn_cast<MemRefType>();
-    if (!memRefType)
+    if (!memRefType) {
       return rewriter.notifyMatchFailure(
           op,
           "failed to convert interface.binding.subspan result to memref type");
+    }
     auto memRefDesc = abi.loadBinding(
         op->getLoc(), interfaceBindingOp.binding().getZExtValue(),
         newOperands.byte_offset(), memRefType, newOperands.dynamic_dims(),

--- a/iree/compiler/Codegen/LLVMCPU/VectorContractToAArch64InlineAsmOp.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/VectorContractToAArch64InlineAsmOp.cpp
@@ -38,8 +38,9 @@ struct ConvertVectorContract4x4x4_i8i8i32_ToAArch64InlineAsmPattern
     auto lhsShape = lhsType.getShape();
     auto rhsShape = rhsType.getShape();
     if (lhsShape[0] != 4 || lhsShape[1] != 4 || rhsShape[0] != 4 ||
-        rhsShape[1] != 4)
+        rhsShape[1] != 4) {
       return failure();
+    }
 
     Value inLhs = contractionOp.lhs();
     Value inRhs = contractionOp.rhs();

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -69,9 +69,11 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
                                 PatternRewriter &rewriter) const override {
     if (allocOp.getType().getMemorySpaceAsInt() != 3) return failure();
     ArrayRef<int64_t> shape = allocOp.getType().getShape();
-    if (llvm::any_of(
-            shape, [](int64_t dim) { return dim == ShapedType::kDynamicSize; }))
+    if (llvm::any_of(shape, [](int64_t dim) {
+          return dim == ShapedType::kDynamicSize;
+        })) {
       return failure();
+    }
     // In CUDA workgroup memory is represented by a global variable.
     MemRefType allocType = allocOp.getType();
     auto funcOp = allocOp->getParentOfType<FuncOp>();
@@ -213,8 +215,9 @@ class ConvertFunc : public ConvertToLLVMPattern {
     rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
                                 newFuncOp.end());
     if (failed(rewriter.convertRegionTypes(&newFuncOp.getBody(), *typeConverter,
-                                           &signatureConverter)))
+                                           &signatureConverter))) {
       return failure();
+    }
 
     rewriter.eraseOp(funcOp);
     return success();

--- a/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -98,8 +98,9 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
         if (isEntryPoint(funcOp)) return false;
         return true;
       });
-      if (failed(applyPartialConversion(m, target, std::move(llvmPatterns))))
+      if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {
         signalPassFailure();
+      }
     }
   }
 };

--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -72,8 +72,9 @@ static bool supportsTensorCore(FuncOp entryPoint, linalg::LinalgOp op) {
   // Limit tensor core pipeline to matmul as not all combinations of transpose
   // are supported upstream.
   // TODO(thomasraoux): Enable batchMatmul and generic contraction.
-  if (getTargetArch(entryPoint) != "sm_80" || !isa<linalg::MatmulOp>(op))
+  if (getTargetArch(entryPoint) != "sm_80" || !isa<linalg::MatmulOp>(op)) {
     return false;
+  }
   // Check that we support converting any fused operation. When using the
   // tensorcore pipeline we need to be sure we can generate MMA ops otherwise
   // the code will be highly inneficent.

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistributeSharedMemoryCopy.cpp
@@ -165,9 +165,10 @@ static void distributeTransferRead(FuncOp funcOp, Value flatThreadId,
       multiplier.push_back(threads);
       Value dimId = id;
       assert(numThreads % threads == 0);
-      if (numThreads / threads > 1)
+      if (numThreads / threads > 1) {
         dimId =
             makeComposedAffineApply(b, funcOp.getLoc(), d0 % threads, {dimId});
+      }
       ids.push_back(dimId);
       numThreads = numThreads / threads;
       id = makeComposedAffineApply(b, funcOp.getLoc(), d0.floorDiv(threads),

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUPipelining.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUPipelining.cpp
@@ -42,8 +42,9 @@ static void getPipelineStages(
   // Track dependencies of the global memory load.
   llvm::SmallDenseSet<Operation*> loadDep;
   for (Operation& op : forOp.getBody()->getOperations()) {
-    if (op.hasAttr(kPipeliningGlobalLoad))
+    if (op.hasAttr(kPipeliningGlobalLoad)) {
       addDepOps(loadDep, &op, forOp.getBody());
+    }
   }
   // Create a modulo schedule with loads from global memory and the operations
   // it depends on in stage 0. Store to shared memory and computation are in
@@ -85,8 +86,9 @@ struct LLVMGPUPipeliningPass
         copyToWorkgroupMemory = true;
         ld->setAttr(kPipeliningGlobalLoad, builder.getUnitAttr());
       }
-      if (copyToWorkgroupMemory)
+      if (copyToWorkgroupMemory) {
         forOp->setAttr(kPipeliningLoopMarker, builder.getUnitAttr());
+      }
     });
     scf::PipeliningOption options;
     options.getScheduleFn = getPipelineStages;

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -41,9 +41,10 @@ struct CombineTransferReadOpBroadcast final
   LogicalResult matchAndRewrite(vector::BroadcastOp op,
                                 PatternRewriter &rewriter) const override {
     auto transferReadOp = op.source().getDefiningOp<vector::TransferReadOp>();
-    if (!transferReadOp) return failure();
-    if (transferReadOp.mask() || transferReadOp.hasOutOfBoundsDim())
+    if (!transferReadOp || transferReadOp.mask() ||
+        transferReadOp.hasOutOfBoundsDim()) {
       return failure();
+    }
     int64_t rankDiff =
         op.getVectorType().getRank() - transferReadOp.getVectorType().getRank();
     SmallVector<AffineExpr> exprs(rankDiff, rewriter.getAffineConstantExpr(0));

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
@@ -51,8 +51,9 @@ static Optional<SmallVector<int64_t, 4>> getGPUNativeVectorSize(Operation *op) {
     // Load 4 elements on the most inner dimension.
     for (auto dim : llvm::enumerate(vt.permutation_map().getResults())) {
       if (auto dimExpr = dim.value().dyn_cast<AffineDimExpr>()) {
-        if (dimExpr.getPosition() == vt.permutation_map().getNumDims() - 1)
+        if (dimExpr.getPosition() == vt.permutation_map().getNumDims() - 1) {
           nativeSize[dim.index()] = 4;
+        }
       }
     }
     return nativeSize;

--- a/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -45,8 +45,9 @@ static Optional<CooperativeMatrixSize> getCooperativeMatrixSize(
       int64_t matmulM = property.m_size().getValue().getZExtValue();
       int64_t matmulN = property.n_size().getValue().getZExtValue();
       int64_t matmulK = property.k_size().getValue().getZExtValue();
-      if (m % matmulM == 0 && n % matmulN == 0 && k % matmulK == 0)
+      if (m % matmulM == 0 && n % matmulN == 0 && k % matmulK == 0) {
         return CooperativeMatrixSize{matmulM, matmulN, matmulK};
+      }
     }
   }
   return llvm::None;

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeOps.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorToCooperativeOps.cpp
@@ -124,8 +124,10 @@ struct ConvertVectorContractOp final
     // Check that this is a matmul operation.
     auto iterators = contractOp.iterator_types().getValue();
     if (iterators.size() != 3 || !isParallelIterator(iterators[0]) ||
-        !isParallelIterator(iterators[1]) || !isReductionIterator(iterators[2]))
+        !isParallelIterator(iterators[1]) ||
+        !isReductionIterator(iterators[2])) {
       return failure();
+    }
     if (contractOp.kind() != vector::CombiningKind::ADD) return failure();
 
     // Column major matmuls should have been lowered to transpose + contract

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -181,9 +181,10 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
     doTiling = true;
     tilingOptions = tilingOptions.setTileSizes(tileSizes);
   }
-  if (!tileInterchange.empty())
+  if (!tileInterchange.empty()) {
     tilingOptions = tilingOptions.setInterchange(
         SmallVector<unsigned>(tileInterchange.begin(), tileInterchange.end()));
+  }
   if (scalarizeDynamicDims) {
     doTiling = true;
     tilingOptions = tilingOptions.scalarizeDynamicDims();

--- a/iree/compiler/Codegen/Transforms/AffineMinCanonicalization.cpp
+++ b/iree/compiler/Codegen/Transforms/AffineMinCanonicalization.cpp
@@ -98,9 +98,11 @@ LogicalResult AffineMinCanonicalizationPattern::matchAndRewrite(
                           << *minOp.getOperation() << "\n");
 
   int64_t min = std::numeric_limits<int64_t>::max();
-  for (auto e : minOp.map().getResults())
-    if (auto cstExpr = e.dyn_cast<AffineConstantExpr>())
+  for (auto e : minOp.map().getResults()) {
+    if (auto cstExpr = e.dyn_cast<AffineConstantExpr>()) {
       min = std::min(min, cstExpr.getValue());
+    }
+  }
   if (min == std::numeric_limits<int64_t>::max()) return failure();
 
   MLIRContext *ctx = minOp.getContext();

--- a/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -31,8 +31,9 @@ static bool isDivisible(Value v, int64_t dividend);
 /// ```
 static bool affineMinOpDivisible(AffineMinOp minOp, int64_t dividend) {
   if (!minOp.getSymbolOperands().empty() ||
-      minOp.getAffineMap().getNumResults() != 2)
+      minOp.getAffineMap().getNumResults() != 2) {
     return {};
+  }
   Value iv;
   Value ub;
   Value lb;
@@ -68,19 +69,21 @@ static bool affineMinOpDivisible(AffineMinOp minOp, int64_t dividend) {
   AffineExpr ivDim;
   AffineExpr ubDim;
   for (auto dim : llvm::enumerate(minOp.getDimOperands())) {
-    if (dim.value() == iv)
+    if (dim.value() == iv) {
       ivDim = getAffineDimExpr(dim.index(), minOp.getContext());
-    else if (dim.value() == ub)
+    } else if (dim.value() == ub) {
       ubDim = getAffineDimExpr(dim.index(), minOp.getContext());
-    else
+    } else {
       return false;
+    }
   }
 
   if (!ubDim) {
-    if (auto cstUb = ub.getDefiningOp<arith::ConstantIndexOp>())
+    if (auto cstUb = ub.getDefiningOp<arith::ConstantIndexOp>()) {
       ubDim = getAffineConstantExpr(cstUb.value(), minOp.getContext());
-    else
+    } else {
       return false;
+    }
   }
   AffineExpr diffExp = ubDim - ivDim;
   // Check that all the affine map results are either constant divisible by
@@ -134,8 +137,9 @@ static Optional<int64_t> foldAffineMin(AffineMinOp minOp) {
   AffineMap map = minOp.getAffineMap();
   int64_t constantResult = 0;
   for (AffineExpr result : map.getResults()) {
-    if (auto cst = result.dyn_cast<AffineConstantExpr>())
+    if (auto cst = result.dyn_cast<AffineConstantExpr>()) {
       constantResult = cst.getValue();
+    }
   }
   if (constantResult == 0) return {};
   // If afine.min map's results are all positive and divisible by

--- a/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
+++ b/iree/compiler/Codegen/Transforms/RemoveSingleIterationLoop.cpp
@@ -169,8 +169,9 @@ struct SimplifyTrivialLoops : public OpRewritePattern<scf::ForOp> {
     // once but the loop may not run at least once by replace the `loop` with an
     // `if`.
     if (!(alwaysRunsFirstIteration(op, getMinMax) &&
-          neverRunsSecondIteration(op, getMinMax)))
+          neverRunsSecondIteration(op, getMinMax))) {
       return failure();
+    }
 
     // The first iteration is always run and the second iteration is never run
     // so the loop always have 1 iteration. Inline its body and remove the loop.

--- a/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.cpp
+++ b/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.cpp
@@ -61,8 +61,9 @@ static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
     } else {
       if (!(staticOffset == 0 && staticSize != ShapedType::kDynamicSize &&
             baseShape[dim - 1] != ShapedType::kDynamicSize &&
-            staticSize == baseShape[dim - 1]))
+            staticSize == baseShape[dim - 1])) {
         fullSlices = false;
+      }
     }
   }
   return true;

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
@@ -293,8 +293,9 @@ struct FoldFillGenericOpPattern : public OpRewritePattern<linalg::GenericOp> {
     if (genericOp.getNumOutputs() != 1) return failure();
 
     // Check linalg.generic does have copy only semantics.
-    if (genericOp.getNumParallelLoops() != genericOp.getNumLoops())
+    if (genericOp.getNumParallelLoops() != genericOp.getNumLoops()) {
       return failure();
+    }
     auto results =
         llvm::to_vector<4>(genericOp.getBody()->getOps<linalg::YieldOp>());
     if (results.size() != 1) return failure();

--- a/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DestructiveUpdateUtils.cpp
@@ -330,9 +330,10 @@ static LogicalResult rewriteDestructiveUpdateInPlace(
           .Default([&](Operation *) { return failure(); });
   if (failed(status)) return failure();
 
-  if (scf::ForOp loopOp = dyn_cast<scf::ForOp>(outermostProducingOp))
+  if (scf::ForOp loopOp = dyn_cast<scf::ForOp>(outermostProducingOp)) {
     loopOp.walk(
         [&](tensor::ExtractSliceOp op) { (void)foldExtractSliceOp(b, op); });
+  }
 
   return success();
 }

--- a/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -100,8 +100,9 @@ struct FusionOfTensorOpsPass
           // expensive.
           // TODO: Add a cost model to allow ops to be duplicated.
           if (!isBroadcast && !isa<arith::ConstantOp>(producer) &&
-              !llvm::hasSingleElement(producerResult.getUsers()))
+              !llvm::hasSingleElement(producerResult.getUsers())) {
             return false;
+          }
           return llvm::all_of(producerResult.getUsers(), [](Operation *user) {
             return isa<linalg::GenericOp>(user);
           });
@@ -113,11 +114,13 @@ struct FusionOfTensorOpsPass
     linalg::ControlElementwiseOpsFusionFn foldReshapeBetweenLinalgFn =
         [](const OpResult &producer, const OpOperand &consumer) {
           auto collapseOp = producer.getDefiningOp<tensor::CollapseShapeOp>();
-          if (collapseOp)
+          if (collapseOp) {
             return collapseOp.src().getDefiningOp<LinalgOp>() != nullptr;
+          }
           auto expandOp = producer.getDefiningOp<tensor::ExpandShapeOp>();
-          if (expandOp)
+          if (expandOp) {
             return expandOp.src().getDefiningOp<LinalgOp>() != nullptr;
+          }
           return false;
         };
     linalg::populateElementwiseOpsFusionPatterns(

--- a/iree/compiler/Dialect/Flow/Transforms/InterchangeGenericOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/InterchangeGenericOps.cpp
@@ -43,8 +43,9 @@ struct GenericOpInterchangePattern
     // If all the parallel loops are outter loops skip the pattern.
     if (!needInterchange) return failure();
     for (auto iter : llvm::enumerate(genericOp.iterator_types())) {
-      if (isReductionIterator(iter.value()))
+      if (isReductionIterator(iter.value())) {
         interchange.push_back(iter.index());
+      }
     }
     rewriter.updateRootInPlace(genericOp, [&]() {
       interchangeGenericOp(rewriter, genericOp, interchange);

--- a/iree/compiler/Dialect/Flow/Transforms/PadLinalgOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/PadLinalgOps.cpp
@@ -54,8 +54,9 @@ class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
     int paddingForN = newNSize - N;
     int paddingForK = newKSize - K;
 
-    if (paddingForM == 0 && paddingForN == 0 && paddingForK == 0)
+    if (paddingForM == 0 && paddingForN == 0 && paddingForK == 0) {
       return failure();
+    }
 
     auto lhsPaddedType =
         RankedTensorType::get({newMSize, newKSize}, lhsType.getElementType());

--- a/iree/compiler/Dialect/Flow/Transforms/PadTensorToSubTensorInsert.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/PadTensorToSubTensorInsert.cpp
@@ -63,10 +63,11 @@ struct PadTensorOpConversion : public OpRewritePattern<linalg::PadTensorOp> {
       SmallVector<Value> mapValues;
       Value sourceDim = rewriter.createOrFold<tensor::DimOp>(loc, source, dim);
       mapValues.push_back(sourceDim);
-      if (auto cstDim = sourceDim.getDefiningOp<arith::ConstantIndexOp>())
+      if (auto cstDim = sourceDim.getDefiningOp<arith::ConstantIndexOp>()) {
         sourceShape.push_back(cstDim.getValue());
-      else
+      } else {
         sourceShape.push_back(sourceDim);
+      }
       AffineExpr expr = rewriter.getAffineDimExpr(0);
       unsigned numSymbols = 0;
       auto addValueOrAttr = [&](AffineExpr e, OpFoldResult valueOrAttr) {

--- a/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/VerifyInputLegality.cpp
@@ -30,9 +30,10 @@ class VerifyInputLegalityPass
     target.addIllegalDialect("mhlo");
     target.addIllegalOp<UnrealizedConversionCastOp>();
 
-    if (failed(
-            iree_compiler::verifyAllOperationsAreLegal(getOperation(), target)))
+    if (failed(iree_compiler::verifyAllOperationsAreLegal(getOperation(),
+                                                          target))) {
       return signalPassFailure();
+    }
   }
 };
 }  // namespace

--- a/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -181,9 +181,10 @@ class ROCMTargetBackend final : public TargetBackend {
     iree_ROCMExecutableDef_start_as_root(builder);
 
     // Link module to Device Library
-    if (options_.ROCMLinkBC)
+    if (options_.ROCMLinkBC) {
       LinkROCDLIfNecessary(llvmModule.get(), options_.ROCMTargetChip,
                            options_.ROCMBitcodeDir);
+    }
 
     // Serialize hsaco kernel into the binary that we will embed in the
     // final flatbuffer.

--- a/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
@@ -997,10 +997,11 @@ class SequenceCloneBuiltinConversion
   }
 
   Type getElementAccessType(Type t) const {
-    if (auto listType = t.dyn_cast<PYDM::ListType>())
+    if (auto listType = t.dyn_cast<PYDM::ListType>()) {
       return listType.getElementStorageType();
-    else if (auto tupleType = t.dyn_cast<PYDM::TupleType>())
+    } else if (auto tupleType = t.dyn_cast<PYDM::TupleType>()) {
       return tupleType.getElementStorageType();
+    }
 
     llvm_unreachable("unsupported list type");
   }


### PR DESCRIPTION
This does _not_ exhaustively update all of the project or add any new automated linting.

clang-tidy can check for this: https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html

I just used regex and manual editting (looking for `if` or `else` without open/close braces) though:
* `if\s[^\{;]*\n`
* ``\s[^\}]+\selse\s[^\{]+``

Style discussions:
* https://google.github.io/styleguide/cppguide.html#Conditionals
* https://llvm.org/docs/CodingStandards.html#don-t-use-braces-on-simple-single-statement-bodies-of-if-else-loop-statements