### PR TITLE
Fixing insertion location of `stream.binding.subspan` ops.

### DIFF
--- a/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD
+++ b/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "dispatch_ops.mlir",
+            "executable_ops.mlir",
             "tensor_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "dispatch_ops.mlir"
+    "executable_ops.mlir"
     "tensor_ops.mlir"
   DATA
     FileCheck

--- a/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/executable_ops.mlir
@@ -1,0 +1,120 @@
+// RUN: iree-opt -split-input-file -iree-stream-conversion -canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @rank_0_binding
+flow.executable private @rank_0_binding {
+  flow.dispatch.entry public @dispatch
+  builtin.module {
+    // CHECK: func @dispatch(%[[INPUT:.+]]: !stream.binding)
+    func @dispatch(%input: !flow.dispatch.tensor<readonly:i64>) {
+      // CHECK: %[[SUBSPAN:.+]] = stream.binding.subspan %[[INPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:i64>
+      // CHECK: = flow.dispatch.tensor.load %[[SUBSPAN]]
+      %tied_input = flow.dispatch.tensor.load %input, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i64> -> tensor<i64>
+      util.do_not_optimize(%tied_input) : tensor<i64>
+      return
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @static_bindings
+flow.executable private @static_bindings {
+  flow.dispatch.entry public @dispatch
+  builtin.module {
+    // CHECK: func @dispatch(%[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
+    func @dispatch(%input: !flow.dispatch.tensor<readonly:1x4xf32>, %output: !flow.dispatch.tensor<writeonly:4xf32>) {
+      // CHECK-DAG: %[[TIED_INPUT:.+]] = stream.binding.subspan %[[INPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:1x4xf32>
+      // CHECK-DAG: %[[TIED_OUTPUT:.+]] = stream.binding.subspan %[[OUTPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:4xf32>
+      %tied_input = flow.dispatch.tie_shape %input : !flow.dispatch.tensor<readonly:1x4xf32>
+      %tied_output = flow.dispatch.tie_shape %output : !flow.dispatch.tensor<writeonly:4xf32>
+
+      // CHECK: %[[TILE:.+]] = flow.dispatch.tensor.load %[[TIED_INPUT]]
+      // CHECK: flow.dispatch.tensor.store %[[TILE]], %[[TIED_OUTPUT]]
+      %tile = flow.dispatch.tensor.load %tied_input, offsets = [0, 0], sizes = [1, 4], strides = [1, 1] : !flow.dispatch.tensor<readonly:1x4xf32> -> tensor<4xf32>
+      flow.dispatch.tensor.store %tile, %tied_output, offsets = [0], sizes = [4], strides = [1] : tensor<4xf32> -> !flow.dispatch.tensor<writeonly:4xf32>
+      return
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @dynamic_bindings
+flow.executable private @dynamic_bindings {
+  flow.dispatch.entry public @dispatch
+  builtin.module {
+    // CHECK: func @dispatch(%[[DIM:.+]]: index, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
+    func @dispatch(%dim: index, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {
+      // CHECK-DAG: %[[TIED_INPUT:.+]] = stream.binding.subspan %[[INPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:1x?xf32>{%[[DIM]]}
+      // CHECK-DAG: %[[TIED_OUTPUT:.+]] = stream.binding.subspan %[[OUTPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:?xf32>{%[[DIM]]}
+      %tied_input = flow.dispatch.tie_shape %input : !flow.dispatch.tensor<readonly:1x?xf32>{%dim}
+      %tied_output = flow.dispatch.tie_shape %output : !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+
+      // CHECK: %[[TILE:.+]] = flow.dispatch.tensor.load %[[TIED_INPUT]]
+      // CHECK: flow.dispatch.tensor.store %[[TILE]], %[[TIED_OUTPUT]]
+      %tile = flow.dispatch.tensor.load %tied_input, offsets = [0, 0], sizes = [1, %dim], strides = [1, 1] : !flow.dispatch.tensor<readonly:1x?xf32>{%dim} -> tensor<?xf32>
+      flow.dispatch.tensor.store %tile, %tied_output, offsets = [0], sizes = [%dim], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+      return
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @indirect_dynamic_bindings
+flow.executable private @indirect_dynamic_bindings {
+  flow.dispatch.entry public @dispatch
+  builtin.module {
+    // CHECK: func @dispatch(%[[DIM_TENSOR:.+]]: !stream.binding, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
+    func @dispatch(%dim_tensor: !flow.dispatch.tensor<readonly:i64>, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {
+      // CHECK: %[[DIM_SUBSPAN:.+]] = stream.binding.subspan %[[DIM_TENSOR]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:i64>
+      // CHECK: %[[DIM_TILE:.+]] = flow.dispatch.tensor.load %[[DIM_SUBSPAN]]
+      // CHECK: %[[DIM_I64:.+]] = tensor.extract %[[DIM_TILE]][] : tensor<i64>
+      // CHECK: %[[DIM:.+]] = arith.index_cast %[[DIM_I64]] : i64 to index
+      %dim_tile = flow.dispatch.tensor.load %dim_tensor, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:i64> -> tensor<i64>
+      %dim_i64 = tensor.extract %dim_tile[] : tensor<i64>
+      %dim = arith.index_cast %dim_i64 : i64 to index
+
+      // CHECK-DAG: %[[TIED_INPUT:.+]] = stream.binding.subspan %[[INPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:1x?xf32>{%[[DIM]]}
+      // CHECK-DAG: %[[TIED_OUTPUT:.+]] = stream.binding.subspan %[[OUTPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:?xf32>{%[[DIM]]}
+      %tied_input = flow.dispatch.tie_shape %input : !flow.dispatch.tensor<readonly:1x?xf32>{%dim}
+      %tied_output = flow.dispatch.tie_shape %output : !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+
+      // CHECK: %[[TILE:.+]] = flow.dispatch.tensor.load %[[TIED_INPUT]]
+      // CHECK: flow.dispatch.tensor.store %[[TILE]], %[[TIED_OUTPUT]]
+      %tile = flow.dispatch.tensor.load %tied_input, offsets = [0, 0], sizes = [1, %dim], strides = [1, 1] : !flow.dispatch.tensor<readonly:1x?xf32>{%dim} -> tensor<?xf32>
+      flow.dispatch.tensor.store %tile, %tied_output, offsets = [0], sizes = [%dim], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+      return
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @nested_bindings
+flow.executable private @nested_bindings {
+  flow.dispatch.entry public @dispatch
+  builtin.module {
+    // CHECK: func @dispatch(%[[DIM:.+]]: index, %[[INPUT:.+]]: !stream.binding, %[[OUTPUT:.+]]: !stream.binding)
+    func @dispatch(%dim: index, %input: !flow.dispatch.tensor<readonly:1x?xf32>, %output: !flow.dispatch.tensor<writeonly:?xf32>) {
+      // CHECK-DAG: %[[TIED_INPUT:.+]] = stream.binding.subspan %[[INPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:1x?xf32>{%[[DIM]]}
+      // CHECK-DAG: %[[TIED_OUTPUT:.+]] = stream.binding.subspan %[[OUTPUT]][%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:?xf32>{%[[DIM]]}
+      %tied_input = flow.dispatch.tie_shape %input : !flow.dispatch.tensor<readonly:1x?xf32>{%dim}
+      %tied_output = flow.dispatch.tie_shape %output : !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+
+      %workgroup_size_0 = flow.dispatch.workgroup.size[0] : index
+      %workgroup_id_0 = flow.dispatch.workgroup.id[0] : index
+      %workgroup_count_0 = flow.dispatch.workgroup.count[0] : index
+      %5 = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%workgroup_size_0, %workgroup_id_0]
+      %6 = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%workgroup_size_0, %workgroup_count_0]
+      scf.for %arg3 = %5 to %dim step %6 {
+        %7 = affine.min affine_map<(d0)[s0, s1] -> (s0, -d0 + s1)>(%arg3)[%workgroup_size_0, %dim]
+        // CHECK: %[[TILE:.+]] = flow.dispatch.tensor.load %[[TIED_INPUT]]
+        // CHECK: flow.dispatch.tensor.store %[[TILE]], %[[TIED_OUTPUT]]
+        %tile = flow.dispatch.tensor.load %tied_input, offsets = [0, %arg3], sizes = [1, %7], strides = [1, 1] : !flow.dispatch.tensor<readonly:1x?xf32>{%dim} -> tensor<?xf32>
+        flow.dispatch.tensor.store %tile, %tied_output, offsets = [%arg3], sizes = [%7], strides = [1] : tensor<?xf32> -> !flow.dispatch.tensor<writeonly:?xf32>{%dim}
+      }
+      return
+    }
+  }
+}

--- a/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -9,13 +9,14 @@ flow.executable private @executable {
     func @dispatch(%arg0: !flow.dispatch.tensor<readonly:?x4xf32>, %arg1: !flow.dispatch.tensor<writeonly:4x?xf32>,
                    %arg0_dim0: index, %arg1_dim1: index) {
       // CHECK: %[[ARG0_TENSOR:.+]] = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:?x4xf32>{%[[ARG0_DIM0]]}
+      %arg0_tied = flow.dispatch.tie_shape %arg0 : !flow.dispatch.tensor<readonly:?x4xf32>{%arg0_dim0}
       // CHECK: %[[ARG1_TENSOR:.+]] = stream.binding.subspan %arg1[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:4x?xf32>{%[[ARG1_DIM1]]}
+      %arg1_tied = flow.dispatch.tie_shape %arg1 : !flow.dispatch.tensor<writeonly:4x?xf32>{%arg1_dim1}
 
       // CHECK: %[[TILE:.+]] = flow.dispatch.tensor.load %[[ARG0_TENSOR]], offsets = [0, 0], sizes = [%[[ARG0_DIM0]], 4], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x4xf32>{%[[ARG0_DIM0]]} -> tensor<?x4xf32>
-      %0 = flow.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [%arg0_dim0, 4], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x4xf32>{%arg0_dim0} -> tensor<?x4xf32>
-
+      %0 = flow.dispatch.tensor.load %arg0_tied, offsets = [0, 0], sizes = [%arg0_dim0, 4], strides = [1, 1] : !flow.dispatch.tensor<readonly:?x4xf32>{%arg0_dim0} -> tensor<?x4xf32>
       // CHECK: flow.dispatch.tensor.store %[[TILE]], %[[ARG1_TENSOR]], offsets = [0, 0], sizes = [4, %[[ARG1_DIM1]]], strides = [1, 1] : tensor<?x4xf32> -> !flow.dispatch.tensor<writeonly:4x?xf32>{%[[ARG1_DIM1]]}
-      flow.dispatch.tensor.store %0, %arg1, offsets = [0, 0], sizes = [4, %arg1_dim1], strides = [1, 1] : tensor<?x4xf32> -> !flow.dispatch.tensor<writeonly:4x?xf32>{%arg1_dim1}
+      flow.dispatch.tensor.store %0, %arg1_tied, offsets = [0, 0], sizes = [4, %arg1_dim1], strides = [1, 1] : tensor<?x4xf32> -> !flow.dispatch.tensor<writeonly:4x?xf32>{%arg1_dim1}
 
       return
     }


### PR DESCRIPTION
Now we use the `flow.dispatch.tie_shape` ops to insert the subspan ops where all dynamic dimension SSA values are guaranteed to be valid. Less magic use-def walks, more structure.