### PR TITLE
Fix benchmark compilation script after TensorFlow de-integration

### DIFF
--- a/build_tools/cmake/build_android_benchmark.sh
+++ b/build_tools/cmake/build_android_benchmark.sh
@@ -40,6 +40,8 @@ BAZEL_BINDIR="$(${BAZEL_CMD[@]} info bazel-bin)"
 "${BAZEL_CMD[@]}" build //iree_tf_compiler:iree-import-tflite \
       --config=generic_clang \
       --config=remote_cache_bazel_ci
+# So the benchmark build below can find the importer binaries that were built.
+export PATH="$PWD/bazel-bin/iree_tf_compiler:$PATH"
 
 # --------------------------------------------------------------------------- #
 # Build for the host.
@@ -61,8 +63,8 @@ cd build-host
   -DIREE_BUILD_COMPILER=ON \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_BENCHMARKS=ON \
-  -DIREE_BUILD_TFLITE_COMPILER=ON \
   -DIREE_BUILD_SAMPLES=OFF
+
 "${CMAKE_BIN}" --build . --target install
 # Also generate artifacts for benchmarking on Android.
 "${CMAKE_BIN}" --build . --target iree-benchmark-suites


### PR DESCRIPTION
The Buildkite benchmark pipeline now fails compilation due to
that it cannot find the `iree-import-tflite` binary after
https://github.com/google/iree/pull/8078.