### PR TITLE
Add support for dumping statistics in JSON format

### DIFF
--- a/iree/compiler/Dialect/Stream/Transforms/PassDetail.h
+++ b/iree/compiler/Dialect/Stream/Transforms/PassDetail.h
@@ -25,6 +25,8 @@ enum class DumpOutputFormat {
   Verbose = 2,
   // Comma separated values for throwing into Sheets.
   CSV = 3,
+  // JSON format for better structure and data exchange.
+  JSON = 4,
 };
 
 #define GEN_PASS_CLASSES

--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -105,7 +105,9 @@ void SchedulingOptions::bindOptions(OptionsBinder &binder) {
                      "Human-readable pretty printed output."),
           clEnumValN(DumpOutputFormat::Verbose, "verbose",
                      "Pretty printed output with additional IR."),
-          clEnumValN(DumpOutputFormat::CSV, "csv", "Comma separated values.")));
+          clEnumValN(DumpOutputFormat::CSV, "csv", "Comma separated values."),
+          clEnumValN(DumpOutputFormat::JSON, "json",
+                     "JSON output with structures for data exchange")));
   binder.opt<std::string>("iree-scheduling-dump-statistics-file",
                           dumpStatisticsFile,
                           llvm::cl::desc("File path to write statistics to; or "

--- a/iree/compiler/Translation/IREEVM.h
+++ b/iree/compiler/Translation/IREEVM.h
@@ -94,6 +94,8 @@ struct SchedulingOptions {
     Verbose = 2,
     // Comma separated values for throwing into Sheets.
     CSV = 3,
+    // JSON format for better structure and data exchange.
+    JSON = 4,
   };
   // Enables and specifies the the format for a stream statistics dump.
   DumpOutputFormat dumpStatisticsFormat = DumpOutputFormat::None;


### PR DESCRIPTION
Existing formats (plain, pretty, CSV) are good for human inspection
but not good at representing information in a hierarchical manner.
So adding support for JSON dump. With nested structures, we can
have more clear categories of statistics and avoid downstream
consumers to parse other formats and rediscover such information.