### PR TITLE
Quick refresh for TensorFlow importer and Python package documentation.

### DIFF
--- a/docs/website/docs/bindings/python.md
+++ b/docs/website/docs/bindings/python.md
@@ -68,8 +68,8 @@ python -m pip install numpy absl-py
 
 ### Prebuilt packages
 
-For now, packages can be installed from our
-[GitHub releases](https://github.com/google/iree/releases):
+Stable release packages are published to
+[PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
 
 === "Minimal"
 
@@ -78,8 +78,7 @@ For now, packages can be installed from our
     ``` shell
     python -m pip install \
       iree-compiler \
-      iree-runtime \
-      --find-links https://github.com/google/iree/releases
+      iree-runtime
     ```
 
 === "All packages"
@@ -92,13 +91,18 @@ For now, packages can be installed from our
       iree-runtime \
       iree-tools-tf \
       iree-tools-tflite \
-      iree-tools-xla \
-      --find-links https://github.com/google/iree/releases
+      iree-tools-xla
     ```
 
-!!! info
-    We plan to publish packages on [PyPI](https://pypi.org/) as they become
-    more stable.
+!!! Tip
+
+    Nightly packages are also published on
+    [GitHub releases](https://github.com/google/iree/releases). To use these,
+    run `pip install` with this extra option:
+
+    ```
+    --find-links https://github.com/google/iree/releases
+    ```
 
 ### Building from source
 
@@ -115,6 +119,6 @@ Check out the samples in IREE's
 [iree-samples repository](https://github.com/google/iree-samples) for examples
 using the Python APIs.
 
-## Troubleshooting
+<!-- ## Troubleshooting -->
 
 <!-- TODO(scotttodd): update python, update pip, search GitHub issues -->

--- a/docs/website/docs/building-from-source/python-bindings-and-importers.md
+++ b/docs/website/docs/building-from-source/python-bindings-and-importers.md
@@ -79,9 +79,18 @@ package manager ([about](https://docs.python.org/3/library/venv.html),
 === "Windows"
 
     ``` powershell
+    # Create a persistent virtual environment (first time only).
     python -m venv .venv
+
+    # Activate the virtual environment (per shell).
+    # Now the `python` command will resolve to your virtual environment
+    # (even on systems where you typically use `python3`).
     .venv\Scripts\activate.bat
+
+    # Upgrade PIP.
     python -m pip install --upgrade pip
+
+    # Install IREE build pre-requisites.
     python -m pip install -r bindings\python\build_requirements.txt
     ```
 
@@ -147,84 +156,13 @@ These tools packages are needed in order for the frontend specific, high-level
 APIs under `import iree.compiler.tf`, `import iree.compiler.tflite`,
 `import iree.compiler.xla`, and `import iree.jax` to be fully functional.
 
-### Environment setup
+!!! Warning
 
-The
-[build_requirements.txt](https://github.com/google/iree/blob/main/integrations/tensorflow/bindings/python/build_requirements.txt)
-file lists prerequisites, such as a recent version of `tf-nightly`:
-
-```shell
-python -m pip install -r \
-    ./integrations/tensorflow/bindings/python/build_requirements.txt
-```
-
-### Building TensorFlow components with Bazel
-
-TensorFlow frontends can only be built with [Bazel](https://bazel.build/),
-and this must be done as a manual step (we used to have automation for this,
-but Bazel integrates poorly with automation and it made diagnosis and cross
-platform usage unreliable). The recommended version of Bazel (used by CI
-systems) can be found in the
-[.bazelversion](https://github.com/google/iree/blob/main/.bazelversion)
-file. In addition, Bazel is hard to use out of tree, so these steps will
-involve working from the source tree (instead of the build tree).
+    This section is under construction. Refer to the
+    [source documentation](https://github.com/google/iree/tree/main/integrations/tensorflow#readme)
+    for the latest building from source instructions.
 
 ???+ Note
     Due to the difficulties using Bazel and compiling TensorFlow, only
     compilation on Linux with clang is supported. Other OS's and compilers are
     "best effort" with patches to improve support welcome.
-
-=== "Linux and MacOS"
-
-    ``` shell
-    # From the iree source directory.
-    cd integrations/tensorflow
-    CC=clang CXX=clang python ../../configure_bazel.py
-    bazel build iree_tf_compiler:importer-binaries
-    ```
-
-=== "Windows"
-
-    ``` powershell
-    # From the iree source directory.
-    cd integrations\tensorflow
-    python ..\..\configure_bazel.py
-    bazel build iree_tf_compiler:importer-binaries
-    ```
-
-Importer binaries can be found under `bazel-bin/iree_tf_compiler` and can
-be used from the command line if desired.
-
-
-???+ Note
-    Bazel's default configuration tends to build almost everything twice,
-    for reasons that can only be surmised to be based in some technically
-    correct but practically challenged viewpoint. It is also incompatible with
-    ccache and other mechanisms for performing less incremental work. It is
-    recommended to address both of these with a `.bazelrc` file in your
-    home directory:
-
-    ```
-    build --disk_cache=/path/to/home/.bazelcache
-    build --nodistinct_host_configuration
-    ```
-
-    We can't set these for you because of other inscrutable reasons.
-
-### Building IREE components with CMake
-
-The main IREE build will embed binaries built above and enable additional
-Python APIs. Within the build, the binaries are symlinked, so can be
-rebuilt per above without re-running these steps for edit-and-continue
-style work.
-
-``` shell
-# From the iree-build/ directory.
-cmake -DIREE_BUILD_TENSORFLOW_ALL=ON .
-cmake --build .
-
-# Validate.
-python -c "import iree.tools.tf as _; print(_.get_tool('iree-import-tf'))"
-python -c "import iree.tools.tflite as _; print(_.get_tool('iree-import-tflite'))"
-python -c "import iree.tools.xla as _; print(_.get_tool('iree-import-xla'))"
-```

--- a/docs/website/docs/deployment-configurations/cpu-dylib.md
+++ b/docs/website/docs/deployment-configurations/cpu-dylib.md
@@ -44,15 +44,12 @@ for the target.
 
 #### Download as Python package
 
-Python packages for various IREE functionalities are regularly published on
-IREE's [GitHub Releases][iree-releases] page.  Right now these are just
-snapshots of the `main` development branch.
-
-You can install the Python package containing the LLVM-based dylib compiler by
+Python packages for various IREE functionalities are regularly published
+to [PyPI][pypi]. See the [Python Bindings][python-bindings] page for more
+details. The core `iree-compiler` package includes the LLVM-based CPU compiler:
 
 ``` shell
-python -m pip install iree-compiler \
-    -f https://github.com/google/iree/releases
+python -m pip install iree-compiler
 ```
 
 !!! tip
@@ -133,9 +130,10 @@ concrete values.
 
 [android-cc]: ../building-from-source/android.md
 [get-started]: ../building-from-source/getting-started.md
-[iree-releases]: https://github.com/google/iree/releases/
 [llvm]: https://llvm.org/
 [mlir]: https://mlir.llvm.org/
+[pypi]: https://pypi.org/user/google-iree-pypi-deploy/
+[python-bindings]: ../bindings/python.md
 [tf-hub-mobilenetv2]: https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification
 [tf-import]: ../ml-frameworks/tensorflow.md
 [tflite-import]: ../ml-frameworks/tensorflow-lite.md

--- a/docs/website/docs/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/deployment-configurations/gpu-vulkan.md
@@ -96,15 +96,12 @@ binary exchange format, which the model must be compiled into.
 
 #### Download as Python package
 
-Python packages for various IREE functionalities are regularly published on
-IREE's [GitHub Releases][iree-releases] page.  Right now these are just
-snapshots of the `main` development branch.
-
-You can install the Python package containing the SPIR-V compiler by
+Python packages for various IREE functionalities are regularly published
+to [PyPI][pypi]. See the [Python Bindings][python-bindings] page for more
+details. The core `iree-compiler` package includes the SPIR-V compiler:
 
 ``` shell
-python -m pip install iree-compiler \
-    -f https://github.com/google/iree/releases
+python -m pip install iree-compiler
 ```
 
 !!! tip
@@ -201,8 +198,9 @@ limits, etc. So the target triple is just an approximation for usage.
 
 [android-cc]: ../building-from-source/android.md
 [get-started]: ../building-from-source/getting-started.md
-[iree-releases]: https://github.com/google/iree/releases/
 [mlir]: https://mlir.llvm.org/
+[pypi]: https://pypi.org/user/google-iree-pypi-deploy/
+[python-bindings]: ../bindings/python.md
 [spirv]: https://www.khronos.org/registry/spir-v/
 [tf-hub-mobilenetv2]: https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification
 [tf-import]: ../ml-frameworks/tensorflow.md

--- a/docs/website/docs/ml-frameworks/tensorflow-lite.md
+++ b/docs/website/docs/ml-frameworks/tensorflow-lite.md
@@ -19,8 +19,7 @@ Install IREE pip packages, either from pip or by
 python -m pip install \
   iree-compiler \
   iree-runtime \
-  iree-tools-tflite \
-  -f https://github.com/google/iree/releases
+  iree-tools-tflite
 ```
 
 !!! warning

--- a/docs/website/docs/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/ml-frameworks/tensorflow.md
@@ -23,8 +23,7 @@ Install IREE pip packages, either from pip or by
 python -m pip install \
   iree-compiler \
   iree-runtime \
-  iree-tools-tf \
-  -f https://github.com/google/iree/releases
+  iree-tools-tf
 ```
 
 !!! warning


### PR DESCRIPTION
Part of https://github.com/google/iree/issues/8086

* Drop `--find-links https://github.com/google/iree/releases` / `-f https://github.com/google/iree/releases` from install commands, now that PyPI packages are published. Include a note about nightly releases on just the "Python bindings" page
  * Samples and Colab notebooks are still using the nightlies - might keep that for now
* Remove old docs for building the TensorFlow importers and just point to https://github.com/google/iree/tree/main/integrations/tensorflow#readme for now

Just updating this documentation quickly for now. These pages are due for a more dedicated review pass soon (within a month, after a few more pieces stablize?).