### PR TITLE
Revert malformed change to emscripten demo script

### DIFF
--- a/experimental/sample_web_static/build_static_emscripten_demo.sh
+++ b/experimental/sample_web_static/build_static_emscripten_demo.sh
@@ -76,7 +76,7 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
   -DIREE_BUILD_COMPILER=OFF \
   -DIREE_BUILD_TESTS=OFF
 
-"${CMAKE_BIN?}" --build . --target \ -- -k 0
+"${CMAKE_BIN?}" --build . --target \
     iree_experimental_sample_web_static_sync \
     iree_experimental_sample_web_static_multithreaded
 


### PR DESCRIPTION
The regex I used in https://github.com/google/iree/pull/8302 neglected
the case of line continuations within the invocation of CMake (which
tbf, were only present in this experimental script). Reverting rather
than moving the arg to the right place because we agreed it's not
really useful in this non-CI script.

Partial revert of https://github.com/google/iree/commit/0f80995367c3