### PR TITLE
Work around LLD breakage by allowing multiple symbol defs.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMAOTTarget.cpp
@@ -303,6 +303,7 @@ class LLVMAOTTargetBackend final : public TargetBackend {
         llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
     queryLibraryFunc->setLinkage(
         llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+    queryLibraryFunc->setDSOLocal(false);
 
     // If linking dynamically, find a suitable linker tool and configure the
     // module with any options that tool requires.
@@ -376,13 +377,22 @@ class LLVMAOTTargetBackend final : public TargetBackend {
     // Fixup visibility from any symbols we may link in - we want to hide all
     // but the query entry point.
     for (auto &func : *llvmModule) {
-      if (func.isDeclaration() ||
-          func.getLinkage() ==
-              llvm::GlobalValue::LinkageTypes::ExternalLinkage) {
+      if (&func == queryLibraryFunc) {
+        // Leave our library query function as public/external so that it is
+        // exported from shared objects and available for linking in static
+        // objects.
+        continue;
+      } else if (func.isDeclaration()) {
+        // Declarations must have their original visibility/linkage; they most
+        // often come from declared llvm builtin ops (llvm.memcpy/etc).
         continue;
       }
       func.setDSOLocal(true);
-      func.setLinkage(llvm::GlobalValue::LinkageTypes::PrivateLinkage);
+      func.setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
+    }
+    for (auto &global : llvmModule->getGlobalList()) {
+      global.setDSOLocal(true);
+      global.setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
     }
 
     SmallVector<Artifact> objectFiles;
@@ -436,7 +446,6 @@ class LLVMAOTTargetBackend final : public TargetBackend {
         bitcodeFile.outputFile->keep();
       }
     }
-
     if (options_.linkStatic) {
       return serializeStaticLibraryExecutable(variantOp, executableBuilder,
                                               libraryName, queryFunctionName,

--- a/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -124,6 +124,11 @@ class EmbeddedLinkerTool : public LinkerTool {
     flags.push_back("--no-undefined");
     flags.push_back("--no-allow-shlib-undefined");
 
+    // Workaround for LLD weirdness on Windows; for some reason we get symbol
+    // conflicts only on Windows starting after
+    // https://github.com/llvm/llvm-project/commit/83d59e05b201760e3f364ff6316301d347cbad95
+    flags.push_back("--allow-multiple-definition");
+
     // Drop unused sections.
     flags.push_back("--gc-sections");
 


### PR DESCRIPTION
Still not fully diagnosed but starting with https://github.com/llvm/llvm-project/commit/83d59e05b201760e3f364ff6316301d347cbad95 the same lld passed the same inputs and flags will succeed on clang/linux and fail on msvc/win with:
```
lld: error: duplicate symbol: iree_hal_executable_library_query
>>> defined at _dynamic_tensor_dispatch_0
>>>            ..\iree-tmp\linking\_dynamic_tensor_dispatch_0-79113a.o:(iree_hal_executable_library_query)
>>> defined at _dynamic_tensor_dispatch_0
>>>            ..\iree-tmp\linking\_dynamic_tensor_dispatch_0-79113a.o:(.text.iree_hal_executable_library_query+0x0)
```

This may be undefined behavior or reliance on implementation-specific CRT behavior and needs to be triaged with the lld team.