### PR TITLE
Drop some frequently-changed general directories from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # for syntax of this file (tl;dr: syntax is like .gitignore. Last matching rule
 # takes precedence).
 # Because of the precedence, rules for directories are listed topologically.
+# @ghost is used to make a pattern have no owners. It is a sentinel GitHub user
+# that takes the place of deleted users.
 
 # No global owners because we don't really want e.g. changing the root
 # CMakeLists.txt file to always ping a bunch of people.
@@ -12,6 +14,10 @@
 # Third-Party Code
 /.gitmodules @GMNGeoffrey @ScottTodd @stellaraccident
 /third_party/ @GMNGeoffrey @ScottTodd @stellaraccident
+# Except for routinely-updated submodules
+/third_party/llvm-project/ @ghost
+/third_party/tensorflow/ @ghost
+/third_party/mlir-hlo/ @ghost
 
 # Bindings
 /bindings/python/ @stellaraccident
@@ -72,5 +78,5 @@
 
 # Other IREE directories
 /iree/samples/ @ScottTodd
-/iree/test/ @MaheshRavishankar @hanhanW @GMNGeoffrey
+/iree/test/ @ghost
 /iree/tools/ @benvanik @GMNGeoffrey


### PR DESCRIPTION
It turns out that getting added as a reviewer every time someone
updates a test or the LLVM submodule is annoying.