### PR TITLE
Move generic op codegeneration path to use tile + fuse expert. 

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -181,11 +181,10 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   // Add the sandbox single tiling expert to tile and vectorize.
   {
-    LinalgSingleTilingExpertPassOptions options;
+    LinalgFusePassOptions options;
     options.vectorize = true;
     options.tilingLevel = static_cast<int64_t>(TilingLevel::L1Tiles);
-    passManager.addNestedPass<FuncOp>(
-        createLinalgSingleTilingExpertPass(options));
+    passManager.addNestedPass<FuncOp>(createLinalgFusePass(options));
   }
 
   // TODO(ravishankarm): This is commented cause this is WIP, to be enabled


### PR DESCRIPTION
Previously it was using the single tiling expert that wouldnt fuse
fill with reduction operations at the vector level. Using fusion
expert addresses this issue.