### PR TITLE
Enable CUDA release builds.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -70,7 +70,7 @@ jobs:
       # Note that on Linux, we run under docker with an altered path.
       # Note that on Windows, we need to configure the compiler api project to
       # but its CMake build directory on a short path to avoid path overflow.
-      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output CMAKE_GENERATOR=Ninja"
+      CIBW_ENVIRONMENT_LINUX: "REPO_DIR=/project/main_checkout BINDIST_DIR=/output CMAKE_GENERATOR=Ninja IREE_TARGET_BACKEND_CUDA=ON"
       CIBW_ENVIRONMENT_MACOS: "REPO_DIR=${{ github.workspace }}/main_checkout CMAKE_GENERATOR=Ninja"
       CIBW_ENVIRONMENT_WINDOWS: "REPO_DIR='${{ github.workspace }}\\main_checkout' CMAKE_GENERATOR=Ninja IREE_COMPILER_API_CMAKE_BUILD_DIR=D:/b"
 

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -124,6 +124,16 @@ def build_main_dist():
   # Clean up install and build trees.
   shutil.rmtree(INSTALL_DIR, ignore_errors=True)
   remove_cmake_cache()
+  extra_cmake_flags = []
+
+  # Enable CUDA if on platforms where we expect to have the deps and produce
+  # such binaries.
+  if platform.system() == "Linux":
+    print("*** Enabling CUDA compiler target and runtime ***")
+    extra_cmake_flags.extend([
+        "-DIREE_TARGET_BACKEND_CUDA=ON",
+        "-DIREE_HAL_DRIVER_CUDA=ON",
+    ])
 
   # CMake configure.
   print("*** Configuring ***")
@@ -131,12 +141,13 @@ def build_main_dist():
       sys.executable,
       CMAKE_CI_SCRIPT,
       f"-B{BUILD_DIR}",
+      "--log-level=VERBOSE",
       f"-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}",
       f"-DCMAKE_BUILD_TYPE=Release",
       f"-DIREE_BUILD_COMPILER=ON",
       f"-DIREE_BUILD_PYTHON_BINDINGS=OFF",
       f"-DIREE_BUILD_SAMPLES=OFF",
-  ],
+  ] + extra_cmake_flags,
                  check=True)
 
   print("*** Building ***")
@@ -192,12 +203,21 @@ def build_py_runtime_pkg(instrumented: bool = False):
         f"-DIREE_BUILD_TRACY=ON",
     ])
 
+  # Enable CUDA if on platforms where we expect to have the deps and produce
+  # such binaries.
+  if platform.system() == "Linux":
+    print("*** Enabling CUDA runtime ***")
+    extra_cmake_flags.extend([
+        "-DIREE_HAL_DRIVER_CUDA=ON",
+    ])
+
   # CMake configure.
   print("*** Configuring ***")
   subprocess.run([
       sys.executable,
       CMAKE_CI_SCRIPT,
       f"-B{BUILD_DIR}",
+      "--log-level=VERBOSE",
       f"-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}",
       f"-DCMAKE_BUILD_TYPE=Release",
       f"-DIREE_BUILD_COMPILER=OFF",

--- a/llvm-external-projects/iree-compiler-api/setup.py
+++ b/llvm-external-projects/iree-compiler-api/setup.py
@@ -91,12 +91,18 @@ class CMakeBuildPy(_build_py):
     cfg = "Release"
     cmake_args = [
         "-GNinja",
+        "--log-level=VERBOSE",
         "-DCMAKE_INSTALL_PREFIX={}".format(cmake_install_dir),
         "-DPython3_EXECUTABLE={}".format(sys.executable),
         "-DPython3_INCLUDE_DIRS={}".format(sysconfig.get_path("include")),
         "-DIREE_VERSION_INFO={}".format(self.distribution.get_version()),
         "-DCMAKE_BUILD_TYPE={}".format(cfg),
     ]
+
+    # Enable CUDA if specified.
+    cuda_target_option = os.getenv("IREE_TARGET_BACKEND_CUDA")
+    if cuda_target_option:
+      cmake_args.append(f"-DIREE_TARGET_BACKEND_CUDA={cuda_target_option}")
 
     build_args = []
     if os.path.exists(cmake_install_dir):


### PR DESCRIPTION
* Release docker container has CUDA dev packages installed on it.
* Main releases platform detect and enable CUDA integration.
* Compiler wheel uses an environment variable that is set by the release pipeline.