### PR TITLE
Remove identity from linalg_ext.scan arguments

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -256,17 +256,15 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     Computes the inclusive/exclusive scan along a given dimension.
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs,
+  let arguments = (ins Variadic<AnyType>:$inputs,
                        Variadic<AnyShaped>:$outputs,
-                       AnyType:$identity,
                        I64Attr:$dimension,
                        BoolAttr:$inclusive
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
-      "Value":$identity, CArg<"int64_t", "0">:$dimension,
-      CArg<"bool", "true">:$inclusive)>
+      CArg<"int64_t", "0">:$dimension, CArg<"bool", "true">:$inclusive)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
@@ -275,7 +273,6 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
     `dimension` `(` $dimension `)`
     `inclusive` `(` $inclusive `)`
     attr-dict
-    `identity` `(` $identity `:` type($identity) `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     (`outs` `(` $outputs^ `:` type($outputs) `)`)?
     $region (`->` type($results)^)?
@@ -284,6 +281,9 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
     Value input() {
       return getInputOperand(0)->get();
+    }
+    Value identity() {
+      return getInputOperand(1)->get();
     }
     Value output() {
       return getOutputOperand(0)->get();

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -508,8 +508,8 @@ func @reverse_dim_0(%arg0: memref<?x?xi32>, %arg1: memref<?x?xi32>) {
 
 func @scan_1d_inclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
   %c0 = arith.constant 0 : i32
-  iree_linalg_ext.scan dimension(0) inclusive(true) identity(%c0 : i32)
-    ins(%0 : memref<128xi32>) outs(%1 : memref<128xi32>) {
+  iree_linalg_ext.scan dimension(0) inclusive(true)
+    ins(%0, %c0 : memref<128xi32>, i32) outs(%1 : memref<128xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32
@@ -539,8 +539,8 @@ func @scan_1d_inclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
 
 func @scan_1d_exclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
   %c0 = arith.constant 0 : i32
-  iree_linalg_ext.scan dimension(0) inclusive(false) identity(%c0 : i32)
-    ins(%0 : memref<128xi32>) outs(%1 : memref<128xi32>) {
+  iree_linalg_ext.scan dimension(0) inclusive(false)
+    ins(%0, %c0 : memref<128xi32>, i32) outs(%1 : memref<128xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32
@@ -570,8 +570,8 @@ func @scan_1d_exclusive(%0: memref<128xi32>, %1: memref<128xi32>) {
 
 func @scan_2d(%0: memref<16x32xi32>, %1: memref<16x32xi32>) {
   %c0 = arith.constant 0 : i32
-  iree_linalg_ext.scan dimension(0) inclusive(true) identity(%c0 : i32)
-    ins(%0 : memref<16x32xi32>) outs(%1 : memref<16x32xi32>) {
+  iree_linalg_ext.scan dimension(0) inclusive(true)
+    ins(%0, %c0 : memref<16x32xi32>, i32) outs(%1 : memref<16x32xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -1215,8 +1215,7 @@ func @scan_1d(%0: tensor<128xi32>) -> tensor<128xi32> {
   %2 = iree_linalg_ext.scan
     dimension(0) inclusive(true)
     {__internal_linalg_transform__ = "outer_reduce_input"}
-    identity(%c0 : i32)
-    ins(%0 : tensor<128xi32>) outs(%1 : tensor<128xi32>) {
+    ins(%0, %c0 : tensor<128xi32>, i32) outs(%1 : tensor<128xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32
@@ -1229,8 +1228,7 @@ func @scan_1d(%0: tensor<128xi32>) -> tensor<128xi32> {
 //      CHECK:   %[[OUTPUT:.+]] = linalg.init_tensor [128] : tensor<128xi32>
 //      CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scan
 // CHECK-SAME:           __internal_linalg_transform__ = "outer_reduce_output"
-// CHECK-SAME:       identity(%[[IDENTITY]] :
-// CHECK-SAME:       ins(%[[OPERAND]] :
+// CHECK-SAME:       ins(%[[OPERAND]], %[[IDENTITY]] :
 // CHECK-SAME:       outs(%[[OUTPUT]] :
 //      CHECK:   return %[[RESULT]]
 
@@ -1242,8 +1240,7 @@ func @scan_2d(%0: tensor<16x32xi32>) -> tensor<16x32xi32> {
   %2 = iree_linalg_ext.scan
     dimension(0) inclusive(true)
     {__internal_linalg_transform__ = "outer_reduce_input"}
-    identity(%c0 : i32)
-    ins(%0 : tensor<16x32xi32>) outs(%1 : tensor<16x32xi32>) {
+    ins(%0, %c0 : tensor<16x32xi32>, i32) outs(%1 : tensor<16x32xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32
@@ -1281,8 +1278,7 @@ func @scan_2d_memref(%0: memref<16x32xi32>, %1: memref<16x32xi32>) {
   iree_linalg_ext.scan
     dimension(0) inclusive(true)
     {__internal_linalg_transform__ = "outer_reduce_input"}
-    identity(%c0 : i32)
-    ins(%0 : memref<16x32xi32>) outs(%1 : memref<16x32xi32>) {
+    ins(%0, %c0 : memref<16x32xi32>, i32) outs(%1 : memref<16x32xi32>) {
     ^bb0(%arg0 : i32, %arg1 : i32):
       %sum = arith.addi %arg0, %arg1 : i32
       iree_linalg_ext.yield %sum : i32


### PR DESCRIPTION
This patch removes identity from linalg_ext.scan
and moves it to the inputs variable. This is to
ensure that the op bufferizes with the linalg
comprehensive bufferization.

TEST: Unit tests pass, iree-translate compiles