### PR TITLE
Add mhlo-to-mhlo decomposition of rank-0 mhlo.scatter

### DIFF
--- a/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -595,6 +595,96 @@ class TransposeReshapeGenericDotGeneral
   }
 };
 
+
+class ScatterRank0Value : public OpRewritePattern<mhlo::ScatterOp> {
+ public:
+  using OpRewritePattern<mhlo::ScatterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::ScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    auto operand = op.operand();
+    auto indices = op.scatter_indices();
+    auto updates = op.updates();
+
+    auto operandTy = operand.getType().dyn_cast<RankedTensorType>();
+    auto indicesTy = indices.getType().dyn_cast<RankedTensorType>();
+    auto updatesTy = updates.getType().dyn_cast<RankedTensorType>();
+    if (!operandTy || !indicesTy || !updatesTy) return failure();
+
+    if (indicesTy.getRank() != 1 || !indicesTy.hasStaticShape() || updatesTy.getRank() != 0)
+      return failure();
+
+    auto dimNumbers = op.scatter_dimension_numbers();
+
+    // We only have one dim for shape so this should be 0.
+    if (dimNumbers.getIndexVectorDim() != 0) return failure();
+
+    // Require canonicalize scatter order.
+    // TODO(suderman): Transpose to canonicalized order.
+    for (auto en : llvm::enumerate(dimNumbers.getScatterDimsToOperandDims())) {
+      if (en.index() != en.value()) return failure();
+    }
+
+    // Inserted window dims should be in order. Technically we just need to
+    // check they are all contained.
+    for (auto en : llvm::enumerate(dimNumbers.getInsertedWindowDims())) {
+      if (en.index() != en.value()) return failure();
+    }
+
+    // This should be empty
+    if (dimNumbers.getUpdateWindowDims().size() != 0) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+
+    // Reshape indices to add the implicit 1x out front.
+    llvm::SmallVector<int64_t> newIndicesShape;
+    llvm::SmallVector<Value> newIndicesDynDims;
+    newIndicesShape.push_back(1);
+    for (auto it : llvm::enumerate(indicesTy.getShape())) {
+      auto dim = it.value();
+      newIndicesShape.push_back(dim);
+    }
+
+    Value reshapedIndices = rewriter.create<mhlo::ReshapeOp>(
+      loc, RankedTensorType::get(newIndicesShape, indicesTy.getElementType()),
+      indices);
+
+    Value reshapedUpdates = rewriter.create<mhlo::ReshapeOp>(
+      loc, RankedTensorType::get({1}, updatesTy.getElementType()),
+      updates);
+
+    auto iota = [](llvm::SmallVector<int64_t>& vec, int start, int end) {
+      for (int i = start; i < end; i++) {
+        vec.push_back(i);
+      }
+    };
+
+    SmallVector<int64_t> updateWindowDims;
+
+    SmallVector<int64_t> insertedWindowDims;
+    iota(insertedWindowDims, 0, operandTy.getRank());
+
+    SmallVector<int64_t> scatterDimsToOperandDims;
+    iota(scatterDimsToOperandDims, 0, operandTy.getRank());
+    auto newDimNumbers = mhlo::ScatterDimensionNumbersAttr::get(
+      op.getContext(), updateWindowDims, insertedWindowDims,
+      scatterDimsToOperandDims, /*indexVectorDim=*/1);
+
+    auto newScatter = rewriter.create<mhlo::ScatterOp>(
+      loc, op.getType(), operand, reshapedIndices, reshapedUpdates,
+      newDimNumbers, op.indices_are_sorted(), op.unique_indices());
+
+    Region& region = newScatter.update_computation();
+    rewriter.cloneRegionBefore(op.update_computation(), region, region.end());
+
+    rewriter.replaceOp(op, newScatter.getResult());
+
+    return success();
+  }
+};
+
 // Generates Gaussian noise with uniform random generator based on Box-Muller
 // transform.
 class ExpandRngNormal : public OpRewritePattern<mhlo::RngNormalOp> {
@@ -781,7 +871,8 @@ struct MHLOToMHLOPreprocessingPass
     mhlo::PopulateComplexLoweringPatterns(context, &patterns);
     mhlo::PopulateGatherToTorchIndexSelectPatterns(context, &patterns);
     patterns.insert<ExtractReduceWindowOpPaddingAttributes,
-                    AdjustDepthwiseFilterShape, ExpandRngNormal>(context);
+                    AdjustDepthwiseFilterShape, ScatterRank0Value,
+                    ExpandRngNormal>(context);
 
     // dot_general canoncalization patterns.
     mhlo::PopulateGeneralDotOpLoweringPatterns(&patterns, context);

--- a/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -79,7 +79,6 @@ static Value getF32Const(ImplicitLocOpBuilder b, ArrayRef<int64_t> shapes,
       .getResult();
 }
 
-
 class ExtractConvOpPaddingAttributes : public OpRewritePattern<mhlo::ConvOp> {
  public:
   using OpRewritePattern<mhlo::ConvOp>::OpRewritePattern;
@@ -654,10 +653,13 @@ class ScatterRank0Value : public OpRewritePattern<mhlo::ScatterOp> {
     Value reshapedUpdates = rewriter.create<mhlo::ReshapeOp>(
         loc, RankedTensorType::get({1}, updatesTy.getElementType()), updates);
 
-    SmallVector<int64_t> insertedWindowDims = llvm::to_vector<4>(llvm::seq<int64_t>(0, operandTy.getRank()));
-    SmallVector<int64_t> scatterDimsToOperandDims = llvm::to_vector<4>(llvm::seq<int64_t>(0, operandTy.getRank()));
+    SmallVector<int64_t> insertedWindowDims =
+        llvm::to_vector<4>(llvm::seq<int64_t>(0, operandTy.getRank()));
+    SmallVector<int64_t> scatterDimsToOperandDims =
+        llvm::to_vector<4>(llvm::seq<int64_t>(0, operandTy.getRank()));
     auto newDimNumbers = mhlo::ScatterDimensionNumbersAttr::get(
-        op.getContext(), {}, insertedWindowDims, scatterDimsToOperandDims, /*indexVectorDim=*/1);
+        op.getContext(), {}, insertedWindowDims, scatterDimsToOperandDims,
+        /*indexVectorDim=*/1);
 
     auto newScatter = rewriter.create<mhlo::ScatterOp>(
         loc, op.getType(), operand, reshapedIndices, reshapedUpdates,

--- a/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
@@ -322,3 +322,19 @@ func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<3x5xf32> {
 // CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[CON]][0] [15] [1] : tensor<16xf32> to tensor<15xf32>
 // CHECK:         %[[RES:.+]] = "mhlo.reshape"(%[[SLICE]]) : (tensor<15xf32>) -> tensor<3x5xf32>
 // CHECK:         return %[[RES]]
+
+// -----
+
+func @scatter_rank0(%arg0: tensor<5x5xi32>, %arg1: tensor<2xi32>, %arg2: tensor<i32>) -> tensor<5x5xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {indices_are_sorted = true, scatter_dimension_numbers = #mhlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = true} : (tensor<5x5xi32>, tensor<2xi32>, tensor<i32>) -> tensor<5x5xi32>
+  return %0 : tensor<5x5xi32>
+}
+
+// CHECK-LABEL: func @scatter_rank0
+// CHECK-DAG: %[[RE_I:.+]] = "mhlo.reshape"(%arg1) : (tensor<2xi32>) -> tensor<1x2xi32>
+// CHECK-DAG: %[[RE_U:.+]] = "mhlo.reshape"(%arg2) : (tensor<i32>) -> tensor<1xi32>
+// CHECK:     %[[SCATTER:.+]] = "mhlo.scatter"(%arg0, %[[RE_I]], %[[RE_U]])
+// CHECK:       "mhlo.return"(%arg4)


### PR DESCRIPTION
Adding reshapes to indices and updates allows the default mhlo-to-linalg
lowering to handle the rank-0 use.