### PR TITLE
Extend linalg_ext.scatter op semantic to carry unique_indices attribute.

### DIFF
--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -65,9 +65,11 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     The first dim of `updates` and `indices` is identical, since they represent
     the number of updates.
 
-    The rank of the `original`/`result` is `index_depth + rank(%updates) - 1`.
-    The first `index_depth` indices are derived from `indices` and the shape of
-    update value must match the rest shape of `original`.
+    The rank of the `original`/`result` is atleast
+    `index_depth + rank(%updates) - 1`. The first `index_depth` indices are
+    derived from `indices` and the shape of update value has the last
+    rank(%original) - index_depth values match %(originals) last dimensions,
+    with the previous dims extending from the index offsets.
 
     The shapes definition follows tensorflow operations execept that it force
     batch dims to be 1D. See more information in
@@ -76,13 +78,13 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,
       Variadic<AnyRankedTensorOrMemRefType>:$outputs,
-      DefaultValuedAttr<BoolAttr, "false">:$unique_indices
+      DefaultValuedAttr<BoolAttr, "true">:$unique_indices
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    `unique_indices` `(` $unique_indices `)`
-    attr-dict(`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    attr-dict `unique_indices` `(` $unique_indices `)`
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];

--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -65,11 +65,15 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     The first dim of `updates` and `indices` is identical, since they represent
     the number of updates.
 
-    The rank of the `original`/`result` is atleast
+    The rank of the `original`/`result` is at least
     `index_depth + rank(%updates) - 1`. The first `index_depth` indices are
     derived from `indices` and the shape of update value has the last
     rank(%original) - index_depth values match %(originals) last dimensions,
     with the previous dims extending from the index offsets.
+
+    The unique_indices attribute carries the information whether all the indices
+    are unique. If there are repeated indices, the first iteration loop will be
+    marked as reduction.
 
     The shapes definition follows tensorflow operations execept that it force
     batch dims to be 1D. See more information in

--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -75,12 +75,14 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   }];
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,
-      Variadic<AnyRankedTensorOrMemRefType>:$outputs
+      Variadic<AnyRankedTensorOrMemRefType>:$outputs,
+      DefaultValuedAttr<BoolAttr, "false">:$unique_indices
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `unique_indices` `(` $unique_indices `)`
+    attr-dict(`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -136,20 +136,50 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
         "mismatch in shape of indices and update value at dim#0");
   }
   auto originalType = op.getOriginalType();
-  // indexDepth + update dims should match to original dims. The first dim of
-  // update is the number of updates.
-  if (originalType.getRank() != indexDepth + updateType.getRank() - 1) {
+  if (updateType.getRank() - 1 > originalType.getRank()) {
     return op.emitOpError(
-        "mismatch in rank of update value, index depth and original value");
+        "update value rank exceeds the rank of the original value");
   }
-  for (auto dim : llvm::seq<unsigned>(indexDepth, originalType.getRank())) {
-    // Offset one because the first dim is the number of updates.
-    if (updateType.getDimSize(1 + dim - indexDepth) !=
-        originalType.getDimSize(dim)) {
+
+  // indexDepth + update dims should cover the original dims. The first dim of
+  // update is the number of updates.
+  if (originalType.getRank() > indexDepth + updateType.getRank() - 1) {
+    return op.emitOpError(
+        "index depth and update value does not cover rank of original value");
+  }
+
+  // Validate the non-indexed update dims covier the full slice size of the
+  // original tensor.
+  int64_t fullSliceDims = originalType.getRank() - indexDepth;
+  for (auto it :
+       llvm::zip(llvm::seq<unsigned>(indexDepth, originalType.getRank()),
+                 llvm::seq<unsigned>(updateType.getRank() - fullSliceDims,
+                                     updateType.getRank()))) {
+    int64_t originalDim = std::get<0>(it);
+    int64_t updateDim = std::get<1>(it);
+    if (updateType.getDimSize(updateDim) !=
+        originalType.getDimSize(originalDim)) {
       return op.emitOpError("mismatch in shape of update value dim#")
-             << (1 + dim - indexDepth) << " and original value at dim#" << dim;
+             << updateDim << " and original value at dim#" << originalDim;
     }
   }
+
+  // Check that the remaining update indices do not exceed the update length.
+  int64_t insertDims = originalType.getRank() - updateType.getRank() + 1;
+  for (auto it : llvm::zip(
+           llvm::seq<unsigned>(insertDims, indexDepth),
+           llvm::seq<unsigned>(1, updateType.getRank() - fullSliceDims))) {
+    int64_t originalDim = std::get<0>(it);
+    int64_t updateDim = std::get<1>(it);
+    if (updateType.getDimSize(updateDim) >
+        originalType.getDimSize(originalDim)) {
+      return op.emitOpError("indexed shape of update value dim#")
+             << updateDim << " exceeds original value at dim#" << originalDim
+             << " " << updateType.getDimSize(updateDim) << " "
+             << originalType.getDimSize(originalDim);
+    }
+  }
+
   Region &region = op.region();
   Block *body = &region.front();
   if (body->getNumArguments() != 2) {
@@ -282,12 +312,26 @@ LogicalResult ScatterOp::generateScalarImplementation(OpBuilder &b,
   SmallVector<Value> loadIndices;
   loadIndices.push_back(ivs.front());
   loadIndices.push_back(Value());
+
+  // Populate with empty values.
+  auto originalTy = original().getType().cast<ShapedType>();
+  starts.resize(originalTy.getRank(), Value());
+  auto updateIvs = ivs.drop_front(1);
+
+  int64_t offset = starts.size() - updateIvs.size();
+  for (auto it : llvm::enumerate(updateIvs)) {
+    starts[it.index() + offset] = it.value();
+  }
+
   for (auto i : llvm::seq<unsigned>(0, indexDepth)) {
     loadIndices.back() = b.create<arith::ConstantIndexOp>(loc, i);
     Value idx = b.create<memref::LoadOp>(loc, indices(), loadIndices);
-    starts.push_back(b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx));
+    Value cast = b.create<arith::IndexCastOp>(loc, b.getIndexType(), idx);
+
+    if (starts[i]) cast = b.create<arith::AddIOp>(loc, cast, starts[i]);
+    starts[i] = cast;
   }
-  starts.append(std::next(ivs.begin()), ivs.end());
+
   Value init = b.create<memref::LoadOp>(loc, original(), starts);
 
   BlockAndValueMapping bvm;

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -190,6 +190,9 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
 SmallVector<StringRef> ScatterOp::getLoopIteratorTypes() {
   SmallVector<StringRef> iteratorTypes(getUpdateType().getRank(),
                                        getParallelIteratorTypeName());
+  if (!unique_indices()) {
+    iteratorTypes[0] = getReductionIteratorTypeName();
+  }
   return iteratorTypes;
 }
 

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -343,6 +343,12 @@ void TiledOpInterfaceTilingPass::runOnOperation() {
           StringAttr::get(context, "tiling_2d_stage5_fft_input"),
           StringAttr::get(context, "tiling_2d_stage5_fft_output")));
 
+  patterns.add<TiledOpInterfaceTilingPattern>(
+      context, linalg::LinalgTilingOptions().setTileSizes({0, 20}),
+      linalg::LinalgTransformationFilter(
+          StringAttr::get(context, "tiling_repeated_indices_scatter_input"),
+          StringAttr::get(context, "tiling_repeated_indices_scatter_output")));
+
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -328,6 +328,41 @@ func @scatter_update_slice_dynamic_2D(
 
 // -----
 
+func @scatter_partial_slices(%arg0: memref<2x64x12xf32>, %arg1: memref<2x3xi32>, %arg2: memref<2x1x12xf32>) {
+  iree_linalg_ext.scatter
+    unique_indices(true)
+    ins(%arg2, %arg1 : memref<2x1x12xf32>, memref<2x3xi32>)
+    outs(%arg0 : memref<2x64x12xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32):
+    iree_linalg_ext.yield %arg4 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: @scatter_partial_slices
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG: %[[C0:.+]] = arith.constant
+// CHECK-DAG: %[[C1:.+]] = arith.constant
+// CHECK-DAG: %[[C2:.+]] = arith.constant
+// CHECK-DAG: %[[C12:.+]] = arith.constant
+// CHECK:     scf.for %[[ARG3:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK-NEXT:   scf.for %[[ARG4:.+]] = %[[C0]] to %[[C1]] step %[[C1]] {
+// CHECK-NEXT:     scf.for %[[ARG5:.+]] = %[[C0]] to %[[C12]] step %[[C1]] {
+// CHECK-NEXT:       %[[LOAD0:.+]] = memref.load %[[ARG1]][%[[ARG3]], %[[C0]]] : memref<2x3xi32>
+// CHECK-NEXT:       %[[CAST0:.+]] = arith.index_cast %[[LOAD0]] : i32 to index
+// CHECK-NEXT:       %[[LOAD1:.+]] = memref.load %[[ARG1]][%[[ARG3]], %[[C1]]] : memref<2x3xi32>
+// CHECK-NEXT:       %[[CAST1:.+]] = arith.index_cast %[[LOAD1]] : i32 to index
+// CHECK-NEXT:       %[[ADD1:.+]] = arith.addi %[[CAST1]], %[[ARG4]] : index
+// CHECK-NEXT:       %[[LOAD2:.+]] = memref.load %[[ARG1]][%[[ARG3]], %[[C2]]] : memref<2x3xi32>
+// CHECK-NEXT:       %[[CAST2:.+]] = arith.index_cast %[[LOAD2]] : i32 to index
+// CHECK-NEXT:       %[[ADD2:.+]] = arith.addi %[[CAST2]], %[[ARG5]] : index
+// CHECK-NEXT:       %[[LOAD3:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[ADD1]], %[[ADD2]]] : memref<2x64x12xf32>
+// CHECK-NEXT:       memref.store %[[LOAD3]], %[[ARG0]][%[[CAST0]], %[[ADD1]], %[[ADD2]]] : memref<2x64x12xf32>
+
+// -----
+
 func @fft_1D(%real: memref<16xf32>, %imag: memref<16xf32>) {
   %stage = arith.constant 1 : index
   iree_linalg_ext.fft

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -100,7 +100,7 @@ func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 func @scatter_update_scalar_1D(
     %original: memref<8xi32>, %indices: memref<3x1xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -126,7 +126,7 @@ func @scatter_update_scalar_1D(
 func @scatter_add_scalar_2D(
     %original: memref<4x3xi32>, %indices: memref<3x2xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x2xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -157,7 +157,7 @@ func @scatter_add_scalar_2D(
 func @scatter_update_slice_2D(
     %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
     %updates: memref<2x3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -187,7 +187,7 @@ func @scatter_update_slice_2D(
 func @scatter_add_scalar_1D(
     %original: memref<8xi32>, %indices: memref<3x1xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -216,7 +216,7 @@ func @scatter_add_scalar_1D(
 func @scatter_add_slice_2D(
     %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
     %updates: memref<2x3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -246,7 +246,7 @@ func @scatter_add_slice_2D(
 func @scatter_update_scalar_dynamic_1D(
     %original: memref<?xi32>, %indices: memref<?x1xi32>,
     %updates: memref<?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x1xi32>)
     outs(%original : memref<?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -272,7 +272,7 @@ func @scatter_update_scalar_dynamic_1D(
 func @scatter_add_scalar_dynamic_2D(
     %original: memref<?x?xi32>, %indices: memref<?x2xi32>,
     %updates: memref<?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x2xi32>)
     outs(%original : memref<?x?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -303,7 +303,7 @@ func @scatter_add_scalar_dynamic_2D(
 func @scatter_update_slice_dynamic_2D(
     %original: memref<?x?xi32>, %indices: memref<?x1xi32>,
     %updates: memref<?x?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?x?xi32>, memref<?x1xi32>)
     outs(%original : memref<?x?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -199,11 +199,11 @@ func @scatter_dim_mismatch(
 // -----
 
 func @scatter_dim_mismatch(
-    %update : tensor<?x?x?xf32>, %indices : tensor<?x1xi32>,
+    %update : tensor<?x?x?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
+  // expected-error @+1 {{op update value rank exceeds the rank of the original value}}
   %0 = iree_linalg_ext.scatter unique_indices(true)
-    ins(%update, %indices : tensor<?x?x?xf32>, tensor<?x1xi32>)
+    ins(%update, %indices : tensor<?x?x?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.addf %arg1, %arg2 : f32
@@ -367,11 +367,11 @@ func @scatter_index_depth_dynamic(
 // -----
 
 func @scatter_original_rank_mismatch(
-    %update : tensor<?x?xi64>, %indices : tensor<?x2xi32>,
+    %update : tensor<?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
+  // expected-error @+1 {{op index depth and update value does not cover rank of original value}}
   %0 = iree_linalg_ext.scatter unique_indices(true)
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
+    ins(%update, %indices : tensor<?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = arith.addi %arg1, %arg2 : i64

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -58,7 +58,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -74,7 +74,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, memref<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -90,7 +90,7 @@ func @scatter_extra_outputs(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
   // expected-error @+1 {{expected number of outputs to be same as the number of results}}
-  %0, %1 = iree_linalg_ext.scatter
+  %0, %1 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -106,7 +106,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : memref<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -122,7 +122,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> memref<?x?xf32> {
   // expected-error @+1 {{expected type of `outs` operand #0 'tensor<?x?xf32>' to be same as result type 'memref<?x?xf32>'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -138,7 +138,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) {
   // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -154,7 +154,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) {
   // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -170,7 +170,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -186,7 +186,7 @@ func @scatter_dim_mismatch(
     %update : tensor<64x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<64x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -202,7 +202,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -218,7 +218,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x4xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of update value dim#1 and original value at dim#1}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x4xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -234,7 +234,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{expected region to have scalar argument of integer or float types}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: index, %arg2: index):
@@ -251,7 +251,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 0 of region 'i64' and element type of update value 'i32'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i64, %arg2: i32):
@@ -268,7 +268,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 1 of region 'i64' and element type of original value 'i32'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i32, %arg2: i64):
@@ -285,7 +285,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{mismatch in region argument types 'i32' and 'i64'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i32, %arg2: i64):
@@ -302,7 +302,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{expected region to have two arguments}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64, %arg3 : i64):
@@ -318,7 +318,7 @@ func @scatter_region_type_mismatch(
 func @scatter_yield_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -335,7 +335,7 @@ func @scatter_yield_mismatch(
 func @scatter_yield_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -353,7 +353,7 @@ func @scatter_index_depth_dynamic(
     %update : tensor<?x?xi64>, %indices : tensor<?x?xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{expected index depth is static}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x?xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -370,7 +370,7 @@ func @scatter_original_rank_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x2xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{mismatch in rank of update value, index depth and original value}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/roundtrip.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/roundtrip.mlir
@@ -74,6 +74,7 @@ func @scatter_tensor_dynamic(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original: tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -87,6 +88,33 @@ func @scatter_tensor_dynamic(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scatter_repeated_tensor_dynamic(
+    %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
+    %update: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.scatter
+    unique_indices(false)
+    ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
+    outs(%original: tensor<?x?xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      iree_linalg_ext.yield %1 : f32
+    } -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @scatter_repeated_tensor_dynamic(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(false)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -98,6 +126,7 @@ func @scatter_tensor_static(
     %original: tensor<128x3xf32>, %indices: tensor<48x1xi32>,
     %update: tensor<48x3xf32>) -> tensor<128x3xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<48x3xf32>, tensor<48x1xi32>)
     outs(%original: tensor<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -111,6 +140,7 @@ func @scatter_tensor_static(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -122,6 +152,7 @@ func @scatter_tensor_multi_index_depth(
     %original: tensor<1x128x3xf32>, %indices: tensor<48x2xi32>,
     %update: tensor<48x3xf32>) -> tensor<1x128x3xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<48x3xf32>, tensor<48x2xi32>)
     outs(%original: tensor<1x128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -135,6 +166,7 @@ func @scatter_tensor_multi_index_depth(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -146,6 +178,7 @@ func @scatter_memref_dynamic(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update: memref<?x?xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original: memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -159,6 +192,7 @@ func @scatter_memref_dynamic(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<?x?xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -170,6 +204,7 @@ func @scatter_memref_static(
     %original: memref<128x3xf32>, %indices: memref<48x1xi32>,
     %update: memref<48x3xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<48x3xf32>, memref<48x1xi32>)
     outs(%original: memref<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -183,6 +218,7 @@ func @scatter_memref_static(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -194,6 +230,7 @@ func @scatter_memref_multi_index_depth(
     %original: memref<1x128x3xf32>, %indices: memref<48x2xi32>,
     %update: memref<48x3xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<48x3xf32>, memref<48x2xi32>)
     outs(%original: memref<1x128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -207,6 +244,7 @@ func @scatter_memref_multi_index_depth(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -218,6 +256,7 @@ func @scatter_update_scalar_1D(
     %original: tensor<8xi32>, %indices: tensor<3x1xi32>,
     %updates: tensor<3xi32>) -> tensor<8xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi32>)
     outs(%original : tensor<8xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -230,6 +269,7 @@ func @scatter_update_scalar_1D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32
@@ -241,6 +281,7 @@ func @scatter_update_scalar_2D(
     %original: tensor<4x3xi32>, %indices: tensor<3x2xi32>,
     %updates: tensor<3xi32>) -> tensor<4x3xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x2xi32>)
     outs(%original : tensor<4x3xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -253,6 +294,7 @@ func @scatter_update_scalar_2D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32
@@ -264,6 +306,7 @@ func @scatter_update_slice_2D(
     %original: tensor<4x3xi32>, %indices: tensor<1x1xi32>,
     %updates: tensor<1x3xi32>) -> tensor<4x3xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<1x3xi32>, tensor<1x1xi32>)
     outs(%original : tensor<4x3xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -276,6 +319,7 @@ func @scatter_update_slice_2D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -1,9 +1,9 @@
-// RUN: iree-dialects-opt -iree-linalg-ext-tile -split-input-file %s | FileCheck  %s
+// RUN: iree-dialects-opt -iree-linalg-ext-tile -split-input-file -verify-diagnostics %s | FileCheck  %s
 
 func @scatter_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "tiling_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -39,6 +39,7 @@ func @scatter_tiling(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INITX]][0, %[[IV1]]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
@@ -53,7 +54,7 @@ func @scatter_tiling(
 func @scatter_tiling_memref(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update : memref<?x?xf32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "tiling_input"}
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
@@ -87,6 +88,7 @@ func @scatter_tiling_memref(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = memref.subview %[[ORIGINAL]][0, %[[IV1]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
@@ -96,7 +98,7 @@ func @scatter_tiling_memref(
 func @scatter_tiling_distribution(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "distribute_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -132,6 +134,7 @@ func @scatter_tiling_distribution(
 //       CHECK:     %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, 0]
 //  CHECK-SAME:         [%[[D2]], %[[D1]]]
 //       CHECK:     %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        __internal_linalg_transform__ = "distribute_output"
 //  CHECK-SAME:        ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:        outs(%[[ORIGINAL_SLICE]]
@@ -144,7 +147,7 @@ func @scatter_tiling_distribution(
 func @scatter_no_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "no_tiling_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -159,6 +162,7 @@ func @scatter_no_tiling(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATES:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       __internal_linalg_transform__ = "no_tiling_output"
 //  CHECK-SAME:       ins(%[[UPDATES]], %[[INDICES]]
 //  CHECK-SAME:       outs(%[[ORIGINAL]]

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -3,8 +3,9 @@
 func @scatter_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -39,8 +40,8 @@ func @scatter_tiling(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INITX]][0, %[[IV1]]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
 //       CHECK:       %[[YIELD:.+]] = tensor.insert_slice %[[SCATTER_TILE]] into %[[INITX]][0, %[[IV1]]]
@@ -54,8 +55,9 @@ func @scatter_tiling(
 func @scatter_tiling_memref(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update : memref<?x?xf32>) {
-  iree_linalg_ext.scatter unique_indices(true)
+  iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -88,8 +90,8 @@ func @scatter_tiling_memref(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = memref.subview %[[ORIGINAL]][0, %[[IV1]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
 
@@ -98,8 +100,9 @@ func @scatter_tiling_memref(
 func @scatter_tiling_distribution(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "distribute_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -134,8 +137,8 @@ func @scatter_tiling_distribution(
 //       CHECK:     %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, 0]
 //  CHECK-SAME:         [%[[D2]], %[[D1]]]
 //       CHECK:     %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        __internal_linalg_transform__ = "distribute_output"
+//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:        outs(%[[ORIGINAL_SLICE]]
 //       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SCATTER_TILE]] into %[[INIT]][0, 0]
@@ -147,8 +150,9 @@ func @scatter_tiling_distribution(
 func @scatter_no_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "no_tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -162,8 +166,8 @@ func @scatter_no_tiling(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATES:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       __internal_linalg_transform__ = "no_tiling_output"
+//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       ins(%[[UPDATES]], %[[INDICES]]
 //  CHECK-SAME:       outs(%[[ORIGINAL]]
 //       CHECK:   return %[[RESULT]]

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -37,7 +37,7 @@ hal.executable private @static_scatter_update_slice  {
             %8 = memref.subview %1[%arg0, 0] [1, 1] [1, 1] : memref<40x1xi32> to memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %9 = memref.cast %8 : memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>> to memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %10 = memref.subview %2[0, %arg1] [100, %5] [1, 1] : memref<100x500xi32> to memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>
-            iree_linalg_ext.scatter unique_indices(true) {lowering.config = #config} ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
+            iree_linalg_ext.scatter {lowering.config = #config} unique_indices(true) ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               iree_linalg_ext.yield %arg2 : i32
             }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -37,7 +37,7 @@ hal.executable private @static_scatter_update_slice  {
             %8 = memref.subview %1[%arg0, 0] [1, 1] [1, 1] : memref<40x1xi32> to memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %9 = memref.cast %8 : memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>> to memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %10 = memref.subview %2[0, %arg1] [100, %5] [1, 1] : memref<100x500xi32> to memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>
-            iree_linalg_ext.scatter {lowering.config = #config} ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
+            iree_linalg_ext.scatter unique_indices(true) {lowering.config = #config} ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               iree_linalg_ext.yield %arg2 : i32
             }
@@ -69,6 +69,6 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:         %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
 //       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
 //       CHECK:         %[[T_TARGET_CAST:.+]] = memref.cast %[[T_TARGET]]
-//       CHECK:         iree_linalg_ext.scatter
+//       CHECK:         iree_linalg_ext.scatter unique_indices(true)
 //  CHECK-SAME:           ins(%[[T_UPDATE_CAST]], %[[T_INDEX]]
 //  CHECK-SAME:           outs(%[[T_TARGET_CAST]]

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -69,6 +69,7 @@ hal.executable private @static_scatter_update_slice  {
 //       CHECK:         %[[T_INDEX:.+]] = memref.cast %[[WG_INDEX]]
 //       CHECK:         %[[T_TARGET:.+]] = memref.subview %[[WG_TARGET]][0, %[[IV_X]]] [100, 1] [1, 1]
 //       CHECK:         %[[T_TARGET_CAST:.+]] = memref.cast %[[T_TARGET]]
-//       CHECK:         iree_linalg_ext.scatter unique_indices(true)
+//       CHECK:         iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           ins(%[[T_UPDATE_CAST]], %[[T_INDEX]]
 //  CHECK-SAME:           outs(%[[T_TARGET_CAST]]

--- a/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -812,6 +812,7 @@ func @scatter(
     %original : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = iree_linalg_ext.scatter
+      unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg0: f32, %arg1: f32):
@@ -840,6 +841,7 @@ func @scatter(
 //  CHECK-DAG:       %[[INDICES:.+]] = flow.dispatch.tensor.load %[[ARG1_CAPTURE]]
 //  CHECK-DAG:       %[[ORIGINAL:.+]] = flow.dispatch.tensor.load %[[ARG0_CAPTURE]]
 //  CHECK-DAG:       %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:               unique_indices(true)
 // CHECK-SAME:               ins(%[[UPDATE]], %[[INDICES]] : tensor<?x?xf32>, tensor<?x1xi32>)
 // CHECK-SAME:               outs(%[[ORIGINAL]] : tensor<?x?xf32>)
 //      CHECK:       flow.dispatch.tensor.store %[[SCATTER]], %[[ARG0_CAPTURE]]
@@ -898,6 +900,7 @@ func @scatter_static(%arg0 : tensor<4xi32>, %arg1 : tensor<4x1xi32>, %arg2 : ten
   %cst_1 = arith.constant dense<[[1], [3], [4], [7]]> : tensor<4x1xi32>
   %cst_2 = arith.constant dense<0> : tensor<8xi32>
   %0 = iree_linalg_ext.scatter
+      unique_indices(true)
       ins(%arg0, %arg1 : tensor<4xi32>, tensor<4x1xi32>)
       outs(%arg2 : tensor<8xi32>)  {
     ^bb0(%arg3: i32, %arg4: i32):  // no predecessors

--- a/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertMHLOToLinalgExt.cpp
@@ -296,7 +296,7 @@ struct ScatterOpConversion : public OpConversionPattern<mhlo::ScatterOp> {
     }
     auto scatterOp = rewriter.create<IREE::LinalgExt::ScatterOp>(
         op.getLoc(), op->getResultTypes(), ValueRange{updates, indices},
-        ValueRange{original});
+        ValueRange{original}, op.unique_indices());
 
     rewriter.inlineRegionBefore(op.update_computation(), scatterOp.region(),
                                 scatterOp.region().begin());

--- a/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -230,7 +230,7 @@ func @scatter_update_scalar_1D(%arg0: tensor<8xi32>, %arg1: tensor<4x1xi32>,
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<8xi32>, tensor<4x1xi32>, tensor<4xi32>) -> tensor<8xi32>
   return %0 : tensor<8xi32>
 }
@@ -239,6 +239,7 @@ func @scatter_update_scalar_1D(%arg0: tensor<8xi32>, %arg1: tensor<4x1xi32>,
 // CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:      unique_indices(true)
 // CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<4xi32>, tensor<4x1xi32>)
 // CHECK-SAME:      outs(%[[ARG0]] : tensor<8xi32>)
 // CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):
@@ -258,7 +259,7 @@ func @scatter_update_scalar_2D(%arg0: tensor<4x3xi32>, %arg1: tensor<3x2xi32>,
         scatter_dims_to_operand_dims = [0, 1],
         index_vector_dim = 1,
       >,
-      unique_indices = false
+      unique_indices = true
   } : (tensor<4x3xi32>, tensor<3x2xi32>, tensor<3xi32>) -> tensor<4x3xi32>
   return %0 : tensor<4x3xi32>
 }
@@ -267,6 +268,7 @@ func @scatter_update_scalar_2D(%arg0: tensor<4x3xi32>, %arg1: tensor<3x2xi32>,
 // CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:      unique_indices(true)
 // CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<3xi32>, tensor<3x2xi32>)
 // CHECK-SAME:      outs(%[[ARG0]] : tensor<4x3xi32>)
 // CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):
@@ -288,7 +290,7 @@ func @scatter_update_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
   return %0 : tensor<6x3xi32>
 }
@@ -297,6 +299,7 @@ func @scatter_update_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
 // CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:      unique_indices(true)
 // CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<2x3xi32>, tensor<2x1xi32>)
 // CHECK-SAME:      outs(%[[ARG0]] : tensor<6x3xi32>)
 // CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):
@@ -328,6 +331,7 @@ func @scatter_add_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
 // CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:      unique_indices(false)
 // CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<2x3xi32>, tensor<2x1xi32>)
 // CHECK-SAME:      outs(%[[ARG0]] : tensor<6x3xi32>)
 // CHECK:           ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):
@@ -364,6 +368,7 @@ func @scatter_update_batch_scalar_1D(%arg0: tensor<8xi32>,
 // CHECK:         %[[COLLAPSED_UPDATES:.+]] = tensor.collapse_shape
 // CHECK-SAME:        %[[ARG2]] {{\[}}[0, 1]] : tensor<3x4xi32> into tensor<12xi32>
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:       unique_indices(false)
 // CHECK-SAME:       ins(%[[COLLAPSED_UPDATES]], %[[COLLAPSED_INDICES]] : tensor<12xi32>, tensor<12x1xi32>)
 // CHECK-SAME:       outs(%[[ARG0]] : tensor<8xi32>)
 // CHECK:            ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):
@@ -384,7 +389,7 @@ func @scatter_update_batch_slice_3D_dynamic(%arg0: tensor<1x24x512xi32>,
         scatter_dims_to_operand_dims = [0, 1],
         index_vector_dim = 2,
       >,
-      unique_indices = false
+      unique_indices = true
   } : (tensor<1x24x512xi32>, tensor<?x3x2xi32>, tensor<?x3x512xi32>) -> tensor<1x24x512xi32>
   return %0 : tensor<1x24x512xi32>
 }
@@ -397,6 +402,7 @@ func @scatter_update_batch_slice_3D_dynamic(%arg0: tensor<1x24x512xi32>,
 // CHECK:         %[[COLLAPSED_UPDATES:.+]] = tensor.collapse_shape
 // CHECK-SAME:        %[[ARG2]] {{\[}}[0, 1], [2]] : tensor<?x3x512xi32> into tensor<?x512xi32>
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:        unique_indices(true)
 // CHECK-SAME:        ins(%[[COLLAPSED_UPDATES]], %[[COLLAPSED_INDICES]] : tensor<?x512xi32>, tensor<?x2xi32>)
 // CHECK-SAME:        outs(%[[ARG0]] : tensor<1x24x512xi32>)
 // CHECK:             ^bb0(%[[V1:.+]]: i32, %[[V2:.+]]: i32):

--- a/iree/test/e2e/xla_ops/scatter.mlir
+++ b/iree/test/e2e/xla_ops/scatter.mlir
@@ -12,9 +12,29 @@ func @scatter_update_scalar_1D() {
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<8xi32>, tensor<4x1xi32>, tensor<4xi32>) -> tensor<8xi32>
   check.expect_eq_const(%0, dense<[0, 9, 0, 10, 11, 0, 0, 12]> : tensor<8xi32>) : tensor<8xi32>
+  return
+}
+
+func @scatter_repeated_update_scalar_1D() {
+  %arg0 = util.unfoldable_constant dense<0> : tensor<8xi32>
+  %arg1 = util.unfoldable_constant dense<[[1], [1], [7], [7]]> : tensor<4x1xi32>
+  %arg2 = util.unfoldable_constant dense<[9, 10, 11, 12]> : tensor<4xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = true
+  } : (tensor<8xi32>, tensor<4x1xi32>, tensor<4xi32>) -> tensor<8xi32>
+  check.expect_eq_const(%0, dense<[0, 10, 0, 0, 0, 0, 0, 12]> : tensor<8xi32>) : tensor<8xi32>
   return
 }
 
@@ -31,7 +51,7 @@ func @scatter_update_scalar_2D() {
         scatter_dims_to_operand_dims = [0, 1],
         index_vector_dim = 1
       >,
-      unique_indices = false
+      unique_indices = true
   } : (tensor<4x3xi32>, tensor<3x2xi32>, tensor<3xi32>) -> tensor<4x3xi32>
   check.expect_eq_const(%0, dense<[[1, 0, 0],
                                    [0, 2, 0],
@@ -56,7 +76,7 @@ func @scatter_update_slice_2D() {
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
   check.expect_eq_const(%0, dense<[[0, 0, 0],
                                    [0, 0, 0],
@@ -84,7 +104,7 @@ func @scatter_add_slice_2D() {
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
   check.expect_eq_const(%0, dense<[[1, 1, 1],
                                    [1, 1, 1],
@@ -148,7 +168,7 @@ func @scatter_1D_large() {
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<1400xi32>, tensor<1400x1xi32>, tensor<1400xi32>) -> tensor<1400xi32>
   check.expect_eq_const(%result, dense<2> : tensor<1400xi32>) : tensor<1400xi32>
   return
@@ -180,7 +200,7 @@ func @scatter_2D_large() {
       scatter_dims_to_operand_dims = [0],
       index_vector_dim = 1,
     >,
-    unique_indices = false
+    unique_indices = true
   } : (tensor<200x300xi32>, tensor<200x1xi32>, tensor<200x300xi32>) -> tensor<200x300xi32>
   check.expect_eq_const(%result, dense<2> : tensor<200x300xi32>) : tensor<200x300xi32>
   return

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -77,12 +77,14 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   }];
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,
-      Variadic<AnyRankedTensorOrMemRefType>:$outputs
+      Variadic<AnyRankedTensorOrMemRefType>:$outputs,
+      DefaultValuedAttr<BoolAttr, "false">:$unique_indices
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    attr-dict (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `unique_indices` `(` $unique_indices `)`
+    attr-dict(`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -65,11 +65,15 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     The first dim of `updates` and `indices` is identical, since they represent
     the number of updates.
 
-    The rank of the `original`/`result` is atleast
+    The rank of the `original`/`result` is at least
     `index_depth + rank(%updates) - 1`. The first `index_depth` indices are
     derived from `indices` and the shape of update value has the last
     rank(%original) - index_depth values match %(originals) last dimensions,
     with the previous dims extending from the index offsets.
+
+    The unique_indices attribute carries the information whether all the indices
+    are unique. If there are repeated indices, the first iteration loop will be
+    marked as reduction.
 
     The shapes definition follows tensorflow operations execept that it force
     batch dims to be 1D. See more information in
@@ -78,13 +82,13 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,
       Variadic<AnyRankedTensorOrMemRefType>:$outputs,
-      DefaultValuedAttr<BoolAttr, "false">:$unique_indices
+      DefaultValuedAttr<BoolAttr, "true">:$unique_indices
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    `unique_indices` `(` $unique_indices `)`
-    attr-dict(`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    attr-dict `unique_indices` `(` $unique_indices `)`
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
   }];

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -220,6 +220,9 @@ static LogicalResult verifyScatterOp(ScatterOp op) {
 SmallVector<StringRef> ScatterOp::getLoopIteratorTypes() {
   SmallVector<StringRef> iteratorTypes(getUpdateType().getRank(),
                                        getParallelIteratorTypeName());
+  if (!unique_indices()) {
+    iteratorTypes[0] = getReductionIteratorTypeName();
+  }
   return iteratorTypes;
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -343,6 +343,12 @@ void TiledOpInterfaceTilingPass::runOnOperation() {
           StringAttr::get(context, "tiling_2d_stage5_fft_input"),
           StringAttr::get(context, "tiling_2d_stage5_fft_output")));
 
+  patterns.add<TiledOpInterfaceTilingPattern>(
+      context, linalg::LinalgTilingOptions().setTileSizes({0, 20}),
+      linalg::LinalgTransformationFilter(
+          StringAttr::get(context, "tiling_repeated_indices_scatter_input"),
+          StringAttr::get(context, "tiling_repeated_indices_scatter_output")));
+
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -329,7 +329,10 @@ func @scatter_update_slice_dynamic_2D(
 // -----
 
 func @scatter_partial_slices(%arg0: memref<2x64x12xf32>, %arg1: memref<2x3xi32>, %arg2: memref<2x1x12xf32>) {
-  iree_linalg_ext.scatter ins(%arg2, %arg1 : memref<2x1x12xf32>, memref<2x3xi32>) outs(%arg0 : memref<2x64x12xf32>) {
+  iree_linalg_ext.scatter
+    unique_indices(true)
+    ins(%arg2, %arg1 : memref<2x1x12xf32>, memref<2x3xi32>)
+    outs(%arg0 : memref<2x64x12xf32>) {
   ^bb0(%arg3: f32, %arg4: f32):
     iree_linalg_ext.yield %arg4 : f32
   }

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -100,7 +100,7 @@ func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
 func @scatter_update_scalar_1D(
     %original: memref<8xi32>, %indices: memref<3x1xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -126,7 +126,7 @@ func @scatter_update_scalar_1D(
 func @scatter_add_scalar_2D(
     %original: memref<4x3xi32>, %indices: memref<3x2xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x2xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -157,7 +157,7 @@ func @scatter_add_scalar_2D(
 func @scatter_update_slice_2D(
     %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
     %updates: memref<2x3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -187,7 +187,7 @@ func @scatter_update_slice_2D(
 func @scatter_add_scalar_1D(
     %original: memref<8xi32>, %indices: memref<3x1xi32>,
     %updates: memref<3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -216,7 +216,7 @@ func @scatter_add_scalar_1D(
 func @scatter_add_slice_2D(
     %original: memref<4x3xi32>, %indices: memref<2x1xi32>,
     %updates: memref<2x3xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -246,7 +246,7 @@ func @scatter_add_slice_2D(
 func @scatter_update_scalar_dynamic_1D(
     %original: memref<?xi32>, %indices: memref<?x1xi32>,
     %updates: memref<?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x1xi32>)
     outs(%original : memref<?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -272,7 +272,7 @@ func @scatter_update_scalar_dynamic_1D(
 func @scatter_add_scalar_dynamic_2D(
     %original: memref<?x?xi32>, %indices: memref<?x2xi32>,
     %updates: memref<?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x2xi32>)
     outs(%original : memref<?x?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -303,7 +303,7 @@ func @scatter_add_scalar_dynamic_2D(
 func @scatter_update_slice_dynamic_2D(
     %original: memref<?x?xi32>, %indices: memref<?x1xi32>,
     %updates: memref<?x?xi32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%updates, %indices : memref<?x?xi32>, memref<?x1xi32>)
     outs(%original : memref<?x?xi32>)  {
   ^bb0(%arg0: i32, %arg1: i32):  // no predecessors

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -58,7 +58,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -74,7 +74,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, memref<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -90,7 +90,7 @@ func @scatter_extra_outputs(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
   // expected-error @+1 {{expected number of outputs to be same as the number of results}}
-  %0, %1 = iree_linalg_ext.scatter
+  %0, %1 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -106,7 +106,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected inputs and outputs to be RankedTensorType or scalar}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : memref<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -122,7 +122,7 @@ func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> memref<?x?xf32> {
   // expected-error @+1 {{expected type of `outs` operand #0 'tensor<?x?xf32>' to be same as result type 'memref<?x?xf32>'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {
       ^bb0(%arg1: f32, %arg2: f32):
@@ -138,7 +138,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : memref<?x?xf32>) {
   // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, tensor<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -154,7 +154,7 @@ func @scatter_mixed_tensor_memref(
     %update : memref<?x?xf32>, %indices : memref<?x1xi32>,
     %original : tensor<?x?xf32>) {
   // expected-error @+1 {{expected inputs and outputs to be MemRefType or scalar}}
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -170,7 +170,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -186,7 +186,7 @@ func @scatter_dim_mismatch(
     %update : tensor<64x?xf32>, %indices : tensor<48x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of indices and update value at dim#0}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<64x?xf32>, tensor<48x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -202,7 +202,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x?x?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{op update value rank exceeds the rank of the original value}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?x?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -218,7 +218,7 @@ func @scatter_dim_mismatch(
     %update : tensor<?x4xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{mismatch in shape of update value dim#1 and original value at dim#1}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x4xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -234,7 +234,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{expected region to have scalar argument of integer or float types}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: index, %arg2: index):
@@ -251,7 +251,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 0 of region 'i64' and element type of update value 'i32'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i64, %arg2: i32):
@@ -268,7 +268,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi32>) -> tensor<?x?xi32> {
   // expected-error @+1 {{mismatch in argument 1 of region 'i64' and element type of original value 'i32'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi32>) {
     ^bb0(%arg1: i32, %arg2: i64):
@@ -285,7 +285,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{mismatch in region argument types 'i32' and 'i64'}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i32, %arg2: i64):
@@ -302,7 +302,7 @@ func @scatter_region_type_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{expected region to have two arguments}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64, %arg3 : i64):
@@ -318,7 +318,7 @@ func @scatter_region_type_mismatch(
 func @scatter_yield_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -335,7 +335,7 @@ func @scatter_yield_mismatch(
 func @scatter_yield_mismatch(
     %update : tensor<?x?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -353,7 +353,7 @@ func @scatter_index_depth_dynamic(
     %update : tensor<?x?xi64>, %indices : tensor<?x?xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{expected index depth is static}}
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x?xi64>, tensor<?x?xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
@@ -370,8 +370,8 @@ func @scatter_original_rank_mismatch(
     %update : tensor<?xi64>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{op index depth and update value does not cover rank of original value}}
-  %0 = iree_linalg_ext.scatter
-    ins(%update, %indices : tensor<?xi64>, tensor<?x1xi32>)
+  %0 = iree_linalg_ext.scatter unique_indices(true)
+    ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = arith.addi %arg1, %arg2 : i64

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -371,7 +371,7 @@ func @scatter_original_rank_mismatch(
     %original : tensor<?x?xi64>) -> tensor<?x?xi64> {
   // expected-error @+1 {{op index depth and update value does not cover rank of original value}}
   %0 = iree_linalg_ext.scatter unique_indices(true)
-    ins(%update, %indices : tensor<?x?xi64>, tensor<?x2xi32>)
+    ins(%update, %indices : tensor<?xi64>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xi64>) {
     ^bb0(%arg1: i64, %arg2: i64):
       %1 = arith.addi %arg1, %arg2 : i64

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/roundtrip.mlir
@@ -74,6 +74,7 @@ func @scatter_tensor_dynamic(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original: tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -87,6 +88,33 @@ func @scatter_tensor_dynamic(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
+//  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
+//  CHECK-SAME:     outs(%[[ORIGINAL]]
+//       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func @scatter_repeated_tensor_dynamic(
+    %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
+    %update: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.scatter
+    unique_indices(false)
+    ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
+    outs(%original: tensor<?x?xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      iree_linalg_ext.yield %1 : f32
+    } -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @scatter_repeated_tensor_dynamic(
+//  CHECK-SAME:   %[[ORIGINAL:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
+//  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(false)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -98,6 +126,7 @@ func @scatter_tensor_static(
     %original: tensor<128x3xf32>, %indices: tensor<48x1xi32>,
     %update: tensor<48x3xf32>) -> tensor<128x3xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<48x3xf32>, tensor<48x1xi32>)
     outs(%original: tensor<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -111,6 +140,7 @@ func @scatter_tensor_static(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -122,6 +152,7 @@ func @scatter_tensor_multi_index_depth(
     %original: tensor<1x128x3xf32>, %indices: tensor<48x2xi32>,
     %update: tensor<48x3xf32>) -> tensor<1x128x3xf32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : tensor<48x3xf32>, tensor<48x2xi32>)
     outs(%original: tensor<1x128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -135,6 +166,7 @@ func @scatter_tensor_multi_index_depth(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: tensor<48x3xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -146,6 +178,7 @@ func @scatter_memref_dynamic(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update: memref<?x?xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original: memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -159,6 +192,7 @@ func @scatter_memref_dynamic(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<?x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<?x?xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -170,6 +204,7 @@ func @scatter_memref_static(
     %original: memref<128x3xf32>, %indices: memref<48x1xi32>,
     %update: memref<48x3xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<48x3xf32>, memref<48x1xi32>)
     outs(%original: memref<128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -183,6 +218,7 @@ func @scatter_memref_static(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x1xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -194,6 +230,7 @@ func @scatter_memref_multi_index_depth(
     %original: memref<1x128x3xf32>, %indices: memref<48x2xi32>,
     %update: memref<48x3xf32>) {
   iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%update, %indices : memref<48x3xf32>, memref<48x2xi32>)
     outs(%original: memref<1x128x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -207,6 +244,7 @@ func @scatter_memref_multi_index_depth(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: memref<48x2xi32>
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]: memref<48x3xf32>
 //       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : f32
@@ -218,6 +256,7 @@ func @scatter_update_scalar_1D(
     %original: tensor<8xi32>, %indices: tensor<3x1xi32>,
     %updates: tensor<3xi32>) -> tensor<8xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi32>)
     outs(%original : tensor<8xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -230,6 +269,7 @@ func @scatter_update_scalar_1D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32
@@ -241,6 +281,7 @@ func @scatter_update_scalar_2D(
     %original: tensor<4x3xi32>, %indices: tensor<3x2xi32>,
     %updates: tensor<3xi32>) -> tensor<4x3xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x2xi32>)
     outs(%original : tensor<4x3xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -253,6 +294,7 @@ func @scatter_update_scalar_2D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32
@@ -264,6 +306,7 @@ func @scatter_update_slice_2D(
     %original: tensor<4x3xi32>, %indices: tensor<1x1xi32>,
     %updates: tensor<1x3xi32>) -> tensor<4x3xi32> {
   %0 = iree_linalg_ext.scatter
+    unique_indices(true)
     ins(%updates, %indices : tensor<1x3xi32>, tensor<1x1xi32>)
     outs(%original : tensor<4x3xi32>)  {
     ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
@@ -276,6 +319,7 @@ func @scatter_update_slice_2D(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[UPDATE:[a-zA-Z0-9_]+]]
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:     unique_indices(true)
 //  CHECK-SAME:     ins(%[[UPDATE]], %[[INDICES]]
 //  CHECK-SAME:     outs(%[[ORIGINAL]]
 //       CHECK:     iree_linalg_ext.yield %{{.+}} : i32

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -1,9 +1,9 @@
-// RUN: iree-dialects-opt -iree-linalg-ext-tile -split-input-file %s | FileCheck  %s
+// RUN: iree-dialects-opt -iree-linalg-ext-tile -split-input-file -verify-diagnostics %s | FileCheck  %s
 
 func @scatter_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "tiling_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -39,6 +39,7 @@ func @scatter_tiling(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INITX]][0, %[[IV1]]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
@@ -53,7 +54,7 @@ func @scatter_tiling(
 func @scatter_tiling_memref(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update : memref<?x?xf32>) {
-  iree_linalg_ext.scatter
+  iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "tiling_input"}
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
@@ -87,6 +88,7 @@ func @scatter_tiling_memref(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = memref.subview %[[ORIGINAL]][0, %[[IV1]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       iree_linalg_ext.scatter
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
@@ -96,7 +98,7 @@ func @scatter_tiling_memref(
 func @scatter_tiling_distribution(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "distribute_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -132,6 +134,7 @@ func @scatter_tiling_distribution(
 //       CHECK:     %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, 0]
 //  CHECK-SAME:         [%[[D2]], %[[D1]]]
 //       CHECK:     %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        __internal_linalg_transform__ = "distribute_output"
 //  CHECK-SAME:        ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:        outs(%[[ORIGINAL_SLICE]]
@@ -144,7 +147,7 @@ func @scatter_tiling_distribution(
 func @scatter_no_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter
+  %0 = iree_linalg_ext.scatter unique_indices(true)
     {__internal_linalg_transform__ = "no_tiling_input"}
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
@@ -159,6 +162,7 @@ func @scatter_no_tiling(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATES:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       __internal_linalg_transform__ = "no_tiling_output"
 //  CHECK-SAME:       ins(%[[UPDATES]], %[[INDICES]]
 //  CHECK-SAME:       outs(%[[ORIGINAL]]

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -3,8 +3,9 @@
 func @scatter_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -39,8 +40,8 @@ func @scatter_tiling(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INITX]][0, %[[IV1]]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
 //       CHECK:       %[[YIELD:.+]] = tensor.insert_slice %[[SCATTER_TILE]] into %[[INITX]][0, %[[IV1]]]
@@ -54,8 +55,9 @@ func @scatter_tiling(
 func @scatter_tiling_memref(
     %original: memref<?x?xf32>, %indices: memref<?x1xi32>,
     %update : memref<?x?xf32>) {
-  iree_linalg_ext.scatter unique_indices(true)
+  iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : memref<?x?xf32>, memref<?x1xi32>)
     outs(%original : memref<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -88,8 +90,8 @@ func @scatter_tiling_memref(
 //       CHECK:       %[[ORIGINAL_SLICE:.+]] = memref.subview %[[ORIGINAL]][0, %[[IV1]]
 //  CHECK-SAME:           [%[[SCATTER_DIM]], %[[USED_TILESIZEX]]]
 //       CHECK:       iree_linalg_ext.scatter
-//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           __internal_linalg_transform__ = "tiling_output"
+//  CHECK-SAME:           unique_indices(true)
 //  CHECK-SAME:           ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:           outs(%[[ORIGINAL_SLICE]]
 
@@ -98,8 +100,9 @@ func @scatter_tiling_memref(
 func @scatter_tiling_distribution(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "distribute_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -134,8 +137,8 @@ func @scatter_tiling_distribution(
 //       CHECK:     %[[ORIGINAL_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, 0]
 //  CHECK-SAME:         [%[[D2]], %[[D1]]]
 //       CHECK:     %[[SCATTER_TILE:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        __internal_linalg_transform__ = "distribute_output"
+//  CHECK-SAME:        unique_indices(true)
 //  CHECK-SAME:        ins(%[[UPDATE_SLICE]], %[[INDEX_SLICE]]
 //  CHECK-SAME:        outs(%[[ORIGINAL_SLICE]]
 //       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SCATTER_TILE]] into %[[INIT]][0, 0]
@@ -147,8 +150,9 @@ func @scatter_tiling_distribution(
 func @scatter_no_tiling(
     %original: tensor<?x?xf32>, %indices: tensor<?x1xi32>,
     %update : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = iree_linalg_ext.scatter unique_indices(true)
+  %0 = iree_linalg_ext.scatter
     {__internal_linalg_transform__ = "no_tiling_input"}
+    unique_indices(true)
     ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
     outs(%original : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
@@ -162,8 +166,8 @@ func @scatter_no_tiling(
 //  CHECK-SAME:   %[[INDICES:[a-zA-Z0-9_]+]]: tensor<?x1xi32>
 //  CHECK-SAME:   %[[UPDATES:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
 //       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.scatter
-//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       __internal_linalg_transform__ = "no_tiling_output"
+//  CHECK-SAME:       unique_indices(true)
 //  CHECK-SAME:       ins(%[[UPDATES]], %[[INDICES]]
 //  CHECK-SAME:       outs(%[[ORIGINAL]]
 //       CHECK:   return %[[RESULT]]


### PR DESCRIPTION
There are cases that the op may update the same indices multiple times.
In this context, we can not parallize updates. Instead, we have to
execute them sequentially. Adding a boolean attribute to control the
behavior.

This also adds a test to DispatchLinalgOnTensors to make sure repeated indices cases won't get tiled and distributed.

Fixes https://github.com/google/iree/issues/8318