### PR TITLE
Adding iree_loop_t and the basic inline and synchronous implementations.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -174,6 +174,33 @@ cc_library(
 )
 
 cc_library(
+    name = "loop_sync",
+    srcs = ["loop_sync.c"],
+    hdrs = ["loop_sync.h"],
+    deps = [
+        ":base",
+        ":tracing",
+        "//iree/base/internal",
+        "//iree/base/internal:wait_handle",
+    ],
+)
+
+cc_test(
+    name = "loop_sync_test",
+    srcs = [
+        "loop_sync_test.cc",
+    ],
+    deps = [
+        ":base",
+        ":cc",
+        ":loop_sync",
+        ":loop_test_hdrs",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
     name = "tracing",
     hdrs = ["tracing.h"],
     deps = [

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -25,6 +25,8 @@ cc_library(
         "assert.h",
         "bitfield.c",
         "bitfield.h",
+        "loop.c",
+        "loop.h",
         "status.c",
         "status.h",
         "string_builder.c",

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -27,6 +27,8 @@ cc_library(
         "bitfield.h",
         "loop.c",
         "loop.h",
+        "loop_inline.c",
+        "loop_inline.h",
         "status.c",
         "status.h",
         "string_builder.c",
@@ -69,6 +71,34 @@ cc_test(
         ":base",
         "//iree/testing:gtest",
         "//iree/testing:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "loop_inline_test",
+    srcs = [
+        "loop_inline_test.cc",
+    ],
+    deps = [
+        ":base",
+        ":cc",
+        ":loop_test_hdrs",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "loop_test_hdrs",
+    testonly = 1,
+    hdrs = [
+        "loop_test.h",
+    ],
+    deps = [
+        ":base",
+        ":tracing",
+        "//iree/base/internal:wait_handle",
+        "//iree/testing:gtest",
     ],
 )
 

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -159,6 +159,36 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    loop_sync
+  HDRS
+    "loop_sync.h"
+  SRCS
+    "loop_sync.c"
+  DEPS
+    ::base
+    ::tracing
+    iree::base::internal
+    iree::base::internal::wait_handle
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    loop_sync_test
+  SRCS
+    "loop_sync_test.cc"
+  DEPS
+    ::base
+    ::cc
+    ::loop_sync
+    ::loop_test_hdrs
+    ::tracing
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 # TODO(benvanik): evaluate if we want this as part of the API. Could restrict it
 # to excusively static linkage scenarios and note that it's unstable. It's just
 # really really useful and the only way for applications to interleave with our

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -18,6 +18,8 @@ iree_cc_library(
     "assert.h"
     "bitfield.c"
     "bitfield.h"
+    "loop.c"
+    "loop.h"
     "status.c"
     "status.h"
     "string_builder.c"

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -20,6 +20,8 @@ iree_cc_library(
     "bitfield.h"
     "loop.c"
     "loop.h"
+    "loop_inline.c"
+    "loop_inline.h"
     "status.c"
     "status.h"
     "string_builder.c"
@@ -70,6 +72,35 @@ iree_cc_test(
     ::base
     iree::testing::gtest
     iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
+    loop_inline_test
+  SRCS
+    "loop_inline_test.cc"
+  DEPS
+    ::base
+    ::cc
+    ::loop_test_hdrs
+    ::tracing
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
+    loop_test_hdrs
+  HDRS
+    "loop_test.h"
+  DEPS
+    ::base
+    ::cc
+    ::tracing
+    iree::base::internal::wait_handle
+    iree::testing::gtest
+  TESTONLY
+  PUBLIC
 )
 
 iree_cc_test(

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -98,6 +98,7 @@
 #include "iree/base/bitfield.h"        // IWYU pragma: export
 #include "iree/base/config.h"          // IWYU pragma: export
 #include "iree/base/loop.h"            // IWYU pragma: export
+#include "iree/base/loop_inline.h"     // IWYU pragma: export
 #include "iree/base/status.h"          // IWYU pragma: export
 #include "iree/base/string_builder.h"  // IWYU pragma: export
 #include "iree/base/string_view.h"     // IWYU pragma: export

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -97,6 +97,7 @@
 #include "iree/base/attributes.h"      // IWYU pragma: export
 #include "iree/base/bitfield.h"        // IWYU pragma: export
 #include "iree/base/config.h"          // IWYU pragma: export
+#include "iree/base/loop.h"            // IWYU pragma: export
 #include "iree/base/status.h"          // IWYU pragma: export
 #include "iree/base/string_builder.h"  // IWYU pragma: export
 #include "iree/base/string_view.h"     // IWYU pragma: export

--- a/iree/base/internal/synchronization_test.cc
+++ b/iree/base/internal/synchronization_test.cc
@@ -206,7 +206,7 @@ TEST(NotificationTest, Timeout) {
       +[](void* entry_arg) -> bool {
         return false;  // condition is never true
       },
-      NULL, iree_make_timeout(100 * 1000000)));
+      NULL, iree_make_timeout_ms(100)));
 
   iree_duration_t delta_ns = iree_time_now() - start_ns;
   iree_duration_t delta_ms = delta_ns / 1000000;

--- a/iree/base/internal/wait_handle.c
+++ b/iree/base/internal/wait_handle.c
@@ -12,14 +12,13 @@
 // iree_wait_handle_t
 //===----------------------------------------------------------------------===//
 
-iree_status_t iree_wait_handle_wrap_primitive(
+void iree_wait_handle_wrap_primitive(
     iree_wait_primitive_type_t primitive_type,
     iree_wait_primitive_value_t primitive_value,
     iree_wait_handle_t* out_handle) {
   memset(out_handle, 0, sizeof(*out_handle));
   out_handle->type = primitive_type;
   out_handle->value = primitive_value;
-  return iree_ok_status();
 }
 
 void iree_wait_handle_deinitialize(iree_wait_handle_t* handle) {
@@ -84,8 +83,8 @@ IREE_API_EXPORT iree_status_t iree_wait_source_import(
   } else {
     iree_wait_handle_t* wait_handle =
         (iree_wait_handle_t*)out_wait_source->storage;
-    IREE_RETURN_IF_ERROR(iree_wait_handle_wrap_primitive(
-        wait_primitive.type, wait_primitive.value, wait_handle));
+    iree_wait_handle_wrap_primitive(wait_primitive.type, wait_primitive.value,
+                                    wait_handle);
     out_wait_source->ctl = iree_wait_handle_ctl;
   }
   return iree_ok_status();

--- a/iree/base/internal/wait_handle.h
+++ b/iree/base/internal/wait_handle.h
@@ -119,6 +119,9 @@ iree_status_t iree_wait_set_allocate(iree_host_size_t capacity,
 // Frees a wait set. The wait set must not be being waited on.
 void iree_wait_set_free(iree_wait_set_t* set);
 
+// Returns true if there are no handles registered with the set.
+bool iree_wait_set_is_empty(const iree_wait_set_t* set);
+
 // Inserts a wait handle into the set.
 // If the handle is already in the set it will be reference counted such that a
 // matching number of iree_wait_set_erase calls are required.

--- a/iree/base/internal/wait_handle.h
+++ b/iree/base/internal/wait_handle.h
@@ -59,7 +59,7 @@ static inline bool iree_wait_handle_is_immediate(iree_wait_handle_t handle) {
 // Initializes a wait handle with the given primitive type and value.
 // Wait handles do not retain the provided primitives and they must be kept
 // valid (allocated and open) for the duration any wait handle references them.
-iree_status_t iree_wait_handle_wrap_primitive(
+void iree_wait_handle_wrap_primitive(
     iree_wait_primitive_type_t primitive_type,
     iree_wait_primitive_value_t primitive_value,
     iree_wait_handle_t* out_handle);

--- a/iree/base/internal/wait_handle_inproc.c
+++ b/iree/base/internal/wait_handle_inproc.c
@@ -145,6 +145,10 @@ void iree_wait_set_free(iree_wait_set_t* set) {
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_wait_set_is_empty(const iree_wait_set_t* set) {
+  return set->handle_count != 0;
+}
+
 iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
                                    iree_wait_handle_t handle) {
   if (set->total_handle_count + 1 > set->capacity) {

--- a/iree/base/internal/wait_handle_inproc.c
+++ b/iree/base/internal/wait_handle_inproc.c
@@ -177,10 +177,8 @@ iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
   ++set->total_handle_count;
   iree_host_size_t index = set->handle_count++;
   iree_wait_handle_t* stored_handle = &set->handles[index];
-  // NOTE: can't fail with LOCAL_FUTEX.
-  IREE_IGNORE_ERROR(iree_wait_handle_wrap_primitive(handle.type, handle.value,
-                                                    stored_handle));
-  stored_handle->set_internal.dupe_count = 0;  // just us so far
+  iree_wait_handle_wrap_primitive(handle.type, handle.value, stored_handle);
+  user_handle->set_internal.dupe_count = 0;  // just us so far
 
   return iree_ok_status();
 }

--- a/iree/base/internal/wait_handle_poll.c
+++ b/iree/base/internal/wait_handle_poll.c
@@ -178,6 +178,10 @@ void iree_wait_set_free(iree_wait_set_t* set) {
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_wait_set_is_empty(const iree_wait_set_t* set) {
+  return set->handle_count != 0;
+}
+
 iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
                                    iree_wait_handle_t handle) {
   if (set->handle_count + 1 > set->handle_capacity) {

--- a/iree/base/internal/wait_handle_poll.c
+++ b/iree/base/internal/wait_handle_poll.c
@@ -188,8 +188,7 @@ iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
   iree_host_size_t index = set->handle_count++;
 
   iree_wait_handle_t* user_handle = &set->user_handles[index];
-  IREE_IGNORE_ERROR(
-      iree_wait_handle_wrap_primitive(handle.type, handle.value, user_handle));
+  iree_wait_handle_wrap_primitive(handle.type, handle.value, user_handle);
 
   // NOTE: poll will ignore any negative fds.
   struct pollfd* poll_fd = &set->poll_fds[index];

--- a/iree/base/internal/wait_handle_test.cc
+++ b/iree/base/internal/wait_handle_test.cc
@@ -98,8 +98,7 @@ TEST(Event, WaitOneInitialTrue) {
 // These are used to neuter events in lists/sets and should be no-ops.
 TEST(Event, ImmediateEvent) {
   iree_event_t event;
-  IREE_ASSERT_OK(iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_NONE,
-                                                 {0}, &event));
+  iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_NONE, {0}, &event);
   iree_event_set(&event);
   IREE_EXPECT_OK(iree_wait_one(&event, IREE_TIME_INFINITE_PAST));
   iree_event_reset(&event);

--- a/iree/base/internal/wait_handle_win32.c
+++ b/iree/base/internal/wait_handle_win32.c
@@ -53,8 +53,9 @@ static iree_status_t iree_wait_primitive_clone(
         iree_status_code_from_win32_error(GetLastError()),
         "unable to duplicate HANDLE; possibly out of process handles");
   }
-  return iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE,
-                                         value, out_target_handle);
+  iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE, value,
+                                  out_target_handle);
+  return iree_ok_status();
 }
 
 // Closes an existing handle that was either created manually or via
@@ -235,8 +236,7 @@ iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
   ++set->total_handle_count;
   iree_host_size_t index = set->handle_count++;
   iree_wait_handle_t* user_handle = &set->user_handles[index];
-  IREE_IGNORE_ERROR(
-      iree_wait_handle_wrap_primitive(handle.type, handle.value, user_handle));
+  iree_wait_handle_wrap_primitive(handle.type, handle.value, user_handle);
   user_handle->set_internal.dupe_count = 0;  // just us so far
   set->native_handles[index] = native_handle;
 
@@ -442,8 +442,9 @@ iree_status_t iree_event_initialize(bool initial_state,
     return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
                             "unable to create event");
   }
-  return iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE,
-                                         value, out_event);
+  iree_wait_handle_wrap_primitive(IREE_WAIT_PRIMITIVE_TYPE_WIN32_HANDLE, value,
+                                  out_event);
+  return iree_ok_status();
 }
 
 void iree_event_deinitialize(iree_event_t* event) {

--- a/iree/base/internal/wait_handle_win32.c
+++ b/iree/base/internal/wait_handle_win32.c
@@ -180,6 +180,10 @@ void iree_wait_set_free(iree_wait_set_t* set) {
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_wait_set_is_empty(const iree_wait_set_t* set) {
+  return set->handle_count != 0;
+}
+
 iree_status_t iree_wait_set_insert(iree_wait_set_t* set,
                                    iree_wait_handle_t handle) {
   if (set->total_handle_count + 1 > set->handle_capacity) {

--- a/iree/base/loop.c
+++ b/iree/base/loop.c
@@ -1,0 +1,203 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/loop.h"
+
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// iree_loop_t
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t iree_loop_call(iree_loop_t loop,
+                                             iree_loop_priority_t priority,
+                                             iree_loop_callback_fn_t callback,
+                                             void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  const iree_loop_call_params_t params = {
+      .callback =
+          {
+              .fn = callback,
+              .user_data = user_data,
+          },
+      .priority = priority,
+  };
+  iree_status_t status =
+      loop.ctl(loop.self, IREE_LOOP_COMMAND_CALL, &params, NULL);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_loop_dispatch(
+    iree_loop_t loop, const uint32_t workgroup_count_xyz[3],
+    iree_loop_workgroup_fn_t workgroup_callback,
+    iree_loop_callback_fn_t completion_callback, void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[0]);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[1]);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)workgroup_count_xyz[2]);
+
+  const iree_loop_dispatch_params_t params = {
+      .callback =
+          {
+              .fn = completion_callback,
+              .user_data = user_data,
+          },
+      .workgroup_fn = workgroup_callback,
+      .workgroup_count_xyz =
+          {
+              workgroup_count_xyz[0],
+              workgroup_count_xyz[1],
+              workgroup_count_xyz[2],
+          },
+  };
+  iree_status_t status =
+      loop.ctl(loop.self, IREE_LOOP_COMMAND_DISPATCH, &params, NULL);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_loop_wait_until(iree_loop_t loop, iree_timeout_t timeout,
+                     iree_loop_callback_fn_t callback, void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Capture time as an absolute value as we don't know when it's going to run.
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  const iree_loop_wait_until_params_t params = {
+      .callback =
+          {
+              .fn = callback,
+              .user_data = user_data,
+          },
+      .deadline_ns = deadline_ns,
+  };
+  iree_status_t status =
+      loop.ctl(loop.self, IREE_LOOP_COMMAND_WAIT_UNTIL, &params, NULL);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_loop_wait_one(
+    iree_loop_t loop, iree_wait_source_t wait_source, iree_timeout_t timeout,
+    iree_loop_callback_fn_t callback, void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Capture time as an absolute value as we don't know when it's going to run.
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  const iree_loop_wait_one_params_t params = {
+      .callback =
+          {
+              .fn = callback,
+              .user_data = user_data,
+          },
+      .deadline_ns = deadline_ns,
+      .wait_source = wait_source,
+  };
+  iree_status_t status =
+      loop.ctl(loop.self, IREE_LOOP_COMMAND_WAIT_ONE, &params, NULL);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_loop_wait_multi(
+    iree_loop_command_t command, iree_loop_t loop, iree_host_size_t count,
+    iree_wait_source_t* wait_sources, iree_timeout_t timeout,
+    iree_loop_callback_fn_t callback, void* user_data) {
+  if (count == 0) {
+    // No wait handles; issue the callback as if it had completed async.
+    return iree_loop_call(loop, IREE_LOOP_PRIORITY_DEFAULT, callback,
+                          user_data);
+  } else if (count == 1) {
+    // One wait handle can go down the fast path.
+    return iree_loop_wait_one(loop, wait_sources[0], timeout, callback,
+                              user_data);
+  }
+
+  // Capture time as an absolute value as we don't know when it's going to run.
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  const iree_loop_wait_multi_params_t params = {
+      .callback =
+          {
+              .fn = callback,
+              .user_data = user_data,
+          },
+      .deadline_ns = deadline_ns,
+      .count = count,
+      .wait_sources = wait_sources,
+  };
+  return loop.ctl(loop.self, command, &params, NULL);
+}
+
+IREE_API_EXPORT iree_status_t iree_loop_wait_any(
+    iree_loop_t loop, iree_host_size_t count, iree_wait_source_t* wait_sources,
+    iree_timeout_t timeout, iree_loop_callback_fn_t callback, void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)count);
+  iree_status_t status =
+      iree_loop_wait_multi(IREE_LOOP_COMMAND_WAIT_ANY, loop, count,
+                           wait_sources, timeout, callback, user_data);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_loop_wait_all(
+    iree_loop_t loop, iree_host_size_t count, iree_wait_source_t* wait_sources,
+    iree_timeout_t timeout, iree_loop_callback_fn_t callback, void* user_data) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)count);
+  iree_status_t status =
+      iree_loop_wait_multi(IREE_LOOP_COMMAND_WAIT_ALL, loop, count,
+                           wait_sources, timeout, callback, user_data);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_loop_drain(iree_loop_t loop,
+                                              iree_timeout_t timeout) {
+  if (IREE_UNLIKELY(!loop.ctl)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null loop");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Capture time as an absolute value as we don't know when it's going to run.
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  const iree_loop_drain_params_t params = {
+      .deadline_ns = deadline_ns,
+  };
+  iree_status_t status =
+      loop.ctl(loop.self, IREE_LOOP_COMMAND_DRAIN, &params, NULL);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/iree/base/loop.h
+++ b/iree/base/loop.h
@@ -1,0 +1,337 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_LOOP_H_
+#define IREE_BASE_LOOP_H_
+
+#include <inttypes.h>
+
+#include "iree/base/allocator.h"
+#include "iree/base/attributes.h"
+#include "iree/base/status.h"
+#include "iree/base/time.h"
+#include "iree/base/wait_source.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_loop_t public API
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_loop_t iree_loop_t;
+typedef uint32_t iree_loop_command_t;
+
+// TODO(benvanik): define prioritization. This is useful for ensuring fast
+// coroutine switching by avoiding the current coroutine being set to the back
+// of the loop. It's easy to shoot yourself in the foot, though: cooperative
+// scheduling can be tricky.
+typedef enum iree_loop_priority_e {
+  IREE_LOOP_PRIORITY_DEFAULT = 0u,
+} iree_loop_priority_t;
+
+// Callback to execute user code used by the loop.
+// |user_data| contains the value provided to the callback when enqueuing the
+// operation and must remain live until the callback is made.
+//
+// If the callback is to be executed as normal |status| will be OK.
+// A non-fatal error case of IREE_STATUS_DEADLINE_EXCEEDED can occur if the
+// operation had a deadline specified and it elapsed prior to the condition
+// being met.
+//
+// |status| otherwise indicates that the operation failed (such as a failed wait
+// or a failed workgroup callback).
+//
+// Callbacks may reentrantly queue work on the |loop| _unless_ the passed
+// |status| is IREE_STATUS_ABORTED indicating that the loop is shutting down or
+// the operation is being aborted because of a prior failure.
+//
+// Any non-OK result will be routed to a loop-global error handler (depending on
+// implementation) or otherwise ignored; users must set their own exit bits.
+typedef iree_status_t(IREE_API_PTR* iree_loop_callback_fn_t)(
+    void* user_data, iree_loop_t loop, iree_status_t status);
+
+// Callback to execute a single workgroup in a grid dispatch.
+// Each call receives the XYZ location in the grid and may run concurrently with
+// any other workgroup call.
+//
+// Any non-OK result will be routed to the completion callback of the dispatch
+// operation but not otherwise trigger loop failure. Other workgroups may
+// continue to run up until the completion callback is issued.
+typedef iree_status_t(IREE_API_PTR* iree_loop_workgroup_fn_t)(
+    void* user_data, iree_loop_t loop, uint32_t workgroup_x,
+    uint32_t workgroup_y, uint32_t workgroup_z);
+
+// Function pointer for an iree_loop_t control function.
+// |command| provides the operation to perform. Commands may use |params| to
+// pass additional operation-specific parameters. |inout_ptr| usage is defined
+// by each operation.
+typedef iree_status_t(IREE_API_PTR* iree_loop_ctl_fn_t)(
+    void* self, iree_loop_command_t command, const void* params,
+    void** inout_ptr);
+
+// An event system for executing queued asynchronous work.
+// Implementations are allowed to execute operations in any order but generally
+// runs FIFO and will only ever execute one operation at a time. The thread used
+// for execution may change from operation to operation. Usage that has order
+// requirements is required to perform the ordering themselves.
+//
+// This is a form of cooperative scheduling and the loop _may_ not make forward
+// progress if a callback issues a blocking operation. All blocking operations
+// should either be done on user-controlled threads or via the loop primitives
+// such as iree_loop_wait_one. Callbacks may enqueue zero or more operations
+// with 2+ performing a conceptual fork. The iree_loop_dispatch operation allows
+// for a constrained style of concurrency matching a GPU grid dispatch and can
+// be used as a primitive to implement other kinds of parallel loops.
+//
+// User data passed to callbacks is unowned and must be kept live by the
+// requester. All callbacks are guaranteed to be issued even on failure and
+// allocations made when enqueuing operations are safe to free in the callbacks.
+//
+// The rough behavior of the loop matches that of the web event loop
+// dispatching events/promises/timeouts/etc. It's a stackless design where the
+// owner of the primary control loop is hidden from the users of the loop. This
+// allows implementations to integrate into existing scheduling mechanisms
+// (ALooper, libuv, io_uring, the browser main event loop, etc) in a generic
+// way. The design of the API here is meant to make it easy to put the
+// implementation in external code (python/javascript/rust/java/etc) as only a
+// single method with a fixed interface is used to cross the boundaries.
+//
+// Note that by default this implementation is only intended for host-level
+// synchronization and scheduling: fairly coarse events performed fairly
+// infrequently. Optimized multi-threaded workloads are intended to execute on
+// the iree/task/ system via command buffers.
+typedef struct iree_loop_t {
+  // Control function data.
+  void* self;
+  // ioctl-style control function servicing all loop-related commands.
+  // See iree_loop_command_t for more information.
+  iree_loop_ctl_fn_t ctl;
+} iree_loop_t;
+
+// A loop that can do no work. Attempts to enqueue work will fail.
+static inline iree_loop_t iree_loop_null() {
+  iree_loop_t loop = {NULL, NULL};
+  return loop;
+}
+
+// Executes |callback| from the loop at some point in the future.
+//
+// The callback is guaranteed to be issued but in an undefined order.
+// |user_data| is not retained and must be live until the callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_call(iree_loop_t loop,
+                                             iree_loop_priority_t priority,
+                                             iree_loop_callback_fn_t callback,
+                                             void* user_data);
+
+// Executes |workgroup_callback| from the loop at some point in the future
+// with grid dispatch of |workgroup_count_xyz| workgroups. Each
+// |workgroup_callback| will receive its XYZ location in the grid and
+// |completion_callback| will be issued upon completion (or failure).
+// The dispatched workgroups are not guaranteed to run concurrently and must
+// not perform blocking operations.
+//
+// The completion callback is guaranteed to be issued but in an undefined order.
+// The workgroup callback runs serially or concurrently from multiple threads.
+// |user_data| is not retained and must be live until the callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_dispatch(
+    iree_loop_t loop, const uint32_t workgroup_count_xyz[3],
+    iree_loop_workgroup_fn_t workgroup_callback,
+    iree_loop_callback_fn_t completion_callback, void* user_data);
+
+// Waits until |timeout| is reached and then issues |callback|.
+// There may be a significant latency between |timeout| and when the |callback|
+// is executed.
+//
+// The callback is guaranteed to be issued.
+// |user_data| is not retained and must be live until the callback is issued.
+IREE_API_EXPORT iree_status_t
+iree_loop_wait_until(iree_loop_t loop, iree_timeout_t timeout,
+                     iree_loop_callback_fn_t callback, void* user_data);
+
+// Waits until the |wait_source| is satisfied or |timeout| is reached and then
+// issues |callback|.
+//
+// The callback is guaranteed to be issued.
+// |user_data| is not retained and must be live until the callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_wait_one(
+    iree_loop_t loop, iree_wait_source_t wait_source, iree_timeout_t timeout,
+    iree_loop_callback_fn_t callback, void* user_data);
+
+// Waits until one or more of the |wait_sources| is satisfied or |timeout| is
+// reached and then issues |callback|.
+//
+// The callback is guaranteed to be issued.
+// |wait_sources| and |user_data| is not retained and must be live until the
+// callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_wait_any(
+    iree_loop_t loop, iree_host_size_t count, iree_wait_source_t* wait_sources,
+    iree_timeout_t timeout, iree_loop_callback_fn_t callback, void* user_data);
+
+// Waits until all of the |wait_sources| is satisfied or |timeout| is reached
+// and then issues |callback|.
+//
+// The callback is guaranteed to be issued.
+// |wait_sources| and |user_data| is not retained and must be live until the
+// callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_wait_all(
+    iree_loop_t loop, iree_host_size_t count, iree_wait_source_t* wait_sources,
+    iree_timeout_t timeout, iree_loop_callback_fn_t callback, void* user_data);
+
+// Blocks the caller and waits until the loop is idle or |timeout| is reached.
+//
+// Not all implementations support this and may return
+// IREE_STATUS_DEADLINE_EXCEEDED immediately when work is still pending.
+// |user_data| is not retained and must be live until the callback is issued.
+IREE_API_EXPORT iree_status_t iree_loop_drain(iree_loop_t loop,
+                                              iree_timeout_t timeout);
+
+//===----------------------------------------------------------------------===//
+// iree_loop_t implementation details
+//===----------------------------------------------------------------------===//
+// These are exposed so that user applications can implement their own loops and
+// are otherwise private to the API.
+
+// Controls the behavior of an iree_loop_ctl_fn_t callback function.
+enum iree_loop_command_e {
+  // Issues the callback from the loop at some point in the future.
+  // The callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_call_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_CALL = 0u,
+
+  // Issues a workgroup callback across a grid and then issues the callback.
+  // The completion callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_dispatch_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_DISPATCH,
+
+  // TODO(benvanik): open/read/write/close/etc with iovecs.
+  // Our iree_byte_span_t matches with `struct iovec` and if we share that we
+  // can do scatter/gather I/O with io_uring.
+  // Want something with an fd, flags, count, and iree_byte_span_t's.
+
+  // TODO(benvanik): IREE_LOOP_COMMAND_WAIT_IDLE to get idle callbacks.
+
+  // Sleeps until the timeout is reached then issues the callback.
+  // The callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_wait_until_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_WAIT_UNTIL,
+
+  // Waits until the wait source has resolved then issues the callback.
+  // The callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_wait_one_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_WAIT_ONE,
+
+  // Waits until one or more wait sources have resolved then issues the
+  // callback. The callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_wait_multi_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_WAIT_ANY,
+
+  // Waits until all of the wait sources have resolved then issues the
+  // callback. The callback will always be called (including when aborted).
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_wait_multi_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_WAIT_ALL,
+
+  // Waits until the loop has no more pending work.
+  // Resolves early with IREE_STATUS_DEADLINE_EXCEEDED if the timeout is reached
+  // before the loop is idle or if the platform does not support the operation.
+  //
+  // iree_loop_ctl_fn_t:
+  //   params: iree_loop_drain_params_t
+  //   inout_ptr: unused
+  IREE_LOOP_COMMAND_DRAIN,
+
+  IREE_LOOP_COMMAND_MAX = IREE_LOOP_COMMAND_DRAIN,
+};
+
+typedef struct iree_loop_callback_t {
+  // Callback function pointer.
+  iree_loop_callback_fn_t fn;
+  // User data passed to the callback function. Unowned.
+  void* user_data;
+} iree_loop_callback_t;
+
+// Parameters for IREE_LOOP_COMMAND_CALL.
+typedef struct iree_loop_call_params_t {
+  // Callback issued to perform the call.
+  iree_loop_callback_t callback;
+  // Controls the scheduling of the call.
+  iree_loop_priority_t priority;
+} iree_loop_call_params_t;
+
+// Parameters for IREE_LOOP_COMMAND_DISPATCH.
+typedef struct iree_loop_dispatch_params_t {
+  // Callback issued when the call completes (successfully or otherwise).
+  iree_loop_callback_t callback;
+  // Callback issued for each workgroup.
+  iree_loop_workgroup_fn_t workgroup_fn;
+  // 3D workgroup count.
+  uint32_t workgroup_count_xyz[3];
+} iree_loop_dispatch_params_t;
+
+// Parameters for IREE_LOOP_COMMAND_WAIT_UTIL.
+typedef struct iree_loop_wait_until_params_t {
+  // Callback issued after the wait condition is satisfied.
+  iree_loop_callback_t callback;
+  // Maximum time to wait before failing the wait with
+  // IREE_STATUS_DEADLINE_EXCEEDED.
+  iree_time_t deadline_ns;
+} iree_loop_wait_until_params_t;
+
+// Parameters for IREE_LOOP_COMMAND_WAIT_ONE.
+typedef struct iree_loop_wait_one_params_t {
+  // Callback issued after the wait condition is satisfied.
+  iree_loop_callback_t callback;
+  // Maximum time to wait before failing the wait with
+  // IREE_STATUS_DEADLINE_EXCEEDED.
+  iree_time_t deadline_ns;
+  // Wait source to wait on.
+  iree_wait_source_t wait_source;
+} iree_loop_wait_one_params_t;
+
+// Parameters for IREE_LOOP_COMMAND_WAIT_ANY / IREE_LOOP_COMMAND_WAIT_ALL.
+typedef struct iree_loop_wait_multi_params_t {
+  // Callback issued after any/all wait conditions are satisfied.
+  iree_loop_callback_t callback;
+  // Maximum time to wait before failing the wait with
+  // IREE_STATUS_DEADLINE_EXCEEDED.
+  iree_time_t deadline_ns;
+  // Total number of wait sources.
+  iree_host_size_t count;
+  // List of wait source to wait on.
+  // Ownership remains with the issuer and must remain live until the callback.
+  iree_wait_source_t* wait_sources;
+} iree_loop_wait_multi_params_t;
+
+// Parameters for IREE_LOOP_COMMAND_DRAIN.
+typedef struct iree_loop_drain_params_t {
+  // Time when the wait will abort.
+  iree_time_t deadline_ns;
+} iree_loop_drain_params_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_LOOP_H_

--- a/iree/base/loop_inline.c
+++ b/iree/base/loop_inline.c
@@ -1,0 +1,514 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/loop_inline.h"
+
+#include "iree/base/assert.h"
+#include "iree/base/tracing.h"
+
+static iree_status_t iree_loop_inline_reentrant_ctl(void* self,
+                                                    iree_loop_command_t command,
+                                                    const void* params,
+                                                    void** inout_ptr);
+
+static void iree_loop_inline_emit_error(iree_loop_t loop, iree_status_t status);
+
+//===----------------------------------------------------------------------===//
+// Inline execution of operations
+//===----------------------------------------------------------------------===//
+
+// IREE_LOOP_COMMAND_CALL
+static void iree_loop_inline_run_call(iree_loop_t loop,
+                                      iree_loop_call_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Ideally a tail call (when not tracing).
+  iree_status_t status =
+      params.callback.fn(params.callback.user_data, loop, iree_ok_status());
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// IREE_LOOP_COMMAND_DISPATCH
+static void iree_loop_inline_run_dispatch(iree_loop_t loop,
+                                          iree_loop_dispatch_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+
+  // We run all workgroups before issuing the completion callback.
+  // If any workgroup fails we exit early and pass the failing status back to
+  // the completion handler exactly once.
+  uint32_t workgroup_count_x = params.workgroup_count_xyz[0];
+  uint32_t workgroup_count_y = params.workgroup_count_xyz[1];
+  uint32_t workgroup_count_z = params.workgroup_count_xyz[2];
+  iree_status_t workgroup_status = iree_ok_status();
+  for (uint32_t z = 0; z < workgroup_count_z; ++z) {
+    for (uint32_t y = 0; y < workgroup_count_y; ++y) {
+      for (uint32_t x = 0; x < workgroup_count_x; ++x) {
+        workgroup_status =
+            params.workgroup_fn(params.callback.user_data, loop, x, y, z);
+        if (!iree_status_is_ok(workgroup_status)) goto workgroup_failed;
+      }
+    }
+  }
+workgroup_failed:
+
+  // Fire the completion callback with either success or the first error hit by
+  // a workgroup.
+  // Ideally a tail call (when not tracing).
+  status =
+      params.callback.fn(params.callback.user_data, loop, workgroup_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// IREE_LOOP_COMMAND_WAIT_UNTIL
+static void iree_loop_inline_run_wait_until(
+    iree_loop_t loop, iree_loop_wait_until_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  bool did_wait = iree_wait_until(params.deadline_ns);
+
+  iree_status_t status = params.callback.fn(
+      params.callback.user_data, loop,
+      did_wait ? iree_ok_status()
+               : iree_make_status(IREE_STATUS_ABORTED,
+                                  "sleep was aborted by a signal/alert"));
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// IREE_LOOP_COMMAND_WAIT_ONE
+static void iree_loop_inline_run_wait_one(iree_loop_t loop,
+                                          iree_loop_wait_one_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_timeout_t timeout = iree_make_deadline(params.deadline_ns);
+
+  // Try waiting on the wait source directly; this is usually the most optimal
+  // implementation when available and for others may drop down to a system
+  // wait primitive.
+  iree_status_t wait_status =
+      iree_wait_source_wait_one(params.wait_source, timeout);
+
+  // Callback after wait, whether it succeeded or failed.
+  iree_status_t status =
+      params.callback.fn(params.callback.user_data, loop, wait_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// IREE_LOOP_COMMAND_WAIT_ANY
+static void iree_loop_inline_run_wait_any(
+    iree_loop_t loop, iree_loop_wait_multi_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_timeout_t timeout = iree_make_deadline(params.deadline_ns);
+
+  // Do a scan down the wait sources to see if any are already set - if so we
+  // can bail early. Otherwise we need to wait on any one.
+  // iree_wait_any is a much more efficient (and fair) way but this keeps the
+  // code working on bare-metal.
+  iree_status_t wait_status = iree_status_from_code(IREE_STATUS_DEFERRED);
+  for (iree_host_size_t i = 0; i < params.count; ++i) {
+    iree_status_code_t wait_status_code = IREE_STATUS_OK;
+    iree_status_t query_status =
+        iree_wait_source_query(params.wait_sources[i], &wait_status_code);
+    if (iree_status_is_ok(query_status)) {
+      if (wait_status_code == IREE_STATUS_OK) {
+        // Signaled - can bail early.
+        break;
+      } else if (wait_status_code == IREE_STATUS_DEFERRED) {
+        // Not signaled yet - keep scanning.
+        continue;
+      } else {
+        // Wait failed - can bail early.
+        wait_status = iree_status_from_code(wait_status_code);
+        break;
+      }
+    } else {
+      // Failed to perform the query, which we treat the same as a wait error.
+      wait_status = query_status;
+      break;
+    }
+  }
+  if (iree_status_is_deferred(wait_status)) {
+    // No queries resolved/failed - commit any real wait.
+    // We choose the first one to be (somewhat) deterministic but really it
+    // should be randomized... or if the user cares they should use a real loop.
+    wait_status = iree_wait_source_wait_one(params.wait_sources[0], timeout);
+  }
+
+  // Callback after wait, whether it succeeded or failed.
+  iree_status_t status =
+      params.callback.fn(params.callback.user_data, loop, wait_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// IREE_LOOP_COMMAND_WAIT_ALL
+static void iree_loop_inline_run_wait_all(
+    iree_loop_t loop, iree_loop_wait_multi_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_timeout_t timeout = iree_make_deadline(params.deadline_ns);
+
+  // Run down the list waiting on each source.
+  // iree_wait_all is a much more efficient way but this keeps the code working
+  // on bare-metal.
+  iree_status_t wait_status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < params.count; ++i) {
+    wait_status = iree_wait_source_wait_one(params.wait_sources[i], timeout);
+    if (!iree_status_is_ok(wait_status)) break;
+  }
+
+  // Callback after wait, whether it succeeded or failed.
+  iree_status_t status =
+      params.callback.fn(params.callback.user_data, loop, wait_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_inline_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_inline_ring_t
+//===----------------------------------------------------------------------===//
+
+// Total capacity of the ringbuffer in operations pending.
+// The usable capacity is always 1 less than this as we mask it off,
+// unfortunately wasting a slot but keeping this all stupid simple. If we wanted
+// to drop another ~32B of stack space we could make this do the right thing.
+#define IREE_LOOP_INLINE_RING_CAPACITY ((uint8_t)8)
+static_assert((IREE_LOOP_INLINE_RING_CAPACITY &
+               (IREE_LOOP_INLINE_RING_CAPACITY - 1)) == 0,
+              "ringbuffer capacity must be a power of two");
+
+// Bitmask used to perform a quick mod of the ringbuffer indices.
+// This must always be ANDed with the indices before use:
+//   uint8_t physical_idx = logical_idx % IREE_LOOP_INLINE_RING_CAPACITY;
+// or this, way better (though the compiler can usually figure it out):
+//   uint8_t physical_idx = logical_idx & IREE_LOOP_INLINE_RING_CAPACITY;
+#define IREE_LOOP_INLINE_RING_MASK (IREE_LOOP_INLINE_RING_CAPACITY - 1)
+
+// An operation in the inline loop ringbuffer containing all the information
+// required to replay it at a future time. All pointers are unowned.
+typedef struct iree_loop_inline_op_t {
+  iree_loop_command_t command;
+  union {
+    iree_loop_callback_t callback;
+    union {
+      iree_loop_call_params_t call;
+      iree_loop_dispatch_params_t dispatch;
+      iree_loop_wait_until_params_t wait_until;
+      iree_loop_wait_one_params_t wait_one;
+      iree_loop_wait_multi_params_t wait_multi;
+    } params;
+  };
+} iree_loop_inline_op_t;
+
+// Returns the size of the parameters required by |command|.
+static inline uint8_t iree_loop_params_size(iree_loop_command_t command) {
+  // Keep this a tail call switch; compilers can work magic here.
+  switch (command) {
+    case IREE_LOOP_COMMAND_CALL:
+      return sizeof(iree_loop_call_params_t);
+    case IREE_LOOP_COMMAND_DISPATCH:
+      return sizeof(iree_loop_dispatch_params_t);
+    case IREE_LOOP_COMMAND_WAIT_UNTIL:
+      return sizeof(iree_loop_wait_until_params_t);
+    case IREE_LOOP_COMMAND_WAIT_ONE:
+      return sizeof(iree_loop_wait_one_params_t);
+    case IREE_LOOP_COMMAND_WAIT_ANY:
+    case IREE_LOOP_COMMAND_WAIT_ALL:
+      return sizeof(iree_loop_wait_multi_params_t);
+    default:
+      return 0;
+  }
+}
+
+// Fixed-size ringbuffer of commands enqueued reentrantly.
+// We ensure the size stays small so we don't blow the stack of tiny systems.
+// The inline loop is explicitly not designed for multi-program cooperative
+// scheduling and well-formed programs shouldn't hit the limit.
+//
+// NOTE: this structure must be in an initialized state if zeroed.
+typedef struct iree_loop_inline_ring_t {
+  iree_loop_inline_op_t ops[IREE_LOOP_INLINE_RING_CAPACITY];
+  uint8_t read_head;
+  uint8_t write_head;
+  iree_status_t* status_ptr;
+} iree_loop_inline_ring_t;
+static_assert(
+    sizeof(iree_loop_inline_ring_t) <= IREE_LOOP_INLINE_STORAGE_SIZE,
+    "iree_loop_inline_ring_t needs to be tiny as it's allocated on the stack");
+
+// Returns a loop that references the current ringbuffer for reentrant usage.
+static inline iree_loop_t iree_loop_inline_reentrant(
+    iree_loop_inline_ring_t* ring) {
+  iree_loop_t loop = {
+      .self = ring,
+      .ctl = iree_loop_inline_reentrant_ctl,
+  };
+  return loop;
+}
+
+// Initializes |out_ring| for use.
+// We don't clear the ops as we (hopefully) don't use them unless they are valid
+// as defined by the ringbuffer parameters.
+static inline void iree_loop_inline_ring_initialize(
+    iree_status_t* status_ptr, iree_loop_inline_ring_t* out_ring) {
+  out_ring->read_head = 0;
+  out_ring->write_head = 0;
+  out_ring->status_ptr = status_ptr;
+}
+
+// Returns true if the ringbuffer is empty (read has caught up to write).
+static inline bool iree_loop_inline_ring_is_empty(
+    const iree_loop_inline_ring_t* ring) {
+  return ring->read_head == ring->write_head;
+}
+
+// Returns true if the ringbuffer is full (write has caught up to read).
+static inline bool iree_loop_inline_ring_is_full(
+    const iree_loop_inline_ring_t* ring) {
+  return ((ring->write_head - ring->read_head) & IREE_LOOP_INLINE_RING_MASK) ==
+         IREE_LOOP_INLINE_RING_MASK;
+}
+
+// Enqueues an operation into |ring|, capacity-permitting.
+// |params| is copied into the ringbuffer and need not remain live upon return.
+static iree_status_t iree_loop_inline_enqueue(iree_loop_inline_ring_t* ring,
+                                              iree_loop_command_t command,
+                                              const void* params) {
+  // The only thing we need to do here is memcpy the params into our ring.
+  // Since all the params differ in size we just effectively perform a lookup
+  // and do the copy.
+  uint8_t params_size = iree_loop_params_size(command);
+  if (IREE_UNLIKELY(params_size) == 0) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "unimplemented loop command");
+  }
+
+  // Ensure there's space for the new operation.
+  if (iree_loop_inline_ring_is_full(ring)) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "inline ringbuffer capacity exceeded; reduce the amount of concurrent "
+        "work or use a real loop implementation");
+  }
+
+  // Reserve a slot for the new operation.
+  uint8_t slot = ring->write_head;
+  ring->write_head = (ring->write_head + 1) & IREE_LOOP_INLINE_RING_MASK;
+
+  // Copy the operation in; the params are on the stack and won't be valid after
+  // the caller returns.
+  ring->ops[slot].command = command;
+  memcpy(&ring->ops[slot].params, params, params_size);
+  return iree_ok_status();
+}
+
+// Dequeues the next operation in |ring| and executes it.
+// The operation may reentrantly enqueue more operations.
+static void iree_loop_inline_dequeue_and_run_next(
+    iree_loop_inline_ring_t* ring) {
+  IREE_ASSERT(!iree_loop_inline_ring_is_empty(ring));
+
+  // Acquire the next operation.
+  uint8_t slot = ring->read_head;
+  ring->read_head = (ring->read_head + 1) & IREE_LOOP_INLINE_RING_MASK;
+
+  // Copy out the parameters; the operation we execute may overwrite them by
+  // enqueuing more work.
+  iree_loop_inline_op_t op = ring->ops[slot];
+
+  // We pass the callbacks a loop that has the reentrancy bit set.
+  // This allows iree_loop_inline_ctl to determine whether it needs to alloc
+  // more stack space.
+  iree_loop_t loop = iree_loop_inline_reentrant(ring);
+
+  // Tail call into the execution routine so we can hopefully tail call all the
+  // way up the stack.
+  // Ideally these are all tail calls.
+  switch (op.command) {
+    case IREE_LOOP_COMMAND_CALL:
+      iree_loop_inline_run_call(loop, op.params.call);
+      break;
+    case IREE_LOOP_COMMAND_DISPATCH:
+      iree_loop_inline_run_dispatch(loop, op.params.dispatch);
+      break;
+    case IREE_LOOP_COMMAND_WAIT_UNTIL:
+      iree_loop_inline_run_wait_until(loop, op.params.wait_until);
+      break;
+    case IREE_LOOP_COMMAND_WAIT_ONE:
+      iree_loop_inline_run_wait_one(loop, op.params.wait_one);
+      break;
+    case IREE_LOOP_COMMAND_WAIT_ANY:
+      iree_loop_inline_run_wait_any(loop, op.params.wait_multi);
+      break;
+    case IREE_LOOP_COMMAND_WAIT_ALL:
+      iree_loop_inline_run_wait_all(loop, op.params.wait_multi);
+      break;
+    default:
+      break;
+  }
+}
+
+// Aborts all operations in the ring and resets it to its initial state.
+static void iree_loop_inline_abort_all(iree_loop_inline_ring_t* ring) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Issue the completion callback of each op to notify it of the abort.
+  // To prevent enqueuing more work while aborting we pass in a NULL loop.
+  // We can't do anything with the errors so we ignore them.
+  while (!iree_loop_inline_ring_is_empty(ring)) {
+    uint8_t slot = ring->read_head;
+    ring->read_head = (ring->read_head + 1) & IREE_LOOP_INLINE_RING_MASK;
+    iree_loop_callback_t callback = ring->ops[slot].callback;
+    iree_status_ignore(callback.fn(callback.user_data, iree_loop_null(),
+                                   iree_make_status(IREE_STATUS_ABORTED)));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static void iree_loop_inline_emit_error(iree_loop_t loop,
+                                        iree_status_t status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(
+      z0, iree_status_code_string(iree_status_code(status)));
+
+  iree_loop_inline_ring_t* ring = (iree_loop_inline_ring_t*)loop.self;
+  if (ring->status_ptr && iree_status_is_ok(*ring->status_ptr)) {
+    *ring->status_ptr = status;
+  } else {
+    iree_status_ignore(status);
+  }
+
+  iree_loop_inline_abort_all(ring);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Runs the |ring| until it is empty or an operation fails.
+static iree_status_t iree_loop_inline_run_all(iree_loop_inline_ring_t* ring) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  do {
+    // Dequeue the next op and run it inline.
+    iree_loop_inline_dequeue_and_run_next(ring);
+  } while (!iree_loop_inline_ring_is_empty(ring));
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_inline_ctl functions
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t iree_loop_inline_ctl(void* self,
+                                                   iree_loop_command_t command,
+                                                   const void* params,
+                                                   void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(self);
+
+  if (command == IREE_LOOP_COMMAND_DRAIN) {
+    // We don't really do anything with this; if called non-reentrantly then
+    // there is no work to drain.
+    return iree_ok_status();
+  }
+
+  iree_status_t* status_ptr = (iree_status_t*)self;
+
+  // Initialize a new execution context on the stack.
+  iree_loop_inline_ring_t stack_ring;
+  iree_loop_inline_ring_initialize(status_ptr, &stack_ring);
+
+  // Enqueue the initial command; we'll dequeue it right away but this keeps
+  // the code size smaller.
+  IREE_RETURN_IF_ERROR(iree_loop_inline_enqueue(&stack_ring, command, params));
+
+  // If the status is not OK then we bail immediately; this allows for sticky
+  // errors that mimic the abort behavior of an actual loop. Inline loops never
+  // run work from multiple scopes as they don't persist beyond the loop
+  // operation.
+  if (iree_status_is_ok(*status_ptr)) {
+    // Run until the ring is empty or we fail.
+    return iree_loop_inline_run_all(&stack_ring);  // tail
+  } else {
+    // Abort all ops.
+    iree_loop_inline_abort_all(&stack_ring);
+    return iree_ok_status();
+  }
+}
+
+IREE_API_EXPORT iree_status_t
+iree_loop_inline_using_storage_ctl(void* self, iree_loop_command_t command,
+                                   const void* params, void** inout_ptr) {
+  if (command == IREE_LOOP_COMMAND_DRAIN) {
+    // We don't really do anything with this; if called non-reentrantly then
+    // there is no work to drain.
+    return iree_ok_status();
+  }
+
+  iree_loop_inline_storage_t* storage = (iree_loop_inline_storage_t*)self;
+  iree_loop_inline_ring_t* ring = (iree_loop_inline_ring_t*)storage->opaque;
+
+  // Top-level call using external storage; run until the ring is empty or
+  // we fail. Note that the storage contents are undefined and we have to
+  // ensure the list is ready for use.
+  iree_loop_inline_ring_initialize(&storage->status, ring);
+
+  IREE_RETURN_IF_ERROR(iree_loop_inline_enqueue(ring, command, params));
+
+  // If the status is not OK then we bail immediately; this allows for sticky
+  // errors that mimic the abort behavior of an actual loop. Inline loops never
+  // run work from multiple scopes as they don't persist beyond the loop
+  // operation.
+  if (iree_status_is_ok(storage->status)) {
+    // Run until the ring is empty or we fail.
+    return iree_loop_inline_run_all(ring);  // tail
+  } else {
+    // Abort all ops.
+    iree_loop_inline_abort_all(ring);
+    return iree_ok_status();
+  }
+}
+
+static iree_status_t iree_loop_inline_reentrant_ctl(void* self,
+                                                    iree_loop_command_t command,
+                                                    const void* params,
+                                                    void** inout_ptr) {
+  if (command == IREE_LOOP_COMMAND_DRAIN) {
+    // We don't really do anything with this; when called reentrantly we are
+    // already draining as we drain on each top-level op.
+    return iree_ok_status();
+  }
+
+  // Enqueue the new command and return to the caller - it'll be run by
+  // the top-level control call.
+  iree_loop_inline_ring_t* ring = (iree_loop_inline_ring_t*)self;
+  return iree_loop_inline_enqueue(ring, command, params);  // tail
+}

--- a/iree/base/loop_inline.h
+++ b/iree/base/loop_inline.h
@@ -1,0 +1,95 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_LOOP_INLINE_H_
+#define IREE_BASE_LOOP_INLINE_H_
+
+#include <inttypes.h>
+
+#include "iree/base/loop.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_loop_inline
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t iree_loop_inline_ctl(void* self,
+                                                   iree_loop_command_t command,
+                                                   const void* params,
+                                                   void** inout_ptr);
+IREE_API_EXPORT iree_status_t
+iree_loop_inline_using_storage_ctl(void* self, iree_loop_command_t command,
+                                   const void* params, void** inout_ptr);
+
+// Returns a loop that doesn't really loop.
+// All operations are run as they are enqueued on the stack. This uses no
+// additional memory and ensures that everything completes upon return to the
+// user but does eliminate the ability for pipelining and overlapping work from
+// multiple subprograms. This approach limits the amount of work that can be
+// reentrantly scheduled and should only be used when in the tiniest of
+// environments with programs tested to be compatible with it.
+//
+// Reentrant enqueuing is possible and can be used to create tail call chains
+// (or recursion) that executes roughly in order.
+//
+// Caveats:
+// - Reentrant enqueuing of operations is limited to some small number (~4).
+// - Waits are performed as they are enqueued and the loop must be able to
+//   make forward progress on each.
+// - Execution deadlines are ignored in order to fully drain on each operation.
+// - Errors propagate immediately to the top-level caller and abort all pending
+//   operations.
+//
+// Thread-compatible: stateless and executes all work on the calling thread.
+static inline iree_loop_t iree_loop_inline(iree_status_t* out_status) {
+  iree_loop_t loop = {out_status, iree_loop_inline_ctl};
+  return loop;
+}
+
+// Minimum size in bytes required for iree_loop_inline_storage_t.
+// If we wanted to shrink this size to the absolute minimum we'd just expose the
+// structures here; not the worst thing but messy (as this is a public API).
+#define IREE_LOOP_INLINE_STORAGE_SIZE 512
+
+// Storage for an inline loop.
+// May be either allocated on the stack or on the heap and only needs to remain
+// valid for the lifetime of the iree_loop_t referencing it.
+typedef iree_alignas(iree_max_align_t) struct iree_loop_inline_storage_t {
+  uint8_t opaque[IREE_LOOP_INLINE_STORAGE_SIZE];
+  iree_status_t status;
+} iree_loop_inline_storage_t;
+
+// Returns an inline loop that uses an external |storage| instead of the stack.
+// The storage will only be used while executing and can be reused if the caller
+// knows it is safe (not reentrantly inside of a loop execution). Errors that
+// arise will be set in the storage status field and must be checked (or
+// ignored) by the caller to avoid leaks.
+//
+// See iree_loop_inline for details on the execution behavior.
+static inline iree_loop_t iree_loop_inline_initialize(
+    iree_loop_inline_storage_t* storage) {
+  storage->status = iree_ok_status();
+  iree_loop_t loop = {
+      storage,
+      iree_loop_inline_using_storage_ctl,
+  };
+  return loop;
+}
+
+static void iree_loop_inline_deinitialize(iree_loop_inline_storage_t* storage) {
+  if (!storage) return;
+  iree_status_ignore(storage->status);
+  storage->status = iree_ok_status();
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_LOOP_INLINE_H_

--- a/iree/base/loop_inline_test.cc
+++ b/iree/base/loop_inline_test.cc
@@ -1,0 +1,51 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+// Contains the test definitions applied to all loop implementations:
+#include "iree/base/loop_test.h"
+
+void AllocateLoop(iree_status_t* out_status, iree_allocator_t allocator,
+                  iree_loop_t* out_loop) {
+  *out_loop = iree_loop_inline(out_status);
+}
+
+void FreeLoop(iree_allocator_t allocator, iree_loop_t loop) {}
+
+// Tests usage of external storage for the inline ringbuffer.
+// The standard tests all use loop allocated stack storage while this one uses
+// the storage we control. Real applications could put that storage in .rwdata
+// somewhere or alias it with other storage (arenas/etc).
+TEST(LoopInlineTest, ExternalStorage) {
+  IREE_TRACE_SCOPE();
+
+  iree_loop_inline_storage_t storage = {{0xCD}, iree_ok_status()};
+  auto loop = iree_loop_inline_initialize(&storage);
+
+  // Issue a call that adds 1 to a counter until it reaches kCountUpTo.
+  static const int kCountUpTo = 128;
+  struct user_data_t {
+    int counter = 0;
+  } user_data;
+  static const iree_loop_callback_fn_t callback_fn =
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        auto* user_data = reinterpret_cast<user_data_t*>(user_data_ptr);
+        if (++user_data->counter < kCountUpTo) {
+          return iree_loop_call(loop, IREE_LOOP_PRIORITY_DEFAULT, callback_fn,
+                                user_data);
+        }
+        return iree_ok_status();
+      };
+  IREE_ASSERT_OK(iree_loop_call(loop, IREE_LOOP_PRIORITY_DEFAULT, callback_fn,
+                                &user_data));
+  EXPECT_EQ(user_data.counter, kCountUpTo);
+  IREE_ASSERT_OK(storage.status);
+
+  iree_loop_inline_deinitialize(&storage);
+}

--- a/iree/base/loop_sync.c
+++ b/iree/base/loop_sync.c
@@ -1,0 +1,1101 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/loop_sync.h"
+
+#include "iree/base/internal/math.h"
+#include "iree/base/internal/wait_handle.h"
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// iree_loop_sync_t utilities
+//===----------------------------------------------------------------------===//
+
+// Amount of time that can remain in a wait-until while still retiring.
+// This prevents additional system sleeps when the remaining time before the
+// deadline is less than the granularity the system is likely able to sleep for.
+// Some platforms may have as much as 10-15ms of potential slop and sleeping for
+// 1ms may result in 10-15ms.
+#define IREE_LOOP_SYNC_DELAY_SLOP_NS (2 /*ms*/ * 1000000)
+
+// NOTE: all callbacks should be at offset 0. This allows for easily zipping
+// through the params lists and issuing callbacks.
+static_assert(offsetof(iree_loop_call_params_t, callback) == 0,
+              "callback must be at offset 0");
+static_assert(offsetof(iree_loop_dispatch_params_t, callback) == 0,
+              "callback must be at offset 0");
+static_assert(offsetof(iree_loop_wait_until_params_t, callback) == 0,
+              "callback must be at offset 0");
+static_assert(offsetof(iree_loop_wait_one_params_t, callback) == 0,
+              "callback must be at offset 0");
+static_assert(offsetof(iree_loop_wait_multi_params_t, callback) == 0,
+              "callback must be at offset 0");
+
+static void iree_loop_sync_abort_scope(iree_loop_sync_t* loop_sync,
+                                       iree_loop_sync_scope_t* scope);
+
+//===----------------------------------------------------------------------===//
+// iree_loop_run_ring_t
+//===----------------------------------------------------------------------===//
+
+// Represents an operation in the loop run ringbuffer.
+// Note that the storage may be reallocated at any time and all pointers must be
+// external to the storage in order to remain valid.
+typedef struct iree_loop_run_op_t {
+  union {
+    iree_loop_callback_t callback;  // asserted at offset 0 above
+    union {
+      iree_loop_call_params_t call;
+      iree_loop_dispatch_params_t dispatch;
+    } params;
+  };
+  iree_loop_command_t command;
+  iree_loop_sync_scope_t* scope;
+
+  // Set on calls when we are issuing a callback for an operation.
+  // Unlike other pointers in the params this is owned by the ring.
+  iree_status_t status;
+} iree_loop_run_op_t;
+
+// Ringbuffer containing pending ready to run callback operations.
+//
+// Generally this works as a FIFO but we allow for head-of-ring replacement
+// for high priority tail calls. New operations are appended to the ring and
+// removed as drained; if the ringbuffer capacity is exceeded then the storage
+// will be reallocated up to the maximum capacity specified at creation time.
+typedef iree_alignas(iree_max_align_t) struct iree_loop_run_ring_t {
+  // Current storage capacity of |ops|.
+  uint32_t capacity;
+  // Index into |ops| where the next operation to be dequeued is located.
+  uint32_t read_head;
+  // Index into |ops| where the last operation to be enqueued is located.
+  uint32_t write_head;
+  // Ringbuffer storage.
+  iree_loop_run_op_t ops[0];
+} iree_loop_run_ring_t;
+
+static iree_host_size_t iree_loop_run_ring_storage_size(
+    iree_loop_sync_options_t options) {
+  return sizeof(iree_loop_run_ring_t) +
+         options.max_queue_depth * sizeof(iree_loop_run_op_t);
+}
+
+static inline uint32_t iree_loop_run_ring_mask(
+    const iree_loop_run_ring_t* run_ring) {
+  return run_ring->capacity - 1;
+}
+
+static iree_host_size_t iree_loop_run_ring_size(
+    const iree_loop_run_ring_t* run_ring) {
+  return run_ring->write_head >= run_ring->read_head
+             ? (run_ring->write_head - run_ring->read_head)
+             : (run_ring->write_head + run_ring->capacity -
+                run_ring->read_head);
+}
+
+static bool iree_loop_run_ring_is_empty(const iree_loop_run_ring_t* run_ring) {
+  return run_ring->read_head == run_ring->write_head;
+}
+
+static bool iree_loop_run_ring_is_full(const iree_loop_run_ring_t* run_ring) {
+  const uint32_t mask = iree_loop_run_ring_mask(run_ring);
+  return ((run_ring->write_head - run_ring->read_head) & mask) == mask;
+}
+
+static void iree_loop_run_ring_initialize(iree_loop_sync_options_t options,
+                                          iree_loop_run_ring_t* out_run_ring) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  out_run_ring->capacity = (uint32_t)options.max_queue_depth;
+  out_run_ring->read_head = 0;
+  out_run_ring->write_head = 0;
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static void iree_loop_run_ring_deinitialize(iree_loop_run_ring_t* run_ring) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Expected abort to be called.
+  IREE_ASSERT(iree_loop_run_ring_is_empty(run_ring));
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_loop_run_ring_enqueue(iree_loop_run_ring_t* run_ring,
+                                                iree_loop_run_op_t op) {
+  if (iree_loop_run_ring_is_full(run_ring)) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "run ringbuffer capacity %u exceeded; reduce the amount of concurrent "
+        "work or use a full loop implementation",
+        run_ring->capacity);
+  }
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_queue_depth",
+                            iree_loop_run_ring_size(run_ring));
+
+  // Reserve a slot for the new operation.
+  uint32_t slot = run_ring->write_head;
+  run_ring->write_head =
+      (run_ring->write_head + 1) & iree_loop_run_ring_mask(run_ring);
+
+  // Copy the operation in; the params are on the stack and won't be valid after
+  // the caller returns.
+  run_ring->ops[slot] = op;
+
+  ++op.scope->pending_count;
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_queue_depth",
+                            iree_loop_run_ring_size(run_ring));
+  return iree_ok_status();
+}
+
+static bool iree_loop_run_ring_dequeue(iree_loop_run_ring_t* run_ring,
+                                       iree_loop_run_op_t* out_op) {
+  if (iree_loop_run_ring_is_empty(run_ring)) return false;
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_queue_depth",
+                            iree_loop_run_ring_size(run_ring));
+
+  // Acquire the next operation.
+  uint32_t slot = run_ring->read_head;
+  run_ring->read_head =
+      (run_ring->read_head + 1) & iree_loop_run_ring_mask(run_ring);
+
+  // Copy out the parameters; the operation we execute may overwrite them by
+  // enqueuing more work.
+  *out_op = run_ring->ops[slot];
+
+  --out_op->scope->pending_count;
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_queue_depth",
+                            iree_loop_run_ring_size(run_ring));
+  return true;
+}
+
+// Aborts all ops that are part of |scope|.
+// A NULL |scope| indicates all work from all scopes should be aborted.
+static void iree_loop_run_ring_abort_scope(iree_loop_run_ring_t* run_ring,
+                                           iree_loop_sync_scope_t* scope) {
+  if (iree_loop_run_ring_is_empty(run_ring)) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Do a single pass over the ring and abort all ops matching the scope.
+  // To keep things simple and preserve dense ordered ops in the ringbuffer we
+  // dequeue all ops and re-enqueue any that don't match. When complete the ring
+  // may be at a different offset but will contain only those ops we didn't
+  // abort in their original order.
+  iree_host_size_t count = iree_loop_run_ring_size(run_ring);
+  for (iree_host_size_t i = 0; i < count; ++i) {
+    iree_loop_run_op_t op;
+    if (!iree_loop_run_ring_dequeue(run_ring, &op)) break;
+    if (scope && op.scope != scope) {
+      // Not part of the scope we are aborting; re-enqueue to the ring.
+      iree_status_ignore(iree_loop_run_ring_enqueue(run_ring, op));
+    } else {
+      // Part of the scope to abort.
+      --op.scope->pending_count;
+      iree_status_ignore(op.status);
+      iree_status_ignore(op.callback.fn(op.callback.user_data, iree_loop_null(),
+                                        iree_make_status(IREE_STATUS_ABORTED)));
+    }
+  }
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_queue_depth",
+                            iree_loop_run_ring_size(run_ring));
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Aborts all ops from all scopes.
+static void iree_loop_run_ring_abort_all(iree_loop_run_ring_t* run_ring) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_loop_run_ring_abort_scope(run_ring, /*scope=*/NULL);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_wait_list_t
+//===----------------------------------------------------------------------===//
+
+// Represents an operation in the loop wait list.
+// Note that the storage may be reallocated at any time and all pointers must be
+// external to the storage in order to remain valid.
+typedef struct iree_loop_wait_op_t {
+  union {
+    iree_loop_callback_t callback;  // asserted at offset 0 above
+    union {
+      iree_loop_wait_until_params_t wait_until;
+      iree_loop_wait_one_params_t wait_one;
+      iree_loop_wait_multi_params_t wait_multi;
+    } params;
+  };
+  iree_loop_command_t command;
+  iree_loop_sync_scope_t* scope;
+} iree_loop_wait_op_t;
+
+// Dense list of pending wait operations.
+// We don't care about the order here as we put them all into a wait set for
+// multi-wait anyway. iree_wait_set_t should really be rewritten such that this
+// is not required (custom data on registered handles, etc).
+typedef iree_alignas(iree_max_align_t) struct iree_loop_wait_list_t {
+  // System wait set used to perform multi-waits.
+  iree_wait_set_t* wait_set;
+  // Current storage capacity of |ops|.
+  uint32_t capacity;
+  // Current count of valid |ops|.
+  uint32_t count;
+  // Pending wait operations.
+  iree_loop_wait_op_t ops[0];
+} iree_loop_wait_list_t;
+
+static iree_host_size_t iree_loop_wait_list_storage_size(
+    iree_loop_sync_options_t options) {
+  return sizeof(iree_loop_wait_list_t) +
+         options.max_wait_count * sizeof(iree_loop_wait_op_t);
+}
+
+static bool iree_loop_wait_list_is_empty(iree_loop_wait_list_t* wait_list) {
+  return wait_list->count == 0;
+}
+
+static iree_status_t iree_loop_wait_list_initialize(
+    iree_loop_sync_options_t options, iree_allocator_t allocator,
+    iree_loop_wait_list_t* out_wait_list) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  out_wait_list->capacity = (uint32_t)options.max_wait_count;
+  out_wait_list->count = 0;
+
+  iree_status_t status = iree_wait_set_allocate(
+      options.max_wait_count, allocator, &out_wait_list->wait_set);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_loop_wait_list_deinitialize(iree_loop_wait_list_t* wait_list) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Expected abort to be called.
+  IREE_ASSERT(iree_loop_wait_list_is_empty(wait_list));
+
+  iree_wait_set_free(wait_list->wait_set);
+  wait_list->wait_set = NULL;
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_loop_wait_list_register_wait_source(
+    iree_loop_wait_list_t* wait_list, iree_wait_source_t* wait_source) {
+  if (iree_wait_source_is_immediate(*wait_source)) {
+    // Task has been neutered and is treated as an immediately resolved wait.
+    return iree_ok_status();
+  } else if (iree_wait_source_is_delay(*wait_source)) {
+    // We can't easily support delays as registered wait sources; we need to be
+    // able to snoop the tasks to find the earliest sleep time and can't easily
+    // do that if we tried to put them in the wait set.
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "delays must come from wait-until ops");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = iree_ok_status();
+
+  // Acquire a wait handle and insert it into the wait set.
+  // We swap out the wait source with the handle so that we don't export it
+  // again and can find it on wake.
+  iree_wait_handle_t wait_handle = iree_wait_handle_immediate();
+  iree_wait_handle_t* wait_handle_ptr =
+      iree_wait_handle_from_source(wait_source);
+  if (wait_handle_ptr) {
+    // Already a wait handle - can directly insert it.
+    wait_handle = *wait_handle_ptr;
+  } else {
+    iree_wait_primitive_t wait_primitive = iree_wait_primitive_immediate();
+    status = iree_wait_source_export(*wait_source, IREE_WAIT_PRIMITIVE_TYPE_ANY,
+                                     iree_immediate_timeout(), &wait_primitive);
+    if (iree_status_is_ok(status)) {
+      // Swap the wait handle with the exported handle so we can wake it later.
+      // It'd be ideal if we retained the wait handle separate so that we could
+      // still do fast queries for local wait sources.
+      iree_wait_handle_wrap_primitive(wait_primitive.type, wait_primitive.value,
+                                      &wait_handle);
+      status = iree_wait_source_import(wait_primitive, wait_source);
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    status = iree_wait_set_insert(wait_list->wait_set, wait_handle);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_loop_wait_list_unregister_wait_source(
+    iree_loop_wait_list_t* wait_list, iree_wait_source_t* wait_source) {
+  if (iree_wait_source_is_immediate(*wait_source) ||
+      iree_wait_source_is_delay(*wait_source)) {
+    // Not registered or it's already been unregistered.
+    return;
+  }
+  iree_wait_handle_t* wait_handle = iree_wait_handle_from_source(wait_source);
+  if (wait_handle) {
+    iree_wait_set_erase(wait_list->wait_set, *wait_handle);
+  }
+  *wait_source = iree_wait_source_immediate();
+}
+
+static void iree_loop_wait_list_unregister_wait_sources(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_op_t* op) {
+  switch (op->command) {
+    case IREE_LOOP_COMMAND_WAIT_ONE:
+      iree_loop_wait_list_unregister_wait_source(
+          wait_list, &op->params.wait_one.wait_source);
+      break;
+    case IREE_LOOP_COMMAND_WAIT_ANY:
+    case IREE_LOOP_COMMAND_WAIT_ALL:
+      for (iree_host_size_t i = 0; i < op->params.wait_multi.count; ++i) {
+        iree_loop_wait_list_unregister_wait_source(
+            wait_list, &op->params.wait_multi.wait_sources[i]);
+      }
+      break;
+    default:
+    case IREE_LOOP_COMMAND_WAIT_UNTIL:
+      break;
+  }
+}
+
+static iree_status_t iree_loop_wait_list_insert(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_op_t op) {
+  if (wait_list->count + 1 >= wait_list->capacity) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "wait list capacity %u reached",
+                            wait_list->capacity);
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+
+  uint32_t slot = wait_list->count++;
+  wait_list->ops[slot] = op;
+
+  iree_status_t status = iree_ok_status();
+  switch (op.command) {
+    case IREE_LOOP_COMMAND_WAIT_UNTIL:
+      // No entry in the wait set; we just need it in the list in order to scan.
+      break;
+    case IREE_LOOP_COMMAND_WAIT_ONE: {
+      status = iree_loop_wait_list_register_wait_source(
+          wait_list, &op.params.wait_one.wait_source);
+      break;
+    }
+    case IREE_LOOP_COMMAND_WAIT_ALL:
+    case IREE_LOOP_COMMAND_WAIT_ANY: {
+      for (iree_host_size_t i = 0;
+           i < op.params.wait_multi.count && iree_status_is_ok(status); ++i) {
+        status = iree_loop_wait_list_register_wait_source(
+            wait_list, &op.params.wait_multi.wait_sources[i]);
+      }
+      break;
+    }
+    default:
+      IREE_ASSERT_UNREACHABLE("unhandled wait list command");
+      break;
+  }
+
+  if (iree_status_is_ok(status)) {
+    ++op.scope->pending_count;
+  }
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_loop_wait_list_notify_wake(
+    iree_loop_wait_list_t* wait_list, iree_loop_run_ring_t* run_ring,
+    iree_host_size_t i, iree_status_t status) {
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+
+  // Unregister all wait handles from the wait set.
+  iree_loop_wait_list_unregister_wait_sources(wait_list, &wait_list->ops[i]);
+
+  // Since we make no guarantees about the order of the lists we can just swap
+  // with the last value. Note that we need to preserve the callback.
+  iree_loop_sync_scope_t* scope = wait_list->ops[i].scope;
+  --scope->pending_count;
+  iree_loop_callback_t callback = wait_list->ops[i].callback;
+  int tail_index = (int)wait_list->count - 1;
+  if (tail_index > i) {
+    memcpy(&wait_list->ops[i], &wait_list->ops[tail_index],
+           sizeof(*wait_list->ops));
+  }
+  --wait_list->count;
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+
+  // Enqueue the callback on the run ring - this ensures it gets sequenced with
+  // other runnable work and keeps ordering easier to reason about.
+  return iree_loop_run_ring_enqueue(
+      run_ring, (iree_loop_run_op_t){
+                    .command = IREE_LOOP_COMMAND_CALL,
+                    .scope = scope,
+                    .params =
+                        {
+                            .call =
+                                {
+                                    .callback = callback,
+                                    // TODO(benvanik): elevate callback priority
+                                    // to reduce latency?
+                                    .priority = IREE_LOOP_PRIORITY_DEFAULT,
+                                },
+                        },
+                    .status = status,
+                });
+}
+
+// Returns DEFERRED if unresolved, OK if resolved, and an error otherwise.
+// If resolved (successful or not) the caller must erase the wait.
+static iree_status_t iree_loop_wait_list_scan_wait_until(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_until_params_t* params,
+    iree_time_t now_ns, iree_time_t* earliest_deadline_ns) {
+  // Task is a delay until some future time; factor that in to our earliest
+  // deadline so that we'll wait in the system until that time. If we wake
+  // earlier because another wait resolved it's still possible for the delay
+  // to have been reached before we get back to this check.
+  if (params->deadline_ns <= now_ns + IREE_LOOP_SYNC_DELAY_SLOP_NS) {
+    // Wait deadline reached.
+    return iree_ok_status();
+  } else {
+    // Still waiting.
+    *earliest_deadline_ns =
+        iree_min(*earliest_deadline_ns, params->deadline_ns);
+    return iree_status_from_code(IREE_STATUS_DEFERRED);
+  }
+}
+
+// Returns DEFERRED if unresolved, OK if resolved, and an error otherwise.
+// If resolved (successful or not) the caller must erase the wait.
+static iree_status_t iree_loop_wait_list_scan_wait_one(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_one_params_t* params,
+    iree_time_t now_ns, iree_time_t* earliest_deadline_ns) {
+  // Query the status.
+  iree_status_code_t wait_status_code = IREE_STATUS_OK;
+  IREE_RETURN_IF_ERROR(
+      iree_wait_source_query(params->wait_source, &wait_status_code));
+
+  if (wait_status_code != IREE_STATUS_OK) {
+    if (params->deadline_ns <= now_ns) {
+      // Deadline reached without having resolved.
+      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    } else {
+      // Still waiting.
+      *earliest_deadline_ns =
+          iree_min(*earliest_deadline_ns, params->deadline_ns);
+    }
+  }
+
+  return iree_status_from_code(wait_status_code);
+}
+
+// Returns DEFERRED if unresolved, OK if resolved, and an error otherwise.
+// If resolved (successful or not) the caller must erase the wait.
+static iree_status_t iree_loop_wait_list_scan_wait_any(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_multi_params_t* params,
+    iree_time_t now_ns, iree_time_t* earliest_deadline_ns) {
+  for (iree_host_size_t i = 0; i < params->count; ++i) {
+    iree_status_code_t wait_status_code = IREE_STATUS_OK;
+    IREE_RETURN_IF_ERROR(
+        iree_wait_source_query(params->wait_sources[i], &wait_status_code));
+    if (wait_status_code == IREE_STATUS_OK) {
+      return iree_ok_status();  // one resolved, wait-any satisfied
+    }
+  }
+  if (params->deadline_ns <= now_ns) {
+    // Deadline reached without having resolved any.
+    return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  } else {
+    // Still waiting.
+    *earliest_deadline_ns =
+        iree_min(*earliest_deadline_ns, params->deadline_ns);
+  }
+  return iree_status_from_code(IREE_STATUS_DEFERRED);  // none resolved
+}
+
+// Returns DEFERRED if unresolved, OK if resolved, and an error otherwise.
+// If resolved (successful or not) the caller must erase the wait.
+static iree_status_t iree_loop_wait_list_scan_wait_all(
+    iree_loop_wait_list_t* wait_list, iree_loop_wait_multi_params_t* params,
+    iree_time_t now_ns, iree_time_t* earliest_deadline_ns) {
+  bool any_unresolved = false;
+  for (iree_host_size_t i = 0; i < params->count; ++i) {
+    if (iree_wait_source_is_immediate(params->wait_sources[i])) continue;
+    iree_status_code_t wait_status_code = IREE_STATUS_OK;
+    IREE_RETURN_IF_ERROR(
+        iree_wait_source_query(params->wait_sources[i], &wait_status_code));
+    if (wait_status_code == IREE_STATUS_OK) {
+      // Wait resolved; remove it from the wait set so that we don't wait on it
+      // again. We do this by neutering the handle.
+      iree_wait_handle_t* wait_handle =
+          iree_wait_handle_from_source(&params->wait_sources[i]);
+      if (wait_handle) {
+        iree_wait_set_erase(wait_list->wait_set, *wait_handle);
+      }
+      params->wait_sources[i] = iree_wait_source_immediate();
+    } else {
+      // Wait not yet resolved.
+      if (params->deadline_ns <= now_ns) {
+        // Deadline reached without having resolved all.
+        return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+      } else {
+        // Still waiting.
+        *earliest_deadline_ns =
+            iree_min(*earliest_deadline_ns, params->deadline_ns);
+        any_unresolved = true;
+      }
+    }
+  }
+  return any_unresolved ? iree_status_from_code(IREE_STATUS_DEFERRED)
+                        : iree_ok_status();
+}
+
+static void iree_loop_wait_list_handle_wake(iree_loop_wait_list_t* wait_list,
+                                            iree_loop_run_ring_t* run_ring,
+                                            iree_wait_handle_t wake_handle) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // TODO(benvanik): scan the list. We need a way to map wake_handle back to
+  // the zero or more tasks that match it but don't currently store the
+  // handle. Ideally we'd have the wait set tell us precisely which things
+  // woke - possibly by having a bitmap of original insertions that match the
+  // handle - but for now we just eat the extra query syscall.
+  int woken_tasks = 0;
+
+  (void)woken_tasks;
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, woken_tasks);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_loop_wait_list_scan(
+    iree_loop_wait_list_t* wait_list, iree_loop_run_ring_t* run_ring,
+    iree_time_t* out_earliest_deadline_ns) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_earliest_deadline_ns = IREE_TIME_INFINITE_FUTURE;
+
+  iree_time_t now_ns = iree_time_now();
+  iree_status_t scan_status = iree_ok_status();
+  for (iree_host_size_t i = 0;
+       i < wait_list->count && iree_status_is_ok(scan_status); ++i) {
+    iree_status_t wait_status = iree_ok_status();
+    switch (wait_list->ops[i].command) {
+      case IREE_LOOP_COMMAND_WAIT_UNTIL:
+        wait_status = iree_loop_wait_list_scan_wait_until(
+            wait_list, &wait_list->ops[i].params.wait_until, now_ns,
+            out_earliest_deadline_ns);
+        break;
+      case IREE_LOOP_COMMAND_WAIT_ONE:
+        wait_status = iree_loop_wait_list_scan_wait_one(
+            wait_list, &wait_list->ops[i].params.wait_one, now_ns,
+            out_earliest_deadline_ns);
+        break;
+      case IREE_LOOP_COMMAND_WAIT_ANY:
+        wait_status = iree_loop_wait_list_scan_wait_any(
+            wait_list, &wait_list->ops[i].params.wait_multi, now_ns,
+            out_earliest_deadline_ns);
+        break;
+      case IREE_LOOP_COMMAND_WAIT_ALL:
+        wait_status = iree_loop_wait_list_scan_wait_all(
+            wait_list, &wait_list->ops[i].params.wait_multi, now_ns,
+            out_earliest_deadline_ns);
+        break;
+    }
+    if (!iree_status_is_deferred(wait_status)) {
+      // Wait completed/failed - erase from the wait set and op list.
+      scan_status =
+          iree_loop_wait_list_notify_wake(wait_list, run_ring, i, wait_status);
+      --i;  // item i removed
+
+      // Don't commit the wait if we woke something; we want the callback to be
+      // issued ASAP and will let the main loop pump again to actually wait if
+      // needed.
+      *out_earliest_deadline_ns = IREE_TIME_INFINITE_PAST;
+    }
+  }
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+  IREE_TRACE_ZONE_END(z0);
+  return scan_status;
+}
+
+static iree_status_t iree_loop_wait_list_commit(
+    iree_loop_wait_list_t* wait_list, iree_loop_run_ring_t* run_ring,
+    iree_time_t deadline_ns) {
+  if (iree_wait_set_is_empty(wait_list->wait_set) == 0) {
+    // No wait handles; this is a sleep.
+    IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_loop_wait_list_commit_sleep");
+    iree_status_t status =
+        iree_wait_until(deadline_ns)
+            ? iree_ok_status()
+            : iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  // Real system wait.
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)wait_list->count);
+
+  // Enter the system wait API.
+  iree_wait_handle_t wake_handle = iree_wait_handle_immediate();
+  iree_status_t status =
+      iree_wait_any(wait_list->wait_set, deadline_ns, &wake_handle);
+  if (iree_status_is_ok(status)) {
+    // One or more waiters is ready. We don't support multi-wake right now so
+    // we'll just take the one we got back and try again.
+    //
+    // To avoid extra syscalls we scan the list and mark whatever tasks were
+    // using the handle the wait set reported waking as completed. On the next
+    // scan they'll be retired immediately. Ideally we'd have the wait set be
+    // able to tell us this precise list.
+    if (iree_wait_handle_is_immediate(wake_handle)) {
+      // No-op wait - ignore.
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, "nop");
+    } else {
+      // Route to zero or more tasks using this handle.
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, "task(s)");
+      iree_loop_wait_list_handle_wake(wait_list, run_ring, wake_handle);
+    }
+  } else if (iree_status_is_deadline_exceeded(status)) {
+    // Indicates nothing was woken within the deadline. We gracefully bail here
+    // and let the scan check for per-op deadline exceeded events or delay
+    // completion.
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, "deadline exceeded");
+  } else {
+    // (Spurious?) error during wait.
+    // TODO(#4026): propagate failure to all scopes involved.
+    // Failures during waits are serious: ignoring them could lead to live-lock
+    // as tasks further in the pipeline expect them to have completed or - even
+    // worse - user code/other processes/drivers/etc may expect them to
+    // complete.
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, "failure");
+    IREE_ASSERT_TRUE(iree_status_is_ok(status));
+    iree_status_ignore(status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+// Aborts all waits that are part of |scope|.
+// A NULL |scope| indicates all work from all scopes should be aborted.
+static void iree_loop_wait_list_abort_scope(iree_loop_wait_list_t* wait_list,
+                                            iree_loop_sync_scope_t* scope) {
+  if (!wait_list->count) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+
+  // Issue the completion callback of each op to notify it of the abort.
+  // To prevent enqueuing more work while aborting we pass in a NULL loop.
+  // We can't do anything with the errors so we ignore them.
+  for (iree_host_size_t i = 0; i < wait_list->count; ++i) {
+    if (scope && wait_list->ops[i].scope != scope) continue;
+
+    --wait_list->ops[i].scope->pending_count;
+    iree_loop_callback_t callback = wait_list->ops[i].callback;
+    iree_status_t status = callback.fn(callback.user_data, iree_loop_null(),
+                                       iree_make_status(IREE_STATUS_ABORTED));
+    iree_status_ignore(status);
+
+    // Since we make no guarantees about the order of the lists we can just swap
+    // with the last value.
+    int tail_index = (int)wait_list->count - 1;
+    if (tail_index > i) {
+      memcpy(&wait_list->ops[i], &wait_list->ops[tail_index],
+             sizeof(*wait_list->ops));
+    }
+    --wait_list->count;
+    --i;
+  }
+
+  IREE_TRACE_PLOT_VALUE_I64("iree_loop_wait_depth", wait_list->count);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Aborts all waits from all scopes.
+static void iree_loop_wait_list_abort_all(iree_loop_wait_list_t* wait_list) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_loop_wait_list_abort_scope(wait_list, /*scope=*/NULL);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_sync_scope_t
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT void iree_loop_sync_scope_initialize(
+    iree_loop_sync_t* loop_sync, iree_loop_sync_error_fn_t error_fn,
+    void* error_user_data, iree_loop_sync_scope_t* out_scope) {
+  memset(out_scope, 0, sizeof(*out_scope));
+  out_scope->loop_sync = loop_sync;
+  out_scope->pending_count = 0;
+  out_scope->error_fn = error_fn;
+  out_scope->error_user_data = error_user_data;
+}
+
+IREE_API_EXPORT void iree_loop_sync_scope_deinitialize(
+    iree_loop_sync_scope_t* scope) {
+  IREE_ASSERT_ARGUMENT(scope);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (scope->loop_sync) {
+    iree_loop_sync_abort_scope(scope->loop_sync, scope);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_sync_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_loop_sync_t {
+  iree_allocator_t allocator;
+
+  iree_loop_run_ring_t* run_ring;
+  iree_loop_wait_list_t* wait_list;
+
+  // Trailing data:
+  // + iree_loop_run_ring_storage_size
+  // + iree_loop_wait_list_storage_size
+} iree_loop_sync_t;
+
+IREE_API_EXPORT iree_status_t iree_loop_sync_allocate(
+    iree_loop_sync_options_t options, iree_allocator_t allocator,
+    iree_loop_sync_t** out_loop_sync) {
+  IREE_ASSERT_ARGUMENT(out_loop_sync);
+
+  // The run queue must be a power of two due to the ringbuffer masking
+  // technique we use.
+  options.max_queue_depth =
+      iree_math_round_up_to_pow2_u32((uint32_t)options.max_queue_depth);
+  if (options.max_queue_depth > UINT16_MAX) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "queue depth exceeds maximum");
+  }
+
+  // Wait sets also have a handle limit but we may want to allow more
+  // outstanding wait operations even if we can't wait on them all
+  // simultaneously.
+  if (IREE_UNLIKELY(options.max_wait_count > UINT16_MAX)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "wait list depth exceeds maximum");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  const iree_host_size_t loop_sync_size =
+      iree_host_align(sizeof(iree_loop_sync_t), iree_max_align_t);
+  const iree_host_size_t run_ring_size = iree_host_align(
+      iree_loop_run_ring_storage_size(options), iree_max_align_t);
+  const iree_host_size_t wait_list_size = iree_host_align(
+      iree_loop_wait_list_storage_size(options), iree_max_align_t);
+  const iree_host_size_t total_storage_size =
+      loop_sync_size + run_ring_size + wait_list_size;
+
+  uint8_t* storage = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(allocator, total_storage_size, (void**)&storage));
+  iree_loop_sync_t* loop_sync = (iree_loop_sync_t*)storage;
+  loop_sync->allocator = allocator;
+  loop_sync->run_ring = (iree_loop_run_ring_t*)(storage + loop_sync_size);
+  loop_sync->wait_list =
+      (iree_loop_wait_list_t*)(storage + loop_sync_size + run_ring_size);
+
+  iree_status_t status = iree_ok_status();
+  if (iree_status_is_ok(status)) {
+    iree_loop_run_ring_initialize(options, loop_sync->run_ring);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_loop_wait_list_initialize(options, allocator,
+                                            loop_sync->wait_list);
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_loop_sync = loop_sync;
+  } else {
+    iree_loop_sync_free(loop_sync);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT void iree_loop_sync_free(iree_loop_sync_t* loop_sync) {
+  IREE_ASSERT_ARGUMENT(loop_sync);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_allocator_t allocator = loop_sync->allocator;
+
+  // Abort all pending operations.
+  // This will issue callbacks for each operation that was aborted directly
+  // with IREE_STATUS_ABORTED.
+  // To ensure we don't enqueue more work while aborting we NULL out the lists.
+  iree_loop_run_ring_t* run_ring = loop_sync->run_ring;
+  iree_loop_wait_list_t* wait_list = loop_sync->wait_list;
+  loop_sync->run_ring = NULL;
+  loop_sync->wait_list = NULL;
+  iree_loop_wait_list_abort_all(wait_list);
+  iree_loop_run_ring_abort_all(run_ring);
+
+  // After all operations are cleared we can release the data structures.
+  iree_loop_run_ring_deinitialize(run_ring);
+  iree_loop_wait_list_deinitialize(wait_list);
+  iree_allocator_free(allocator, loop_sync);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Aborts all operations in the loop attributed to |scope|.
+static void iree_loop_sync_abort_scope(iree_loop_sync_t* loop_sync,
+                                       iree_loop_sync_scope_t* scope) {
+  iree_loop_wait_list_abort_scope(loop_sync->wait_list, scope);
+  iree_loop_run_ring_abort_scope(loop_sync->run_ring, scope);
+}
+
+// Emits |status| to the given |loop| scope and aborts associated operations.
+static void iree_loop_sync_emit_error(iree_loop_t loop, iree_status_t status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(
+      z0, iree_status_code_string(iree_status_code(status)));
+
+  iree_loop_sync_scope_t* scope = (iree_loop_sync_scope_t*)loop.self;
+  iree_loop_sync_t* loop_sync = scope->loop_sync;
+
+  if (scope->error_fn) {
+    scope->error_fn(scope->error_user_data, status);
+  } else {
+    iree_status_ignore(status);
+  }
+
+  iree_loop_sync_abort_scope(loop_sync, scope);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static void iree_loop_sync_run_call(iree_loop_sync_t* loop_sync,
+                                    iree_loop_t loop,
+                                    const iree_loop_call_params_t params,
+                                    iree_status_t op_status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      params.callback.fn(params.callback.user_data, loop, op_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_sync_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static void iree_loop_sync_run_dispatch(
+    iree_loop_sync_t* loop_sync, iree_loop_t loop,
+    const iree_loop_dispatch_params_t params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+
+  // We run all workgroups before issuing the completion callback.
+  // If any workgroup fails we exit early and pass the failing status back to
+  // the completion handler exactly once.
+  uint32_t workgroup_count_x = params.workgroup_count_xyz[0];
+  uint32_t workgroup_count_y = params.workgroup_count_xyz[1];
+  uint32_t workgroup_count_z = params.workgroup_count_xyz[2];
+  iree_status_t workgroup_status = iree_ok_status();
+  for (uint32_t z = 0; z < workgroup_count_z; ++z) {
+    for (uint32_t y = 0; y < workgroup_count_y; ++y) {
+      for (uint32_t x = 0; x < workgroup_count_x; ++x) {
+        workgroup_status =
+            params.workgroup_fn(params.callback.user_data, loop, x, y, z);
+        if (!iree_status_is_ok(workgroup_status)) goto workgroup_failed;
+      }
+    }
+  }
+workgroup_failed:
+
+  // Fire the completion callback with either success or the first error hit by
+  // a workgroup.
+  status =
+      params.callback.fn(params.callback.user_data, loop, workgroup_status);
+  if (!iree_status_is_ok(status)) {
+    iree_loop_sync_emit_error(loop, status);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+// Drains work from the loop until all work in |scope| has completed.
+// A NULL |scope| indicates all work from all scopes should be drained.
+static iree_status_t iree_loop_sync_drain_scope(iree_loop_sync_t* loop_sync,
+                                                iree_loop_sync_scope_t* scope,
+                                                iree_time_t deadline_ns) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  do {
+    // If we are draining a particular scope we can bail whenever there's no
+    // more work remaining.
+    if (scope && !scope->pending_count) break;
+
+    // Run an op from the runnable queue.
+    // We dequeue operations here so that re-entrant enqueuing works.
+    // We only want to run one op at a time before checking our deadline so that
+    // we don't get into infinite loops or exceed the deadline (too much).
+    iree_loop_run_op_t run_op;
+    if (iree_loop_run_ring_dequeue(loop_sync->run_ring, &run_op)) {
+      iree_loop_t loop = {
+          .self = run_op.scope,
+          .ctl = iree_loop_sync_ctl,
+      };
+      switch (run_op.command) {
+        case IREE_LOOP_COMMAND_CALL:
+          iree_loop_sync_run_call(loop_sync, loop, run_op.params.call,
+                                  run_op.status);
+          break;
+        case IREE_LOOP_COMMAND_DISPATCH:
+          iree_loop_sync_run_dispatch(loop_sync, loop, run_op.params.dispatch);
+          break;
+      }
+      continue;  // loop back around only if under the deadline
+    }
+
+    // -- if here then the run ring is currently empty --
+
+    // If there are no pending waits then the drain has completed.
+    if (iree_loop_wait_list_is_empty(loop_sync->wait_list)) {
+      break;
+    }
+
+    // Scan the wait list and check for resolved ops.
+    // If there are any waiting ops the next earliest timeout is returned. An
+    // immediate timeout indicates that there's work in the run ring and we
+    // shouldn't perform a wait operation this go around the loop.
+    iree_time_t earliest_deadline_ns = IREE_TIME_INFINITE_FUTURE;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_loop_wait_list_scan(loop_sync->wait_list, loop_sync->run_ring,
+                                     &earliest_deadline_ns));
+    if (earliest_deadline_ns != IREE_TIME_INFINITE_PAST &&
+        earliest_deadline_ns != IREE_TIME_INFINITE_FUTURE) {
+      // Commit the wait operation, waiting up until the minimum of the user
+      // specified and wait list derived values.
+      iree_time_t wait_deadline_ns = earliest_deadline_ns < deadline_ns
+                                         ? earliest_deadline_ns
+                                         : deadline_ns;
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_loop_wait_list_commit(
+                  loop_sync->wait_list, loop_sync->run_ring, wait_deadline_ns));
+    }
+  } while (iree_time_now() < deadline_ns);
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t
+iree_loop_sync_wait_idle(iree_loop_sync_t* loop_sync, iree_timeout_t timeout) {
+  IREE_ASSERT_ARGUMENT(loop_sync);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+  iree_status_t status =
+      iree_loop_sync_drain_scope(loop_sync, /*scope=*/NULL, deadline_ns);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+// Control function for the synchronous loop.
+// |self| must be an iree_loop_sync_scope_t.
+IREE_API_EXPORT iree_status_t iree_loop_sync_ctl(void* self,
+                                                 iree_loop_command_t command,
+                                                 const void* params,
+                                                 void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(self);
+  iree_loop_sync_scope_t* scope = (iree_loop_sync_scope_t*)self;
+  iree_loop_sync_t* loop_sync = scope->loop_sync;
+
+  if (IREE_UNLIKELY(!loop_sync->run_ring)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "new work cannot be enqueued while the loop is shutting down");
+  }
+
+  // NOTE: we return immediately to make this all (hopefully) tail calls.
+  switch (command) {
+    case IREE_LOOP_COMMAND_CALL:
+      return iree_loop_run_ring_enqueue(
+          loop_sync->run_ring,
+          (iree_loop_run_op_t){
+              .command = command,
+              .scope = scope,
+              .params =
+                  {
+                      .call = *(const iree_loop_call_params_t*)params,
+                  },
+          });
+    case IREE_LOOP_COMMAND_DISPATCH:
+      return iree_loop_run_ring_enqueue(
+          loop_sync->run_ring,
+          (iree_loop_run_op_t){
+              .command = command,
+              .scope = scope,
+              .params =
+                  {
+                      .dispatch = *(const iree_loop_dispatch_params_t*)params,
+                  },
+          });
+    case IREE_LOOP_COMMAND_WAIT_UNTIL:
+      return iree_loop_wait_list_insert(
+          loop_sync->wait_list,
+          (iree_loop_wait_op_t){
+              .command = command,
+              .scope = scope,
+              .params =
+                  {
+                      .wait_until =
+                          *(const iree_loop_wait_until_params_t*)params,
+                  },
+          });
+    case IREE_LOOP_COMMAND_WAIT_ONE:
+      return iree_loop_wait_list_insert(
+          loop_sync->wait_list,
+          (iree_loop_wait_op_t){
+              .command = command,
+              .scope = scope,
+              .params =
+                  {
+                      .wait_one = *(const iree_loop_wait_one_params_t*)params,
+                  },
+          });
+    case IREE_LOOP_COMMAND_WAIT_ALL:
+    case IREE_LOOP_COMMAND_WAIT_ANY:
+      return iree_loop_wait_list_insert(
+          loop_sync->wait_list,
+          (iree_loop_wait_op_t){
+              .command = command,
+              .scope = scope,
+              .params =
+                  {
+                      .wait_multi =
+                          *(const iree_loop_wait_multi_params_t*)params,
+                  },
+          });
+    case IREE_LOOP_COMMAND_DRAIN:
+      return iree_loop_sync_drain_scope(
+          loop_sync, scope,
+          ((const iree_loop_drain_params_t*)params)->deadline_ns);
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unimplemented loop command");
+  }
+}

--- a/iree/base/loop_sync.h
+++ b/iree/base/loop_sync.h
@@ -1,0 +1,109 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BASE_LOOP_SYNC_H_
+#define IREE_BASE_LOOP_SYNC_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_loop_sync_t
+//===----------------------------------------------------------------------===//
+
+// Configuration options for the synchronous loop implementation.
+typedef struct iree_loop_sync_options_t {
+  // Specifies the maximum operation queue depth in number of operations.
+  // Growth is not currently supported and if the capacity is reached during
+  // execution then IREE_STATUS_RESOURCE_EXHAUSTED will be returned when new
+  // operations are enqueued.
+  iree_host_size_t max_queue_depth;
+
+  // Specifies how many pending waits are allowed at the same time.
+  // Growth is not currently supported and if the capacity is reached during
+  // execution then IREE_STATUS_RESOURCE_EXHAUSTED will be returned when new
+  // waits are enqueued.
+  iree_host_size_t max_wait_count;
+} iree_loop_sync_options_t;
+
+// A lightweight loop that greedily runs operations as they are available.
+// This does not require any system threading support and has deterministic
+// behavior unless multi-waits are used.
+//
+// Thread-compatible: the loop only performs work when iree_loop_drain is
+// called and must not be used from multiple threads concurrently.
+typedef struct iree_loop_sync_t iree_loop_sync_t;
+
+// Allocates a synchronous loop using |allocator| stored into |out_loop_sync|.
+IREE_API_EXPORT iree_status_t iree_loop_sync_allocate(
+    iree_loop_sync_options_t options, iree_allocator_t allocator,
+    iree_loop_sync_t** out_loop_sync);
+
+// Frees a synchronous |loop_sync|, aborting all pending operations.
+IREE_API_EXPORT void iree_loop_sync_free(iree_loop_sync_t* loop_sync);
+
+// Waits until the loop is idle (all operations in all scopes have retired).
+// Returns IREE_STATUS_DEADLINE_EXCEEDED if |timeout| is reached before the
+// loop is idle.
+IREE_API_EXPORT iree_status_t
+iree_loop_sync_wait_idle(iree_loop_sync_t* loop_sync, iree_timeout_t timeout);
+
+// Handles scope errors returned from loop callback operations.
+// Ownership of |status| is passed to the handler and must be freed.
+// All operations of the same scope will be aborted.
+typedef void(IREE_API_PTR* iree_loop_sync_error_fn_t)(void* user_data,
+                                                      iree_status_t status);
+
+// A scope of execution within a loop.
+// Each scope has a dedicated error handler that is notified when an error
+// propagates from a loop operation scheduled against the scope. When an error
+// arises all other operations in the same scope will be aborted.
+typedef struct iree_loop_sync_scope_t {
+  // Target loop for execution.
+  iree_loop_sync_t* loop_sync;
+
+  // Total number of pending operations in the scope.
+  // When 0 the scope is considered idle.
+  int32_t pending_count;
+
+  // Optional function used to report errors that occur during execution.
+  iree_loop_sync_error_fn_t error_fn;
+  void* error_user_data;
+} iree_loop_sync_scope_t;
+
+// Initializes a loop scope that runs operations against |loop_sync|.
+IREE_API_EXPORT void iree_loop_sync_scope_initialize(
+    iree_loop_sync_t* loop_sync, iree_loop_sync_error_fn_t error_fn,
+    void* error_user_data, iree_loop_sync_scope_t* out_scope);
+
+// Deinitializes a loop |scope| and aborts any pending operations.
+IREE_API_EXPORT void iree_loop_sync_scope_deinitialize(
+    iree_loop_sync_scope_t* scope);
+
+IREE_API_EXPORT iree_status_t iree_loop_sync_ctl(void* self,
+                                                 iree_loop_command_t command,
+                                                 const void* params,
+                                                 void** inout_ptr);
+
+// Returns a loop that schedules operations against |scope|.
+// The scope must remain valid until all operations scheduled against it have
+// completed.
+static inline iree_loop_t iree_loop_sync_scope(iree_loop_sync_scope_t* scope) {
+  iree_loop_t loop = {
+      scope,
+      iree_loop_sync_ctl,
+  };
+  return loop;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_BASE_LOOP_SYNC_H_

--- a/iree/base/loop_sync_test.cc
+++ b/iree/base/loop_sync_test.cc
@@ -1,0 +1,52 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/loop_sync.h"
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+// Contains the test definitions applied to all loop implementations:
+#include "iree/base/loop_test.h"
+
+void AllocateLoop(iree_status_t* out_status, iree_allocator_t allocator,
+                  iree_loop_t* out_loop) {
+  iree_loop_sync_options_t options = {0};
+  options.max_queue_depth = 128;
+  options.max_wait_count = 32;
+
+  iree_loop_sync_t* loop_sync = NULL;
+  IREE_CHECK_OK(iree_loop_sync_allocate(options, allocator, &loop_sync));
+
+  iree_loop_sync_scope_t* scope = NULL;
+  IREE_CHECK_OK(
+      iree_allocator_malloc(allocator, sizeof(*scope), (void**)&scope));
+  iree_loop_sync_scope_initialize(
+      loop_sync,
+      +[](void* user_data, iree_status_t status) {
+        iree_status_t* status_ptr = (iree_status_t*)user_data;
+        if (iree_status_is_ok(*status_ptr)) {
+          *status_ptr = status;
+        } else {
+          iree_status_ignore(status);
+        }
+      },
+      out_status, scope);
+  *out_loop = iree_loop_sync_scope(scope);
+}
+
+void FreeLoop(iree_allocator_t allocator, iree_loop_t loop) {
+  iree_loop_sync_scope_t* scope = (iree_loop_sync_scope_t*)loop.self;
+  iree_loop_sync_t* loop_sync = scope->loop_sync;
+
+  iree_loop_sync_scope_deinitialize(scope);
+  iree_allocator_free(allocator, scope);
+
+  iree_loop_sync_free(loop_sync);
+}
+
+// TODO(benvanik): test multiple scopes and scoped abort behavior.

--- a/iree/base/loop_test.h
+++ b/iree/base/loop_test.h
@@ -1,0 +1,980 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <chrono>
+#include <thread>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/wait_handle.h"
+#include "iree/base/tracing.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+// NOTE: this file is meant to be included inside of a _test.cc source file.
+// The file must define these functions to allocate/free the loop.
+// |out_status| should receive the last global error encountered in the loop.
+void AllocateLoop(iree_status_t* out_status, iree_allocator_t allocator,
+                  iree_loop_t* out_loop);
+void FreeLoop(iree_allocator_t allocator, iree_loop_t loop);
+
+namespace iree {
+namespace testing {
+
+struct LoopTest : public ::testing::Test {
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_loop_t loop;
+  iree_status_t loop_status = iree_ok_status();
+
+  void SetUp() override {
+    IREE_TRACE_SCOPE();
+    AllocateLoop(&loop_status, allocator, &loop);
+  }
+  void TearDown() override {
+    IREE_TRACE_SCOPE();
+    FreeLoop(allocator, loop);
+    iree_status_ignore(loop_status);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// iree_loop_call
+//===----------------------------------------------------------------------===//
+
+// Tests the simple call interface for running work.
+TEST_F(LoopTest, Call) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    iree_status_t call_status = iree_status_from_code(IREE_STATUS_DATA_LOSS);
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_call(
+      loop, IREE_LOOP_PRIORITY_DEFAULT,
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->call_status = status;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  IREE_ASSERT_OK(user_data.call_status);
+}
+
+// Tests a call that forks into two other calls.
+TEST_F(LoopTest, CallFork) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool called_a = false;
+    bool called_b = false;
+    bool called_c = false;
+  } user_data;
+
+  // A -> [B, C]
+  IREE_ASSERT_OK(iree_loop_call(
+      loop, IREE_LOOP_PRIORITY_DEFAULT,
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->called_a = true;
+
+        // B
+        IREE_EXPECT_OK(iree_loop_call(
+            loop, IREE_LOOP_PRIORITY_DEFAULT,
+            +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+              IREE_TRACE_SCOPE();
+              IREE_EXPECT_OK(status);
+              auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+              user_data->called_b = true;
+              return iree_ok_status();
+            },
+            user_data));
+
+        // C
+        IREE_EXPECT_OK(iree_loop_call(
+            loop, IREE_LOOP_PRIORITY_DEFAULT,
+            +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+              IREE_TRACE_SCOPE();
+              IREE_EXPECT_OK(status);
+              auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+              user_data->called_c = true;
+              return iree_ok_status();
+            },
+            user_data));
+
+        return iree_ok_status();
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.called_a);
+  EXPECT_TRUE(user_data.called_b);
+  EXPECT_TRUE(user_data.called_c);
+}
+
+// Tests a repeating call - since the loops are intended to be stackless we
+// should in theory be able to issue calls forever. This test ensures we can do
+// a really large amount without blowing the native stack.
+struct CallRepeatedData {
+  int remaining = 2 * 1024;
+};
+static iree_status_t CallRepeatedFn(void* user_data_ptr, iree_loop_t loop,
+                                    iree_status_t status) {
+  IREE_TRACE_SCOPE();
+  IREE_EXPECT_OK(status);
+  auto* user_data = reinterpret_cast<CallRepeatedData*>(user_data_ptr);
+  if (--user_data->remaining) {
+    IREE_RETURN_IF_ERROR(iree_loop_call(loop, IREE_LOOP_PRIORITY_DEFAULT,
+                                        CallRepeatedFn, user_data));
+  }
+  return iree_ok_status();
+}
+TEST_F(LoopTest, CallRepeated) {
+  IREE_TRACE_SCOPE();
+  CallRepeatedData user_data;
+  IREE_ASSERT_OK(iree_loop_call(loop, IREE_LOOP_PRIORITY_DEFAULT,
+                                CallRepeatedFn, &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_EQ(user_data.remaining, 0);
+}
+
+// Tests a call that results in failure.
+TEST_F(LoopTest, CallFailure) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool completed = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_call(
+      loop, IREE_LOOP_PRIORITY_DEFAULT,
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->completed);
+        user_data->completed = true;
+        return iree_status_from_code(IREE_STATUS_DATA_LOSS);
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, loop_status);
+}
+
+// Tests that a failure will abort other pending tasks.
+TEST_F(LoopTest, CallFailureAborts) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool did_call_callback = false;
+    bool did_wait_callback = false;
+  } user_data;
+
+  // Issue the call that will fail.
+  IREE_ASSERT_OK(iree_loop_call(
+      loop, IREE_LOOP_PRIORITY_DEFAULT,
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->did_call_callback);
+        user_data->did_call_callback = true;
+        return iree_status_from_code(IREE_STATUS_DATA_LOSS);
+      },
+      &user_data));
+
+  // Enqueue a wait that will never complete - if it runs it means we didn't
+  // correctly abort it.
+  IREE_ASSERT_OK(iree_loop_wait_until(
+      loop, iree_make_timeout_ms(1 * 60 * 1000),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, status);
+        iree_status_ignore(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->did_wait_callback);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, loop_status);
+  EXPECT_TRUE(user_data.did_call_callback);
+  EXPECT_TRUE(user_data.did_wait_callback);
+}
+
+// Tests that a failure will abort other pending tasks, including those enqueued
+// from within the failing call itself.
+TEST_F(LoopTest, CallFailureAbortsNested) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool did_call_callback = false;
+    bool did_wait_callback = false;
+  } user_data;
+
+  // Issue the call that will fail.
+  IREE_ASSERT_OK(iree_loop_call(
+      loop, IREE_LOOP_PRIORITY_DEFAULT,
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->did_call_callback);
+        user_data->did_call_callback = true;
+
+        // Enqueue a wait that will never complete - if it runs it means we
+        // didn't correctly abort it. We are enqueuing it reentrantly as a user
+        // would before we encounter the error below.
+        IREE_EXPECT_OK(iree_loop_wait_until(
+            loop, iree_make_timeout_ms(1 * 60 * 1000),
+            +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+              IREE_TRACE_SCOPE();
+              IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, status);
+              iree_status_ignore(status);
+              auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+              EXPECT_FALSE(user_data->did_wait_callback);
+              user_data->did_wait_callback = true;
+              return iree_ok_status();
+            },
+            user_data));
+
+        return iree_status_from_code(IREE_STATUS_DATA_LOSS);
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, loop_status);
+  EXPECT_TRUE(user_data.did_call_callback);
+  EXPECT_TRUE(user_data.did_wait_callback);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_dispatch
+//===----------------------------------------------------------------------===//
+
+// Tests a grid dispatch operation with an empty grid.
+// The completion callback should still be issued but no workgroups.
+TEST_F(LoopTest, DispatchEmpty) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    std::atomic<int> workgroup_count = {0};
+    bool completed = false;
+  } user_data;
+  const uint32_t xyz[3] = {1, 0, 0};
+  IREE_ASSERT_OK(iree_loop_dispatch(
+      loop, xyz,
+      +[](void* user_data_ptr, iree_loop_t loop, uint32_t workgroup_x,
+          uint32_t workgroup_y, uint32_t workgroup_z) {
+        IREE_TRACE_SCOPE();
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        ++user_data->workgroup_count;
+        return iree_ok_status();
+      },
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->completed);
+        user_data->completed = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_EQ(user_data.workgroup_count, 0);
+  EXPECT_TRUE(user_data.completed);
+}
+
+// Tests a grid dispatch operation and ensures all workgroups are issued.
+TEST_F(LoopTest, DispatchGrid) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    std::atomic<int> workgroup_count = {0};
+    bool completed = false;
+  } user_data;
+  const uint32_t xyz[3] = {4, 2, 1};
+  IREE_ASSERT_OK(iree_loop_dispatch(
+      loop, xyz,
+      +[](void* user_data_ptr, iree_loop_t loop, uint32_t workgroup_x,
+          uint32_t workgroup_y, uint32_t workgroup_z) {
+        IREE_TRACE_SCOPE();
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        ++user_data->workgroup_count;
+        return iree_ok_status();
+      },
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->completed);
+        user_data->completed = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_EQ(user_data.workgroup_count, xyz[0] * xyz[1] * xyz[2]);
+  EXPECT_TRUE(user_data.completed);
+}
+
+// Tests a grid dispatch operation with a workgroup failure.
+TEST_F(LoopTest, DispatchWorkgroupFailure) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool completed = false;
+  } user_data;
+  const uint32_t xyz[3] = {4, 2, 1};
+  IREE_ASSERT_OK(iree_loop_dispatch(
+      loop, xyz,
+      +[](void* user_data_ptr, iree_loop_t loop, uint32_t workgroup_x,
+          uint32_t workgroup_y, uint32_t workgroup_z) {
+        IREE_TRACE_SCOPE();
+        return iree_status_from_code(IREE_STATUS_DATA_LOSS);
+      },
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, status);
+        iree_status_ignore(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        EXPECT_FALSE(user_data->completed);
+        user_data->completed = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.completed);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_wait_until
+//===----------------------------------------------------------------------===//
+
+// Tests a wait-until delay with an immediate timeout.
+TEST_F(LoopTest, WaitUntilImmediate) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    iree_status_t wait_status = iree_status_from_code(IREE_STATUS_DATA_LOSS);
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_until(
+      loop, iree_immediate_timeout(),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->wait_status = status;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  IREE_ASSERT_OK(user_data.wait_status);
+}
+
+// Tests a wait-until delay with an actual delay.
+TEST_F(LoopTest, WaitUntil) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    iree_time_t start_ns = iree_time_now();
+    iree_time_t end_ns = IREE_TIME_INFINITE_FUTURE;
+    iree_status_t wait_status = iree_status_from_code(IREE_STATUS_DATA_LOSS);
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_until(
+      loop, iree_make_timeout_ms(50),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->end_ns = iree_time_now();
+        user_data->wait_status = status;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  IREE_ASSERT_OK(user_data.wait_status);
+  // Not checking exact timing as some devices may not have clocks.
+  EXPECT_GE(user_data.end_ns, user_data.start_ns);
+}
+
+// Tests that multiple wait-until's can be active at once.
+// NOTE: loops are not required to wake in any particular order.
+TEST_F(LoopTest, MultiWaitUntil) {
+  IREE_TRACE_SCOPE();
+  struct UserData {
+    bool woke_a = false;
+    bool woke_b = false;
+  } user_data;
+
+  IREE_ASSERT_OK(iree_loop_wait_until(
+      loop, iree_make_timeout_ms(25),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->woke_a = true;
+        return iree_ok_status();
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_wait_until(
+      loop, iree_make_timeout_ms(50),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->woke_b = true;
+        return iree_ok_status();
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.woke_a);
+  EXPECT_TRUE(user_data.woke_b);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_wait_one
+//===----------------------------------------------------------------------===//
+
+// Tests a wait-one with an immediate timeout.
+// The handle is never resolved and if we didn't bail immediately we'd hang.
+TEST_F(LoopTest, WaitOneImmediate) {
+  IREE_TRACE_SCOPE();
+
+  // An event that never resolves.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_one(
+      loop, wait_source, iree_immediate_timeout(),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event);
+}
+
+// Tests a wait-one with a non-immediate timeout.
+TEST_F(LoopTest, WaitOneTimeout) {
+  IREE_TRACE_SCOPE();
+
+  // An event that never resolves.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_one(
+      loop, wait_source, iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event);
+}
+
+// Tests a wait-one that times out does not abort other loop ops.
+// The deadline exceeded status passed to the callback is sufficient.
+TEST_F(LoopTest, WaitOneTimeoutNoAbort) {
+  IREE_TRACE_SCOPE();
+
+  // An event that never resolves.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  struct UserData {
+    bool did_wait_callback = false;
+    bool did_call_callback = false;
+  } user_data;
+
+  // Wait that will time out.
+  IREE_ASSERT_OK(iree_loop_wait_one(
+      loop, wait_source, iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+
+        // Call that should still be issued correctly.
+        // Note that we queue it here as if we did it outside the wait we'd
+        // immediately execute it on out-of-order implementations.
+        IREE_EXPECT_OK(iree_loop_call(
+            loop, IREE_LOOP_PRIORITY_DEFAULT,
+            +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+              IREE_TRACE_SCOPE();
+              IREE_EXPECT_OK(status);
+              auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+              EXPECT_FALSE(user_data->did_call_callback);
+              user_data->did_call_callback = true;
+              return iree_ok_status();
+            },
+            user_data));
+
+        return iree_ok_status();
+      },
+      &user_data));
+
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+  EXPECT_TRUE(user_data.did_call_callback);
+
+  iree_event_deinitialize(&event);
+}
+
+// Tests a wait-one with an already signaled wait source.
+TEST_F(LoopTest, WaitOneSignaled) {
+  IREE_TRACE_SCOPE();
+
+  // An event that is resolved immediately.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_one(
+      loop, wait_source, iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event);
+}
+
+// Tests a wait-one on a wait handle signaled out-of-band.
+TEST_F(LoopTest, WaitOneBlocking) {
+  IREE_TRACE_SCOPE();
+
+  // Initially unsignaled.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  // Spin up the thread to signal the event after a short delay.
+  // We need to do this before we issue the wait so that loops which perform the
+  // wait inline can still make forward progress even if they block.
+  std::thread thread([&]() {
+    IREE_TRACE_SCOPE();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    iree_event_set(&event);
+  });
+
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_one(
+      loop, wait_source, iree_make_timeout_ms(200),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  thread.join();
+  iree_event_deinitialize(&event);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_wait_any
+//===----------------------------------------------------------------------===//
+
+// Tests a wait-any with a immediate timeout (a poll).
+TEST_F(LoopTest, WaitAnyImmediate) {
+  IREE_TRACE_SCOPE();
+
+  // Events that are never resolved such that we time out.
+  iree_event_t event_a;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_a));
+  iree_wait_source_t wait_source_a = iree_event_await(&event_a);
+  iree_event_t event_b;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_b));
+  iree_wait_source_t wait_source_b = iree_event_await(&event_b);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source_a,
+      wait_source_b,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_any(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_immediate_timeout(),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event_a);
+  iree_event_deinitialize(&event_b);
+}
+
+// Tests a wait-any with a non-immediate timeout.
+TEST_F(LoopTest, WaitAnyTimeout) {
+  IREE_TRACE_SCOPE();
+
+  // Events that are never resolved such that we time out.
+  iree_event_t event_a;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_a));
+  iree_wait_source_t wait_source_a = iree_event_await(&event_a);
+  iree_event_t event_b;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_b));
+  iree_wait_source_t wait_source_b = iree_event_await(&event_b);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source_a,
+      wait_source_b,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_any(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event_a);
+  iree_event_deinitialize(&event_b);
+}
+
+// Tests a wait-any with an already-resolved wait handle.
+TEST_F(LoopTest, WaitAnySignaled) {
+  IREE_TRACE_SCOPE();
+
+  // An event that is resolved immediately.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  // Always unsignaled so we test the wait-any behavior.
+  iree_event_t unresolved_event;
+  IREE_ASSERT_OK(
+      iree_event_initialize(/*initial_state=*/false, &unresolved_event));
+  iree_wait_source_t unresolved_wait_source =
+      iree_event_await(&unresolved_event);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source,
+      unresolved_wait_source,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_any(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event);
+  iree_event_deinitialize(&unresolved_event);
+}
+
+// Tests a wait-any with a wait handle signaled out-of-band.
+TEST_F(LoopTest, WaitAnyBlocking) {
+  IREE_TRACE_SCOPE();
+
+  // Initially unsignaled.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  // Always unsignaled so we test the wait-any behavior.
+  iree_event_t unresolved_event;
+  IREE_ASSERT_OK(
+      iree_event_initialize(/*initial_state=*/false, &unresolved_event));
+  iree_wait_source_t unresolved_wait_source =
+      iree_event_await(&unresolved_event);
+
+  // Spin up the thread to signal the event after a short delay.
+  // We need to do this before we issue the wait so that loops which perform the
+  // wait inline can still make forward progress even if they block.
+  std::thread thread([&]() {
+    IREE_TRACE_SCOPE();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    iree_event_set(&event);
+  });
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source,
+      unresolved_wait_source,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_any(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(200),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  thread.join();
+  iree_event_deinitialize(&event);
+  iree_event_deinitialize(&unresolved_event);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_loop_wait_all
+//===----------------------------------------------------------------------===//
+
+// Tests a wait-all with a immediate timeout (a poll).
+TEST_F(LoopTest, WaitAllImmediate) {
+  IREE_TRACE_SCOPE();
+
+  // One unresolved and one resolved event (should fail the wait-all).
+  iree_event_t event_a;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_a));
+  iree_wait_source_t wait_source_a = iree_event_await(&event_a);
+  iree_event_t event_b;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event_b));
+  iree_wait_source_t wait_source_b = iree_event_await(&event_b);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source_a,
+      wait_source_b,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_all(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_immediate_timeout(),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event_a);
+  iree_event_deinitialize(&event_b);
+}
+
+// Tests a wait-all with a non-immediate timeout.
+TEST_F(LoopTest, WaitAllTimeout) {
+  IREE_TRACE_SCOPE();
+
+  // One unresolved and one resolved event (should fail the wait-all).
+  iree_event_t event_a;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event_a));
+  iree_wait_source_t wait_source_a = iree_event_await(&event_a);
+  iree_event_t event_b;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event_b));
+  iree_wait_source_t wait_source_b = iree_event_await(&event_b);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source_a,
+      wait_source_b,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_all(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event_a);
+  iree_event_deinitialize(&event_b);
+}
+
+// Tests a wait-all with already-resolved wait handles.
+TEST_F(LoopTest, WaitAllSignaled) {
+  IREE_TRACE_SCOPE();
+
+  // Signaled events so the wait-all succeeds.
+  iree_event_t event_a;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event_a));
+  iree_wait_source_t wait_source_a = iree_event_await(&event_a);
+  iree_event_t event_b;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &event_b));
+  iree_wait_source_t wait_source_b = iree_event_await(&event_b);
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source_a,
+      wait_source_b,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_all(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(10),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  iree_event_deinitialize(&event_a);
+  iree_event_deinitialize(&event_b);
+}
+
+// Tests a wait-all with wait handles signaled out-of-band.
+TEST_F(LoopTest, WaitAllBlocking) {
+  IREE_TRACE_SCOPE();
+
+  // Initially unsignaled.
+  iree_event_t event;
+  IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &event));
+  iree_wait_source_t wait_source = iree_event_await(&event);
+
+  // Always unsignaled so we test the wait-any behavior.
+  iree_event_t resolved_event;
+  IREE_ASSERT_OK(
+      iree_event_initialize(/*initial_state=*/true, &resolved_event));
+  iree_wait_source_t resolved_wait_source = iree_event_await(&resolved_event);
+
+  // Spin up the thread to signal the event after a short delay.
+  // We need to do this before we issue the wait so that loops which perform the
+  // wait inline can still make forward progress even if they block.
+  std::thread thread([&]() {
+    IREE_TRACE_SCOPE();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    iree_event_set(&event);
+  });
+
+  iree_wait_source_t wait_sources[2] = {
+      wait_source,
+      resolved_wait_source,
+  };
+  struct UserData {
+    bool did_wait_callback = false;
+  } user_data;
+  IREE_ASSERT_OK(iree_loop_wait_all(
+      loop, IREE_ARRAYSIZE(wait_sources), wait_sources,
+      iree_make_timeout_ms(200),
+      +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
+        IREE_TRACE_SCOPE();
+        IREE_EXPECT_OK(status);
+        auto* user_data = reinterpret_cast<UserData*>(user_data_ptr);
+        user_data->did_wait_callback = true;
+        return iree_ok_status();
+      },
+      &user_data));
+  IREE_ASSERT_OK(iree_loop_drain(loop, iree_infinite_timeout()));
+
+  IREE_ASSERT_OK(loop_status);
+  EXPECT_TRUE(user_data.did_wait_callback);
+
+  thread.join();
+  iree_event_deinitialize(&event);
+  iree_event_deinitialize(&resolved_event);
+}
+
+}  // namespace testing
+}  // namespace iree

--- a/iree/base/time.h
+++ b/iree/base/time.h
@@ -130,8 +130,18 @@ static inline iree_timeout_t iree_make_deadline(iree_time_t deadline_ns) {
 }
 
 // Defines a relative timeout with the given time in nanoseconds.
-static inline iree_timeout_t iree_make_timeout(iree_duration_t timeout_ns) {
+static inline iree_timeout_t iree_make_timeout_ns(iree_duration_t timeout_ns) {
   iree_timeout_t timeout = {IREE_TIMEOUT_RELATIVE, timeout_ns};
+  return timeout;
+}
+
+// Defines a relative timeout with the given time in milliseconds.
+static inline iree_timeout_t iree_make_timeout_ms(iree_duration_t timeout_ms) {
+  iree_timeout_t timeout = {
+      IREE_TIMEOUT_RELATIVE,
+      timeout_ms == IREE_DURATION_INFINITE ? IREE_DURATION_INFINITE
+                                           : timeout_ms * 1000000,
+  };
   return timeout;
 }
 

--- a/iree/hal/cts/semaphore_test.h
+++ b/iree/hal/cts/semaphore_test.h
@@ -88,10 +88,10 @@ TEST_P(semaphore_test, EmptyWait) {
 
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ANY, NULL,
-      iree_make_timeout(IREE_DURATION_INFINITE)));
+      iree_make_timeout_ns(IREE_DURATION_INFINITE)));
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
       device_, IREE_HAL_WAIT_MODE_ALL, NULL,
-      iree_make_timeout(IREE_DURATION_INFINITE)));
+      iree_make_timeout_ns(IREE_DURATION_INFINITE)));
 }
 
 // Tests waiting on a semaphore that has already been signaled.
@@ -107,9 +107,9 @@ TEST_P(semaphore_test, DISABLED_WaitAlreadySignaled) {
       semaphore, 2ull, iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      semaphore, 1ull, iree_make_timeout(IREE_DURATION_INFINITE)));
+      semaphore, 1ull, iree_make_timeout_ns(IREE_DURATION_INFINITE)));
   IREE_ASSERT_OK(iree_hal_semaphore_wait(
-      semaphore, 2ull, iree_make_timeout(IREE_DURATION_INFINITE)));
+      semaphore, 2ull, iree_make_timeout_ns(IREE_DURATION_INFINITE)));
 
   iree_hal_semaphore_release(semaphore);
 }

--- a/iree/task/poller.c
+++ b/iree/task/poller.c
@@ -183,8 +183,12 @@ static iree_status_t iree_task_poller_insert_wait_handle(
         iree_wait_source_export(task->wait_source, IREE_WAIT_PRIMITIVE_TYPE_ANY,
                                 iree_immediate_timeout(), &wait_primitive);
     if (iree_status_is_ok(status)) {
-      status = iree_wait_handle_wrap_primitive(
-          wait_primitive.type, wait_primitive.value, &wait_handle);
+      // Swap the wait handle with the exported handle so we can wake it later.
+      // It'd be ideal if we retained the wait handle separate so that we could
+      // still do fast queries for local wait sources.
+      iree_wait_handle_wrap_primitive(wait_primitive.type, wait_primitive.value,
+                                      &wait_handle);
+      status = iree_wait_source_import(wait_primitive, &task->wait_source);
     }
   }
 


### PR DESCRIPTION
This ioctl-like interface exposes an event loop that can run deferred tasks and perform aggregated waits: it's effectively the browser event loop (call = setImmediate, wait_until = setTimeout, etc) as a virtual interface. The API has some requirements such as mandatory forward progress that allow for a variety of implementations including those not owned by IREE (hosting application job systems, the browser event loop when running on the web, an RTOS scheduler, etc).

The intent is that each VM context will be assigned a loop where all invocations against the context run cooperatively. Multiple contexts may share the same underlying loop and run their invocations concurrently while still preserving proper ordering within their own scopes. All waits the context wants to perform - such as HAL semaphore waits - will route through the loop to enable wait-free execution and compatibility with environments where blocking is not possible (such as web).

There are two implementations here to start: one for running singular loop-based programs on bare-metal and one for cooperatively scheduling one or more loop-based programs on a single thread. Future implementations will go down to the browser APIs when running on the web and the IREE task system for running multiple programs concurrently in the thread pool. When running in the task system and executing device work there the latency of submit-to-issue and retire-to-wake goes to zero and there are no context switches.