### PR TITLE
Add READMEs to some top level directories.

### DIFF
--- a/iree/compiler/README.md
+++ b/iree/compiler/README.md
@@ -1,0 +1,78 @@
+# IREE Compiler
+
+This directory contains IREE's main [MLIR](https://mlir.llvm.org/)-based
+compiler.
+
+Paths of particular interest include:
+
+```
+└── compiler/
+    ├── Bindings/    (used to generate different ABI bindings)
+    ├── Codegen/     (device code generation for assorted APIs)
+    ├── Dialect/
+    │   ├── Flow/    (tensor program modeling and compute workload partitioning)
+    │   ├── HAL/     (Hardware Abstraction Layer for buffer and execution management)
+    │   │   └── Target/
+    │   │       ├── LLVM/
+    │   │       ├── VMVX/
+    │   │       ├── VulkanSPIRV/
+    │   │       └── etc.
+    │   ├── Stream/  (device placement and asynchronous scheduling)
+    │   ├── Util/    (common types across other IREE dialects)
+    │   └── VM/      (abstract Virtual Machine)
+    ├── InputConversion/  (conversions from frontend/input dialects)
+    └── Translation/      (translation pipeline definitions)
+```
+
+Noteworthy compiler components _not_ included here include:
+
+```
+├── integrations/
+│   └── tensorflow/
+│       └── iree_tf_compiler/  (passes and tools for importing TensorFlow programs)
+└── llvm-external-projects/
+    ├── iree-compiler-api/     (C and Python APIs for the compiler)
+    └── iree-dialects/         (public IREE dialects for other projects to target)
+```
+
+The general flow of data from a frontend framework down to a compiled program
+is:
+
+```
+program written in framework
+
+    |
+    |  import tool
+    V
+
+imported .mlir file
+
+    |
+    |  main IREE compiler
+    V
+
+compiled program
+```
+
+where import tools live outside of the compiler/ directory (and possibly
+outside of the IREE repo itself).
+
+Refer to IREE's
+[presentations and talks](../../README.md#presentations-and-talks) and this
+architecture diagram for details on how the pieces fit together:
+
+![IREE Architecture](../../docs/website/docs/assets/images/iree_architecture.svg)
+
+## Coding Style
+
+Like the rest of the project, the compiler/ directory uses clang-format with the
+`BasedOnStyle: Google` option. However, since the code in this directory makes
+heavy use of LLVM and MLIR, it also adheres to LLVM style for variable naming
+(use `int variableName` instead of `int variable_name` and pointer alignment
+(use `int *a` instead of `int* a`).
+
+Read more:
+
+* https://google.github.io/styleguide/cppguide.html
+* https://llvm.org/docs/CodingStandards.html
+* https://clang.llvm.org/docs/ClangFormatStyleOptions.html

--- a/iree/hal/README.md
+++ b/iree/hal/README.md
@@ -1,0 +1,18 @@
+# IREE Hardware Abstraction Layer (HAL)
+
+The IREE HAL expresses a low-level abstraction over modern compute APIs like
+Vulkan (CPUs count too!). Each implementation of the HAL interface can:
+
+* Enumerate and query devices and their capabilities
+* Define executable code that runs on the device
+* Allocate unified or discrete memory and provide cache control
+* Organize work into sequences for deferred submission
+* Provide explicit synchronization primitives for ordering submissions
+
+Refer to IREE's
+[presentations and talks](../../README.md#presentations-and-talks) for further
+details.
+
+## Testing
+
+See the [cts/ folder](./cts/) for the HAL Conformance Test Suite.

--- a/iree/hal/cts/README.md
+++ b/iree/hal/cts/README.md
@@ -1,4 +1,4 @@
-# Conformance Test Suite (CTS) for HAL implementations.
+# Conformance Test Suite (CTS) for HAL implementations
 
 These tests exercise IREE's Hardware Abstraction Layer (HAL) in a way that
 checks for conformance across implementations and devices. The tests themselves

--- a/iree/runtime/README.md
+++ b/iree/runtime/README.md
@@ -1,0 +1,11 @@
+# IREE Higher-Level Runtime API
+
+This directory implements a higher-level runtime API on top of the low level
+APIs split across `iree/base/api.h`, `iree/hal/api.h`, and `iree/vm/api.h`.
+
+Using this higher level API may pull in additional dependencies and perform
+additional allocations compared to what you can get by directly going to the
+lower levels. For the most part, the higher level and lower levels APIs may be
+mixed.
+
+See [the demo directory](./demo/) for sample usage.

--- a/iree/samples/README.md
+++ b/iree/samples/README.md
@@ -1,0 +1,3 @@
+# IREE Samples
+
+Also see the [iree-samples](https://github.com/google/iree-samples) repository.


### PR DESCRIPTION
These parts of the project's architecture are relatively stable and could benefit from some cross referencing and overview documentation.