### PR TITLE
Enable multithreading and SIMD in static web demo.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -304,6 +304,21 @@ else()
   # Android provides its own pthreads support with no linking required.
 endif()
 
+# Emscripten needs -pthread specified in link _and_ compile options when using
+# atomics, shared memory, or pthreads. If we bring our own threading impl and
+# try to omit this, we get this error:
+#   `--shared-memory is disallowed because it was not compiled with 'atomics'
+#    or 'bulk-memory' features`
+# TODO(scotttodd): Figure out how to use atomics and/or shared memory without
+#                  Specifying this flag
+# https://emscripten.org/docs/porting/pthreads.html#compiling-with-pthreads-enabled
+if(EMSCRIPTEN AND ${IREE_ENABLE_THREADING})
+  iree_select_compiler_opts(IREE_DEFAULT_COPTS
+    ALL
+      "-pthread"
+  )
+endif()
+
 if(ANDROID)
   # logging.h on Android needs llog to link in Android logging.
   iree_select_compiler_opts(_IREE_LOGGING_LINKOPTS

--- a/experimental/sample_web_static/CMakeLists.txt
+++ b/experimental/sample_web_static/CMakeLists.txt
@@ -116,5 +116,12 @@ target_link_options(${_NAME} PRIVATE
   "-sPTHREAD_POOL_SIZE_STRICT=0"
   # "-sPTHREAD_POOL_SIZE=N"
   # "-sPROXY_TO_PTHREAD"
+  #
+  # Threads use memory, so using a larger pool of memory or allowing memory
+  # growth may be necessary when using `emscripten_num_logical_cores()`
+  # or `navigator.hardwareConcurrency` to pick the worker thread count.
+  # IREE is pretty good about not allocating outside of startup, so concerns
+  # about this causing slow access to memory *may* not affect IREE too much.
+  # "-sALLOW_MEMORY_GROWTH=1"
   # ------------------------------------------------------------------------- #
 )

--- a/experimental/sample_web_static/CMakeLists.txt
+++ b/experimental/sample_web_static/CMakeLists.txt
@@ -96,10 +96,25 @@ target_link_options(${_NAME} PRIVATE
   "-g"
   "-gseparate-dwarf"
   #
-  # https://emscripten.org/docs/porting/pthreads.html#compiling-with-pthreads-enabled
+  # ------------------------------------------------------------------------- #
+  # Multithreading with pthreads, built on Web Workers and SharedArrayBuffer.
+  # Docs: https://emscripten.org/docs/porting/pthreads.html
+  # IREE's use of threading is pretty restricted so we could eventually drop
+  # Emscripten's pthreads implementation in favor of our own.
+  #
+  # Note: this -pthread flag also needs to be set in compile options.
   "-pthread"
-  # "-sINITIAL_MEMORY=67108864"  # 64MB
-  "-sPTHREAD_POOL_SIZE=2"
-  # https://emscripten.org/docs/porting/pthreads.html#additional-flags
+  #
+  # IREE creates long lived worker threads during device creation around system
+  # startup time. No fixed size thread pool is necessary, so disable thread
+  # pool size checks and do not specify the pool size.
+  # By starting IREE from a Web Worker, we can avoid needing `PROXY_TO_PTHREAD`
+  # and can block when interacting with threads.
+  # Web Worker creation requires yielding back to the main browser event loop,
+  # so splitting program execution across multiple JavaScript function calls
+  # (e.g. `createDevice(); runInference();`) also helps avoid deadlocks.
+  "-sPTHREAD_POOL_SIZE_STRICT=0"
+  # "-sPTHREAD_POOL_SIZE=N"
   # "-sPROXY_TO_PTHREAD"
+  # ------------------------------------------------------------------------- #
 )

--- a/experimental/sample_web_static/README.md
+++ b/experimental/sample_web_static/README.md
@@ -29,9 +29,29 @@ embedded into a C file that is similarly linked in.
 [Emscripten](https://emscripten.org/) is used (via the `emcmake` CMake wrapper)
 to compile the output binary into WebAssembly and JavaScript files.
 
-The provided `index.html` file can be served together with the output `.js`
-and `.wasm` files.
+The provided [`index.html`](./index.html) file can be served together with the
+output `.js` and `.wasm` files.
 
-## Multithreading
+### Asynchronous API
 
-TODO(scotttodd): this is incomplete - more changes are needed to the C runtime
+* [`iree_api.js`](./iree_api.js) exposes a Promise-based API to the hosting
+  application in [`index.html`](./index.html)
+* [`iree_api.js`](./iree_api.js) creates a worker running iree_worker.js, which
+  includes Emscripten's JS code and instantiates the WebAssembly module
+* messages are passed back and forth between [`iree_api.js`](./iree_api.js) and
+  [`iree_worker.js`](./iree_worker.js) internally
+
+### Multithreading
+
+The sample supports running both single-threaded using
+[`device_sync.c`](./device_sync.c) (backed by the local HAL's 'sync' device)
+and multi-threaded using [`device_multithreaded.c`](./device_multithreaded.c)
+(backed by the local HAL's 'task' device).
+
+Each configuration is offered as a CMake target, then
+[`iree_worker.js`](./iree_worker.js) specifies which script URL to load.
+
+Multithreading requires Web Workers and SharedArrayBuffer:
+
+* https://caniuse.com/webworkers
+* https://caniuse.com/sharedarraybuffer

--- a/experimental/sample_web_static/build_static_emscripten_demo.sh
+++ b/experimental/sample_web_static/build_static_emscripten_demo.sh
@@ -43,6 +43,7 @@ ${TRANSLATE_TOOL?} ${INPUT_PATH} \
   --iree-input-type=mhlo \
   --iree-hal-target-backends=llvm \
   --iree-llvm-target-triple=wasm32-unknown-unknown \
+  --iree-llvm-target-cpu-features=+simd128 \
   --iree-llvm-link-embedded=false \
   --iree-llvm-link-static \
   --iree-llvm-static-library-output-path=${BINARY_DIR}/${INPUT_NAME}_static.o \
@@ -76,8 +77,9 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_TESTS=OFF
 
 "${CMAKE_BIN?}" --build . --target \
-  iree_experimental_sample_web_static_sync
-  # iree_experimental_sample_web_static_multithreaded
+    iree_experimental_sample_web_static_sync \
+    iree_experimental_sample_web_static_multithreaded
+
 popd
 
 ###############################################################################

--- a/experimental/sample_web_static/device_multithreaded.c
+++ b/experimental/sample_web_static/device_multithreaded.c
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <emscripten/threading.h>
+
 #include "iree/hal/local/loaders/static_library_loader.h"
 #include "iree/hal/local/task_device.h"
 #include "iree/task/api.h"
@@ -33,8 +35,13 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_host_size_t worker_local_memory = 0;
   iree_task_topology_t topology;
   iree_task_topology_initialize(&topology);
-  // TODO(scotttodd): Try with more threads
-  iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
+  iree_task_topology_initialize_from_group_count(
+      /*group_count=*/4, &topology);
+  // Note: threads increase memory usage. If using a high thread count, consider
+  // passing in a larger WebAssembly.Memory object, increasing Emscripten's
+  // INITIAL_MEMORY, or setting Emscripten's ALLOW_MEMORY_GROWTH.
+  // iree_task_topology_initialize_from_group_count(
+  //     /*group_count=*/emscripten_num_logical_cores(), &topology);
   if (iree_status_is_ok(status)) {
     status = iree_task_executor_create(scheduling_mode, &topology,
                                        worker_local_memory, host_allocator,

--- a/experimental/sample_web_static/device_multithreaded.c
+++ b/experimental/sample_web_static/device_multithreaded.c
@@ -34,7 +34,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   iree_task_topology_t topology;
   iree_task_topology_initialize(&topology);
   // TODO(scotttodd): Try with more threads
-  iree_task_topology_initialize_from_group_count(/*group_count=*/1, &topology);
+  iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
   if (iree_status_is_ok(status)) {
     status = iree_task_executor_create(scheduling_mode, &topology,
                                        worker_local_memory, host_allocator,

--- a/experimental/sample_web_static/index.html
+++ b/experimental/sample_web_static/index.html
@@ -61,6 +61,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       ireePredictDigit(getRescaledCanvasData()).then((result) => {
         predictionResultElement.innerHTML = result;
       }).catch((error) => {
+        console.error('error predicting digit:', error);
         predictionResultElement.innerHTML = "<b>" + error + "</b>";
       });
     }

--- a/experimental/sample_web_static/iree_api.js
+++ b/experimental/sample_web_static/iree_api.js
@@ -29,7 +29,7 @@ function _handleMessageFromWorker(messageEvent) {
     pendingPromises['initialize']['resolve']();
     delete pendingPromises['initialize'];
   } else if (messageType == 'predictResult') {
-    if (payload) {
+    if (payload !== undefined) {
       pendingPromises[id]['resolve'](payload);
     } else {
       pendingPromises[id]['reject'](error);
@@ -47,7 +47,7 @@ function ireeInitializeWorker() {
       'reject': reject,
     };
 
-    ireeWorker = new Worker('iree_worker.js');
+    ireeWorker = new Worker('iree_worker.js', {name: 'IREE-main'});
     ireeWorker.onmessage = _handleMessageFromWorker;
   });
 }

--- a/experimental/sample_web_static/iree_worker.js
+++ b/experimental/sample_web_static/iree_worker.js
@@ -16,6 +16,7 @@ function ireeError(...args) {
   console.error(ireeNamePrefix(), ...args);
 }
 
+// TODO(scotttodd): configure this through the build system / scripts?
 const MAIN_SCRIPT_URL = 'sample-web-static-multithreaded.js';
 // const MAIN_SCRIPT_URL = 'sample-web-static-sync.js';
 

--- a/experimental/sample_web_static/iree_worker.js
+++ b/experimental/sample_web_static/iree_worker.js
@@ -4,6 +4,21 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Helpers that prefix logs with the 'name' from DedicatedWorkerGlobalScope.
+// This helps with debugging thread creation.
+function ireeNamePrefix() {
+  return self.name ? (self.name + ':') : '(unnamed scope)';
+}
+function ireeLog(...args) {
+  console.log(ireeNamePrefix(), ...args);
+}
+function ireeError(...args) {
+  console.error(ireeNamePrefix(), ...args);
+}
+
+const MAIN_SCRIPT_URL = 'sample-web-static-multithreaded.js';
+// const MAIN_SCRIPT_URL = 'sample-web-static-sync.js';
+
 let wasmSetupSampleFn;
 let wasmCleanupSampleFn;
 let wasmRunSampleFn;
@@ -16,13 +31,13 @@ let imageBuffer;
 
 var Module = {
   print: function(text) {
-    console.log('(C)', text);
+    ireeLog('(C/Wasm) ' + text);
   },
   printErr: function(text) {
-    console.error('(C)', text);
+    ireeError('(C/Wasm) ' + text);
   },
   onRuntimeInitialized: function() {
-    console.log('WebAssembly module onRuntimeInitialized()');
+    ireeLog('WebAssembly module onRuntimeInitialized()');
 
     wasmSetupSampleFn = Module.cwrap('setup_sample', 'number', []);
     wasmCleanupSampleFn = Module.cwrap('cleanup_sample', null, ['number']);
@@ -31,6 +46,7 @@ var Module = {
 
     initializeSample();
   },
+  mainScriptUrlOrBlob: MAIN_SCRIPT_URL,
   noInitialRun: true,
 };
 
@@ -96,7 +112,7 @@ function handlePredict(id, canvasData) {
   }
 }
 
-onmessage = function(messageEvent) {
+self.onmessage = function(messageEvent) {
   const {messageType, id, payload} = messageEvent.data;
 
   if (messageType == 'predict') {
@@ -104,5 +120,6 @@ onmessage = function(messageEvent) {
   }
 };
 
-importScripts('sample-web-static-sync.js');
-// importScripts('sample-web-static-multithreaded.js');
+ireeLog('iree_worker importing \'' + MAIN_SCRIPT_URL + '\'');
+
+importScripts(MAIN_SCRIPT_URL);


### PR DESCRIPTION
Multithreading is using IREE's task system, which creates one thread as a "poller" and multiple worker threads (hardcoded to 4, but could use `emscripten_num_logical_cores()`/`navigator.hardwareConcurrency`):

![image](https://user-images.githubusercontent.com/4010439/153466906-017cf991-a237-439a-bfb4-4309afc08d2a.png)


I've also started a custom implementation of threading using Web Workers without Emscripten's pthreads, since configuring Emscripten for our usage was tricky. By moving away from Emscripten we'll also be able to cut down on binary size, startup time, and build complexity. Well, that's the hope, anyways. This works for now :D

Tested on Chrome 98, Windows 10 desktop. SharedArrayBuffer and SIMD may require feature flags on other/older browsers.