### PR TITLE
Plumbing a user-level memory trimming and notification API.

### DIFF
--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -67,6 +67,11 @@ static iree_allocator_t iree_hal_rocm_allocator_host_allocator(
   return allocator->context->host_allocator;
 }
 
+static iree_status_t iree_hal_rocm_allocator_trim(
+    iree_hal_allocator_t* base_allocator) {
+  return iree_ok_status();
+}
+
 static void iree_hal_rocm_allocator_query_statistics(
     iree_hal_allocator_t* base_allocator,
     iree_hal_allocator_statistics_t* out_statistics) {
@@ -206,6 +211,7 @@ static void iree_hal_rocm_allocator_deallocate_buffer(
 static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .destroy = iree_hal_rocm_allocator_destroy,
     .host_allocator = iree_hal_rocm_allocator_host_allocator,
+    .trim = iree_hal_rocm_allocator_trim,
     .query_statistics = iree_hal_rocm_allocator_query_statistics,
     .query_buffer_compatibility =
         iree_hal_rocm_allocator_query_buffer_compatibility,

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -168,6 +168,12 @@ static iree_status_t iree_hal_rocm_device_query_i32(
       (int)category.size, category.data, (int)key.size, key.data);
 }
 
+static iree_status_t iree_hal_rocm_device_trim(iree_hal_device_t* base_device) {
+  iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
+  // TODO(benvanik): trim of ROCM resources, whenever we care.
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
 static iree_status_t iree_hal_rocm_device_create_command_buffer(
     iree_hal_device_t* base_device, iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,
@@ -289,6 +295,7 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .id = iree_hal_rocm_device_id,
     .host_allocator = iree_hal_rocm_device_host_allocator,
     .device_allocator = iree_hal_rocm_device_allocator,
+    .trim = iree_hal_rocm_device_trim,
     .query_i32 = iree_hal_rocm_device_query_i32,
     .create_command_buffer = iree_hal_rocm_device_create_command_buffer,
     .create_descriptor_set = iree_hal_rocm_device_create_descriptor_set,

--- a/iree/hal/allocator.c
+++ b/iree/hal/allocator.c
@@ -53,6 +53,15 @@ iree_hal_allocator_host_allocator(const iree_hal_allocator_t* allocator) {
   return _VTABLE_DISPATCH(allocator, host_allocator)(allocator);
 }
 
+IREE_API_EXPORT
+iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(allocator, trim)(allocator);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT void iree_hal_allocator_query_statistics(
     iree_hal_allocator_t* allocator,
     iree_hal_allocator_statistics_t* out_statistics) {

--- a/iree/hal/allocator.h
+++ b/iree/hal/allocator.h
@@ -95,6 +95,10 @@ IREE_API_EXPORT void iree_hal_allocator_release(
 IREE_API_EXPORT iree_allocator_t
 iree_hal_allocator_host_allocator(const iree_hal_allocator_t* allocator);
 
+// Trims cached/unused pooled buffers, if any.
+IREE_API_EXPORT
+iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator);
+
 // Queries the aggregate statistics from the allocator since creation.
 // Thread-safe; statistics are captured at the time the call is made.
 //
@@ -194,6 +198,8 @@ typedef struct iree_hal_allocator_vtable_t {
 
   iree_allocator_t(IREE_API_PTR* host_allocator)(
       const iree_hal_allocator_t* allocator);
+
+  iree_status_t(IREE_API_PTR* trim)(iree_hal_allocator_t* allocator);
 
   void(IREE_API_PTR* query_statistics)(
       iree_hal_allocator_t* allocator,

--- a/iree/hal/allocator_heap.c
+++ b/iree/hal/allocator_heap.c
@@ -81,6 +81,11 @@ static iree_allocator_t iree_hal_heap_allocator_host_allocator(
   return allocator->host_allocator;
 }
 
+static iree_status_t iree_hal_heap_allocator_trim(
+    iree_hal_allocator_t* base_allocator) {
+  return iree_ok_status();
+}
+
 static void iree_hal_heap_allocator_query_statistics(
     iree_hal_allocator_t* base_allocator,
     iree_hal_allocator_statistics_t* out_statistics) {
@@ -190,6 +195,7 @@ static void iree_hal_heap_allocator_deallocate_buffer(
 static const iree_hal_allocator_vtable_t iree_hal_heap_allocator_vtable = {
     .destroy = iree_hal_heap_allocator_destroy,
     .host_allocator = iree_hal_heap_allocator_host_allocator,
+    .trim = iree_hal_heap_allocator_trim,
     .query_statistics = iree_hal_heap_allocator_query_statistics,
     .query_buffer_compatibility =
         iree_hal_heap_allocator_query_buffer_compatibility,

--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -96,6 +96,11 @@ static iree_allocator_t iree_hal_cuda_allocator_host_allocator(
   return allocator->context->host_allocator;
 }
 
+static iree_status_t iree_hal_cuda_allocator_trim(
+    iree_hal_allocator_t* base_allocator) {
+  return iree_ok_status();
+}
+
 static void iree_hal_cuda_allocator_query_statistics(
     iree_hal_allocator_t* base_allocator,
     iree_hal_allocator_statistics_t* out_statistics) {
@@ -255,6 +260,7 @@ static void iree_hal_cuda_allocator_deallocate_buffer(
 static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .destroy = iree_hal_cuda_allocator_destroy,
     .host_allocator = iree_hal_cuda_allocator_host_allocator,
+    .trim = iree_hal_cuda_allocator_trim,
     .query_statistics = iree_hal_cuda_allocator_query_statistics,
     .query_buffer_compatibility =
         iree_hal_cuda_allocator_query_buffer_compatibility,

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -198,6 +198,12 @@ static iree_hal_allocator_t* iree_hal_cuda_device_allocator(
   return device->device_allocator;
 }
 
+static iree_status_t iree_hal_cuda_device_trim(iree_hal_device_t* base_device) {
+  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
+  // TODO(benvanik): trim of CUDA resources, whenever we care.
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
 static iree_status_t iree_hal_cuda_device_query_i32(
     iree_hal_device_t* base_device, iree_string_view_t category,
     iree_string_view_t key, int32_t* out_value) {
@@ -363,6 +369,7 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .id = iree_hal_cuda_device_id,
     .host_allocator = iree_hal_cuda_device_host_allocator,
     .device_allocator = iree_hal_cuda_device_allocator,
+    .trim = iree_hal_cuda_device_trim,
     .query_i32 = iree_hal_cuda_device_query_i32,
     .create_command_buffer = iree_hal_cuda_device_create_command_buffer,
     .create_descriptor_set = iree_hal_cuda_device_create_descriptor_set,

--- a/iree/hal/device.c
+++ b/iree/hal/device.c
@@ -33,6 +33,15 @@ IREE_API_EXPORT iree_hal_allocator_t* iree_hal_device_allocator(
   return _VTABLE_DISPATCH(device, device_allocator)(device);
 }
 
+IREE_API_EXPORT
+iree_status_t iree_hal_device_trim(iree_hal_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(device, trim)(device);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_device_query_i32(
     iree_hal_device_t* device, iree_string_view_t category,
     iree_string_view_t key, int32_t* out_value) {

--- a/iree/hal/device.h
+++ b/iree/hal/device.h
@@ -144,6 +144,12 @@ iree_hal_device_host_allocator(iree_hal_device_t* device);
 IREE_API_EXPORT iree_hal_allocator_t* iree_hal_device_allocator(
     iree_hal_device_t* device);
 
+// Trims pools and caches used by the HAL to the minimum required for live
+// allocations. This can be used on low-memory conditions or when
+// suspending/parking instances.
+IREE_API_EXPORT
+iree_status_t iree_hal_device_trim(iree_hal_device_t* device);
+
 // Queries a configuration value as an int32_t.
 // The |category| and |key| will be provided to the device driver to interpret
 // in a device-specific way and if recognized the value will be converted to an
@@ -254,6 +260,8 @@ typedef struct iree_hal_device_vtable_t {
   iree_allocator_t(IREE_API_PTR* host_allocator)(iree_hal_device_t* device);
   iree_hal_allocator_t*(IREE_API_PTR* device_allocator)(
       iree_hal_device_t* device);
+
+  iree_status_t(IREE_API_PTR* trim)(iree_hal_device_t* device);
 
   iree_status_t(IREE_API_PTR* query_i32)(iree_hal_device_t* device,
                                          iree_string_view_t category,

--- a/iree/hal/local/sync_device.c
+++ b/iree/hal/local/sync_device.c
@@ -133,6 +133,11 @@ static iree_hal_allocator_t* iree_hal_sync_device_allocator(
   return device->device_allocator;
 }
 
+static iree_status_t iree_hal_sync_device_trim(iree_hal_device_t* base_device) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
 static iree_status_t iree_hal_sync_device_query_i32(
     iree_hal_device_t* base_device, iree_string_view_t category,
     iree_string_view_t key, int32_t* out_value) {
@@ -288,6 +293,7 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .id = iree_hal_sync_device_id,
     .host_allocator = iree_hal_sync_device_host_allocator,
     .device_allocator = iree_hal_sync_device_allocator,
+    .trim = iree_hal_sync_device_trim,
     .query_i32 = iree_hal_sync_device_query_i32,
     .create_command_buffer = iree_hal_sync_device_create_command_buffer,
     .create_descriptor_set = iree_hal_sync_device_create_descriptor_set,

--- a/iree/hal/local/task_device.c
+++ b/iree/hal/local/task_device.c
@@ -192,6 +192,14 @@ static iree_hal_allocator_t* iree_hal_task_device_allocator(
   return device->device_allocator;
 }
 
+static iree_status_t iree_hal_task_device_trim(iree_hal_device_t* base_device) {
+  iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
+  iree_arena_block_pool_trim(&device->small_block_pool);
+  iree_arena_block_pool_trim(&device->large_block_pool);
+  iree_task_executor_trim(device->executor);
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
 static iree_status_t iree_hal_task_device_query_i32(
     iree_hal_device_t* base_device, iree_string_view_t category,
     iree_string_view_t key, int32_t* out_value) {
@@ -350,6 +358,7 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .id = iree_hal_task_device_id,
     .host_allocator = iree_hal_task_device_host_allocator,
     .device_allocator = iree_hal_task_device_allocator,
+    .trim = iree_hal_task_device_trim,
     .query_i32 = iree_hal_task_device_query_i32,
     .create_command_buffer = iree_hal_task_device_create_command_buffer,
     .create_descriptor_set = iree_hal_task_device_create_descriptor_set,

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -188,6 +188,11 @@ static iree_allocator_t iree_hal_vulkan_vma_allocator_host_allocator(
   return allocator->host_allocator;
 }
 
+static iree_status_t iree_hal_vulkan_vma_allocator_trim(
+    iree_hal_allocator_t* base_allocator) {
+  return iree_ok_status();
+}
+
 static void iree_hal_vulkan_vma_allocator_query_statistics(
     iree_hal_allocator_t* base_allocator,
     iree_hal_allocator_statistics_t* out_statistics) {
@@ -364,6 +369,7 @@ namespace {
 const iree_hal_allocator_vtable_t iree_hal_vulkan_vma_allocator_vtable = {
     /*.destroy=*/iree_hal_vulkan_vma_allocator_destroy,
     /*.host_allocator=*/iree_hal_vulkan_vma_allocator_host_allocator,
+    /*.trim=*/iree_hal_vulkan_vma_allocator_trim,
     /*.query_statistics=*/iree_hal_vulkan_vma_allocator_query_statistics,
     /*.query_buffer_compatibility=*/
     iree_hal_vulkan_vma_allocator_query_buffer_compatibility,

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -915,6 +915,13 @@ static iree_hal_allocator_t* iree_hal_vulkan_device_allocator(
   return device->device_allocator;
 }
 
+static iree_status_t iree_hal_vulkan_device_trim(
+    iree_hal_device_t* base_device) {
+  iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
+  // TODO(benvanik): trim of vulkan resources, whenever we care.
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
 static iree_status_t iree_hal_vulkan_device_query_i32(
     iree_hal_device_t* base_device, iree_string_view_t category,
     iree_string_view_t key, int32_t* out_value) {
@@ -1120,6 +1127,7 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.id=*/iree_hal_vulkan_device_id,
     /*.host_allocator=*/iree_hal_vulkan_device_host_allocator,
     /*.device_allocator=*/iree_hal_vulkan_device_allocator,
+    /*.trim=*/iree_hal_vulkan_device_trim,
     /*.query_i32=*/iree_hal_vulkan_device_query_i32,
     /*.create_command_buffer=*/iree_hal_vulkan_device_create_command_buffer,
     /*.create_descriptor_set=*/iree_hal_vulkan_device_create_descriptor_set,

--- a/iree/runtime/session.c
+++ b/iree/runtime/session.c
@@ -171,6 +171,16 @@ IREE_API_EXPORT iree_hal_allocator_t* iree_runtime_session_device_allocator(
   return iree_hal_device_allocator(device);
 }
 
+IREE_API_EXPORT iree_status_t
+iree_runtime_session_trim(iree_runtime_session_t* session) {
+  IREE_ASSERT_ARGUMENT(session);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = iree_vm_context_notify(
+      iree_runtime_session_context(session), IREE_VM_SIGNAL_LOW_MEMORY);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT iree_status_t iree_runtime_session_append_module(
     iree_runtime_session_t* session, iree_vm_module_t* module) {
   IREE_ASSERT_ARGUMENT(session);

--- a/iree/runtime/session.h
+++ b/iree/runtime/session.h
@@ -128,6 +128,13 @@ IREE_API_EXPORT iree_hal_device_t* iree_runtime_session_device(
 IREE_API_EXPORT iree_hal_allocator_t* iree_runtime_session_device_allocator(
     const iree_runtime_session_t* session);
 
+// Trims transient/cached resources used by the session.
+// Upon resuming these resources may be expensive to rematerialize/reload and
+// as such this should only be called when it is known the resources will not
+// be needed soon.
+IREE_API_EXPORT iree_status_t
+iree_runtime_session_trim(iree_runtime_session_t* session);
+
 // Appends the given |module| to the context.
 // The module will be retained by the context.
 //

--- a/iree/task/executor.c
+++ b/iree/task/executor.c
@@ -211,6 +211,15 @@ void iree_task_executor_release(iree_task_executor_t* executor) {
   }
 }
 
+void iree_task_executor_trim(iree_task_executor_t* executor) {
+  // TODO(benvanik): figure out a good way to do this; the pools require that
+  // no tasks are in-flight to trim but our caller can't reliably make that
+  // guarantee. We'd need some global executor lock that we did here and
+  // on submit - or rework pools to not have this limitation.
+  // iree_task_pool_trim(&executor->fence_task_pool);
+  // iree_task_pool_trim(&executor->dispatch_task_pool);
+}
+
 iree_status_t iree_task_executor_acquire_fence(iree_task_executor_t* executor,
                                                iree_task_scope_t* scope,
                                                iree_task_fence_t** out_fence) {

--- a/iree/task/executor.h
+++ b/iree/task/executor.h
@@ -321,6 +321,9 @@ void iree_task_executor_retain(iree_task_executor_t* executor);
 // Releases the given |executor| from the caller.
 void iree_task_executor_release(iree_task_executor_t* executor);
 
+// Trims pools and caches used by the executor and its workers.
+void iree_task_executor_trim(iree_task_executor_t* executor);
+
 // Acquires a fence for the given |scope| from the executor fence pool.
 iree_status_t iree_task_executor_acquire_fence(iree_task_executor_t* executor,
                                                iree_task_scope_t* scope,

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -788,6 +788,11 @@ static iree_status_t iree_vm_bytecode_module_resolve_import(
   return iree_ok_status();
 }
 
+static iree_status_t IREE_API_PTR iree_vm_bytecode_module_notify(
+    void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
+  return iree_ok_status();
+}
+
 static iree_status_t iree_vm_bytecode_module_begin_call(
     void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
     iree_vm_execution_result_t* out_result) {
@@ -914,6 +919,7 @@ IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(
   module->interface.alloc_state = iree_vm_bytecode_module_alloc_state;
   module->interface.free_state = iree_vm_bytecode_module_free_state;
   module->interface.resolve_import = iree_vm_bytecode_module_resolve_import;
+  module->interface.notify = iree_vm_bytecode_module_notify;
   module->interface.begin_call = iree_vm_bytecode_module_begin_call;
   module->interface.get_function_reflection_attr =
       iree_vm_bytecode_module_get_function_reflection_attr;

--- a/iree/vm/context.h
+++ b/iree/vm/context.h
@@ -106,6 +106,10 @@ IREE_API_EXPORT iree_status_t iree_vm_context_resolve_function(
     const iree_vm_context_t* context, iree_string_view_t full_name,
     iree_vm_function_t* out_function);
 
+// Notifies all modules in the context of a system signal.
+IREE_API_EXPORT iree_status_t iree_vm_context_notify(iree_vm_context_t* context,
+                                                     iree_vm_signal_t signal);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/vm/native_module.c
+++ b/iree/vm/native_module.c
@@ -270,6 +270,15 @@ static iree_status_t IREE_API_PTR iree_vm_native_module_resolve_import(
                           "native module does not support imports");
 }
 
+static iree_status_t IREE_API_PTR iree_vm_native_module_notify(
+    void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
+  iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
+  if (module->user_interface.notify) {
+    return module->user_interface.notify(module->self, module_state, signal);
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t IREE_API_PTR iree_vm_native_module_begin_call(
     void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
     iree_vm_execution_result_t* out_result) {
@@ -428,6 +437,7 @@ IREE_API_EXPORT iree_status_t iree_vm_native_module_initialize(
   module->base_interface.alloc_state = iree_vm_native_module_alloc_state;
   module->base_interface.free_state = iree_vm_native_module_free_state;
   module->base_interface.resolve_import = iree_vm_native_module_resolve_import;
+  module->base_interface.notify = iree_vm_native_module_notify;
   module->base_interface.begin_call = iree_vm_native_module_begin_call;
   module->base_interface.resume_call = iree_vm_native_module_resume_call;
 


### PR DESCRIPTION
This routes notifications to both system and user modules in the VM on suspend/resume and low memory warnings. System modules can implement a notify method for internal handling and here the HAL is extended to trim its pools. The compiler will be able to add a `__notify` export to generated modules that handles end-user resources (computed state from initializers, compiler-owned pools, etc) and we could extend this all the way up to the frontend as a discardable attribute.