### PR TITLE
Revert "Disable clang-format GitHub action"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,7 +91,6 @@ jobs:
         run: ./build_tools/pytype/check_diff.sh "${GITHUB_BASE_REF?}"
 
   clang-format:
-    if: ${{ false }}  # Disable until GitHub actions stop being broken: https://github.com/google/iree/runs/4794478921?check_suite_focus=true
     runs-on: ubuntu-18.04
     steps:
       - name: Installing dependencies


### PR DESCRIPTION
This appears to be "fixed" insofar as the hour-long syncs that apparently break GitHub
actions are not happening right now

Reverts google/iree#8098