### PR TITLE
Adding iree_hal_resource_set_t.

### DIFF
--- a/iree/base/internal/arena.c
+++ b/iree/base/internal/arena.c
@@ -64,8 +64,7 @@ iree_status_t iree_arena_block_pool_acquire(iree_arena_block_pool_t* block_pool,
         z0, iree_allocator_malloc_uninitialized(block_pool->block_allocator,
                                                 block_pool->total_block_size,
                                                 (void**)&block_base));
-    block = (iree_arena_block_t*)(block_base + (block_pool->total_block_size -
-                                                sizeof(iree_arena_block_t)));
+    block = (iree_arena_block_t*)(block_base + block_pool->usable_block_size);
   }
 
   block->next = NULL;

--- a/iree/base/status.c
+++ b/iree/base/status.c
@@ -527,9 +527,9 @@ IREE_API_EXPORT iree_status_t iree_status_ignore(iree_status_t status) {
 
 IREE_API_EXPORT IREE_ATTRIBUTE_NORETURN void iree_status_abort(
     iree_status_t status) {
+  iree_status_fprint(stderr, status);
   IREE_ASSERT(!iree_status_is_ok(status),
               "only valid to call with failing status codes");
-  iree_status_fprint(stderr, status);
   iree_status_free(status);
   abort();
 }

--- a/iree/hal/utils/BUILD
+++ b/iree/hal/utils/BUILD
@@ -22,3 +22,40 @@ cc_library(
         "//iree/hal",
     ],
 )
+
+cc_library(
+    name = "resource_set",
+    srcs = ["resource_set.c"],
+    hdrs = ["resource_set.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//iree/base",
+        "//iree/base:tracing",
+        "//iree/base/internal:arena",
+        "//iree/hal",
+    ],
+)
+
+cc_test(
+    name = "resource_set_benchmark",
+    srcs = ["resource_set_benchmark.c"],
+    deps = [
+        ":resource_set",
+        "//iree/base",
+        "//iree/base/internal:prng",
+        "//iree/hal",
+        "//iree/testing:benchmark",
+    ],
+)
+
+cc_test(
+    name = "resource_set_test",
+    srcs = ["resource_set_test.cc"],
+    deps = [
+        ":resource_set",
+        "//iree/base",
+        "//iree/hal",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)

--- a/iree/hal/utils/CMakeLists.txt
+++ b/iree/hal/utils/CMakeLists.txt
@@ -25,4 +25,45 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    resource_set
+  HDRS
+    "resource_set.h"
+  SRCS
+    "resource_set.c"
+  DEPS
+    iree::base
+    iree::base::internal::arena
+    iree::base::tracing
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    resource_set_benchmark
+  SRCS
+    "resource_set_benchmark.c"
+  DEPS
+    ::resource_set
+    iree::base
+    iree::base::internal::prng
+    iree::hal
+    iree::testing::benchmark
+)
+
+iree_cc_test(
+  NAME
+    resource_set_test
+  SRCS
+    "resource_set_test.cc"
+  DEPS
+    ::resource_set
+    iree::base
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/hal/utils/resource_set.c
+++ b/iree/hal/utils/resource_set.c
@@ -1,0 +1,244 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/resource_set.h"
+
+#include "iree/base/tracing.h"
+
+IREE_API_EXPORT iree_status_t iree_hal_resource_set_allocate(
+    iree_arena_block_pool_t* block_pool, iree_hal_resource_set_t** out_set) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // We could allow larger sizes (would require widening the capacity/count
+  // fields in the chunk) but in real usage having even 64k is a bit too much.
+  IREE_ASSERT_LE(block_pool->total_block_size, 64 * 1024,
+                 "keep block sizes small for resource sets");
+
+  // Acquire block and place the set struct at the head.
+  iree_arena_block_t* block = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_arena_block_pool_acquire(block_pool, &block));
+  uint8_t* block_ptr = (uint8_t*)block - block_pool->usable_block_size;
+  iree_hal_resource_set_t* set = (iree_hal_resource_set_t*)block_ptr;
+  memset(set, 0, sizeof(*set));
+  set->block_pool = block_pool;
+  block_ptr += sizeof(*set);
+
+  // Inline the first chunk into the block using all of the remaining space.
+  // This is a special case chunk that is released back to the pool with the
+  // resource set and lets us avoid an additional allocation.
+  iree_hal_resource_set_chunk_t* inlined_chunk =
+      (iree_hal_resource_set_chunk_t*)block_ptr;
+  inlined_chunk->flags = IREE_HAL_RESOURCE_SET_CHUNK_FLAG_INLINE;
+  inlined_chunk->capacity =
+      (block_pool->total_block_size - sizeof(*set) - sizeof(*inlined_chunk)) /
+      sizeof(iree_hal_resource_t*);
+  inlined_chunk->capacity = iree_min(inlined_chunk->capacity,
+                                     IREE_HAL_RESOURCE_SET_CHUNK_MAX_CAPACITY);
+  inlined_chunk->count = 0;
+  set->chunk_head = inlined_chunk;
+
+  *out_set = set;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT void iree_hal_resource_set_free(iree_hal_resource_set_t* set) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Release all resources in all chunks and stitch together the blocks in a
+  // linked list. We do this first so that we can release all of the chunks back
+  // to the block pool in one operation. Ideally we'd maintain the linked list
+  // in our chunks but there's some weirdness with prefix/suffix header/footers
+  // that isn't worth the complexity.
+  iree_arena_block_t* block_head = NULL;
+  iree_arena_block_t* block_tail = NULL;
+  iree_hal_resource_set_chunk_t* chunk = set->chunk_head;
+  while (chunk) {
+    // Release all resources in the chunk.
+    for (iree_host_size_t i = 0; i < chunk->count; ++i) {
+      iree_hal_resource_release(chunk->resources[i]);
+    }
+    // Consume the chunk and add it to the block pool release linked list.
+    iree_hal_resource_set_chunk_t* next_chunk = chunk->next_chunk;
+    iree_arena_block_t* block = NULL;
+    if (iree_hal_resource_set_chunk_is_stored_inline(chunk)) {
+      // This is the inlined first chunk that also stores the set header.
+      // We use the easily-available set pointer as the base.
+      block = (iree_arena_block_t*)((uint8_t*)set +
+                                    set->block_pool->usable_block_size);
+      next_chunk = NULL;
+    } else {
+      // A chunk acquired after the set was acquired.
+      block = (iree_arena_block_t*)((uint8_t*)chunk +
+                                    set->block_pool->usable_block_size);
+    }
+    block->next = block_head;
+    block_head = block;
+    if (!block_tail) block_tail = block;
+    chunk = next_chunk;
+  }
+
+  // Release all blocks back to the block pool in one operation.
+  // NOTE: this invalidates the |set| memory.
+  iree_arena_block_pool_t* block_pool = set->block_pool;
+  iree_arena_block_pool_release(block_pool, block_head, block_tail);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Retains |resource| and adds it to the main |set| list.
+static iree_status_t iree_hal_resource_set_insert_retain(
+    iree_hal_resource_set_t* set, iree_hal_resource_t* resource) {
+  iree_hal_resource_set_chunk_t* chunk = set->chunk_head;
+  if (IREE_UNLIKELY(chunk->count + 1 > chunk->capacity)) {
+    // Ran out of room in the current chunk - acquire a new one and link it into
+    // the list of chunks.
+    iree_arena_block_t* block = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_arena_block_pool_acquire(set->block_pool, &block));
+    chunk =
+        (iree_hal_resource_set_chunk_t*)((uint8_t*)block -
+                                         set->block_pool->usable_block_size);
+    chunk->next_chunk = set->chunk_head;
+    set->chunk_head = chunk;
+    chunk->capacity = (set->block_pool->total_block_size - sizeof(*chunk)) /
+                      sizeof(iree_hal_resource_t*);
+    chunk->capacity =
+        iree_min(chunk->capacity, IREE_HAL_RESOURCE_SET_CHUNK_MAX_CAPACITY);
+    chunk->count = 0;
+  }
+
+  // Retain and insert into the chunk.
+  chunk->resources[chunk->count++] = resource;
+  iree_hal_resource_retain(resource);
+  return iree_ok_status();
+}
+
+// Scans the lookaside for the resource pointer and updates the order if found.
+// If the resource was not found then it will be inserted into the main list as
+// well as the MRU.
+//
+// This performs a full scan over the MRU and if the resource is found will
+// move the resource to the front of the list before returning. Otherwise the
+// resource will be retained in the main source-of-truth list.
+//
+// Example (hit):
+//   +----+----+----+----+
+//   | AA | BB | CC | DD |  resource: CC
+//   +----+----+----+----+
+//   scan mru to find CC:
+//     found at mru[2]
+//     shift prefix down 1:
+//       +----+----+----+----+
+//       | AA | AA | BB | DD |
+//       +----+----+----+----+
+//     insert resource at front:
+//       +----+----+----+----+
+//       | CC | AA | BB | DD |
+//       +----+----+----+----+
+//
+// Example (miss):
+//   +----+----+----+----+
+//   | AA | BB | CC | DD |  resource: EE
+//   +----+----+----+----+
+//   scan mru to find EE: not found
+//   shift set down 1:
+//     +----+----+----+----+
+//     | AA | AA | BB | CC |
+//     +----+----+----+----+
+//   insert resource at front:
+//     +----+----+----+----+
+//     | EE | AA | BB | CC |
+//     +----+----+----+----+
+//   insert resource into main list
+//
+// The intent here is that we can model this behavior with SIMD ops to perform
+// both the scan and update using comparison, extraction, and permutation. The
+// best and worst case flows will load the entire MRU into registers from a
+// single cache line, do all the scanning and shifting in registers, and then
+// store back to the single cache line.
+//
+// Today, though, we leave this as an exercise to whoever comes across this :)
+// Notes:
+//   As the MRU is a fixed size we can unroll it entirely and avoid any looping.
+//   On a 32-bit system with uint32x4_t we only need 4 registers.
+//   On a 64-bit system with uint64x2_t we also only need 4 registers - though
+//   the MRU has half as many entries and we may want to go >1 cache line.
+//
+//   If we wanted to process more than one resource at a time we can specialize
+//   the code paths to handle 1/2/4/etc resources and process in batches with
+//   an optional remainder. This would increase the ratio of work performed on
+//   the loaded MRU registers before we do the shift/store.
+//
+//   The tree sequence we likely want is something like:
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vdupq_n_u32
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vceqq_u32
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vorrq_u32
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_u32
+//    or
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vdupq_n_u64
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vceqq_u64
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vorrq_u64
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vreinterpretq_u64_u32
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_u32
+//   This would yield whether the pointer was found, but instead of maxing at
+//   the end we can use the produced mask to extract out a single register with
+//   which positions are hits and use that to then permute the registers into
+//   the proper order. At the end we could use a table instruction to remap and
+//   extract out a byte/bitmap of the indices that we need to insert into the
+//   main set.
+//
+//   The shifting can be performed with
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vextq_u32
+//    https://developer.arm.com/architectures/instruction-sets/intrinsics/vextq_u64
+//   This takes n low elements of LHS and rest from RHS and we can cascade them
+//   to shift down the whole MRU.
+//
+//   We can use SIMDE as a rosetta stone for getting neon/avx/wasm/etc:
+//   https://github.com/simd-everywhere/simde/blob/master/simde/arm/neon/ceq.h#L591
+static iree_status_t iree_hal_resource_set_insert_1(
+    iree_hal_resource_set_t* set, iree_hal_resource_t* resource) {
+  // Scan and hope for a hit.
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(set->mru); ++i) {
+    if (set->mru[i] != resource) continue;
+    // Hit - keep the list sorted by most->least recently used.
+    // We shift the MRU down to make room at index 0 and store the
+    // resource there.
+    if (i > 0) {
+      memmove(&set->mru[1], &set->mru[0], sizeof(set->mru[0]) * i);
+      set->mru[0] = resource;
+    }
+    return iree_ok_status();
+  }
+
+  // Miss - insert into the main list (slow path).
+  // Note that we do this before updating the MRU in case allocation fails - we
+  // don't want to keep the pointer around unless we've really retained it.
+  IREE_RETURN_IF_ERROR(iree_hal_resource_set_insert_retain(set, resource));
+
+  // Shift the MRU down and insert the new item at the head.
+  memmove(&set->mru[1], &set->mru[0],
+          sizeof(set->mru[0]) * (IREE_ARRAYSIZE(set->mru) - 1));
+  set->mru[0] = resource;
+
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_resource_set_insert(
+    iree_hal_resource_set_t* set, iree_host_size_t count,
+    iree_hal_resource_t* const* resources) {
+  // For now we process one at a time. We should have a stride that lets us
+  // amortize the cost of doing the MRU update and insertion allocation by
+  // say slicing off 4/8/16/32 resources at a time etc. Today each miss that
+  // requires a full insertion goes down the whole path of checking chunk
+  // capacity and such.
+  for (iree_host_size_t i = 0; i < count; ++i) {
+    iree_hal_resource_t* resource = resources[i];
+    IREE_RETURN_IF_ERROR(iree_hal_resource_set_insert_1(set, resource));
+  }
+  return iree_ok_status();
+}

--- a/iree/hal/utils/resource_set.h
+++ b/iree/hal/utils/resource_set.h
@@ -1,0 +1,136 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_RESOURCE_SET_H_
+#define IREE_HAL_UTILS_RESOURCE_SET_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "iree/hal/resource.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Bit 0 of the next_chunk pointer indicates whether we are inlined into the
+// resource set block - the chunks are always aligned and the bit is unused.
+#define IREE_HAL_RESOURCE_SET_CHUNK_FLAG_INLINE 0x1
+
+// Capacity is limited by how many bits we reserve for the count.
+#define IREE_HAL_RESOURCE_SET_CHUNK_MAX_CAPACITY 0xFFFFu
+
+// A chunk of resources within a resource set.
+// Chunks contain a fixed number of resources based on the block size of the
+// pool the set was allocated from.
+typedef struct iree_hal_resource_set_chunk_t {
+  // Next chunk in the chunk linked list.
+  // Bit 0 indicates whether this was an allocated block; 0 means that the
+  // chunk is stored within the parent resource set and should not be returned
+  // to the block pool. This works only because we know the blocks are allocated
+  // at an alignment >= 16 and we have a few bits to work with.
+  union {
+    struct iree_hal_resource_set_chunk_t* next_chunk;
+    uintptr_t flags;
+  };
+
+  // Retained resources - may be less than the capacity derived from the block
+  // pool block size. We keep the counts small here to reduce chunk overhead. We
+  // could recompute the capacity each time but at the point that we use even 1
+  // byte we've already consumed 4 (or 8) thanks to padding and should make use
+  // of the rest.
+  uint16_t capacity;
+  uint16_t count;
+  iree_hal_resource_t* resources[];
+} iree_hal_resource_set_chunk_t;
+
+// Returns true if the chunk is stored inline in the parent resource set.
+#define iree_hal_resource_set_chunk_is_stored_inline(chunk)      \
+  (((chunk)->flags & IREE_HAL_RESOURCE_SET_CHUNK_FLAG_INLINE) == \
+   IREE_HAL_RESOURCE_SET_CHUNK_FLAG_INLINE)
+
+// Number of elements in the most-recently-used resource list of a set.
+// The larger the number the greater the chance of having a hit but the more
+// expensive every miss will be.
+//
+// To try to keep the MRU in cache we size this based on how many pointers will
+// fit in a single cache line. This also makes it easier to author SIMD lookups
+// as we'll (in-theory) be able to load the entries into SIMD registers.
+//
+// Values for the platforms we specify for:
+//   32-bit: 64 / 4 = 16x4b ptrs (4 x uint32x4_t)
+//   64-bit: 64 / 8 = 8x8b ptrs (4 x uint64x2_t)
+// We could scale this up if we wanted but being able to unroll is nice.
+#define IREE_HAL_RESOURCE_SET_MRU_SIZE \
+  (iree_hardware_constructive_interference_size / sizeof(uintptr_t))
+
+// "Efficient" append-only set for retaining a set of resources.
+// This is a non-deterministic data structure that tries to reduce the amount of
+// overhead involved in tracking a reasonably-sized set of resources (~dozens to
+// hundreds). Set insertion may have false negatives and retain resources more
+// than strictly required by trading off the expense of precisely detecting
+// redundant insertions with the expense of an additional atomic operation.
+//
+// This tries to elide insertions by maintaining a most-recently-used list.
+// This optimizes for temporal locality of resources used (the same executables,
+// same buffers, etc) and is implemented to have a fixed cost regardless of
+// whether the values are found and should hopefully trigger enough to avoid the
+// subsequent full insertion that can introduce allocations and ref counting.
+// The idea is that if we can keep the MRU in cache and spend a dozen cycles to
+// manage it we only need to avoid a single cache miss that would occur doing
+// the full insertion. We care here because this is on the critical path of
+// command encoding and the parasitic cost of maintaining the set scales with
+// the number of commands issued. This never needs to be free, only as fast as
+// whatever user code may need to do to maintain proper lifetime - or as small
+// in terms of code-size.
+//
+// **WARNING**: thread-unsafe insertion: it's assumed that sets are constructed
+// by a single thread, sealed, and then released at once at a future time point.
+// Multiple threads needing to insert into a set should have their own sets and
+// then join them afterward.
+typedef struct iree_hal_resource_set_t {
+  // A small MRUish list of resources for quickly deduplicating insertions.
+  // We use this to perform an O(k) comparison traded off with the cost of a
+  // miss that results in an atomic inc/dec. We shouldn't make this
+  // more expensive than the additional cost of the retain/release.
+  //
+  // This lives at the head of the struct as it's used in 100% of insertions and
+  // if we can get lucky with it staying in cache we reduce a lot of memory
+  // traffic. Once we spill the MRU and go to main memory to add the resource
+  // we're going to have a cache miss and this way we avoid two (one for the
+  // set and one for the chunk).
+  //
+  // TODO(benvanik): ensure alignment on the set - should be at
+  // iree_hardware_constructive_interference_size.
+  iree_hal_resource_t* mru[IREE_HAL_RESOURCE_SET_MRU_SIZE];
+
+  // Block pool used for allocating additional set storage slabs.
+  iree_arena_block_pool_t* block_pool;
+
+  // Linked list of storage chunks.
+  iree_hal_resource_set_chunk_t* chunk_head;
+} iree_hal_resource_set_t;
+
+// Allocates a new resource from the given |block_pool|.
+// Resources can be inserted and are retained until the set is freed.
+IREE_API_EXPORT iree_status_t iree_hal_resource_set_allocate(
+    iree_arena_block_pool_t* block_pool, iree_hal_resource_set_t** out_set);
+
+// Frees a resource set and releases all inserted resources.
+// The |set| itself will be returned back to the block pool it was allocated
+// from.
+IREE_API_EXPORT void iree_hal_resource_set_free(iree_hal_resource_set_t* set);
+
+// Inserts zero or more resources into the set.
+// Each resource will be retained for at least the lifetime of the set.
+IREE_API_EXPORT iree_status_t iree_hal_resource_set_insert(
+    iree_hal_resource_set_t* set, iree_host_size_t count,
+    iree_hal_resource_t* const* resources);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_RESOURCE_SET_H_

--- a/iree/hal/utils/resource_set_benchmark.c
+++ b/iree/hal/utils/resource_set_benchmark.c
@@ -1,0 +1,287 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/prng.h"
+#include "iree/hal/api.h"
+#include "iree/hal/utils/resource_set.h"
+#include "iree/testing/benchmark.h"
+
+typedef struct iree_hal_test_resource_t {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+} iree_hal_test_resource_t;
+
+typedef struct iree_hal_test_resource_vtable_t {
+  void(IREE_API_PTR* destroy)(iree_hal_test_resource_t* resource);
+} iree_hal_test_resource_vtable_t;
+IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_test_resource_vtable_t);
+
+static const iree_hal_test_resource_vtable_t iree_hal_test_resource_vtable;
+
+static iree_status_t iree_hal_test_resource_create(
+    iree_allocator_t host_allocator, iree_hal_resource_t** out_resource) {
+  iree_hal_test_resource_t* test_resource = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      host_allocator, sizeof(*test_resource), (void**)&test_resource));
+  iree_hal_resource_initialize(&iree_hal_test_resource_vtable,
+                               &test_resource->resource);
+  test_resource->host_allocator = host_allocator;
+  *out_resource = (iree_hal_resource_t*)test_resource;
+  return iree_ok_status();
+}
+
+static void iree_hal_test_resource_destroy(iree_hal_test_resource_t* resource) {
+  iree_allocator_t host_allocator = resource->host_allocator;
+  iree_allocator_free(host_allocator, resource);
+}
+
+static const iree_hal_test_resource_vtable_t iree_hal_test_resource_vtable = {
+    /*.destroy=*/iree_hal_test_resource_destroy,
+};
+
+// Tests init/deinit performance when 0+ resources are in the set.
+// This is our worst-case with unique resources that never match the MRU.
+//
+// user_data is a count of elements to insert into each set.
+static iree_status_t iree_hal_resource_set_benchmark_lifecycle_n(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t host_allocator = benchmark_state->host_allocator;
+
+  // Initialize the block pool we'll be serving from.
+  // Sized like we usually do it in the runtime for ~512-1024 elements.
+  iree_arena_block_pool_t block_pool;
+  iree_arena_block_pool_initialize(4096, host_allocator, &block_pool);
+
+  // Allocate the resources we'll be using - we keep them live so that we are
+  // measuring just the retain/release and set times instead of the timing of
+  // resource creation/deletion.
+  uint32_t count = (uint32_t)(uintptr_t)benchmark_def->user_data;
+  iree_hal_resource_t** resources = NULL;
+  if (count > 0) {
+    IREE_CHECK_OK(iree_allocator_malloc(host_allocator,
+                                        sizeof(iree_hal_resource_t*) * count,
+                                        (void**)&resources));
+  }
+  for (uint32_t i = 0; i < count; ++i) {
+    IREE_CHECK_OK(iree_hal_test_resource_create(host_allocator, &resources[i]));
+  }
+
+  // Create/insert/delete lifecycle.
+  while (iree_benchmark_keep_running(benchmark_state, /*batch_count=*/1)) {
+    iree_hal_resource_set_t* set = NULL;
+    IREE_CHECK_OK(iree_hal_resource_set_allocate(&block_pool, &set));
+    IREE_CHECK_OK(iree_hal_resource_set_insert(set, count, resources));
+    iree_hal_resource_set_free(set);
+  }
+
+  // Cleanup.
+  for (uint32_t i = 0; i < count; ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  iree_allocator_free(host_allocator, resources);
+  iree_arena_block_pool_deinitialize(&block_pool);
+
+  return iree_ok_status();
+}
+
+// Tests insertion performance when either the MRU is used (n < MRU size) or
+// the worst-case performance when all resources are unique and guaranteed to
+// miss the MRU. Expect to see a cliff where we spill the MRU.
+//
+// user_data is a count of unique elements to insert.
+static iree_status_t iree_hal_resource_set_benchmark_insert_n(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t host_allocator = benchmark_state->host_allocator;
+
+  // Initialize the block pool we'll be serving from.
+  // Sized like we usually do it in the runtime for ~512-1024 elements.
+  iree_arena_block_pool_t block_pool;
+  iree_arena_block_pool_initialize(4096, host_allocator, &block_pool);
+
+  // Create the empty set using the block pool for additional memory.
+  iree_hal_resource_set_t* set = NULL;
+  IREE_CHECK_OK(iree_hal_resource_set_allocate(&block_pool, &set));
+
+  // Allocate the resources we'll be using - we keep them live so that we are
+  // measuring just the retain/release and set times instead of the timing of
+  // resource creation/deletion.
+  uint32_t count = (uint32_t)(uintptr_t)benchmark_def->user_data;
+  iree_hal_resource_t** resources = NULL;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator,
+                                      sizeof(iree_hal_resource_t*) * count,
+                                      (void**)&resources));
+  for (uint32_t i = 0; i < count; ++i) {
+    IREE_CHECK_OK(iree_hal_test_resource_create(host_allocator, &resources[i]));
+  }
+
+  // Insert the resources. After the first iteration these should all be hits.
+  while (iree_benchmark_keep_running(benchmark_state, /*batch_count=*/1)) {
+    IREE_CHECK_OK(iree_hal_resource_set_insert(set, count, resources));
+  }
+
+  // Cleanup.
+  for (uint32_t i = 0; i < count; ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  iree_hal_resource_set_free(set);
+  iree_allocator_free(host_allocator, resources);
+  iree_arena_block_pool_deinitialize(&block_pool);
+
+  return iree_ok_status();
+}
+
+// Tests insertion into the set in a randomized order.
+// This lets us get a somewhat reasonable approximation of average performance.
+// In reality what the compiler spits out is non-random and often just
+// alternating A/B/C/B/A/C/A/B/C etc kind of sequences.
+//
+// This is the most important benchmark: if this is fast then we are :thumbsup:.
+//
+// user_data is a count of unique element pool to insert N times. The higher
+// the pool size the more likely we are to miss the MRU.
+static iree_status_t iree_hal_resource_set_benchmark_randomized_n(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_allocator_t host_allocator = benchmark_state->host_allocator;
+
+  // Initialize the block pool we'll be serving from.
+  // Sized like we usually do it in the runtime for ~512-1024 elements.
+  iree_arena_block_pool_t block_pool;
+  iree_arena_block_pool_initialize(4096, host_allocator, &block_pool);
+
+  // Allocate the resources we'll be using - we keep them live so that we are
+  // measuring just the retain/release and set times instead of the timing of
+  // resource creation/deletion.
+  uint32_t count = (uint32_t)(uintptr_t)benchmark_def->user_data;
+  iree_hal_resource_t** resources = NULL;
+  IREE_CHECK_OK(iree_allocator_malloc(host_allocator,
+                                      sizeof(iree_hal_resource_t*) * count,
+                                      (void**)&resources));
+  for (uint32_t i = 0; i < count; ++i) {
+    IREE_CHECK_OK(iree_hal_test_resource_create(host_allocator, &resources[i]));
+  }
+
+  // The same set is maintained; we'll eventually have all resources in the set
+  // and be testing the MRU hit %.
+  iree_hal_resource_set_t* set = NULL;
+  IREE_CHECK_OK(iree_hal_resource_set_allocate(&block_pool, &set));
+
+  // The PRNG we use to select the elements.
+  iree_prng_xoroshiro128_state_t prng = {0};
+  iree_prng_xoroshiro128_initialize(123ull, &prng);
+
+  // Insert N random resources into the set. To hide some of the overhead we do
+  // multiple insertions in each loop.
+  while (iree_benchmark_keep_running(benchmark_state, /*batch_count=*/256)) {
+    for (uint32_t i = 0; i < 256; ++i) {
+      uint32_t resource_idx =
+          iree_prng_xoroshiro128plus_next_uint32(&prng) % count;
+      iree_hal_resource_t* resource = resources[resource_idx];
+      IREE_CHECK_OK(iree_hal_resource_set_insert(set, 1, &resource));
+    }
+  }
+
+  // Cleanup.
+  iree_hal_resource_set_free(set);
+  for (uint32_t i = 0; i < count; ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  iree_allocator_free(host_allocator, resources);
+  iree_arena_block_pool_deinitialize(&block_pool);
+
+  return iree_ok_status();
+}
+
+int main(int argc, char** argv) {
+  iree_benchmark_initialize(&argc, argv);
+
+  // iree_hal_resource_set_benchmark_lifecycle_n
+  {
+    iree_benchmark_def_t benchmark_def = {
+        .flags = IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME |
+                 IREE_BENCHMARK_FLAG_USE_REAL_TIME,
+        .time_unit = IREE_BENCHMARK_UNIT_NANOSECOND,
+        .minimum_duration_ns = 0,
+        .iteration_count = 0,
+        .run = iree_hal_resource_set_benchmark_lifecycle_n,
+    };
+    benchmark_def.user_data = (void*)0u;
+    iree_benchmark_register(iree_make_cstring_view("lifecycle_0"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)1u;
+    iree_benchmark_register(iree_make_cstring_view("lifecycle_1"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)256u;
+    iree_benchmark_register(iree_make_cstring_view("lifecycle_256"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)1024u;
+    iree_benchmark_register(iree_make_cstring_view("lifecycle_1024"),
+                            &benchmark_def);
+  }
+
+  // iree_hal_resource_set_benchmark_insert_n
+  {
+    iree_benchmark_def_t benchmark_def = {
+        .flags = IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME |
+                 IREE_BENCHMARK_FLAG_USE_REAL_TIME,
+        .time_unit = IREE_BENCHMARK_UNIT_NANOSECOND,
+        .minimum_duration_ns = 0,
+        .iteration_count = 0,
+        .run = iree_hal_resource_set_benchmark_insert_n,
+    };
+    benchmark_def.user_data = (void*)1u;
+    iree_benchmark_register(iree_make_cstring_view("insert_1"), &benchmark_def);
+    benchmark_def.user_data = (void*)5u;
+    iree_benchmark_register(iree_make_cstring_view("insert_5"), &benchmark_def);
+    benchmark_def.user_data = (void*)32u;
+    iree_benchmark_register(iree_make_cstring_view("insert_32"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)64u;
+    iree_benchmark_register(iree_make_cstring_view("insert_64"),
+                            &benchmark_def);
+  }
+
+  // iree_hal_resource_set_benchmark_randomized_n
+  {
+    iree_benchmark_def_t benchmark_def = {
+        .flags = IREE_BENCHMARK_FLAG_MEASURE_PROCESS_CPU_TIME |
+                 IREE_BENCHMARK_FLAG_USE_REAL_TIME,
+        .time_unit = IREE_BENCHMARK_UNIT_NANOSECOND,
+        .minimum_duration_ns = 0,
+        .iteration_count = 0,
+        .run = iree_hal_resource_set_benchmark_randomized_n,
+    };
+    benchmark_def.user_data = (void*)1u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_1"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)4u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_4"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)8u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_8"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)32u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_32"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)256u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_256"),
+                            &benchmark_def);
+    benchmark_def.user_data = (void*)4096u;
+    iree_benchmark_register(iree_make_cstring_view("randomized_4096"),
+                            &benchmark_def);
+  }
+
+  iree_benchmark_run_specified();
+  return 0;
+}

--- a/iree/hal/utils/resource_set_test.cc
+++ b/iree/hal/utils/resource_set_test.cc
@@ -1,0 +1,257 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/resource_set.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace hal {
+namespace {
+
+using ::iree::testing::status::IsOkAndHolds;
+using ::iree::testing::status::StatusIs;
+using ::testing::Eq;
+
+typedef struct iree_hal_test_resource_t {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+  uint32_t index;
+  uint32_t* live_bitmap;
+} iree_hal_test_resource_t;
+
+typedef struct iree_hal_test_resource_vtable_t {
+  void(IREE_API_PTR* destroy)(iree_hal_test_resource_t* resource);
+} iree_hal_test_resource_vtable_t;
+IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_test_resource_vtable_t);
+
+extern const iree_hal_test_resource_vtable_t iree_hal_test_resource_vtable;
+
+static iree_status_t iree_hal_test_resource_create(
+    uint32_t index, uint32_t* live_bitmap, iree_allocator_t host_allocator,
+    iree_hal_resource_t** out_resource) {
+  iree_hal_test_resource_t* test_resource = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      host_allocator, sizeof(*test_resource), (void**)&test_resource));
+  iree_hal_resource_initialize(&iree_hal_test_resource_vtable,
+                               &test_resource->resource);
+  test_resource->host_allocator = host_allocator;
+  test_resource->index = index;
+  test_resource->live_bitmap = live_bitmap;
+  *live_bitmap |= 1 << index;
+  *out_resource = (iree_hal_resource_t*)test_resource;
+  return iree_ok_status();
+}
+
+static void iree_hal_test_resource_destroy(iree_hal_test_resource_t* resource) {
+  iree_allocator_t host_allocator = resource->host_allocator;
+  *resource->live_bitmap &= ~(1 << resource->index);
+  iree_allocator_free(host_allocator, resource);
+}
+
+const iree_hal_test_resource_vtable_t iree_hal_test_resource_vtable = {
+    /*.destroy=*/iree_hal_test_resource_destroy,
+};
+
+struct ResourceSetTest : public ::testing::Test {
+  // We could check the allocator to ensure all memory is freed if we wanted to
+  // reduce the reliance on asan.
+  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_arena_block_pool_t block_pool;
+
+  void SetUp() override {
+    memset(&block_pool, 0, sizeof(block_pool));
+    iree_arena_block_pool_initialize(128, host_allocator, &block_pool);
+  }
+
+  void TearDown() override {
+    // This may assert (or at least trigger asan) if there are blocks
+    // outstanding.
+    iree_arena_block_pool_deinitialize(&block_pool);
+  }
+};
+
+using resource_set_ptr = std::unique_ptr<iree_hal_resource_set_t,
+                                         decltype(&iree_hal_resource_set_free)>;
+static resource_set_ptr make_resource_set(iree_arena_block_pool_t* block_pool) {
+  iree_hal_resource_set_t* set = NULL;
+  IREE_CHECK_OK(iree_hal_resource_set_allocate(block_pool, &set));
+  return resource_set_ptr(set, iree_hal_resource_set_free);
+}
+
+// Tests a set that has no resources added to it.
+TEST_F(ResourceSetTest, Empty) {
+  iree_hal_resource_set_t* set = NULL;
+  IREE_ASSERT_OK(iree_hal_resource_set_allocate(&block_pool, &set));
+  iree_hal_resource_set_free(set);
+}
+
+// Tests insertion of a single resource.
+TEST_F(ResourceSetTest, Insert1) {
+  auto resource_set = make_resource_set(&block_pool);
+
+  // Create test resource; it'll set its bit in the live_bitmap.
+  iree_hal_resource_t* resource = NULL;
+  uint32_t live_bitmap = 0u;
+  IREE_ASSERT_OK(iree_hal_test_resource_create(0, &live_bitmap, host_allocator,
+                                               &resource));
+  EXPECT_EQ(live_bitmap, 1u);
+
+  // Insert the resource and drop the reference; it should still be live as the
+  // set retains it.
+  IREE_ASSERT_OK(
+      iree_hal_resource_set_insert(resource_set.get(), 1, &resource));
+  iree_hal_resource_release(resource);
+  EXPECT_EQ(live_bitmap, 1u);
+
+  // Drop the set and expect the resource to be destroyed as it loses its last
+  // reference.
+  resource_set.reset();
+  EXPECT_EQ(live_bitmap, 0u);
+}
+
+// Tests inserting multiple resources at a time.
+TEST_F(ResourceSetTest, Insert5) {
+  auto resource_set = make_resource_set(&block_pool);
+
+  // Allocate 5 resources - this lets us test for special paths that may handle
+  // 4 at a time (to fit in SIMD registers) as well as the leftovers.
+  iree_hal_resource_t* resources[5] = {NULL};
+  uint32_t live_bitmap = 0u;
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    IREE_ASSERT_OK(iree_hal_test_resource_create(
+        i, &live_bitmap, host_allocator, &resources[i]));
+  }
+  EXPECT_EQ(live_bitmap, 0x1Fu);
+
+  // Transfer ownership of the resources to the set.
+  IREE_ASSERT_OK(iree_hal_resource_set_insert(
+      resource_set.get(), IREE_ARRAYSIZE(resources), resources));
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  EXPECT_EQ(live_bitmap, 0x1Fu);
+
+  // Ensure the set releases the resources.
+  resource_set.reset();
+  EXPECT_EQ(live_bitmap, 0u);
+}
+
+// Tests inserting enough resources to force set growth. This is ensured by
+// choosing a sufficiently small block size such that even 32 elements triggers
+// a growth. Of course, real usage should have at least ~4KB for the block size.
+TEST_F(ResourceSetTest, InsertionGrowth) {
+  auto resource_set = make_resource_set(&block_pool);
+
+  // Allocate 32 resources (one for each bit in our live map).
+  iree_hal_resource_t* resources[32] = {NULL};
+  uint32_t live_bitmap = 0u;
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    IREE_ASSERT_OK(iree_hal_test_resource_create(
+        i, &live_bitmap, host_allocator, &resources[i]));
+  }
+  EXPECT_EQ(live_bitmap, 0xFFFFFFFFu);
+
+  // Transfer ownership of the resources to the set.
+  IREE_ASSERT_OK(iree_hal_resource_set_insert(
+      resource_set.get(), IREE_ARRAYSIZE(resources), resources));
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  EXPECT_EQ(live_bitmap, 0xFFFFFFFFu);
+
+  // Ensure the set releases the resources.
+  resource_set.reset();
+  EXPECT_EQ(live_bitmap, 0u);
+}
+
+// Tests insertion of resources multiple times to verify the MRU works.
+TEST_F(ResourceSetTest, RedundantInsertion) {
+  auto resource_set = make_resource_set(&block_pool);
+
+  // Allocate 32 resources (one for each bit in our live map).
+  // We want to be able to miss in the MRU.
+  iree_hal_resource_t* resources[32] = {NULL};
+  static_assert(IREE_ARRAYSIZE(resources) > IREE_HAL_RESOURCE_SET_MRU_SIZE,
+                "need to pick a value that lets us exceed the MRU capacity");
+  uint32_t live_bitmap = 0u;
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    IREE_ASSERT_OK(iree_hal_test_resource_create(
+        i, &live_bitmap, host_allocator, &resources[i]));
+  }
+  EXPECT_EQ(live_bitmap, 0xFFFFFFFFu);
+
+  // NOTE: the only requirement of the MRU is that it's _mostly_ MRU - we may
+  // for performance reasons make it a little fuzzy to avoid additional
+  // shuffling. Today it's always a proper MRU and we check the pointers here.
+
+  // NOTE: the MRU size can vary across architectures; we know it should always
+  // be at least ~6 though so that's what we work with here.
+  static_assert(IREE_HAL_RESOURCE_SET_MRU_SIZE > 6,
+                "need at least enough elements to test with");
+
+  // Insert in sequence, MRU should contain:
+  //   31 30 29 28 27 ...
+  IREE_ASSERT_OK(iree_hal_resource_set_insert(
+      resource_set.get(), IREE_ARRAYSIZE(resources), resources));
+  EXPECT_EQ(resource_set->mru[0], resources[31]);
+  EXPECT_EQ(resource_set->mru[1], resources[30]);
+  EXPECT_EQ(resource_set->mru[2], resources[29]);
+  EXPECT_EQ(resource_set->mru[3], resources[28]);
+  EXPECT_EQ(resource_set->mru[4], resources[27]);
+
+  // Insert 31 again, MRU should remain the same as it's at the head.
+  IREE_ASSERT_OK(
+      iree_hal_resource_set_insert(resource_set.get(), 1, &resources[31]));
+  EXPECT_EQ(resource_set->mru[0], resources[31]);
+  EXPECT_EQ(resource_set->mru[1], resources[30]);
+  EXPECT_EQ(resource_set->mru[2], resources[29]);
+  EXPECT_EQ(resource_set->mru[3], resources[28]);
+  EXPECT_EQ(resource_set->mru[4], resources[27]);
+
+  // Insert 28 again, MRU should be updated to move it to the front:
+  //   28 31 30 29 27 ...
+  IREE_ASSERT_OK(
+      iree_hal_resource_set_insert(resource_set.get(), 1, &resources[28]));
+  EXPECT_EQ(resource_set->mru[0], resources[28]);
+  EXPECT_EQ(resource_set->mru[1], resources[31]);
+  EXPECT_EQ(resource_set->mru[2], resources[30]);
+  EXPECT_EQ(resource_set->mru[3], resources[29]);
+  EXPECT_EQ(resource_set->mru[4], resources[27]);
+
+  // Insert 0 again, which should be a miss as it fell off the end of the MRU:
+  //   0 28 31 30 29 27 ...
+  IREE_ASSERT_OK(
+      iree_hal_resource_set_insert(resource_set.get(), 1, &resources[0]));
+  EXPECT_EQ(resource_set->mru[0], resources[0]);
+  EXPECT_EQ(resource_set->mru[1], resources[28]);
+  EXPECT_EQ(resource_set->mru[2], resources[31]);
+  EXPECT_EQ(resource_set->mru[3], resources[30]);
+  EXPECT_EQ(resource_set->mru[4], resources[29]);
+  EXPECT_EQ(resource_set->mru[5], resources[27]);
+
+  // Release all of the resources - they should still be owned by the set.
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(resources); ++i) {
+    iree_hal_resource_release(resources[i]);
+  }
+  EXPECT_EQ(live_bitmap, 0xFFFFFFFFu);
+
+  // Ensure the set releases the resources.
+  resource_set.reset();
+  EXPECT_EQ(live_bitmap, 0u);
+}
+
+}  // namespace
+}  // namespace hal
+}  // namespace iree

--- a/iree/testing/benchmark_full.cc
+++ b/iree/testing/benchmark_full.cc
@@ -114,10 +114,11 @@ void iree_benchmark_register(iree_string_view_t name,
                              const iree_benchmark_def_t* benchmark_def) {
   std::string name_str(name.data, name.size);
   std::string prefixed_str = "BM_" + name_str;
+  iree_benchmark_def_t cloned_def = *benchmark_def;
   auto* instance = benchmark::RegisterBenchmark(
       prefixed_str.c_str(),
-      [name_str, benchmark_def](benchmark::State& state) -> void {
-        iree_benchmark_run(name_str.c_str(), benchmark_def, state);
+      [name_str, cloned_def](benchmark::State& state) -> void {
+        iree_benchmark_run(name_str.c_str(), &cloned_def, state);
       });
 
   if (iree_all_bits_set(benchmark_def->flags,


### PR DESCRIPTION
This utility allows for efficient tracking of resource lifetime by
relying on false negatives on set insertion being valid. Basically we
only need to ensure that each resource is inserted at least once and
the only cost to inserting it multiple times is a retain/release and
sizeof(void*). By relying on a block pool and inlining the sets into
the first block acquired we also stay (steady-state) allocation-free
and in the cases where the compiler does a good job will never grow
at all (once we canonicalize interfaces). That puts us in the nice
place of being able to reduce the overhead of this with compiler
tweaks.

A big design point here was to make this possible to implement with
SIMD operations. We're already in the double-digit nanosecond territory
and can go even faster (~20 cycles per insertion when hit). I've left
some notes for future me (or someone else who gets nerdsniped).

Future changes will make command buffer implementations that need to
retain resources use this to do so. Command buffers that don't retain
(such as RPC client/inline execution/cuda stream at the other end of
a deferred_command_buffer/etc) won't need to use this and won't pay
the cost.