### PR TITLE
Remove accidental device->host transfer on function dispatch.

### DIFF
--- a/bindings/python/iree/runtime/function.py
+++ b/bindings/python/iree/runtime/function.py
@@ -343,7 +343,7 @@ def _buffer_view_to_vm(inv: Invocation, t: VmVariantList, x, desc):
 def _ndarray_like_to_vm(inv: Invocation, t: VmVariantList, x, desc):
   if isinstance(x, HalBufferView):
     return _buffer_view_to_vm(inv, t, x, desc)
-  return _ndarray_to_vm(inv, t, np.asarray(x), desc)
+  return _ndarray_to_vm(inv, t, x, desc)
 
 
 class _MissingArgument:


### PR DESCRIPTION
* This was caught when attempting to explicitly use DeviceArrays, since they are setup by default to raise an exception on an implicit transfer to host.
* Added a test to verify.