### PR TITLE
[EmitC] Run canonicalizer after the conversion

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -93,8 +93,7 @@ Optional<Value> EmitCTypeConverter::materializeRef(Value ref) {
     }
   }
 
-  emitc::ApplyOp applyOp = vmAnalysis.getValue().get().lookupLocalRef(ordinal);
-  return applyOp.getResult();
+  return vmAnalysis.getValue().get().lookupLocalRef(ordinal);
 }
 
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
@@ -44,25 +44,24 @@ struct VMAnalysis {
     return valueLiveness.isLastValueUse(ref, op);
   }
 
-  void cacheLocalRef(int64_t ordinal, emitc::ApplyOp &applyOp) {
+  void cacheLocalRef(int64_t ordinal, Value ref) {
     assert(!refs.count(ordinal));
-    refs[ordinal] = applyOp.getOperation();
+    refs[ordinal] = ref;
   }
 
-  emitc::ApplyOp lookupLocalRef(int64_t ordinal) {
+  Value lookupLocalRef(int64_t ordinal) {
     assert(refs.count(ordinal));
-    Operation *op = refs[ordinal];
-    return cast<emitc::ApplyOp>(op);
+    return refs[ordinal];
   }
 
-  DenseMap<int64_t, Operation *> &localRefs() { return refs; }
+  DenseMap<int64_t, Value> &localRefs() { return refs; }
   size_t numRefArguments;
   FunctionType originalFunctionType;
 
  private:
   RegisterAllocation registerAllocation;
   ValueLiveness valueLiveness;
-  DenseMap<int64_t, Operation *> refs;
+  DenseMap<int64_t, Value> refs;
 };
 
 using VMAnalysisCache = DenseMap<Operation *, VMAnalysis>;

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -30,10 +30,11 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @my_module_const_ref_zero
   vm.func @const_ref_zero() {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
-    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [#emitc.opaque<"iree_vm_ref_t">]} : () -> i32
-    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.opaque<"iree_vm_ref_t*">, i32) -> ()
+    // CHECK: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: %[[VOIDPTR:.+]] = emitc.call "iree_alloca"(%[[SIZE]]) : (i32) -> !emitc.opaque<"void*">
+    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.call "EMITC_CAST"(%[[VOIDPTR]]) {args = [0 : index, !emitc.opaque<"iree_vm_ref_t*">]} : (!emitc.opaque<"void*">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK-NEXT: %[[SIZE_2:.+]] = emitc.call "sizeof"() {args = [#emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: emitc.call "memset"(%[[REFPTR]], %[[SIZE_2]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.opaque<"iree_vm_ref_t*">, i32) -> ()
     // CHECK-NEXT: emitc.call "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.opaque<"iree_vm_ref_t*">) -> ()
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -3,8 +3,9 @@
 vm.module @my_module {
   // CHECK-LABEL: @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: %[[VOIDPTR:.+]] = emitc.call "iree_alloca"(%[[SIZE]]) : (i32) -> !emitc.opaque<"void*">
+    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.call "EMITC_CAST"(%[[VOIDPTR]]) {args = [0 : index, !emitc.opaque<"iree_vm_ref_t*">]} : (!emitc.opaque<"void*">) -> !emitc.opaque<"iree_vm_ref_t*">
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     %list_dno = util.do_not_optimize(%list) : !vm.list<i32>
     // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.opaque<"iree_vm_ref_t*">
@@ -14,8 +15,9 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_list_size
   vm.func @list_size(%arg0: i32) {
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: %[[VOIDPTR:.+]] = emitc.call "iree_alloca"(%[[SIZE]]) : (i32) -> !emitc.opaque<"void*">
+    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.call "EMITC_CAST"(%[[VOIDPTR]]) {args = [0 : index, !emitc.opaque<"iree_vm_ref_t*">]} : (!emitc.opaque<"void*">) -> !emitc.opaque<"iree_vm_ref_t*">
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
     // CHECK: %[[SIZE:.+]] = emitc.call "iree_vm_list_size"(%{{.+}})
     %size_dno = util.do_not_optimize(%size) : i32
@@ -31,8 +33,9 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_ref
   vm.export @ref
   vm.func @ref(%arg0: i32) {
-    // CHECK: %[[REF:.+]] = "emitc.constant"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.opaque<"iree_vm_ref_t*">
+    // CHECK: %[[SIZE:.+]] = emitc.call "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> i32
+    // CHECK-NEXT: %[[VOIDPTR:.+]] = emitc.call "iree_alloca"(%[[SIZE]]) : (i32) -> !emitc.opaque<"void*">
+    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.call "EMITC_CAST"(%[[VOIDPTR]]) {args = [0 : index, !emitc.opaque<"iree_vm_ref_t*">]} : (!emitc.opaque<"void*">) -> !emitc.opaque<"iree_vm_ref_t*">
     %buffer = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %buffer_dno = util.do_not_optimize(%buffer) : !vm.buffer
     // CHECK: util.do_not_optimize(%[[REFPTR]]) : !emitc.opaque<"iree_vm_ref_t*">

--- a/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -317,6 +317,7 @@ static LogicalResult canonicalizeModule(
 
   // C target specific pass
   modulePasses.addPass(createConvertVMToEmitCPass());
+  modulePasses.addPass(mlir::createCanonicalizerPass());
 
   modulePasses.addPass(IREE::Util::createDropCompilerHintsPass());
 

--- a/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/control_flow.mlir
@@ -2,17 +2,13 @@
 
 vm.module @control_flow_module {
   vm.func @control_flow_test(%a: i32, %cond: i32) -> i32 {
-    vm.cond_br %cond, ^bb1, ^bb2
+    vm.cond_br %cond, ^bb2(%a, %a : i32, i32), ^bb1
   ^bb1:
-    vm.br ^bb3(%a: i32)
-  ^bb2:
     %b = vm.add.i32 %a, %a : i32
-    vm.br ^bb3(%b: i32)
-  ^bb3(%c: i32):
-    vm.br ^bb4(%c, %a : i32, i32)
-  ^bb4(%d : i32, %e : i32):
-    %0 = vm.add.i32 %d, %e : i32
-    vm.return %0 : i32
+    vm.br ^bb2(%b, %a : i32, i32)
+  ^bb2(%c: i32, %d: i32):
+    %e = vm.add.i32 %c, %d : i32
+    vm.return %e : i32
   }
 }
 // CHECK: static iree_status_t control_flow_module_control_flow_test(iree_vm_stack_t* v1, control_flow_module_t* v2, control_flow_module_state_t* v3, int32_t [[A:[^ ]*]], int32_t [[COND:[^ ]*]], int32_t* [[RESULT:[^ ]*]]) {
@@ -23,27 +19,22 @@ vm.module @control_flow_module {
   // CHECK-NEXT: iree_status_t [[STATUS:[^ ]*]];
   // CHECK-NEXT: int32_t [[C:[^ ]*]];
   // CHECK-NEXT: int32_t [[D:[^ ]*]];
-  // CHECK-NEXT: int32_t [[E:[^ ]*]];
   // CHECK-NEXT: [[COND_NZ]] = vm_cmp_nz_i32([[COND]]);
   // CHECK-NEXT: [[COND_BOOL]] = EMITC_CAST([[COND_NZ]], bool);
   // CHECK-NEXT: if ([[COND_BOOL]]) {
-  // CHECK-NEXT: goto [[BB1:[^ ]*]];
-  // CHECK-NEXT: } else {
+  // CHECK-NEXT: [[C]] = [[A]];
+  // CHECK-NEXT: [[D]] = [[A]];
   // CHECK-NEXT: goto [[BB2:[^ ]*]];
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: goto [[BB1:[^ ]*]];
   // CHECK-NEXT: }
   // CHECK-NEXT: [[BB1]]:
-  // CHECK-NEXT: [[C]] = [[A]];
-  // CHECK-NEXT: goto [[BB3:[^ ]*]];
-  // CHECK-NEXT: [[BB2]]:
   // CHECK-NEXT: [[B]] = vm_add_i32([[A]], [[A]]);
   // CHECK-NEXT: [[C]] = [[B]];
-  // CHECK-NEXT: goto [[BB3]];
-  // CHECK-NEXT: [[BB3]]:
-  // CHECK-NEXT: [[D]] = [[C]];
-  // CHECK-NEXT: [[E]] = [[A]];
-  // CHECK-NEXT: goto [[BB4:[^ ]*]];
-  // CHECK-NEXT: [[BB4]]:
-  // CHECK-NEXT: [[V0]] = vm_add_i32([[D]], [[E]]);
+  // CHECK-NEXT: [[D]] = [[A]];
+  // CHECK-NEXT: goto [[BB2:[^ ]*]];
+  // CHECK-NEXT: [[BB2]]:
+  // CHECK-NEXT: [[V0]] = vm_add_i32([[C]], [[D]]);
   // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE([[RESULT]], [[V0]]);
   // CHECK-NEXT: [[STATUS]] = iree_ok_status();
   // CHECK-NEXT: return [[STATUS]];


### PR DESCRIPTION
In order to make this work allocation of uninitialized stack variables is now done through calls to `iree_alloca`. This shrinks the [static library C sample](https://github.com/google/iree/blob/04bd09470ea92af9b5172093eee05835fedb61d1/iree/samples/static_library/CMakeLists.txt#L153) by ~900 bytes in release mode.

Progress on #6737