### PR TITLE
Remove unused variable in graph_command_buffer.c.

### DIFF
--- a/iree/hal/cuda/graph_command_buffer.c
+++ b/iree/hal/cuda/graph_command_buffer.c
@@ -348,8 +348,6 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_update_buffer(
 
   CUdeviceptr target_device_buffer = iree_hal_cuda_buffer_device_pointer(
       iree_hal_buffer_allocated_buffer(target_buffer));
-  CUdeviceptr dst = target_device_buffer +
-                    iree_hal_buffer_byte_offset(target_buffer) + target_offset;
   CUDA_MEMCPY3D params = {
       .srcMemoryType = CU_MEMORYTYPE_HOST,
       .srcHost = storage,


### PR DESCRIPTION
device buffer and offset are used below in
```
      .dstDevice = target_device_buffer,
      .dstXInBytes = target_offset,
```