### PR TITLE
Adding `--cuda_allow_inline_execution` flag.

### DIFF
--- a/iree/hal/cuda/api.h
+++ b/iree/hal/cuda/api.h
@@ -39,6 +39,11 @@ typedef struct iree_hal_cuda_device_params_t {
 
   // Specifies how command buffers are recorded and executed.
   iree_hal_cuda_command_buffer_mode_t command_buffer_mode;
+
+  // Allow executing command buffers against CUDA streams as they are recorded.
+  // Only command buffers produced by the compiler that have the
+  // IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION bit set will use this.
+  bool allow_inline_execution;
 } iree_hal_cuda_device_params_t;
 
 // Initializes |out_params| to default values.

--- a/iree/hal/cuda/cuda_device.c
+++ b/iree/hal/cuda/cuda_device.c
@@ -42,6 +42,9 @@ typedef struct iree_hal_cuda_device_t {
   // to ensure the symbols remains valid.
   iree_hal_driver_t* driver;
 
+  // Parameters used to control device behavior.
+  iree_hal_cuda_device_params_t params;
+
   CUdevice device;
 
   // TODO: support multiple streams.
@@ -49,8 +52,6 @@ typedef struct iree_hal_cuda_device_t {
   iree_hal_cuda_context_wrapper_t context_wrapper;
   iree_hal_allocator_t* device_allocator;
 
-  // The command buffer type that should be used when recording commands.
-  iree_hal_cuda_command_buffer_mode_t command_buffer_mode;
   // Cache of the direct stream command buffer initialized when in stream mode.
   // TODO: have one cached per stream once there are multiple streams.
   iree_hal_command_buffer_t* stream_command_buffer;
@@ -69,6 +70,7 @@ void iree_hal_cuda_device_params_initialize(
   out_params->arena_block_size = 32 * 1024;
   out_params->queue_count = 8;
   out_params->command_buffer_mode = IREE_HAL_CUDA_COMMAND_BUFFER_MODE_GRAPH;
+  out_params->allow_inline_execution = false;
 }
 
 static iree_status_t iree_hal_cuda_device_check_params(
@@ -100,6 +102,7 @@ static iree_status_t iree_hal_cuda_device_create_internal(
   iree_string_view_append_to_buffer(
       identifier, &device->identifier,
       (char*)device + iree_sizeof_struct(*device));
+  device->params = *params;
   device->device = cu_device;
   device->stream = stream;
   device->context_wrapper.cu_context = context;
@@ -112,9 +115,8 @@ static iree_status_t iree_hal_cuda_device_create_internal(
       (iree_hal_device_t*)device, &device->context_wrapper, cu_device, stream,
       &device->device_allocator);
 
-  device->command_buffer_mode = params->command_buffer_mode;
   if (iree_status_is_ok(status) &&
-      device->command_buffer_mode == IREE_HAL_CUDA_COMMAND_BUFFER_MODE_STREAM) {
+      params->command_buffer_mode == IREE_HAL_CUDA_COMMAND_BUFFER_MODE_STREAM) {
     status = iree_hal_cuda_stream_command_buffer_create(
         (iree_hal_device_t*)device, &device->context_wrapper,
         IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
@@ -233,7 +235,18 @@ static iree_status_t iree_hal_cuda_device_create_command_buffer(
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_command_buffer_t** out_command_buffer) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
-  switch (device->command_buffer_mode) {
+  if (device->params.allow_inline_execution &&
+      iree_all_bits_set(mode,
+                        IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION)) {
+    // The caller has indicated the command buffer can be executed as it is
+    // recorded, implying that the command buffer cannot be reused and doesn't
+    // need to be persisted. This lets us lower the execution delay as we can
+    // directly route commands to a CUDA stream and let it eagerly flush.
+    return iree_hal_cuda_stream_command_buffer_create(
+        base_device, &device->context_wrapper, mode, command_categories,
+        device->stream, out_command_buffer);
+  }
+  switch (device->params.command_buffer_mode) {
     case IREE_HAL_CUDA_COMMAND_BUFFER_MODE_GRAPH:
       return iree_hal_cuda_graph_command_buffer_create(
           base_device, &device->context_wrapper, mode, command_categories,
@@ -312,7 +325,12 @@ static iree_status_t iree_hal_cuda_device_queue_submit(
   for (int i = 0; i < batch_count; i++) {
     for (int j = 0; j < batches[i].command_buffer_count; j++) {
       iree_hal_command_buffer_t* command_buffer = batches[i].command_buffers[j];
-      if (iree_hal_cuda_graph_command_buffer_isa(command_buffer)) {
+      if (iree_hal_cuda_stream_command_buffer_isa(command_buffer)) {
+        // Nothing to do for an inline command buffer; all the work has already
+        // been submitted. When we support semaphores we'll still need to signal
+        // their completion but do not have to worry about any waits: if there
+        // were waits we wouldn't have been able to execute inline!
+      } else if (iree_hal_cuda_graph_command_buffer_isa(command_buffer)) {
         CUgraphExec exec = iree_hal_cuda_graph_command_buffer_exec(
             batches[i].command_buffers[j]);
         CUDA_RETURN_IF_ERROR(device->context_wrapper.syms,

--- a/iree/hal/cuda/registration/driver_module.c
+++ b/iree/hal/cuda/registration/driver_module.c
@@ -18,7 +18,13 @@
 
 // Force using CUDA streams until we support command buffer caching to avoid the
 // overhead of graph creation.
-IREE_FLAG(bool, cuda_use_streams, true, "Force to use cuda streams");
+IREE_FLAG(
+    bool, cuda_use_streams, true,
+    "Use CUDA streams for executing command buffers (instead of graphs).");
+
+IREE_FLAG(bool, cuda_allow_inline_execution, false,
+          "Allow command buffers to execute inline against CUDA streams when "
+          "possible.");
 
 static iree_status_t iree_hal_cuda_driver_factory_enumerate(
     void* self, const iree_hal_driver_info_t** out_driver_infos,
@@ -53,6 +59,7 @@ static iree_status_t iree_hal_cuda_driver_factory_try_create(
     default_params.command_buffer_mode =
         IREE_HAL_CUDA_COMMAND_BUFFER_MODE_STREAM;
   }
+  default_params.allow_inline_execution = FLAG_cuda_allow_inline_execution;
 
   iree_hal_cuda_driver_options_t driver_options;
   iree_hal_cuda_driver_options_initialize(&driver_options);


### PR DESCRIPTION
This allows command buffers with the
IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION flag set to execute
directly against a CUDA stream to lower latency.

Disabled by default because this is slower in almost all cases where the
model actually uses the GPU to do work. simple_embedding_test (a single
dispatch) for example goes 39.47us -> 39.32us with this enabled, while
mobilessd (GPU-bound) goes 2.56s -> 2.69s.