### PR TITLE
Decouple destructive update handling from loops.

### DIFF
--- a/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -362,56 +362,102 @@ static LogicalResult analyseScfForOp(scf::ForOp forOp,
   return success();
 }
 
-/// Look for destructive update loop pattern.
-///
-/// ```mlir
-///   %result = scf.for %arg0 = ... iter_args(%arg1 = %init) {
-///     %st = subtensor %arg1[...]
-///
-///     %yieldVal = tensor.insert_slice %val, %arg1[...]
-///     scf.yield %yieldVal
-///   }
-///
-/// `%result`, `%arg1` and `%yieldVal` are all already in the same equivalence
-/// class. `%st` and `%arg` can be added to the same equivalence class even
-/// though `%arg1` has multiple uses. Same is true for `%yieldVal` and
-/// `%arg1`. Here we also verify there are no other "value" uses of
-/// `%arg1`. This might be overly constraining, but we can relax gradually.
-static LogicalResult hasDestructiveUpdateLoopPattern(scf::ForOp forOp,
-                                                     BufferizationPlan &plan) {
-  for (BlockArgument arg : forOp.getRegionIterArgs()) {
-    auto isDestructiveUpdateUses = [&](OpOperand &use) -> bool {
-      Operation *user = use.getOwner();
-      return TypeSwitch<Operation *, bool>(user)
-          .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
-            return sliceOp.source() == arg;
-          })
-          .Case<tensor::InsertSliceOp>(
-              [&](tensor::InsertSliceOp subTensorInsertOp) {
-                return subTensorInsertOp.dest() == arg;
-              })
-          .Case<memref::DimOp, scf::YieldOp, tensor::DimOp>(
-              [&](auto op) { return true; })
-          .Default([&](Operation *op) { return false; });
-    };
-    if (llvm::all_of(arg.getUses(), isDestructiveUpdateUses)) {
-      for (Operation *user : arg.getUsers()) {
-        TypeSwitch<Operation *>(user)
-            .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp sliceOp) {
-              plan.unionSets(sliceOp.source(), sliceOp.result());
-            })
-            .Case<tensor::InsertSliceOp>(
-                [&](tensor::InsertSliceOp subTensorInsertOp) {
-                  if (!isFromReadOnlyTensor(subTensorInsertOp.source(), plan)) {
-                    plan.unionSets(subTensorInsertOp.source(),
-                                   subTensorInsertOp.dest());
-                  }
-                })
-            .Default([&](Operation *) {});
+/// Look for destructive update loop pattern involving `source` using these
+/// constraints
+/// - single tensor.insert_slice operation where `source` is the `dest` operand.
+/// - all `tensor.extract_slice` operations dominate the `tensor.insert_slice`
+/// op.
+static void hasDestructiveUpdatePattern(Value source, BufferizationPlan &plan) {
+  auto isUpdateOp = [](Operation *op) {
+    return isa<tensor::InsertSliceOp, vector::TransferWriteOp>(op);
+  };
+  auto isReadOp = [](Operation *op) {
+    return isa<tensor::ExtractSliceOp, vector::TransferReadOp>(op);
+  };
+  auto getDest = [](Operation *op) -> Value {
+    if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(op)) {
+      return insertSliceOp.dest();
+    }
+    if (auto transferWriteOp = dyn_cast<vector::TransferWriteOp>(op)) {
+      return transferWriteOp.source();
+    }
+    return nullptr;
+  };
+  auto getSource = [](Operation *op) -> Value {
+    if (auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(op)) {
+      return extractSliceOp.source();
+    }
+    if (auto transferReadOp = dyn_cast<vector::TransferReadOp>(op)) {
+      return transferReadOp.source();
+    }
+    return nullptr;
+  };
+  // Source should have only one use that is a tensor::InsertSliceOp as a `dest`
+  // operand.
+  Operation *updateOp = nullptr;
+  for (OpOperand &use : source.getUses()) {
+    auto user = use.getOwner();
+    // Process only update ops uses here.
+    if (!isUpdateOp(user)) continue;
+    // If this is not the first use in a tensor::InsertSliceOp abort.
+    if (updateOp) {
+      return;
+    }
+    // If the use is not the `dest` operand, abort.
+    Value dest = getDest(user);
+    assert(dest && "unable to get dest of update op");
+    if (use.get() != dest) {
+      return;
+    }
+    if (isFromReadOnlyTensor(dest, plan)) {
+      return;
+    }
+    updateOp = user;
+  }
+  // Need to have one use of tensor::InsertSliceOp for destructive update
+  // pattern.
+  if (!updateOp) {
+    return;
+  }
+
+  Block *updateOpBlock = updateOp->getBlock();
+  for (OpOperand &use : source.getUses()) {
+    Operation *user = use.getOwner();
+    if (user == updateOp) continue;
+    if (isReadOp(user)) {
+      Value source = getSource(user);
+      assert(source && "unable to find source from read op");
+      if (source != use.get()) {
+        return;
+      }
+      // The read must dominate the insert op. For now just check its in the
+      // same block and before it.
+      if (user->getBlock() != updateOpBlock ||
+          !user->isBeforeInBlock(updateOp)) {
+        return;
+      }
+      continue;
+    } else if (isa<scf::YieldOp, tensor::DimOp>(user)) {
+      continue;
+    }
+    // Unaccounted for use. Return without doing anything;
+    return;
+  }
+
+  // Found destructive update pattern. Tie all the
+  // - extract_slice source and result
+  // - insert_slice value and dest
+  for (Operation *user : source.getUsers()) {
+    if (auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(user)) {
+      plan.unionSets(extractSliceOp.source(), extractSliceOp.result());
+      continue;
+    }
+    if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(user)) {
+      if (!isFromReadOnlyTensor(insertSliceOp.source(), plan)) {
+        plan.unionSets(insertSliceOp.source(), insertSliceOp.dest());
       }
     }
   }
-  return success();
 }
 
 /// Ties together operands for operand fusion as exists today by reusing buffer
@@ -521,11 +567,16 @@ LogicalResult createTensorEquivalenceClasses(FuncOp funcOp,
         })
         .Case<vector::TransferReadOp>(
             [&](vector::TransferReadOp transferReadOp) {
-              plan.insert(transferReadOp.source());
+              if (transferReadOp.source().getType().isa<RankedTensorType>()) {
+                plan.insert(transferReadOp.source());
+              }
               return success();
             })
         .Case<vector::TransferWriteOp>(
             [&](vector::TransferWriteOp transferWriteOp) {
+              if (!transferWriteOp.result().getType().isa<RankedTensorType>()) {
+                return success();
+              }
               return analyseDestructiveUpdateOp(transferWriteOp, nullptr,
                                                 transferWriteOp.source(),
                                                 transferWriteOp.result(), plan);
@@ -544,13 +595,17 @@ LogicalResult createTensorEquivalenceClasses(FuncOp funcOp,
     plan.dump();
   });
 
-  if (funcOp
-          .walk([&](scf::ForOp forOp) -> WalkResult {
-            return hasDestructiveUpdateLoopPattern(forOp, plan);
-          })
-          .wasInterrupted()) {
-    return failure();
-  }
+  funcOp.walk([&](Operation *updateOp) {
+    if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(updateOp)) {
+      hasDestructiveUpdatePattern(insertSliceOp.dest(), plan);
+      return;
+    }
+    if (auto vectorWriteOp = dyn_cast<vector::TransferWriteOp>(updateOp)) {
+      if (vectorWriteOp.source().getType().isa<RankedTensorType>()) {
+        hasDestructiveUpdatePattern(vectorWriteOp.source(), plan);
+      }
+    }
+  });
   DEBUG_WITH_TYPE(DEBUG_TYPE, {
     llvm::dbgs() << "After Destructive update walk ";
     plan.dump();

--- a/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/LinalgBufferizePass.cpp
@@ -79,10 +79,16 @@ namespace iree_compiler {
 static SmallVector<Value, 4> getDynamicDims(OpBuilder &b, Location loc,
                                             Value v) {
   SmallVector<Value, 4> dynamicDims;
-  for (auto shape : enumerate(v.getType().cast<ShapedType>().getShape())) {
+  Type t = v.getType();
+  for (auto shape : enumerate(t.cast<ShapedType>().getShape())) {
     if (shape.value() == ShapedType::kDynamicSize) {
-      dynamicDims.push_back(
-          b.createOrFold<memref::DimOp>(loc, v, shape.index()));
+      if (t.isa<MemRefType>()) {
+        dynamicDims.push_back(
+            b.createOrFold<memref::DimOp>(loc, v, shape.index()));
+      } else {
+        dynamicDims.push_back(
+            b.createOrFold<tensor::DimOp>(loc, v, shape.index()));
+      }
     }
   }
   return dynamicDims;


### PR DESCRIPTION
Current bufferization heuristics for handling destructive updates
relies on loops. This can be decoupled to look at just the uses of the
`dest` of `tensor.insert_slice`/`vector.transfer_write` operations.