### PR TITLE
Ensuring buffer deallocation always routes through allocators.

### DIFF
--- a/experimental/rocm/rocm_buffer.c
+++ b/experimental/rocm/rocm_buffer.c
@@ -127,6 +127,7 @@ void* iree_hal_rocm_buffer_host_pointer(iree_hal_buffer_t* base_buffer) {
 }
 
 static const iree_hal_buffer_vtable_t iree_hal_rocm_buffer_vtable = {
+    .recycle = iree_hal_buffer_recycle,
     .destroy = iree_hal_rocm_buffer_destroy,
     .map_range = iree_hal_rocm_buffer_map_range,
     .unmap_range = iree_hal_rocm_buffer_unmap_range,

--- a/iree/hal/buffer_heap.c
+++ b/iree/hal/buffer_heap.c
@@ -214,6 +214,7 @@ static iree_status_t iree_hal_heap_buffer_flush_range(
 }
 
 static const iree_hal_buffer_vtable_t iree_hal_heap_buffer_vtable = {
+    .recycle = iree_hal_buffer_recycle,
     .destroy = iree_hal_heap_buffer_destroy,
     .map_range = iree_hal_heap_buffer_map_range,
     .unmap_range = iree_hal_heap_buffer_unmap_range,

--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -147,6 +147,7 @@ iree_hal_cuda_allocator_query_buffer_compatibility(
 static void iree_hal_cuda_buffer_free(iree_hal_cuda_context_wrapper_t* context,
                                       iree_hal_memory_type_t memory_type,
                                       CUdeviceptr device_ptr, void* host_ptr) {
+  IREE_TRACE_ZONE_BEGIN(z0);
   if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     // Device local.
     CUDA_IGNORE_ERROR(context->syms, cuMemFree(device_ptr));
@@ -154,6 +155,7 @@ static void iree_hal_cuda_buffer_free(iree_hal_cuda_context_wrapper_t* context,
     // Host local.
     CUDA_IGNORE_ERROR(context->syms, cuMemFreeHost(host_ptr));
   }
+  IREE_TRACE_ZONE_END(z0);
 }
 
 static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
@@ -181,9 +183,10 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   }
 
-  iree_status_t status;
+  iree_status_t status = iree_ok_status();
   void* host_ptr = NULL;
   CUdeviceptr device_ptr = 0;
+  IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_cuda_buffer_allocate");
   if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     // Device local case.
     if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
@@ -218,6 +221,7 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
           cuMemHostGetDevicePointer(&device_ptr, host_ptr, /*flags=*/0));
     }
   }
+  IREE_TRACE_ZONE_END(z0);
 
   iree_hal_buffer_t* buffer = NULL;
   if (iree_status_is_ok(status)) {

--- a/iree/hal/cuda/cuda_buffer.c
+++ b/iree/hal/cuda/cuda_buffer.c
@@ -127,6 +127,7 @@ void* iree_hal_cuda_buffer_host_pointer(iree_hal_buffer_t* base_buffer) {
 }
 
 static const iree_hal_buffer_vtable_t iree_hal_cuda_buffer_vtable = {
+    .recycle = iree_hal_buffer_recycle,
     .destroy = iree_hal_cuda_buffer_destroy,
     .map_range = iree_hal_cuda_buffer_map_range,
     .unmap_range = iree_hal_cuda_buffer_unmap_range,

--- a/iree/hal/vulkan/vma_buffer.cc
+++ b/iree/hal/vulkan/vma_buffer.cc
@@ -169,6 +169,7 @@ static iree_status_t iree_hal_vulkan_vma_buffer_flush_range(
 
 namespace {
 const iree_hal_buffer_vtable_t iree_hal_vulkan_vma_buffer_vtable = {
+    /*.recycle=*/iree_hal_buffer_recycle,
     /*.destroy=*/iree_hal_vulkan_vma_buffer_destroy,
     /*.map_range=*/iree_hal_vulkan_vma_buffer_map_range,
     /*.unmap_range=*/iree_hal_vulkan_vma_buffer_unmap_range,

--- a/iree/modules/hal/module.c
+++ b/iree/modules/hal/module.c
@@ -54,7 +54,7 @@ IREE_API_EXPORT iree_status_t iree_hal_module_register_types(void) {
                               iree_hal_allocator_destroy,
                               iree_hal_allocator_descriptor);
   IREE_VM_REGISTER_HAL_C_TYPE(iree_hal_buffer_t, "hal.buffer",
-                              iree_hal_buffer_destroy,
+                              iree_hal_buffer_recycle,
                               iree_hal_buffer_descriptor);
   IREE_VM_REGISTER_HAL_C_TYPE(iree_hal_buffer_view_t, "hal.buffer_view",
                               iree_hal_buffer_view_destroy,

--- a/iree/tools/iree-benchmark-trace-main.c
+++ b/iree/tools/iree-benchmark-trace-main.c
@@ -23,6 +23,9 @@
 
 IREE_FLAG(string, driver, "vmvx", "Backend driver to use.");
 
+IREE_FLAG(bool, print_statistics, false,
+          "Prints runtime statistics to stderr on exit.");
+
 IREE_FLAG(int32_t, call_iterations, 1,
           "Number of times to invoke each call in the trace. May break usage "
           "with stateful models.");
@@ -224,7 +227,10 @@ static iree_status_t iree_replay_benchmark_run_file(
   }
 
   iree_replay_benchmark_call_list_deinitialize(&call_list);
-  iree_trace_replay_deinitialize(&replay);
+  iree_trace_replay_deinitialize(
+      &replay, FLAG_print_statistics
+                   ? IREE_TRACE_REPLAY_SHUTDOWN_PRINT_STATISTICS
+                   : IREE_TRACE_REPLAY_SHUTDOWN_QUIET);
   return iree_ok_status();
 }
 

--- a/iree/tools/iree-e2e-matmul-test.c
+++ b/iree/tools/iree-e2e-matmul-test.c
@@ -624,7 +624,7 @@ static iree_status_t run_trace_file(iree_string_view_t root_path, FILE* file,
 
   yaml_parser_t parser;
   if (!yaml_parser_initialize(&parser)) {
-    iree_trace_replay_deinitialize(&replay);
+    iree_trace_replay_deinitialize(&replay, IREE_TRACE_REPLAY_SHUTDOWN_QUIET);
     return iree_make_status(IREE_STATUS_INTERNAL,
                             "yaml_parser_initialize failed");
   }
@@ -649,7 +649,7 @@ static iree_status_t run_trace_file(iree_string_view_t root_path, FILE* file,
   }
 
   yaml_parser_delete(&parser);
-  iree_trace_replay_deinitialize(&replay);
+  iree_trace_replay_deinitialize(&replay, IREE_TRACE_REPLAY_SHUTDOWN_QUIET);
   return status;
 }
 

--- a/iree/tools/iree-run-trace-main.c
+++ b/iree/tools/iree-run-trace-main.c
@@ -19,6 +19,9 @@
 
 IREE_FLAG(bool, trace_execution, false, "Traces VM execution to stderr.");
 
+IREE_FLAG(bool, print_statistics, false,
+          "Prints runtime statistics to stderr on exit.");
+
 IREE_FLAG(string, driver, "vmvx", "Backend driver to use.");
 
 // Runs the trace in |file| using |root_path| as the base for any path lookups
@@ -37,7 +40,7 @@ static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
 
   yaml_parser_t parser;
   if (!yaml_parser_initialize(&parser)) {
-    iree_trace_replay_deinitialize(&replay);
+    iree_trace_replay_deinitialize(&replay, IREE_TRACE_REPLAY_SHUTDOWN_QUIET);
     return iree_make_status(IREE_STATUS_INTERNAL,
                             "yaml_parser_initialize failed");
   }
@@ -61,7 +64,10 @@ static iree_status_t iree_run_trace_file(iree_string_view_t root_path,
   }
 
   yaml_parser_delete(&parser);
-  iree_trace_replay_deinitialize(&replay);
+  iree_trace_replay_deinitialize(
+      &replay, FLAG_print_statistics
+                   ? IREE_TRACE_REPLAY_SHUTDOWN_PRINT_STATISTICS
+                   : IREE_TRACE_REPLAY_SHUTDOWN_QUIET);
   return status;
 }
 

--- a/iree/tools/utils/trace_replay.h
+++ b/iree/tools/utils/trace_replay.h
@@ -16,6 +16,12 @@
 extern "C" {
 #endif  // __cplusplus
 
+enum iree_trace_replay_shutdown_flag_bits_e {
+  IREE_TRACE_REPLAY_SHUTDOWN_QUIET = 0u,
+  IREE_TRACE_REPLAY_SHUTDOWN_PRINT_STATISTICS = 1 << 0u,
+};
+typedef uint32_t iree_trace_replay_shutdown_flags_t;
+
 typedef struct iree_trace_replay_t {
   iree_allocator_t host_allocator;
   iree_string_view_t root_path;
@@ -36,7 +42,8 @@ iree_status_t iree_trace_replay_initialize(
     iree_trace_replay_t* out_replay);
 
 // Deinitializes a trace replay context and releases all resources.
-void iree_trace_replay_deinitialize(iree_trace_replay_t* replay);
+void iree_trace_replay_deinitialize(iree_trace_replay_t* replay,
+                                    iree_trace_replay_shutdown_flags_t flags);
 
 // Overrides the HAL driver used in the trace with the given |driver|.
 void iree_trace_replay_set_hal_driver_override(iree_trace_replay_t* replay,


### PR DESCRIPTION
If the HAL module was the last retainer of a buffer (such as those
whose last use was in a command buffer) it was bypassing the device
allocator and directly destroying the buffer. CUDA (and ROCM) require
the allocator to free their buffer memory and this resulted in them
leaking device memory even if it appeared that memory was freed from
our side.