### PR TITLE
Enable vector transfer flattening.

### DIFF
--- a/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -94,6 +94,8 @@ struct OptimizeVectorTransferPass
     // ops. This increases the chance that we can forward more transfer writes
     // to transfer reads.
     OwningRewritePatternList patterns(&getContext());
+    mlir::vector::populateVectorTransferDropUnitDimsPatterns(patterns);
+    mlir::vector::populateFlattenVectorTransferPatterns(patterns);
     mlir::vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
     patterns.add<TransposeUnitDimToShapeCast>(&getContext());
     mlir::vector::populateVectorTransferCollapseInnerMostContiguousDimsPatterns(


### PR DESCRIPTION
This fixes the codegen for the 2d vector transfers that we need to do
in matmul kernels targeting 2D (matrix) simd operations, for instance
allowing PR #7778 to achieve nice codegen such as:

```
   11a14: ad 05 00 f1      subs    x13, x13, #1
   11a18: f8 66 c1 ac      ldp    q24, q25, [x23], #32
   11a1c: 7a 6f c1 ac      ldp    q26, q27, [x27], #32
   11a20: 41 e3 98 4f      sdot    v1.4s, v26.16b, v24.4b[0]
   11a24: 60 e3 98 4f      sdot    v0.4s, v27.16b, v24.4b[0]
   11a28: 43 e3 b8 4f      sdot    v3.4s, v26.16b, v24.4b[1]
   11a2c: 62 e3 b8 4f      sdot    v2.4s, v27.16b, v24.4b[1]
   11a30: 46 eb 98 4f      sdot    v6.4s, v26.16b, v24.4b[2]
   11a34: 64 eb 98 4f      sdot    v4.4s, v27.16b, v24.4b[2]
   11a38: 53 eb b8 4f      sdot    v19.4s, v26.16b, v24.4b[3]
   11a3c: 70 eb b8 4f      sdot    v16.4s, v27.16b, v24.4b[3]
   11a40: 54 e3 99 4f      sdot    v20.4s, v26.16b, v25.4b[0]
   11a44: 71 e3 99 4f      sdot    v17.4s, v27.16b, v25.4b[0]
   11a48: 57 e3 b9 4f      sdot    v23.4s, v26.16b, v25.4b[1]
   11a4c: 76 e3 b9 4f      sdot    v22.4s, v27.16b, v25.4b[1]
   11a50: 55 eb 99 4f      sdot    v21.4s, v26.16b, v25.4b[2]
   11a54: 72 eb 99 4f      sdot    v18.4s, v27.16b, v25.4b[2]
   11a58: 47 eb b9 4f      sdot    v7.4s, v26.16b, v25.4b[3]
   11a5c: 65 eb b9 4f      sdot    v5.4s, v27.16b, v25.4b[3]
   11a60: a1 fd ff 54      b.ne    0x11a14 <.text+0x11a8>
```