### PR TITLE
Use `emitc.ptr`in VMToEmitC conversions

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4149,7 +4149,8 @@ class ListOpConversion : public OpConversionPattern<SrcOpTy> {
     auto listDerefOp = failListNull(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -4233,12 +4234,15 @@ class ListAllocOpConversion
 
     auto listOp = rewriter.create<emitc::ConstantOp>(
         /*location=*/loc,
-        /*resultType=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*resultType=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*value=*/emitc::OpaqueAttr::get(ctx, "NULL"));
 
     auto listPtrOp = rewriter.create<emitc::ApplyOp>(
         /*location=*/loc,
-        /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t**"),
+        /*result=*/
+        emitc::PointerType::get(emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_list_t"))),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/listOp.getResult());
 
@@ -4355,7 +4359,8 @@ class ListGetOpConversion : public OpConversionPattern<GetOpTy> {
     auto listDerefOp = failListNull(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -4413,7 +4418,8 @@ class ListGetRefOpConversion
     auto listDerefOp = failListNull(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -3837,7 +3837,7 @@ class GlobalLoadOpConversion : public OpConversionPattern<LoadOpTy> {
     BlockArgument stateArg = funcOp.getArgument(2);
     auto rwDataPtr = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "uint8_t*"),
+        /*type=*/emitc::PointerType::get(rewriter.getIntegerType(8, false)),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1535,7 +1535,8 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
 
     Type stackType =
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_stack_t"));
-    Type callType = emitc::OpaqueType::get(ctx, "iree_vm_function_call_t*");
+    Type callType = emitc::PointerType::get(
+        emitc::OpaqueType::get(ctx, "iree_vm_function_call_t"));
     Type moduleType =
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
     Type moduleStateType =
@@ -2669,15 +2670,15 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                 /*templateArgs=*/ArrayAttr{},
                 /*operands=*/ArrayRef<Value>{import})
             .getResult(0);
-    auto callPtr =
-        rewriter
-            .create<emitc::ApplyOp>(
-                /*location=*/loc,
-                /*result=*/
-                emitc::OpaqueType::get(ctx, "iree_vm_function_call_t*"),
-                /*applicableOperator=*/StringAttr::get(ctx, "&"),
-                /*operand=*/call)
-            .getResult();
+    auto callPtr = rewriter
+                       .create<emitc::ApplyOp>(
+                           /*location=*/loc,
+                           /*result=*/
+                           emitc::PointerType::get(emitc::OpaqueType::get(
+                               ctx, "iree_vm_function_call_t")),
+                           /*applicableOperator=*/StringAttr::get(ctx, "&"),
+                           /*operand=*/call)
+                       .getResult();
     auto executionResultPtr =
         rewriter
             .create<emitc::ApplyOp>(

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1793,7 +1793,7 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       // arguments.data
       auto argumentsData = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "uint8_t*"),
+          /*type=*/emitc::PointerType::get(rewriter.getIntegerType(8, false)),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -1833,7 +1833,7 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       // results.data
       auto resultsData = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "uint8_t*"),
+          /*type=*/emitc::PointerType::get(rewriter.getIntegerType(8, false)),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -2316,7 +2316,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
             .getResult(0);
 
     // uint8_t *byteSpan_data = (uint8_t*)byteSpan_data_void;
-    Type bytePtr = emitc::OpaqueType::get(ctx, "uint8_t*");
+    Type bytePtr = emitc::PointerType::get(rewriter.getIntegerType(8, false));
     auto byteSpanData = rewriter
                             .create<emitc::CallOp>(
                                 /*location=*/loc,
@@ -2389,7 +2389,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                 /*operands=*/ArrayRef<Value>{call})
             .getResult(0);
 
-    Type bytePtrType = emitc::OpaqueType::get(ctx, "uint8_t*");
+    Type bytePtrType =
+        emitc::PointerType::get(rewriter.getIntegerType(8, false));
     Value uint8Ptr =
         rewriter
             .create<emitc::CallOp>(
@@ -2511,7 +2512,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                 /*operands=*/ArrayRef<Value>{call})
             .getResult(0);
 
-    Type bytePtrType = emitc::OpaqueType::get(ctx, "uint8_t*");
+    Type bytePtrType =
+        emitc::PointerType::get(rewriter.getIntegerType(8, false));
     Value uint8Ptr =
         rewriter
             .create<emitc::CallOp>(

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1541,8 +1541,8 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
     Type moduleStateType =
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
-    Type executionResultType =
-        emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t*");
+    Type executionResultType = emitc::PointerType::get(
+        emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t"));
 
     SmallVector<Type, 5> inputTypes = {stackType, callType, moduleType,
                                        moduleStateType, executionResultType};
@@ -2684,7 +2684,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
             .create<emitc::ApplyOp>(
                 /*location=*/loc,
                 /*result=*/
-                emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t*"),
+                emitc::PointerType::get(
+                    emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t")),
                 /*applicableOperator=*/StringAttr::get(ctx, "&"),
                 /*operand=*/executionResult)
             .getResult();

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -1125,7 +1125,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
             emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
             emitc::OpaqueType::get(ctx, "iree_host_size_t"),
-            emitc::OpaqueType::get(ctx, "const iree_vm_function_t*"),
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "const iree_vm_function_t")),
             emitc::OpaqueType::get(ctx, "const iree_vm_function_signature_t*"),
         },
         {emitc::OpaqueType::get(ctx, "iree_status_t")});
@@ -1159,7 +1160,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto imports = builder.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -1169,7 +1172,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto import = builder.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -2183,7 +2188,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
 
     Type stackType =
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_stack_t"));
-    Type funcType = emitc::OpaqueType::get(ctx, "iree_vm_function_t*");
+    Type funcType = emitc::PointerType::get(
+        emitc::OpaqueType::get(ctx, "iree_vm_function_t"));
 
     SmallVector<Type> types{stackType, funcType};
 
@@ -2860,7 +2866,9 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
 
     auto imports = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -2870,7 +2878,9 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
 
     auto import = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_function_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -445,7 +445,8 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
     auto typeDescriptor = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
         /*type=*/
-        emitc::OpaqueType::get(ctx, "const iree_vm_ref_type_descriptor_t*"),
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "const iree_vm_ref_type_descriptor_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_ref_lookup_registered_type"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},
@@ -478,7 +479,9 @@ Optional<emitc::ApplyOp> createVmTypeDefPtr(ConversionPatternRewriter &rewriter,
 
   auto elementTypePtrOp = rewriter.create<emitc::ApplyOp>(
       /*location=*/loc,
-      /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t*"),
+      /*result=*/
+      emitc::PointerType::get(
+          emitc::OpaqueType::get(ctx, "iree_vm_type_def_t")),
       /*applicableOperator=*/StringAttr::get(ctx, "&"),
       /*operand=*/elementTypeOp.getResult());
 
@@ -1136,7 +1139,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             emitc::OpaqueType::get(ctx, "iree_host_size_t"),
             emitc::PointerType::get(
                 emitc::OpaqueType::get(ctx, "const iree_vm_function_t")),
-            emitc::OpaqueType::get(ctx, "const iree_vm_function_signature_t*"),
+            emitc::PointerType::get(emitc::OpaqueType::get(
+                ctx, "const iree_vm_function_signature_t")),
         },
         {emitc::OpaqueType::get(ctx, "iree_status_t")});
 
@@ -1844,14 +1848,16 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
           /*operands=*/ArrayRef<Value>{callArguments.getResult(0)});
 
       // cast
-      std::string argumentsType = argumentStruct.name.getValue() + "*";
+      std::string argumentsType = argumentStruct.name.getValue();
       auto arguments = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, argumentsType),
+          /*type=*/
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, argumentsType)),
           /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
           /*args=*/
-          ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, argumentsType)}),
+          ArrayAttr::get(ctx,
+                         {rewriter.getIndexAttr(0),
+                          emitc::OpaqueAttr::get(ctx, argumentsType + "*")}),
           /*templateArgs=*/ArrayAttr{},
           /*operands=*/ArrayRef<Value>{argumentsData.getResult(0)});
 
@@ -1884,14 +1890,15 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
           /*operands=*/ArrayRef<Value>{callResults.getResult(0)});
 
       // cast
-      std::string resultType = resultStruct.name.getValue() + "*";
+      std::string resultType = resultStruct.name.getValue();
       auto results = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, resultType),
+          /*type=*/
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, resultType)),
           /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
           /*args=*/
           ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, resultType)}),
+                               emitc::OpaqueAttr::get(ctx, resultType + "*")}),
           /*templateArgs=*/ArrayAttr{},
           /*operands=*/ArrayRef<Value>{resultsData.getResult(0)});
 
@@ -2337,7 +2344,9 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
         rewriter
             .create<emitc::CallOp>(
                 /*location=*/loc,
-                /*type=*/emitc::OpaqueType::get(ctx, "iree_byte_span_t*"),
+                /*type=*/
+                emitc::PointerType::get(
+                    emitc::OpaqueType::get(ctx, "iree_byte_span_t")),
                 /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ADDRESS"),
                 /*args=*/
                 ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -4343,7 +4352,8 @@ class ListGetOpConversion : public OpConversionPattern<GetOpTy> {
 
     auto valuePtrOp = rewriter.create<emitc::ApplyOp>(
         /*location=*/loc,
-        /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_value_t*"),
+        /*result=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_value_t")),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/valueOp.getResult());
 

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -817,7 +817,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto voidPtr = builder.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "void**"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"))),
         /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
         /*args=*/
         ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -1232,7 +1234,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto voidPtr = builder.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "void**"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"))),
         /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
         /*args=*/
         ArrayAttr::get(ctx, {builder.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -910,7 +910,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
       auto buffers = builder.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+          /*type=*/
+          emitc::PointerType::get(
+              emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -920,7 +922,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
       auto buffer = builder.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+          /*type=*/
+          emitc::PointerType::get(
+              emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
           /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
@@ -3304,7 +3308,9 @@ class ConstRefRodataOpConversion
     BlockArgument stateArg = funcOp.getArgument(2);
     auto rodataBuffersPtr = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
@@ -3314,7 +3320,9 @@ class ConstRefRodataOpConversion
 
     auto byteBufferPtrOp = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_buffer_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
         /*args=*/
         ArrayAttr::get(ctx,

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -720,7 +720,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     OpBuilder::InsertionGuard guard(builder);
 
     auto funcType = mlir::FunctionType::get(
-        ctx, {emitc::OpaqueType::get(ctx, "void*")}, {});
+        ctx, {emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"))},
+        {});
 
     auto funcOp =
         builder.create<mlir::FuncOp>(loc, moduleName + "_destroy", funcType);
@@ -774,7 +775,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto funcType = mlir::FunctionType::get(
         ctx,
-        {emitc::OpaqueType::get(ctx, "void*"),
+        {emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
          emitc::OpaqueType::get(ctx, "iree_allocator_t"),
          emitc::OpaqueType::get(ctx, "iree_vm_module_state_t**")},
         {emitc::OpaqueType::get(ctx, "iree_status_t")});
@@ -861,7 +862,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
       auto bufferVoid = builder.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "void*"),
+          /*type=*/emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
           /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
           /*args=*/
           ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, bufferName),
@@ -1008,7 +1009,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto funcType = mlir::FunctionType::get(
         ctx,
-        {emitc::OpaqueType::get(ctx, "void*"),
+        {emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
          emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*")},
         {});
 
@@ -1107,7 +1108,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     auto funcType = mlir::FunctionType::get(
         ctx,
         {
-            emitc::OpaqueType::get(ctx, "void*"),
+            emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
             emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
             emitc::OpaqueType::get(ctx, "iree_host_size_t"),
             emitc::OpaqueType::get(ctx, "const iree_vm_function_t*"),
@@ -1509,8 +1510,10 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
 
     Type stackType = emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
     Type callType = emitc::OpaqueType::get(ctx, "iree_vm_function_call_t*");
-    Type moduleType = emitc::OpaqueType::get(ctx, "void*");
-    Type moduleStateType = emitc::OpaqueType::get(ctx, "void*");
+    Type moduleType =
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
+    Type moduleStateType =
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
     Type executionResultType =
         emitc::OpaqueType::get(ctx, "iree_vm_execution_result_t*");
 
@@ -2300,7 +2303,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
         rewriter
             .create<emitc::CallOp>(
                 /*location=*/loc,
-                /*type=*/emitc::OpaqueType::get(ctx, "void*"),
+                /*type=*/
+                emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
                 /*callee=*/StringAttr::get(ctx, "iree_alloca"),
                 /*args=*/ArrayAttr{},
                 /*templateArgs=*/ArrayAttr{},

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -3760,7 +3760,8 @@ class FailOpConversion : public OpConversionPattern<IREE::VM::FailOp> {
 
       auto messageDataOp = rewriter.create<emitc::CallOp>(
           /*location=*/loc,
-          /*type=*/emitc::OpaqueType::get(ctx, "const char*"),
+          /*type=*/
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, "const char")),
           /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER"),
           /*args=*/
           ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -154,7 +154,8 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   std::string moduleTypeName = (moduleOp.getName() + "_t*").str();
   std::string moduleStateTypeName = (moduleOp.getName() + "_state_t*").str();
 
-  Type stackType = emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
+  Type stackType =
+      emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_stack_t"));
   Type moduleType = emitc::OpaqueType::get(ctx, moduleTypeName);
   Type moduleStateType = emitc::OpaqueType::get(ctx, moduleStateTypeName);
 
@@ -1512,7 +1513,8 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
 
     std::string newFuncName = (funcOp.getName() + "_export_shim").str();
 
-    Type stackType = emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
+    Type stackType =
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_stack_t"));
     Type callType = emitc::OpaqueType::get(ctx, "iree_vm_function_call_t*");
     Type moduleType =
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"));
@@ -2153,7 +2155,8 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
                                         Location loc) const {
     auto ctx = rewriter.getContext();
 
-    Type stackType = emitc::OpaqueType::get(ctx, "iree_vm_stack_t*");
+    Type stackType =
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_stack_t"));
     Type funcType = emitc::OpaqueType::get(ctx, "iree_vm_function_t*");
 
     SmallVector<Type> types{stackType, funcType};

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -782,7 +782,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
         ctx,
         {emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
          emitc::OpaqueType::get(ctx, "iree_allocator_t"),
-         emitc::OpaqueType::get(ctx, "iree_vm_module_state_t**")},
+         emitc::PointerType::get(emitc::PointerType::get(
+             emitc::OpaqueType::get(ctx, "iree_vm_module_state_t")))},
         {emitc::OpaqueType::get(ctx, "iree_status_t")});
 
     auto funcOp = builder.create<mlir::FuncOp>(loc, moduleName + "_alloc_state",
@@ -989,7 +990,9 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
     auto baseStateOp = builder.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
+        /*type=*/
+        emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, "iree_vm_module_state_t")),
         /*callee=*/StringAttr::get(ctx, "EMITC_CAST"),
         /*args=*/
         ArrayAttr::get(
@@ -1025,7 +1028,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     auto funcType = mlir::FunctionType::get(
         ctx,
         {emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
-         emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*")},
+         emitc::PointerType::get(
+             emitc::OpaqueType::get(ctx, "iree_vm_module_state_t"))},
         {});
 
     auto funcOp =
@@ -1127,7 +1131,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
         ctx,
         {
             emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
-            emitc::OpaqueType::get(ctx, "iree_vm_module_state_t*"),
+            emitc::PointerType::get(
+                emitc::OpaqueType::get(ctx, "iree_vm_module_state_t")),
             emitc::OpaqueType::get(ctx, "iree_host_size_t"),
             emitc::PointerType::get(
                 emitc::OpaqueType::get(ctx, "const iree_vm_function_t")),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4015,7 +4015,7 @@ class GlobalStoreOpConversion : public OpConversionPattern<StoreOpTy> {
     BlockArgument stateArg = funcOp.getArgument(2);
     auto rwDataPtr = rewriter.create<emitc::CallOp>(
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "uint8_t*"),
+        /*type=*/emitc::PointerType::get(rewriter.getIntegerType(8, false)),
         /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4531,7 +4531,8 @@ class ListSetOpConversion : public OpConversionPattern<SetOpTy> {
 
     auto valuePtrOp = rewriter.create<emitc::ApplyOp>(
         /*location=*/loc,
-        /*result=*/emitc::OpaqueType::get(ctx, "iree_vm_value_t*"),
+        /*result=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_value_t")),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/valueOp.getResult(0));
 
@@ -4547,7 +4548,8 @@ class ListSetOpConversion : public OpConversionPattern<SetOpTy> {
     auto listDerefOp = failListNull(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4594,7 +4594,8 @@ class ListSetRefOpConversion
     auto listDerefOp = failListNull(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_list_t*"),
+        /*type=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
         /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
         /*args=*/ArrayAttr{},
         /*templateArgs=*/ArrayAttr{},

--- a/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -809,6 +809,12 @@ LogicalResult CppEmitter::emitType(Location loc, Type type) {
     os << oType.getValue();
     return success();
   }
+  if (auto pType = type.dyn_cast<emitc::PointerType>()) {
+    if (failed(emitType(loc, pType.getPointee())))
+      return failure();
+    os << "*";
+    return success();
+  }
   return emitError(loc, "cannot emit type ") << type;
 }
 


### PR DESCRIPTION
Refactors the VMToEmitC conversions to use the recently introduced `emitc.ptr`.
The refactoring of `iree_vm_ref_t*` is still needs to be done.