### PR TITLE
Fix mhlo.dynamic_reshape lowering to Flow dialect

### DIFF
--- a/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
+++ b/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
@@ -736,13 +736,14 @@ struct ConvertDynamicReshapeOp
     SmallVector<Value> castedTargetDims;
     for (Value dim : targetDims) {
       if (dim.getType().isa<IntegerType>()) {
-        dim = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), dim);
+        dim = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(),
+                                                  dim);
       }
       castedTargetDims.push_back(dim);
     }
 
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
-      op, resultType, input, castedTargetDims);
+        op, resultType, input, castedTargetDims);
     return success();
   }
 };

--- a/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
+++ b/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
@@ -733,8 +733,16 @@ struct ConvertDynamicReshapeOp
       }
     }
 
-    rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(op, resultType,
-                                                             input, targetDims);
+    SmallVector<Value> castedTargetDims;
+    for (Value dim : targetDims) {
+      if (dim.getType().isa<IntegerType>()) {
+        dim = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), dim);
+      }
+      castedTargetDims.push_back(dim);
+    }
+
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
+      op, resultType, input, castedTargetDims);
     return success();
   }
 };

--- a/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/broadcasting.mlir
@@ -426,3 +426,25 @@ func @fallbackDynamicReshape(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tensor<5xinde
   // CHECK: return %[[RESULT]]
   return %0 : tensor<12x?x?x1x?xui32>
 }
+
+// -----
+// CHECK-LABEL: @fallbackDynamicReshapeInt
+func @fallbackDynamicReshapeInt(%arg0 : tensor<4x?x3x?xui32>, %arg1 : tensor<5xi32>) -> tensor<12x?x?x1x?xui32> {
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+  // CHECK-DAG: %[[D1:.*]] = tensor.extract %arg1[%[[C1]]] : tensor<5xi32>
+  // CHECK-DAG: %[[D2:.*]] = tensor.extract %arg1[%[[C2]]] : tensor<5xi32>
+  // CHECK-DAG: %[[D4:.*]] = tensor.extract %arg1[%[[C4]]] : tensor<5xi32>
+  // CHECK-DAG: %[[RESULT_D1:.*]] = arith.index_cast %0 : i32 to index
+  // CHECK-DAG: %[[RESULT_D2:.*]] = arith.index_cast %1 : i32 to index
+  // CHECK-DAG: %[[RESULT_D4:.*]] = arith.index_cast %2 : i32 to index
+  // CHECK-DAG: %[[INDEX1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[ARG_D1:.*]] = tensor.dim %arg0, %[[INDEX1]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[INDEX3:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[ARG_D3:.*]] = tensor.dim %arg0, %[[INDEX3]] : tensor<4x?x3x?xi32>
+  // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x?x3x?xi32>{%[[ARG_D1]], %[[ARG_D3]]} -> tensor<12x?x?x1x?xi32>{%[[RESULT_D1]], %[[RESULT_D2]], %[[RESULT_D4]]}
+  %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<4x?x3x?xui32>, tensor<5xi32>) -> tensor<12x?x?x1x?xui32>
+  // CHECK: return %[[RESULT]]
+  return %0 : tensor<12x?x?x1x?xui32>
+}


### PR DESCRIPTION
Dynamic shape for MHLO is usually an i32 so include an IndexCastOp to make compatible with flow.tensor.reshape.