### PR TITLE
Disable C++ allocation tracing for Python bindings.

### DIFF
--- a/bindings/python/iree/runtime/CMakeLists.txt
+++ b/bindings/python/iree/runtime/CMakeLists.txt
@@ -34,6 +34,10 @@ iree_pyext_module(
     "vm.cc"
   UNIX_LINKER_SCRIPT
     "unix_version.lds"
+  DEFINES
+    # Pybind code seems to be incompatible with C++ allocation tracing
+    # hooks so disable it.
+    IREE_TRACING_HOOK_CPP_NEW_DELETE=0
   DEPS
     iree::base
     iree::base::cc

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -142,11 +142,14 @@ endfunction()
 # MODULE_NAME: Base-name of the module.
 # SRCS: List of source files for the library
 # DEPS: List of other targets the test python libraries require
+# COPTS: List of private compile options
+# DEFINES: List of public defines
+# INCLUDES: Include directories to add to dependencies
 function(iree_pyext_module)
   cmake_parse_arguments(ARG
     ""
     "NAME;MODULE_NAME;UNIX_LINKER_SCRIPT"
-    "SRCS;DEPS;COPTS;INCLUDES"
+    "SRCS;DEPS;COPTS;DEFINES;INCLUDES"
     ${ARGN})
 
   iree_package_ns(_PACKAGE_NS)
@@ -214,6 +217,11 @@ function(iree_pyext_module)
     ${ARG_COPTS}
     ${IREE_DEFAULT_COPTS}
     ${_RTTI_AND_EXCEPTION_COPTS}
+  )
+
+  target_compile_definitions(
+    ${_NAME} PUBLIC
+    ${ARG_DEFINES}
   )
 
   # Link flags.

--- a/iree/base/tracing.cc
+++ b/iree/base/tracing.cc
@@ -203,21 +203,3 @@ void iree_tracing_mutex_after_unlock(uint32_t lock_id) {
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-#if defined(__cplusplus) &&                                               \
-    (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING) && \
-    !IREE_SANITIZER_ADDRESS && !IREE_SANITIZER_MEMORY &&                  \
-    !IREE_SANITIZER_THREAD
-
-void* operator new(size_t count) noexcept {
-  auto ptr = malloc(count);
-  IREE_TRACE_ALLOC(ptr, count);
-  return ptr;
-}
-
-void operator delete(void* ptr) noexcept {
-  IREE_TRACE_FREE(ptr);
-  free(ptr);
-}
-
-#endif  // __cplusplus && IREE_TRACING_FEATURE_ALLOCATION_TRACKING


### PR DESCRIPTION
* I've generally found that hooking the operator new/delete in arbitrary C++ programs does not produce balanced allocations that make Tracy happy (ahem, LLVM).
* Something about pybind code exhibits these issues, so disable the C++ hooking there.
* While in there, brings this up to C++11 compliance by handling both the throwing and non-throwing overloads properly (this was failing to compile if exceptions were enabled).
* I'm not an expert on this -- just did some digging and trying to fix the issue I see.

Fixes #8263