### PR TITLE
Update python-bindings-and-importers.md

### DIFF
--- a/docs/website/docs/building-from-source/python-bindings-and-importers.md
+++ b/docs/website/docs/building-from-source/python-bindings-and-importers.md
@@ -115,7 +115,6 @@ From the `iree-build` directory:
     # Add ./bindings/python and compiler-api/python_package to PYTHONPATH and
     # use the API.
     source .env && export PYTHONPATH
-    export PYTHONPATH="$PWD/bindings/python"
     python -c "import iree.compiler"
     python -c "import iree.runtime"
     ```


### PR DESCRIPTION
Exporting PYTHONPATH just post setting it results in overriding it and the .env file already includes the path the 2nd export overrides PYTHONPATH with. So removing the extra export.