### PR TITLE
Stripping assert ops from within flow.executables.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -170,6 +170,12 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   // wrapped in executables.
   passManager.addPass(createOutlineDispatchRegionsPass());
 
+  // Strip assertions from executables. We could support them with a bunch of
+  // work but our generated executables are designed to be safe in the face of
+  // invalid values and it'd only be useful for debugging.
+  passManager.addNestedPass<IREE::Flow::ExecutableOp>(
+      IREE::Util::createStripDebugOpsPass());
+
   // Cleanup identity ops that clutter up the IR and canonicalize.
   FunctionLikeNest(passManager).addPass(mlir::createCanonicalizerPass);
 


### PR DESCRIPTION
Frontends can introduce these and they don't work with our async
execution model. We could support them in the future using the same
kind of mechanism as #8015: pass in a system buffer to dispatches that
could assert and atomic rmw a failure flag we can then lazily check on
the host to indicate device loss.