### PR TITLE
Struct for controlling all codegen driver options from pass pipeline.

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -180,8 +180,11 @@ void addTensorToVectorsPassPipeline(OpPassManager &passManager,
 void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   // Add the sandbox single tiling expert to tile and vectorize.
-  passManager.addNestedPass<FuncOp>(createLinalgSingleTilingExpertPass(
-      static_cast<int64_t>(TilingLevel::L1Tiles), true));
+  LinalgSingleTilingExpertPassOptions options;
+  options.vectorize = true;
+  options.tilingLevel = static_cast<int64_t>(TilingLevel::L1Tiles);
+  passManager.addNestedPass<FuncOp>(
+      createLinalgSingleTilingExpertPass(options));
 
   // TODO(ravishankarm): This is commented cause this is WIP, to be enabled
   // soon.

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -89,10 +89,25 @@ struct LinalgFusePass : public LinalgFuseBase<LinalgFusePass> {
 
 struct LinalgSingleTilingExpertPass
     : public LinalgSingleTilingExpertBase<LinalgSingleTilingExpertPass> {
-  LinalgSingleTilingExpertPass(int64_t tilingLevel = -1,
-                               bool vectorize = false) {
-    this->tilingLevel.setValue(tilingLevel);
-    this->vectorize.setValue(vectorize);
+  LinalgSingleTilingExpertPass() = default;
+  LinalgSingleTilingExpertPass(
+      const LinalgSingleTilingExpertPassOptions &options) {
+    this->anchorFuncOpName = options.anchorFuncOpName;
+    this->anchorOpName = options.anchorOpName;
+    this->tileSizes = options.tileSizes;
+    this->tileInterchange = options.tileInterchange;
+    this->peeledLoops = options.peeledLoops;
+    this->pad = options.pad;
+    this->packPaddings = options.packPaddings;
+    this->hoistPaddings = options.hoistPaddings;
+    this->packPaddings = options.packPaddings;
+    this->scalarizeDynamicDims = options.scalarizeDynamicDims;
+    this->generalize = options.generalize;
+    this->iteratorInterchange = options.iteratorInterchange;
+    this->decomposeToLowerDimOp = options.decomposeToLowerDimOp;
+    this->vectorize = options.vectorize;
+    this->vectorizePadding = options.vectorizePadding;
+    this->tilingLevel = options.tilingLevel;
   }
   LinalgSingleTilingExpertPass(const LinalgSingleTilingExpertPass &pass) {}
 
@@ -322,6 +337,10 @@ std::unique_ptr<OperationPass<FuncOp>>
 mlir::createLinalgSingleTilingExpertPass() {
   return std::make_unique<LinalgSingleTilingExpertPass>();
 }
+std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgSingleTilingExpertPass(
+    const LinalgSingleTilingExpertPassOptions &passOptions) {
+  return std::make_unique<LinalgSingleTilingExpertPass>(passOptions);
+}
 
 std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgVectorLoweringPass(
     int64_t vectorLoweringStage) {
@@ -349,13 +368,7 @@ void mlir::addLowerToVectorTransforms(OpPassManager &passManager) {
 
 std::unique_ptr<OperationPass<FuncOp>>
 mlir::iree_compiler::createLinalgFusePass(int64_t tilingLevel, bool vectorize) {
-  return std::make_unique<LinalgSingleTilingExpertPass>(tilingLevel, vectorize);
-}
-
-std::unique_ptr<OperationPass<FuncOp>>
-mlir::iree_compiler::createLinalgSingleTilingExpertPass(int64_t tilingLevel,
-                                                        bool vectorize) {
-  return std::make_unique<LinalgSingleTilingExpertPass>(tilingLevel, vectorize);
+  return std::make_unique<LinalgFusePass>(tilingLevel, vectorize);
 }
 
 namespace mlir {

--- a/iree/compiler/Codegen/Sandbox/Passes.h
+++ b/iree/compiler/Codegen/Sandbox/Passes.h
@@ -14,8 +14,29 @@ namespace mlir {
 /// Creates a pass to drive tile + fuse transformations of `LinalgOp`s.
 std::unique_ptr<OperationPass<FuncOp>> createLinalgFusePass();
 
+/// Struct to control pass options for `LinalgSingleTilingExpert` pass.
+struct LinalgSingleTilingExpertPassOptions {
+  std::string anchorFuncOpName = "";
+  std::string anchorOpName = "";
+  SmallVector<int64_t> tileSizes = {};
+  SmallVector<int64_t> tileInterchange = {};
+  SmallVector<int64_t> peeledLoops = {};
+  bool pad = false;
+  SmallVector<int64_t> packPaddings = {};
+  SmallVector<int64_t> hoistPaddings = {};
+  bool scalarizeDynamicDims = false;
+  bool generalize = false;
+  SmallVector<int64_t> iteratorInterchange = {};
+  bool decomposeToLowerDimOp = false;
+  bool vectorize = false;
+  bool vectorizePadding = false;
+  int64_t tilingLevel = -1;
+};
+
 /// Creates a pass to drive one level tiling + vectorization of `LinalgOp`s.
 std::unique_ptr<OperationPass<FuncOp>> createLinalgSingleTilingExpertPass();
+std::unique_ptr<OperationPass<FuncOp>> createLinalgSingleTilingExpertPass(
+    const LinalgSingleTilingExpertPassOptions &passOptions);
 
 /// Creates a pass to drive the lowering of vector operations in a staged
 /// manner.


### PR DESCRIPTION
Add a struct that mirrors all the options specified for the
`LinalgSingleTilingExpert` in codegen. This allows the pass pipeline
to control these options.

https://github.com/llvm/llvm-project/issues/53145 is the feature
request to auto-generate the struct (and potentially constructors as
well).