### PR TITLE
Add 'keep going' option to CMake CI builds

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -51,7 +51,7 @@ cd build-host
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_BENCHMARKS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build -k . --target install
+"${CMAKE_BIN}" --build . --target install -- -k 0
 # --------------------------------------------------------------------------- #
 
 cd "${ROOT_DIR}"
@@ -78,4 +78,4 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build -k .
+"${CMAKE_BIN}" --build . -- -k 0

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -51,7 +51,7 @@ cd build-host
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_BENCHMARKS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build . --target install
+"${CMAKE_BIN}" --build -k . --target install
 # --------------------------------------------------------------------------- #
 
 cd "${ROOT_DIR}"
@@ -78,4 +78,4 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build .
+"${CMAKE_BIN}" --build -k .

--- a/build_tools/cmake/build_android_benchmark.sh
+++ b/build_tools/cmake/build_android_benchmark.sh
@@ -66,9 +66,9 @@ cd build-host
   -DIREE_BUILD_BENCHMARKS=ON \
   -DIREE_BUILD_SAMPLES=OFF
 
-"${CMAKE_BIN}" --build -k . --target install
+"${CMAKE_BIN}" --build . --target install -- -k 0
 # Also generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build -k . --target iree-benchmark-suites
+"${CMAKE_BIN}" --build . --target iree-benchmark-suites -- -k 0
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #
@@ -94,7 +94,7 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build -k . --target iree-benchmark-module
+"${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
 
 # --------------------------------------------------------------------------- #
 # Build for the target (Android) with tracing.
@@ -120,4 +120,4 @@ cd build-android-trace
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build -k . --target iree-benchmark-module
+"${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0

--- a/build_tools/cmake/build_android_benchmark.sh
+++ b/build_tools/cmake/build_android_benchmark.sh
@@ -66,9 +66,9 @@ cd build-host
   -DIREE_BUILD_BENCHMARKS=ON \
   -DIREE_BUILD_SAMPLES=OFF
 
-"${CMAKE_BIN}" --build . --target install
+"${CMAKE_BIN}" --build -k . --target install
 # Also generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build . --target iree-benchmark-suites
+"${CMAKE_BIN}" --build -k . --target iree-benchmark-suites
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #
@@ -94,7 +94,7 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build . --target iree-benchmark-module
+"${CMAKE_BIN}" --build -k . --target iree-benchmark-module
 
 # --------------------------------------------------------------------------- #
 # Build for the target (Android) with tracing.
@@ -120,4 +120,4 @@ cd build-android-trace
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build . --target iree-benchmark-module
+"${CMAKE_BIN}" --build -k . --target iree-benchmark-module

--- a/build_tools/cmake/build_host_install.sh
+++ b/build_tools/cmake/build_host_install.sh
@@ -33,4 +33,4 @@ cd build-host
   -DCMAKE_INSTALL_PREFIX=./install \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN?}" --build . --target install
+"${CMAKE_BIN?}" --build -k . --target install

--- a/build_tools/cmake/build_host_install.sh
+++ b/build_tools/cmake/build_host_install.sh
@@ -33,4 +33,4 @@ cd build-host
   -DCMAKE_INSTALL_PREFIX=./install \
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN?}" --build -k . --target install
+"${CMAKE_BIN?}" --build . --target install -- -k 0

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -45,7 +45,7 @@ fi
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF \
   "${ROOT_DIR?}"
-"${CMAKE_BIN?}" --build "${BUILD_HOST_DIR?}" --target install
+"${CMAKE_BIN?}" --build -k "${BUILD_HOST_DIR?}" --target install
 # --------------------------------------------------------------------------- #
 
 
@@ -89,4 +89,4 @@ fi
 
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN?}" ${args_str} "${ROOT_DIR?}"
-"${CMAKE_BIN?}" --build "${BUILD_RISCV_DIR?}"
+"${CMAKE_BIN?}" --build -k "${BUILD_RISCV_DIR?}"

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -45,7 +45,7 @@ fi
   -DIREE_BUILD_TESTS=OFF \
   -DIREE_BUILD_SAMPLES=OFF \
   "${ROOT_DIR?}"
-"${CMAKE_BIN?}" --build -k "${BUILD_HOST_DIR?}" --target install
+"${CMAKE_BIN?}" --build "${BUILD_HOST_DIR?}" --target install -- -k 0
 # --------------------------------------------------------------------------- #
 
 
@@ -89,4 +89,4 @@ fi
 
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN?}" ${args_str} "${ROOT_DIR?}"
-"${CMAKE_BIN?}" --build -k "${BUILD_RISCV_DIR?}"
+"${CMAKE_BIN?}" --build "${BUILD_RISCV_DIR?}" -- -k 0

--- a/build_tools/cmake/build_runtime.sh
+++ b/build_tools/cmake/build_runtime.sh
@@ -31,4 +31,4 @@ cd build-runtime
 "${CMAKE_BIN?}" -G Ninja .. \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build .
+"${CMAKE_BIN?}" --build -k .

--- a/build_tools/cmake/build_runtime.sh
+++ b/build_tools/cmake/build_runtime.sh
@@ -31,4 +31,4 @@ cd build-runtime
 "${CMAKE_BIN?}" -G Ninja .. \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build -k .
+"${CMAKE_BIN?}" --build . -- -k 0

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -48,4 +48,4 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_SAMPLES=ON
 
 # TODO(scotttodd): expand this list of targets
-"${CMAKE_BIN?}" --build -k . --target iree_samples_simple_embedding_simple_embedding_vmvx_sync
+"${CMAKE_BIN?}" --build . --target iree_samples_simple_embedding_simple_embedding_vmvx_sync -- -k 0

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -48,4 +48,4 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_SAMPLES=ON
 
 # TODO(scotttodd): expand this list of targets
-"${CMAKE_BIN?}" --build . --target iree_samples_simple_embedding_simple_embedding_vmvx_sync
+"${CMAKE_BIN?}" --build -k . --target iree_samples_simple_embedding_simple_embedding_vmvx_sync

--- a/build_tools/cmake/build_runtime_small.sh
+++ b/build_tools/cmake/build_runtime_small.sh
@@ -32,4 +32,4 @@ cd build-runtime-small
   -DCMAKE_BUILD_TYPE=MinSizeRel \
   -DIREE_SIZE_OPTIMIZED=ON \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build -k .
+"${CMAKE_BIN?}" --build . -- -k 0

--- a/build_tools/cmake/build_runtime_small.sh
+++ b/build_tools/cmake/build_runtime_small.sh
@@ -32,4 +32,4 @@ cd build-runtime-small
   -DCMAKE_BUILD_TYPE=MinSizeRel \
   -DIREE_SIZE_OPTIMIZED=ON \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build .
+"${CMAKE_BIN?}" --build -k .

--- a/build_tools/cmake/build_tracing.sh
+++ b/build_tools/cmake/build_tracing.sh
@@ -35,4 +35,4 @@ cd build-tracing
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_ENABLE_RUNTIME_TRACING=ON \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build -k .
+"${CMAKE_BIN?}" --build . -- -k 0

--- a/build_tools/cmake/build_tracing.sh
+++ b/build_tools/cmake/build_tracing.sh
@@ -35,4 +35,4 @@ cd build-tracing
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_ENABLE_RUNTIME_TRACING=ON \
   -DIREE_BUILD_COMPILER=OFF
-"${CMAKE_BIN?}" --build .
+"${CMAKE_BIN?}" --build -k .

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -51,4 +51,4 @@ CMAKE_ARGS=(
 )
 
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..
-"$CMAKE_BIN" --build -k .
+"$CMAKE_BIN" --build . -- -k 0

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -51,4 +51,4 @@ CMAKE_ARGS=(
 )
 
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..
-"$CMAKE_BIN" --build .
+"$CMAKE_BIN" --build -k .

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -71,4 +71,4 @@ echo "******************** Running main project ctests ************************"
 ctest --timeout 900 --output-on-failure --label-exclude "${label_exclude_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
-cmake --build . --target check-iree-dialects
+cmake --build -k . --target check-iree-dialects

--- a/build_tools/cmake/test.sh
+++ b/build_tools/cmake/test.sh
@@ -71,4 +71,4 @@ echo "******************** Running main project ctests ************************"
 ctest --timeout 900 --output-on-failure --label-exclude "${label_exclude_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
-cmake --build -k . --target check-iree-dialects
+cmake --build . --target check-iree-dialects -- -k 0

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -74,9 +74,9 @@ cd build-host
   -DIREE_BUILD_BENCHMARKS=ON \
   -DIREE_BUILD_SAMPLES=OFF
 
-"${CMAKE_BIN}" --build -k . --target install
+"${CMAKE_BIN}" --build . --target install -- -k 0
 # Also make sure that we can generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build -k . --target iree-benchmark-suites
+"${CMAKE_BIN}" --build . --target iree-benchmark-suites -- -k 0
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #
@@ -103,4 +103,4 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build -k .
+"${CMAKE_BIN}" --build . -- -k 0

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -74,9 +74,9 @@ cd build-host
   -DIREE_BUILD_BENCHMARKS=ON \
   -DIREE_BUILD_SAMPLES=OFF
 
-"${CMAKE_BIN}" --build . --target install
+"${CMAKE_BIN}" --build -k . --target install
 # Also make sure that we can generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build . --target iree-benchmark-suites
+"${CMAKE_BIN}" --build -k . --target iree-benchmark-suites
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #
@@ -103,4 +103,4 @@ cd build-android
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=ON \
   -DIREE_BUILD_SAMPLES=OFF
-"${CMAKE_BIN}" --build .
+"${CMAKE_BIN}" --build -k .

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -42,7 +42,7 @@ echo "Configuring CMake"
 "${CMAKE_BIN?}" "${CMAKE_ARGS[@]?}"
 
 echo "Building with CMake"
-"${CMAKE_BIN?}" --build -k "${CMAKE_BUILD_DIR?}"
+"${CMAKE_BIN?}" --build "${CMAKE_BUILD_DIR?}" -- -k 0
 
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-swiftshader-asan/build.sh
@@ -42,7 +42,7 @@ echo "Configuring CMake"
 "${CMAKE_BIN?}" "${CMAKE_ARGS[@]?}"
 
 echo "Building with CMake"
-"${CMAKE_BIN?}" --build "${CMAKE_BUILD_DIR?}"
+"${CMAKE_BIN?}" --build -k "${CMAKE_BUILD_DIR?}"
 
 # Respect the user setting, but default to as many jobs as we have cores.
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
@@ -64,7 +64,7 @@ CMAKE_ARGS=(
 )
 
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..
-"$CMAKE_BIN" --build -k .
+"$CMAKE_BIN" --build . -- -k 0
 
 cd ${ROOT_DIR?}
 

--- a/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/linux/x86-turing/build.sh
@@ -64,7 +64,7 @@ CMAKE_ARGS=(
 )
 
 "$CMAKE_BIN" "${CMAKE_ARGS[@]?}" "$@" ..
-"$CMAKE_BIN" --build .
+"$CMAKE_BIN" --build -k .
 
 cd ${ROOT_DIR?}
 

--- a/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
+++ b/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
@@ -86,7 +86,7 @@ cmake -B "${SWIFTSHADER_INSTALL_DIR?}" \
     "${SWIFTSHADER_DIR?}"
 
 # Build the project, choosing just the vk_swiftshader target.
-cmake --build -k "${SWIFTSHADER_INSTALL_DIR?}" --config Release --target vk_swiftshader
+cmake --build "${SWIFTSHADER_INSTALL_DIR?}" --config Release --target vk_swiftshader -- -k 0
 
 echo
 echo "Ensure the following variable is set in your enviroment:"

--- a/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
+++ b/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
@@ -86,7 +86,7 @@ cmake -B "${SWIFTSHADER_INSTALL_DIR?}" \
     "${SWIFTSHADER_DIR?}"
 
 # Build the project, choosing just the vk_swiftshader target.
-cmake --build "${SWIFTSHADER_INSTALL_DIR?}" --config Release --target vk_swiftshader
+cmake --build -k "${SWIFTSHADER_INSTALL_DIR?}" --config Release --target vk_swiftshader
 
 echo
 echo "Ensure the following variable is set in your enviroment:"

--- a/experimental/sample_web_static/build_static_emscripten_demo.sh
+++ b/experimental/sample_web_static/build_static_emscripten_demo.sh
@@ -76,7 +76,7 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=OFF
 
-"${CMAKE_BIN?}" --build -k . --target \
+"${CMAKE_BIN?}" --build . --target \ -- -k 0
     iree_experimental_sample_web_static_sync \
     iree_experimental_sample_web_static_multithreaded
 

--- a/experimental/sample_web_static/build_static_emscripten_demo.sh
+++ b/experimental/sample_web_static/build_static_emscripten_demo.sh
@@ -76,7 +76,7 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=OFF
 
-"${CMAKE_BIN?}" --build . --target \
+"${CMAKE_BIN?}" --build -k . --target \
     iree_experimental_sample_web_static_sync \
     iree_experimental_sample_web_static_multithreaded
 

--- a/iree/samples/dynamic_shapes/test.sh
+++ b/iree/samples/dynamic_shapes/test.sh
@@ -23,7 +23,7 @@ test -f ${ARTIFACTS_DIR}/dynamic_shapes.mlir && echo "dynamic_shapes.mlir exists
 
 # 2. Compile the `iree-translate` tool.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
-cmake --build -k ${BUILD_DIR} --target iree_tools_iree-translate
+cmake --build ${BUILD_DIR} --target iree_tools_iree-translate -- -k 0
 
 # 3. Compile `dynamic_shapes.mlir` using `iree-translate`.
 ${BUILD_DIR}/iree/tools/iree-translate \
@@ -33,7 +33,7 @@ ${BUILD_DIR}/iree/tools/iree-translate \
   ${ARTIFACTS_DIR}/dynamic_shapes.mlir -o ${ARTIFACTS_DIR}/dynamic_shapes_dylib.vmfb
 
 # 4. Build the `iree_samples_dynamic_shapes` CMake target.
-cmake --build -k ${BUILD_DIR} --target iree_samples_dynamic_shapes
+cmake --build ${BUILD_DIR} --target iree_samples_dynamic_shapes -- -k 0
 
 # 5. Run the sample binary.
 ${BUILD_DIR}/iree/samples/dynamic_shapes/dynamic-shapes \

--- a/iree/samples/dynamic_shapes/test.sh
+++ b/iree/samples/dynamic_shapes/test.sh
@@ -23,7 +23,7 @@ test -f ${ARTIFACTS_DIR}/dynamic_shapes.mlir && echo "dynamic_shapes.mlir exists
 
 # 2. Compile the `iree-translate` tool.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
-cmake --build ${BUILD_DIR} --target iree_tools_iree-translate
+cmake --build -k ${BUILD_DIR} --target iree_tools_iree-translate
 
 # 3. Compile `dynamic_shapes.mlir` using `iree-translate`.
 ${BUILD_DIR}/iree/tools/iree-translate \
@@ -33,7 +33,7 @@ ${BUILD_DIR}/iree/tools/iree-translate \
   ${ARTIFACTS_DIR}/dynamic_shapes.mlir -o ${ARTIFACTS_DIR}/dynamic_shapes_dylib.vmfb
 
 # 4. Build the `iree_samples_dynamic_shapes` CMake target.
-cmake --build ${BUILD_DIR} --target iree_samples_dynamic_shapes
+cmake --build -k ${BUILD_DIR} --target iree_samples_dynamic_shapes
 
 # 5. Run the sample binary.
 ${BUILD_DIR}/iree/samples/dynamic_shapes/dynamic-shapes \

--- a/iree/samples/variables_and_state/test.sh
+++ b/iree/samples/variables_and_state/test.sh
@@ -24,7 +24,7 @@ test -f ${ARTIFACTS_DIR}/counter_vmvx.vmfb && echo "counter_vmvx.vmfb exists"
 
 # 2. Compile the `iree_samples_variables_and_state` CMake target.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
-cmake --build -k ${BUILD_DIR} --target iree_samples_variables_and_state
+cmake --build ${BUILD_DIR} --target iree_samples_variables_and_state -- -k 0
 
 # 3. Run the sample binary.
 ${BUILD_DIR}/iree/samples/variables_and_state/variables-and-state \

--- a/iree/samples/variables_and_state/test.sh
+++ b/iree/samples/variables_and_state/test.sh
@@ -24,7 +24,7 @@ test -f ${ARTIFACTS_DIR}/counter_vmvx.vmfb && echo "counter_vmvx.vmfb exists"
 
 # 2. Compile the `iree_samples_variables_and_state` CMake target.
 cmake -B ${BUILD_DIR} -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${ROOT_DIR}
-cmake --build ${BUILD_DIR} --target iree_samples_variables_and_state
+cmake --build -k ${BUILD_DIR} --target iree_samples_variables_and_state
 
 # 3. Run the sample binary.
 ${BUILD_DIR}/iree/samples/variables_and_state/variables-and-state \


### PR DESCRIPTION
These are primarily used in CI, where it's useful to learn what all the
failures are up front. We already have the `--keep-going` option set in
the Bazel build.