### PR TITLE
Redo linalg_ext.scatter to support explicitly defined index update sizes

### DIFF
--- a/iree/test/e2e/xla_ops/scatter.mlir
+++ b/iree/test/e2e/xla_ops/scatter.mlir
@@ -95,6 +95,34 @@ func @scatter_add_slice_2D() {
   return
 }
 
+func @scatter_add_slice_no_insert_2D() {
+  %arg0 = util.unfoldable_constant dense<1> : tensor<6x3xi32>
+  %arg1 = util.unfoldable_constant dense<[[2], [4]]> : tensor<2x1xi32>
+  %arg2 = util.unfoldable_constant dense<[[[1, 2, 3]],
+                                          [[4, 5, 6]]]> : tensor<2x1x3xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    %1 = mhlo.add %arg3, %arg4 : tensor<i32>
+    "mhlo.return"(%1) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      update_window_dims = [0, 1],
+      inserted_window_dims = [],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x1x3xi32>) -> tensor<6x3xi32>
+  check.expect_eq_const(%0, dense<[[1, 1, 1],
+                                   [1, 1, 1],
+                                   [2, 3, 4],
+                                   [1, 1, 1],
+                                   [5, 6, 7],
+                                   [1, 1, 1]]> : tensor<6x3xi32>) : tensor<6x3xi32>
+  return
+}
+
 func @scatter_1D_large() {
   %original = util.unfoldable_constant dense<1> : tensor<1400xi32>
   %update = util.unfoldable_constant dense<2> : tensor<1400xi32>
@@ -154,6 +182,38 @@ func @scatter_2D_large() {
     >,
     unique_indices = false
   } : (tensor<200x300xi32>, tensor<200x1xi32>, tensor<200x300xi32>) -> tensor<200x300xi32>
+  check.expect_eq_const(%result, dense<2> : tensor<200x300xi32>) : tensor<200x300xi32>
+  return
+}
+
+func @scatter_2D_no_insert_large() {
+  %original = util.unfoldable_constant dense<1> : tensor<200x300xi32>
+  %update = util.unfoldable_constant dense<2> : tensor<200x1x300xi32>
+  %init = linalg.init_tensor [200] : tensor<200xi32>
+  %indices = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%init : tensor<200xi32>) {
+      ^bb0(%arg0: i32):
+        %0 = linalg.index 0 : index
+        %1 = arith.index_cast %0 : index to i32
+        linalg.yield %1 : i32
+      } -> tensor<200xi32>
+  %indices_reshaped = tensor.expand_shape %indices [[0, 1]] :
+      tensor<200xi32> into tensor<200x1xi32>
+  %result = "mhlo.scatter"(%original, %indices_reshaped, %update)({
+    ^bb0(%arg3 : tensor<i32>, %arg4 : tensor<i32>):
+      "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+    }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<200x300xi32>, tensor<200x1xi32>, tensor<200x1x300xi32>) -> tensor<200x300xi32>
   check.expect_eq_const(%result, dense<2> : tensor<200x300xi32>) : tensor<200x300xi32>
   return
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -65,9 +65,11 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     The first dim of `updates` and `indices` is identical, since they represent
     the number of updates.
 
-    The rank of the `original`/`result` is `index_depth + rank(%updates) - 1`.
-    The first `index_depth` indices are derived from `indices` and the shape of
-    update value must match the rest shape of `original`.
+    The rank of the `original`/`result` is atleast
+    `index_depth + rank(%updates) - 1`. The first `index_depth` indices are
+    derived from `indices` and the shape of update value has the last
+    rank(%original) - index_depth values match %(originals) last dimensions,
+    with the previous dims extending from the index offsets.
 
     The shapes definition follows tensorflow operations execept that it force
     batch dims to be 1D. See more information in

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -148,14 +148,16 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "index depth and update value does not cover rank of original value");
   }
 
-  // Validate the non-indexed update dims are 
+  // Validate the non-indexed update dims are
   int64_t fullSliceDims = originalType.getRank() - indexDepth;
-  for (auto it : llvm::zip(
-        llvm::seq<unsigned>(indexDepth, originalType.getRank()),
-        llvm::seq<unsigned>(updateType.getRank() - fullSliceDims, updateType.getRank()))) {
+  for (auto it :
+       llvm::zip(llvm::seq<unsigned>(indexDepth, originalType.getRank()),
+                 llvm::seq<unsigned>(updateType.getRank() - fullSliceDims,
+                                     updateType.getRank()))) {
     int64_t originalDim = std::get<0>(it);
     int64_t updateDim = std::get<1>(it);
-    if (updateType.getDimSize(updateDim) != originalType.getDimSize(originalDim)) {
+    if (updateType.getDimSize(updateDim) !=
+        originalType.getDimSize(originalDim)) {
       return op.emitOpError("mismatch in shape of update value dim#")
              << updateDim << " and original value at dim#" << originalDim;
     }
@@ -164,14 +166,16 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
   // Check that the remaining update indices do not exceed the update length.
   int64_t insertDims = originalType.getRank() - updateType.getRank() + 1;
   for (auto it : llvm::zip(
-        llvm::seq<unsigned>(insertDims, indexDepth),
-        llvm::seq<unsigned>(1, updateType.getRank() - fullSliceDims))) {
+           llvm::seq<unsigned>(insertDims, indexDepth),
+           llvm::seq<unsigned>(1, updateType.getRank() - fullSliceDims))) {
     int64_t originalDim = std::get<0>(it);
     int64_t updateDim = std::get<1>(it);
-    if (updateType.getDimSize(updateDim) > originalType.getDimSize(originalDim)) {
+    if (updateType.getDimSize(updateDim) >
+        originalType.getDimSize(originalDim)) {
       return op.emitOpError("indexed shape of update value dim#")
              << updateDim << " exceeds original value at dim#" << originalDim
-             << " " << updateType.getDimSize(updateDim) << " " << originalType.getDimSize(originalDim);
+             << " " << updateType.getDimSize(updateDim) << " "
+             << originalType.getDimSize(originalDim);
     }
   }
 
@@ -323,7 +327,7 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
     if (starts[i]) cast = b.create<arith::AddIOp>(loc, cast, starts[i]);
     starts[i] = cast;
   }
-  
+
   Value init = b.create<memref::LoadOp>(loc, original(), starts);
 
   BlockAndValueMapping bvm;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -136,20 +136,45 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "mismatch in shape of indices and update value at dim#0");
   }
   auto originalType = op.getOriginalType();
-  // indexDepth + update dims should match to original dims. The first dim of
-  // update is the number of updates.
-  if (originalType.getRank() != indexDepth + updateType.getRank() - 1) {
+  if (updateType.getRank() - 1 > originalType.getRank()) {
     return op.emitOpError(
-        "mismatch in rank of update value, index depth and original value");
+        "update value rank exceeds the rank of the original value");
   }
-  for (auto dim : llvm::seq<unsigned>(indexDepth, originalType.getRank())) {
-    // Offset one because the first dim is the number of updates.
-    if (updateType.getDimSize(1 + dim - indexDepth) !=
-        originalType.getDimSize(dim)) {
+
+  // indexDepth + update dims should cover the original dims. The first dim of
+  // update is the number of updates.
+  if (originalType.getRank() > indexDepth + updateType.getRank() - 1) {
+    return op.emitOpError(
+        "index depth and update value does not cover rank of original value");
+  }
+
+  // Validate the non-indexed update dims are 
+  int64_t fullSliceDims = originalType.getRank() - indexDepth;
+  for (auto it : llvm::zip(
+        llvm::seq<unsigned>(indexDepth, originalType.getRank()),
+        llvm::seq<unsigned>(updateType.getRank() - fullSliceDims, updateType.getRank()))) {
+    int64_t originalDim = std::get<0>(it);
+    int64_t updateDim = std::get<1>(it);
+    if (updateType.getDimSize(updateDim) != originalType.getDimSize(originalDim)) {
       return op.emitOpError("mismatch in shape of update value dim#")
-             << (1 + dim - indexDepth) << " and original value at dim#" << dim;
+             << updateDim << " and original value at dim#" << originalDim;
     }
   }
+
+  // Check that the remaining update indices do not exceed the update length.
+  int64_t insertDims = originalType.getRank() - updateType.getRank() + 1;
+  for (auto it : llvm::zip(
+        llvm::seq<unsigned>(insertDims, indexDepth),
+        llvm::seq<unsigned>(1, updateType.getRank() - fullSliceDims))) {
+    int64_t originalDim = std::get<0>(it);
+    int64_t updateDim = std::get<1>(it);
+    if (updateType.getDimSize(updateDim) > originalType.getDimSize(originalDim)) {
+      return op.emitOpError("indexed shape of update value dim#")
+             << updateDim << " exceeds original value at dim#" << originalDim
+             << " " << updateType.getDimSize(updateDim) << " " << originalType.getDimSize(originalDim);
+    }
+  }
+
   Region &region = op.region();
   Block *body = &region.front();
   if (body->getNumArguments() != 2) {
@@ -279,12 +304,26 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
   SmallVector<Value> loadIndices;
   loadIndices.push_back(ivs.front());
   loadIndices.push_back(Value());
+
+  // Populate with empty values.
+  auto originalTy = original().getType().cast<ShapedType>();
+  starts.resize(originalTy.getRank(), Value());
+  auto updateIvs = ivs.drop_front(1);
+
+  int64_t offset = starts.size() - updateIvs.size();
+  for (auto it : llvm::enumerate(updateIvs)) {
+    starts[it.index() + offset] = it.value();
+  }
+
   for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
     loadIndices.back() = b.create<arith::ConstantIndexOp>(loc, i);
     Value idx = b.create<memref::LoadOp>(loc, indices(), loadIndices);
-    starts.push_back(b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx));
+    Value cast = b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx);
+
+    if (starts[i]) cast = b.create<arith::AddIOp>(loc, cast, starts[i]);
+    starts[i] = cast;
   }
-  starts.append(std::next(ivs.begin()), ivs.end());
+  
   Value init = b.create<memref::LoadOp>(loc, original(), starts);
 
   BlockAndValueMapping bvm;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -148,7 +148,8 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "index depth and update value does not cover rank of original value");
   }
 
-  // Validate the non-indexed update dims are
+  // Validate the non-indexed update dims covier the full slice size of the
+  // original tensor.
   int64_t fullSliceDims = originalType.getRank() - indexDepth;
   for (auto it :
        llvm::zip(llvm::seq<unsigned>(indexDepth, originalType.getRank()),

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -199,11 +199,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<?x?x?xf32>, %indices : tensor<?x1xi32>,
+    %update : tensor<?x?x?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
+  // expected-error @+1 {{op update value rank exceeds the rank of the original value}}
   %0 = iree_linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?x?xf32>, tensor<?x1xi32>)
+    ins(%update, %indices : tensor<?x?x?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.addf %arg1, %arg2 : f32
@@ -367,11 +367,11 @@ func @scatter_index_depth_dynamic(
 // -----
 
 func @scatter_original_rank_mismatch(
-    %update : tensor<?x?xi64>, %indices : tensor<?x2xi32>,
+    %update : tensor<?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
+  // expected-error @+1 {{op index depth and update value does not cover rank of original value}}
   %0 = iree_linalg_ext.scatter
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
+    ins(%update, %indices : tensor<?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = arith.addi %arg1, %arg2 : i64


### PR DESCRIPTION
Scatter can be performed by now allowing additional dimensions on the update
tensor. This supports the existing tiling method but requires slight
modifications to validators and the scalar computation.
