### PR TITLE
Updated linalg_ext sort conversion for unsigned integers

### DIFF
--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -54,8 +54,7 @@ static Type convertShapedToSignless(ShapedType shapedType) {
 }
 
 static Optional<Value> materializeCast(OpBuilder &builder, Type toType,
-                                       ValueRange inputs,
-                                       Location loc) {
+                                       ValueRange inputs, Location loc) {
   assert(inputs.size() == 1 && "too many inputs to type conversion");
   Value fromValue = inputs[0];
   auto fromType = fromValue.getType().dyn_cast<RankedTensorType>();
@@ -69,8 +68,8 @@ static Optional<Value> materializeCast(OpBuilder &builder, Type toType,
 
   if (fromType.getRank() != 0) return fromValue;
 
-    Type extractType = fromType.getElementType();
-    return builder.createOrFold<tensor::ExtractOp>(loc, extractType, fromValue);
+  Type extractType = fromType.getElementType();
+  return builder.createOrFold<tensor::ExtractOp>(loc, extractType, fromValue);
 }
 
 /// Note: only designed to work for casts involving rank-0 tensors and scalars
@@ -158,7 +157,8 @@ struct SortOpConversion : public OpConversionPattern<mhlo::SortOp> {
     Location loc = mhloSortOp.getLoc();
 
     llvm::SmallVector<Type> resultTypes;
-    (void)this->typeConverter->convertTypes(mhloSortOp.getResultTypes(), resultTypes);
+    (void)this->typeConverter->convertTypes(mhloSortOp.getResultTypes(),
+                                            resultTypes);
     auto sortOp = rewriter.create<IREE::LinalgExt::SortOp>(
         loc, resultTypes,
         /*inputs=*/ValueRange{}, adaptor.getOperands(),

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -162,8 +162,10 @@ struct SortOpConversion : public OpConversionPattern<mhlo::SortOp> {
     Location loc = mhloSortOp.getLoc();
 
     llvm::SmallVector<Type> resultTypes;
-    (void)this->typeConverter->convertTypes(mhloSortOp.getResultTypes(),
-                                            resultTypes);
+    if (this->typeConverter->convertTypes(mhloSortOp.getResultTypes(),
+                                            resultTypes).failed()) {
+      return failure();
+    };
     auto sortOp = rewriter.create<IREE::LinalgExt::SortOp>(
         loc, resultTypes,
         /*inputs=*/ValueRange{}, adaptor.getOperands(),

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -176,9 +176,10 @@ struct SortOpConversion : public OpConversionPattern<mhlo::SortOp> {
       if (newType == input.getType()) {
         inputs.push_back(input);
       } else {
-        inputs.push_back(rewriter.create<UnrealizedConversionCastOp>(
-          loc, newType, input).getResult(0));
-      } 
+        inputs.push_back(
+            rewriter.create<UnrealizedConversionCastOp>(loc, newType, input)
+                .getResult(0));
+      }
     }
 
     llvm::SmallVector<Type> resultTypes;
@@ -196,20 +197,21 @@ struct SortOpConversion : public OpConversionPattern<mhlo::SortOp> {
         block.getNumArguments());
     for (auto en : llvm::enumerate(block.getArguments())) {
       signature_converter.addInputs(
-        en.index(), this->typeConverter->convertType(
-          getElementTypeOrSelf(en.value().getType())));
+          en.index(), this->typeConverter->convertType(
+                          getElementTypeOrSelf(en.value().getType())));
     }
     rewriter.applySignatureConversion(&region, signature_converter);
 
     llvm::SmallVector<Value> results;
     for (auto it : llvm::zip(sortOp->getResults(), op.getResultTypes())) {
       Value v = std::get<0>(it);
-      Type t = std::get<1>(it); 
+      Type t = std::get<1>(it);
       if (v.getType() == t) {
         results.push_back(v);
       } else {
-        results.push_back(rewriter.create<UnrealizedConversionCastOp>( 
-          loc, t, v).getResult(0));
+        results.push_back(
+            rewriter.create<UnrealizedConversionCastOp>(loc, t, v).getResult(
+                0));
       }
     }
 

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -162,8 +162,9 @@ struct SortOpConversion : public OpConversionPattern<mhlo::SortOp> {
     Location loc = mhloSortOp.getLoc();
 
     llvm::SmallVector<Type> resultTypes;
-    if (this->typeConverter->convertTypes(mhloSortOp.getResultTypes(),
-                                            resultTypes).failed()) {
+    if (this->typeConverter
+            ->convertTypes(mhloSortOp.getResultTypes(), resultTypes)
+            .failed()) {
       return failure();
     };
     auto sortOp = rewriter.create<IREE::LinalgExt::SortOp>(

--- a/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -13,12 +13,12 @@
 //===----------------------------------------------------------------------===//
 #include <memory>
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/InputConversion/MHLO/ConvertMHLOToFlow.h"
 #include "iree/compiler/InputConversion/MHLO/PassDetail.h"
 #include "iree/compiler/InputConversion/MHLO/Passes.h"
 #include "iree/compiler/InputConversion/MHLO/Rewriters.h"
-#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"

--- a/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/InputConversion/MHLO/PassDetail.h"
 #include "iree/compiler/InputConversion/MHLO/Passes.h"
 #include "iree/compiler/InputConversion/MHLO/Rewriters.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
@@ -362,6 +363,7 @@ struct ConvertMHLOToLinalgOnTensorsPass
 
     // Let the rest fall through.
     target.addLegalDialect<BuiltinDialect>();
+    target.addLegalDialect<IREE::LinalgExt::IREELinalgExtDialect>();
     target.markUnknownOpDynamicallyLegal(isLegallyTypedOp);
 
     if (failed(applyPartialConversion(getOperation(), target,


### PR DESCRIPTION
Unsigned integers result in conversion failures during the mhlo.sort
conversion. Updated the type-convert to handle unsigned/signed for
additional cases.

They are cleaned up during the final conversion to linalg.