### PR TITLE
Disable clang-format GitHub action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,6 +91,7 @@ jobs:
         run: ./build_tools/pytype/check_diff.sh "${GITHUB_BASE_REF?}"
 
   clang-format:
+    if: ${{ false }}  # Disable until GitHub actions stop being broken: https://github.com/google/iree/runs/4794478921?check_suite_focus=true
     runs-on: ubuntu-18.04
     steps:
       - name: Installing dependencies


### PR DESCRIPTION
GitHub actions are failing to apt-get install this right
now. I filed a ticket, but disabling so people aren't
blocked.