### PR TITLE
Fix vulkan_inference_gui sample after HAL and ABI changes.

### DIFF
--- a/iree/testing/vulkan/vulkan_gui_util.cc
+++ b/iree/testing/vulkan/vulkan_gui_util.cc
@@ -222,6 +222,20 @@ void SetupVulkan(iree_hal_vulkan_features_t vulkan_features,
     create_info.enabledExtensionCount =
         static_cast<uint32_t>(device_extensions.size());
     create_info.ppEnabledExtensionNames = device_extensions.data();
+
+    // Enable timeline semaphores.
+    VkPhysicalDeviceFeatures2 features2;
+    memset(&features2, 0, sizeof(features2));
+    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    create_info.pNext = &features2;
+    VkPhysicalDeviceTimelineSemaphoreFeatures semaphore_features;
+    memset(&semaphore_features, 0, sizeof(semaphore_features));
+    semaphore_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+    semaphore_features.pNext = features2.pNext;
+    features2.pNext = &semaphore_features;
+    semaphore_features.timelineSemaphore = VK_TRUE;
+
     err = vkCreateDevice(*physical_device, &create_info, allocator, device);
     check_vk_result(err);
     vkGetDeviceQueue(*device, *queue_family_index, 0, queue);


### PR DESCRIPTION
This sample compiles and runs again now, though it has validation layer errors about leaks on shutdown. We might also move this out of the core repo soon anyways (https://github.com/google/iree/issues/8011).

* `$async` ABI was removed in https://github.com/google/iree/pull/6200
* timeline semaphore feature must be enabled during device creation (IREE itself does this already, but the device created by the hosting application in the sample was not)
* removed `iree_allocator_system()` extra argument to `iree_hal_buffer_view_allocate_buffer`