### PR TITLE
Add a pass to propagate unsupported element type conversion.

### DIFF
--- a/integrations/tensorflow/test/iree_tf_tests/math/llvmaot__reduce_all.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/llvmaot__reduce_all.run
@@ -1,3 +1,2 @@
-# XFAIL: *
 # REQUIRES: llvmaot
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_llvmaot --dynamic_dims=false --functions=reduce_all -artifacts_dir=%t

--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "OptimizeVectorTransferPass.cpp",
         "RemoveTrivialLoops.cpp",
         "SetNumWorkgroupsPass.cpp",
+        "TypePropagationPass.cpp",
         "VectorizeConv.cpp",
         "VectorizeMMT4d.cpp",
     ],

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     "OptimizeVectorTransferPass.cpp"
     "RemoveTrivialLoops.cpp"
     "SetNumWorkgroupsPass.cpp"
+    "TypePropagationPass.cpp"
     "VectorizeConv.cpp"
     "VectorizeMMT4d.cpp"
   DEPS

--- a/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -26,6 +26,7 @@
 
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -41,10 +42,10 @@ namespace iree_compiler {
 static Optional<Type> getLegalizedElementType(Type elementType) {
   if (auto intType = elementType.dyn_cast<IntegerType>()) {
     unsigned bitWidth = intType.getWidth();
-    unsigned byteAlignedWidth =
-        std::max<unsigned>(8, llvm::PowerOf2Ceil(bitWidth));
-    if (byteAlignedWidth == bitWidth) return elementType;
-    return IntegerType::get(elementType.getContext(), byteAlignedWidth);
+    unsigned byteAlignedBitWidth =
+        IREE::Util::getRoundedElementByteWidth(intType) * 8;
+    if (byteAlignedBitWidth == bitWidth) return elementType;
+    return IntegerType::get(elementType.getContext(), byteAlignedBitWidth);
   }
   return elementType;
 }

--- a/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -1,0 +1,359 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===- TypePropagationPass.cpp -------------------------------------------===//
+//
+// The dispatch regions passed to the backends legalizes the bitwidth of
+// element types used for the input/output buffers. To avoid illegal load/stores
+// within the dispatch, the type needs to be propagated to avoid having tensors
+// of illegal bitwidths.
+//
+// This pass uses the dialect conversion framework to propagate the types,
+// - All ops are marked dynamically illegal if their operands/result uses
+//   unsupported element type.
+// - A generic pattern is added to legalize all such ops that triggers on every
+//   operation.
+//   - For operations with illegal result types, it creates a new
+//     operations with legalized return types.
+//   - This pattern uses the generic operation creation methods to be
+//     op-agnostic.
+// - For ops that need specifc handling, patterns are added with higher benefit,
+//   so that they trigger first during legalization.
+//
+//===---------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Returns the legal element type to use instead of the passed in element type.
+/// If the type is already legal, returns llvm::None.
+static Optional<Type> getLegalizedElementType(Type elementType) {
+  if (auto intType = elementType.dyn_cast<IntegerType>()) {
+    unsigned bitWidth = intType.getWidth();
+    unsigned byteAlignedWidth =
+        std::max<unsigned>(8, llvm::PowerOf2Ceil(bitWidth));
+    if (byteAlignedWidth == bitWidth) return elementType;
+    return IntegerType::get(elementType.getContext(), byteAlignedWidth);
+  }
+  return elementType;
+}
+
+/// Insert instructions to convert from one element type to another.
+static Value convertElementType(OpBuilder &b, Location loc, Type targetType,
+                                Value source) {
+  Type sourceType = source.getType();
+  if (sourceType.isa<IntegerType>() && targetType.isa<IntegerType>()) {
+    unsigned sourceBitWidth = sourceType.getIntOrFloatBitWidth();
+    unsigned destBitWidth = targetType.getIntOrFloatBitWidth();
+    if (sourceBitWidth > destBitWidth) {
+      return b.create<arith::TruncIOp>(loc, targetType, source);
+    } else if (sourceBitWidth < destBitWidth) {
+      return b.create<arith::ExtUIOp>(loc, targetType, source);
+    } else {
+      return source;
+    }
+  }
+  return nullptr;
+}
+
+/// Legalizes the given type. If the type is already legal, returns llvm::None.
+static Optional<Type> getLegalizedType(Type t) {
+  if (auto shapedType = t.dyn_cast<RankedTensorType>()) {
+    Type elementType = shapedType.getElementType();
+    Optional<Type> legalizedElementType = getLegalizedElementType(elementType);
+    if (!legalizedElementType) return llvm::None;
+    return RankedTensorType::get(shapedType.getShape(),
+                                 legalizedElementType.getValue());
+  }
+  return llvm::None;
+}
+
+namespace {
+
+/// Type converter to use for type propagation.
+struct TypePropagationTypeConverter : public TypeConverter {
+  TypePropagationTypeConverter() {
+    addConversion([](Type t) {
+      auto convertedType = getLegalizedType(t);
+      if (!convertedType) return t;
+      return convertedType.getValue();
+    });
+  }
+};
+
+/// Base class for patterns that handle individual operations.
+template <typename T>
+struct TypePropagationPattern : public OpConversionPattern<T> {
+  TypePropagationPattern(TypePropagationTypeConverter &typeConverter,
+                         MLIRContext *context)
+      : OpConversionPattern<T>(typeConverter, context, 100) {}
+};
+
+/// Propagates the type for `linalg.generic` operation.
+/// - Convert operands whose type has changed.
+/// - Convert corresponding basic block argument type and introduce element
+/// conversion ops to get back the original type.
+/// - Convert the result type if the `outs` operand has changed.
+struct GenericOpTypePropagation
+    : public TypePropagationPattern<linalg::GenericOp> {
+  using TypePropagationPattern<linalg::GenericOp>::TypePropagationPattern;
+
+  LogicalResult matchAndRewrite(
+      linalg::GenericOp genericOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
+    llvm::SmallSetVector<unsigned, 8> modifiedOperandIndex;
+    SmallVector<Type> resultTypes;
+
+    // 1. Check if any of the operands needs to be legalized.
+    for (auto operand : llvm::enumerate(genericOp->getOpOperands())) {
+      Type operandType = operand.value().get().getType();
+      Type legalizedType = this->getTypeConverter()->convertType(operandType);
+      if (operandType != legalizedType) {
+        modifiedOperandIndex.insert(operand.index());
+      }
+      // If the operand is an `outs` tensor, its type needs to be changed.
+      if (genericOp.isOutputTensor(&operand.value())) {
+        resultTypes.push_back(legalizedType);
+      }
+    }
+
+    // 2. If there are no operands modified, just return failure.
+    if (modifiedOperandIndex.empty()) {
+      return rewriter.notifyMatchFailure(genericOp, "all types legal");
+    }
+
+    // 3. Create a clone of the operation without cloning its regions.
+    auto linalgOp = cast<linalg::LinalgOp>(genericOp.getOperation());
+    auto modifiedOp = cast<linalg::LinalgOp>(linalgOp.cloneWithoutRegions(
+        rewriter, genericOp.getLoc(), resultTypes, adaptor.getOperands()));
+
+    if (genericOp->getNumRegions() != 1) {
+      return genericOp.emitOpError("unhanled linalg op with numRegions != 1");
+    }
+
+    // 4. Inline the region from the original operation into the new
+    // operation.
+    rewriter.inlineRegionBefore(genericOp->getRegions().front(),
+                                modifiedOp->getRegions().front(),
+                                modifiedOp->getRegions().front().begin());
+    Region &modifiedOpRegion = modifiedOp->getRegions().front();
+
+    // 5. Convert the signature of the region to use the corresponding element
+    // type.
+    TypeConverter::SignatureConversion signatureConverter(
+        modifiedOpRegion.getNumArguments());
+    for (auto arg : llvm::enumerate(modifiedOpRegion.getArguments())) {
+      Type argType = arg.value().getType();
+      if (!modifiedOperandIndex.count(arg.index())) {
+        signatureConverter.addInputs(arg.index(), argType);
+        continue;
+      }
+      Optional<Type> legalizedArgType = getLegalizedElementType(argType);
+      if (!legalizedArgType) {
+        return genericOp.emitOpError("failed to get legalized type for arg ")
+               << arg.index();
+      }
+      signatureConverter.addInputs(arg.index(), legalizedArgType.getValue());
+    }
+    rewriter.applySignatureConversion(&modifiedOpRegion, signatureConverter);
+
+    // 6. Introduce scalar conversion operations to convert back to the
+    // original scalar type.
+    {
+      OpBuilder::InsertionGuard g(rewriter);
+      Block *entryBlock = modifiedOp.getBlock();
+      for (auto modifiedOperandIndex : modifiedOperandIndex) {
+        OpOperand *modifiedOpOperand =
+            &modifiedOp->getOpOperand(modifiedOperandIndex);
+        BlockArgument source =
+            modifiedOp.getTiedBlockArgument(modifiedOpOperand);
+        Type destType = getElementTypeOrSelf(
+            genericOp.getOperand(modifiedOperandIndex).getType());
+
+        // 6a. If the value of the argument is used the argument is in the
+        // legalized type. Convert it to a value that is in the original
+        // element type for replacement of all uses in the block.
+        rewriter.setInsertionPointToStart(entryBlock);
+        Value replacement =
+            convertElementType(rewriter, source.getLoc(), destType, source);
+        rewriter.replaceUsesOfBlockArgument(source, replacement);
+      }
+
+      // 6b. If any of the operands modified were outputs, the yield values
+      // need to be modified as well.
+      Operation *yieldOp = entryBlock->getTerminator();
+      rewriter.setInsertionPoint(yieldOp);
+      bool modifyYield = false;
+      SmallVector<Value> yieldOperands(yieldOp->operand_begin(),
+                                       yieldOp->operand_end());
+      for (auto modifiedOperandIndex : modifiedOperandIndex) {
+        OpOperand *modifiedOpOperand =
+            &modifiedOp->getOpOperand(modifiedOperandIndex);
+        if (modifiedOp.isOutputTensor(modifiedOpOperand)) {
+          modifyYield = true;
+          OpOperand *yieldOperand =
+              modifiedOp.getTiedYieldValue(modifiedOpOperand);
+          Optional<Type> legalizedType =
+              getLegalizedElementType(yieldOperand->get().getType());
+          if (!legalizedType) {
+            return genericOp.emitOpError(
+                "failed to get legalized type for yield value");
+          }
+          yieldOperands[yieldOperand->getOperandNumber()] =
+              convertElementType(rewriter, yieldOp->getLoc(),
+                                 legalizedType.getValue(), yieldOperand->get());
+        }
+      }
+      if (modifyYield) {
+        rewriter.replaceOpWithNewOp<linalg::YieldOp>(yieldOp, yieldOperands);
+      }
+    }
+
+    rewriter.replaceOp(genericOp, modifiedOp->getResults());
+    return success();
+  }
+};
+
+/// Simple rewrite pattern that just forwards the source as the result if the
+/// result type is not legal (but source type is)
+template <typename OpTy>
+struct ForwardSourceType : public TypePropagationPattern<OpTy> {
+  using TypePropagationPattern<OpTy>::TypePropagationPattern;
+
+  LogicalResult matchAndRewrite(
+      OpTy op, typename OpTy::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
+    if (op->getNumResults() != 1 || adaptor.getOperands().size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "unhandled op with multiple operands/results");
+    }
+    Type outputType = op->getResult(0).getType();
+    Type legalizedOutputType = this->typeConverter->convertType(outputType);
+    Value input = adaptor.getOperands()[0];
+    Value originalInput = op->getOperand(0);
+    if (outputType == legalizedOutputType &&
+        input.getType() == originalInput.getType()) {
+      return rewriter.notifyMatchFailure(op, "op is legal");
+    }
+    rewriter.replaceOp(op, input);
+    return success();
+  }
+};
+
+/// Rewrite pattern to replace the element type (if it is not legal) with the
+/// legal element type.
+struct LegalizeResultElementType : public ConversionPattern {
+  LegalizeResultElementType(TypePropagationTypeConverter &typeConverter,
+                            MLIRContext *context)
+      : ConversionPattern(typeConverter, MatchAnyOpTypeTag(), /*benefit=*/1,
+                          context) {}
+
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> convertedOperands,
+      ConversionPatternRewriter &rewriter) const final {
+    if (op->getNumSuccessors()) {
+      return rewriter.notifyMatchFailure(op, "unhandled ops with successors");
+    }
+    Location loc = op->getLoc();
+    bool illegalOp = llvm::any_of(
+        llvm::zip(op->getOperands(), convertedOperands),
+        [](std::tuple<Value, Value> tuple) {
+          return std::get<0>(tuple).getType() != std::get<1>(tuple).getType();
+        });
+    SmallVector<Type> resultTypes;
+    for (Type resultType : op->getResultTypes()) {
+      Type legalizedType = this->typeConverter->convertType(resultType);
+      resultTypes.push_back(legalizedType);
+      illegalOp |= legalizedType != resultType;
+    }
+    if (!illegalOp) {
+      return rewriter.notifyMatchFailure(op, "op is already legal");
+    }
+    OperationState state(loc, op->getName(), convertedOperands, resultTypes,
+                         op->getAttrs());
+    for (unsigned i = 0, e = op->getNumRegions(); i != e; ++i) {
+      state.addRegion();
+    }
+    Operation *newOp = rewriter.createOperation(state);
+
+    // Move all the regions from the old op to the new op and legalize its
+    // signature.
+    for (auto &region : llvm::enumerate(op->getRegions())) {
+      Region &newOpRegion = newOp->getRegion(region.index());
+      rewriter.inlineRegionBefore(region.value(), newOpRegion,
+                                  newOpRegion.begin());
+      TypeConverter::SignatureConversion signatureConverter(
+          newOpRegion.getNumArguments());
+      bool doSignatureConversion = false;
+      for (auto arg : llvm::enumerate(newOpRegion.getArguments())) {
+        Type argType = arg.value().getType();
+        Type legalizedType = this->typeConverter->convertType(argType);
+        signatureConverter.addInputs(arg.index(), legalizedType);
+        doSignatureConversion |= argType != legalizedType;
+      }
+      if (doSignatureConversion) {
+        rewriter.applySignatureConversion(&newOpRegion, signatureConverter);
+      }
+    }
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
+struct TypePropagationPass : public TypePropagationBase<TypePropagationPass> {
+  TypePropagationPass() = default;
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithmeticDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(context);
+
+    TypePropagationTypeConverter typeConverter;
+    patterns.insert<ForwardSourceType<arith::ExtUIOp>,
+                    ForwardSourceType<arith::TruncIOp>,
+                    GenericOpTypePropagation, LegalizeResultElementType>(
+        typeConverter, context);
+
+    ConversionTarget target(*context);
+    target.markUnknownOpDynamicallyLegal([&](Operation *op) {
+      for (auto operand : op->getOperands()) {
+        Type operandType = operand.getType();
+        if (operandType != typeConverter.convertType(operandType)) {
+          return false;
+        }
+      }
+      for (auto result : op->getResults()) {
+        Type resultType = result.getType();
+        if (resultType != typeConverter.convertType(resultType)) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createTypePropagationPass() {
+  return std::make_unique<TypePropagationPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/Common/test/BUILD
+++ b/iree/compiler/Codegen/Common/test/BUILD
@@ -33,6 +33,7 @@ iree_lit_test_suite(
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
             "transpose_canonicalization.mlir",
+            "type_propagation.mlir",
             "vectorize_linalg_conv.mlir",
             "vectorize_linalg_mmt4d.mlir",
         ],

--- a/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_lit_test_suite(
     "remove_dead_allocs.mlir"
     "remove_trivial_loops.mlir"
     "transpose_canonicalization.mlir"
+    "type_propagation.mlir"
     "vectorize_linalg_conv.mlir"
     "vectorize_linalg_mmt4d.mlir"
   TOOLS

--- a/iree/compiler/Codegen/Common/test/type_propagation.mlir
+++ b/iree/compiler/Codegen/Common/test/type_propagation.mlir
@@ -1,0 +1,219 @@
+// RUN: iree-opt -iree-codegen-type-propagation -split-input-file %s | FileCheck %s
+
+func @generic_op_illegal_operand() {
+  %d = hal.interface.constant.load[0] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %3 = arith.trunci %2 : tensor<?xi8> to tensor<?xi1>
+  %4 = linalg.init_tensor [%d] : tensor<?xi8>
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%3 : tensor<?xi1>) outs(%4 : tensor<?xi8>) {
+      ^bb0(%arg0 : i1, %arg1 : i8):
+        %6 = arith.extui %arg0 : i1 to i8
+        linalg.yield %6 : i8
+    } -> tensor<?xi8>
+  flow.dispatch.tensor.store %5, %1, offsets = [0], sizes=[%d], strides=[1] : tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return
+}
+// CHECK-LABEL: func @generic_op_illegal_operand()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor [%{{.+}}] : tensor<?xi8>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[INTENSOR]] : tensor<?xi8>)
+//  CHECK-SAME:       outs(%[[INIT]] : tensor<?xi8>)
+//  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i8, %[[ARG1:[a-zA-Z0-9]+]]: i8)
+//   CHECK-DAG:       %[[TRUNC:.+]] = arith.trunci %[[ARG0]] : i8 to i1
+//   CHECK-DAG:       %[[EXTUI:.+]] = arith.extui %[[TRUNC]] : i1 to i8
+//       CHECK:       linalg.yield %[[EXTUI]]
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUT]]
+
+// -----
+
+func @generic_op_illegal_operand_i7() {
+  %d = hal.interface.constant.load[0] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %3 = arith.trunci %2 : tensor<?xi8> to tensor<?xi7>
+  %4 = linalg.init_tensor [%d] : tensor<?xi8>
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%3 : tensor<?xi7>) outs(%4 : tensor<?xi8>) {
+      ^bb0(%arg0 : i7, %arg1 : i8):
+        %6 = arith.extui %arg0 : i7 to i8
+        linalg.yield %6 : i8
+    } -> tensor<?xi8>
+  flow.dispatch.tensor.store %5, %1, offsets = [0], sizes=[%d], strides=[1] : tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return
+}
+// CHECK-LABEL: func @generic_op_illegal_operand_i7()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor [%{{.+}}] : tensor<?xi8>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[INTENSOR]] : tensor<?xi8>)
+//  CHECK-SAME:       outs(%[[INIT]] : tensor<?xi8>)
+//  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i8, %[[ARG1:[a-zA-Z0-9]+]]: i8)
+//   CHECK-DAG:       %[[TRUNC:.+]] = arith.trunci %[[ARG0]] : i8 to i7
+//   CHECK-DAG:       %[[EXTUI:.+]] = arith.extui %[[TRUNC]] : i7 to i8
+//       CHECK:       linalg.yield %[[EXTUI]]
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUT]]
+
+// -----
+
+func @generic_op_illegal_operand_i33() {
+  %d = hal.interface.constant.load[0] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi64>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi64>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi64>{%d} -> tensor<?xi64>
+  %3 = arith.trunci %2 : tensor<?xi64> to tensor<?xi33>
+  %4 = linalg.init_tensor [%d] : tensor<?xi64>
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%3 : tensor<?xi33>) outs(%4 : tensor<?xi64>) {
+      ^bb0(%arg0 : i33, %arg1 : i64):
+        %6 = arith.extui %arg0 : i33 to i64
+        linalg.yield %6 : i64
+    } -> tensor<?xi64>
+  flow.dispatch.tensor.store %5, %1, offsets = [0], sizes=[%d], strides=[1] : tensor<?xi64> -> !flow.dispatch.tensor<writeonly:?xi64>{%d}
+  return
+}
+// CHECK-LABEL: func @generic_op_illegal_operand_i33()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor [%{{.+}}] : tensor<?xi64>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[INTENSOR]] : tensor<?xi64>)
+//  CHECK-SAME:       outs(%[[INIT]] : tensor<?xi64>)
+//  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i64, %[[ARG1:[a-zA-Z0-9]+]]: i64)
+//   CHECK-DAG:       %[[TRUNC:.+]] = arith.trunci %[[ARG0]] : i64 to i33
+//   CHECK-DAG:       %[[EXTUI:.+]] = arith.extui %[[TRUNC]] : i33 to i64
+//       CHECK:       linalg.yield %[[EXTUI]]
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUT]]
+
+
+// -----
+
+func @generic_op_illegal_result() {
+  %d = hal.interface.constant.load[0] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %3 = linalg.init_tensor [%d] : tensor<?xi1>
+  %4 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%2 : tensor<?xi8>) outs(%3 : tensor<?xi1>) {
+      ^bb0(%arg0 : i8, %arg1 : i1):
+        %5 = arith.trunci %arg0 : i8 to i1
+        linalg.yield %5 : i1
+    } -> tensor<?xi1>
+  %5 = arith.extui %4 : tensor<?xi1> to tensor<?xi8>
+  flow.dispatch.tensor.store %5, %1, offsets = [0], sizes=[%d], strides=[1] : tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return
+}
+// CHECK-LABEL: func @generic_op_illegal_result()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[INIT:.+]] = linalg.init_tensor [%{{.+}}] : tensor<?xi8>
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[INTENSOR]] : tensor<?xi8>)
+//  CHECK-SAME:       outs(%[[INIT]] : tensor<?xi8>)
+//  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i8, %[[ARG1:[a-zA-Z0-9]+]]: i8)
+//   CHECK-DAG:       %[[TRUNC:.+]] = arith.trunci %[[ARG0]] : i8 to i1
+//   CHECK-DAG:       %[[EXTUI:.+]] = arith.extui %[[TRUNC]] : i1 to i8
+//       CHECK:       linalg.yield %[[EXTUI]]
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[OUT]]
+
+// -----
+
+func @tensor_extract() {
+  %d = hal.interface.constant.load[0] : index
+  %offset = hal.interface.constant.load[1] : index
+  %size = hal.interface.constant.load[2] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %3 = tensor.extract_slice %2[%offset] [%size] [1] : tensor<?xi8> to tensor<?xi8>
+  %4 = arith.trunci %3 : tensor<?xi8> to tensor<?xi1>
+  %5 = arith.extui %4 : tensor<?xi1> to tensor<?xi8>
+  flow.dispatch.tensor.store %5, %1, offsets = [%offset], sizes=[%size], strides=[1] : tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return   
+}
+// CHECK-LABEL: func @tensor_extract()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[INTENSOR]]
+//       CHECK:   flow.dispatch.tensor.store %[[EXTRACT]], %[[OUT]]
+
+// -----
+
+func @tensor_insert() {
+  %d = hal.interface.constant.load[0] : index
+  %offset = hal.interface.constant.load[1] : index
+  %size = hal.interface.constant.load[2] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %3 = flow.dispatch.tensor.load %0, offsets = [%offset], sizes=[%size], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %5 = arith.trunci %3 : tensor<?xi8> to tensor<?xi1>
+  %6 = arith.trunci %4 : tensor<?xi8> to tensor<?xi1>
+  %7 = tensor.insert_slice %5 into %6[%offset] [%size] [1] : tensor<?xi1> into tensor<?xi1>
+  %8 = arith.extui %7 : tensor<?xi1> to tensor<?xi8>
+  flow.dispatch.tensor.store %8, %2, offsets = [0], sizes=[%d], strides=[1] : tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return
+}
+// CHECK-LABEL: func @tensor_insert()
+//   CHECK-DAG:   %[[IN1:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[IN2:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(2)
+//   CHECK-DAG:   %[[IN1TENSOR:.+]] = flow.dispatch.tensor.load %[[IN1]]
+//   CHECK-DAG:   %[[IN2TENSOR:.+]] = flow.dispatch.tensor.load %[[IN2]]
+//       CHECK:   %[[INSERT:.+]] = tensor.insert_slice %[[IN1TENSOR]] into %[[IN2TENSOR]]
+//       CHECK:   flow.dispatch.tensor.store %[[INSERT]], %[[OUT]]
+
+// -----
+
+func @for_loop() {
+  %d = hal.interface.constant.load[0] : index
+  %lb = hal.interface.constant.load[1] : index
+  %step = hal.interface.constant.load[2] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:?xi8>{%d}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  %2 = flow.dispatch.tensor.load %0, offsets=[0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<readonly:?xi8>{%d} -> tensor<?xi8>
+  %3 = flow.dispatch.tensor.load %1, offsets=[0], sizes=[%d], strides=[1] : !flow.dispatch.tensor<writeonly:?xi8>{%d} -> tensor<?xi8>
+  %4 = arith.trunci %2 : tensor<?xi8> to tensor<?xi1>
+  %5 = arith.trunci %3 : tensor<?xi8> to tensor<?xi1>
+  %c0 = arith.constant 0 : index
+  %6 = scf.for %arg0 = %c0 to %d step %step iter_args(%arg1 = %5) -> tensor<?xi1> {
+    %7 = tensor.extract_slice %4[%arg0][%step][1] : tensor<?xi1> to tensor<?xi1>
+    %8 = tensor.insert_slice %7 into %arg1[%arg0][%step][1] : tensor<?xi1> into tensor<?xi1>
+    scf.yield %8 : tensor<?xi1>
+  }
+  %8 = arith.extui %6 : tensor<?xi1> to tensor<?xi8>
+  flow.dispatch.tensor.store %8, %1, offsets=[0], sizes=[%d], strides=[1]: tensor<?xi8> -> !flow.dispatch.tensor<writeonly:?xi8>{%d}
+  return
+}
+// CHECK-LABEL: func @for_loop()
+//   CHECK-DAG:   %[[IN:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[OUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[INTENSOR:.+]] = flow.dispatch.tensor.load %[[IN]]
+//   CHECK-DAG:   %[[OUTTENSOR:.+]] = flow.dispatch.tensor.load %[[OUT]]
+//       CHECK:   %[[FOR:.+]] = scf.for
+//  CHECK-SAME:       iter_args(%[[ARG1:.+]] = %[[OUTTENSOR]])
+//       CHECK:     %[[SLICE:.+]] = tensor.extract_slice %[[INTENSOR]]
+//       CHECK:     %[[INSERT:.+]] = tensor.insert_slice %[[SLICE]] into %[[ARG1]]
+//       CHECK:     scf.yield %[[INSERT]]
+//       CHECK:   flow.dispatch.tensor.store %[[FOR]], %[[OUT]]

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -337,6 +337,8 @@ static void addLowerToLLVMPasses(OpPassManager &passManager) {
 }
 
 void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
+  passManager.nest<ModuleOp>().nest<FuncOp>().addPass(
+      createTypePropagationPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   addLowerToLLVMPasses(nestedModulePM);

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -166,6 +166,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 }
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
+  pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
+
   OpPassManager &bufferizePassPM = pm.nest<ModuleOp>();
   addLinalgBufferizePasses(bufferizePassPM, gpuAllocationFunction);
   pm.addPass(createLLVMGPULowerExecutableTargetPass());

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -114,6 +114,9 @@ std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeMMT4dPass();
 /// Pass to optimize vector transfer_read and transfer_write.
 std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass();
 
+/// Pass to propagate type to avoid generating load/stores of illegal types.
+std::unique_ptr<OperationPass<FuncOp>> createTypePropagationPass();
+
 /// Sets the number of workgroups to use for each entry point in the dispatch
 /// region.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -78,6 +78,12 @@ def OptimizeVectorTransfer :
   let constructor = "mlir::iree_compiler::createOptimizeVectorTransferPass()";
 }
 
+def TypePropagation :
+    Pass<"iree-codegen-type-propagation", "FuncOp"> {
+  let summary = "Propogate the type of tensor to avoid load/stores of illegal bit widths";
+  let constructor = "mlir::iree_compiler::createTypePropagationPass()";
+}
+
 def RemoveSingleIterationLoop :
     Pass<"iree-codegen-remove-single-iteration-loop", "FuncOp"> {
   let summary = "Remove distributed loop with single iteration.";

--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -224,6 +224,7 @@ void addSPIRVTileAndDistributeCopyPassPipeline(OpPassManager &pm) {
 //===----------------------------------------------------------------------===//
 
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm) {
+  pm.nest<ModuleOp>().nest<FuncOp>().addPass(createTypePropagationPass());
   pm.addPass(createSPIRVLowerExecutableTargetPass());
   addMemRefLoweringPasses(pm.nest<ModuleOp>());
   addSPIRVLoweringPasses(pm.nest<ModuleOp>());

--- a/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.cpp
@@ -28,6 +28,8 @@ namespace IREE {
 namespace VMVX {
 
 static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
+  passManager.nest<ModuleOp>().nest<FuncOp>().addPass(
+      createTypePropagationPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();

--- a/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -111,9 +111,8 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
       IREE::Stream::createEncodeHostTensorsPass());
   passManager.addNestedPass<mlir::FuncOp>(
       IREE::Stream::createEncodeHostTensorsPass());
-  // TODO(ravishankarm): enable when codegen can handle extui/trunc ops.
-  // passManager.addNestedPass<IREE::Stream::ExecutableOp>(
-  //     IREE::Stream::createEncodeDeviceTensorsPass());
+  passManager.addNestedPass<IREE::Stream::ExecutableOp>(
+      IREE::Stream::createEncodeDeviceTensorsPass());
 
   // Expand builtins to dispatches. This may introduce new executables.
   passManager.addPass(IREE::Stream::createMaterializeBuiltinsPass());


### PR DESCRIPTION
With PR #8155, the buffer for `tensor` with unsupported element types
(like `i1`, `i2`, etc.) are converted to use a supported element type
through widening (and truncation if needed in future). This introduces
`arith.trunci` and `arith.extui` operations to convert back and forth
from the program representation in its original form. Propagate the
use of supported element type for all `tensor` operations to ensure
that the no load/stores of unsupported element types are used.