### PR TITLE
Adding iree_hal_allocator_t APIs for buffer import/export.

### DIFF
--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -204,15 +204,6 @@ static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
   return status;
 }
 
-static iree_status_t iree_hal_rocm_allocator_wrap_buffer(
-    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "wrapping of external buffers not supported");
-}
-
 static void iree_hal_rocm_allocator_deallocate_buffer(
     iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* base_buffer) {
   iree_hal_rocm_allocator_t* allocator =
@@ -230,6 +221,34 @@ static void iree_hal_rocm_allocator_deallocate_buffer(
   iree_hal_buffer_destroy(base_buffer);
 }
 
+static iree_status_t iree_hal_rocm_allocator_wrap_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "wrapping of external buffers not supported");
+}
+
+static iree_status_t iree_hal_rocm_allocator_import_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_external_buffer_t* external_buffer,
+    iree_hal_buffer_t** out_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "importing from external buffers not supported");
+}
+
+static iree_status_t iree_hal_rocm_allocator_export_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* buffer,
+    iree_hal_external_buffer_type_t requested_type,
+    iree_hal_external_buffer_flags_t requested_flags,
+    iree_hal_external_buffer_t* out_external_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "exporting to external buffers not supported");
+}
+
 static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .destroy = iree_hal_rocm_allocator_destroy,
     .host_allocator = iree_hal_rocm_allocator_host_allocator,
@@ -238,6 +257,8 @@ static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .query_buffer_compatibility =
         iree_hal_rocm_allocator_query_buffer_compatibility,
     .allocate_buffer = iree_hal_rocm_allocator_allocate_buffer,
-    .wrap_buffer = iree_hal_rocm_allocator_wrap_buffer,
     .deallocate_buffer = iree_hal_rocm_allocator_deallocate_buffer,
+    .wrap_buffer = iree_hal_rocm_allocator_wrap_buffer,
+    .import_buffer = iree_hal_rocm_allocator_import_buffer,
+    .export_buffer = iree_hal_rocm_allocator_export_buffer,
 };

--- a/iree/hal/allocator.c
+++ b/iree/hal/allocator.c
@@ -72,57 +72,6 @@ IREE_API_EXPORT void iree_hal_allocator_query_statistics(
   });
 }
 
-IREE_API_EXPORT iree_hal_buffer_compatibility_t
-iree_hal_allocator_query_buffer_compatibility(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_buffer_usage_t intended_usage,
-    iree_device_size_t allocation_size) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  return _VTABLE_DISPATCH(allocator, query_buffer_compatibility)(
-      allocator, memory_type, allowed_usage, intended_usage, allocation_size);
-}
-
-IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage, iree_host_size_t allocation_size,
-    iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  IREE_ASSERT_ARGUMENT(out_buffer);
-  *out_buffer = NULL;
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(allocator, allocate_buffer)(
-      allocator, memory_type, allowed_usage, allocation_size, initial_data,
-      out_buffer);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  IREE_ASSERT_ARGUMENT(out_buffer);
-  *out_buffer = NULL;
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(allocator, wrap_buffer)(
-      allocator, memory_type, allowed_access, allowed_usage, data,
-      data_allocator, out_buffer);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer) {
-  IREE_ASSERT_ARGUMENT(allocator);
-  IREE_ASSERT_ARGUMENT(buffer);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  _VTABLE_DISPATCH(allocator, deallocate_buffer)(allocator, buffer);
-  IREE_TRACE_ZONE_END(z0);
-}
-
 IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
     FILE* file, iree_hal_allocator_t* allocator) {
 #if IREE_STATISTICS_ENABLE
@@ -153,4 +102,89 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
   // No-op.
   return iree_ok_status();
 #endif  // IREE_STATISTICS_ENABLE
+}
+
+IREE_API_EXPORT iree_hal_buffer_compatibility_t
+iree_hal_allocator_query_buffer_compatibility(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_buffer_usage_t intended_usage,
+    iree_device_size_t allocation_size) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  return _VTABLE_DISPATCH(allocator, query_buffer_compatibility)(
+      allocator, memory_type, allowed_usage, intended_usage, allocation_size);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_usage_t allowed_usage, iree_host_size_t allocation_size,
+    iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(allocator, allocate_buffer)(
+      allocator, memory_type, allowed_usage, allocation_size, initial_data,
+      out_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
+    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  _VTABLE_DISPATCH(allocator, deallocate_buffer)(allocator, buffer);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(allocator, wrap_buffer)(
+      allocator, memory_type, allowed_access, allowed_usage, data,
+      data_allocator, out_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
+    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_external_buffer_t* external_buffer,
+    iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(external_buffer);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(allocator, import_buffer)(
+      allocator, memory_type, allowed_access, allowed_usage, external_buffer,
+      out_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_allocator_export_buffer(
+    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer,
+    iree_hal_external_buffer_type_t requested_type,
+    iree_hal_external_buffer_flags_t requested_flags,
+    iree_hal_external_buffer_t* out_external_buffer) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_ASSERT_ARGUMENT(out_external_buffer);
+  memset(out_external_buffer, 0, sizeof(*out_external_buffer));
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(allocator, export_buffer)(
+      allocator, buffer, requested_type, requested_flags, out_external_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }

--- a/iree/hal/cuda/cuda_allocator.c
+++ b/iree/hal/cuda/cuda_allocator.c
@@ -259,15 +259,6 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
   return status;
 }
 
-static iree_status_t iree_hal_cuda_allocator_wrap_buffer(
-    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
-    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "wrapping of external buffers not supported");
-}
-
 static void iree_hal_cuda_allocator_deallocate_buffer(
     iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* base_buffer) {
   iree_hal_cuda_allocator_t* allocator =
@@ -284,6 +275,34 @@ static void iree_hal_cuda_allocator_deallocate_buffer(
   iree_hal_buffer_destroy(base_buffer);
 }
 
+static iree_status_t iree_hal_cuda_allocator_wrap_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "wrapping of external buffers not supported");
+}
+
+static iree_status_t iree_hal_cuda_allocator_import_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_external_buffer_t* external_buffer,
+    iree_hal_buffer_t** out_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "importing from external buffers not supported");
+}
+
+static iree_status_t iree_hal_cuda_allocator_export_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* buffer,
+    iree_hal_external_buffer_type_t requested_type,
+    iree_hal_external_buffer_flags_t requested_flags,
+    iree_hal_external_buffer_t* out_external_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "exporting to external buffers not supported");
+}
+
 static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .destroy = iree_hal_cuda_allocator_destroy,
     .host_allocator = iree_hal_cuda_allocator_host_allocator,
@@ -292,6 +311,8 @@ static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .query_buffer_compatibility =
         iree_hal_cuda_allocator_query_buffer_compatibility,
     .allocate_buffer = iree_hal_cuda_allocator_allocate_buffer,
-    .wrap_buffer = iree_hal_cuda_allocator_wrap_buffer,
     .deallocate_buffer = iree_hal_cuda_allocator_deallocate_buffer,
+    .wrap_buffer = iree_hal_cuda_allocator_wrap_buffer,
+    .import_buffer = iree_hal_cuda_allocator_import_buffer,
+    .export_buffer = iree_hal_cuda_allocator_export_buffer,
 };

--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -383,6 +383,12 @@ static iree_status_t iree_hal_vulkan_vma_allocator_allocate_buffer(
       /*flags=*/0, out_buffer);
 }
 
+static void iree_hal_vulkan_vma_allocator_deallocate_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* base_buffer) {
+  // VMA does the pooling for us so we don't need anything special.
+  iree_hal_buffer_destroy(base_buffer);
+}
+
 static iree_status_t iree_hal_vulkan_vma_allocator_wrap_buffer(
     iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
@@ -393,10 +399,23 @@ static iree_status_t iree_hal_vulkan_vma_allocator_wrap_buffer(
                           "wrapping of external buffers not supported");
 }
 
-static void iree_hal_vulkan_vma_allocator_deallocate_buffer(
-    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* base_buffer) {
-  // VMA does the pooling for us so we don't need anything special.
-  iree_hal_buffer_destroy(base_buffer);
+static iree_status_t iree_hal_vulkan_vma_allocator_import_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_external_buffer_t* external_buffer,
+    iree_hal_buffer_t** out_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "importing from external buffers not supported");
+}
+
+static iree_status_t iree_hal_vulkan_vma_allocator_export_buffer(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* buffer,
+    iree_hal_external_buffer_type_t requested_type,
+    iree_hal_external_buffer_flags_t requested_flags,
+    iree_hal_external_buffer_t* out_external_buffer) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "exporting to external buffers not supported");
 }
 
 namespace {
@@ -408,7 +427,9 @@ const iree_hal_allocator_vtable_t iree_hal_vulkan_vma_allocator_vtable = {
     /*.query_buffer_compatibility=*/
     iree_hal_vulkan_vma_allocator_query_buffer_compatibility,
     /*.allocate_buffer=*/iree_hal_vulkan_vma_allocator_allocate_buffer,
-    /*.wrap_buffer=*/iree_hal_vulkan_vma_allocator_wrap_buffer,
     /*.deallocate_buffer=*/iree_hal_vulkan_vma_allocator_deallocate_buffer,
+    /*.wrap_buffer=*/iree_hal_vulkan_vma_allocator_wrap_buffer,
+    /*.import_buffer=*/iree_hal_vulkan_vma_allocator_import_buffer,
+    /*.export_buffer=*/iree_hal_vulkan_vma_allocator_export_buffer,
 };
 }  // namespace


### PR DESCRIPTION
These are just stubs on all but the heap allocator today.
This will allow us to plumb import/export higher up into frontends
and concurrently start implementing it in backends.

Progress on #3379.