### PR TITLE
Adding iree_wait_source_t and cleaning up iree_wait_handle_t.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -33,6 +33,8 @@ cc_library(
         "string_view.h",
         "time.c",
         "time.h",
+        "wait_source.c",
+        "wait_source.h",
     ],
     hdrs = ["api.h"],
     visibility = ["//visibility:public"],

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -26,9 +26,22 @@ iree_cc_library(
     "string_view.h"
     "time.c"
     "time.h"
+    "wait_source.c"
+    "wait_source.h"
   DEPS
     ::core_headers
     ::tracing
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    core_headers
+  HDRS
+    "alignment.h"
+    "attributes.h"
+    "config.h"
+    "target_platform.h"
   PUBLIC
 )
 
@@ -89,17 +102,6 @@ iree_cc_test(
     ::base
     iree::testing::gtest
     iree::testing::gtest_main
-)
-
-iree_cc_library(
-  NAME
-    core_headers
-  HDRS
-    "alignment.h"
-    "attributes.h"
-    "config.h"
-    "target_platform.h"
-  PUBLIC
 )
 
 iree_cc_library(

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -101,6 +101,7 @@
 #include "iree/base/string_builder.h"  // IWYU pragma: export
 #include "iree/base/string_view.h"     // IWYU pragma: export
 #include "iree/base/time.h"            // IWYU pragma: export
+#include "iree/base/wait_source.h"     // IWYU pragma: export
 
 #ifdef __cplusplus
 extern "C" {

--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -304,6 +304,37 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "wait_handle",
+    srcs = [
+        "wait_handle.c",
+        "wait_handle_epoll.c",
+        "wait_handle_impl.h",
+        "wait_handle_kqueue.c",
+        "wait_handle_null.c",
+        "wait_handle_poll.c",
+        "wait_handle_posix.c",
+        "wait_handle_posix.h",
+        "wait_handle_win32.c",
+    ],
+    hdrs = ["wait_handle.h"],
+    deps = [
+        "//iree/base",
+        "//iree/base:core_headers",
+        "//iree/base:tracing",
+    ],
+)
+
+cc_test(
+    name = "wait_handle_test",
+    srcs = ["wait_handle_test.cc"],
+    deps = [
+        ":wait_handle",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
 #===------------------------------------------------------------------------===#
 # Utilities with thread dependencies
 #===------------------------------------------------------------------------===#
@@ -363,36 +394,6 @@ cc_test(
         ":synchronization",
         ":threading",
         "//iree/base:cc",
-        "//iree/testing:gtest",
-        "//iree/testing:gtest_main",
-    ],
-)
-
-cc_library(
-    name = "wait_handle",
-    srcs = [
-        "wait_handle.c",
-        "wait_handle_epoll.c",
-        "wait_handle_impl.h",
-        "wait_handle_kqueue.c",
-        "wait_handle_poll.c",
-        "wait_handle_posix.c",
-        "wait_handle_posix.h",
-        "wait_handle_win32.c",
-    ],
-    hdrs = ["wait_handle.h"],
-    deps = [
-        "//iree/base",
-        "//iree/base:core_headers",
-        "//iree/base:tracing",
-    ],
-)
-
-cc_test(
-    name = "wait_handle_test",
-    srcs = ["wait_handle_test.cc"],
-    deps = [
-        ":wait_handle",
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
     ],

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -320,6 +320,39 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_library(
+  NAME
+    wait_handle
+  HDRS
+    "wait_handle.h"
+  SRCS
+    "wait_handle.c"
+    "wait_handle_epoll.c"
+    "wait_handle_impl.h"
+    "wait_handle_kqueue.c"
+    "wait_handle_null.c"
+    "wait_handle_poll.c"
+    "wait_handle_posix.c"
+    "wait_handle_posix.h"
+    "wait_handle_win32.c"
+  DEPS
+    iree::base
+    iree::base::core_headers
+    iree::base::tracing
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    wait_handle_test
+  SRCS
+    "wait_handle_test.cc"
+  DEPS
+    ::wait_handle
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
@@ -373,38 +406,6 @@ iree_cc_test(
     ::synchronization
     ::threading
     iree::base::cc
-    iree::testing::gtest
-    iree::testing::gtest_main
-)
-
-iree_cc_library(
-  NAME
-    wait_handle
-  HDRS
-    "wait_handle.h"
-  SRCS
-    "wait_handle.c"
-    "wait_handle_epoll.c"
-    "wait_handle_impl.h"
-    "wait_handle_kqueue.c"
-    "wait_handle_poll.c"
-    "wait_handle_posix.c"
-    "wait_handle_posix.h"
-    "wait_handle_win32.c"
-  DEPS
-    iree::base
-    iree::base::core_headers
-    iree::base::tracing
-  PUBLIC
-)
-
-iree_cc_test(
-  NAME
-    wait_handle_test
-  SRCS
-    "wait_handle_test.cc"
-  DEPS
-    ::wait_handle
     iree::testing::gtest
     iree::testing::gtest_main
 )

--- a/iree/base/internal/wait_handle.c
+++ b/iree/base/internal/wait_handle.c
@@ -25,3 +25,79 @@ iree_status_t iree_wait_handle_wrap_primitive(
 void iree_wait_handle_deinitialize(iree_wait_handle_t* handle) {
   memset(handle, 0, sizeof(*handle));
 }
+
+iree_status_t iree_wait_handle_ctl(iree_wait_source_t wait_source,
+                                   iree_wait_source_command_t command,
+                                   const void* params, void** inout_ptr) {
+  iree_wait_handle_t* wait_handle = (iree_wait_handle_t*)wait_source.storage;
+  switch (command) {
+    case IREE_WAIT_SOURCE_COMMAND_QUERY: {
+      iree_status_code_t* out_wait_status_code = (iree_status_code_t*)inout_ptr;
+      if (iree_wait_handle_is_immediate(*wait_handle)) {
+        // Immediately resolved.
+        *out_wait_status_code = IREE_STATUS_OK;
+        return iree_ok_status();
+      } else {
+        // Poll the handle: a deadline exceeded indicates unresolved.
+        iree_status_t status =
+            iree_wait_one(wait_handle, IREE_TIME_INFINITE_PAST);
+        if (iree_status_is_deadline_exceeded(status)) {
+          *out_wait_status_code = IREE_STATUS_DEFERRED;
+          return iree_status_ignore(status);
+        }
+        return status;
+      }
+    }
+    case IREE_WAIT_SOURCE_COMMAND_WAIT_ONE: {
+      // Wait for the handle.
+      return iree_wait_one(
+          wait_handle,
+          iree_timeout_as_deadline_ns(
+              ((const iree_wait_source_wait_params_t*)params)->timeout));
+    }
+    case IREE_WAIT_SOURCE_COMMAND_EXPORT: {
+      iree_wait_primitive_type_t target_type =
+          ((const iree_wait_source_export_params_t*)params)->target_type;
+      if (target_type != IREE_WAIT_PRIMITIVE_TYPE_ANY &&
+          target_type != wait_handle->type) {
+        return iree_make_status(
+            IREE_STATUS_UNAVAILABLE,
+            "requested wait primitive type %d is unavailable; have %d",
+            (int)target_type, (int)wait_handle->type);
+      }
+      iree_wait_primitive_t* out_wait_primitive =
+          (iree_wait_primitive_t*)inout_ptr;
+      out_wait_primitive->type = wait_handle->type;
+      out_wait_primitive->value = wait_handle->value;
+      return iree_ok_status();
+    }
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unimplemented wait_source command");
+  }
+}
+
+IREE_API_EXPORT iree_status_t iree_wait_source_import(
+    iree_wait_primitive_t wait_primitive, iree_wait_source_t* out_wait_source) {
+  if (iree_wait_primitive_is_immediate(wait_primitive)) {
+    *out_wait_source = iree_wait_source_immediate();
+  } else {
+    iree_wait_handle_t* wait_handle =
+        (iree_wait_handle_t*)out_wait_source->storage;
+    IREE_RETURN_IF_ERROR(iree_wait_handle_wrap_primitive(
+        wait_primitive.type, wait_primitive.value, wait_handle));
+    out_wait_source->ctl = iree_wait_handle_ctl;
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_event_t
+//===----------------------------------------------------------------------===//
+
+iree_wait_source_t iree_event_await(iree_event_t* event) {
+  iree_wait_source_t wait_source;
+  memcpy(wait_source.storage, event, sizeof(*event));
+  wait_source.ctl = iree_wait_handle_ctl;
+  return wait_source;
+}

--- a/iree/base/internal/wait_handle_null.c
+++ b/iree/base/internal/wait_handle_null.c
@@ -1,0 +1,92 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// clang-format off: must be included before all other headers.
+#include "iree/base/internal/wait_handle_impl.h"
+// clang-format on
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/wait_handle.h"
+#include "iree/base/target_platform.h"
+
+#if IREE_WAIT_API == IREE_WAIT_API_NULL
+
+//===----------------------------------------------------------------------===//
+// iree_wait_primitive_* raw calls
+//===----------------------------------------------------------------------===//
+
+void iree_wait_handle_close(iree_wait_handle_t* handle) {
+  iree_wait_handle_deinitialize(handle);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_wait_set_t
+//===----------------------------------------------------------------------===//
+
+struct iree_wait_set_t {
+  int reserved;
+};
+
+iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
+                                     iree_allocator_t allocator,
+                                     iree_wait_set_t** out_set) {
+  *out_set = NULL;
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "wait primitives not available on this platform");
+}
+
+void iree_wait_set_free(iree_wait_set_t* set) {}
+
+iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
+                                   iree_wait_handle_t handle) {
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "wait primitives not available on this platform");
+}
+
+void iree_wait_set_erase(iree_wait_set_t* set, iree_wait_handle_t handle) {}
+
+void iree_wait_set_clear(iree_wait_set_t* set) {}
+
+iree_status_t iree_wait_all(iree_wait_set_t* set, iree_time_t deadline_ns) {
+  return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                          "wait primitives not available on this platform");
+}
+
+iree_status_t iree_wait_any(iree_wait_set_t* set, iree_time_t deadline_ns,
+                            iree_wait_handle_t* out_wake_handle) {
+  return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                          "wait primitives not available on this platform");
+}
+
+iree_status_t iree_wait_one(iree_wait_handle_t* handle,
+                            iree_time_t deadline_ns) {
+  return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                          "wait primitives not available on this platform");
+}
+
+//===----------------------------------------------------------------------===//
+// iree_event_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_event_initialize(bool initial_state,
+                                    iree_event_t* out_event) {
+  memset(out_event, 0, sizeof(*out_event));
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "events not available on this platform");
+}
+
+void iree_event_deinitialize(iree_event_t* event) {}
+
+void iree_event_set(iree_event_t* event) {}
+
+void iree_event_reset(iree_event_t* event) {}
+
+#endif  // IREE_WAIT_API == IREE_WAIT_API_NULL

--- a/iree/base/internal/wait_handle_posix.c
+++ b/iree/base/internal/wait_handle_posix.c
@@ -9,7 +9,7 @@
 #include "iree/base/tracing.h"
 
 // NOTE: we could be tighter here, but we today only have win32 or not-win32.
-#if !defined(IREE_PLATFORM_WINDOWS)
+#if IREE_WAIT_API != IREE_WAIT_API_NULL && IREE_WAIT_API != IREE_WAIT_API_WIN32
 
 #include <errno.h>
 #include <fcntl.h>
@@ -76,7 +76,7 @@ static iree_status_t iree_wait_primitive_create_pipe(
   if (initial_state) {
     iree_status_t status = iree_wait_primitive_write(out_handle);
     if (!iree_status_is_ok(status)) {
-      iree_wait_primitive_close(out_handle);
+      iree_wait_handle_close(out_handle);
       return status;
     }
   }
@@ -100,7 +100,7 @@ iree_status_t iree_wait_primitive_create_native(
 #endif  // IREE_HAVE_WAIT_TYPE_*
 }
 
-void iree_wait_primitive_close_fd(int fd) {
+static void iree_wait_handle_close_fd(int fd) {
   int rv;
   IREE_SYSCALL(rv, close(fd));
   // NOTE: we could fail to close if the handle is invalid/already closed/etc.
@@ -109,23 +109,23 @@ void iree_wait_primitive_close_fd(int fd) {
   // fine to ignore the error.
 }
 
-void iree_wait_primitive_close(iree_wait_handle_t* handle) {
+void iree_wait_handle_close(iree_wait_handle_t* handle) {
   switch (handle->type) {
 #if defined(IREE_HAVE_WAIT_TYPE_EVENTFD)
     case IREE_WAIT_PRIMITIVE_TYPE_EVENT_FD: {
-      iree_wait_primitive_close_fd(handle->value.event.fd);
+      iree_wait_handle_close_fd(handle->value.event.fd);
       break;
     }
 #endif  // IREE_HAVE_WAIT_TYPE_EVENTFD
 #if defined(IREE_HAVE_WAIT_TYPE_SYNC_FILE)
     case IREE_WAIT_PRIMITIVE_TYPE_SYNC_FILE:
-      iree_wait_primitive_close_fd(handle->value.sync_file.fd);
+      iree_wait_handle_close_fd(handle->value.sync_file.fd);
       break;
 #endif  // IREE_HAVE_WAIT_TYPE_SYNC_FILE
 #if defined(IREE_HAVE_WAIT_TYPE_PIPE)
     case IREE_WAIT_PRIMITIVE_TYPE_PIPE: {
-      iree_wait_primitive_close_fd(handle->value.pipe.read_fd);
-      iree_wait_primitive_close_fd(handle->value.pipe.write_fd);
+      iree_wait_handle_close_fd(handle->value.pipe.read_fd);
+      iree_wait_handle_close_fd(handle->value.pipe.write_fd);
       break;
     }
 #endif  // IREE_HAVE_WAIT_TYPE_PIPE
@@ -268,7 +268,7 @@ iree_status_t iree_event_initialize(bool initial_state,
 }
 
 void iree_event_deinitialize(iree_event_t* event) {
-  iree_wait_primitive_close(event);
+  iree_wait_handle_close(event);
 }
 
 void iree_event_set(iree_event_t* event) {
@@ -279,4 +279,4 @@ void iree_event_reset(iree_event_t* event) {
   IREE_IGNORE_ERROR(iree_wait_primitive_clear(event));
 }
 
-#endif  // !IREE_PLATFORM_WINDOWS
+#endif  // IREE_WAIT_API != IREE_WAIT_API_NULL || IREE_WAIT_API_WIN32

--- a/iree/base/internal/wait_handle_posix.h
+++ b/iree/base/internal/wait_handle_posix.h
@@ -11,7 +11,7 @@
 #define IREE_BASE_INTERNAL_WAIT_HANDLE_POSIX_H_
 
 // NOTE: we could be tighter here, but we today only have win32 or not-win32.
-#if !defined(IREE_PLATFORM_WINDOWS)
+#if IREE_WAIT_API != IREE_WAIT_API_NULL && IREE_WAIT_API != IREE_WAIT_API_WIN32
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +34,7 @@ extern "C" {
 
 // Creates a wait primitive of the type native to the current platform.
 // May fail if resources are exhausted or wait handles are not supported.
-// The handle must be closed with iree_wait_primitive_close to release its
+// The handle must be closed with iree_wait_handle_close to release its
 // resources.
 iree_status_t iree_wait_primitive_create_native(bool initial_state,
                                                 iree_wait_handle_t* out_handle);
@@ -42,7 +42,7 @@ iree_status_t iree_wait_primitive_create_native(bool initial_state,
 // Closes an existing handle from iree_wait_primitive_create_native or
 // iree_wait_primitive_clone. Must not be called while there are any waiters on
 // the handle.
-void iree_wait_primitive_close(iree_wait_handle_t* handle);
+void iree_wait_handle_close(iree_wait_handle_t* handle);
 
 // Returns true if the two handles are identical in representation.
 // Note that two unique handles may point to the same underlying primitive
@@ -73,6 +73,6 @@ iree_status_t iree_wait_primitive_clear(iree_wait_handle_t* handle);
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // !IREE_PLATFORM_WINDOWS
+#endif  // !IREE_WAIT_API_NULL && !IREE_WAIT_API_WIN32
 
 #endif  // IREE_BASE_INTERNAL_WAIT_HANDLE_POSIX_H_

--- a/iree/base/internal/wait_handle_win32.c
+++ b/iree/base/internal/wait_handle_win32.c
@@ -17,7 +17,7 @@
 #include "iree/base/internal/wait_handle.h"
 #include "iree/base/target_platform.h"
 
-#if defined(IREE_PLATFORM_WINDOWS)
+#if IREE_WAIT_API == IREE_WAIT_API_WIN32
 
 #include "iree/base/tracing.h"
 
@@ -35,7 +35,7 @@ static_assert(
 
 // Clones a wait handle such that both the |source_handle| and new
 // |out_target_handle| both reference the same wait primitive. The handle must
-// be closed with iree_wait_primitive_close as if it had been created.
+// be closed with iree_wait_handle_close as if it had been created.
 static iree_status_t iree_wait_primitive_clone(
     iree_wait_handle_t* source_handle, iree_wait_handle_t* out_target_handle) {
   if (source_handle->type != IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE) {
@@ -60,7 +60,7 @@ static iree_status_t iree_wait_primitive_clone(
 // Closes an existing handle that was either created manually or via
 // iree_wait_primitive_clone. Must not be called while there are any waiters on
 // the handle.
-static void iree_wait_primitive_close(iree_wait_handle_t* handle) {
+void iree_wait_handle_close(iree_wait_handle_t* handle) {
   if (IREE_LIKELY(handle->value.win32.handle != 0)) {
     CloseHandle((HANDLE)handle->value.win32.handle);
   }
@@ -439,7 +439,7 @@ iree_status_t iree_event_initialize(bool initial_state,
 }
 
 void iree_event_deinitialize(iree_event_t* event) {
-  iree_wait_primitive_close(event);
+  iree_wait_handle_close(event);
 }
 
 void iree_event_set(iree_event_t* event) {
@@ -450,4 +450,4 @@ void iree_event_reset(iree_event_t* event) {
   ResetEvent((HANDLE)event->value.win32.handle);
 }
 
-#endif  // IREE_PLATFORM_WINDOWS
+#endif  // IREE_WAIT_API == IREE_WAIT_API_WIN32

--- a/iree/base/wait_source.c
+++ b/iree/base/wait_source.c
@@ -1,0 +1,74 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/wait_source.h"
+
+#include "iree/base/assert.h"
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// iree_wait_source_t
+//===----------------------------------------------------------------------===//
+
+// NOTE: iree_wait_source_import lives in iree/base/internal/wait_handle.c
+// for now as that lets us compile out native wait handle support at a coarse
+// level.
+
+IREE_API_EXPORT iree_status_t iree_wait_source_export(
+    iree_wait_source_t wait_source, iree_wait_primitive_type_t target_type,
+    iree_timeout_t timeout, iree_wait_primitive_t* out_wait_primitive) {
+  IREE_ASSERT_ARGUMENT(out_wait_primitive);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+  if (IREE_LIKELY(wait_source.ctl)) {
+    const iree_wait_source_export_params_t params = {
+        .target_type = target_type,
+        .timeout = timeout,
+    };
+    status = wait_source.ctl(wait_source, IREE_WAIT_SOURCE_COMMAND_EXPORT,
+                             &params, (void**)out_wait_primitive);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_wait_source_query(
+    iree_wait_source_t wait_source, iree_status_code_t* out_wait_status_code) {
+  IREE_ASSERT_ARGUMENT(out_wait_status_code);
+  *out_wait_status_code = IREE_STATUS_OK;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+  if (IREE_LIKELY(wait_source.ctl)) {
+    status = wait_source.ctl(wait_source, IREE_WAIT_SOURCE_COMMAND_QUERY, NULL,
+                             (void**)out_wait_status_code);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_wait_source_wait_one(
+    iree_wait_source_t wait_source, iree_timeout_t timeout) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Capture time as an absolute value as we don't know when it's going to run.
+  iree_convert_timeout_to_absolute(&timeout);
+
+  iree_status_t status = iree_ok_status();
+  if (IREE_LIKELY(wait_source.ctl)) {
+    const iree_wait_source_wait_params_t params = {
+        .timeout = timeout,
+    };
+    status = wait_source.ctl(wait_source, IREE_WAIT_SOURCE_COMMAND_WAIT_ONE,
+                             &params, NULL);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/iree/base/wait_source.h
+++ b/iree/base/wait_source.h
@@ -1,0 +1,287 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_WAIT_SOURCE_H_
+#define IREE_BASE_WAIT_SOURCE_H_
+
+#include "iree/base/attributes.h"
+#include "iree/base/status.h"
+#include "iree/base/target_platform.h"
+#include "iree/base/time.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_wait_primitive_t
+//===----------------------------------------------------------------------===//
+
+#if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+// Bare metal/no synchronization available; wait handles are no-oped.
+#define IREE_WAIT_HANDLE_DISABLED 1
+#elif defined(IREE_PLATFORM_WINDOWS)
+// Though Windows can support pipes no one uses them so for simplicity we only
+// exposes HANDLEs.
+#define IREE_HAVE_WAIT_TYPE_WIN32_HANDLE 1
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+// Treat Android and modern linux as (mostly) the same.
+#define IREE_HAVE_WAIT_TYPE_EVENTFD 1
+#define IREE_HAVE_WAIT_TYPE_PIPE 1
+#else
+// BSD/Darwin/etc all have pipe.
+#define IREE_HAVE_WAIT_TYPE_PIPE 1
+#endif  // IREE_PLATFORM_*
+
+// TODO(benvanik): see if we can get sync file on linux too:
+#if defined(IREE_PLATFORM_ANDROID)
+#define IREE_HAVE_WAIT_TYPE_SYNC_FILE 1
+#endif  // IREE_PLATFORM_ANDROID
+
+// Specifies the type of a system wait primitive.
+// Enums that are unavailable on a platform are still present to allow for
+// platform-independent code to still route wait primitives but actually using
+// them will fail.
+enum iree_wait_primitive_type_bits_t {
+  // Empty handle; immediately resolved.
+  IREE_WAIT_PRIMITIVE_TYPE_NONE = 0u,
+
+  // Android/Linux eventfd handle.
+  // These are akin to pipe() but require only a single handle and have
+  // significantly lower overhead (equivalent if not slightly better than
+  // pthreads condvars).
+  //
+  // eventfds support acting as both semaphores and auto reset events.
+  //
+  // More information:
+  // http://man7.org/linux/man-pages/man2/eventfd.2.html
+  IREE_WAIT_PRIMITIVE_TYPE_EVENT_FD = 1u,
+
+  // Android/Linux sync_file handle (aka 'sync fence').
+  // The handle is allocated indirectly by the device driver via the
+  // <linux/sync_file.h> API. It may be waited upon with poll(), select(), or
+  // epoll() and must be closed with close() when no longer required. If
+  // waiting on multiple sync_files the caller should first merge them
+  // together.
+  //
+  // A sync_file must only be used as fences (one-shot manual reset events).
+  //
+  // More information:
+  // https://www.kernel.org/doc/Documentation/sync_file.txt
+  // https://lwn.net/Articles/702339/
+  // https://source.android.com/devices/graphics/implement-vsync#explicit_synchronization
+  // https://developer.android.com/ndk/reference/group/sync
+  IREE_WAIT_PRIMITIVE_TYPE_SYNC_FILE = 2u,
+
+  // Android/Linux/iOS-compatible POSIX pipe handle.
+  // Two handles are generated: one for transmitting and one for receiving.
+  //
+  // More information:
+  // http://man7.org/linux/man-pages/man2/pipe.2.html
+  IREE_WAIT_PRIMITIVE_TYPE_PIPE = 3u,
+
+  // Windows HANDLE type.
+  // The HANDLE may represent a thread, event, semaphore, timer, etc.
+  //
+  // More information:
+  // https://docs.microsoft.com/en-us/windows/win32/sysinfo/object-categories
+  // https://docs.microsoft.com/en-us/windows/win32/sync/using-event-objects
+  IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE = 4u,
+
+  // Placeholder for wildcard queries of primitive types.
+  // On an export request this indicates that the source may export any type it
+  // can.
+  IREE_WAIT_PRIMITIVE_TYPE_ANY = 0xFFu,
+};
+typedef uint8_t iree_wait_primitive_type_t;
+
+// A handle value whose behavior is defined by the iree_wait_primitive_type_t.
+// Only the primitives available on a platform are compiled in as syscalls and
+// other associated operations that act on them aren't available anyway.
+typedef union {
+  int reserved;  // to avoid zero-sized unions
+#if defined(IREE_HAVE_WAIT_TYPE_EVENTFD)
+  // IREE_WAIT_PRIMITIVE_TYPE_EVENT_FD
+  struct {
+    int fd;
+  } event;
+#endif  // IREE_HAVE_WAIT_TYPE_EVENTFD
+#if defined(IREE_HAVE_WAIT_TYPE_SYNC_FILE)
+  // IREE_WAIT_PRIMITIVE_TYPE_SYNC_FILE
+  struct {
+    int fd;
+  } sync_file;
+#endif  // IREE_HAVE_WAIT_TYPE_SYNC_FILE
+#if defined(IREE_HAVE_WAIT_TYPE_PIPE)
+  // IREE_WAIT_PRIMITIVE_TYPE_PIPE
+  union {
+    struct {
+      int read_fd;
+      int write_fd;
+    };
+    int fds[2];
+  } pipe;
+#endif  // IREE_HAVE_WAIT_TYPE_PIPE
+#if defined(IREE_HAVE_WAIT_TYPE_WIN32_HANDLE)
+  // IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE
+  struct {
+    uintptr_t handle;
+  } win32;
+#endif  // IREE_HAVE_WAIT_TYPE_WIN32_HANDLE
+} iree_wait_primitive_value_t;
+
+// A (type, value) pair describing a system wait primitive handle.
+typedef struct iree_wait_primitive_t {
+  iree_wait_primitive_type_t type;
+  iree_wait_primitive_value_t value;
+} iree_wait_primitive_t;
+
+// Returns a wait primitive with the given (|type|, |value|).
+static inline iree_wait_primitive_t iree_make_wait_primitive(
+    iree_wait_primitive_type_t type, iree_wait_primitive_value_t value) {
+  iree_wait_primitive_t primitive = {type, value};
+  return primitive;
+}
+
+// Returns true if the |wait_primitive| is resolved immediately (empty).
+static inline bool iree_wait_primitive_is_immediate(
+    iree_wait_primitive_t wait_primitive) {
+  return wait_primitive.type == IREE_WAIT_PRIMITIVE_TYPE_NONE;
+}
+
+//===----------------------------------------------------------------------===//
+// iree_wait_source_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_wait_source_t iree_wait_source_t;
+
+// Controls the behavior of an iree_wait_source_ctl_fn_t callback function.
+typedef enum iree_wait_source_command_e {
+  // Queries the state of the wait source.
+  // Returns IREE_STATUS_DEFERRED if the wait source is not yet resolved.
+  //
+  // iree_wait_source_ctl_fn_t:
+  //   params: unused
+  //   inout_ptr: iree_status_code_t* out_wait_status_code
+  IREE_WAIT_SOURCE_COMMAND_QUERY = 0u,
+
+  // Tries to wait for the wait source to resolve.
+  // Returns IREE_STATUS_DEFERRED if the wait source does not support waiting.
+  //
+  // iree_wait_source_ctl_fn_t:
+  //   params: iree_wait_source_wait_params_t
+  //   inout_ptr: unused
+  IREE_WAIT_SOURCE_COMMAND_WAIT_ONE,
+
+  // Exports the wait source to a system wait handle.
+  //
+  // iree_wait_source_ctl_fn_t:
+  //   params: iree_wait_source_export_params_t
+  //   inout_ptr: iree_wait_primitive_t* out_wait_primitive
+  IREE_WAIT_SOURCE_COMMAND_EXPORT,
+} iree_wait_source_command_t;
+
+// Parameters for IREE_WAIT_SOURCE_COMMAND_WAIT_ONE.
+typedef struct iree_wait_source_wait_params_t {
+  // Timeout after which the wait will return even if the wait source is not
+  // resolved with IREE_STATUS_DEADLINE_EXCEEDED.
+  iree_timeout_t timeout;
+} iree_wait_source_wait_params_t;
+
+// Parameters for IREE_WAIT_SOURCE_COMMAND_EXPORT.
+typedef struct iree_wait_source_export_params_t {
+  // Indicates the target handle type of the export operation.
+  iree_wait_primitive_type_t target_type;
+  // Timeout after which the export will return even if the wait source is not
+  // yet available for export with IREE_STATUS_DEADLINE_EXCEEDED.
+  iree_timeout_t timeout;
+} iree_wait_source_export_params_t;
+
+// Function pointer for an iree_wait_source_t control function.
+// |command| provides the operation to perform. Optionally some commands may use
+// |params| to pass additional operation-specific parameters. |inout_ptr| usage
+// is defined by each operation.
+typedef iree_status_t(IREE_API_PTR* iree_wait_source_ctl_fn_t)(
+    iree_wait_source_t wait_source, iree_wait_source_command_t command,
+    const void* params, void** inout_ptr);
+
+// A wait source instance representing some future point in time.
+// Wait sources are promises for a system native wait handle that allow for
+// cheaper queries and waits when the full system wait path is not required.
+//
+// Wait sources may have user-defined implementations or come from system wait
+// handles via iree_wait_source_import.
+typedef struct iree_wait_source_t {
+  union {
+    struct {
+      // Control function data.
+      void* self;
+      // Implementation-defined data identifying the point in time.
+      uint64_t data;
+    };
+    // Large enough to store an iree_wait_handle_t, used when importing a
+    // system wait handle into a wait source.
+    uint64_t storage[2];
+  };
+  // ioctl-style control function servicing wait source commands.
+  // See iree_wait_source_command_t for more information.
+  iree_wait_source_ctl_fn_t ctl;
+} iree_wait_source_t;
+
+// Returns a wait source that will always immediately return as resolved.
+static inline iree_wait_source_t iree_wait_source_immediate(void) {
+  iree_wait_source_t v = {{{NULL, 0ull}}, NULL};
+  return v;
+}
+
+// Imports a system |wait_primitive| into a wait source in |out_wait_source|.
+// Ownership of the wait handle remains will the caller and it must remain valid
+// for the duration the wait source is in use.
+IREE_API_EXPORT iree_status_t iree_wait_source_import(
+    iree_wait_primitive_t wait_primitive, iree_wait_source_t* out_wait_source);
+
+// Exports a |wait_source| to a system wait primitive in |out_wait_primitive|.
+// If the wait source is already resolved then the wait handle will be set to
+// immediate and callers can check it with iree_wait_primitive_is_immediate.
+// If the wait source resolved with a failure then the error status will be
+// returned. The returned wait handle is owned by the wait source and will
+// remain valid for the lifetime of the wait source.
+//
+// Exporting may require a blocking operation and |timeout| can be used to
+// limit its duration.
+//
+// Returns IREE_STATUS_UNAVAILABLE if the requested primitive |target_type| is
+// unavailable on the current platform or from the given wait source.
+// Passing IREE_WAIT_PRIMITIVE_TYPE_ANY will allow the implementation to return
+// any primitive that it can.
+IREE_API_EXPORT iree_status_t iree_wait_source_export(
+    iree_wait_source_t wait_source, iree_wait_primitive_type_t target_type,
+    iree_timeout_t timeout, iree_wait_primitive_t* out_wait_primitive);
+
+// Queries the state of a |wait_source| without waiting.
+// |out_wait_status_code| will indicate the status of the source while the
+// returned value indicates the status of the query. |out_wait_status_code| will
+// be set to IREE_STATUS_DEFERRED if the wait source has not yet resolved and
+// IREE_STATUS_OK otherwise.
+IREE_API_EXPORT iree_status_t iree_wait_source_query(
+    iree_wait_source_t wait_source, iree_status_code_t* out_wait_status_code);
+
+// Blocks the caller and waits for a |wait_source| to resolve.
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if |timeout| is reached before the
+// wait source resolves. If the wait source resolved with a failure then the
+// error status will be returned.
+IREE_API_EXPORT iree_status_t iree_wait_source_wait_one(
+    iree_wait_source_t wait_source, iree_timeout_t timeout);
+
+// TODO(benvanik): iree_wait_source_wait_any/all: allow multiple wait sources
+// that share the same control function. The implementation can decide if it
+// wants to coalesce them or not.
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_WAIT_SOURCE_H_


### PR DESCRIPTION
Wait sources add an abstraction between the platform primitives such
that core code can pass them around. Wait sources can be implemented
with the platform wait handles or with custom types (such as HAL
semaphores) and enable deferred handle creation. In this way we can
pass around the wait sources and only if/when the consumer of them
wants to perform a system wait will we need to materialize the wait
handle.

This also works to move more out from behind the IREE_ENABLE_THREADING
flag: wait handles are not related to threading.