### PR TITLE
Bump CMake version to 3.22.2 to build compiler wheels.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -51,10 +51,10 @@ jobs:
           # Windows packages.
           - os: windows-2019
             build_package: py-compiler-pkg
-            experimental: false
+            experimental: true
           - os: windows-2019
             build_package: py-runtime-pkg
-            experimental: false
+            experimental: true
 
           # Macos packages.
           - os: macos-latest
@@ -66,7 +66,6 @@ jobs:
     env:
       CIBW_BUILD_VERBOSITY: 1
 
-      # TODO: in-tree-build can be removed once pip 21.3 is released.
       # Note that on Linux, we run under docker with an altered path.
       # Note that on Windows, we need to configure the compiler api project to
       # but its CMake build directory on a short path to avoid path overflow.
@@ -191,14 +190,9 @@ jobs:
         if: "matrix.build_package == 'py-compiler-pkg'"
         shell: bash
         run: |
-          # Need a newer pip to use in-tree-build. *but* the old default pip
-          # can't accept the in-tree-build feature while upgrading itself.
-          # Facepalm. Since there is no way to customize CIBW, we just manually
-          # install a pre-release build of 21.3, in which the in-tree-build
-          # feature is enabled by default, obviating the need to configure it.
-          # After the 2021 October release, this can just be changed to install
-          # pip >= 21.3 from official sources. I'm sorry about this folks.
-          export CIBW_BEFORE_BUILD="python -m pip install --upgrade pip==21.3dev0 -f https://github.com/stellaraccident/pip/releases/tag/21.3dev20210925"
+          # In pip 21.3, in-tree builds became the default and only way to
+          # build. We require that and make sure to be past that threshold.
+          export CIBW_BEFORE_BUILD="python -m pip install --upgrade pip>=21.3"
           python -m cibuildwheel --output-dir bindist ./main_checkout/llvm-external-projects/iree-compiler-api
 
       # Compiler tools wheels are not python version specific, so just build

--- a/llvm-external-projects/iree-compiler-api/pyproject.toml
+++ b/llvm-external-projects/iree-compiler-api/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     # There is no fundamental reason to pin this CMake version, beyond
     # build stability.
-    "cmake==3.18",
+    "cmake==3.22.2",
     "ninja==1.10.2",
     # MLIR build depends.
     "numpy",


### PR DESCRIPTION
* The Windows and MacOS compiler builds have been failing on a Python detection race. CMake has gotten less buggy in this area over time so in lieu of root causing, just bumping to current as a first step.
* Also rolls back the pip version hack now that the official version has the patch we need.
* Marks Windows/MacOS builds experimental so that they do not block Linux builds and we can get a clean release out tomorrow (fingers crossed).