### PR TITLE
Reordering global simplification to happen before folding.

### DIFF
--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -55,17 +55,17 @@ static void addCleanupPatterns(OpPassManager &passManager) {
   passManager.addPass(mlir::createCanonicalizerPass());
   passManager.addPass(mlir::createCSEPass());
 
-  // Cleanup and canonicalization of util.global (and other util ops).
-  passManager.addPass(IREE::Util::createApplyPatternsPass());
-  passManager.addPass(IREE::Util::createFoldGlobalsPass());
-  passManager.addPass(IREE::Util::createFuseGlobalsPass());
-
   // Simplify util.global accesses; this can help with data flow tracking as
   // redundant store-loads are removed.
   passManager.addNestedPass<IREE::Util::InitializerOp>(
       IREE::Util::createSimplifyGlobalAccessesPass());
   passManager.addNestedPass<mlir::FuncOp>(
       IREE::Util::createSimplifyGlobalAccessesPass());
+
+  // Cleanup and canonicalization of util.global (and other util ops).
+  passManager.addPass(IREE::Util::createApplyPatternsPass());
+  passManager.addPass(IREE::Util::createFoldGlobalsPass());
+  passManager.addPass(IREE::Util::createFuseGlobalsPass());
 }
 
 void buildHALTransformPassPipeline(OpPassManager &passManager,

--- a/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -27,17 +27,17 @@ static void addCleanupPatterns(OpPassManager &passManager) {
   passManager.addPass(mlir::createCanonicalizerPass());
   passManager.addPass(mlir::createCSEPass());
 
-  // Cleanup and canonicalization of util.global (and other util ops).
-  passManager.addPass(IREE::Util::createApplyPatternsPass());
-  passManager.addPass(IREE::Util::createFoldGlobalsPass());
-  passManager.addPass(IREE::Util::createFuseGlobalsPass());
-
   // Simplify util.global accesses; this can help with data flow tracking as
   // redundant store-loads are removed.
   passManager.addNestedPass<IREE::Util::InitializerOp>(
       IREE::Util::createSimplifyGlobalAccessesPass());
   passManager.addNestedPass<mlir::FuncOp>(
       IREE::Util::createSimplifyGlobalAccessesPass());
+
+  // Cleanup and canonicalization of util.global (and other util ops).
+  passManager.addPass(IREE::Util::createApplyPatternsPass());
+  passManager.addPass(IREE::Util::createFoldGlobalsPass());
+  passManager.addPass(IREE::Util::createFuseGlobalsPass());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
I'd still like to rewrite the pass, but at least now we can get rid of
globals only used for a single store->load - like all descriptor set
layouts in the HAL that are only used in initializers.