### PR TITLE
Delete iree/samples/ops/.

### DIFF
--- a/iree/samples/ops/dynamic-mhlo-dot.mlir
+++ b/iree/samples/ops/dynamic-mhlo-dot.mlir
@@ -1,4 +1,0 @@
-func @dot(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = "mhlo.dot"(%lhs, %rhs) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %0 : tensor<?x?xf32>
-}

--- a/iree/samples/ops/mhlo-dot.mlir
+++ b/iree/samples/ops/mhlo-dot.mlir
@@ -1,4 +1,0 @@
-func @dot(%lhs: tensor<32x1024xf32>, %rhs: tensor<1024x64xf32>) -> tensor<32x64xf32> {
-  %0 = "mhlo.dot"(%lhs, %rhs) : (tensor<32x1024xf32>, tensor<1024x64xf32>) -> tensor<32x64xf32>
-  return %0 : tensor<32x64xf32>
-}


### PR DESCRIPTION
These were used for IR conversion samples, but are no longer being used or tested. Users are finding these and are confused about how to use them / if they should be working: https://llvm.discourse.group/t/iree-example-error/5093

If we bring back those samples (https://github.com/google/iree/issues/5958), we can pick new files and rework the automation.