### PR TITLE
Disable hoisting of sub-byte aligned leaf values into globals.

### DIFF
--- a/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -242,12 +242,12 @@ void ConstExprHoistingPolicy::initialize() {
   for (auto *info : worklist) {
     Decision *decision = getDecision(info);
     makeInvariantDecision(info, decision);
-    Outcome outcome = decision->getOutcome();
-    if (outcome != UNDECIDED) {
+    Outcome postDecisionOutcome = decision->getOutcome();
+    if (postDecisionOutcome != UNDECIDED) {
       LLVM_DEBUG(dbgs() << "ConstExprHoistPolicy(INVARIANT, ");
-      if (outcome == ENABLE_HOIST) {
+      if (postDecisionOutcome == ENABLE_HOIST) {
         LLVM_DEBUG(dbgs() << "ENABLE_HOIST");
-      } else if (outcome == DISABLE_HOIST) {
+      } else if (postDecisionOutcome == DISABLE_HOIST) {
         LLVM_DEBUG(dbgs() << "DISABLE_HOIST");
       }
       LLVM_DEBUG(dbgs() << "): " << info->constValue << "\n");
@@ -298,7 +298,7 @@ void ConstExprHoistingPolicy::makeInvariantDecision(
 
   // Check 2: Is it a root (these are already hoisted).
   if (info->isRoot) {
-    decision->disableHoist();
+    return decision->disableHoist();
   }
 
   // Check 3: Is the op itself a valid "leaf" that can become a global.

--- a/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
+++ b/iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.cpp
@@ -112,6 +112,15 @@ bool isHoistableConstExprLeaf(const ConstExprAnalysis::ConstValueInfo *info) {
     }
   }
 
+  // Never hoist sub-byte aligned values: in legal programs, these will be
+  // cast or packed in some successor.
+  if (auto integerType = getElementTypeOrSelf(info->constValue.getType())
+                             .dyn_cast<IntegerType>()) {
+    if (integerType.getWidth() % 8 != 0) {
+      return false;
+    }
+  }
+
   // Generally, we prefer to not hoist broadcasts.
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
     // Detect op that only broadcast input as fusing them makes the new


### PR DESCRIPTION
This is certainly necessary as a temporary measure, given that layers below this cannot support i1 globals. But I also suspect this is the right long term answer as well (for once we insert appropriate casts).