### PR TITLE
Adding optional target_storage to hal.tensor.export.

### DIFF
--- a/iree/base/internal/arena.c
+++ b/iree/base/internal/arena.c
@@ -18,22 +18,32 @@
 void iree_arena_block_pool_initialize(iree_host_size_t total_block_size,
                                       iree_allocator_t block_allocator,
                                       iree_arena_block_pool_t* out_block_pool) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   memset(out_block_pool, 0, sizeof(*out_block_pool));
   out_block_pool->total_block_size = total_block_size;
   out_block_pool->usable_block_size =
       total_block_size - sizeof(iree_arena_block_t);
   out_block_pool->block_allocator = block_allocator;
   iree_atomic_arena_block_slist_initialize(&out_block_pool->available_slist);
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 void iree_arena_block_pool_deinitialize(iree_arena_block_pool_t* block_pool) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   // Since all blocks must have been released we can just reuse trim (today) as
   // it doesn't retain any blocks.
   iree_arena_block_pool_trim(block_pool);
   iree_atomic_arena_block_slist_deinitialize(&block_pool->available_slist);
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 void iree_arena_block_pool_trim(iree_arena_block_pool_t* block_pool) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   iree_arena_block_t* head = NULL;
   iree_atomic_arena_block_slist_flush(
       &block_pool->available_slist,
@@ -43,6 +53,8 @@ void iree_arena_block_pool_trim(iree_arena_block_pool_t* block_pool) {
     head = head->next;
     iree_allocator_free(block_pool->block_allocator, ptr);
   }
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 iree_status_t iree_arena_block_pool_acquire(iree_arena_block_pool_t* block_pool,
@@ -99,6 +111,8 @@ void iree_arena_deinitialize(iree_arena_allocator_t* arena) {
 }
 
 void iree_arena_reset(iree_arena_allocator_t* arena) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   if (arena->allocation_head != NULL) {
     iree_arena_oversized_allocation_t* head = arena->allocation_head;
     do {
@@ -114,6 +128,8 @@ void iree_arena_reset(iree_arena_allocator_t* arena) {
     arena->block_head = NULL;
     arena->block_tail = NULL;
   }
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
@@ -127,16 +143,20 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     // Oversized allocation that can't be handled by the block pool. We'll
     // allocate directly from the system allocator and track it ourselves for
     // freeing during reset.
+    IREE_TRACE_ZONE_BEGIN(z0);
     iree_host_size_t allocation_size =
         sizeof(iree_arena_oversized_allocation_t) + byte_length;
     iree_arena_oversized_allocation_t* allocation = NULL;
-    IREE_RETURN_IF_ERROR(iree_allocator_malloc_uninitialized(
-        block_pool->block_allocator, allocation_size, (void**)&allocation));
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_allocator_malloc_uninitialized(
+            block_pool->block_allocator, allocation_size, (void**)&allocation));
     allocation->next = arena->allocation_head;
     arena->allocation_head = allocation;
     arena->total_allocation_size += allocation_size;
     arena->used_allocation_size += byte_length;
     *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
+    IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }
 
@@ -148,14 +168,16 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
   // Check to see if the current block (if any) has space - if not, get another.
   if (arena->block_head == NULL ||
       arena->block_bytes_remaining < aligned_length) {
+    IREE_TRACE_ZONE_BEGIN(z0);
     iree_arena_block_t* block = NULL;
-    IREE_RETURN_IF_ERROR(
-        iree_arena_block_pool_acquire(arena->block_pool, &block));
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_arena_block_pool_acquire(arena->block_pool, &block));
     block->next = arena->block_head;
     arena->block_head = block;
     if (!arena->block_tail) arena->block_tail = block;
     arena->total_allocation_size += block_pool->total_block_size;
     arena->block_bytes_remaining = block_pool->usable_block_size;
+    IREE_TRACE_ZONE_END(z0);
   }
 
   // Slice out the allocation from the current block.

--- a/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
+++ b/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
@@ -11,11 +11,11 @@
 //  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
 //  CHECK-NEXT:   %[[ARG1_DIM0:.+]] = hal.buffer_view.dim<%[[ARG1]] : !hal.buffer_view>[0] : index
 //  CHECK-NEXT:   %[[ARG1_TENSOR:.+]] = hal.tensor.import %[[ARG1]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG1_DIM0]]}
-//  CHECK-NEXT:   %[[RET_TENSOR:.+]]:2 = call @_dynamicEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
-//       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSOR]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSOR]]#0 : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
-//       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSOR]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
-//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSOR]]#1 : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_dynamicEntry(%[[ARG0_TENSOR]], %[[ARG1_TENSOR]])
+//       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
 //  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
 //  CHECK-NEXT: }
 
@@ -23,6 +23,34 @@
 func @dynamicEntry(%arg0: tensor<?x8x8x3xf32>, %arg1: tensor<?x8x8x3xf32>) ->
     (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) {
   %0 = "mhlo.add"(%arg0, %arg1) : (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) -> tensor<?x8x8x3xf32>
+  %1 = "mhlo.add"(%0, %arg0) : (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) -> tensor<?x8x8x3xf32>
+  return %0, %1 : tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @outputStorage(
+//  CHECK-SAME:   %[[ARG0:.+]]: !hal.buffer_view,
+//  CHECK-SAME:   %[[RET1_STORAGE:.+]]: !hal.buffer
+//  CHECK-SAME: -> (
+//  CHECK-SAME:   !hal.buffer_view, !hal.buffer_view
+//  CHECK-SAME: ) attributes {
+//  CHECK-SAME:   iree.abi.stub
+//  CHECK-SAME: } {
+//  CHECK-NEXT:   %[[ARG0_DIM0:.+]] = hal.buffer_view.dim<%[[ARG0]] : !hal.buffer_view>[0] : index
+//  CHECK-NEXT:   %[[ARG0_TENSOR:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<?x8x8x3xf32>{%[[ARG0_DIM0]]}
+//  CHECK-NEXT:   %[[RET_TENSORS:.+]]:2 = call @_outputStorage(%[[ARG0_TENSOR]], %[[RET1_STORAGE]])
+//       CHECK:   %[[RET0_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#0, %c0{{.*}} : tensor<?x8x8x3xf32>
+//  CHECK-NEXT:   %[[RET0_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#0 : tensor<?x8x8x3xf32>{%[[RET0_DIM0]]} -> !hal.buffer_view
+//       CHECK:   %[[RET1_DIM0:.+]] = tensor.dim %[[RET_TENSORS]]#1, %c0{{.*}} : tensor<?x8x8x3xf32>
+//  CHECK-NEXT:   %[[RET1_VIEW:.+]] = hal.tensor.export %[[RET_TENSORS]]#1 into %[[RET1_STORAGE]] : tensor<?x8x8x3xf32>{%[[RET1_DIM0]]} -> !hal.buffer_view
+//  CHECK-NEXT:   return %[[RET0_VIEW]], %[[RET1_VIEW]] : !hal.buffer_view, !hal.buffer_view
+//  CHECK-NEXT: }
+
+// CHECK-LABEL: func private @_outputStorage(
+func @outputStorage(%arg0: tensor<?x8x8x3xf32>, %ret1: !hal.buffer {iree.abi.output = 1 : index}) ->
+    (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) {
+  %0 = "mhlo.add"(%arg0, %arg0) : (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) -> tensor<?x8x8x3xf32>
   %1 = "mhlo.add"(%0, %arg0) : (tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>) -> tensor<?x8x8x3xf32>
   return %0, %1 : tensor<?x8x8x3xf32>, tensor<?x8x8x3xf32>
 }

--- a/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -543,7 +543,7 @@ class WrapEntryPointsPass
       }
       callResults.push_back(entryBuilder.create<IREE::HAL::TensorExportOp>(
           result.getLoc(), bufferType, result, outputDynamicDims.tensorType,
-          dynamicDims));
+          dynamicDims, /*target_storage=*/nullptr));
       for (auto it : llvm::zip(dynamicDims, outputDynamicDims.globalOps)) {
         auto dynamicDim = std::get<0>(it);
         auto globalOp = std::get<1>(it);

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -269,7 +269,7 @@ void TensorExportOp::build(OpBuilder &builder, OperationState &result,
   auto dynamicDims =
       IREE::Util::buildDynamicDimsForValue(result.location, source, builder);
   build(builder, result, resultType, source, TypeAttr::get(source.getType()),
-        dynamicDims);
+        dynamicDims, /*target_storage=*/nullptr);
 }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -115,6 +115,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
 }
 
 def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
+  AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedResult",
     "getTiedResultOperandIndex",
@@ -135,19 +136,27 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
     dynamically shaped values must have the same number of dynamic dimensions.
     This allows for casting between rank-0 and rank-N types, different element
     types, etc.
+
+    An optional `target_storage` buffer can be provided to hold the exported
+    result. The export will fail at runtime if the storage is null or if it has
+    insufficient capacity to store the output. The storage must be
+    device-visible and defined for transfer-target and dispatch usage.
   }];
 
   let arguments = (ins
     AnyTensor:$source,
     TypeAttr:$source_encoding,
-    HAL_ShapeDynamicDims:$source_dims
+    HAL_ShapeDynamicDims:$source_dims,
+    Optional<HAL_Buffer>:$target_storage
   );
   let results = (outs
     AnyTypeOf<[HAL_Buffer, HAL_BufferView]>:$target
   );
 
   let assemblyFormat = [{
-    $source `:`
+    $source
+    (`into` $target_storage^)?
+    `:`
     custom<TypeAlias>($source_encoding, type($source)) (`{` $source_dims^ `}`)?
     `->`
     type($target)

--- a/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/tensor_ops.mlir
@@ -24,3 +24,12 @@ func @tensorExportDynamic(%arg0: tensor<?x3xi32>, %arg1 : index) -> !hal.buffer_
   %0 = hal.tensor.export %arg0 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
   return %0 : !hal.buffer_view
 }
+
+// -----
+
+// CHECK-LABEL: @tensorExportInPlace
+func @tensorExportInPlace(%arg0: tensor<?x3xi32>, %arg1 : index, %arg2: !hal.buffer) -> !hal.buffer_view {
+  // CHECK: hal.tensor.export %arg0 into %arg2 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  %0 = hal.tensor.export %arg0 into %arg2 : tensor<?x3xf32> as tensor<?x3xi32>{%arg1} -> !hal.buffer_view
+  return %0 : !hal.buffer_view
+}

--- a/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
+++ b/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/abi_ops.mlir
@@ -47,3 +47,21 @@ func @exportBufferView(%tensor: tensor<?x?x4xf32>, %dim0: index, %dim1: index) -
   // CHECK: return %[[RESULT]]
   return %0 : !hal.buffer_view
 }
+
+// -----
+
+// CHECK-LABEL: @exportBufferViewInPlace
+// CHECK-SAME: (%[[TENSOR:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[DIM0:.+]]: index, %[[DIM1:.+]]: index, %[[STORAGE:.+]]: !hal.buffer)
+func @exportBufferViewInPlace(%tensor: tensor<?x?x4xf32>, %dim0: index, %dim1: index, %storage: !hal.buffer) -> !hal.buffer_view {
+  //      CHECK: %[[STORAGE_LENGTH:.+]] = hal.buffer.length<%[[STORAGE]]
+  // CHECK-NEXT: %[[STORAGE_IMPORT:.+]] = stream.tensor.import %[[STORAGE]]
+  // CHECK-SAME:   : !hal.buffer -> tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[STORAGE_LENGTH]]}
+  // CHECK-NEXT: %[[STORAGE_UPDATE:.+]] = stream.async.update %[[TENSOR]], %[[STORAGE_IMPORT]][%c0 to %[[SIZE]]]
+  // CHECK-SAME:   : !stream.resource<*>{%[[SIZE]]} -> %[[STORAGE_IMPORT]] as !stream.resource<external>{%[[STORAGE_LENGTH]]}
+  // CHECK-NEXT: %[[STORAGE_RESULT:.+]] = stream.tensor.export %[[STORAGE_UPDATE]] :
+  // CHECK-SAME:     tensor<?x?x4xf32>{%[[DIM0]], %[[DIM1]]} in !stream.resource<external>{%[[STORAGE_LENGTH]]}
+  // CHECK-SAME:     -> !hal.buffer_view
+  %0 = hal.tensor.export %tensor into %storage : tensor<?x?x4xf32>{%dim0, %dim1} -> !hal.buffer_view
+  // CHECK: return %[[STORAGE_RESULT]]
+  return %0 : !hal.buffer_view
+}

--- a/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -110,7 +110,8 @@ class TensorToBufferViewPattern
     if (!resultType) return failure();
     rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
         srcOp, resultType, adaptor.source(),
-        TypeAttr::get(adaptor.source().getType()), adaptor.source_dims());
+        TypeAttr::get(adaptor.source().getType()), adaptor.source_dims(),
+        /*target_storage=*/nullptr);
     return success();
   }
 };

--- a/iree/hal/local/task_command_buffer.c
+++ b/iree/hal/local/task_command_buffer.c
@@ -493,14 +493,14 @@ static iree_status_t iree_hal_cmd_fill_tile(
   const iree_hal_cmd_fill_buffer_t* cmd =
       (const iree_hal_cmd_fill_buffer_t*)user_context;
   IREE_TRACE_ZONE_BEGIN(z0);
-  uint32_t length_per_slice = tile_context->workgroup_size[0];
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, length_per_slice);
 
+  uint32_t length_per_slice = tile_context->workgroup_size[0];
   iree_device_size_t slice_offset =
       tile_context->workgroup_xyz[0] * length_per_slice;
   iree_device_size_t remaining_length = cmd->length - slice_offset;
   iree_device_size_t slice_length =
       iree_min(length_per_slice, remaining_length);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)slice_length);
 
   iree_status_t status = iree_hal_buffer_fill(
       cmd->target_buffer, cmd->target_offset + slice_offset, slice_length,
@@ -626,14 +626,14 @@ static iree_status_t iree_hal_cmd_copy_tile(
   const iree_hal_cmd_copy_buffer_t* cmd =
       (const iree_hal_cmd_copy_buffer_t*)user_context;
   IREE_TRACE_ZONE_BEGIN(z0);
-  uint32_t length_per_slice = tile_context->workgroup_size[0];
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, length_per_slice);
 
+  uint32_t length_per_slice = tile_context->workgroup_size[0];
   iree_device_size_t slice_offset =
       tile_context->workgroup_xyz[0] * length_per_slice;
   iree_device_size_t remaining_length = cmd->length - slice_offset;
   iree_device_size_t slice_length =
       iree_min(length_per_slice, remaining_length);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)slice_length);
 
   iree_status_t status = iree_hal_buffer_copy_data(
       cmd->source_buffer, cmd->source_offset + slice_offset, cmd->target_buffer,

--- a/iree/task/api.c
+++ b/iree/task/api.c
@@ -34,8 +34,9 @@ IREE_FLAG(
     "threads that would otherwise need to perform the syscalls during\n"
     "coordination.");
 
+// TODO(benvanik): enable this when we use it - though hopefully we don't!
 IREE_FLAG(
-    int32_t, task_worker_local_memory, 64 * 1024,
+    int32_t, task_worker_local_memory, 0,  // 64 * 1024,
     "Specifies the bytes of per-worker local memory allocated for use by\n"
     "dispatched tiles. Tiles may use less than this but will fail to dispatch\n"
     "if they require more. Conceptually it is like a stack reservation and\n"

--- a/iree/tools/utils/vm_util_test.cc
+++ b/iree/tools/utils/vm_util_test.cc
@@ -38,6 +38,18 @@ class VmUtilTest : public ::testing::Test {
 };
 
 TEST_F(VmUtilTest, ParsePrintBuffer) {
+  std::string buf_string = "&2x2xi32=[42 43][44 45]";
+  vm::ref<iree_vm_list_t> variant_list;
+  IREE_ASSERT_OK(ParseToVariantList(
+      allocator_, std::vector<std::string>{buf_string}, &variant_list));
+  std::stringstream os;
+  IREE_ASSERT_OK(PrintVariantList(variant_list.get(), &os));
+  // TODO(benvanik): add a !hal.buffer printer.
+  EXPECT_EQ(os.str(),
+            std::string("result[0]: hal.buffer\n") + "(no printer)" + "\n");
+}
+
+TEST_F(VmUtilTest, ParsePrintBufferView) {
   std::string buf_string = "2x2xi32=[42 43][44 45]";
   vm::ref<iree_vm_list_t> variant_list;
   IREE_ASSERT_OK(ParseToVariantList(
@@ -58,7 +70,7 @@ TEST_F(VmUtilTest, ParsePrintScalar) {
   EXPECT_EQ(os.str(), std::string("result[0]: i32=") + input_string + "\n");
 }
 
-TEST_F(VmUtilTest, ParsePrintRank0Buffer) {
+TEST_F(VmUtilTest, ParsePrintRank0BufferView) {
   std::string buf_string = "i32=42";
   vm::ref<iree_vm_list_t> variant_list;
   IREE_ASSERT_OK(ParseToVariantList(
@@ -69,7 +81,7 @@ TEST_F(VmUtilTest, ParsePrintRank0Buffer) {
             std::string("result[0]: hal.buffer_view\n") + buf_string + "\n");
 }
 
-TEST_F(VmUtilTest, ParsePrintMultipleBuffers) {
+TEST_F(VmUtilTest, ParsePrintMultipleBufferViews) {
   std::string buf_string1 = "2x2xi32=[42 43][44 45]";
   std::string buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
   vm::ref<iree_vm_list_t> variant_list;


### PR DESCRIPTION
This allows frontends to control the storage for exported tensors by
tying arguments to results. Today it's required that these do not alias
but we could do fun things in the future with providing slabs to place
multiple results into.

The native bindings have been updated to support iree.abi.output arg
attrs indicating the result an argument provides storage for. Other
bindings may decide this on their own however they want.

There's still inefficiencies here (a copy is almost always performed)
but this allows us to avoid the allocation and eliding the copy is
something that we eventually need to do anyway.

Output buffers can now be passed to tools as inputs with leading `&`
(indicating storage reference), ex: `--function_input=&4x8xf32`.