### PR TITLE
Add HAL CTS 'variants' support and cuda_graph CTS test suite.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -333,6 +333,7 @@ class BuildFileFunctions(object):
               defines=None,
               data=None,
               deps=None,
+              args=None,
               tags=None,
               **kwargs):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
@@ -342,6 +343,7 @@ class BuildFileFunctions(object):
     defines_block = _convert_string_list_block("DEFINES", defines)
     data_block = _convert_target_list_block("DATA", data)
     deps_block = _convert_target_list_block("DEPS", deps)
+    args_block = _convert_string_list_block("ARGS", args)
     labels_block = _convert_string_list_block("LABELS", tags)
 
     self.converter.body += (f"iree_cc_test(\n"
@@ -352,6 +354,7 @@ class BuildFileFunctions(object):
                             f"{defines_block}"
                             f"{data_block}"
                             f"{deps_block}"
+                            f"{args_block}"
                             f"{labels_block}"
                             f")\n\n")
 

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -137,18 +137,13 @@ function(iree_cc_test)
 
     # Define a custom target for pushing and running the test on Android device.
     set(_NAME_PATH ${_NAME_PATH}_on_android_device)
-    set(_COMMAND
-      "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_android_test.${IREE_HOST_SCRIPT_EXT}"
-      "${_ANDROID_REL_DIR}/$<TARGET_FILE_NAME:${_NAME}>"
-    )
-    if(_RULE_ARGS)
-      list(APPEND _COMMAND ${_RULE_ARGS})
-    endif()
     add_test(
       NAME
         ${_NAME_PATH}
       COMMAND
-        ${_COMMAND}
+        "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_android_test.${IREE_HOST_SCRIPT_EXT}"
+        "${_ANDROID_REL_DIR}/$<TARGET_FILE_NAME:${_NAME}>"
+        ${_RULE_ARGS}
     )
     # Use environment variables to instruct the script to push artifacts
     # onto the Android device before running the test. This needs to match
@@ -161,20 +156,15 @@ function(iree_cc_test)
     )
     set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
   else(ANDROID)
-    set(_COMMAND
-      # We run all our tests through a custom test runner to allow temp
-      # directory cleanup upon test completion.
-      "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
-      "$<TARGET_FILE:${_NAME}>"
-    )
-    if(_RULE_ARGS)
-      list(APPEND _COMMAND ${_RULE_ARGS})
-    endif()
     add_test(
       NAME
         ${_NAME_PATH}
       COMMAND
-        ${_COMMAND}
+        # We run all our tests through a custom test runner to allow temp
+        # directory cleanup upon test completion.
+        "${CMAKE_SOURCE_DIR}/build_tools/cmake/run_test.${IREE_HOST_SCRIPT_EXT}"
+        "$<TARGET_FILE:${_NAME}>"
+        ${_RULE_ARGS}
       )
     set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT "TEST_TMPDIR=${IREE_BINARY_DIR}/tmp/${_NAME}_test_tmpdir")
     iree_add_test_environment_properties(${_NAME_PATH})

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -165,7 +165,12 @@ function(iree_hal_cts_test_suite)
     # Note: driver names may contain dashes and other special characters. We
     # could sanitize for file and target names, but passing through directly
     # may be more intuitive.
-    set(_TEST_SOURCE_NAME "${_RULE_DRIVER_NAME}${_RULE_VARIANT_SUFFIX}_${_TEST_NAME}_test.cc")
+    if(DEFINED _RULE_VARIANT_SUFFIX)
+      set(_TEST_TARGET_NAME "${_RULE_DRIVER_NAME}_${_RULE_VARIANT_SUFFIX}_${_TEST_NAME}_test")
+    else()
+      set(_TEST_TARGET_NAME "${_RULE_DRIVER_NAME}_${_TEST_NAME}_test")
+    endif()
+    set(_TEST_SOURCE_NAME "${_TEST_TARGET_NAME}.cc")
     set(_TEST_LIBRARY_DEP "iree::hal::cts::${_TEST_NAME}_test_library")
 
     # Generate the source file for this [test x driver] pair.
@@ -187,7 +192,7 @@ function(iree_hal_cts_test_suite)
 
     iree_cc_test(
       NAME
-        ${_RULE_DRIVER_NAME}${_RULE_VARIANT_SUFFIX}_${_TEST_NAME}_test
+        ${_TEST_TARGET_NAME}
       ARGS
         ${_RULE_ARGS}
       SRCS

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -14,6 +14,9 @@ include(CMakeParseArguments)
 # Parameters:
 #   DRIVER_NAME: The name of the driver to test. Used for both target names and
 #       for `iree_hal_driver_registry_try_create_by_name()` within test code.
+#   VARIANT_SUFFIX: Suffix to add to the test names, separate from the driver
+#       name. Useful when specifying multiple configurations using `ARGS` or
+#       other parameters.
 #   DRIVER_REGISTRATION_HDR: The C #include path for `DRIVER_REGISTRATION_FN`.
 #   DRIVER_REGISTRATION_FN: The C function which registers `DRIVER_NAME`.
 #   COMPILER_TARGET_BACKEND: Optional target backend name to pass to the
@@ -25,10 +28,13 @@ include(CMakeParseArguments)
 #       Examples:
 #           "\"vmvx-bytecode-fb\"" -> "vmvx-bytecode-fb"
 #           "\"embedded-elf-\" IREE_ARCH" -> "embedded-elf-x86_64"
+#   ARGS: List of command line arguments to pass to test binaries.
 #   DEPS: List of other libraries to link in to the binary targets (typically
 #       the dependency for `DRIVER_REGISTRATION_HDR`).
-#   EXCLUDED_TESTS: List of test names from `IREE_ALL_CTS_TESTS` to
-#       exclude from the test suite for this driver.
+#   INCLUDED_TESTS: List of test names to include from the test suite.
+#       Defaults to `IREE_ALL_CTS_TESTS`.
+#   EXCLUDED_TESTS: List of test names to exclude from the test suite for this
+#       driver. Generally set either this _or_ `INCLUDED_TESTS`.
 #   LABELS: Additional labels to forward to `iree_cc_test`. The package path
 #     and "driver=${DRIVER}" are added automatically.
 function(iree_hal_cts_test_suite)
@@ -39,8 +45,8 @@ function(iree_hal_cts_test_suite)
   cmake_parse_arguments(
     _RULE
     ""
-    "DRIVER_NAME;DRIVER_REGISTRATION_HDR;DRIVER_REGISTRATION_FN;COMPILER_TARGET_BACKEND;EXECUTABLE_FORMAT"
-    "DEPS;EXCLUDED_TESTS;LABELS"
+    "DRIVER_NAME;VARIANT_SUFFIX;DRIVER_REGISTRATION_HDR;DRIVER_REGISTRATION_FN;COMPILER_TARGET_BACKEND;EXECUTABLE_FORMAT"
+    "DEPS;ARGS;INCLUDED_TESTS;EXCLUDED_TESTS;LABELS"
     ${ARGN}
   )
 
@@ -141,7 +147,13 @@ function(iree_hal_cts_test_suite)
     )
   endif()
 
-  foreach(_TEST_NAME ${IREE_ALL_CTS_TESTS})
+  if(_RULE_INCLUDED_TESTS)
+    set(_INCLUDED_TESTS ${_RULE_INCLUDED_TESTS})
+  else()
+    set(_INCLUDED_TESTS ${IREE_ALL_CTS_TESTS})
+  endif()
+
+  foreach(_TEST_NAME ${_INCLUDED_TESTS})
     if("${_TEST_NAME}" IN_LIST _RULE_EXCLUDED_TESTS)
       continue()
     endif()
@@ -153,7 +165,7 @@ function(iree_hal_cts_test_suite)
     # Note: driver names may contain dashes and other special characters. We
     # could sanitize for file and target names, but passing through directly
     # may be more intuitive.
-    set(_TEST_SOURCE_NAME "${_TEST_NAME}_${_RULE_DRIVER_NAME}_test.cc")
+    set(_TEST_SOURCE_NAME "${_RULE_DRIVER_NAME}${_RULE_VARIANT_SUFFIX}_${_TEST_NAME}_test.cc")
     set(_TEST_LIBRARY_DEP "iree::hal::cts::${_TEST_NAME}_test_library")
 
     # Generate the source file for this [test x driver] pair.
@@ -175,7 +187,9 @@ function(iree_hal_cts_test_suite)
 
     iree_cc_test(
       NAME
-        ${_RULE_DRIVER_NAME}_${_TEST_NAME}_test
+        ${_RULE_DRIVER_NAME}${_RULE_VARIANT_SUFFIX}_${_TEST_NAME}_test
+      ARGS
+        ${_RULE_ARGS}
       SRCS
         "${CMAKE_CURRENT_BINARY_DIR}/${_TEST_SOURCE_NAME}"
       DEPS

--- a/iree/hal/cuda/cts/CMakeLists.txt
+++ b/iree/hal/cuda/cts/CMakeLists.txt
@@ -27,3 +27,28 @@ iree_hal_cts_test_suite(
     "semaphore_submission"
     "semaphore"
 )
+
+# Variant test suite using graph command buffers (--cuda_use_streams=0)
+iree_hal_cts_test_suite(
+  DRIVER_NAME
+    cuda
+  VARIANT_SUFFIX
+    _graph
+  DRIVER_REGISTRATION_HDR
+    "iree/hal/cuda/registration/driver_module.h"
+  DRIVER_REGISTRATION_FN
+    "iree_hal_cuda_driver_module_register"
+  COMPILER_TARGET_BACKEND
+    "cuda"
+  EXECUTABLE_FORMAT
+    "\"PTXE\""
+  ARGS
+    "--cuda_use_streams=0"
+  DEPS
+    iree::hal::cuda::registration
+  INCLUDED_TESTS
+    "command_buffer"
+    # This test depends on iree_hal_cuda_stream_command_buffer_update_buffer
+    # via iree_hal_buffer_view_allocate_buffer, which is not implemented yet.
+    # "command_buffer_dispatch"
+)

--- a/iree/hal/cuda/cts/CMakeLists.txt
+++ b/iree/hal/cuda/cts/CMakeLists.txt
@@ -33,7 +33,7 @@ iree_hal_cts_test_suite(
   DRIVER_NAME
     cuda
   VARIANT_SUFFIX
-    _graph
+    graph
   DRIVER_REGISTRATION_HDR
     "iree/hal/cuda/registration/driver_module.h"
   DRIVER_REGISTRATION_FN


### PR DESCRIPTION
* `iree_hal_cts_test_suite()` now supports a `VARIANT_SUFFIX`, which creates a new test suite for the same `DRIVER_NAME`, but with the flexibility to change the other arguments (`DRIVER_REGISTRATION_FN`, `COMPILER_TARGET_BACKEND`, etc.)
* This also adds an `ARGS` argument, which contains a list of strings to pass to any underlying `cc_test`s when run under `ctest`

Together, these features are used to create a `cuda_graph` variant test suite that sets the `--cuda_use_streams=0` CLI flag.

Note: this can create duplicate test binaries and the flag passing is only enforced by CTest, so running the tests directly (e.g. under a debugger) won't pass the flags :/