### PR TITLE
Cast from uint8_t* to char* in generate_embed_data, fixing warning.

### DIFF
--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -169,7 +169,7 @@ static bool GenerateImpl(const std::string& identifier,
   for (size_t i = 0, e = input_files.size(); i < e; ++i) {
     f << "  {\n";
     f << "    \"" << CEscape(toc_files[i]) << "\",\n";
-    f << "    file_" << i << ",\n";
+    f << "    (const char*)file_" << i << ",\n";
     f << "    sizeof(file_" << i << ") - 1\n";
     f << "  },\n";
   }


### PR DESCRIPTION
(open to other fixes here, but this seemed like the obvious one to me)

```
[1/4] Building C object experimental/sample_web_...web_static.dir/generated/simple_mul_bytecode.c.o
../experimental/sample_web_static/generated/simple_mul_bytecode.c:38:5: warning:
initializing 'const char *' with an expression of type 'const uint8_t[3991]' (aka 'const unsigned char[3991]')
converts between pointers to integer types where one is of the unique plain 'char' type and the other is
not [-Wpointer-sign]
    file_0,
    ^~~~~~
```

generated code before (note the `const char* data` and `uint8_t`):
```c
typedef struct iree_file_toc_t {
  const char* name;             // the file's original name
  const char* data;             // beginning of the file
  size_t size;                  // length of the file
} iree_file_toc_t;
IREE_DATA_ALIGNAS_PTR static uint8_t const file_0[] = {16,0,0,0, ...};
static const struct iree_file_toc_t toc[] = {
  {
    "simple_mul.vmfb",
    file_0,
    sizeof(file_0) - 1
  },
  {NULL, NULL, 0},
};
```

with this change, keeping the types but just inserting a cast:
```c
static const struct iree_file_toc_t toc[] = {
  {
    "simple_mul.vmfb",
    (const char*)file_0,
    sizeof(file_0) - 1
  },
  {NULL, NULL, 0},
};
```