### PR TITLE
Fixing releases for tensorflow packages

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -45,12 +45,6 @@ jobs:
             build_package: instrumented-py-runtime-pkg
             experimental: true
           - os: ubuntu-18.04
-            build_package: py-xla-compiler-tools-pkg
-            experimental: false
-          - os: ubuntu-18.04
-            build_package: py-tflite-compiler-tools-pkg
-            experimental: false
-          - os: ubuntu-18.04
             build_package: py-tf-compiler-tools-pkg
             experimental: false
 
@@ -209,50 +203,14 @@ jobs:
 
       # Compiler tools wheels are not python version specific, so just build
       # for one examplar python version.
-      - name: Build XLA Compiler Tools wheels
-        if: "matrix.build_package == 'py-xla-compiler-tools-pkg'"
-        shell: bash
-        run: |
-          # Just need to build for one examplar python3 variant.
-          export CIBW_BUILD="cp38-*"
-          package_dir="./iree-install/python_packages/iree_tools_xla"
-          export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py py-xla-compiler-tools-pkg"
-          # TODO: cibuildwheel sanity checks this, but our setup.py is the
-          # *output* of the build :( Make source packages.
-          mkdir -p $package_dir && touch $package_dir/setup.py
-          python -m cibuildwheel --output-dir bindist $package_dir
-
-      # Compiler tools wheels are not python version specific, so just build
-      # for one examplar python version.
-      - name: Build TFLite Compiler Tools wheels
-        if: "matrix.build_package == 'py-tflite-compiler-tools-pkg'"
-        shell: bash
-        run: |
-          # Just need to build for one examplar python3 variant.
-          export CIBW_BUILD="cp38-*"
-
-          package_dir="./iree-install/python_packages/iree_tools_tflite"
-          export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py py-tflite-compiler-tools-pkg"
-          # TODO: cibuildwheel sanity checks this, but our setup.py is the
-          # *output* of the build :( Make source packages.
-          mkdir -p $package_dir && touch $package_dir/setup.py
-          python -m cibuildwheel --output-dir bindist $package_dir
-
-      # Compiler tools wheels are not python version specific, so just build
-      # for one examplar python version.
       - name: Build TF Compiler Tools wheels
         if: "matrix.build_package == 'py-tf-compiler-tools-pkg'"
         shell: bash
         run: |
-          # Just need to build for one examplar python3 variant.
-          export CIBW_BUILD="cp38-*"
-
-          package_dir="./iree-install/python_packages/iree_tools_tf"
-          export CIBW_BEFORE_BUILD="python ./main_checkout/build_tools/github_actions/build_dist.py py-tf-compiler-tools-pkg"
-          # TODO: cibuildwheel sanity checks this, but our setup.py is the
-          # *output* of the build :( Make source packages.
-          mkdir -p $package_dir && touch $package_dir/setup.py
-          python -m cibuildwheel --output-dir bindist $package_dir
+          docker run --rm -w=/work \
+            -v $PWD:/work \
+            "${CIBW_MANYLINUX_X86_64_IMAGE}" \
+            bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py py-tf-compiler-tools-pkg'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/integrations/tensorflow/python_projects/iree_tf/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tf/setup.py
@@ -10,6 +10,7 @@
 # Built artifacts are per-platform and build out of the build tree.
 
 from distutils.command.install import install
+import json
 import os
 import platform
 from setuptools import setup, find_namespace_packages
@@ -25,6 +26,26 @@ if not os.access(import_tf_path, os.X_OK):
   raise RuntimeError(
       f"Tool not found ({import_tf_path}). Be sure to build "
       f"//iree_tf_compiler:iree-import-tf and run ./symlink_binaries.sh")
+
+# Setup and get version information.
+THIS_DIR = os.path.realpath(os.path.dirname(__file__))
+IREESRC_DIR = os.path.join(THIS_DIR, "..", "..", "..", "..")
+VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+
+
+def load_version_info():
+  with open(VERSION_INFO_FILE, "rt") as f:
+    return json.load(f)
+
+
+try:
+  version_info = load_version_info()
+except FileNotFoundError:
+  print("version_info.json not found. Using defaults")
+  version_info = {}
+
+PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
+PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
 # Force platform specific wheel.
 # https://stackoverflow.com/questions/45150304
@@ -60,8 +81,8 @@ class platlib_install(install):
 
 
 setup(
-    name="iree-tools-tf",
-    version="0.1",
+    name=f"iree-tools-tf{PACKAGE_SUFFIX}",
+    version=f"{PACKAGE_VERSION}",
     author="The IREE Team",
     author_email="iree-discuss@googlegroups.com",
     license="Apache",

--- a/integrations/tensorflow/python_projects/iree_tflite/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tflite/setup.py
@@ -10,6 +10,7 @@
 # Built artifacts are per-platform and build out of the build tree.
 
 from distutils.command.install import install
+import json
 import os
 import platform
 from setuptools import setup, find_namespace_packages
@@ -25,6 +26,26 @@ if not os.access(import_tflite_path, os.X_OK):
   raise RuntimeError(
       f"Tool not found ({import_tflite_path}). Be sure to build "
       f"//iree_tf_compiler:iree-import-tflite and run ./symlink_binaries.sh")
+
+# Setup and get version information.
+THIS_DIR = os.path.realpath(os.path.dirname(__file__))
+IREESRC_DIR = os.path.join(THIS_DIR, "..", "..", "..", "..")
+VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+
+
+def load_version_info():
+  with open(VERSION_INFO_FILE, "rt") as f:
+    return json.load(f)
+
+
+try:
+  version_info = load_version_info()
+except FileNotFoundError:
+  print("version_info.json not found. Using defaults")
+  version_info = {}
+
+PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
+PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
 # Force platform specific wheel.
 # https://stackoverflow.com/questions/45150304
@@ -60,8 +81,8 @@ class platlib_install(install):
 
 
 setup(
-    name="iree-tools-tflite",
-    version="0.1",
+    name=f"iree-tools-tflite{PACKAGE_SUFFIX}",
+    version=f"{PACKAGE_VERSION}",
     author="The IREE Team",
     author_email="iree-discuss@googlegroups.com",
     license="Apache",

--- a/integrations/tensorflow/python_projects/iree_xla/setup.py
+++ b/integrations/tensorflow/python_projects/iree_xla/setup.py
@@ -10,6 +10,7 @@
 # Built artifacts are per-platform and build out of the build tree.
 
 from distutils.command.install import install
+import json
 import os
 import platform
 from setuptools import setup, find_namespace_packages
@@ -25,6 +26,26 @@ if not os.access(import_xla_path, os.X_OK):
   raise RuntimeError(
       f"Tool not found ({import_xla_path}). Be sure to build "
       f"//iree_tf_compiler:iree-import-xla and run ./symlink_binaries.sh")
+
+# Setup and get version information.
+THIS_DIR = os.path.realpath(os.path.dirname(__file__))
+IREESRC_DIR = os.path.join(THIS_DIR, "..", "..", "..", "..")
+VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+
+
+def load_version_info():
+  with open(VERSION_INFO_FILE, "rt") as f:
+    return json.load(f)
+
+
+try:
+  version_info = load_version_info()
+except FileNotFoundError:
+  print("version_info.json not found. Using defaults")
+  version_info = {}
+
+PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
+PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
 # Force platform specific wheel.
 # https://stackoverflow.com/questions/45150304
@@ -60,8 +81,8 @@ class platlib_install(install):
 
 
 setup(
-    name="iree-tools-xla",
-    version="0.1",
+    name=f"iree-tools-xla{PACKAGE_SUFFIX}",
+    version=f"{PACKAGE_VERSION}",
     author="The IREE Team",
     author_email="iree-discuss@googlegroups.com",
     license="Apache",


### PR DESCRIPTION
TensorFlow python packages are now "pure" in that they are built by invoking setup.py and not as part of some larger build. Reworks the release to build them all at once. Will adapt further depending on how the next candidate looks.