### PR TITLE
Integrate llvm-project at 5061eb6b0121af11a784d92e2dee5996858d04cd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/google/googletest.git
 [submodule "third_party/llvm-project"]
 	path = third_party/llvm-project
-	url = https://github.com/llvm/llvm-project.git
+	url = https://github.com/google/iree-llvm-fork.git
 [submodule "third_party/vulkan_headers"]
 	path = third_party/vulkan_headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git


### PR DESCRIPTION
* Reset third_party/llvm-project: 5061eb6b0121af11a784d92e2dee5996858d04cd (2022-01-21 09:57:17 -0800): [Sparc] Don't define __sparcv9 and __sparcv9__ when targeting V8+