### PR TITLE
Adding support for globals in AnnotateDispatchArguments.

### DIFF
--- a/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2705,7 +2705,6 @@ def Stream_ExecutableOp : Stream_Op<"executable", [
     custom<SymbolVisibility>($sym_visibility)
     $sym_name
     attr-dict-with-keyword
-    ``
     regions
   }];
 

--- a/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -122,6 +122,13 @@ void Explorer::initializeInverseCallGraph() {
   });
 }
 
+const Explorer::GlobalInfo *Explorer::getGlobalInfo(
+    IREE::Util::GlobalOp globalOp) {
+  auto it = globalInfos.find(globalOp);
+  if (it == globalInfos.end()) return nullptr;
+  return &it->second;
+}
+
 const Explorer::GlobalInfo *Explorer::queryGlobalInfoFrom(StringRef globalName,
                                                           Operation *from) {
   auto *symbolTableOp = SymbolTable::getNearestSymbolTable(from);

--- a/iree/compiler/Dialect/Util/Analysis/Explorer.h
+++ b/iree/compiler/Dialect/Util/Analysis/Explorer.h
@@ -135,6 +135,9 @@ class Explorer {
     SmallVector<Operation *> uses;
   };
 
+  // Gets analyzed global information for the given global operation.
+  const GlobalInfo *getGlobalInfo(IREE::Util::GlobalOp globalOp);
+
   // Queries memoized information about a global variable, returning nullptr if
   // not found.
   const GlobalInfo *queryGlobalInfoFrom(StringRef globalName, Operation *from);


### PR DESCRIPTION
This allows the potential value set analysis to integrate initial
global values and properly derive alignment from resource offsets that
may vary at runtime.

Fixes #8162.