### PR TITLE
Implementation of the GPUMatmulSimtPassPipeline verifier

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -26,6 +26,7 @@ iree_lit_test_suite(
             "gpu_set_num_workgroups.mlir",
             "nvvm_pipeline_test.mlir",
             "rocdl_pipeline_test.mlir",
+            "illegal_configuration.mlir",
             "legalize.mlir",
             "tensorcore_vectorization.mlir",
             "vectorization.mlir",

--- a/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "distribute_to_thread.mlir"
     "distribute_wg_copy.mlir"
     "gpu_set_num_workgroups.mlir"
+    "illegal_configuration.mlir"
     "legalize.mlir"
     "nvvm_pipeline_test.mlir"
     "rocdl_pipeline_test.mlir"

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -1,0 +1,31 @@
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass{test-lowering-configuration=true}))' -verify-diagnostics -split-input-file %s
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [128, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [32 : index, 8 : index, 8 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
+        // expected-error @+1 {{expected workgroup size to be <=1024 for LLVMGPUMatmulSimt, got 2048}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}

--- a/iree/compiler/Codegen/Passes.cpp
+++ b/iree/compiler/Codegen/Passes.cpp
@@ -62,6 +62,9 @@ LogicalResult verifyLoweringConfiguration(
     case IREE::Codegen::DispatchLoweringPassPipeline::CPUTileFuseAndVectorize:
       return verifyDoubleTilingExpertPassPipelineConfig(op, loweringConfig,
                                                         translationInfo);
+    case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt:
+      return verifyGPUMatmulSimtPassPipeline(op, loweringConfig,
+                                             translationInfo, workgroupSize);
     default:
       break;
   }

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -247,6 +247,10 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager);
 void addGPUVectorizationPassPipeline(OpPassManager &pm);
 
 /// Lowering calling vectorization patterns.
+LogicalResult verifyGPUMatmulSimtPassPipeline(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize = {});
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 
 /// Lowering using tensorcore operations.


### PR DESCRIPTION
Implementation of a verifier for the GPUMatmulSimtPassPipeline. Currently checks for the workgroupsize <=1024. Exposes verifier to both the `GPULowerExecutableTarget` as well as external verification. 