### PR TITLE
Avoid null dereference for missing translation

### DIFF
--- a/iree/tools/iree_translate_lib.cc
+++ b/iree/tools/iree_translate_lib.cc
@@ -107,7 +107,8 @@ int mlir::iree_compiler::runIreeTranslateMain(int argc, char **argv) {
   // flag above then there is an error reported per possible translation rather
   // than single one, so check explicitly instead.
   if (!translationRequested) {
-    llvm::errs() << "Translation to perform option: must be specified at least once!\n";
+    llvm::errs()
+        << "Translation to perform option: must be specified at least once!\n";
     return 1;
   }
 

--- a/iree/tools/iree_translate_lib.cc
+++ b/iree/tools/iree_translate_lib.cc
@@ -103,6 +103,14 @@ int mlir::iree_compiler::runIreeTranslateMain(int argc, char **argv) {
     return 1;
   }
 
+  // The value is required in processBuffer but if Required option is set on
+  // flag above then there is an error reported per possible translation rather
+  // than single one, so check explicitly instead.
+  if (!translationRequested) {
+    llvm::errs() << "Translation to perform option: must be specified at least once!\n";
+    return 1;
+  }
+
   /// Processes the memory buffer with a new MLIRContext.
   auto processBuffer = [&](std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
                            llvm::raw_ostream &os) {


### PR DESCRIPTION
When no translation is set this would have resulted in nullptr
dereference.
