### PR TITLE
Adding `-iree-util-strip-debug-ops` pass.

### DIFF
--- a/docs/website/docs/reference/optimization-options.md
+++ b/docs/website/docs/reference/optimization-options.md
@@ -52,3 +52,12 @@ and constant data rewritten to lower precision types.
 
 This feature is actively evolving and will be the subject of dedicated
 documentation when ready.
+
+### Strip Debug Assertions (`--iree-opt-strip-assertions` (off))
+
+Strips all `std.assert` ops in the input program after useful information for
+optimization analysis has been extracted. Assertions provide useful user-visible
+error messages but can prevent critical optimizations. Assertions are not,
+however, a substitution for control flow and frontends that want to check errors
+in optimized release builds should do so via actual code - similar to when one
+would `if (foo) return false;` vs. `assert(foo);` in a normal program.

--- a/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -267,4 +267,8 @@ def YieldPoint : NativeOpTrait<"IREE::Util::YieldPoint">;
 // runtime if loaded for dynamic execution.
 def Unsafe : NativeOpTrait<"IREE::Util::Unsafe">;
 
+// Denotes that an operation is only valid in debug builds.
+// These ops are removed by the -iree-util-strip-debug-ops pass.
+def Util_DebugOnly : NativeOpTrait<"IREE::Util::DebugOnly">;
+
 #endif  // IREE_DIALECT_UTIL_IR_UTIL_BASE

--- a/iree/compiler/Dialect/Util/IR/UtilTraits.h
+++ b/iree/compiler/Dialect/Util/IR/UtilTraits.h
@@ -15,8 +15,7 @@ namespace IREE {
 namespace Util {
 
 template <typename ConcreteType>
-class YieldPoint : public OpTrait::TraitBase<ConcreteType, YieldPoint> {
- public:
+struct YieldPoint : public OpTrait::TraitBase<ConcreteType, YieldPoint> {
   static LogicalResult verifyTrait(Operation *op) {
     // TODO(benvanik): verify yield point.
     return success();
@@ -24,12 +23,18 @@ class YieldPoint : public OpTrait::TraitBase<ConcreteType, YieldPoint> {
 };
 
 template <typename ConcreteType>
-class Unsafe : public OpTrait::TraitBase<ConcreteType, Unsafe> {
- public:
+struct Unsafe : public OpTrait::TraitBase<ConcreteType, Unsafe> {
   static LogicalResult verifyTrait(Operation *op) {
     // TODO(benvanik): verify that entire tree is marked unsafe.
     return success();
   }
+};
+
+template <typename ConcreteType>
+struct DebugOnly : public OpTrait::TraitBase<ConcreteType, DebugOnly> {
+  // TODO(benvanik): helper for eliding safely on ops that return values.
+
+  static LogicalResult verifyTrait(Operation *op) { return success(); }
 };
 
 }  // namespace Util

--- a/iree/compiler/Dialect/Util/Transforms/BUILD
+++ b/iree/compiler/Dialect/Util/Transforms/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "HoistIntoGlobals.cpp",
         "Patterns.cpp",
         "SimplifyGlobalAccesses.cpp",
+        "StripDebugOps.cpp",
         "TestFloatRangeAnalysis.cpp",
     ],
     hdrs = [

--- a/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "HoistIntoGlobals.cpp"
     "Patterns.cpp"
     "SimplifyGlobalAccesses.cpp"
+    "StripDebugOps.cpp"
     "TestFloatRangeAnalysis.cpp"
   DEPS
     LLVMSupport

--- a/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -18,12 +18,13 @@ namespace Util {
 std::unique_ptr<OperationPass<void>> createApplyPatternsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createCombineInitializersPass();
 std::unique_ptr<OperationPass<void>> createDropCompilerHintsPass();
+std::unique_ptr<OperationPass<void>> createFixedPointIteratorPass(
+    OpPassManager pipeline);
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createFoldGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createFuseGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createHoistIntoGlobalsPass();
 std::unique_ptr<OperationPass<void>> createSimplifyGlobalAccessesPass();
-std::unique_ptr<OperationPass<void>> createFixedPointIteratorPass(
-    OpPassManager pipeline);
+std::unique_ptr<OperationPass<void>> createStripDebugOpsPass();
 
 // Test passes.
 std::unique_ptr<OperationPass<void>> createTestFloatRangeAnalysis();
@@ -34,11 +35,12 @@ inline void registerTransformPasses() {
   createApplyPatternsPass();
   createCombineInitializersPass();
   createDropCompilerHintsPass();
+  createFixedPointIteratorPass(OpPassManager("dummy_op"));
   createFoldGlobalsPass();
   createFuseGlobalsPass();
   createHoistIntoGlobalsPass();
   createSimplifyGlobalAccessesPass();
-  createFixedPointIteratorPass(OpPassManager("dummy_op"));
+  createStripDebugOpsPass();
   createTestFloatRangeAnalysis();
 }
 

--- a/iree/compiler/Dialect/Util/Transforms/StripDebugOps.cpp
+++ b/iree/compiler/Dialect/Util/Transforms/StripDebugOps.cpp
@@ -1,0 +1,52 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Util {
+
+namespace {
+
+class StripDebugOpsPass
+    : public PassWrapper<StripDebugOpsPass, OperationPass<void>> {
+ public:
+  StringRef getArgument() const override { return "iree-util-strip-debug-ops"; }
+
+  StringRef getDescription() const override {
+    return "Strips debug ops, like assertions.";
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([](Operation *op) {
+      if (isa<mlir::AssertOp>(op) ||
+          op->hasTrait<OpTrait::IREE::Util::DebugOnly>()) {
+        op->erase();
+      }
+    });
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<void>> createStripDebugOpsPass() {
+  return std::make_unique<StripDebugOpsPass>();
+}
+
+static PassRegistration<StripDebugOpsPass> pass;
+
+}  // namespace Util
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Util/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Util/Transforms/test/BUILD
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "hoist_into_globals.mlir",
             "hoist_into_globals_linalg.mlir",
             "simplify_global_accesses.mlir",
+            "strip_debug_ops.mlir",
             "test_float_range_analysis.mlir",
             "test_float_range_analysis_linalg.mlir",
         ],

--- a/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Util/Transforms/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "hoist_into_globals.mlir"
     "hoist_into_globals_linalg.mlir"
     "simplify_global_accesses.mlir"
+    "strip_debug_ops.mlir"
     "test_float_range_analysis.mlir"
     "test_float_range_analysis_linalg.mlir"
   DATA

--- a/iree/compiler/Dialect/Util/Transforms/test/strip_debug_ops.mlir
+++ b/iree/compiler/Dialect/Util/Transforms/test/strip_debug_ops.mlir
@@ -1,0 +1,8 @@
+// RUN: iree-opt -split-input-file -pass-pipeline='builtin.func(iree-util-strip-debug-ops)' %s | IreeFileCheck %s
+
+// CHECK-LABEL: @stripAssert
+func @stripAssert(%cond: i1) {
+  // CHECK-NOT: assert
+  assert %cond, "hello!"
+  return
+}

--- a/iree/compiler/Translation/IREEVM.h
+++ b/iree/compiler/Translation/IREEVM.h
@@ -75,6 +75,9 @@ struct HighLevelOptimizationOptions {
   // Optimizations to reduce numeric precision where it is safe to do so.
   bool numericPrecisionReduction = false;
 
+  // Strips debug assertions after any useful information has been extracted.
+  bool stripAssertions = false;
+
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<HighLevelOptimizationOptions>;
 };


### PR DESCRIPTION
This removes any op with the DebugOnly trait and std.assert.
This is exposed as part of the optimization pipeline stage as
`-iree-opt-strip-assertions`. We may want to run this later on as
well (such as after we insert new assertions in stream/hal/vm) but
the bulk of things that hurt us come from the inputs.

We may want an interface instead of a trait (so we can register on
ops in upstream dialects) but this is all just a workaround for assert
having no optimizations and can change later.

(#8034 and #8074 are the assertion optimizations that we need to do)