### PR TITLE
Remove the "-snapshot" release suffix.

### DIFF
--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -1,4 +1,4 @@
-name: Schedule snapshot release
+name: Schedule candidate release
 
 on:
   schedule:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tag_release:
-    name: "Tag snapshot release"
+    name: "Tag candidate release"
     runs-on: ubuntu-18.04
     # Don't run this in everyone's forks.
     if: github.repository == 'google/iree'
@@ -22,11 +22,11 @@ jobs:
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           package_version="$(printf '%(%Y%m%d)T.${{ github.run_number }}')"
-          tag_name="snapshot-${package_version}"
+          tag_name="candidate-${package_version}"
           echo "package_version=${package_version}" >> $GITHUB_ENV
           echo "tag_name=${tag_name}" >> $GITHUB_ENV
 
-      - name: Updating snapshot tag
+      - name: Updating candidate tag
         run: |
           git tag "${tag_name}"
 
@@ -44,9 +44,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           tag_name: ${{ env.tag_name }}
-          release_name: iree snapshot ${{ env.tag_name }}
+          release_name: iree candidate ${{ env.tag_name }}
           body: |
-            Automatic snapshot release of iree.
+            Automatic candidate release of iree.
           draft: true
           prerelease: true
 
@@ -56,4 +56,4 @@ jobs:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
-          inputs: '{"package_suffix": "-snapshot", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'
+          inputs: '{"package_suffix": "-candidate", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -30,7 +30,7 @@ jobs:
           run_id: ${{ github.event.inputs.build_run_id }}
       - name: Extract and display downloaded files
         run: |
-          tar -xf artifact/iree-dist-snapshot-${{ github.event.inputs.package_version }}-linux-x86_64.tar.xz
+          tar -xf artifact/iree-dist-${{ github.event.inputs.package_version }}-linux-x86_64.tar.xz
           pwd
           ls -R
       - name: Set up python
@@ -41,7 +41,7 @@ jobs:
       - name: Install python packages
         id: install_python_packages
         run: |
-          python -m pip install -f file://$PWD/artifact/ iree-compiler-snapshot iree-runtime-snapshot iree-tools-tflite-snapshot iree-tools-tf-snapshot iree-tools-xla-snapshot
+          python -m pip install -f file://$PWD/artifact/ iree-compiler iree-runtime iree-tools-tflite iree-tools-tf iree-tools-xla
       - name: Run iree-benchmark-module
         id: run_iree_benchmark_module
         run: ./bin/iree-benchmark-module --help

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,7 +71,7 @@ These steps help reproduce the failures in TFLite models.
 
 1.  Install `iree-import-tflite`.
     ```
-    $ python -m pip install iree-tools-tflite-snapshot -f https://github.com/google/iree/releases
+    $ python -m pip install iree-tools-tflite -f https://github.com/google/iree/releases
     ```
 
 2. Confirm the binary `iree-import-tflite` is in your path by running

--- a/colab/edge_detection.ipynb
+++ b/colab/edge_detection.ipynb
@@ -66,7 +66,7 @@
         "outputId": "91312c08-0bee-4835-b1c6-7a13a72d7fcc"
       },
       "source": [
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot iree-tools-tf-snapshot -f https://github.com/google/iree/releases"
+        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://github.com/google/iree/releases"
       ],
       "execution_count": 2,
       "outputs": [
@@ -74,17 +74,17 @@
           "output_type": "stream",
           "text": [
             "Looking in links: https://github.com/google/iree/releases\n",
-            "Collecting iree-compiler-snapshot\n",
+            "Collecting iree-compiler\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_compiler_snapshot-20210608.328-py3-none-manylinux2014_x86_64.whl (33.6MB)\n",
             "\u001b[K     |████████████████████████████████| 33.6MB 109kB/s \n",
-            "\u001b[?25hCollecting iree-runtime-snapshot\n",
+            "\u001b[?25hCollecting iree-runtime\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_runtime_snapshot-20210608.328-cp37-cp37m-manylinux2014_x86_64.whl (521kB)\n",
             "\u001b[K     |████████████████████████████████| 522kB 44.2MB/s \n",
-            "\u001b[?25hCollecting iree-tools-tf-snapshot\n",
+            "\u001b[?25hCollecting iree-tools-tf\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_tools_tf_snapshot-20210608.328-py3-none-manylinux2014_x86_64.whl (53.6MB)\n",
             "\u001b[K     |████████████████████████████████| 53.6MB 133kB/s \n",
-            "\u001b[?25hInstalling collected packages: iree-compiler-snapshot, iree-runtime-snapshot, iree-tools-tf-snapshot\n",
-            "Successfully installed iree-compiler-snapshot-20210608.328 iree-runtime-snapshot-20210608.328 iree-tools-tf-snapshot-20210608.328\n"
+            "\u001b[?25hInstalling collected packages: iree-compiler, iree-runtime, iree-tools-tf\n",
+            "Successfully installed iree-compiler-20210608.328 iree-runtime-20210608.328 iree-tools-tf-20210608.328\n"
           ],
           "name": "stdout"
         }

--- a/colab/low_level_invoke_function.ipynb
+++ b/colab/low_level_invoke_function.ipynb
@@ -66,7 +66,7 @@
         "outputId": "bfd1cc6a-bc75-4d16-850d-64776dc6d64f"
       },
       "source": [
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot -f https://github.com/google/iree/releases"
+        "!python -m pip install iree-compiler iree-runtime -f https://github.com/google/iree/releases"
       ],
       "execution_count": 2,
       "outputs": [
@@ -74,14 +74,14 @@
           "output_type": "stream",
           "text": [
             "Looking in links: https://github.com/google/iree/releases\n",
-            "Collecting iree-compiler-snapshot\n",
+            "Collecting iree-compiler\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_compiler_snapshot-20210608.328-py3-none-manylinux2014_x86_64.whl (33.6MB)\n",
             "\u001b[K     |████████████████████████████████| 33.6MB 118kB/s \n",
-            "\u001b[?25hCollecting iree-runtime-snapshot\n",
+            "\u001b[?25hCollecting iree-runtime\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_runtime_snapshot-20210608.328-cp37-cp37m-manylinux2014_x86_64.whl (521kB)\n",
             "\u001b[K     |████████████████████████████████| 522kB 27.1MB/s \n",
-            "\u001b[?25hInstalling collected packages: iree-compiler-snapshot, iree-runtime-snapshot\n",
-            "Successfully installed iree-compiler-snapshot-20210608.328 iree-runtime-snapshot-20210608.328\n"
+            "\u001b[?25hInstalling collected packages: iree-compiler, iree-runtime\n",
+            "Successfully installed iree-compiler-20210608.328 iree-runtime-20210608.328\n"
           ],
           "name": "stdout"
         }

--- a/colab/mnist_training.ipynb
+++ b/colab/mnist_training.ipynb
@@ -64,7 +64,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot iree-tools-tf-snapshot -f https://github.com/google/iree/releases"
+        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://github.com/google/iree/releases"
       ],
       "execution_count": 1,
       "outputs": []

--- a/colab/resnet.ipynb
+++ b/colab/resnet.ipynb
@@ -65,7 +65,7 @@
         "outputId": "d266854b-414f-4add-9f4c-9119b1d91ef6"
       },
       "source": [
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot iree-tools-tf-snapshot -f https://github.com/google/iree/releases"
+        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://github.com/google/iree/releases"
       ],
       "execution_count": 2,
       "outputs": [
@@ -73,17 +73,17 @@
           "output_type": "stream",
           "text": [
             "Looking in links: https://github.com/google/iree/releases\n",
-            "Collecting iree-compiler-snapshot\n",
+            "Collecting iree-compiler\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_compiler_snapshot-20210608.328-py3-none-manylinux2014_x86_64.whl (33.6MB)\n",
             "\u001b[K     |████████████████████████████████| 33.6MB 122kB/s \n",
-            "\u001b[?25hCollecting iree-runtime-snapshot\n",
+            "\u001b[?25hCollecting iree-runtime\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_runtime_snapshot-20210608.328-cp37-cp37m-manylinux2014_x86_64.whl (521kB)\n",
             "\u001b[K     |████████████████████████████████| 522kB 36.5MB/s \n",
-            "\u001b[?25hCollecting iree-tools-tf-snapshot\n",
+            "\u001b[?25hCollecting iree-tools-tf\n",
             "\u001b[?25l  Downloading https://github.com/google/iree/releases/download/snapshot-20210608.328/iree_tools_tf_snapshot-20210608.328-py3-none-manylinux2014_x86_64.whl (53.6MB)\n",
             "\u001b[K     |████████████████████████████████| 53.6MB 76kB/s \n",
-            "\u001b[?25hInstalling collected packages: iree-compiler-snapshot, iree-runtime-snapshot, iree-tools-tf-snapshot\n",
-            "Successfully installed iree-compiler-snapshot-20210608.328 iree-runtime-snapshot-20210608.328 iree-tools-tf-snapshot-20210608.328\n"
+            "\u001b[?25hInstalling collected packages: iree-compiler, iree-runtime, iree-tools-tf\n",
+            "Successfully installed iree-compiler-20210608.328 iree-runtime-20210608.328 iree-tools-tf-20210608.328\n"
           ],
           "name": "stdout"
         }

--- a/colab/tensorflow_hub_import.ipynb
+++ b/colab/tensorflow_hub_import.ipynb
@@ -77,7 +77,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot iree-tools-tf-snapshot -f https://github.com/google/iree/releases"
+        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://github.com/google/iree/releases"
       ],
       "execution_count": 2,
       "outputs": []

--- a/colab/tflite_text_classification.ipynb
+++ b/colab/tflite_text_classification.ipynb
@@ -60,7 +60,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler-snapshot iree-runtime-snapshot iree-tools-tflite-snapshot -f https://github.com/google/iree/releases/latest\n",
+        "!python -m pip install iree-compiler iree-runtime iree-tools-tflite -f https://github.com/google/iree/releases/latest\n",
         "!pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime"
       ],
       "execution_count": 14,

--- a/docs/api_docs/python/requirements.txt
+++ b/docs/api_docs/python/requirements.txt
@@ -7,5 +7,5 @@ sphinx_toolbox==2.15.0
 
 # IREE Python API
 -f https://github.com/google/iree/releases
-iree-compiler-snapshot
-iree-runtime-snapshot
+iree-compiler
+iree-runtime

--- a/docs/developers/get_started/getting_started_tensorflow.md
+++ b/docs/developers/get_started/getting_started_tensorflow.md
@@ -58,9 +58,9 @@ Roughly:
 
 ```shell
 python -m pip install \
-  iree-tools-tf-snapshot \
-  iree-tools-tflite-snapshot \
-  iree-tools-xla-snapshot \
+  iree-tools-tf \
+  iree-tools-tflite \
+  iree-tools-xla \
   -f https://github.com/google/iree/releases
 ```
 

--- a/docs/website/docs/bindings/python.md
+++ b/docs/website/docs/bindings/python.md
@@ -12,12 +12,12 @@ components:
 
 | PIP package name             | Description                                                                 |
 |------------------------------|-----------------------------------------------------------------------------|
-| `iree-compiler-snapshot`     | IREE's generic compiler tools and helpers                                   |
-| `iree-runtime-snapshot`      | IREE's runtime, including CPU and GPU backends                              |
-| `iree-tools-tf-snapshot`     | Tools for importing from [TensorFlow](https://www.tensorflow.org/)          |
-| `iree-tools-tflite-snapshot` | Tools for importing from [TensorFlow Lite](https://www.tensorflow.org/lite) |
-| `iree-tools-xla-snapshot`    | Tools for importing from [XLA](https://www.tensorflow.org/xla)              |
-| `iree-jax-snapshot`          | Tools for importing from [JAX](https://github.com/google/jax)               |
+| `iree-compiler`     | IREE's generic compiler tools and helpers                                   |
+| `iree-runtime`      | IREE's runtime, including CPU and GPU backends                              |
+| `iree-tools-tf`     | Tools for importing from [TensorFlow](https://www.tensorflow.org/)          |
+| `iree-tools-tflite` | Tools for importing from [TensorFlow Lite](https://www.tensorflow.org/lite) |
+| `iree-tools-xla`    | Tools for importing from [XLA](https://www.tensorflow.org/xla)              |
+| `iree-jax`          | Tools for importing from [JAX](https://github.com/google/jax)               |
 
 Collectively, these packages allow for importing from frontends, compiling
 towards various targets, and executing compiled code on IREE's backends.
@@ -77,8 +77,8 @@ For now, packages can be installed from our
 
     ``` shell
     python -m pip install \
-      iree-compiler-snapshot \
-      iree-runtime-snapshot \
+      iree-compiler \
+      iree-runtime \
       --find-links https://github.com/google/iree/releases
     ```
 
@@ -88,11 +88,11 @@ For now, packages can be installed from our
 
     ``` shell
     python -m pip install \
-      iree-compiler-snapshot \
-      iree-runtime-snapshot \
-      iree-tools-tf-snapshot \
-      iree-tools-tflite-snapshot \
-      iree-tools-xla-snapshot \
+      iree-compiler \
+      iree-runtime \
+      iree-tools-tf \
+      iree-tools-tflite \
+      iree-tools-xla \
       --find-links https://github.com/google/iree/releases
     ```
 

--- a/docs/website/docs/deployment-configurations/cpu-dylib.md
+++ b/docs/website/docs/deployment-configurations/cpu-dylib.md
@@ -51,7 +51,7 @@ snapshots of the `main` development branch.
 You can install the Python package containing the LLVM-based dylib compiler by
 
 ``` shell
-python -m pip install iree-compiler-snapshot \
+python -m pip install iree-compiler \
     -f https://github.com/google/iree/releases
 ```
 

--- a/docs/website/docs/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/deployment-configurations/gpu-vulkan.md
@@ -103,7 +103,7 @@ snapshots of the `main` development branch.
 You can install the Python package containing the SPIR-V compiler by
 
 ``` shell
-python -m pip install iree-compiler-snapshot \
+python -m pip install iree-compiler \
     -f https://github.com/google/iree/releases
 ```
 

--- a/docs/website/docs/ml-frameworks/tensorflow-lite.md
+++ b/docs/website/docs/ml-frameworks/tensorflow-lite.md
@@ -17,9 +17,9 @@ Install IREE pip packages, either from pip or by
 
 ```shell
 python -m pip install \
-  iree-compiler-snapshot \
-  iree-runtime-snapshot \
-  iree-tools-tflite-snapshot \
+  iree-compiler \
+  iree-runtime \
+  iree-tools-tflite \
   -f https://github.com/google/iree/releases
 ```
 

--- a/docs/website/docs/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/ml-frameworks/tensorflow.md
@@ -21,9 +21,9 @@ Install IREE pip packages, either from pip or by
 
 ```shell
 python -m pip install \
-  iree-compiler-snapshot \
-  iree-runtime-snapshot \
-  iree-tools-tf-snapshot \
+  iree-compiler \
+  iree-runtime \
+  iree-tools-tf \
   -f https://github.com/google/iree/releases
 ```
 


### PR DESCRIPTION
* Renames the job that kicks it off to use "candidate" instead of "snapshot".
* Keeps the latest-snapshot branch in order to retain compatibility with any workflows depending on it.