### PR TITLE
Modify createConvertToFlowAfterDispatchFormation Pass

### DIFF
--- a/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.cpp
+++ b/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.cpp
@@ -331,7 +331,8 @@ void populateTensorToFlowPatternsBeforeDispatchFormation(
 
 void populateTensorToFlowPatternsAfterDispatchFormation(
     MLIRContext *context, RewritePatternSet &patterns) {
-  patterns.insert<ConvertTensorExtractPattern>(context);
+  patterns.insert<ConvertTensorExtractPattern, ConvertTensorCastPattern>(
+      context);
 }
 
 }  // namespace Flow


### PR DESCRIPTION
This pass has been modified to handle the cases where `tensor.cast`
op is not converted to `flow.tensor.reshape` even after the
formation of dispatch regions.