### PR TITLE
Implementation of Verifiers.cpp for linalg.matmul.

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "LLVMGPUVectorToGPU.cpp",
         "LLVMGPUVectorization.cpp",
         "Passes.cpp",
+        "Verifiers.cpp",
     ],
     hdrs = [
         "ConvertToLLVM.h",

--- a/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     "LLVMGPUVectorToGPU.cpp"
     "LLVMGPUVectorization.cpp"
     "Passes.cpp"
+    "Verifiers.cpp"
   DEPS
     IREELinalgExtDialect
     IREELinalgExtPasses

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -88,6 +88,11 @@ static LogicalResult verifyEntryPoint(
                                            workgroupSizes,
                                            verifyGPUMatmulSimtPassPipeline);
         break;
+      case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore:
+        return verifyLoweringConfiguration(moduleOp, translationInfo,
+                                           workgroupSizes,
+                                           verifyGPUMatmulTensorCorePipeline);
+      break;
       default:;
     }
   }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -92,7 +92,7 @@ static LogicalResult verifyEntryPoint(
         return verifyLoweringConfiguration(moduleOp, translationInfo,
                                            workgroupSizes,
                                            verifyGPUMatmulTensorCorePipeline);
-      break;
+        break;
       default:;
     }
   }

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -37,32 +37,6 @@ static Value gpuAllocationFunction(OpBuilder &builder, Location loc,
   return builder.create<memref::AllocOp>(loc, allocType, dynamicSizes);
 }
 
-//===---------------------------------------------------------------------===//
-// Codegen configuration verifications.
-//===---------------------------------------------------------------------===//
-
-LogicalResult verifyGPUMatmulSimtPassPipeline(
-    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
-    IREE::Codegen::TranslationInfoAttr translationInfo,
-    ArrayRef<int64_t> workgroupSize) {
-  if (workgroupSize.empty()) {
-    return op->emitOpError("Expected workgroup size for GPU pipelines");
-  }
-
-  // Verify that the workgroup size is <= 1024
-  auto pipeline =
-      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt;
-  StringRef pipelineName = stringifyEnum(pipeline);
-  int64_t totalWorkgroupSize =
-      workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
-
-  if (totalWorkgroupSize > 1024) {
-    return op->emitOpError("expected workgroup size to be <=1024 for ")
-           << pipelineName << ", got " << totalWorkgroupSize;
-  }
-
-  return success();
-}
 
 //===---------------------------------------------------------------------===//
 // Codegen pipelines.

--- a/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -1,0 +1,160 @@
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Passes.h"
+#include "iree/compiler/Codegen/LLVMGPU/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Conversion/VectorToGPU/VectorToGPU.h"
+#include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/StandardOps/Transforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassOptions.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+constexpr unsigned kWorkgroupTileLevel = 0;
+constexpr int kSharedMemSizeBytes = 64 * 1024;
+
+LogicalResult verifyGPUMatmulSimtPassPipeline(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize) {
+  auto pipeline =
+      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt;
+  StringRef pipelineName = stringifyEnum(pipeline);
+  if (workgroupSize.empty()) {
+    return op->emitOpError("expected workgroup size for GPU pipelines");
+  }
+
+  // Verify the total workgroup size is <= 1024
+  int64_t totalWorkgroupSize =
+      workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
+  if (totalWorkgroupSize > 1024) {
+    return op->emitOpError("expected workgroup size to be <=1024 for ")
+           << pipelineName << ", got " << totalWorkgroupSize;
+  }
+
+  // Verify that the workgroup X dimension is 32 aligned
+  if (workgroupSize[0] % 32 != 0) {
+    return op->emitOpError("workgroup size is not 32 aligned for ")
+           << pipelineName << ", got " << workgroupSize[0];
+  }
+
+  // Verify the workgroup.z component should always be 1
+  if (workgroupSize[2] != 1) {
+    return op->emitOpError("expected workgroup z component to be 1 for ")
+           << pipelineName << ", got " << workgroupSize[2];
+  }
+
+  // For linalg::MatmulOp, verify shared memory usage of operands after tiling
+  // requires <= 64Kb combined space.
+  linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
+  if (matmulOp) {
+    SmallVector<int64_t> firstLevelTileSizes =
+        loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
+    MemRefType type =
+        matmulOp.getInputOperand(0)->get().getType().cast<mlir::MemRefType>();
+    unsigned bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+
+    // Input shape sizes: A [ M x K],  B [ K x N]
+    unsigned totalSharedMemSizeBytes =
+        (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
+         firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
+        bytesSize;
+
+    if (totalSharedMemSizeBytes > kSharedMemSizeBytes) {
+      return op->emitOpError("expected shared memory usage <= 64Kb for ")
+             << pipelineName << ", got " << totalSharedMemSizeBytes;
+    }
+  }
+  return success();
+}
+
+LogicalResult verifyGPUMatmulTensorCorePipeline(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize) {
+  auto pipeline =
+      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore;
+  StringRef pipelineName = stringifyEnum(pipeline);
+  if (workgroupSize.empty()) {
+    return op->emitOpError("expected workgroup size for GPU pipelines");
+  }
+
+  // Verify the total workgroup size is <= 1024
+  int64_t totalWorkgroupSize =
+      workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
+  if (totalWorkgroupSize > 1024) {
+    return op->emitOpError("expected workgroup size to be <=1024 for ")
+           << pipelineName << ", got " << totalWorkgroupSize;
+  }
+
+  // Verify that the workgroup X dimension is 32 aligned
+  if (workgroupSize[0] % 32 != 0) {
+    return op->emitOpError("workgroup size is not 32 aligned for ")
+           << pipelineName << ", got " << workgroupSize[0];
+  }
+
+  // Verify the workgroup.z component should always be 1
+  if (workgroupSize[2] != 1) {
+    return op->emitOpError("expected workgroup z component to be 1 for ")
+           << pipelineName << ", got " << workgroupSize[2];
+  }
+
+  // Verify the second level of tiling = first level tile size divided by the
+  // warps per workgroup size
+  SmallVector<int64_t> firstLevelTileSizes =
+      loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
+  std::array<int64_t, 3> warpsPerWorkgroup = {
+      workgroupSize[0] / kWarpSize, workgroupSize[1], workgroupSize[2]};
+  SmallVector<int64_t, 3> secondLevelTileSizes;
+  for (int i = 0; i < firstLevelTileSizes.size(); ++i) {
+    secondLevelTileSizes.push_back(firstLevelTileSizes[i] /
+                                   warpsPerWorkgroup[i]);
+  }
+
+  // Verify the TensorCore size divides the second level tile size
+  SmallVector<int64_t, 3> tensorCoreSize({16, 16, 8});
+  if (secondLevelTileSizes[0] % tensorCoreSize[0] != 0 ||
+      secondLevelTileSizes[1] % tensorCoreSize[1] != 0 ||
+      secondLevelTileSizes[2] % tensorCoreSize[2] != 0) {
+    return op->emitOpError(
+               "tensorcore size doesn't factor into second level tile size "
+               "for ")
+           << pipelineName;
+  }
+
+  // For linalg::MatmulOp, verify the first level tile size divides the matmul
+  // inputs A [M x K] & B [K x N]
+  linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
+  if (matmulOp) {
+    ArrayRef<int64_t> lhsShape =
+        getUntiledShape(matmulOp.getInputOperand(0)->get());
+    ArrayRef<int64_t> rhsShape =
+        getUntiledShape(matmulOp.getInputOperand(1)->get());
+
+    if (lhsShape[0] % firstLevelTileSizes[0] != 0 ||
+        lhsShape[1] % firstLevelTileSizes[2] != 0) {
+      return op->emitOpError(
+                 "lhsShape doesn't factor into first level tile size for ")
+             << pipelineName;
+    }
+
+    if (rhsShape[0] % firstLevelTileSizes[2] != 0 ||
+        rhsShape[1] % firstLevelTileSizes[1] != 0) {
+      return op->emitOpError(
+                 "rhsShape doesn't factor into first level tile size for ")
+             << pipelineName;
+    }
+  }
+  return success();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -122,8 +122,13 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
   // inputs A [M x K] & B [K x N]
   linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
   if (matmulOp) {
-    MemRefType type =
-        matmulOp.getInputOperand(0)->get().getType().cast<mlir::MemRefType>();
+    MemRefType type = matmulOp.getInputOperand(0)
+                          ->get()
+                          .getType()
+                          .dyn_cast<mlir::MemRefType>();
+    if (!type) {
+      return success();
+    }
     unsigned bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
 
     // Input shape sizes: A [ M x K],  B [ K x N]

--- a/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -25,6 +25,10 @@ LogicalResult verifyGPUMatmulSimtPassPipeline(
   if (workgroupSize.empty()) {
     return op->emitOpError("expected workgroup size for GPU pipelines");
   }
+  linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
+  if (!matmulOp) {
+    return success(); // Only verify matmul.
+  }
 
   // Verify the total workgroup size is <= 1024
   int64_t totalWorkgroupSize =
@@ -40,27 +44,25 @@ LogicalResult verifyGPUMatmulSimtPassPipeline(
            << pipelineName << ", got " << workgroupSize[2];
   }
 
-  // For linalg::MatmulOp, verify shared memory usage of operands after tiling
+  // Verify shared memory usage of operands after tiling
   // requires <= 64Kb combined space.
-  linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
-  if (matmulOp) {
-    SmallVector<int64_t> firstLevelTileSizes =
-        loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
-    MemRefType type =
-        matmulOp.getInputOperand(0)->get().getType().cast<mlir::MemRefType>();
-    unsigned bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+  SmallVector<int64_t> firstLevelTileSizes =
+      loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
+  MemRefType type =
+      matmulOp.getInputOperand(0)->get().getType().cast<mlir::MemRefType>();
+  unsigned bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
 
-    // Input shape sizes: A [ M x K],  B [ K x N]
-    unsigned totalSharedMemSizeBytes =
-        (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
-         firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
-        bytesSize;
+  // Input shape sizes: A [ M x K],  B [ K x N]
+  unsigned totalSharedMemSizeBytes =
+      (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
+       firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
+      bytesSize;
 
-    if (totalSharedMemSizeBytes > kSharedMemSizeBytes) {
-      return op->emitOpError("expected shared memory usage <= 64Kb for ")
-             << pipelineName << ", got " << totalSharedMemSizeBytes;
-    }
+  if (totalSharedMemSizeBytes > kSharedMemSizeBytes) {
+    return op->emitOpError("expected shared memory usage <= 64Kb for ")
+           << pipelineName << ", got " << totalSharedMemSizeBytes;
   }
+
   return success();
 }
 
@@ -73,6 +75,38 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
   StringRef pipelineName = stringifyEnum(pipeline);
   if (workgroupSize.empty()) {
     return op->emitOpError("expected workgroup size for GPU pipelines");
+  }
+
+  ArrayRef<int64_t> lhsShape;
+  ArrayRef<int64_t> rhsShape;
+  Type inputType;
+  SmallVector<int64_t> firstLevelTileSizes;
+  if (linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op)) {
+    inputType = matmulOp.getInputOperand(0)->get().getType();
+    lhsShape = getUntiledShape(matmulOp.getInputOperand(0)->get());
+    rhsShape = getUntiledShape(matmulOp.getInputOperand(1)->get());
+    firstLevelTileSizes = loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
+  } else if (linalg::BatchMatmulOp batchMatmulOp =
+                 dyn_cast<linalg::BatchMatmulOp>(op)) {
+    inputType = batchMatmulOp.getInputOperand(0)->get().getType();
+
+    // First dimension is the batch dimension. We don't check the shape batch.
+    lhsShape =
+        getUntiledShape(batchMatmulOp.getInputOperand(0)->get()).drop_front(1);
+    rhsShape =
+        getUntiledShape(batchMatmulOp.getInputOperand(1)->get()).drop_front(1);
+
+    // First tile dimensions should be 1 for batched, use remaining dimensions
+    // for comparisons.
+    firstLevelTileSizes = loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
+    if (firstLevelTileSizes[0] != 1) {
+      op->emitError("Received first tile dimension of ")
+          << firstLevelTileSizes[0] << " instead of 1 for " << pipelineName;
+    }
+    firstLevelTileSizes = {firstLevelTileSizes[1], firstLevelTileSizes[2],
+                           firstLevelTileSizes[3]};
+  } else {
+    return success(); // Only verify batched and unbatched matmul.
   }
 
   // Verify the total workgroup size is <= 1024
@@ -95,14 +129,12 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
            << pipelineName << ", got " << workgroupSize[2];
   }
 
-  // Verify the second level of tiling = first level tile size divided by the
+  // The second level of tiling = first level tile size divided by the
   // warps per workgroup size
-  SmallVector<int64_t> firstLevelTileSizes =
-      loweringConfig.getTileSizeVals(kWorkgroupTileLevel);
-  std::array<int64_t, 3> warpsPerWorkgroup = {
+  SmallVector<int64_t, 3> warpsPerWorkgroup = {
       workgroupSize[0] / kWarpSize, workgroupSize[1], workgroupSize[2]};
   SmallVector<int64_t, 3> secondLevelTileSizes;
-  for (int i = 0; i < firstLevelTileSizes.size(); ++i) {
+  for (int i = 0; i < 3; ++i) {
     secondLevelTileSizes.push_back(firstLevelTileSizes[i] /
                                    warpsPerWorkgroup[i]);
   }
@@ -118,60 +150,47 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
            << pipelineName;
   }
 
-  // For linalg::MatmulOp, verify the first level tile size divides the matmul
+  // Verify the first level tile size divides the matmul
   // inputs A [M x K] & B [K x N]
-  linalg::MatmulOp matmulOp = dyn_cast<linalg::MatmulOp>(op);
-  if (matmulOp) {
-    ArrayRef<int64_t> lhsShape =
-        getUntiledShape(matmulOp.getInputOperand(0)->get());
-    ArrayRef<int64_t> rhsShape =
-        getUntiledShape(matmulOp.getInputOperand(1)->get());
+  if (lhsShape[0] % firstLevelTileSizes[0] != 0 ||
+      lhsShape[1] % firstLevelTileSizes[2] != 0) {
+    return op->emitOpError(
+               "lhsShape doesn't factor into first level tile size for ")
+           << pipelineName << " [ " << lhsShape[0] << ", " << lhsShape[1]
+           << "]";
+  }
+  if (rhsShape[0] % firstLevelTileSizes[2] != 0 ||
+      rhsShape[1] % firstLevelTileSizes[1] != 0) {
+    return op->emitOpError(
+               "rhsShape doesn't factor into first level tile size for ")
+           << pipelineName << " [ " << rhsShape[0] << ", " << rhsShape[1]
+           << "]";
+  }
 
-    if (lhsShape[0] % firstLevelTileSizes[0] != 0 ||
-        lhsShape[1] % firstLevelTileSizes[2] != 0) {
-      return op->emitOpError(
-                 "lhsShape doesn't factor into first level tile size for ")
-             << pipelineName;
-    }
+  // Verify shared memory usage of operands after tiling requires <= 64Kb
+  // combined space.
+  unsigned bytesSize;
+  if (MemRefType type = inputType.dyn_cast<mlir::MemRefType>()) {
+    bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+  } else if (RankedTensorType type = inputType.dyn_cast<RankedTensorType>()) {
+    bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+  } else if (UnrankedTensorType type =
+                 inputType.dyn_cast<UnrankedTensorType>()) {
+    bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
+  } else {
+    // Unable to determine type, skip rest of verification.
+    return success();
+  }
 
-    if (rhsShape[0] % firstLevelTileSizes[2] != 0 ||
-        rhsShape[1] % firstLevelTileSizes[1] != 0) {
-      return op->emitOpError(
-                 "rhsShape doesn't factor into first level tile size for ")
-             << pipelineName;
-    }
+  // Input shape sizes: A [ M x K],  B [ K x N]
+  unsigned totalSharedMemSizeBytes =
+      (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
+       firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
+      bytesSize;
 
-    unsigned bytesSize;
-    if (MemRefType type = matmulOp.getInputOperand(0)
-                              ->get()
-                              .getType()
-                              .dyn_cast<mlir::MemRefType>()) {
-      bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
-    } else if (RankedTensorType type = matmulOp.getInputOperand(0)
-                                           ->get()
-                                           .getType()
-                                           .dyn_cast<RankedTensorType>()) {
-      bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
-    } else if (UnrankedTensorType type = matmulOp.getInputOperand(0)
-                                             ->get()
-                                             .getType()
-                                             .dyn_cast<UnrankedTensorType>()) {
-      bytesSize = type.getElementType().getIntOrFloatBitWidth() / 8;
-    } else {
-      // Unable to determine type, skip rest of verification.
-      return success();
-    }
-
-    // Input shape sizes: A [ M x K],  B [ K x N]
-    unsigned totalSharedMemSizeBytes =
-        (firstLevelTileSizes[0] * firstLevelTileSizes[2] +
-         firstLevelTileSizes[1] * firstLevelTileSizes[2]) *
-        bytesSize;
-
-    if (totalSharedMemSizeBytes > kSharedMemSizeBytes) {
-      return op->emitOpError("expected shared memory usage <= 64Kb for ")
-             << pipelineName << ", got " << totalSharedMemSizeBytes;
-    }
+  if (totalSharedMemSizeBytes > kSharedMemSizeBytes) {
+    return op->emitOpError("expected shared memory usage <= 64Kb for ")
+           << pipelineName << ", got " << totalSharedMemSizeBytes;
   }
   return success();
 }

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -250,7 +250,7 @@ hal.executable @tensor_insert {
             %10 = affine.apply affine_map<(d0) -> (d0 + 3)>(%arg1)
             %11 = memref.subview %1[%9, %10] [%4, %7] [1, 1] : memref<?x?xi32> to memref<?x?xi32, affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>>
             linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
-              ins(%8 : memref<?x?xi32, affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>>) 
+              ins(%8 : memref<?x?xi32, affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>>)
               outs(%11 : memref<?x?xi32, affine_map<(d0, d1)[s0, s1] -> (d0 * s1 + s0 + d1)>>) {
               ^bb0(%arg4: i32, %s: i32):  // no predecessors
                 linalg.yield %arg4 : i32
@@ -389,7 +389,7 @@ hal.executable private @static_3d_fft_stage3 {
 // -----
 
 #compilation = #iree_codegen.compilation.info<
-    #iree_codegen.lowering.config<tile_sizes = [[32, 256, 64]], native_vector_size = []>,
+    #iree_codegen.lowering.config<tile_sizes = [[32, 128, 64]], native_vector_size = []>,
     #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [256, 32]>,
     workgroup_size = [16, 8, 1]>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
@@ -443,7 +443,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb">
 }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 256, 64]{{\]}}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering.config<tile_sizes = {{\[}}[32, 128, 64]{{\]}}
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [256, 32]>
 //      CHECK: hal.executable.entry_point public @_lowering_config_test_dispatch_1
 // CHECK-SAME:     translation.info = #[[TRANSLATION]]

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -45,7 +45,7 @@ hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) attributes {
       translation.info = #translation,
-      workgroup_size = [48 : index, 8 : index, 1 : index]
+      workgroup_size = [24 : index, 6 : index, 1 : index]
     }
     builtin.module {
       func @illegal() {
@@ -53,7 +53,7 @@ hal.executable private @matmul_tensors {
         %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
-        // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulSimt, got 48}}
+        // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulSimt, got 144}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
           outs(%result: memref<4x16xf32>)
         return
@@ -95,7 +95,6 @@ hal.executable private @matmul_tensors {
 }
 
 // -----
-
 
 #config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
 #translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
@@ -214,7 +213,7 @@ hal.executable private @matmul_tensors {
         %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
-        // expected-error @+1 {{tensorcore size doesn't factor into second level tiling size for LLVMGPUMatmulTensorCore}}
+        // expected-error @+1 {{tensorcore size doesn't factor into second level tile size for LLVMGPUMatmulTensorCore}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
           outs(%result: memref<32x32xf32>)
         return
@@ -246,7 +245,7 @@ hal.executable private @matmul_tensors {
         %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<48x16xf32>
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<48x32xf32>
-        // expected-error @+1 {{lhsShape doesn't factor into first level tiling size for LLVMGPUMatmulTensorCore}}
+        // expected-error @+1 {{lhsShape doesn't factor into first level tile size for LLVMGPUMatmulTensorCore}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<48x16xf32>, memref<16x32xf32>)
           outs(%result: memref<48x32xf32>)
         return
@@ -278,7 +277,7 @@ hal.executable private @matmul_tensors {
         %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
         %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x48xf32>
         %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x48xf32>
-        // expected-error @+1 {{rhsShape doesn't factor into first level tiling size for LLVMGPUMatmulTensorCore}}
+        // expected-error @+1 {{rhsShape doesn't factor into first level tile size for LLVMGPUMatmulTensorCore}}
         linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x48xf32>)
           outs(%result: memref<32x48xf32>)
         return

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -29,3 +29,262 @@ hal.executable private @matmul_tensors {
     }
   }
 }
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [128, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [48 : index, 8 : index, 1 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
+        // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulSimt, got 48}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [128, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [32 : index, 8 : index, 2 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
+        // expected-error @+1 {{expected workgroup z component to be 1 for LLVMGPUMatmulSimt, got 2}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
+          outs(%result: memref<4x16xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 10 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
+        // expected-error @+1 {{expected workgroup size to be <=1024 for LLVMGPUMatmulTensorCore, got 1280}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+          outs(%result: memref<32x32xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [48 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
+        // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulTensorCore, got 48}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+          outs(%result: memref<32x32xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 2 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
+        // expected-error @+1 {{expected workgroup z component to be 1 for LLVMGPUMatmulTensorCore, got 2}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+          outs(%result: memref<32x32xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 20]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x32xf32>
+        // expected-error @+1 {{tensorcore size doesn't factor into second level tiling size for LLVMGPUMatmulTensorCore}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x32xf32>)
+          outs(%result: memref<32x32xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<48x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x32xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<48x32xf32>
+        // expected-error @+1 {{lhsShape doesn't factor into first level tiling size for LLVMGPUMatmulTensorCore}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<48x16xf32>, memref<16x32xf32>)
+          outs(%result: memref<48x32xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 32]>
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
+    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func @illegal() {
+        %c0 = arith.constant 0 : index
+        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<32x16xf32>
+        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16x48xf32>
+        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<32x48xf32>
+        // expected-error @+1 {{rhsShape doesn't factor into first level tiling size for LLVMGPUMatmulTensorCore}}
+        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<32x16xf32>, memref<16x48xf32>)
+          outs(%result: memref<32x48xf32>)
+        return
+      }
+    }
+  }
+}
+
+// -----

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -45,38 +45,6 @@ hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
     hal.executable.entry_point @illegal layout(#executable_layout) attributes {
       translation.info = #translation,
-      workgroup_size = [24 : index, 6 : index, 1 : index]
-    }
-    builtin.module {
-      func @illegal() {
-        %c0 = arith.constant 0 : index
-        %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<4x8xf32>
-        %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8x16xf32>
-        %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<4x16xf32>
-        // expected-error @+1 {{workgroup size is not 32 aligned for LLVMGPUMatmulSimt, got 144}}
-        linalg.matmul {lowering.config = #config} ins(%lhs, %rhs : memref<4x8xf32>, memref<8x16xf32>)
-          outs(%result: memref<4x16xf32>)
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-#config = #iree_codegen.lowering.config<tile_sizes = [], native_vector_size = []>
-#translation = #iree_codegen.translation.info<"LLVMGPUMatmulSimt", workload_per_wg = [128, 32]>
-#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>
-  ]>
-]>
-hal.executable private @matmul_tensors {
-  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @illegal layout(#executable_layout) attributes {
-      translation.info = #translation,
       workgroup_size = [32 : index, 8 : index, 2 : index]
     }
     builtin.module {

--- a/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -255,3 +255,62 @@ hal.executable private @matmul_tensors {
 }
 
 // -----
+
+#config = #iree_codegen.lowering.config<tile_sizes = [[2, 32, 32, 16]], native_vector_size = []>
+#translation = #iree_codegen.translation.info<"LLVMGPUMatmulTensorCore", workload_per_wg = [32, 8, 1]>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @batch_matmul_func  {
+  hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
+    hal.executable.entry_point @batch_matmul_func layout(#executable_layout) attributes {
+      translation.info = #translation,
+      workgroup_size = [64 : index, 2 : index, 1 : index]
+    }
+builtin.module {
+  func @batch_matmul_func() {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(32) : memref<4x32x1024xf32>
+    memref.assume_alignment %0, 32 : memref<4x32x1024xf32>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(32) : memref<4x1024x64xf32>
+    memref.assume_alignment %1, 32 : memref<4x1024x64xf32>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(32) : memref<4x32x64xf32>
+    memref.assume_alignment %2, 32 : memref<4x32x64xf32>
+    %workgroup_id_x = hal.interface.workgroup.id[0] : index
+    %workgroup_count_x = hal.interface.workgroup.count[0] : index
+    %workgroup_id_y = hal.interface.workgroup.id[1] : index
+    %workgroup_count_y = hal.interface.workgroup.count[1] : index
+    %workgroup_id_z = hal.interface.workgroup.id[2] : index
+    %workgroup_count_z = hal.interface.workgroup.count[2] : index
+    scf.for %arg0 = %workgroup_id_z to %c4 step %workgroup_count_z {
+      %3 = affine.apply affine_map<()[s0] -> (s0 * 8)>()[%workgroup_id_y]
+      %4 = affine.apply affine_map<()[s0] -> (s0 * 8)>()[%workgroup_count_y]
+      scf.for %arg1 = %3 to %c32 step %4 {
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
+        %6 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
+        scf.for %arg2 = %5 to %c64 step %6 {
+          %7 = memref.subview %0[%arg0, %arg1, 0] [1, 8, 1024] [1, 1, 1] : memref<4x32x1024xf32> to memref<1x8x1024xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>>
+          %8 = memref.subview %1[%arg0, 0, %arg2] [1, 1024, 32] [1, 1, 1] : memref<4x1024x64xf32> to memref<1x1024x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>>
+          %9 = memref.subview %2[%arg0, %arg1, %arg2] [1, 8, 32] [1, 1, 1] : memref<4x32x64xf32> to memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>
+          linalg.fill(%cst, %9) {lowering.config = #config} : f32, memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>
+          // expected-error @+1 {{Received first tile dimension of 2 instead of 1 for LLVMGPUMatmulTensorCore}}
+          linalg.batch_matmul {lowering.config = #config} ins(%7, %8 : memref<1x8x1024xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 32768 + s0 + d1 * 1024 + d2)>>, memref<1x1024x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 65536 + s0 + d1 * 64 + d2)>>) outs(%9 : memref<1x8x32xf32, affine_map<(d0, d1, d2)[s0] -> (d0 * 2048 + s0 + d1 * 64 + d2)>>)
+        }
+      }
+    }
+    return
+  }
+}
+}
+}
+
+// -----

--- a/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -487,14 +487,14 @@ hal.executable @mma_fused {
           %9 = affine.min affine_map<(d0)[s0] -> (s0, -d0 + 512)>(%arg1)[%workgroup_size_x]
           %10 = memref.subview %1[0, %arg1] [1024, %9] [1, 1] : memref<1024x512xf32> to memref<1024x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>
           %11 = memref.subview %2[%arg0, %arg1] [%7, %9] [1, 1] : memref<2048x512xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>
-          linalg.fill(%cst, %11) : f32, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>> 
+          linalg.fill(%cst, %11) : f32, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>
           linalg.matmul ins(%8, %10 : memref<?x1024xf32, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>, memref<1024x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>) outs(%11 : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>)
           linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
               iterator_types = ["parallel", "parallel"]} ins(%11, %11 : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>, memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>) outs(%11 : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d0 * 512 + s0 + d1)>>) {
             ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
               %19 = arith.addf %arg3, %arg4 : f32
              linalg.yield %19 : f32
-            }     
+            }
         }
       }
       return
@@ -559,8 +559,8 @@ hal.executable @mma_fused {
 
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>, 
-    #hal.descriptor_set.binding<1, storage_buffer>, 
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
@@ -612,7 +612,7 @@ hal.executable @mma_fused {
                 %15 = affine.min #map5(%arg1)[%workgroup_size_y]
                 %16 = affine.min #map6(%arg2)[%workgroup_size_x]
                 %17 = linalg.init_tensor [%14, %15, %16] : tensor<?x?x?xf32>
-                %18 = linalg.fill(%cst, %17) : f32, tensor<?x?x?xf32> -> tensor<?x?x?xf32> 
+                %18 = linalg.fill(%cst, %17) : f32, tensor<?x?x?xf32> -> tensor<?x?x?xf32>
                 %19 = linalg.batch_matmul ins(%11, %13 : tensor<?x?x1024xf32>, tensor<?x1024x?xf32>) outs(%18 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
                 flow.dispatch.tensor.store %19, %2, offsets = [%arg0, %arg1, %arg2], sizes = [%9, %10, %12], strides = [1, 1, 1] : tensor<?x?x?xf32> -> !flow.dispatch.tensor<writeonly:4x32x64xf32>
               }

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -254,10 +254,14 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm);
 LogicalResult verifyGPUMatmulSimtPassPipeline(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
-    ArrayRef<int64_t> workgroupSize = {});
+    ArrayRef<int64_t> workgroupSize);
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 
 /// Lowering using tensorcore operations.
+LogicalResult verifyGPUMatmulTensorCorePipeline(
+    Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
+    IREE::Codegen::TranslationInfoAttr translationInfo,
+    ArrayRef<int64_t> workgroupSize);
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm);
 
 /// Simple lowering only distributute linalg ops on blocks and threads. This


### PR DESCRIPTION
Implements verifiers for the `LLVMGPUMatmulSimt` and `LLVMGPUMatmulTensorCore` pipelines with tests. 

Adds `Verifiers.cpp` to the `LLVMGPU` module for more thorough  verification. 