### PR TITLE
First pass at linalg_ext.scan op

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -247,6 +247,56 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
   }];
 }
 
+def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
+    [DeclareOpInterfaceMethods<TiledOpInterface,
+      ["getPartitionableLoops", "generateScalarImplementation",
+       "getTiledImplementation"]>]> {
+  let summary = "Scan operator";
+  let description = [{
+    Computes the inclusive/exclusive scan along a given dimension.
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       AnyType:$identity,
+                       I64Attr:$dimension,
+                       BoolAttr:$inclusive
+  );
+
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
+      "Value":$identity, CArg<"int64_t", "0">:$dimension,
+      CArg<"bool", "true">:$inclusive)>
+  ];
+
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region AnyRegion:$region);
+  let assemblyFormat = [{
+    `dimension` `(` $dimension `)`
+    `inclusive` `(` $inclusive `)`
+    attr-dict
+    `identity` `(` $identity `:` type($identity) `)`
+    `ins` `(` $inputs `:` type($inputs) `)`
+    (`outs` `(` $outputs^ `:` type($outputs) `)`)?
+    $region (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value input() {
+      return getInputOperand(0)->get();
+    }
+    Value output() {
+      return getOutputOperand(0)->get();
+    }
+    ShapedType getOperandType() {
+      return input().getType().cast<ShapedType>();
+    }
+    int64_t getOperandRank() {
+      return getOperandType().getRank();
+    }
+  }];
+}
+
 def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
   DeclareOpInterfaceMethods<
       TiledOpInterface,

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -505,3 +505,96 @@ func @reverse_dim_0(%arg0: memref<?x?xi32>, %arg1: memref<?x?xi32>) {
 // CHECK:             %[[T2:.+]] = arith.subi %[[T1]], %[[I]] : index
 // CHECK:             %[[V0:.+]] = memref.load %[[IN]][%[[I]], %[[J]]]
 // CHECK:             memref.store %[[V0]], %[[OUT]][%[[T2]], %[[J]]] : memref<?x?xi32>
+
+func @scan_1d_inclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
+  %c0 = arith.constant 0 : i32
+  iree_linalg_ext.scan dimension(0) inclusive(true) identity(%c0 : i32)
+    ins(%0 : memref<128xi32>) outs(%1 : memref<128xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scan_1d_inclusive
+// CHECK-SAME:    %[[BUFI:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[BUFO:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C128]] step %[[C1]]
+// CHECK:           %[[COND:.+]] = arith.cmpi eq, %[[ARG1]], %[[C0]] : index
+// CHECK:           scf.if %[[COND]] {
+// CHECK:             %[[V1:.+]] = memref.load %[[BUFI]][%[[ARG1]]]
+// CHECK:             memref.store %[[V1]], %[[BUFO]][%[[ARG1]]]
+// CHECK:           } else {
+// CHECK:             %[[T1:.+]] = arith.subi %[[ARG1]], %[[C1]] : index
+// CHECK:             %[[V2:.+]] = memref.load %[[BUFO]][%[[T1]]]
+// CHECK:             %[[V3:.+]] = memref.load %[[BUFI]][%[[ARG1]]]
+// CHECK:             %[[V4:.+]] = arith.addi %[[V2]], %[[V3]] : i32
+// CHECK:             memref.store %[[V4]], %[[BUFO]][%[[ARG1]]]
+// CHECK:           }
+
+// -----
+
+func @scan_1d_exclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
+  %c0 = arith.constant 0 : i32
+  iree_linalg_ext.scan dimension(0) inclusive(false) identity(%c0 : i32)
+    ins(%0 : memref<128xi32>) outs(%1 : memref<128xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scan_1d_exclusive
+// CHECK-SAME:    %[[BUFI:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[BUFO:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C128]] step %[[C1]]
+// CHECK:           %[[COND:.+]] = arith.cmpi eq, %[[ARG1]], %[[C0]] : index
+// CHECK:           scf.if %[[COND]] {
+// CHECK:             memref.store %[[C0_I32]], %[[BUFO]][%[[ARG1]]]
+// CHECK:           } else {
+// CHECK:             %[[T1:.+]] = arith.subi %[[ARG1]], %[[C1]] : index
+// CHECK:             %[[V2:.+]] = memref.load %[[BUFO]][%[[T1]]]
+// CHECK:             %[[V3:.+]] = memref.load %[[BUFI]][%[[T1]]]
+// CHECK:             %[[V4:.+]] = arith.addi %[[V2]], %[[V3]] : i32
+// CHECK:             memref.store %[[V4]], %[[BUFO]][%[[ARG1]]]
+// CHECK:           }
+
+// -----
+
+func @scan_2d(%0: memref<16x32xi32>, %1: memref<16x32xi32>) {
+  %c0 = arith.constant 0 : i32
+  iree_linalg_ext.scan dimension(0) inclusive(true) identity(%c0 : i32)
+    ins(%0 : memref<16x32xi32>) outs(%1 : memref<16x32xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  }
+  return
+}
+// CHECK-LABEL: func @scan_2d
+// CHECK-SAME:    %[[BUFI:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[BUFO:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:     %[[C32:.+]] = arith.constant 32 : index
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         scf.for %[[ARG1:.+]] = %[[C0]] to %[[C16]] step %[[C1]]
+// CHECK:           scf.for %[[ARG2:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
+// CHECK:             %[[COND:.+]] = arith.cmpi eq, %[[ARG1]], %[[C0]] : index
+// CHECK:             scf.if %[[COND]] {
+// CHECK:               %[[V1:.+]] = memref.load %[[BUFI]][%[[ARG1]], %[[ARG2]]]
+// CHECK:               memref.store %[[V1]], %[[BUFO]][%[[ARG1]], %[[ARG2]]]
+// CHECK:             } else {
+// CHECK:               %[[T1:.+]] = arith.subi %[[ARG1]], %[[C1]] : index
+// CHECK:               %[[V2:.+]] = memref.load %[[BUFO]][%[[T1]], %[[ARG2]]]
+// CHECK:               %[[V3:.+]] = memref.load %[[BUFI]][%[[ARG1]], %[[ARG2]]]
+// CHECK:               %[[V4:.+]] = arith.addi %[[V2]], %[[V3]] : i32
+// CHECK:               memref.store %[[V4]], %[[BUFO]][%[[ARG1]], %[[ARG2]]]
+// CHECK:             }

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -1206,3 +1206,106 @@ func @pad_tensor(%arg0 : tensor<?x?xf32>, %arg1 : index, %arg2 : index,
 //      CHECK:       scf.yield %[[INSERT]]
 //      CHECK:     scf.yield %[[YIELD]]
 //      CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scan_1d(%0: tensor<128xi32>) -> tensor<128xi32> {
+  %c0 = arith.constant 0 : i32
+  %1 = linalg.init_tensor [128] : tensor<128xi32>
+  %2 = iree_linalg_ext.scan
+    dimension(0) inclusive(true)
+    {__internal_linalg_transform__ = "outer_reduce_input"}
+    identity(%c0 : i32)
+    ins(%0 : tensor<128xi32>) outs(%1 : tensor<128xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  } -> tensor<128xi32>
+  return %2 : tensor<128xi32>
+}
+//      CHECK: func @scan_1d(
+// CHECK-SAME:   %[[OPERAND:.+]]: tensor<128xi32>
+//      CHECK:   %[[IDENTITY:.+]] = arith.constant 0 : i32
+//      CHECK:   %[[OUTPUT:.+]] = linalg.init_tensor [128] : tensor<128xi32>
+//      CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scan
+// CHECK-SAME:           __internal_linalg_transform__ = "outer_reduce_output"
+// CHECK-SAME:       identity(%[[IDENTITY]] :
+// CHECK-SAME:       ins(%[[OPERAND]] :
+// CHECK-SAME:       outs(%[[OUTPUT]] :
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scan_2d(%0: tensor<16x32xi32>) -> tensor<16x32xi32> {
+  %c0 = arith.constant 0 : i32
+  %1 = linalg.init_tensor [16, 32] : tensor<16x32xi32>
+  %2 = iree_linalg_ext.scan
+    dimension(0) inclusive(true)
+    {__internal_linalg_transform__ = "outer_reduce_input"}
+    identity(%c0 : i32)
+    ins(%0 : tensor<16x32xi32>) outs(%1 : tensor<16x32xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  } -> tensor<16x32xi32>
+  return %2 : tensor<16x32xi32>
+}
+//  CHECK-DAG:  #[[MAP0:.+]] = affine_map<(d0)[s0, s1] -> (20, -d0 + s1)>
+//      CHECK:  func @scan_2d(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+//  CHECK-DAG:    %[[IDENTITY:.+]] = arith.constant 0 : i32
+//      CHECK:    %[[C0:.+]] = arith.constant 0 : index
+//      CHECK:    %[[C16:.+]] = arith.constant 16 : index
+//      CHECK:    %[[C32:.+]] = arith.constant 32 : index
+//      CHECK:    %[[C20:.+]] = arith.constant 20 : index
+//      CHECK:    %[[OUTPUT:.+]] = linalg.init_tensor [16, 32] : tensor<16x32xi32>
+//      CHECK:    %[[RESULT:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C32]] step %[[C20]] 
+// CHECK-SAME:      iter_args(%[[ARG2:.+]] = %[[OUTPUT]])
+//      CHECK:      %[[SIZE:.+]] = affine.min #[[MAP0]](%[[I]])[%[[C20]], %[[C32]]]
+//      CHECK:      %[[UPDATE_SLICE_IN:.+]] = tensor.extract_slice %[[ARG0]][0, %[[I]]] [%[[C16]], %[[SIZE]]]
+//      CHECK:      %[[UPDATE_SLICE_OUT:.+]] = tensor.extract_slice %[[OUTPUT]][0, %[[I]]] [%[[C16]], %[[SIZE]]]
+//      CHECK:      %[[SCAN_TILE:.+]] = iree_linalg_ext.scan
+// CHECK-SAME:       dimension(0) inclusive(true)
+// CHECK-SAME:       {__internal_linalg_transform__ = "outer_reduce_output"}
+// CHECK-SAME:       ins(%[[UPDATE_SLICE_IN]]
+// CHECK-SAME:       outs(%[[UPDATE_SLICE_OUT]]
+//      CHECK:       %[[YIELD:.+]] = tensor.insert_slice %[[SCAN_TILE]] into %[[ARG2]][0, %[[I]]]
+// CHECK-SAME:           [%[[C16]], %[[SIZE]]]
+//      CHECK:       scf.yield %[[YIELD]]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scan_2d_memref(%0: memref<16x32xi32>, %1: memref<16x32xi32>) {
+  %c0 = arith.constant 0 : i32
+  iree_linalg_ext.scan
+    dimension(0) inclusive(true)
+    {__internal_linalg_transform__ = "outer_reduce_input"}
+    identity(%c0 : i32)
+    ins(%0 : memref<16x32xi32>) outs(%1 : memref<16x32xi32>) {
+    ^bb0(%arg0 : i32, %arg1 : i32):
+      %sum = arith.addi %arg0, %arg1 : i32
+      iree_linalg_ext.yield %sum : i32
+  }
+  return
+}
+//  CHECK-DAG:  #[[MAP0:.+]] = affine_map<(d0)[s0, s1] -> (20, -d0 + s1)>
+//  CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1)[s0] -> (d0 * 32 + s0 + d1)>
+//      CHECK:  func @scan_2d_memref(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+//  CHECK-DAG:    %[[IDENTITY:.+]] = arith.constant 0 : i32
+//      CHECK:    %[[C0:.+]] = arith.constant 0 : index
+//      CHECK:    %[[C16:.+]] = arith.constant 16 : index
+//      CHECK:    %[[C32:.+]] = arith.constant 32 : index
+//      CHECK:    %[[C20:.+]] = arith.constant 20 : index
+//      CHECK:    scf.for %[[I:.+]] = %[[C0]] to %[[C32]] step %[[C20]]
+//      CHECK:      %[[SIZE:.+]] = affine.min #[[MAP0]](%[[I]])[%[[C20]], %[[C32]]]
+//      CHECK:      %[[UPDATE_SLICE_IN:.+]] = memref.subview %[[ARG0]][0, %[[I]]] [%[[C16]], %[[SIZE]]]
+//      CHECK:      %[[UPDATE_SLICE_OUT:.+]] = memref.subview %[[ARG1]][0, %[[I]]] [%[[C16]], %[[SIZE]]]
+//      CHECK:      iree_linalg_ext.scan
+// CHECK-SAME:       dimension(0) inclusive(true)
+// CHECK-SAME:       {__internal_linalg_transform__ = "outer_reduce_output"}
+// CHECK-SAME:       ins(%[[UPDATE_SLICE_IN]]
+// CHECK-SAME:       outs(%[[UPDATE_SLICE_OUT]]
+//      CHECK:   return


### PR DESCRIPTION
This pass adds the first version of the scan op in
the linalg_ext dialect. Currently, the op requires specifying
the dimension, whether the scan is inclusive or not as well
as body specifying the operator for scan.

The current patch adds code to lower the op to loops
using the naive sequential implementation. The tiled implementation
is borrowed from the sort op.

Finally, some unit tests have also been added to test the passes.