### PR TITLE
Turn fusion of generic op with reduction producer on by default

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -22,7 +22,7 @@
 static llvm::cl::opt<bool> clEnableFusionWithReductionOps(
     "iree-enable-fusion-with-reduction-ops",
     llvm::cl::desc("Allow fusing generic ops with reductions"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 namespace mlir {
 namespace iree_compiler {


### PR DESCRIPTION
Just trying to see if we still need this flag and if this still cause perf regressions. 