### PR TITLE
Move VM Constant ops to declarative assembly

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/command_buffer_ops.mlir
@@ -43,7 +43,7 @@ func @command_buffer_fill_buffer_i8(
 ) {
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
-  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 1 : i32
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 1
   // CHECK-DAG: %[[EXTEND:.+]] = vm.ext.i8.i32.u %arg2 : i32 -> i32
   // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[EXTEND]], %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
@@ -62,7 +62,7 @@ func @command_buffer_fill_buffer_i16(
 ) {
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
-  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 2 : i32
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 2
   // CHECK-DAG: %[[EXTEND:.+]] = vm.ext.i16.i32.u %arg2 : i32 -> i32
   // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %[[EXTEND]], %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
@@ -81,7 +81,7 @@ func @command_buffer_fill_buffer_i32(
 ) {
   %c100 = arith.constant 100 : index
   %c200 = arith.constant 200 : index
-  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 4 : i32
+  // CHECK-DAG: %[[PATTERN_LENGTH:.+]] = vm.const.i32 4
   // CHECK: vm.call @hal.command_buffer.fill_buffer(%arg0, %arg1, %c100, %c200, %arg2, %[[PATTERN_LENGTH]]) : (!vm.ref<!hal.command_buffer>, !vm.ref<!hal.buffer>, i32, i32, i32, i32) -> ()
   hal.command_buffer.fill_buffer<%arg0 : !hal.command_buffer>
       target(%arg1 : !hal.buffer)[%c100, %c200]

--- a/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -47,11 +47,11 @@ stream.executable public @add_dispatch_0 {
 //  CHECK-NEXT:         vm.func private @add_dispatch_0(
 //  CHECK-SAME:             %[[SCRATCHPAD:.+]]: !vm.buffer, %[[CONSTANTS:.+]]: !vm.buffer,
 //  CHECK-SAME:             %[[BINDINGS:.+]]: !vm.list<!vm.buffer>
-//   CHECK-DAG:           %c16 = vm.const.i32 16 : i32
-//   CHECK-DAG:           %zero = vm.const.i32.zero : i32
-//   CHECK-DAG:           %c1 = vm.const.i32 1 : i32
-//   CHECK-DAG:           %c2 = vm.const.i32 2 : i32
-//   CHECK-DAG:           %c4 = vm.const.i32 4 : i32
+//   CHECK-DAG:           %c16 = vm.const.i32 16
+//   CHECK-DAG:           %zero = vm.const.i32.zero
+//   CHECK-DAG:           %c1 = vm.const.i32 1
+//   CHECK-DAG:           %c2 = vm.const.i32 2
+//   CHECK-DAG:           %c4 = vm.const.i32 4
 //  CHECK-NEXT:           %[[LHS_BUF:.+]] = vm.list.get.ref %[[BINDINGS]], %zero : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
 //  CHECK-NEXT:           %[[RHS_BUF:.+]] = vm.list.get.ref %[[BINDINGS]], %c1 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
 //  CHECK-NEXT:           %[[RET_BUF:.+]] = vm.list.get.ref %[[BINDINGS]], %c2 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer

--- a/iree/compiler/Dialect/Util/IR/test/hint_folding.mlir
+++ b/iree/compiler/Dialect/Util/IR/test/hint_folding.mlir
@@ -13,8 +13,8 @@ func @no_fold_constant() -> (i32) {
 
 // CHECK-LABEL: @no_fold_add
 func @no_fold_add() -> (i32) {
-  // CHECK-NEXT: %[[C1:.+]] = vm.const.i32 1 : i32
-  %c1 = vm.const.i32 1 : i32
+  // CHECK-NEXT: %[[C1:.+]] = vm.const.i32 1
+  %c1 = vm.const.i32 1
   // CHECK-NEXT: %[[R1:.+]] = util.do_not_optimize(%[[C1]])
   %0 = util.do_not_optimize(%c1) : i32
   // CHECK-NEXT: %[[R2:.+]] = vm.add.i32 %[[R1]], %[[R1]]
@@ -30,7 +30,7 @@ func @no_fold_add() -> (i32) {
 func @fold_add() -> (i32) {
   // CHECK-NEXT: %[[C2:.+]] = vm.const.i32 2
   // CHECK-NEXT: return %[[C2]]
-  %c1 = vm.const.i32 1 : i32
+  %c1 = vm.const.i32 1
   %0 = vm.add.i32 %c1, %c1 : i32
   return %0 : i32
 }

--- a/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
@@ -19,7 +19,7 @@ vm.module @module {
     // CHECK: vm.const.i32.zero
     // CHECK-SAME: block_registers = ["i0", "i1"]
     // CHECK-SAME: result_registers = ["i0"]
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     vm.return %zero : i32
   }
 
@@ -28,7 +28,7 @@ vm.module @module {
     // CHECK: vm.const.i32 5
     // CHECK-SAME: block_registers = ["i0", "i1"]
     // CHECK-SAME: result_registers = ["i2"]
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     // CHECK: vm.cond_br
     // CHECK-SAME: remap_registers = [
     // CHECK-SAME:   [], ["i1->i3"]
@@ -187,13 +187,13 @@ vm.module @module {
     // CHECK: vm.const.i32
     // CHECK-SAME: block_registers = []
     // CHECK-SAME: result_registers = ["i0"]
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     // CHECK: vm.const.i32
     // CHECK-SAME: result_registers = ["i1"]
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     // CHECK: vm.const.i32.zero
     // CHECK-SAME: result_registers = ["i2"]
-    %i0 = vm.const.i32.zero : i32
+    %i0 = vm.const.i32.zero
     // CHECK: vm.br
     // CHECK-SAME: remap_registers = [
     // CHECK-SAME:   []

--- a/iree/compiler/Dialect/VM/Analysis/test/value_liveness.mlir
+++ b/iree/compiler/Dialect/VM/Analysis/test/value_liveness.mlir
@@ -27,7 +27,7 @@ vm.module @module {
     // CHECK-SAME: block_live_in = []
     // CHECK-SAME: block_live_out = []
     // CHECK-SAME: live = ["%arg0", "%arg1", "%zero"]
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     // CHECK: vm.return
     // CHECK-SAME: live = ["%zero"]
     vm.return %zero : i32
@@ -41,7 +41,7 @@ vm.module @module {
     // CHECK-SAME: block_live_in = []
     // CHECK-SAME: block_live_out = ["%arg1", "%zero"]
     // CHECK-SAME: live = ["%arg0", "%arg1", "%zero"]
-    %c4 = vm.const.i32.zero : i32
+    %c4 = vm.const.i32.zero
     // CHECK: vm.br
     // CHECK-SAME: live = ["%arg0", "%arg1", "%zero"]
     vm.br ^bb1(%arg0 : i32)
@@ -115,13 +115,13 @@ vm.module @module {
     // CHECK-SAME: block_live_in = []
     // CHECK-SAME: block_live_out = ["%c1", "%c5"]
     // CHECK-SAME: live = ["%c1"]
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     // CHECK: vm.const.i32
     // CHECK-SAME: live = ["%c1", "%c5"]
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     // CHECK: vm.const.i32.zero
     // CHECK-SAME: live = ["%c1", "%c5", "%zero"]
-    %i0 = vm.const.i32.zero : i32
+    %i0 = vm.const.i32.zero
     // CHECK: vm.br
     // CHECK-SAME: live = ["%c1", "%c5", "%zero"]
     vm.br ^loop(%i0 : i32)

--- a/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/load_store_ops.mlir
@@ -4,11 +4,11 @@ module {
   // CHECK-LABEL: vm.func private @load_store
   // CHECK-SAME: (%[[BUFFER:.+]]: !vm.buffer, %[[IDX0:.+]]: i32, %[[IDX1:.+]]: i32) -> f32 {
   func @load_store(%buffer: memref<?xf32>, %idx0: index, %idx1: index) -> f32 {
-    // CHECK-NEXT: %[[C4_0:.+]] = vm.const.i32 4 : i32
+    // CHECK-NEXT: %[[C4_0:.+]] = vm.const.i32 4
     // CHECK-NEXT: %[[OFFSET0:.+]] = vm.mul.i32 %[[IDX0]], %[[C4_0]] : i32
     // CHECK-NEXT: %[[VALUE:.+]] = vm.buffer.load.f32 %[[BUFFER]][%[[OFFSET0]]] : !vm.buffer -> f32
     %0 = memref.load %buffer[%idx0] : memref<?xf32>
-    // CHECK-NEXT: %[[C4_1:.+]] = vm.const.i32 4 : i32
+    // CHECK-NEXT: %[[C4_1:.+]] = vm.const.i32 4
     // CHECK-NEXT: %[[OFFSET1:.+]] = vm.mul.i32 %[[IDX1]], %[[C4_1]] : i32
     // CHECK-NEXT: vm.buffer.store.f32 %[[VALUE]], %[[BUFFER]][%[[OFFSET1]]] : f32 -> !vm.buffer
     memref.store %0, %buffer[%idx1] : memref<?xf32>
@@ -27,7 +27,7 @@ module {
   func @load_global(%idx: index) -> f32 {
     // CHECK-NEXT: %[[BUFFER:.+]] = vm.const.ref.rodata @__constant : !vm.buffer
     %0 = memref.get_global @__constant : memref<2xf32>
-    // CHECK-NEXT: %[[C4:.+]] = vm.const.i32 4 : i32
+    // CHECK-NEXT: %[[C4:.+]] = vm.const.i32 4
     // CHECK-NEXT: %[[OFFSET:.+]] = vm.mul.i32 %[[IDX]], %[[C4]] : i32
     // CHECK-NEXT: %[[VALUE:.+]] = vm.buffer.load.f32 %[[BUFFER]][%[[OFFSET]]] : !vm.buffer -> f32
     %1 = memref.load %0[%idx] : memref<2xf32>

--- a/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/const_ops.mlir
@@ -6,7 +6,7 @@ module @t001_const.i32.nonzero {
 
 module {
   func @non_zero() -> (i32) {
-    // CHECK: vm.const.i32 1 : i32
+    // CHECK: vm.const.i32 1
     %1 = arith.constant 1 : i32
     return %1 : i32
   }
@@ -20,7 +20,7 @@ module @t001_const.i32.zero {
 
 module {
   func @zero() -> (i32) {
-    // CHECK: vm.const.i32.zero : i32
+    // CHECK: vm.const.i32.zero
     %1 = arith.constant 0 : i32
     return %1 : i32
   }
@@ -34,7 +34,7 @@ module @t002_const.f32.nonzero {
 
 module {
   func @non_zero() -> (f32) {
-    // CHECK: vm.const.f32 1.000000e+00 : f32
+    // CHECK: vm.const.f32 1.000000e+00
     %1 = arith.constant 1. : f32
     return %1 : f32
   }
@@ -48,7 +48,7 @@ module @t003_const.f32.zero {
 
 module {
   func @zero() -> (f32) {
-    // CHECK: vm.const.f32.zero : f32
+    // CHECK: vm.const.f32.zero
     %1 = arith.constant 0. : f32
     return %1 : f32
   }

--- a/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/alignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/alignment_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @utilAlign
 func @utilAlign(%arg0 : index, %arg1: index) ->  (index) {
   %result = util.align %arg0, %arg1 : index
-  //CHECK-DAG: %c1 = vm.const.i32 1 : i32
+  //CHECK-DAG: %c1 = vm.const.i32 1
   //CHECK-DAG: %0 = vm.sub.i32 %arg1, %c1 : i32
   //CHECK-DAG: %1 = vm.add.i32 %arg0, %0 : i32
   //CHECK-DAG: %2 = vm.not.i32 %0 : i32
@@ -18,7 +18,7 @@ func @utilAlign(%arg0 : index, %arg1: index) ->  (index) {
 // CHECK-LABEL: @utilAlignInt32
 func @utilAlignInt32(%arg0 : i32, %arg1: i32) ->  (i32) {
   %result = util.align %arg0, %arg1 : i32
-  //CHECK-DAG: %c1 = vm.const.i32 1 : i32
+  //CHECK-DAG: %c1 = vm.const.i32 1
   //CHECK-DAG: %0 = vm.sub.i32 %arg1, %c1 : i32
   //CHECK-DAG: %1 = vm.add.i32 %arg0, %0 : i32
   //CHECK-DAG: %2 = vm.not.i32 %0 : i32
@@ -33,7 +33,7 @@ func @utilAlignInt32(%arg0 : i32, %arg1: i32) ->  (i32) {
 // CHECK-LABEL: @utilAlignInt64
 func @utilAlignInt64(%arg0 : i64, %arg1: i64) ->  (i64) {
   %result = util.align %arg0, %arg1 : i64
-  //CHECK-DAG: %c1 = vm.const.i64 1 : i64
+  //CHECK-DAG: %c1 = vm.const.i64 1
   //CHECK-DAG: %0 = vm.sub.i64 %arg1, %c1 : i64
   //CHECK-DAG: %1 = vm.add.i64 %arg0, %0 : i64
   //CHECK-DAG: %2 = vm.not.i64 %0 : i64

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -5,7 +5,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_i32_zero
   vm.func @const_i32_zero() -> i32 {
     // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0 : i32} : () -> i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     vm.return %zero : i32
   }
 }
@@ -16,11 +16,11 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_i32
   vm.func @const_i32() {
     // CHECK-NEXT: %0 = "emitc.constant"() {value = 0 : i32} : () -> i32
-    %0 = vm.const.i32 0 : i32
+    %0 = vm.const.i32 0
     // CHECK-NEXT: %1 = "emitc.constant"() {value = 2 : i32} : () -> i32
-    %1 = vm.const.i32 2 : i32
+    %1 = vm.const.i32 2
     // CHECK-NEXT: %2 = "emitc.constant"() {value = -2 : i32} : () -> i32
-    %2 = vm.const.i32 -2 : i32
+    %2 = vm.const.i32 -2
     vm.return
   }
 }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_f32.mlir
@@ -4,7 +4,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_f32_zero
   vm.func @const_f32_zero() -> f32 {
     // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0.000000e+00 : f32} : () -> f32
-    %zero = vm.const.f32.zero : f32
+    %zero = vm.const.f32.zero
     vm.return %zero : f32
   }
 }
@@ -15,11 +15,11 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_f32
   vm.func @const_f32() {
     // CHECK-NEXT: %0 = "emitc.constant"() {value = 5.000000e-01 : f32} : () -> f32
-    %0 = vm.const.f32 0.5 : f32
+    %0 = vm.const.f32 0.5
     // CHECK-NEXT: %1 = "emitc.constant"() {value = 2.500000e+00 : f32} : () -> f32
-    %1 = vm.const.f32 2.5 : f32
+    %1 = vm.const.f32 2.5
     // CHECK-NEXT: %2 = "emitc.constant"() {value = -2.500000e+00 : f32} : () -> f32
-    %2 = vm.const.f32 -2.5 : f32
+    %2 = vm.const.f32 -2.5
     vm.return
   }
 }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops_i64.mlir
@@ -5,7 +5,7 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_i64_zero
   vm.func @const_i64_zero() -> i64 {
     // CHECK: %[[ZERO:.+]] = "emitc.constant"() {value = 0 : i64} : () -> i64
-    %zero = vm.const.i64.zero : i64
+    %zero = vm.const.i64.zero
     vm.return %zero : i64
   }
 }
@@ -16,11 +16,11 @@ vm.module @my_module {
   // CHECK-LABEL: @my_module_const_i64
   vm.func @const_i64() {
     // CHECK-NEXT: %0 = "emitc.constant"() {value = 0 : i64} : () -> i64
-    %0 = vm.const.i64 0 : i64
+    %0 = vm.const.i64 0
     // CHECK-NEXT: %1 = "emitc.constant"() {value = 2 : i64} : () -> i64
-    %1 = vm.const.i64 2 : i64
+    %1 = vm.const.i64 2
     // CHECK-NEXT: %2 = "emitc.constant"() {value = -2 : i64} : () -> i64
-    %2 = vm.const.i64 -2 : i64
+    %2 = vm.const.i64 -2
     vm.return
   }
 }

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -368,14 +368,10 @@ def VM_PrimitiveType : AnyTypeOf<[
   FloatOfWidths<[16, 32, 64]>,
 ]>;
 
-class VM_ConstantIntegerValueAttr<I type> : Attr<
-    Or<[
-      SignlessIntegerAttrBase<type,
-                              type.bitwidth # "-bit integer value">.predicate,
-      SignlessIntElementsAttr<type.bitwidth>.predicate,
-    ]>> {
-  let storageType = "Attribute";
-  let returnType = "Attribute";
+class VM_ConstantIntegerValueAttr<I type> : SignlessIntegerAttrBase<type,
+                              type.bitwidth # "-bit integer value"> {
+  let storageType = "IntegerAttr";
+  let returnType = "IntegerAttr";
   let convertFromStorage = "$_self";
   let constBuilderCall = "$0";
 }

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -511,34 +511,6 @@ static LogicalResult verifyGlobalStoreOp(Operation *op) {
 // Constants
 //===----------------------------------------------------------------------===//
 
-template <typename T>
-static ParseResult parseConstOp(OpAsmParser &parser, OperationState &result) {
-  Attribute valueAttr;
-  NamedAttrList dummyAttrs;
-  if (failed(parser.parseAttribute(valueAttr, "value", dummyAttrs))) {
-    return parser.emitError(parser.getCurrentLocation())
-           << "Invalid attribute encoding";
-  }
-  if (!T::isBuildableWith(valueAttr, valueAttr.getType())) {
-    return parser.emitError(parser.getCurrentLocation())
-           << "Incompatible type or invalid type value formatting";
-  }
-  valueAttr = T::convertConstValue(valueAttr);
-  result.addAttribute("value", valueAttr);
-  if (failed(parser.parseOptionalAttrDict(result.attributes))) {
-    return parser.emitError(parser.getCurrentLocation())
-           << "Failed to parse optional attribute dict";
-  }
-  return parser.addTypeToList(valueAttr.getType(), result.types);
-}
-
-template <typename T>
-static void printConstOp(OpAsmPrinter &p, T &op) {
-  p << ' ';
-  p.printAttribute(op.value());
-  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"value"});
-}
-
 template <int SZ>
 static bool isConstIntegerBuildableWith(Attribute value, Type type) {
   // FlatSymbolRefAttr can only be used with a function type.

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -360,8 +360,6 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<Trait> traits = []> :
     Optional<IntegerAttr> getOrdinalAttr() { return ordinalAttr(); }
   }];
 
-  let parser = [{ return parseGlobalOp(parser, &result); }];
-  let printer = [{ return printGlobalOp(p, *this); }];
   let verifier = [{ return verifyGlobalOp(*this); }];
 }
 
@@ -790,9 +788,7 @@ class VM_ConstantPrimitiveOp<Type type, int width, string mnemonic,
     VM_EncResult<"result">,
   ];
 
-  let hasCustomAssemblyFormat = 0;
-  let parser = [{ return parseConstOp<$cppClass>(parser, result); }];
-  let printer = [{ return printConstOp<$cppClass>(p, *this); }];
+  let assemblyFormat = "$value attr-dict";
 }
 
 def VM_ConstI32Op :
@@ -855,7 +851,7 @@ class VM_ConstantPrimitiveZeroOp<Type type, string mnemonic, VM_OPC opcode,
     type:$result
   );
 
-  let assemblyFormat = "`:` type($result) attr-dict";
+  let assemblyFormat = "attr-dict";
 
   let encoding = [
     VM_EncOpcode<opcode>,
@@ -3654,7 +3650,7 @@ def VM_FailOp : VM_Op<"fail", [
     or pending when the failure occurs will complete.
 
     ```
-    %statusCode = vm.const.i32 9 : i32
+    %statusCode = vm.const.i32 9
     vm.fail %statusCode, "oh no!"
     ```
   }];
@@ -3708,7 +3704,7 @@ def VM_CondFailOp : VM_Op<"cond_fail", [
 
     ```
     %nz = vm.cmp.nz.i32 %value : i32
-    %statusCode = vm.const.i32 9 : i32
+    %statusCode = vm.const.i32 9
     vm.cond_fail %nz, %statusCode, "expected non-zero"
     ```
   }];

--- a/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
@@ -7,7 +7,7 @@ vm.module @add_i32_folds {
   // CHECK-LABEL: @add_i32_0_y
   vm.func @add_i32_0_y(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.add.i32 %zero, %arg0 : i32
     vm.return %0 : i32
   }
@@ -15,17 +15,17 @@ vm.module @add_i32_folds {
   // CHECK-LABEL: @add_i32_x_0
   vm.func @add_i32_x_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.add.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @add_i32_const
   vm.func @add_i32_const() -> i32 {
-    // CHECK: %c5 = vm.const.i32 5 : i32
+    // CHECK: %c5 = vm.const.i32 5
     // CHECK-NEXT: vm.return %c5 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %0 = vm.add.i32 %c1, %c4 : i32
     vm.return %0 : i32
   }
@@ -38,17 +38,17 @@ vm.module @sub_i32_folds {
   // CHECK-LABEL: @sub_i32_x_0
   vm.func @sub_i32_x_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.sub.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @sub_i32_const
   vm.func @sub_i32_const() -> i32 {
-    // CHECK: %c3 = vm.const.i32 3 : i32
+    // CHECK: %c3 = vm.const.i32 3
     // CHECK-NEXT: vm.return %c3 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %0 = vm.sub.i32 %c4, %c1 : i32
     vm.return %0 : i32
   }
@@ -95,9 +95,9 @@ vm.module @add_sub_i32_folds {
 vm.module @mul_i32_folds {
   // CHECK-LABEL: @mul_i32_by_0
   vm.func @mul_i32_by_0(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.mul.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
@@ -105,7 +105,7 @@ vm.module @mul_i32_folds {
   // CHECK-LABEL: @mul_i32_1_y
   vm.func @mul_i32_1_y(%arg0 : i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %0 = vm.mul.i32 %c1, %arg0 : i32
     vm.return %0 : i32
   }
@@ -113,17 +113,17 @@ vm.module @mul_i32_folds {
   // CHECK-LABEL: @mul_i32_x_1
   vm.func @mul_i32_x_1(%arg0 : i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %0 = vm.mul.i32 %arg0, %c1 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @mul_i32_const
   vm.func @mul_i32_const() -> i32 {
-    // CHECK: %c8 = vm.const.i32 8 : i32
+    // CHECK: %c8 = vm.const.i32 8
     // CHECK-NEXT: vm.return %c8 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c2 = vm.const.i32 2
+    %c4 = vm.const.i32 4
     %0 = vm.mul.i32 %c2, %c4 : i32
     vm.return %0 : i32
   }
@@ -135,9 +135,9 @@ vm.module @mul_i32_folds {
 vm.module @mul_mul_i32_folds {
   // CHECK-LABEL: @mul_mul_i32_const
   vm.func @mul_mul_i32_const(%arg0 : i32) -> i32 {
-    // CHECK: %c40 = vm.const.i32 40 : i32
-    %c4 = vm.const.i32 4 : i32
-    %c10 = vm.const.i32 10 : i32
+    // CHECK: %c40 = vm.const.i32 40
+    %c4 = vm.const.i32 4
+    %c10 = vm.const.i32 10
     // CHECK: %0 = vm.mul.i32 %arg0, %c40 : i32
     %0 = vm.mul.i32 %arg0, %c4 : i32
     %1 = vm.mul.i32 %0, %c10 : i32
@@ -152,9 +152,9 @@ vm.module @mul_mul_i32_folds {
 vm.module @div_i32_folds {
   // CHECK-LABEL: @div_i32_0_y
   vm.func @div_i32_0_y(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.div.i32.s %zero, %arg0 : i32
     vm.return %0 : i32
   }
@@ -162,17 +162,17 @@ vm.module @div_i32_folds {
   // CHECK-LABEL: @div_i32_x_1
   vm.func @div_i32_x_1(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %0 = vm.div.i32.s %arg0, %c1 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @div_i32_const
   vm.func @div_i32_const() -> i32 {
-    // CHECK: %c3 = vm.const.i32 3 : i32
+    // CHECK: %c3 = vm.const.i32 3
     // CHECK-NEXT: vm.return %c3 : i32
-    %c15 = vm.const.i32 15 : i32
-    %c5 = vm.const.i32 5 : i32
+    %c15 = vm.const.i32 15
+    %c5 = vm.const.i32 5
     %0 = vm.div.i32.s %c15, %c5 : i32
     vm.return %0 : i32
   }
@@ -184,28 +184,28 @@ vm.module @div_i32_folds {
 vm.module @rem_i32_folds {
   // CHECK-LABEL: @rem_i32_x_1
   vm.func @rem_i32_x_1(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %0 = vm.rem.i32.s %arg0, %c1 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @rem_i32_0_y
   vm.func @rem_i32_0_y(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.rem.i32.s %zero, %arg0 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @rem_i32_const
   vm.func @rem_i32_const() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c3 = vm.const.i32 3 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c3 = vm.const.i32 3
+    %c4 = vm.const.i32 4
     %0 = vm.rem.i32.s %c4, %c3 : i32
     vm.return %0 : i32
   }
@@ -217,9 +217,9 @@ vm.module @rem_i32_folds {
 vm.module @not_i32_folds {
   // CHECK-LABEL: @not_i32_const
   vm.func @not_i32_const() -> i32 {
-    // CHECK: %c889262066 = vm.const.i32 889262066 : i32
+    // CHECK: %c889262066 = vm.const.i32 889262066
     // CHECK-NEXT: vm.return %c889262066 : i32
-    %c = vm.const.i32 0xCAFEF00D : i32
+    %c = vm.const.i32 0xCAFEF00D
     %0 = vm.not.i32 %c : i32
     vm.return %0 : i32
   }
@@ -231,9 +231,9 @@ vm.module @not_i32_folds {
 vm.module @and_i32_folds {
   // CHECK-LABEL: @and_i32_zero
   vm.func @and_i32_zero(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.and.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
@@ -247,10 +247,10 @@ vm.module @and_i32_folds {
 
   // CHECK-LABEL: @and_i32_const
   vm.func @and_i32_const() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c3 = vm.const.i32 3 : i32
+    %c1 = vm.const.i32 1
+    %c3 = vm.const.i32 3
     %0 = vm.and.i32 %c1, %c3 : i32
     vm.return %0 : i32
   }
@@ -263,7 +263,7 @@ vm.module @or_i32_folds {
   // CHECK-LABEL: @or_i32_0_y
   vm.func @or_i32_0_y(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.or.i32 %zero, %arg0 : i32
     vm.return %0 : i32
   }
@@ -271,7 +271,7 @@ vm.module @or_i32_folds {
   // CHECK-LABEL: @or_i32_x_0
   vm.func @or_i32_x_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.or.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
@@ -285,10 +285,10 @@ vm.module @or_i32_folds {
 
   // CHECK-LABEL: @or_i32_const
   vm.func @or_i32_const() -> i32 {
-    // CHECK: %c5 = vm.const.i32 5 : i32
+    // CHECK: %c5 = vm.const.i32 5
     // CHECK-NEXT: vm.return %c5 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %0 = vm.or.i32 %c1, %c4 : i32
     vm.return %0 : i32
   }
@@ -301,7 +301,7 @@ vm.module @xor_i32_folds {
   // CHECK-LABEL: @xor_i32_0_y
   vm.func @xor_i32_0_y(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.xor.i32 %zero, %arg0 : i32
     vm.return %0 : i32
   }
@@ -309,14 +309,14 @@ vm.module @xor_i32_folds {
   // CHECK-LABEL: @xor_i32_x_0
   vm.func @xor_i32_x_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.xor.i32 %arg0, %zero : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @xor_i32_x_x
   vm.func @xor_i32_x_x(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %0 = vm.xor.i32 %arg0, %arg0 : i32
     vm.return %0 : i32
@@ -324,10 +324,10 @@ vm.module @xor_i32_folds {
 
   // CHECK-LABEL: @xor_i32_const
   vm.func @xor_i32_const() -> i32 {
-    // CHECK: %c2 = vm.const.i32 2 : i32
+    // CHECK: %c2 = vm.const.i32 2
     // CHECK-NEXT: vm.return %c2 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c3 = vm.const.i32 3 : i32
+    %c1 = vm.const.i32 1
+    %c3 = vm.const.i32 3
     %0 = vm.xor.i32 %c1, %c3 : i32
     vm.return %0 : i32
   }
@@ -339,10 +339,10 @@ vm.module @xor_i32_folds {
 vm.module @shl_i32_folds {
   // CHECK-LABEL: @shl_i32_0_by_y
   vm.func @shl_i32_0_by_y() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
-    %c4 = vm.const.i32 4 : i32
+    %zero = vm.const.i32.zero
+    %c4 = vm.const.i32 4
     %0 = vm.shl.i32 %zero, %c4 : i32
     vm.return %0 : i32
   }
@@ -350,17 +350,17 @@ vm.module @shl_i32_folds {
   // CHECK-LABEL: @shl_i32_x_by_0
   vm.func @shl_i32_x_by_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %0 = vm.shl.i32 %arg0, %c0 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @shl_i32_const
   vm.func @shl_i32_const() -> i32 {
-    // CHECK: %c16 = vm.const.i32 16 : i32
+    // CHECK: %c16 = vm.const.i32 16
     // CHECK-NEXT: vm.return %c16 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %0 = vm.shl.i32 %c1, %c4 : i32
     vm.return %0 : i32
   }
@@ -372,10 +372,10 @@ vm.module @shl_i32_folds {
 vm.module @shr_i32_s_folds {
   // CHECK-LABEL: @shr_i32_s_0_by_y
   vm.func @shr_i32_s_0_by_y() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c0 = vm.const.i32.zero : i32
-    %c4 = vm.const.i32 4 : i32
+    %c0 = vm.const.i32.zero
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i32.s %c0, %c4 : i32
     vm.return %0 : i32
   }
@@ -383,17 +383,17 @@ vm.module @shr_i32_s_folds {
   // CHECK-LABEL: @shr_i32_s_x_by_0
   vm.func @shr_i32_s_x_by_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %c0 = vm.const.i32.zero : i32
+    %c0 = vm.const.i32.zero
     %0 = vm.shr.i32.s %arg0, %c0 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @shr_i32_s_const
   vm.func @shr_i32_s_const() -> i32 {
-    // CHECK: %[[C:.+]] = vm.const.i32 -134217728 : i32
+    // CHECK: %[[C:.+]] = vm.const.i32 -134217728
     // CHECK-NEXT: vm.return %[[C]]
-    %c = vm.const.i32 0x80000000 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c = vm.const.i32 0x80000000
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i32.s %c, %c4 : i32
     vm.return %0 : i32
   }
@@ -405,10 +405,10 @@ vm.module @shr_i32_s_folds {
 vm.module @shr_i32_u_folds {
   // CHECK-LABEL: @shr_i32_u_0_by_y
   vm.func @shr_i32_u_0_by_y() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %zero = vm.const.i32.zero : i32
-    %c4 = vm.const.i32 4 : i32
+    %zero = vm.const.i32.zero
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i32.u %zero, %c4 : i32
     vm.return %0 : i32
   }
@@ -416,17 +416,17 @@ vm.module @shr_i32_u_folds {
   // CHECK-LABEL: @shr_i32_u_x_by_0
   vm.func @shr_i32_u_x_by_0(%arg0 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %0 = vm.shr.i32.u %arg0, %c0 : i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @shr_i32_u_const
   vm.func @shr_i32_u_const() -> i32 {
-    // CHECK: %[[C:.+]] = vm.const.i32 134217728 : i32
+    // CHECK: %[[C:.+]] = vm.const.i32 134217728
     // CHECK-NEXT: vm.return %[[C]]
-    %c = vm.const.i32 0x80000000 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c = vm.const.i32 0x80000000
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i32.u %c, %c4 : i32
     vm.return %0 : i32
   }
@@ -438,10 +438,10 @@ vm.module @shr_i32_u_folds {
 vm.module @shr_i64_u_folds {
   // CHECK-LABEL: @shr_i64_u_0_by_y
   vm.func @shr_i64_u_0_by_y() -> i64 {
-    // CHECK: %zero = vm.const.i64.zero : i64
+    // CHECK: %zero = vm.const.i64.zero
     // CHECK-NEXT: vm.return %zero : i64
-    %zero = vm.const.i64.zero : i64
-    %c4 = vm.const.i32 4 : i32
+    %zero = vm.const.i64.zero
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i64.u %zero, %c4 : i64
     vm.return %0 : i64
   }
@@ -449,17 +449,17 @@ vm.module @shr_i64_u_folds {
   // CHECK-LABEL: @shr_i64_u_x_by_0
   vm.func @shr_i64_u_x_by_0(%arg0 : i64) -> i64 {
     // CHECK: vm.return %arg0 : i64
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %0 = vm.shr.i64.u %arg0, %c0 : i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @shr_i64_u_const
   vm.func @shr_i64_u_const() -> i64 {
-    // CHECK: %[[C:.+]] = vm.const.i64 576460752303423488 : i64
+    // CHECK: %[[C:.+]] = vm.const.i64 576460752303423488
     // CHECK-NEXT: vm.return %[[C]]
-    %c = vm.const.i64 0x8000000000000000 : i64
-    %c4 = vm.const.i32 4 : i32
+    %c = vm.const.i64 0x8000000000000000
+    %c4 = vm.const.i32 4
     %0 = vm.shr.i64.u %c, %c4 : i64
     vm.return %0 : i64
   }
@@ -471,28 +471,28 @@ vm.module @shr_i64_u_folds {
 vm.module @fma_i32_folds {
   // CHECK-LABEL: @fma_i32_0_b_c
   vm.func @fma_i32_0_b_c(%b: i32, %c: i32) -> i32 {
-    %c0 = vm.const.i32.zero : i32
+    %c0 = vm.const.i32.zero
     %d = vm.fma.i32 %c0, %b, %c : i32
     vm.return %d : i32
   }
 
   // CHECK-LABEL: @fma_i32_1_b_c
   vm.func @fma_i32_1_b_c(%b: i32, %c: i32) -> i32 {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %d = vm.fma.i32 %c1, %b, %c : i32
     vm.return %d : i32
   }
 
   // CHECK-LABEL: @fma_i32_a_1_c
   vm.func @fma_i32_a_1_c(%a: i32, %c: i32) -> i32 {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %d = vm.fma.i32 %a, %c1, %c : i32
     vm.return %d : i32
   }
 
   // CHECK-LABEL: @fma_i32_a_b_0
   vm.func @fma_i32_a_b_0(%a: i32, %b: i32) -> i32 {
-    %c0 = vm.const.i32.zero : i32
+    %c0 = vm.const.i32.zero
     %d = vm.fma.i32 %a, %b, %c0 : i32
     vm.return %d : i32
   }

--- a/iree/compiler/Dialect/VM/IR/test/assignment_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_folding.mlir
@@ -7,7 +7,7 @@ vm.module @select_i32_folds {
   // CHECK-LABEL: @select_i32_zero
   vm.func @select_i32_zero(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK: vm.return %arg1 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.select.i32 %zero, %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -15,7 +15,7 @@ vm.module @select_i32_folds {
   // CHECK-LABEL: @select_i32_one
   vm.func @select_i32_one(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
-    %c123 = vm.const.i32 123 : i32
+    %c123 = vm.const.i32 123
     %0 = vm.select.i32 %c123, %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -36,7 +36,7 @@ vm.module @select_ref_folds {
   vm.func @select_ref_zero(%arg0 : !vm.ref<?>,
                            %arg1 : !vm.ref<?>) -> !vm.ref<?> {
     // CHECK: vm.return %arg1 : !vm.ref<?>
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     %0 = vm.select.ref %zero, %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : !vm.ref<?>
   }
@@ -45,7 +45,7 @@ vm.module @select_ref_folds {
   vm.func @select_ref_one(%arg0 : !vm.ref<?>,
                           %arg1 : !vm.ref<?>) -> !vm.ref<?> {
     // CHECK: vm.return %arg0 : !vm.ref<?>
-    %c123 = vm.const.i32 123 : i32
+    %c123 = vm.const.i32 123
     %0 = vm.select.ref %c123, %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : !vm.ref<?>
   }
@@ -65,7 +65,7 @@ vm.module @select_ref_folds {
 vm.module @switch_i32_folds {
   // CHECK-LABEL: @switch_i32_nop
   vm.func @switch_i32_nop(%arg0 : i32) -> i32 {
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     // CHECK: vm.return %c5 : i32
     %0 = vm.switch.i32 %arg0[] else %c5 : i32
     vm.return %0 : i32
@@ -73,7 +73,7 @@ vm.module @switch_i32_folds {
 
   // CHECK-LABEL: @switch_i32_identical
   vm.func @switch_i32_identical(%arg0 : i32) -> i32 {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
     // CHECK: vm.return %c100 : i32
     %0 = vm.switch.i32 %arg0[%c100, %c100, %c100] else %c100 : i32
     vm.return %0 : i32
@@ -81,14 +81,14 @@ vm.module @switch_i32_folds {
 
   // CHECK-LABEL: @switch_i32_constant_index
   vm.func @switch_i32_constant_index() -> (i32, i32, i32, i32) {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c3 = vm.const.i32 3 : i32
-    %c100 = vm.const.i32 100 : i32
-    %c200 = vm.const.i32 200 : i32
-    %c300 = vm.const.i32 300 : i32
-    %c400 = vm.const.i32 400 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c3 = vm.const.i32 3
+    %c100 = vm.const.i32 100
+    %c200 = vm.const.i32 200
+    %c300 = vm.const.i32 300
+    %c400 = vm.const.i32 400
     // CHECK: vm.return %c100, %c200, %c300, %c400 : i32, i32, i32, i32
     %0 = vm.switch.i32 %c0[%c100, %c200, %c300] else %c400 : i32
     %1 = vm.switch.i32 %c1[%c100, %c200, %c300] else %c400 : i32

--- a/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/assignment_ops.mlir
@@ -27,10 +27,10 @@ vm.module @my_module {
 // CHECK-LABEL: @switch_i32
 vm.module @my_module {
   vm.func @switch_i32(%arg0 : i32) -> i32 {
-    %c5 = vm.const.i32 5 : i32
-    %c100 = vm.const.i32 100 : i32
-    %c200 = vm.const.i32 200 : i32
-    %c300 = vm.const.i32 300 : i32
+    %c5 = vm.const.i32 5
+    %c100 = vm.const.i32 100
+    %c200 = vm.const.i32 200
+    %c300 = vm.const.i32 300
     // CHECK: vm.switch.i32 %arg0[%c100, %c200, %c300] else %c5 : i32
     %0 = vm.switch.i32 %arg0[%c100, %c200, %c300] else %c5 : i32
     vm.return %0 : i32

--- a/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/comparison_folding.mlir
@@ -6,7 +6,7 @@
 vm.module @cmp_eq_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %eq = vm.cmp.eq.i32 %arg0, %arg0 : i32
     vm.return %eq : i32
@@ -14,20 +14,20 @@ vm.module @cmp_eq_i32_folds {
 
   // CHECK-LABEL: @const_eq
   vm.func @const_eq() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c1d = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
+    %c1d = vm.const.i32 1
     %eq = vm.cmp.eq.i32 %c1, %c1d : i32
     vm.return %eq : i32
   }
 
   // CHECK-LABEL: @const_ne
   vm.func @const_ne() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
     %eq = vm.cmp.eq.i32 %c1, %c2 : i32
     vm.return %eq : i32
   }
@@ -39,7 +39,7 @@ vm.module @cmp_eq_i32_folds {
 vm.module @cmp_ne_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %ne = vm.cmp.ne.i32 %arg0, %arg0 : i32
     vm.return %ne : i32
@@ -56,20 +56,20 @@ vm.module @cmp_ne_i32_folds {
 
   // CHECK-LABEL: @const_ne
   vm.func @const_ne() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
     %ne = vm.cmp.ne.i32 %c1, %c2 : i32
     vm.return %ne : i32
   }
 
   // CHECK-LABEL: @const_eq
   vm.func @const_eq() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 1 : i32
-    %c1d = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
+    %c1d = vm.const.i32 1
     %ne = vm.cmp.ne.i32 %c1, %c1d : i32
     vm.return %ne : i32
   }
@@ -78,7 +78,7 @@ vm.module @cmp_ne_i32_folds {
   vm.func @cmp_const_zero(%arg0 : i32, %arg1 : i32) -> (i32, i32) {
     // CHECK-DAG: vm.cmp.nz.i32 %arg0 : i32
     // CHECK-DAG: vm.cmp.nz.i32 %arg1 : i32
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %nz0 = vm.cmp.ne.i32 %arg0, %c0 : i32
     %nz1 = vm.cmp.ne.i32 %c0, %arg1 : i32
     vm.return %nz0, %nz1 : i32, i32
@@ -91,7 +91,7 @@ vm.module @cmp_ne_i32_folds {
 vm.module @cmp_slt_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %cmp = vm.cmp.lt.i32.s %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -99,20 +99,20 @@ vm.module @cmp_slt_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lt.i32.s %c1, %c2 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lt.i32.s %c2, %c1 : i32
     vm.return %cmp : i32
   }
@@ -124,7 +124,7 @@ vm.module @cmp_slt_i32_folds {
 vm.module @cmp_ult_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %cmp = vm.cmp.lt.i32.u %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -132,20 +132,20 @@ vm.module @cmp_ult_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lt.i32.u %c2, %c1 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lt.i32.u %c1, %c2 : i32
     vm.return %cmp : i32
   }
@@ -157,7 +157,7 @@ vm.module @cmp_ult_i32_folds {
 vm.module @cmp_slte_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %cmp = vm.cmp.lte.i32.s %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -165,20 +165,20 @@ vm.module @cmp_slte_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lte.i32.s %c1, %c2 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lte.i32.s %c2, %c1 : i32
     vm.return %cmp : i32
   }
@@ -190,7 +190,7 @@ vm.module @cmp_slte_i32_folds {
 vm.module @cmp_ulte_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %cmp = vm.cmp.lte.i32.u %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -198,20 +198,20 @@ vm.module @cmp_ulte_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lte.i32.u %c2, %c1 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.lte.i32.u %c1, %c2 : i32
     vm.return %cmp : i32
   }
@@ -223,7 +223,7 @@ vm.module @cmp_ulte_i32_folds {
 vm.module @cmp_sgt_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %cmp = vm.cmp.gt.i32.s %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -231,20 +231,20 @@ vm.module @cmp_sgt_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gt.i32.s %c2, %c1 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gt.i32.s %c1, %c2 : i32
     vm.return %cmp : i32
   }
@@ -256,7 +256,7 @@ vm.module @cmp_sgt_i32_folds {
 vm.module @cmp_ugt_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %cmp = vm.cmp.gt.i32.u %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -264,20 +264,20 @@ vm.module @cmp_ugt_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gt.i32.u %c1, %c2 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gt.i32.u %c2, %c1 : i32
     vm.return %cmp : i32
   }
@@ -289,7 +289,7 @@ vm.module @cmp_ugt_i32_folds {
 vm.module @cmp_sgte_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %cmp = vm.cmp.gte.i32.s %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -297,20 +297,20 @@ vm.module @cmp_sgte_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gte.i32.s %c2, %c1 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gte.i32.s %c1, %c2 : i32
     vm.return %cmp : i32
   }
@@ -322,7 +322,7 @@ vm.module @cmp_sgte_i32_folds {
 vm.module @cmp_ugte_i32_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : i32) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %cmp = vm.cmp.gte.i32.u %arg0, %arg0 : i32
     vm.return %cmp : i32
@@ -330,20 +330,20 @@ vm.module @cmp_ugte_i32_folds {
 
   // CHECK-LABEL: @const_true
   vm.func @const_true() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gte.i32.u %c1, %c2 : i32
     vm.return %cmp : i32
   }
 
   // CHECK-LABEL: @const_false
   vm.func @const_false() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c1 = vm.const.i32 -1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 -1
+    %c2 = vm.const.i32 2
     %cmp = vm.cmp.gte.i32.u %c2, %c1 : i32
     vm.return %cmp : i32
   }
@@ -355,18 +355,18 @@ vm.module @cmp_ugte_i32_folds {
 vm.module @cmp_nz_i32_folds {
   // CHECK-LABEL: @const_nonzero
   vm.func @const_nonzero() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %nz = vm.cmp.nz.i32 %c1 : i32
     vm.return %nz : i32
   }
 
   // CHECK-LABEL: @const_zero
   vm.func @const_zero() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %nz = vm.cmp.nz.i32 %c0 : i32
     vm.return %nz : i32
   }
@@ -378,7 +378,7 @@ vm.module @cmp_nz_i32_folds {
 vm.module @cmp_eq_ref_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 : !vm.ref<?>) -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %eq = vm.cmp.eq.ref %arg0, %arg0 : !vm.ref<?>
     vm.return %eq : i32
@@ -386,7 +386,7 @@ vm.module @cmp_eq_ref_folds {
 
   // CHECK-LABEL: @const_eq
   vm.func @const_eq() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1 : i32
     %null = vm.const.ref.zero : !vm.ref<?>
     %null0 = vm.const.ref.zero : !vm.ref<?>
@@ -411,7 +411,7 @@ vm.module @cmp_eq_ref_folds {
 vm.module @cmp_ne_ref_folds {
   // CHECK-LABEL: @always_eq
   vm.func @always_eq(%arg0 :  !vm.ref<?>) -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %ne = vm.cmp.ne.ref %arg0, %arg0 :  !vm.ref<?>
     vm.return %ne : i32
@@ -419,7 +419,7 @@ vm.module @cmp_ne_ref_folds {
 
   // CHECK-LABEL: @const_eq
   vm.func @const_eq() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %null = vm.const.ref.zero : !vm.ref<?>
     %null0 = vm.const.ref.zero : !vm.ref<?>
@@ -443,7 +443,7 @@ vm.module @cmp_ne_ref_folds {
 vm.module @cmp_nz_ref_folds {
   // CHECK-LABEL: @const_null
   vm.func @const_null() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %null = vm.const.ref.zero : !vm.ref<?>
     %ne = vm.cmp.nz.ref %null : !vm.ref<?>
@@ -457,9 +457,9 @@ vm.module @cmp_nz_ref_folds {
 vm.module @cast_si32_f32_folds {
   // CHECK-LABEL: @cast_exact
   vm.func @cast_exact() -> f32 {
-    // CHECK: %0 = vm.const.f32 -2.000000e+00 : f32
+    // CHECK: %0 = vm.const.f32 -2.000000e+00
     // CHECK-NEXT: vm.return %0 : f32
-    %c-2 = vm.const.i32 -2 : i32
+    %c-2 = vm.const.i32 -2
     %1 = vm.cast.si32.f32 %c-2 : i32 -> f32
     vm.return %1 : f32
   }
@@ -471,9 +471,9 @@ vm.module @cast_si32_f32_folds {
 vm.module @cast_ui32_f32_folds {
   // CHECK-LABEL: @cast_exact
   vm.func @cast_exact() -> f32 {
-    // CHECK: %0 = vm.const.f32 4.000000e+00 : f32
+    // CHECK: %0 = vm.const.f32 4.000000e+00
     // CHECK-NEXT: vm.return %0 : f32
-    %c4 = vm.const.i32 4 : i32
+    %c4 = vm.const.i32 4
     %1 = vm.cast.ui32.f32 %c4 : i32 -> f32
     vm.return %1 : f32
   }
@@ -485,27 +485,27 @@ vm.module @cast_ui32_f32_folds {
 vm.module @cast_f32_si32_folds {
   // CHECK-LABEL: @cast_exact
   vm.func @cast_exact() -> i32 {
-    // CHECK: %c-2 = vm.const.i32 -2 : i32
+    // CHECK: %c-2 = vm.const.i32 -2
     // CHECK-NEXT: vm.return %c-2 : i32
-    %c-2 = vm.const.f32 -2.0 : f32
+    %c-2 = vm.const.f32 -2.0
     %1 = vm.cast.f32.si32 %c-2 : f32 -> i32
     vm.return %1 : i32
   }
 
   // CHECK-LABEL: @cast_round_neg
   vm.func @cast_round_neg() -> i32 {
-    // CHECK: %c-3 = vm.const.i32 -3 : i32
+    // CHECK: %c-3 = vm.const.i32 -3
     // CHECK-NEXT: vm.return %c-3 : i32
-    %0 = vm.const.f32 -2.5 : f32
+    %0 = vm.const.f32 -2.5
     %1 = vm.cast.f32.si32 %0 : f32 -> i32
     vm.return %1 : i32
   }
 
   // CHECK-LABEL: @cast_round_pos
   vm.func @cast_round_pos() -> i32 {
-    // CHECK: %c3 = vm.const.i32 3 : i32
+    // CHECK: %c3 = vm.const.i32 3
     // CHECK-NEXT: vm.return %c3 : i32
-    %0 = vm.const.f32 2.5 : f32
+    %0 = vm.const.f32 2.5
     %1 = vm.cast.f32.si32 %0 : f32 -> i32
     vm.return %1 : i32
   }

--- a/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_folding.mlir
@@ -6,19 +6,19 @@
 vm.module @const_i32_folds {
   // CHECK-LABEL: @cse
   vm.func @cse() -> (i32, i32) {
-    // CHECK-NEXT: %c1 = vm.const.i32 1 : i32
+    // CHECK-NEXT: %c1 = vm.const.i32 1
     // CHECK-NEXT: vm.return %c1, %c1 : i32, i32
-    %0 = vm.const.i32 1 : i32
-    %1 = vm.const.i32 1 : i32
+    %0 = vm.const.i32 1
+    %1 = vm.const.i32 1
     vm.return %0, %1 : i32, i32
   }
 
   // CHECK-LABEL: @cse_zero
   vm.func @cse_zero() -> (i32, i32) {
-    // CHECK-NEXT: %zero = vm.const.i32.zero : i32
+    // CHECK-NEXT: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero, %zero : i32, i32
-    %0 = vm.const.i32 0 : i32
-    %1 = vm.const.i32 0 : i32
+    %0 = vm.const.i32 0
+    %1 = vm.const.i32 0
     vm.return %0, %1 : i32, i32
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/const_ops.mlir
@@ -3,8 +3,8 @@
 vm.module @my_module {
   // CHECK-LABEL: @const_i32_zero
   vm.func @const_i32_zero() -> i32 {
-    // CHECK: %zero = vm.const.i32.zero : i32
-    %zero = vm.const.i32.zero : i32
+    // CHECK: %zero = vm.const.i32.zero
+    %zero = vm.const.i32.zero
     vm.return %zero : i32
   }
 }
@@ -14,8 +14,8 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: @const_i32
   vm.func @const_i32() -> i32 {
-    // CHECK: %c1 = vm.const.i32 1 : i32
-    %c1 = vm.const.i32 1 : i32
+    // CHECK: %c1 = vm.const.i32 1
+    %c1 = vm.const.i32 1
     vm.return %c1 : i32
   }
 }
@@ -24,7 +24,7 @@ vm.module @my_module {
 
 vm.module @my_module {
   // CHECK-LABEL: @const_ref_zero
-  vm.func @const_ref_zero() -> !vm.ref<?> {
+vm.func @const_ref_zero() -> !vm.ref<?> {
     // CHECK: %null = vm.const.ref.zero : !vm.ref<?>
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return %null : !vm.ref<?>

--- a/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/control_flow_folding.mlir
@@ -7,7 +7,7 @@ vm.module @cond_br_folds {
   // CHECK-LABEL: @const_cond_br_true
   vm.func @const_cond_br_true(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.cond_br %c1, ^bb1(%arg0 : i32), ^bb2(%arg1 : i32)
   ^bb1(%0 : i32):
     vm.return %0 : i32
@@ -18,7 +18,7 @@ vm.module @cond_br_folds {
   // CHECK-LABEL: @const_cond_br_false
   vm.func @const_cond_br_false(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK-NEXT: vm.return %arg1 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     vm.cond_br %zero, ^bb1(%arg0 : i32), ^bb2(%arg1 : i32)
   ^bb1(%0 : i32):
     vm.return %0 : i32
@@ -47,7 +47,7 @@ vm.module @cond_br_folds {
   // // DISABLED-LABEL: @swap_inverted_cond_br
   // vm.func @swap_inverted_cond_br(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
   //   // DISABLED-NEXT: vm.cond_br %arg0, ^bb2(%arg1 : i32), ^bb1(%arg0 : i32)
-  //   %c1 = vm.const.i32 1 : i32
+  //   %c1 = vm.const.i32 1
   //   %inv = vm.xor.i32 %arg0, %c1 : i32
   //   vm.cond_br %inv, ^bb1(%arg0 : i32), ^bb2(%arg1 : i32)
   // ^bb1(%0 : i32):

--- a/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
@@ -6,16 +6,16 @@
 vm.module @trunc_folds {
   // CHECK-LABEL: @trunc_i8_const
   vm.func @trunc_i8_const() -> i32 {
-    // CHECK: vm.const.i32 255 : i32
-    %c = vm.const.i32 0xFFFFFFFF : i32
+    // CHECK: vm.const.i32 255
+    %c = vm.const.i32 0xFFFFFFFF
     %0 = vm.trunc.i32.i8 %c : i32 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @trunc_i16_const
   vm.func @trunc_i16_const() -> i32 {
-    // CHECK: vm.const.i32 65535 : i32
-    %c = vm.const.i32 0xFFFFFFFF : i32
+    // CHECK: vm.const.i32 65535
+    %c = vm.const.i32 0xFFFFFFFF
     %0 = vm.trunc.i32.i16 %c : i32 -> i32
     vm.return %0 : i32
   }
@@ -27,24 +27,24 @@ vm.module @trunc_folds {
 vm.module @trunc_folds_i64 {
   // CHECK-LABEL: @trunc_i8_const
   vm.func @trunc_i8_const() -> i32 {
-    // CHECK: vm.const.i32 255 : i32
-    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    // CHECK: vm.const.i32 255
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF
     %0 = vm.trunc.i64.i8 %c : i64 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @trunc_i16_const
   vm.func @trunc_i16_const() -> i32 {
-    // CHECK: vm.const.i32 65535 : i32
-    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    // CHECK: vm.const.i32 65535
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF
     %0 = vm.trunc.i64.i16 %c : i64 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @trunc_i32_const
   vm.func @trunc_i32_const() -> i32 {
-    // CHECK: vm.const.i32 -1 : i32
-    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    // CHECK: vm.const.i32 -1
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF
     %0 = vm.trunc.i64.i32 %c : i64 -> i32
     vm.return %0 : i32
   }
@@ -56,32 +56,32 @@ vm.module @trunc_folds_i64 {
 vm.module @ext_folds {
   // CHECK-LABEL: @ext_i8_i32_s_const
   vm.func @ext_i8_i32_s_const() -> i32 {
-    // CHECK: vm.const.i32 -1 : i32
-    %c = vm.const.i32 0x000000FF : i32
+    // CHECK: vm.const.i32 -1
+    %c = vm.const.i32 0x000000FF
     %0 = vm.ext.i8.i32.s %c : i32 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @ext_i8_i32_u_const
   vm.func @ext_i8_i32_u_const() -> i32 {
-    // CHECK: vm.const.i32 255 : i32
-    %c = vm.const.i32 0x000000FF : i32
+    // CHECK: vm.const.i32 255
+    %c = vm.const.i32 0x000000FF
     %0 = vm.ext.i8.i32.u %c : i32 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @ext_i16_i32_s_const
   vm.func @ext_i16_i32_s_const() -> i32 {
-    // CHECK: vm.const.i32 -1 : i32
-    %c = vm.const.i32 0x0000FFFF : i32
+    // CHECK: vm.const.i32 -1
+    %c = vm.const.i32 0x0000FFFF
     %0 = vm.ext.i16.i32.s %c : i32 -> i32
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @ext_i16_i32_u_const
   vm.func @ext_i16_i32_u_const() -> i32 {
-    // CHECK: vm.const.i32 65535 : i32
-    %c = vm.const.i32 0x0000FFFF : i32
+    // CHECK: vm.const.i32 65535
+    %c = vm.const.i32 0x0000FFFF
     %0 = vm.ext.i16.i32.u %c : i32 -> i32
     vm.return %0 : i32
   }
@@ -93,48 +93,48 @@ vm.module @ext_folds {
 vm.module @ext_folds_i64 {
   // CHECK-LABEL: @ext_i8_i64_s_const
   vm.func @ext_i8_i64_s_const() -> i64 {
-    // CHECK: vm.const.i64 -1 : i64
-    %c = vm.const.i32 0x000000FF : i32
+    // CHECK: vm.const.i64 -1
+    %c = vm.const.i32 0x000000FF
     %0 = vm.ext.i8.i64.s %c : i32 -> i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @ext_i8_i64_u_const
   vm.func @ext_i8_i64_u_const() -> i64 {
-    // CHECK: vm.const.i64 255 : i64
-    %c = vm.const.i32 0x000000FF : i32
+    // CHECK: vm.const.i64 255
+    %c = vm.const.i32 0x000000FF
     %0 = vm.ext.i8.i64.u %c : i32 -> i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @ext_i16_i64_s_const
   vm.func @ext_i16_i64_s_const() -> i64 {
-    // CHECK: vm.const.i64 -1 : i64
-    %c = vm.const.i32 0x0000FFFF : i32
+    // CHECK: vm.const.i64 -1
+    %c = vm.const.i32 0x0000FFFF
     %0 = vm.ext.i16.i64.s %c : i32 -> i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @ext_i16_i64_u_const
   vm.func @ext_i16_i64_u_const() -> i64 {
-    // CHECK: vm.const.i64 65535 : i64
-    %c = vm.const.i32 0x0000FFFF : i32
+    // CHECK: vm.const.i64 65535
+    %c = vm.const.i32 0x0000FFFF
     %0 = vm.ext.i16.i64.u %c : i32 -> i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @ext_i32_i64_s_const
   vm.func @ext_i32_i64_s_const() -> i64 {
-    // CHECK: vm.const.i64 -1 : i64
-    %c = vm.const.i32 0xFFFFFFFF : i32
+    // CHECK: vm.const.i64 -1
+    %c = vm.const.i32 0xFFFFFFFF
     %0 = vm.ext.i32.i64.s %c : i32 -> i64
     vm.return %0 : i64
   }
 
   // CHECK-LABEL: @ext_i32_i64_u_const
   vm.func @ext_i32_i64_u_const() -> i64 {
-    // CHECK: vm.const.i64 4294967295 : i64
-    %c = vm.const.i32 0xFFFFFFFF : i32
+    // CHECK: vm.const.i64 4294967295
+    %c = vm.const.i32 0xFFFFFFFF
     %0 = vm.ext.i32.i64.u %c : i32 -> i64
     vm.return %0 : i64
   }

--- a/iree/compiler/Dialect/VM/IR/test/debug_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/debug_folding.mlir
@@ -7,7 +7,7 @@ vm.module @cond_break_folds {
   // CHECK-LABEL: @const_cond_break_true
   vm.func @const_cond_break_true(%arg0 : i32) -> i32 {
     // CHECK-NEXT: vm.break ^bb1(%arg0 : i32)
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.cond_break %c1, ^bb1(%arg0 : i32)
   ^bb1(%0 : i32):
     vm.return %0 : i32
@@ -16,7 +16,7 @@ vm.module @cond_break_folds {
   // CHECK-LABEL: @const_cond_break_false
   vm.func @const_cond_break_false(%arg0 : i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     vm.cond_break %zero, ^bb1(%arg0 : i32)
   ^bb1(%0 : i32):
     vm.return %0 : i32

--- a/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/global_folding.mlir
@@ -7,7 +7,7 @@ vm.module @global_i32_folds {
   // CHECK: vm.global.i32 public mutable @g0 = 123 : i32
   vm.global.i32 mutable @g0 : i32
   vm.initializer {
-    %c123 = vm.const.i32 123 : i32
+    %c123 = vm.const.i32 123
     vm.global.store.i32 %c123, @g0 : i32
     vm.return
   }
@@ -20,7 +20,7 @@ vm.module @global_i32_folds {
   // CHECK: vm.global.i32 public mutable @g3 : i32
   vm.global.i32 mutable @g3 : i32
   vm.initializer {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.global.store.i32 %c0, @g3 : i32
     vm.return
   }
@@ -46,7 +46,7 @@ vm.module @global_load_i32_folds {
   vm.global.i32 @g0 = 123 : i32
   // CHECK-LABEL: @inline_const_value
   vm.func @inline_const_value() -> i32 {
-    // CHECK-NEXT: %c123 = vm.const.i32 123 : i32
+    // CHECK-NEXT: %c123 = vm.const.i32 123
     // CHECK-NEXT: vm.return %c123 : i32
     %g0 = vm.global.load.i32 @g0 : i32
     vm.return %g0 : i32

--- a/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
@@ -6,7 +6,7 @@
 
 vm.module @module {
   vm.func @primitive_ref_list_type_mismatch(%arg0 : !vm.list<!vm.ref<?>>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
     // expected-error @+1 {{but got '!vm.list<!vm.ref<?>>}}
     %1 = vm.list.get.i32 %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<?>
     vm.return
@@ -17,7 +17,7 @@ vm.module @module {
 
 vm.module @module {
   vm.func @ref_primitive_list_type_mismatch(%arg0 : !vm.list<i32>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
     // expected-error @+1 {{cannot convert between list type 'i32' and result type '!vm.ref<?>'}}
     %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<i32>, i32) -> !vm.ref<?>
     vm.return
@@ -28,7 +28,7 @@ vm.module @module {
 
 vm.module @module {
   vm.func @strongly_typed_ref_type_mismatch(%arg0 : !vm.list<!vm.buffer>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
     // expected-error @+1 {{cannot be accessed as '!vm.ref<!util.mutable_byte_buffer>'}}
     %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.ref<!util.mutable_byte_buffer>
     vm.return

--- a/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
@@ -4,11 +4,11 @@
 vm.module @module {
   // CHECK-LABEL: @list_common
   vm.func @list_common() {
-    %c42 = vm.const.i32 42 : i32
+    %c42 = vm.const.i32 42
     // CHECK: %list = vm.list.alloc %c42 : (i32) -> !vm.list<i32>
     %list = vm.list.alloc %c42 : (i32) -> !vm.list<i32>
 
-    %c43 = vm.const.i32 43 : i32
+    %c43 = vm.const.i32 43
     // CHECK: vm.list.reserve %list, %c43 : (!vm.list<i32>, i32)
     vm.list.reserve %list, %c43 : (!vm.list<i32>, i32)
 
@@ -16,7 +16,7 @@ vm.module @module {
     %0 = vm.list.size %list : (!vm.list<i32>) -> i32
 
     // CHECK: vm.list.resize %list, %c44 : (!vm.list<i32>, i32)
-    %c44 = vm.const.i32 44 : i32
+    %c44 = vm.const.i32 44
     vm.list.resize %list, %c44 : (!vm.list<i32>, i32)
 
     vm.return
@@ -29,13 +29,13 @@ vm.module @module {
 vm.module @module {
   // CHECK: @list_i32
   vm.func @list_i32(%arg0: !vm.list<i32>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
 
     // CHECK: vm.list.get.i32 %arg0, %c100 : (!vm.list<i32>, i32) -> i32
     %0 = vm.list.get.i32 %arg0, %c100 : (!vm.list<i32>, i32) -> i32
 
     // CHECK: vm.list.set.i32 %arg0, %c100, %c123 : (!vm.list<i32>, i32, i32)
-    %c123 = vm.const.i32 123 : i32
+    %c123 = vm.const.i32 123
     vm.list.set.i32 %arg0, %c100, %c123 : (!vm.list<i32>, i32, i32)
 
     vm.return
@@ -43,7 +43,7 @@ vm.module @module {
 
   // CHECK: @list_i8_coerce
   vm.func @list_i8_coerce(%arg0: !vm.list<i8>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
 
     // CHECK: = vm.list.get.i32 %arg0, %c100 : (!vm.list<i8>, i32) -> i32
     %0 = vm.list.get.i32 %arg0, %c100 : (!vm.list<i8>, i32) -> i32
@@ -61,7 +61,7 @@ vm.module @module {
 vm.module @module {
   // CHECK: @list_ref_any
   vm.func @list_ref_any(%arg0: !vm.list<!vm.ref<?>>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
 
     // CHECK: %[[BUFFER:.+]] = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
     %buffer = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
@@ -79,7 +79,7 @@ vm.module @module {
 vm.module @module {
   // CHECK: @list_ref_typed
   vm.func @list_ref_typed(%arg0: !vm.list<!vm.buffer>) {
-    %c100 = vm.const.i32 100 : i32
+    %c100 = vm.const.i32 100
 
     // CHECK: %[[BUFFER:.+]] = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
     %buffer = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.buffer>, i32) -> !vm.buffer
@@ -97,7 +97,7 @@ vm.module @module {
 vm.module @module {
   // CHECK: @list_create_variant
   vm.func @list_create_variant() {
-    %c42 = vm.const.i32 42 : i32
+    %c42 = vm.const.i32 42
     // CHECK: %list = vm.list.alloc %c42 : (i32) -> !vm.list<?>
     %list = vm.list.alloc %c42 : (i32) -> !vm.list<?>
 
@@ -106,8 +106,8 @@ vm.module @module {
 
   // CHECK: @list_access_variant
   vm.func @list_access_variant(%arg0: !vm.list<?>) {
-    %c100 = vm.const.i32 100 : i32
-    %c101 = vm.const.i32 101 : i32
+    %c100 = vm.const.i32 100
+    %c101 = vm.const.i32 101
 
     // CHECK: = vm.list.get.i32 %arg0, %c100 : (!vm.list<?>, i32) -> i32
     %0 = vm.list.get.i32 %arg0, %c100 : (!vm.list<?>, i32) -> i32

--- a/iree/compiler/Dialect/VM/IR/test/shift_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/shift_ops.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: @shl_i32
 vm.module @my_module {
   vm.func @shl_i32(%arg0 : i32) -> i32 {
-    // CHECK: %[[C2:.+]] = vm.const.i32 2 : i32
-    %c2 = vm.const.i32 2 : i32
+    // CHECK: %[[C2:.+]] = vm.const.i32 2
+    %c2 = vm.const.i32 2
     // CHECK: %0 = vm.shl.i32 %arg0, %[[C2]] : i32
     %0 = vm.shl.i32 %arg0, %c2 : i32
     vm.return %0 : i32
@@ -16,8 +16,8 @@ vm.module @my_module {
 // CHECK-LABEL: @shr_i32_s
 vm.module @my_module {
   vm.func @shr_i32_s(%arg0 : i32) -> i32 {
-    // CHECK: %[[C2:.+]] = vm.const.i32 2 : i32
-    %c2 = vm.const.i32 2 : i32
+    // CHECK: %[[C2:.+]] = vm.const.i32 2
+    %c2 = vm.const.i32 2
     // CHECK: %0 = vm.shr.i32.s %arg0, %[[C2]] : i32
     %0 = vm.shr.i32.s %arg0, %c2 : i32
     vm.return %0 : i32
@@ -29,8 +29,8 @@ vm.module @my_module {
 // CHECK-LABEL: @shr_i32_u
 vm.module @my_module {
   vm.func @shr_i32_u(%arg0 : i32) -> i32 {
-    // CHECK: %[[C2:.+]] = vm.const.i32 2 : i32
-    %c2 = vm.const.i32 2 : i32
+    // CHECK: %[[C2:.+]] = vm.const.i32 2
+    %c2 = vm.const.i32 2
     // CHECK: %0 = vm.shr.i32.u %arg0, %[[C2]] : i32
     %0 = vm.shr.i32.u %arg0, %c2 : i32
     vm.return %0 : i32

--- a/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/structural_ops.mlir
@@ -86,8 +86,8 @@ vm.module @initializers {
 
   // CHECK-NEXT: vm.initializer {
   vm.initializer {
-    // CHECK-NEXT: %zero = vm.const.i32 0 : i32
-    %zero = vm.const.i32 0 : i32
+    // CHECK-NEXT: %zero = vm.const.i32 0
+    %zero = vm.const.i32 0
     // CHECK-NEXT:   vm.br ^bb1(%zero : i32)
     vm.br ^bb1(%zero: i32)
     // CHECK-NEXT: ^bb1(%0: i32):

--- a/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/calling_convention.mlir
@@ -23,7 +23,7 @@ vm.module @calling_convention_test {
     // CHECK-NEXT: int32_t v5;
     // CHECK-NEXT: iree_status_t v6;
     // CHECK-NEXT: v5 = 32;
-    %0 = vm.const.i32 32 : i32
+    %0 = vm.const.i32 32
     // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v4, v5);
     // CHECK-NEXT: v6 = iree_ok_status();
     // CHECK-NEXT: return v6;
@@ -35,7 +35,7 @@ vm.module @calling_convention_test {
     // CHECK-NEXT: int32_t v6;
     // CHECK-NEXT: iree_status_t v7;
     // CHECK-NEXT: v6 = 32;
-    %0 = vm.const.i32 32 : i32
+    %0 = vm.const.i32 32
     // CHECK-NEXT: EMITC_DEREF_ASSIGN_VALUE(v5, v6);
     // CHECK-NEXT: v7 = iree_ok_status();
     // CHECK-NEXT: return v7;

--- a/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
@@ -49,7 +49,7 @@ vm.module @constant_ops {
     // CHECK: int32_t [[CONST:[^ ]*]];
     // CHECK-NOT: [[CONST]] = 4294967292;
     // CHECK: [[CONST]] = -4;
-    %c-4_i32 = vm.const.i32 -4 : i32
+    %c-4_i32 = vm.const.i32 -4
     vm.return %c-4_i32 : i32
   }
 }

--- a/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
+++ b/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
@@ -37,7 +37,7 @@ vm.module @global_ops {
     // CHECK-NEXT: int32_t v8;
     // CHECK-NEXT: iree_status_t v9;
     // CHECK-NEXT: v5 = 17;
-    %c17 = vm.const.i32 17 : i32
+    %c17 = vm.const.i32 17
     // CHECK-NEXT: v6 = EMITC_STRUCT_PTR_MEMBER(v3, rwdata);
     // CHECK-NEXT: vm_global_store_i32(v6, 4, v5);
     vm.global.store.i32 %c17, @c107_mut : i32

--- a/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/global_initialization.mlir
@@ -19,9 +19,9 @@ vm.module @initI32 {
   vm.global.i32 private @g2 = 123 : i32
 
   // CHECK: vm.func private @__init() {
-  // CHECK-NEXT:   %c123 = vm.const.i32 123 : i32
+  // CHECK-NEXT:   %c123 = vm.const.i32 123
   // CHECK-NEXT:   vm.global.store.i32 %c123, @g1
-  // CHECK-NEXT:   %c123_0 = vm.const.i32 123 : i32
+  // CHECK-NEXT:   %c123_0 = vm.const.i32 123
   // CHECK-NEXT:   vm.global.store.i32 %c123_0, @g2
   // CHECK-NEXT:   vm.return
   // CHECK-NEXT: }
@@ -51,7 +51,7 @@ vm.module @initializers {
   vm.global.i32 private @g0 : i32
   // CHECK-NOT: vm.initializer
   vm.initializer {
-    %c123 = vm.const.i32 123 : i32
+    %c123 = vm.const.i32 123
     vm.global.store.i32 %c123, @g0 : i32
     vm.return
   }
@@ -75,7 +75,7 @@ vm.module @initializers {
   }
 
   //      CHECK: vm.func private @__init() {
-  // CHECK-NEXT:   %c123 = vm.const.i32 123 : i32
+  // CHECK-NEXT:   %c123 = vm.const.i32 123
   // CHECK-NEXT:   vm.global.store.i32 %c123, @g0 : i32
   // CHECK-NEXT:   %null = vm.const.ref.zero : !vm.ref<?>
   // CHECK-NEXT:   vm.global.store.ref %null, @g1 : !vm.ref<?>

--- a/iree/compiler/Dialect/VM/Transforms/test/sink_defining_ops.mlir
+++ b/iree/compiler/Dialect/VM/Transforms/test/sink_defining_ops.mlir
@@ -3,16 +3,16 @@
 vm.module @module {
   // CHECK-LABEL: @single_uses
   vm.func @single_uses(%arg0 : i32) -> i32 {
-    %c4 = vm.const.i32 4 : i32
-    %c5 = vm.const.i32 5 : i32
+    %c4 = vm.const.i32 4
+    %c5 = vm.const.i32 5
     // CHECK: vm.cond_br
     vm.cond_br %arg0, ^bb1, ^bb2
   ^bb1:
-    //      CHECK: %c4 = vm.const.i32 4 : i32
+    //      CHECK: %c4 = vm.const.i32 4
     // CHECK-NEXT: vm.return %c4 : i32
     vm.return %c4 : i32
   ^bb2:
-    //      CHECK: %c5 = vm.const.i32 5 : i32
+    //      CHECK: %c5 = vm.const.i32 5
     // CHECK-NEXT: vm.return %c5 : i32
     vm.return %c5 : i32
   }
@@ -23,13 +23,13 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @multiple_uses
   vm.func @multiple_uses(%arg0 : i32) -> (i32, i32) {
-    %c4 = vm.const.i32 4 : i32
-    %c5 = vm.const.i32 5 : i32
-    // CHECK: %c5 = vm.const.i32 5 : i32
+    %c4 = vm.const.i32 4
+    %c5 = vm.const.i32 5
+    // CHECK: %c5 = vm.const.i32 5
     // CHECK: vm.cond_br
     vm.cond_br %arg0, ^bb1, ^bb2
   ^bb1:
-    //      CHECK: %c4 = vm.const.i32 4 : i32
+    //      CHECK: %c4 = vm.const.i32 4
     // CHECK-NEXT: vm.return %c4, %c5
     vm.return %c4, %c5 : i32, i32
   ^bb2:
@@ -43,16 +43,16 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: @common_dominator
   vm.func @common_dominator(%arg0 : i32, %arg1 : i32) -> (i32, i32) {
-    %c4 = vm.const.i32 4 : i32
-    %c5 = vm.const.i32 5 : i32
-    %c6 = vm.const.i32 6 : i32
-    //      CHECK: %c5 = vm.const.i32 5 : i32
+    %c4 = vm.const.i32 4
+    %c5 = vm.const.i32 5
+    %c6 = vm.const.i32 6
+    //      CHECK: %c5 = vm.const.i32 5
     // CHECK-NEXT: vm.cond_br %arg0
     vm.cond_br %arg0, ^bb1, ^bb_end
   ^bb1:
     //      CHECK: "test.do_something_else"
     "test.do_something_else"() : () -> ()
-    // CHECK-NEXT: %c4 = vm.const.i32 4 : i32
+    // CHECK-NEXT: %c4 = vm.const.i32 4
     // CHECK-NEXT: "test.do_thing"(%c4) : (i32) -> ()
     "test.do_thing"(%c4) : (i32) -> ()
     // CHECK-NEXT: vm.cond_br %arg1
@@ -63,7 +63,7 @@ vm.module @module {
     // CHECK: vm.br
     vm.br ^bb_end
   ^bb_end:
-    //      CHECK: %c6 = vm.const.i32 6 : i32
+    //      CHECK: %c6 = vm.const.i32 6
     // CHECK-NEXT: vm.return %c5, %c6
     vm.return %c5, %c6 : i32, i32
   }

--- a/iree/vm/bytecode_module_benchmark.mlir
+++ b/iree/vm/bytecode_module_benchmark.mlir
@@ -66,8 +66,8 @@ vm.module @bytecode_module_benchmark {
   // Measures the cost of a simple for-loop.
   vm.export @loop_sum
   vm.func @loop_sum(%count : i32) -> i32 {
-    %c1 = vm.const.i32 1 : i32
-    %i0 = vm.const.i32.zero : i32
+    %c1 = vm.const.i32 1
+    %i0 = vm.const.i32.zero
     vm.br ^loop(%i0 : i32)
   ^loop(%i : i32):
     %in = vm.add.i32 %i, %c1 : i32
@@ -80,9 +80,9 @@ vm.module @bytecode_module_benchmark {
   // Measures the cost of lots of buffer loads.
   vm.export @buffer_reduce
   vm.func @buffer_reduce(%count : i32) -> i32 {
-    %c0 = vm.const.i32.zero : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c0 = vm.const.i32.zero
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %max = vm.mul.i32 %count, %c4 : i32
     %buf = vm.buffer.alloc %max : !vm.buffer
     vm.buffer.fill.i32 %buf, %c0, %max, %c1 : i32 -> !vm.buffer
@@ -101,9 +101,9 @@ vm.module @bytecode_module_benchmark {
   // NOTE: unrolled 8x, requires %count to be % 8 = 0.
   vm.export @buffer_reduce_unrolled
   vm.func @buffer_reduce_unrolled(%count : i32) -> i32 {
-    %c0 = vm.const.i32.zero : i32
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c0 = vm.const.i32.zero
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
     %max = vm.mul.i32 %count, %c4 : i32
     %buf = vm.buffer.alloc %max : !vm.buffer
     vm.buffer.fill.i32 %buf, %c0, %max, %c1 : i32 -> !vm.buffer

--- a/iree/vm/test/arithmetic_ops.mlir
+++ b/iree/vm/test/arithmetic_ops.mlir
@@ -6,140 +6,140 @@ vm.module @arithmetic_ops {
 
   vm.export @test_add_i32
   vm.func @test_add_i32() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.add.i32 %c1dno, %c1dno : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     vm.check.eq %v, %c2, "1+1=2" : i32
     vm.return
   }
 
   vm.export @test_sub_i32
   vm.func @test_sub_i32() {
-    %c1 = vm.const.i32 3 : i32
+    %c1 = vm.const.i32 3
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.sub.i32 %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 1 : i32
+    %c3 = vm.const.i32 1
     vm.check.eq %v, %c3, "3-2=1" : i32
     vm.return
   }
 
   vm.export @test_mul_i32
   vm.func @test_mul_i32() {
-    %c1 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 2
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.mul.i32 %c1dno, %c1dno : i32
-    %c2 = vm.const.i32 4 : i32
+    %c2 = vm.const.i32 4
     vm.check.eq %v, %c2, "2*2=4" : i32
     vm.return
   }
 
   vm.export @test_div_i32s
   vm.func @test_div_i32s() {
-    %c1 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 4
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 -2 : i32
+    %c2 = vm.const.i32 -2
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.div.i32.s %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 -2 : i32
+    %c3 = vm.const.i32 -2
     vm.check.eq %v, %c3, "4/-2=-2" : i32
     vm.return
   }
 
   vm.export @test_div_i32u
   vm.func @test_div_i32u() {
-    %c1 = vm.const.i32 4 : i32
+    %c1 = vm.const.i32 4
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.div.i32.u %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 2 : i32
+    %c3 = vm.const.i32 2
     vm.check.eq %v, %c3, "4/2=2" : i32
     vm.return
   }
 
   vm.export @test_rem_i32s
   vm.func @test_rem_i32s() {
-    %c1 = vm.const.i32 -3 : i32
+    %c1 = vm.const.i32 -3
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 -2 : i32
+    %c2 = vm.const.i32 -2
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.rem.i32.s %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 -1 : i32
+    %c3 = vm.const.i32 -1
     vm.check.eq %v, %c3, "-3%-2=-1" : i32
     vm.return
   }
 
   vm.export @test_rem_i32u
   vm.func @test_rem_i32u() {
-    %c1 = vm.const.i32 3 : i32
+    %c1 = vm.const.i32 3
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.rem.i32.u %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 1 : i32
+    %c3 = vm.const.i32 1
     vm.check.eq %v, %c3, "3%2=1" : i32
     vm.return
   }
 
   vm.export @test_fma_i32
   vm.func @test_fma_i32() {
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2dno = util.do_not_optimize(%c2) : i32
-    %c3 = vm.const.i32 3 : i32
+    %c3 = vm.const.i32 3
     %c3dno = util.do_not_optimize(%c3) : i32
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     %c5dno = util.do_not_optimize(%c5) : i32
     %v = vm.fma.i32 %c2dno, %c3dno, %c5dno : i32
-    %c11 = vm.const.i32 11 : i32
+    %c11 = vm.const.i32 11
     vm.check.eq %v, %c11, "2*3+5=11" : i32
     vm.return
   }
 
   vm.export @test_not_i32
   vm.func @test_not_i32() {
-    %c1 = vm.const.i32 0 : i32
+    %c1 = vm.const.i32 0
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.not.i32 %c1dno : i32
-    %c2 = vm.const.i32 -1 : i32
+    %c2 = vm.const.i32 -1
     vm.check.eq %v, %c2, "~0=-1" : i32
     vm.return
   }
 
   vm.export @test_and_i32
   vm.func @test_and_i32() {
-    %c1 = vm.const.i32 5 : i32
+    %c1 = vm.const.i32 5
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 3 : i32
+    %c2 = vm.const.i32 3
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.and.i32 %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 1 : i32
+    %c3 = vm.const.i32 1
     vm.check.eq %v, %c3, "5&3=1" : i32
     vm.return
   }
 
   vm.export @test_or_i32
   vm.func @test_or_i32() {
-    %c1 = vm.const.i32 5 : i32
+    %c1 = vm.const.i32 5
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 3 : i32
+    %c2 = vm.const.i32 3
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.or.i32 %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 7 : i32
+    %c3 = vm.const.i32 7
     vm.check.eq %v, %c3, "5|3=7" : i32
     vm.return
   }
 
   vm.export @test_xor_i32
   vm.func @test_xor_i32() {
-    %c1 = vm.const.i32 5 : i32
+    %c1 = vm.const.i32 5
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 3 : i32
+    %c2 = vm.const.i32 3
     %c2dno = util.do_not_optimize(%c2) : i32
     %v = vm.xor.i32 %c1dno, %c2dno : i32
-    %c3 = vm.const.i32 6 : i32
+    %c3 = vm.const.i32 6
     vm.check.eq %v, %c3, "5^3=6" : i32
     vm.return
   }

--- a/iree/vm/test/arithmetic_ops_f32.mlir
+++ b/iree/vm/test/arithmetic_ops_f32.mlir
@@ -6,264 +6,264 @@ vm.module @arithmetic_ops_f32 {
 
   vm.export @test_add_f32
   vm.func @test_add_f32() {
-    %c1 = vm.const.f32 1.5 : f32
+    %c1 = vm.const.f32 1.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.add.f32 %c1dno, %c1dno : f32
-    %c2 = vm.const.f32 3.0 : f32
+    %c2 = vm.const.f32 3.0
     vm.check.eq %v, %c2, "1.5+1.5=3" : f32
     vm.return
   }
 
   vm.export @test_sub_f32
   vm.func @test_sub_f32() {
-    %c1 = vm.const.f32 3.0 : f32
+    %c1 = vm.const.f32 3.0
     %c1dno = util.do_not_optimize(%c1) : f32
-    %c2 = vm.const.f32 2.5 : f32
+    %c2 = vm.const.f32 2.5
     %c2dno = util.do_not_optimize(%c2) : f32
     %v = vm.sub.f32 %c1dno, %c2dno : f32
-    %c3 = vm.const.f32 0.5 : f32
+    %c3 = vm.const.f32 0.5
     vm.check.eq %v, %c3, "3.0-2.5=0.5" : f32
     vm.return
   }
 
   vm.export @test_mul_f32
   vm.func @test_mul_f32() {
-    %c1 = vm.const.f32 2.5 : f32
+    %c1 = vm.const.f32 2.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.mul.f32 %c1dno, %c1dno : f32
-    %c2 = vm.const.f32 6.25 : f32
+    %c2 = vm.const.f32 6.25
     vm.check.eq %v, %c2, "2.5*2.5=6.25" : f32
     vm.return
   }
 
   vm.export @test_div_f32
   vm.func @test_div_f32() {
-    %c1 = vm.const.f32 4.0 : f32
+    %c1 = vm.const.f32 4.0
     %c1dno = util.do_not_optimize(%c1) : f32
-    %c2 = vm.const.f32 -2.0 : f32
+    %c2 = vm.const.f32 -2.0
     %c2dno = util.do_not_optimize(%c2) : f32
     %v = vm.div.f32 %c1dno, %c2dno : f32
-    %c3 = vm.const.f32 -2.0 : f32
+    %c3 = vm.const.f32 -2.0
     vm.check.eq %v, %c3, "4.0/-2.0=-2.0" : f32
     vm.return
   }
 
   vm.export @test_rem_f32
   vm.func @test_rem_f32() {
-    %c1 = vm.const.f32 -3.0 : f32
+    %c1 = vm.const.f32 -3.0
     %c1dno = util.do_not_optimize(%c1) : f32
-    %c2 = vm.const.f32 -2.0 : f32
+    %c2 = vm.const.f32 -2.0
     %c2dno = util.do_not_optimize(%c2) : f32
     %v = vm.rem.f32 %c1dno, %c2dno : f32
-    %c3 = vm.const.f32 1.0 : f32
+    %c3 = vm.const.f32 1.0
     vm.check.eq %v, %c3, "-3.0%-2.0=1.0" : f32
     vm.return
   }
 
   vm.export @test_fma_f32
   vm.func @test_fma_f32() {
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     %c2dno = util.do_not_optimize(%c2) : f32
-    %c3 = vm.const.f32 3.0 : f32
+    %c3 = vm.const.f32 3.0
     %c3dno = util.do_not_optimize(%c3) : f32
-    %c5 = vm.const.f32 5.0 : f32
+    %c5 = vm.const.f32 5.0
     %c5dno = util.do_not_optimize(%c5) : f32
     %v = vm.fma.f32 %c2dno, %c3dno, %c5dno : f32
-    %c11 = vm.const.f32 11.0 : f32
+    %c11 = vm.const.f32 11.0
     vm.check.eq %v, %c11, "2.0*3.0+5.0=11.0" : f32
     vm.return
   }
 
   vm.export @test_abs_f32
   vm.func @test_abs_f32() {
-    %c1 = vm.const.f32 -1.0 : f32
+    %c1 = vm.const.f32 -1.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.abs.f32 %c1dno : f32
-    %c2 = vm.const.f32 1.0 : f32
+    %c2 = vm.const.f32 1.0
     vm.check.eq %v, %c2, "abs(-1.0)=1.0" : f32
     vm.return
   }
 
   vm.export @test_neg_f32
   vm.func @test_neg_f32() {
-    %c1 = vm.const.f32 -1.0 : f32
+    %c1 = vm.const.f32 -1.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.neg.f32 %c1dno : f32
-    %c2 = vm.const.f32 1.0 : f32
+    %c2 = vm.const.f32 1.0
     vm.check.eq %v, %c2, "neg(-1.0)=1.0" : f32
     vm.return
   }
 
   vm.export @test_ceil_f32
   vm.func @test_ceil_f32() {
-    %c1 = vm.const.f32 1.5 : f32
+    %c1 = vm.const.f32 1.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.ceil.f32 %c1dno : f32
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     vm.check.eq %v, %c2, "ceil(1.5)=2.0" : f32
     vm.return
   }
 
   vm.export @test_floor_f32
   vm.func @test_floor_f32() {
-    %c1 = vm.const.f32 1.5 : f32
+    %c1 = vm.const.f32 1.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.floor.f32 %c1dno : f32
-    %c2 = vm.const.f32 1.0 : f32
+    %c2 = vm.const.f32 1.0
     vm.check.eq %v, %c2, "floor(1.5)=1.0" : f32
     vm.return
   }
 
   vm.export @test_atan_f32
   vm.func @test_atan_f32() {
-    %c1 = vm.const.f32 1.0 : f32
+    %c1 = vm.const.f32 1.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.atan.f32 %c1dno : f32
-    %c2 = vm.const.f32 0.7853981633974483: f32
+    %c2 = vm.const.f32 0.7853981633974483
     vm.check.eq %v, %c2, "atan(1.0)=0.7853981633974483" : f32
     vm.return
   }
 
   vm.export @test_atan2_f32
   vm.func @test_atan2_f32() {
-    %c1 = vm.const.f32 1.0 : f32
+    %c1 = vm.const.f32 1.0
     %c1dno = util.do_not_optimize(%c1) : f32
-    %c2 = vm.const.f32 0.0 : f32
+    %c2 = vm.const.f32 0.0
     %c2dno = util.do_not_optimize(%c2) : f32
     %v = vm.atan2.f32 %c1dno, %c2dno : f32
-    %c3 = vm.const.f32 1.5707963267948966 : f32
+    %c3 = vm.const.f32 1.5707963267948966
     vm.check.eq %v, %c3, "atan2(1.0,0.0)=1.5707963267948966" : f32
     vm.return
   }
 
   vm.export @test_cos_f32
   vm.func @test_cos_f32() {
-    %c1 = vm.const.f32 0.5 : f32
+    %c1 = vm.const.f32 0.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cos.f32 %c1dno : f32
-    %c2 = vm.const.f32 0.8775825618903728: f32
+    %c2 = vm.const.f32 0.8775825618903728
     vm.check.eq %v, %c2, "cos(0.5)=0.8775825618903728" : f32
     vm.return
   }
 
   vm.export @test_sin_f32
   vm.func @test_sin_f32() {
-    %c1 = vm.const.f32 0.5 : f32
+    %c1 = vm.const.f32 0.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.sin.f32 %c1dno : f32
-    %c2 = vm.const.f32 0.479425538604203: f32
+    %c2 = vm.const.f32 0.479425538604203
     vm.check.eq %v, %c2, "sin(0.5)=0.479425538604203" : f32
     vm.return
   }
 
   vm.export @test_exp_f32
   vm.func @test_exp_f32() {
-    %c1 = vm.const.f32 1.0 : f32
+    %c1 = vm.const.f32 1.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.exp.f32 %c1dno : f32
-    %c2 = vm.const.f32 2.718281828459045: f32
+    %c2 = vm.const.f32 2.718281828459045
     vm.check.eq %v, %c2, "exp(1.0)=2.718281828459045" : f32
     vm.return
   }
 
   vm.export @test_exp2_f32
   vm.func @test_exp2_f32() {
-    %c1 = vm.const.f32 2.0 : f32
+    %c1 = vm.const.f32 2.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.exp2.f32 %c1dno : f32
-    %c2 = vm.const.f32 4.0: f32
+    %c2 = vm.const.f32 4.0
     vm.check.eq %v, %c2, "exp(2.0)=4.0" : f32
     vm.return
   }
 
   vm.export @test_expm1_f32
   vm.func @test_expm1_f32() {
-    %c1 = vm.const.f32 2.0 : f32
+    %c1 = vm.const.f32 2.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.expm1.f32 %c1dno : f32
-    %c2 = vm.const.f32 6.38905609893065: f32
+    %c2 = vm.const.f32 6.38905609893065
     vm.check.eq %v, %c2, "expm1(2.0)=6.38905609893065" : f32
     vm.return
   }
 
   vm.export @test_log_f32
   vm.func @test_log_f32() {
-    %c1 = vm.const.f32 10.0 : f32
+    %c1 = vm.const.f32 10.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.log.f32 %c1dno : f32
-    %c2 = vm.const.f32 2.302585092994046: f32
+    %c2 = vm.const.f32 2.302585092994046
     vm.check.eq %v, %c2, "log(10.0)=2.302585092994046" : f32
     vm.return
   }
 
   vm.export @test_log10_f32
   vm.func @test_log10_f32() {
-    %c1 = vm.const.f32 10.0 : f32
+    %c1 = vm.const.f32 10.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.log10.f32 %c1dno : f32
-    %c2 = vm.const.f32 1.0: f32
+    %c2 = vm.const.f32 1.0
     vm.check.eq %v, %c2, "log10(10.0)=1.0" : f32
     vm.return
   }
 
   vm.export @test_log1p_f32
   vm.func @test_log1p_f32() {
-    %c1 = vm.const.f32 10.0 : f32
+    %c1 = vm.const.f32 10.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.log1p.f32 %c1dno : f32
-    %c2 = vm.const.f32 2.3978952727983707: f32
+    %c2 = vm.const.f32 2.3978952727983707
     vm.check.eq %v, %c2, "log1p(10.0)=2.3978952727983707" : f32
     vm.return
   }
 
   vm.export @test_log2_f32
   vm.func @test_log2_f32() {
-    %c1 = vm.const.f32 10.0 : f32
+    %c1 = vm.const.f32 10.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.log2.f32 %c1dno : f32
-    %c2 = vm.const.f32 3.321928094887362: f32
+    %c2 = vm.const.f32 3.321928094887362
     vm.check.eq %v, %c2, "log2(10.0)=3.321928094887362" : f32
     vm.return
   }
 
   vm.export @test_pow_f32
   vm.func @test_pow_f32() {
-    %c1 = vm.const.f32 3.0 : f32
+    %c1 = vm.const.f32 3.0
     %c1dno = util.do_not_optimize(%c1) : f32
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     %c2dno = util.do_not_optimize(%c2) : f32
     %v = vm.pow.f32 %c1dno, %c2dno : f32
-    %c3 = vm.const.f32 9.0 : f32
+    %c3 = vm.const.f32 9.0
     vm.check.eq %v, %c3, "pow(3.0,2.0)=9.0" : f32
     vm.return
   }
 
   vm.export @test_rsqrt_f32
   vm.func @test_rsqrt_f32() {
-    %c1 = vm.const.f32 4.0 : f32
+    %c1 = vm.const.f32 4.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.rsqrt.f32 %c1dno : f32
-    %c2 = vm.const.f32 0.5: f32
+    %c2 = vm.const.f32 0.5
     vm.check.eq %v, %c2, "rsqrt(4.0)=0.5" : f32
     vm.return
   }
 
   vm.export @test_sqrt_f32
   vm.func @test_sqrt_f32() {
-    %c1 = vm.const.f32 4.0 : f32
+    %c1 = vm.const.f32 4.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.sqrt.f32 %c1dno : f32
-    %c2 = vm.const.f32 2.0: f32
+    %c2 = vm.const.f32 2.0
     vm.check.eq %v, %c2, "sqrt(4.0)=2.0" : f32
     vm.return
   }
 
   vm.export @test_tanh_f32
   vm.func @test_tanh_f32() {
-    %c1 = vm.const.f32 0.5 : f32
+    %c1 = vm.const.f32 0.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.tanh.f32 %c1dno : f32
-    %c2 = vm.const.f32 0.46211715726000974: f32
+    %c2 = vm.const.f32 0.46211715726000974
     vm.check.eq %v, %c2, "tanh(0.5)=0.46211715726000974" : f32
     vm.return
   }
@@ -271,10 +271,10 @@ vm.module @arithmetic_ops_f32 {
   // TODO(#5854): vm.check.nearly_eq; this can differ across libm impls.
   // vm.export @test_erf_f32
   // vm.func @test_erf_f32() {
-  //   %c1 = vm.const.f32 0.5 : f32
+  //   %c1 = vm.const.f32 0.5
   //   %c1dno = util.do_not_optimize(%c1) : f32
   //   %v = vm.erf.f32 %c1dno : f32
-  //   %c2 = vm.const.f32 0.520499945 : f32
+  //   %c2 = vm.const.f32 0.520499945
   //   vm.check.eq %v, %c2, "erf(0.5)=0.520499945" : f32
   //   vm.return
   // }

--- a/iree/vm/test/arithmetic_ops_i64.mlir
+++ b/iree/vm/test/arithmetic_ops_i64.mlir
@@ -6,140 +6,140 @@ vm.module @arithmetic_ops_i64 {
 
   vm.export @test_add_i64
   vm.func @test_add_i64() {
-    %c1 = vm.const.i64 1 : i64
+    %c1 = vm.const.i64 1
     %c1dno = util.do_not_optimize(%c1) : i64
     %v = vm.add.i64 %c1dno, %c1dno : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     vm.check.eq %v, %c2, "1+1=2" : i64
     vm.return
   }
 
   vm.export @test_sub_i64
   vm.func @test_sub_i64() {
-    %c1 = vm.const.i64 3 : i64
+    %c1 = vm.const.i64 3
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.sub.i64 %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 1 : i64
+    %c3 = vm.const.i64 1
     vm.check.eq %v, %c3, "3-2=1" : i64
     vm.return
   }
 
   vm.export @test_mul_i64
   vm.func @test_mul_i64() {
-    %c1 = vm.const.i64 2 : i64
+    %c1 = vm.const.i64 2
     %c1dno = util.do_not_optimize(%c1) : i64
     %v = vm.mul.i64 %c1dno, %c1dno : i64
-    %c2 = vm.const.i64 4 : i64
+    %c2 = vm.const.i64 4
     vm.check.eq %v, %c2, "2*2=4" : i64
     vm.return
   }
 
   vm.export @test_div_i64s
   vm.func @test_div_i64s() {
-    %c1 = vm.const.i64 4 : i64
+    %c1 = vm.const.i64 4
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 -2 : i64
+    %c2 = vm.const.i64 -2
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.div.i64.s %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 -2 : i64
+    %c3 = vm.const.i64 -2
     vm.check.eq %v, %c3, "4/-2=-2" : i64
     vm.return
   }
 
   vm.export @test_div_i64u
   vm.func @test_div_i64u() {
-    %c1 = vm.const.i64 4 : i64
+    %c1 = vm.const.i64 4
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.div.i64.u %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 2 : i64
+    %c3 = vm.const.i64 2
     vm.check.eq %v, %c3, "4/2=2" : i64
     vm.return
   }
 
   vm.export @test_rem_i64s
   vm.func @test_rem_i64s() {
-    %c1 = vm.const.i64 -3 : i64
+    %c1 = vm.const.i64 -3
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 -2 : i64
+    %c2 = vm.const.i64 -2
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.rem.i64.s %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 -1 : i64
+    %c3 = vm.const.i64 -1
     vm.check.eq %v, %c3, "-3%-2=-1" : i64
     vm.return
   }
 
   vm.export @test_rem_i64u
   vm.func @test_rem_i64u() {
-    %c1 = vm.const.i64 3 : i64
+    %c1 = vm.const.i64 3
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.rem.i64.u %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 1 : i64
+    %c3 = vm.const.i64 1
     vm.check.eq %v, %c3, "3%2=1" : i64
     vm.return
   }
 
   vm.export @test_fma_i64
   vm.func @test_fma_i64() {
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2dno = util.do_not_optimize(%c2) : i64
-    %c3 = vm.const.i64 3 : i64
+    %c3 = vm.const.i64 3
     %c3dno = util.do_not_optimize(%c3) : i64
-    %c5 = vm.const.i64 5 : i64
+    %c5 = vm.const.i64 5
     %c5dno = util.do_not_optimize(%c5) : i64
     %v = vm.fma.i64 %c2dno, %c3dno, %c5dno : i64
-    %c11 = vm.const.i64 11 : i64
+    %c11 = vm.const.i64 11
     vm.check.eq %v, %c11, "2*3+5=11" : i64
     vm.return
   }
 
   vm.export @test_not_i64
   vm.func @test_not_i64() {
-    %c1 = vm.const.i64 0 : i64
+    %c1 = vm.const.i64 0
     %c1dno = util.do_not_optimize(%c1) : i64
     %v = vm.not.i64 %c1dno : i64
-    %c2 = vm.const.i64 -1 : i64
+    %c2 = vm.const.i64 -1
     vm.check.eq %v, %c2, "~0=-1" : i64
     vm.return
   }
 
   vm.export @test_and_i64
   vm.func @test_and_i64() {
-    %c1 = vm.const.i64 5 : i64
+    %c1 = vm.const.i64 5
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 3 : i64
+    %c2 = vm.const.i64 3
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.and.i64 %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 1 : i64
+    %c3 = vm.const.i64 1
     vm.check.eq %v, %c3, "5&3=1" : i64
     vm.return
   }
 
   vm.export @test_or_i64
   vm.func @test_or_i64() {
-    %c1 = vm.const.i64 5 : i64
+    %c1 = vm.const.i64 5
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 3 : i64
+    %c2 = vm.const.i64 3
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.or.i64 %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 7 : i64
+    %c3 = vm.const.i64 7
     vm.check.eq %v, %c3, "5|3=7" : i64
     vm.return
   }
 
   vm.export @test_xor_i64
   vm.func @test_xor_i64() {
-    %c1 = vm.const.i64 5 : i64
+    %c1 = vm.const.i64 5
     %c1dno = util.do_not_optimize(%c1) : i64
-    %c2 = vm.const.i64 3 : i64
+    %c2 = vm.const.i64 3
     %c2dno = util.do_not_optimize(%c2) : i64
     %v = vm.xor.i64 %c1dno, %c2dno : i64
-    %c3 = vm.const.i64 6 : i64
+    %c3 = vm.const.i64 6
     vm.check.eq %v, %c3, "5^3=6" : i64
     vm.return
   }

--- a/iree/vm/test/assignment_ops.mlir
+++ b/iree/vm/test/assignment_ops.mlir
@@ -6,9 +6,9 @@ vm.module @assignment_ops {
 
   vm.export @test_select_i32
   vm.func @test_select_i32() {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %c0dno = util.do_not_optimize(%c0) : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     %v1 = vm.select.i32 %c0dno, %c0dno, %c1dno : i32
     vm.check.eq %v1, %c1, "0 ? 0 : 1 = 1" : i32
@@ -19,11 +19,11 @@ vm.module @assignment_ops {
 
   vm.export @test_select_ref attributes {emitc.exclude}
   vm.func private @test_select_ref() {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %list0 = vm.list.alloc %c0 : (i32) -> !vm.list<i8>
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %list1 = vm.list.alloc %c1 : (i32) -> !vm.list<i8>
-    %cond = vm.const.i32 0 : i32
+    %cond = vm.const.i32 0
     %cond_dno = util.do_not_optimize(%cond) : i32
     %list = vm.select.ref %cond_dno, %list0, %list1 : !vm.list<i8>
     vm.check.eq %list, %list1, "0 ? list0 : list1 = list1" : !vm.list<i8>

--- a/iree/vm/test/assignment_ops_f32.mlir
+++ b/iree/vm/test/assignment_ops_f32.mlir
@@ -6,12 +6,12 @@ vm.module @assignment_ops_f32 {
 
   vm.export @test_select_f32
   vm.func @test_select_f32() {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %c0dno = util.do_not_optimize(%c0) : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.f32 0.0 : f32
-    %c3 = vm.const.f32 1.0 : f32
+    %c2 = vm.const.f32 0.0
+    %c3 = vm.const.f32 1.0
     %v1 = vm.select.f32 %c0dno, %c2, %c3 : f32
     vm.check.eq %v1, %c3, "0 ? 0.0 : 1.0 = 1.0" : f32
     %v2 = vm.select.f32 %c1dno, %c2, %c3 : f32

--- a/iree/vm/test/assignment_ops_i64.mlir
+++ b/iree/vm/test/assignment_ops_i64.mlir
@@ -6,12 +6,12 @@ vm.module @assignment_ops_i64 {
 
   vm.export @test_select_i64
   vm.func @test_select_i64() {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %c0dno = util.do_not_optimize(%c0) : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i64 0 : i64
-    %c3 = vm.const.i64 1 : i64
+    %c2 = vm.const.i64 0
+    %c3 = vm.const.i64 1
     %v1 = vm.select.i64 %c0dno, %c2, %c3 : i64
     vm.check.eq %v1, %c3, "0 ? 0 : 1 = 1" : i64
     %v2 = vm.select.i64 %c1dno, %c2, %c3 : i64

--- a/iree/vm/test/buffer_ops.mlir
+++ b/iree/vm/test/buffer_ops.mlir
@@ -19,7 +19,7 @@ vm.module @buffer_ops {
     %rodata_a_dno = util.do_not_optimize(%rodata_a) : !vm.buffer
     %rodata_b_dno = util.do_not_optimize(%rodata_b) : !vm.buffer
 
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %length = vm.buffer.length %rodata_a_dno : !vm.buffer -> i32
 
     %cmp0 = vm.buffer.compare %rodata_a_dno, %c0, %rodata_a_dno, %c0, %length : !vm.buffer, !vm.buffer
@@ -39,8 +39,8 @@ vm.module @buffer_ops {
     %rodata_a_dno = util.do_not_optimize(%rodata_a) : !vm.buffer
     %rodata_b_dno = util.do_not_optimize(%rodata_b) : !vm.buffer
 
-    %c0 = vm.const.i32 0 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c0 = vm.const.i32 0
+    %c2 = vm.const.i32 2
 
     %cmp = vm.buffer.compare %rodata_a_dno, %c2, %rodata_a_dno, %c2, %c0 : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "empty buffer ranges are always equal" : i32
@@ -55,7 +55,7 @@ vm.module @buffer_ops {
   // Tests allocating a buffer.
   vm.export @test_alloc attributes {emitc.exclude}
   vm.func private @test_alloc() {
-    %c128 = vm.const.i32 128 : i32
+    %c128 = vm.const.i32 128
     %buf = vm.buffer.alloc %c128 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
@@ -69,7 +69,7 @@ vm.module @buffer_ops {
   // Tests that zero-length buffers can be allocated.
   vm.export @test_alloc_empty attributes {emitc.exclude}
   vm.func private @test_alloc_empty() {
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %buf = vm.buffer.alloc %c0 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
@@ -91,14 +91,14 @@ vm.module @buffer_ops {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
 
     // Clone the last two 32-bit elements.
-    %c4 = vm.const.i32 4 : i32
-    %c8 = vm.const.i32 8 : i32
+    %c4 = vm.const.i32 4
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.clone %rodata, %c4, %c8 : !vm.buffer -> !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Compare the cloned range to the original.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %cmp = vm.buffer.compare %rodata, %c4, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "buffer subspans are equal" : i32
 
@@ -109,7 +109,7 @@ vm.module @buffer_ops {
   vm.export @test_clone_empty attributes {emitc.exclude}
   vm.func private @test_clone_empty() {
     // Allocate source zero-length buffer.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %buf0 = vm.buffer.alloc %c0 : !vm.buffer
     %buf0_dno = util.do_not_optimize(%buf0) : !vm.buffer
     vm.check.nz %buf0_dno, "!null" : !vm.buffer
@@ -135,7 +135,7 @@ vm.module @buffer_ops {
     vm.check.nz %rodata_dno, "!null" : !vm.buffer
 
     // Try to clone off the end of the buffer.
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.clone %rodata, %c8, %c8 : !vm.buffer -> !vm.buffer
 
     vm.return
@@ -159,7 +159,7 @@ vm.module @buffer_ops {
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Copy the entire contents.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %rodata_length : !vm.buffer -> !vm.buffer
 
     // Compare to source.
@@ -175,14 +175,14 @@ vm.module @buffer_ops {
   vm.export @test_copy_partial attributes {emitc.exclude}
   vm.func private @test_copy_partial() {
     // Allocate target buffer.
-    %c4 = vm.const.i32 4 : i32
+    %c4 = vm.const.i32 4
     %buf = vm.buffer.alloc %c4 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Copy the middle 4-byte element.
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.buffer.copy %rodata, %c4, %buf, %c0, %c4 : !vm.buffer -> !vm.buffer
 
     // Compare to reference.
@@ -197,13 +197,13 @@ vm.module @buffer_ops {
   vm.export @fail_copy_out_of_range_source_offset attributes {emitc.exclude}
   vm.func private @fail_copy_out_of_range_source_offset() {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
-    %c128 = vm.const.i32 128 : i32
+    %c128 = vm.const.i32 128
     %buf = vm.buffer.alloc %c128 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Try to clone off the end of the source buffer.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %c128 : !vm.buffer -> !vm.buffer
 
     vm.return
@@ -213,14 +213,14 @@ vm.module @buffer_ops {
   vm.export @fail_copy_out_of_range_source_length attributes {emitc.exclude}
   vm.func private @fail_copy_out_of_range_source_length() {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
-    %c128 = vm.const.i32 128 : i32
+    %c128 = vm.const.i32 128
     %buf = vm.buffer.alloc %c128 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Try to clone off the end of the source buffer.
-    %c0 = vm.const.i32 0 : i32
-    %c8 = vm.const.i32 8 : i32
+    %c0 = vm.const.i32 0
+    %c8 = vm.const.i32 8
     vm.buffer.copy %rodata, %c8, %buf_dno, %c0, %c8 : !vm.buffer -> !vm.buffer
 
     vm.return
@@ -231,13 +231,13 @@ vm.module @buffer_ops {
   vm.func private @fail_copy_out_of_range_target_offset() {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
     %rodata_length = vm.buffer.length %rodata : !vm.buffer -> i32
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.alloc %c8 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Try to clone off the end of the target buffer.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.buffer.copy %rodata, %c0, %buf_dno, %c0, %rodata_length : !vm.buffer -> !vm.buffer
 
     vm.return
@@ -247,13 +247,13 @@ vm.module @buffer_ops {
   vm.export @fail_copy_out_of_range_target_length attributes {emitc.exclude}
   vm.func private @fail_copy_out_of_range_target_length() {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.alloc %c8 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Try to clone off the end of the target buffer.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     vm.buffer.copy %rodata, %c0, %buf_dno, %c8, %c8 : !vm.buffer -> !vm.buffer
 
     vm.return
@@ -269,19 +269,19 @@ vm.module @buffer_ops {
   vm.export @test_fill_i16 attributes {emitc.exclude}
   vm.func private @test_fill_i16() {
     // Allocate zeroed buffer.
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.alloc %c8 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
     vm.check.nz %buf_dno, "!null" : !vm.buffer
 
     // Fill the middle two elements.
-    %c2 = vm.const.i32 2 : i32
-    %c4 = vm.const.i32 4 : i32
-    %cafe = vm.const.i32 0xCAFE : i32
+    %c2 = vm.const.i32 2
+    %c4 = vm.const.i32 4
+    %cafe = vm.const.i32 0xCAFE
     vm.buffer.fill.i16 %buf_dno, %c2, %c4, %cafe : i32 -> !vm.buffer
 
     // Compare to reference.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %rodata_ref = vm.const.ref.rodata @test_fill_i16_ref : !vm.buffer
     %cmp = vm.buffer.compare %rodata_ref, %c0, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "buffer should match reference" : i32
@@ -295,18 +295,18 @@ vm.module @buffer_ops {
   vm.export @test_fill_i16_misaligned_offset attributes {emitc.exclude}
   vm.func private @test_fill_i16_misaligned_offset() {
     // Allocate zeroed buffer.
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.alloc %c8 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
     // Try filling from offset 1, which is not i16-aligned.
-    %c1 = vm.const.i32 1 : i32
-    %c4 = vm.const.i32 4 : i32
-    %cafe = vm.const.i32 0xCAFE : i32
+    %c1 = vm.const.i32 1
+    %c4 = vm.const.i32 4
+    %cafe = vm.const.i32 0xCAFE
     vm.buffer.fill.i16 %buf_dno, %c1, %c4, %cafe : i32 -> !vm.buffer
 
     // Compare to reference - should have written at offset 0.
-    %c0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
     %rodata_ref = vm.const.ref.rodata @test_fill_i16_misaligned_offset_ref : !vm.buffer
     %cmp = vm.buffer.compare %rodata_ref, %c0, %buf_dno, %c0, %c8 : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "buffer should match reference" : i32
@@ -321,14 +321,14 @@ vm.module @buffer_ops {
   vm.export @test_fill_i16_misaligned_length attributes {emitc.exclude}
   vm.func private @test_fill_i16_misaligned_length() {
     // Allocate zeroed buffer.
-    %c8 = vm.const.i32 8 : i32
+    %c8 = vm.const.i32 8
     %buf = vm.buffer.alloc %c8 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
     // Try filling for length 1, which is not i16-aligned.
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %cafe = vm.const.i32 0xCAFE : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %cafe = vm.const.i32 0xCAFE
     vm.buffer.fill.i16 %buf_dno, %c0, %c1, %cafe : i32 -> !vm.buffer
 
     // Compare to reference - should have written 0 bytes.
@@ -345,9 +345,9 @@ vm.module @buffer_ops {
     %rodata = vm.const.ref.rodata @rodata_3xi32 : !vm.buffer
 
     // Permission denied:
-    %c0 = vm.const.i32 0 : i32
-    %c2 = vm.const.i32 2 : i32
-    %cafe = vm.const.i32 0xCAFE : i32
+    %c0 = vm.const.i32 0
+    %c2 = vm.const.i32 2
+    %cafe = vm.const.i32 0xCAFE
     vm.buffer.fill.i16 %rodata, %c0, %c2, %cafe : i32 -> !vm.buffer
 
     vm.return
@@ -361,52 +361,52 @@ vm.module @buffer_ops {
 
   vm.export @test_load_i8u attributes {emitc.exclude}
   vm.func private @test_load_i8u() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c3 = vm.const.i32 3 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c3 = vm.const.i32 3
+    %c4 = vm.const.i32 4
     %rodata = vm.const.ref.rodata @test_load_i8_data : !vm.buffer
     %v0 = vm.buffer.load.i8.u %rodata[%c0] : !vm.buffer -> i32
-    %e0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
     %v1 = vm.buffer.load.i8.u %rodata[%c1] : !vm.buffer -> i32
-    %e1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
     %v2 = vm.buffer.load.i8.u %rodata[%c2] : !vm.buffer -> i32
-    %e2 = vm.const.i32 0x7F : i32
+    %e2 = vm.const.i32 0x7F
     vm.check.eq %v2, %e2, "0x7F" : i32
     %v3 = vm.buffer.load.i8.u %rodata[%c3] : !vm.buffer -> i32
-    %e3 = vm.const.i32 0x80 : i32
+    %e3 = vm.const.i32 0x80
     vm.check.eq %v3, %e3, "0x80" : i32
     %v4 = vm.buffer.load.i8.u %rodata[%c4] : !vm.buffer -> i32
-    %e4 = vm.const.i32 0xFF : i32
+    %e4 = vm.const.i32 0xFF
     vm.check.eq %v4, %e4, "0xFF" : i32
     vm.return
   }
 
   vm.export @test_load_i8s attributes {emitc.exclude}
   vm.func private @test_load_i8s() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c3 = vm.const.i32 3 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c3 = vm.const.i32 3
+    %c4 = vm.const.i32 4
     %rodata = vm.const.ref.rodata @test_load_i8_data : !vm.buffer
     %v0 = vm.buffer.load.i8.s %rodata[%c0] : !vm.buffer -> i32
-    %e0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
     %v1 = vm.buffer.load.i8.s %rodata[%c1] : !vm.buffer -> i32
-    %e1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
     %v2 = vm.buffer.load.i8.s %rodata[%c2] : !vm.buffer -> i32
-    %e2 = vm.const.i32 0x7F : i32
+    %e2 = vm.const.i32 0x7F
     vm.check.eq %v2, %e2, "0x7F" : i32
     %v3 = vm.buffer.load.i8.s %rodata[%c3] : !vm.buffer -> i32
-    %e3 = vm.const.i32 -128 : i32
+    %e3 = vm.const.i32 -128
     vm.check.eq %v3, %e3, "-128" : i32
     %v4 = vm.buffer.load.i8.s %rodata[%c4] : !vm.buffer -> i32
-    %e4 = vm.const.i32 -1 : i32
+    %e4 = vm.const.i32 -1
     vm.check.eq %v4, %e4, "-1" : i32
     vm.return
   }
@@ -415,52 +415,52 @@ vm.module @buffer_ops {
 
   vm.export @test_load_i16u attributes {emitc.exclude}
   vm.func private @test_load_i16u() {
-    %c0 = vm.const.i32 0 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c4 = vm.const.i32 4 : i32
-    %c6 = vm.const.i32 6 : i32
-    %c8 = vm.const.i32 8 : i32
+    %c0 = vm.const.i32 0
+    %c2 = vm.const.i32 2
+    %c4 = vm.const.i32 4
+    %c6 = vm.const.i32 6
+    %c8 = vm.const.i32 8
     %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
     %v0 = vm.buffer.load.i16.u %rodata[%c0] : !vm.buffer -> i32
-    %e0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
     %v1 = vm.buffer.load.i16.u %rodata[%c2] : !vm.buffer -> i32
-    %e1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
     %v2 = vm.buffer.load.i16.u %rodata[%c4] : !vm.buffer -> i32
-    %e2 = vm.const.i32 0x7FFF : i32
+    %e2 = vm.const.i32 0x7FFF
     vm.check.eq %v2, %e2, "0x7FFF" : i32
     %v3 = vm.buffer.load.i16.u %rodata[%c6] : !vm.buffer -> i32
-    %e3 = vm.const.i32 0x8000 : i32
+    %e3 = vm.const.i32 0x8000
     vm.check.eq %v3, %e3, "0x8000" : i32
     %v4 = vm.buffer.load.i16.u %rodata[%c8] : !vm.buffer -> i32
-    %e4 = vm.const.i32 0xFFFF : i32
+    %e4 = vm.const.i32 0xFFFF
     vm.check.eq %v4, %e4, "0xFFFF" : i32
     vm.return
   }
 
   vm.export @test_load_i16s attributes {emitc.exclude}
   vm.func private @test_load_i16s() {
-    %c0 = vm.const.i32 0 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c4 = vm.const.i32 4 : i32
-    %c6 = vm.const.i32 6 : i32
-    %c8 = vm.const.i32 8 : i32
+    %c0 = vm.const.i32 0
+    %c2 = vm.const.i32 2
+    %c4 = vm.const.i32 4
+    %c6 = vm.const.i32 6
+    %c8 = vm.const.i32 8
     %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
     %v0 = vm.buffer.load.i16.s %rodata[%c0] : !vm.buffer -> i32
-    %e0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
     %v1 = vm.buffer.load.i16.s %rodata[%c2] : !vm.buffer -> i32
-    %e1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
     %v2 = vm.buffer.load.i16.s %rodata[%c4] : !vm.buffer -> i32
-    %e2 = vm.const.i32 0x7FFF : i32
+    %e2 = vm.const.i32 0x7FFF
     vm.check.eq %v2, %e2, "0x7FFF" : i32
     %v3 = vm.buffer.load.i16.s %rodata[%c6] : !vm.buffer -> i32
-    %e3 = vm.const.i32 -32768 : i32
+    %e3 = vm.const.i32 -32768
     vm.check.eq %v3, %e3, "-32768" : i32
     %v4 = vm.buffer.load.i16.s %rodata[%c8] : !vm.buffer -> i32
-    %e4 = vm.const.i32 -1 : i32
+    %e4 = vm.const.i32 -1
     vm.check.eq %v4, %e4, "-1" : i32
     vm.return
   }
@@ -469,26 +469,26 @@ vm.module @buffer_ops {
 
   vm.export @test_load_i32 attributes {emitc.exclude}
   vm.func private @test_load_i32() {
-    %c0 = vm.const.i32 0 : i32
-    %c4 = vm.const.i32 4 : i32
-    %c8 = vm.const.i32 8 : i32
-    %c12 = vm.const.i32 12 : i32
-    %c16 = vm.const.i32 16 : i32
+    %c0 = vm.const.i32 0
+    %c4 = vm.const.i32 4
+    %c8 = vm.const.i32 8
+    %c12 = vm.const.i32 12
+    %c16 = vm.const.i32 16
     %rodata = vm.const.ref.rodata @test_load_i32_data : !vm.buffer
     %v0 = vm.buffer.load.i32 %rodata[%c0] : !vm.buffer -> i32
-    %e0 = vm.const.i32 0 : i32
+    %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
     %v1 = vm.buffer.load.i32 %rodata[%c4] : !vm.buffer -> i32
-    %e1 = vm.const.i32 1 : i32
+    %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
     %v2 = vm.buffer.load.i32 %rodata[%c8] : !vm.buffer -> i32
-    %e2 = vm.const.i32 0x7FFFFFFF : i32
+    %e2 = vm.const.i32 0x7FFFFFFF
     vm.check.eq %v2, %e2, "0x7FFFFFFF" : i32
     %v3 = vm.buffer.load.i32 %rodata[%c12] : !vm.buffer -> i32
-    %e3 = vm.const.i32 0x80000000 : i32
+    %e3 = vm.const.i32 0x80000000
     vm.check.eq %v3, %e3, "0x80000000" : i32
     %v4 = vm.buffer.load.i32 %rodata[%c16] : !vm.buffer -> i32
-    %e4 = vm.const.i32 0xFFFFFFFF : i32
+    %e4 = vm.const.i32 0xFFFFFFFF
     vm.check.eq %v4, %e4, "0xFFFFFFFF" : i32
     vm.return
   }
@@ -501,9 +501,9 @@ vm.module @buffer_ops {
     %rodata = vm.const.ref.rodata @test_load_i32_unaligned_data : !vm.buffer
 
     // Byte offset 5 rounded to byte offset 4 (element 1).
-    %c5 = vm.const.i32 5 : i32
+    %c5 = vm.const.i32 5
     %v1 = vm.buffer.load.i32 %rodata[%c5] : !vm.buffer -> i32
-    %e1 = vm.const.i32 0x44556677 : i32
+    %e1 = vm.const.i32 0x44556677
     vm.check.eq %v1, %e1, "0x44556677" : i32
 
     vm.return
@@ -524,20 +524,20 @@ vm.module @buffer_ops {
     %buf = vm.buffer.alloc %ref_length : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
-    %c0 = vm.const.i32 0 : i32
-    %e0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
+    %e0 = vm.const.i32 0
     vm.buffer.store.i8 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
-    %c1 = vm.const.i32 1 : i32
-    %e1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
+    %e1 = vm.const.i32 1
     vm.buffer.store.i8 %e1, %buf_dno[%c1] : i32 -> !vm.buffer
-    %c2 = vm.const.i32 2 : i32
-    %e2 = vm.const.i32 0x7F : i32
+    %c2 = vm.const.i32 2
+    %e2 = vm.const.i32 0x7F
     vm.buffer.store.i8 %e2, %buf_dno[%c2] : i32 -> !vm.buffer
-    %c3 = vm.const.i32 3 : i32
-    %e3 = vm.const.i32 0x80 : i32
+    %c3 = vm.const.i32 3
+    %e3 = vm.const.i32 0x80
     vm.buffer.store.i8 %e3, %buf_dno[%c3] : i32 -> !vm.buffer
-    %c4 = vm.const.i32 4 : i32
-    %e4 = vm.const.i32 0xFF : i32
+    %c4 = vm.const.i32 4
+    %e4 = vm.const.i32 0xFF
     vm.buffer.store.i8 %e4, %buf_dno[%c4] : i32 -> !vm.buffer
 
     %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
@@ -557,20 +557,20 @@ vm.module @buffer_ops {
     %buf = vm.buffer.alloc %ref_length : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
-    %c0 = vm.const.i32 0 : i32
-    %e0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
+    %e0 = vm.const.i32 0
     vm.buffer.store.i16 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
-    %c2 = vm.const.i32 2 : i32
-    %e1 = vm.const.i32 1 : i32
+    %c2 = vm.const.i32 2
+    %e1 = vm.const.i32 1
     vm.buffer.store.i16 %e1, %buf_dno[%c2] : i32 -> !vm.buffer
-    %c4 = vm.const.i32 4 : i32
-    %e2 = vm.const.i32 0x7FFF : i32
+    %c4 = vm.const.i32 4
+    %e2 = vm.const.i32 0x7FFF
     vm.buffer.store.i16 %e2, %buf_dno[%c4] : i32 -> !vm.buffer
-    %c6 = vm.const.i32 6 : i32
-    %e3 = vm.const.i32 0x8000 : i32
+    %c6 = vm.const.i32 6
+    %e3 = vm.const.i32 0x8000
     vm.buffer.store.i16 %e3, %buf_dno[%c6] : i32 -> !vm.buffer
-    %c8 = vm.const.i32 8 : i32
-    %e4 = vm.const.i32 0xFFFF : i32
+    %c8 = vm.const.i32 8
+    %e4 = vm.const.i32 0xFFFF
     vm.buffer.store.i16 %e4, %buf_dno[%c8] : i32 -> !vm.buffer
 
     %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
@@ -590,20 +590,20 @@ vm.module @buffer_ops {
     %buf = vm.buffer.alloc %ref_length : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
-    %c0 = vm.const.i32 0 : i32
-    %e0 = vm.const.i32 0 : i32
+    %c0 = vm.const.i32 0
+    %e0 = vm.const.i32 0
     vm.buffer.store.i32 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
-    %c4 = vm.const.i32 4 : i32
-    %e1 = vm.const.i32 1 : i32
+    %c4 = vm.const.i32 4
+    %e1 = vm.const.i32 1
     vm.buffer.store.i32 %e1, %buf_dno[%c4] : i32 -> !vm.buffer
-    %c8 = vm.const.i32 8 : i32
-    %e2 = vm.const.i32 0x7FFFFFFF : i32
+    %c8 = vm.const.i32 8
+    %e2 = vm.const.i32 0x7FFFFFFF
     vm.buffer.store.i32 %e2, %buf_dno[%c8] : i32 -> !vm.buffer
-    %c12 = vm.const.i32 12 : i32
-    %e3 = vm.const.i32 0x80000000 : i32
+    %c12 = vm.const.i32 12
+    %e3 = vm.const.i32 0x80000000
     vm.buffer.store.i32 %e3, %buf_dno[%c12] : i32 -> !vm.buffer
-    %c16 = vm.const.i32 16 : i32
-    %e4 = vm.const.i32 0xFFFFFFFF : i32
+    %c16 = vm.const.i32 16
+    %e4 = vm.const.i32 0xFFFFFFFF
     vm.buffer.store.i32 %e4, %buf_dno[%c16] : i32 -> !vm.buffer
 
     %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
@@ -615,17 +615,17 @@ vm.module @buffer_ops {
   // Unaligned stores are not supported and offsets will be rounded down.
   vm.export @test_store_i32_unaligned attributes {emitc.exclude}
   vm.func private @test_store_i32_unaligned() {
-    %c12 = vm.const.i32 12 : i32
+    %c12 = vm.const.i32 12
     %buf = vm.buffer.alloc %c12 : !vm.buffer
     %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
 
     // Byte offset 5 rounded to byte offset 4 (element 1).
-    %c5 = vm.const.i32 5 : i32
-    %e1 = vm.const.i32 0x44556677 : i32
+    %c5 = vm.const.i32 5
+    %e1 = vm.const.i32 0x44556677
     vm.buffer.store.i32 %e1, %buf_dno[%c5] : i32 -> !vm.buffer
 
     // Read back at offset 4 (where the data should be).
-    %c4 = vm.const.i32 4 : i32
+    %c4 = vm.const.i32 4
     %a1 = vm.buffer.load.i32 %buf_dno[%c4] : !vm.buffer -> i32
     vm.check.eq %a1, %e1, "0x44556677" : i32
 

--- a/iree/vm/test/call_ops.mlir
+++ b/iree/vm/test/call_ops.mlir
@@ -10,7 +10,7 @@ vm.module @call_ops {
 
   vm.export @test_call_i_v
   vm.func @test_call_i_v() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.call @_i_v(%c1) : (i32) -> ()
     vm.return
   }
@@ -52,7 +52,7 @@ vm.module @call_ops {
 
   vm.export @test_call_v_i
   vm.func @test_call_v_i() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %0 = vm.call @_v_i() : () -> (i32)
     vm.check.eq %0, %c1, "_v_i()=1" : i32
     vm.return
@@ -69,8 +69,8 @@ vm.module @call_ops {
 
   vm.export @test_call_v_ii
   vm.func @test_call_v_ii() {
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
     %0:2 = vm.call @_v_ii() : () -> (i32, i32)
     vm.check.eq %0#0, %c1, "_v_ii()#0=1" : i32
     vm.check.eq %0#1, %c2, "_v_ii()#1=2" : i32
@@ -84,7 +84,7 @@ vm.module @call_ops {
   }
 
   vm.func @_i_v(%arg : i32) attributes {noinline} {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.check.eq %arg, %c1, "Expected %arg to be 1" : i32
     vm.return
   }
@@ -112,7 +112,7 @@ vm.module @call_ops {
   }
 
   vm.func @_v_i() -> i32 attributes {noinline} {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.return %c1 : i32
   }
 
@@ -122,8 +122,8 @@ vm.module @call_ops {
   }
 
   vm.func @_v_ii() -> (i32, i32) attributes {noinline} {
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
     vm.return %c1, %c2 : i32, i32
   }
 
@@ -132,7 +132,7 @@ vm.module @call_ops {
   }
 
   vm.func @_v_v_fail() attributes {noinline} {
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     vm.fail %c2
   }
 

--- a/iree/vm/test/comparison_ops.mlir
+++ b/iree/vm/test/comparison_ops.mlir
@@ -6,24 +6,24 @@ vm.module @comparison_ops {
 
   vm.export @test_cmp_lt_s_0
   vm.func @test_cmp_lt_s_0() {
-    %lhs = vm.const.i32 2 : i32
+    %lhs = vm.const.i32 2
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 -2 : i32
+    %rhs = vm.const.i32 -2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "2 < -2" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_s_1
   vm.func @test_cmp_lt_s_1() {
-    %lhs = vm.const.i32 -2 : i32
+    %lhs = vm.const.i32 -2
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 2 : i32
+    %rhs = vm.const.i32 2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "-2 < 2" : i32
     vm.return
   }
@@ -31,12 +31,12 @@ vm.module @comparison_ops {
   // Expect UINT_MAX to be interpreted as -1 when doing a signed compare.
   vm.export @test_cmp_lt_s_2
   vm.func @test_cmp_lt_s_2() {
-    %lhs = vm.const.i32 4294967295 : i32
+    %lhs = vm.const.i32 4294967295
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 2 : i32
+    %rhs = vm.const.i32 2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "4294967295 (UINT_MAX) < 2" : i32
     vm.return
   }
@@ -47,36 +47,36 @@ vm.module @comparison_ops {
 
   vm.export @test_cmp_lt_u_0
   vm.func @test_cmp_lt_u_0() {
-    %lhs = vm.const.i32 2 : i32
+    %lhs = vm.const.i32 2
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 -2 : i32
+    %rhs = vm.const.i32 -2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "2 < -2 (as unsigned)" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_u_1
   vm.func @test_cmp_lt_u_1() {
-    %lhs = vm.const.i32 -2 : i32
+    %lhs = vm.const.i32 -2
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 2 : i32
+    %rhs = vm.const.i32 2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "-2 < 2 (as unsigned)" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_u_2
   vm.func @test_cmp_lt_u_2() {
-    %lhs = vm.const.i32 4294967295 : i32
+    %lhs = vm.const.i32 4294967295
     %lhs_dno = util.do_not_optimize(%lhs) : i32
-    %rhs = vm.const.i32 2 : i32
+    %rhs = vm.const.i32 2
     %rhs_dno = util.do_not_optimize(%rhs) : i32
     %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "4294967295 (UINT_MAX) < 2 (as unsigned)" : i32
     vm.return
   }
@@ -90,12 +90,12 @@ vm.module @comparison_ops {
 
   vm.export @test_cmp_lte
   vm.func @test_cmp_lte() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i32 -2 : i32
+    %cn2 = vm.const.i32 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2_dno = util.do_not_optimize(%c2) : i32
 
     %cmp_0 = vm.cmp.lte.i32.s %cn2_dno, %c2_dno : i32
@@ -117,12 +117,12 @@ vm.module @comparison_ops {
 
   vm.export @test_cmp_gt
   vm.func @test_cmp_gt() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i32 -2 : i32
+    %cn2 = vm.const.i32 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2_dno = util.do_not_optimize(%c2) : i32
 
     %cmp_0 = vm.cmp.gt.i32.s %cn2_dno, %c2_dno : i32
@@ -144,12 +144,12 @@ vm.module @comparison_ops {
 
   vm.export @test_cmp_gte
   vm.func @test_cmp_gte() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i32 -2 : i32
+    %cn2 = vm.const.i32 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %c2_dno = util.do_not_optimize(%c2) : i32
 
     %cmp_0 = vm.cmp.gte.i32.s %cn2_dno, %c2_dno : i32

--- a/iree/vm/test/comparison_ops_f32.mlir
+++ b/iree/vm/test/comparison_ops_f32.mlir
@@ -6,24 +6,24 @@ vm.module @comparison_ops_f32 {
 
   vm.export @test_cmp_lt_0_f32
   vm.func @test_cmp_lt_0_f32() {
-    %lhs = vm.const.f32 4.0 : f32
+    %lhs = vm.const.f32 4.0
     %lhs_dno = util.do_not_optimize(%lhs) : f32
-    %rhs = vm.const.f32 -4.0 : f32
+    %rhs = vm.const.f32 -4.0
     %rhs_dno = util.do_not_optimize(%rhs) : f32
     %actual = vm.cmp.lt.f32.o %lhs_dno, %rhs_dno : f32
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "4.0 < -4.0" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_1_f32
   vm.func @test_cmp_lt_1_f32() {
-    %lhs = vm.const.f32 -4.0 : f32
+    %lhs = vm.const.f32 -4.0
     %lhs_dno = util.do_not_optimize(%lhs) : f32
-    %rhs = vm.const.f32 4.0 : f32
+    %rhs = vm.const.f32 4.0
     %rhs_dno = util.do_not_optimize(%rhs) : f32
     %actual = vm.cmp.lt.f32.o %lhs_dno, %rhs_dno : f32
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "-4.0 < 4.0" : i32
     vm.return
   }
@@ -37,12 +37,12 @@ vm.module @comparison_ops_f32 {
 
   vm.export @test_cmp_lte_f32
   vm.func @test_cmp_lte_f32() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.f32 -2.0 : f32
+    %cn2 = vm.const.f32 -2.0
     %cn2_dno = util.do_not_optimize(%cn2) : f32
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     %c2_dno = util.do_not_optimize(%c2) : f32
 
     %cmp_0 = vm.cmp.lte.f32.o %cn2_dno, %c2_dno : f32
@@ -57,12 +57,12 @@ vm.module @comparison_ops_f32 {
 
   vm.export @test_cmp_gt_f32
   vm.func @test_cmp_gt_f32() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.f32 -2.0 : f32
+    %cn2 = vm.const.f32 -2.0
     %cn2_dno = util.do_not_optimize(%cn2) : f32
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     %c2_dno = util.do_not_optimize(%c2) : f32
 
     %cmp_0 = vm.cmp.gt.f32.o %cn2_dno, %c2_dno : f32
@@ -77,12 +77,12 @@ vm.module @comparison_ops_f32 {
 
   vm.export @test_cmp_gte_f32
   vm.func @test_cmp_gte_f32() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.f32 -2.0 : f32
+    %cn2 = vm.const.f32 -2.0
     %cn2_dno = util.do_not_optimize(%cn2) : f32
-    %c2 = vm.const.f32 2.0 : f32
+    %c2 = vm.const.f32 2.0
     %c2_dno = util.do_not_optimize(%c2) : f32
 
     %cmp_0 = vm.cmp.gte.f32.o %cn2_dno, %c2_dno : f32

--- a/iree/vm/test/comparison_ops_i64.mlir
+++ b/iree/vm/test/comparison_ops_i64.mlir
@@ -6,24 +6,24 @@ vm.module @comparison_ops_i64 {
 
   vm.export @test_cmp_lt_s_0_i64
   vm.func @test_cmp_lt_s_0_i64() {
-    %lhs = vm.const.i64 4294967295 : i64
+    %lhs = vm.const.i64 4294967295
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 -4294967295 : i64
+    %rhs = vm.const.i64 -4294967295
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.s %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "4294967295 (UINT_MAX) < -4294967295 (UINT_MAX)" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_s_1_i64
   vm.func @test_cmp_lt_s_1_i64() {
-    %lhs = vm.const.i64 -4294967295 : i64
+    %lhs = vm.const.i64 -4294967295
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 4294967295 : i64
+    %rhs = vm.const.i64 4294967295
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.s %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "-4294967295 (UINT_MAX) < 4294967295 (UINT_MAX)" : i32
     vm.return
   }
@@ -31,12 +31,12 @@ vm.module @comparison_ops_i64 {
   // Expect ULONG_MAX to be interpreted as -1 when doing a signed compare.
   vm.export @test_cmp_lt_s_2_i64
   vm.func @test_cmp_lt_s_2_i64() {
-    %lhs = vm.const.i64 18446744073709551615 : i64
+    %lhs = vm.const.i64 18446744073709551615
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 2 : i64
+    %rhs = vm.const.i64 2
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.s %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "18446744073709551615 (ULONG_MAX) < 2" : i32
     vm.return
   }
@@ -47,36 +47,36 @@ vm.module @comparison_ops_i64 {
 
   vm.export @test_cmp_lt_u_0_i64
   vm.func @test_cmp_lt_u_0_i64() {
-    %lhs = vm.const.i64 2 : i64
+    %lhs = vm.const.i64 2
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 -2 : i64
+    %rhs = vm.const.i64 -2
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.u %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 1 : i32
+    %expected = vm.const.i32 1
     vm.check.eq %actual, %expected, "2 < -2 (as unsigned)" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_u_1_i64
   vm.func @test_cmp_lt_u_1_i64() {
-    %lhs = vm.const.i64 -2 : i64
+    %lhs = vm.const.i64 -2
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 2 : i64
+    %rhs = vm.const.i64 2
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.u %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "-2 < 2 (as unsigned)" : i32
     vm.return
   }
 
   vm.export @test_cmp_lt_u_2_i64
   vm.func @test_cmp_lt_u_2_i64() {
-    %lhs = vm.const.i64 18446744073709551615 : i64
+    %lhs = vm.const.i64 18446744073709551615
     %lhs_dno = util.do_not_optimize(%lhs) : i64
-    %rhs = vm.const.i64 2 : i64
+    %rhs = vm.const.i64 2
     %rhs_dno = util.do_not_optimize(%rhs) : i64
     %actual = vm.cmp.lt.i64.u %lhs_dno, %rhs_dno : i64
-    %expected = vm.const.i32 0 : i32
+    %expected = vm.const.i32 0
     vm.check.eq %actual, %expected, "18446744073709551615 (ULONG_MAX) < 2 (as unsigned)" : i32
     vm.return
   }
@@ -90,12 +90,12 @@ vm.module @comparison_ops_i64 {
 
   vm.export @test_cmp_lte_i64
   vm.func @test_cmp_lte_i64() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i64 -2 : i64
+    %cn2 = vm.const.i64 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2_dno = util.do_not_optimize(%c2) : i64
 
     %cmp_0 = vm.cmp.lte.i64.s %cn2_dno, %c2_dno : i64
@@ -117,12 +117,12 @@ vm.module @comparison_ops_i64 {
 
   vm.export @test_cmp_gt_i64
   vm.func @test_cmp_gt_i64() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i64 -2 : i64
+    %cn2 = vm.const.i64 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2_dno = util.do_not_optimize(%c2) : i64
 
     %cmp_0 = vm.cmp.gt.i64.s %cn2_dno, %c2_dno : i64
@@ -144,12 +144,12 @@ vm.module @comparison_ops_i64 {
 
   vm.export @test_cmp_gte_i64
   vm.func @test_cmp_gte_i64() {
-    %true = vm.const.i32 1 : i32
-    %false = vm.const.i32 0 : i32
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
 
-    %cn2 = vm.const.i64 -2 : i64
+    %cn2 = vm.const.i64 -2
     %cn2_dno = util.do_not_optimize(%cn2) : i64
-    %c2 = vm.const.i64 2 : i64
+    %c2 = vm.const.i64 2
     %c2_dno = util.do_not_optimize(%c2) : i64
 
     %cmp_0 = vm.cmp.gte.i64.s %cn2_dno, %c2_dno : i64

--- a/iree/vm/test/control_flow_ops.mlir
+++ b/iree/vm/test/control_flow_ops.mlir
@@ -15,7 +15,7 @@ vm.module @control_flow_ops {
 
   vm.export @fail_always
   vm.func @fail_always() {
-    %code = vm.const.i32 4 : i32
+    %code = vm.const.i32 4
     vm.fail %code, "error!"
   }
 
@@ -25,7 +25,7 @@ vm.module @control_flow_ops {
 
   vm.export @test_check_eq_always
   vm.func @test_check_eq_always() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     vm.check.eq %c1, %c1dno, "error!" : i32
     vm.return
@@ -33,8 +33,8 @@ vm.module @control_flow_ops {
 
   vm.export @fail_check_eq_never
   vm.func @fail_check_eq_never() {
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
     %c1dno = util.do_not_optimize(%c1) : i32
     %c2dno = util.do_not_optimize(%c2) : i32
     vm.check.eq %c1dno, %c2dno, "error!" : i32
@@ -47,33 +47,33 @@ vm.module @control_flow_ops {
 
   vm.export @test_cond_br
   vm.func @test_cond_br() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     vm.cond_br %c1dno, ^bb1, ^bb2
   ^bb1:
     vm.check.eq %c1dno, %c1dno, "error!" : i32
     vm.return
   ^bb2:
-    %code = vm.const.i32 4 : i32
+    %code = vm.const.i32 4
     vm.fail %code, "unreachable!"
   }
 
   vm.export @test_cond_br_int_arg
   vm.func @test_cond_br_int_arg() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     vm.cond_br %c1dno, ^bb1(%c1dno : i32), ^bb2(%c1dno : i32)
   ^bb1(%arg1 : i32):
     vm.check.eq %arg1, %c1dno, "error!" : i32
     vm.return
   ^bb2(%arg2 : i32):
-    %code = vm.const.i32 4 : i32
+    %code = vm.const.i32 4
     vm.fail %code, "unreachable!"
   }
 
   vm.export @test_cond_br_ref_arg
   vm.func @test_cond_br_ref_arg() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
     %ref = vm.const.ref.zero : !vm.ref<?>
     vm.cond_br %c1dno, ^bb1(%ref : !vm.ref<?>), ^bb2(%ref : !vm.ref<?>)
@@ -81,7 +81,7 @@ vm.module @control_flow_ops {
     vm.check.eq %arg1, %ref, "error!" : !vm.ref<?>
     vm.return
   ^bb2(%arg2 : !vm.ref<?>):
-    %code = vm.const.i32 4 : i32
+    %code = vm.const.i32 4
     vm.fail %code, "unreachable!"
   }
 

--- a/iree/vm/test/conversion_ops.mlir
+++ b/iree/vm/test/conversion_ops.mlir
@@ -6,20 +6,20 @@ vm.module @conversion_ops {
 
   vm.export @test_trunc_i32_i8
   vm.func @test_trunc_i32_i8() {
-    %c1 = vm.const.i32 2147483647 : i32
+    %c1 = vm.const.i32 2147483647
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.trunc.i32.i8 %c1dno : i32 -> i32
-    %c2 = vm.const.i32 255 : i32
+    %c2 = vm.const.i32 255
     vm.check.eq %v, %c2, "truncate unsigned i32 to unsigned i8" : i32
     vm.return
   }
 
   vm.export @test_trunc_i32_i16
   vm.func @test_trunc_i32_i16() {
-    %c1 = vm.const.i32 2147483647 : i32
+    %c1 = vm.const.i32 2147483647
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.trunc.i32.i16 %c1dno : i32 -> i32
-    %c2 = vm.const.i32 65535 : i32
+    %c2 = vm.const.i32 65535
     vm.check.eq %v, %c2, "truncate unsigned i32 to unsigned i16" : i32
     vm.return
   }

--- a/iree/vm/test/conversion_ops_f32.mlir
+++ b/iree/vm/test/conversion_ops_f32.mlir
@@ -7,10 +7,10 @@ vm.module @conversion_ops_f32 {
   // 5.5 f32 (0x40b00000 hex) -> 1085276160 int32
   vm.export @test_bitcast_i32_f32
   vm.func @test_bitcast_i32_f32() {
-    %c1 = vm.const.i32 1085276160 : i32
+    %c1 = vm.const.i32 1085276160
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.bitcast.i32.f32 %c1dno : i32 -> f32
-    %c2 = vm.const.f32 5.5 : f32
+    %c2 = vm.const.f32 5.5
     vm.check.eq %v, %c2, "bitcast i32 to f32" : f32
     vm.return
   }
@@ -18,100 +18,100 @@ vm.module @conversion_ops_f32 {
   // 1085276160 int32 (0x40b00000 hex) -> 5.5 f32
   vm.export @test_bitcast_f32_i32
   vm.func @test_bitcast_f32_i32() {
-    %c1 = vm.const.f32 5.5 : f32
+    %c1 = vm.const.f32 5.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.bitcast.f32.i32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 1085276160 : i32
+    %c2 = vm.const.i32 1085276160
     vm.check.eq %v, %c2, "bitcast f32 to i32" : i32
     vm.return
   }
 
   vm.export @test_cast_si32_f32_int_max
   vm.func @test_cast_si32_f32_int_max() {
-    %c1 = vm.const.i32 2147483647 : i32
+    %c1 = vm.const.i32 2147483647
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.cast.si32.f32 %c1dno : i32 -> f32
-    %c2 = vm.const.f32 2147483647.0 : f32
+    %c2 = vm.const.f32 2147483647.0
     vm.check.eq %v, %c2, "cast signed integer to a floating-point value" : f32
     vm.return
   }
 
   vm.export @test_cast_si32_f32_int_min
   vm.func @test_cast_si32_f32_int_min() {
-    %c1 = vm.const.i32 -2147483648 : i32
+    %c1 = vm.const.i32 -2147483648
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.cast.si32.f32 %c1dno : i32 -> f32
-    %c2 = vm.const.f32 -2147483648.0 : f32
+    %c2 = vm.const.f32 -2147483648.0
     vm.check.eq %v, %c2, "cast signed integer to a floating-point value" : f32
     vm.return
   }
 
   vm.export @test_cast_ui32_f32_int_max
   vm.func @test_cast_ui32_f32_int_max() {
-    %c1 = vm.const.i32 4294967295 : i32
+    %c1 = vm.const.i32 4294967295
     %c1dno = util.do_not_optimize(%c1) : i32
     %v = vm.cast.ui32.f32 %c1dno : i32 -> f32
-    %c2 = vm.const.f32 4294967295.0 : f32
+    %c2 = vm.const.f32 4294967295.0
     vm.check.eq %v, %c2, "cast unsigned integer to a floating-point value" : f32
     vm.return
   }
 
   vm.export @test_cast_f32_si32_int_max
   vm.func @test_cast_f32_si32_int_max() {
-    %c1 = vm.const.f32 2147483647.0 : f32
+    %c1 = vm.const.f32 2147483647.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 -2147483648 : i32
+    %c2 = vm.const.i32 -2147483648
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
 
   vm.export @test_cast_f32_si32_int_min
   vm.func @test_cast_f32_si32_int_min() {
-    %c1 = vm.const.f32 -2147483648.0 : f32
+    %c1 = vm.const.f32 -2147483648.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 -2147483648 : i32
+    %c2 = vm.const.i32 -2147483648
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
 
   vm.export @test_cast_f32_si32_away_from_zero_pos
   vm.func @test_cast_f32_si32_away_from_zero_pos() {
-    %c1 = vm.const.f32 2.5 : f32
+    %c1 = vm.const.f32 2.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 3 : i32
+    %c2 = vm.const.i32 3
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
 
   vm.export @test_cast_f32_si32_away_from_zero_neg
   vm.func @test_cast_f32_si32_away_from_zero_neg() {
-    %c1 = vm.const.f32 -2.5 : f32
+    %c1 = vm.const.f32 -2.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.si32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 -3 : i32
+    %c2 = vm.const.i32 -3
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }
 
   vm.export @test_cast_f32_ui32_int_max
   vm.func @test_cast_f32_ui32_int_max() {
-    %c1 = vm.const.f32 4294967295.0 : f32
+    %c1 = vm.const.f32 4294967295.0
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.ui32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 0 : i32
+    %c2 = vm.const.i32 0
     vm.check.eq %v, %c2, "cast floating-point value to an unsigned integer" : i32
     vm.return
   }
 
   vm.export @test_cast_f32_ui32_away_from_zero
   vm.func @test_cast_f32_ui32_away_from_zero() {
-    %c1 = vm.const.f32 2.5 : f32
+    %c1 = vm.const.f32 2.5
     %c1dno = util.do_not_optimize(%c1) : f32
     %v = vm.cast.f32.ui32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 3 : i32
+    %c2 = vm.const.i32 3
     vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i32
     vm.return
   }

--- a/iree/vm/test/conversion_ops_i64.mlir
+++ b/iree/vm/test/conversion_ops_i64.mlir
@@ -6,10 +6,10 @@ vm.module @conversion_ops_i64 {
 
   vm.export @test_trunc_i64_i32
   vm.func @test_trunc_i64_i32() {
-    %c1 = vm.const.i64 9223372036854775807 : i64
+    %c1 = vm.const.i64 9223372036854775807
     %c1dno = util.do_not_optimize(%c1) : i64
     %v = vm.trunc.i64.i32 %c1dno : i64 -> i32
-    %c2 = vm.const.i32 4294967295 : i32
+    %c2 = vm.const.i32 4294967295
     vm.check.eq %v, %c2, "truncate unsigned i64 to unsigned i32" : i32
     vm.return
   }

--- a/iree/vm/test/global_ops.mlir
+++ b/iree/vm/test/global_ops.mlir
@@ -15,7 +15,7 @@ vm.module @global_ops {
   vm.export @test_global_load_i32
   vm.func @test_global_load_i32() {
     %actual = vm.global.load.i32 @c42 : i32
-    %expected = vm.const.i32 42 : i32
+    %expected = vm.const.i32 42
     vm.check.eq %actual, %expected, "@c42 != 42" : i32
     vm.return
   }
@@ -31,7 +31,7 @@ vm.module @global_ops {
 
   vm.export @test_global_store_i32
   vm.func @test_global_store_i32() {
-    %c17 = vm.const.i32 17 : i32
+    %c17 = vm.const.i32 17
     vm.global.store.i32 %c17, @c107_mut : i32
     %actual = vm.global.load.i32 @c107_mut : i32
     vm.check.eq %actual, %c17, "@c107_mut != 17" : i32

--- a/iree/vm/test/global_ops_f32.mlir
+++ b/iree/vm/test/global_ops_f32.mlir
@@ -11,14 +11,14 @@ vm.module @global_ops_f32 {
   vm.export @test_global_load_f32
   vm.func @test_global_load_f32() {
     %actual = vm.global.load.f32 @c42 : f32
-    %expected = vm.const.f32 42.5 : f32
+    %expected = vm.const.f32 42.5
     vm.check.eq %actual, %expected, "@c42 != 42.5" : f32
     vm.return
   }
 
   vm.export @test_global_store_f32
   vm.func @test_global_store_f32() {
-    %c17 = vm.const.f32 17.5 : f32
+    %c17 = vm.const.f32 17.5
     vm.global.store.f32 %c17, @c107_mut : f32
     %actual = vm.global.load.f32 @c107_mut : f32
     vm.check.eq %actual, %c17, "@c107_mut != 17.5" : f32

--- a/iree/vm/test/global_ops_i64.mlir
+++ b/iree/vm/test/global_ops_i64.mlir
@@ -11,14 +11,14 @@ vm.module @global_ops_i64 {
   vm.export @test_global_load_i64
   vm.func @test_global_load_i64() {
     %actual = vm.global.load.i64 @c42 : i64
-    %expected = vm.const.i64 42 : i64
+    %expected = vm.const.i64 42
     vm.check.eq %actual, %expected, "@c42 != 42" : i64
     vm.return
   }
 
   vm.export @test_global_store_i64
   vm.func @test_global_store_i64() {
-    %c17 = vm.const.i64 17 : i64
+    %c17 = vm.const.i64 17
     vm.global.store.i64 %c17, @c107_mut : i64
     %actual = vm.global.load.i64 @c107_mut : i64
     vm.check.eq %actual, %c17, "@c107_mut != 17" : i64

--- a/iree/vm/test/list_ops.mlir
+++ b/iree/vm/test/list_ops.mlir
@@ -6,9 +6,9 @@ vm.module @list_ops {
 
   vm.export @test_i8
   vm.func @test_i8() {
-    %c42 = vm.const.i32 42 : i32
-    %c100 = vm.const.i32 100 : i32
-    %c0 = vm.const.i32 0 : i32
+    %c42 = vm.const.i32 42
+    %c100 = vm.const.i32 100
+    %c0 = vm.const.i32 0
     %list = vm.list.alloc %c42 : (i32) -> !vm.list<i8>
     vm.list.reserve %list, %c100 : (!vm.list<i8>, i32)
     %sz = vm.list.size %list : (!vm.list<i8>) -> i32
@@ -23,9 +23,9 @@ vm.module @list_ops {
 
   vm.export @test_i16
   vm.func @test_i16() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c27 = vm.const.i32 27 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c27 = vm.const.i32 27
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<i16>
     vm.list.resize %list, %c1 : (!vm.list<i16>, i32)
     vm.list.set.i32 %list, %c0, %c27 : (!vm.list<i16>, i32, i32)
@@ -40,11 +40,11 @@ vm.module @list_ops {
 
   vm.export @test_i32
   vm.func @test_i32() {
-    %c42 = vm.const.i32 42 : i32
+    %c42 = vm.const.i32 42
     %list = vm.list.alloc %c42 : (i32) -> !vm.list<i32>
     %sz = vm.list.size %list : (!vm.list<i32>) -> i32
-    %c100 = vm.const.i32 100 : i32
-    %c101 = vm.const.i32 101 : i32
+    %c100 = vm.const.i32 100
+    %c101 = vm.const.i32 101
     vm.list.resize %list, %c101 : (!vm.list<i32>, i32)
     vm.list.set.i32 %list, %c100, %c42 : (!vm.list<i32>, i32, i32)
     %v = vm.list.get.i32 %list, %c100 : (!vm.list<i32>, i32) -> i32
@@ -68,10 +68,10 @@ vm.module @list_ops {
 
   vm.export @test_multiple_lists
   vm.func @test_multiple_lists() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c27 = vm.const.i32 27 : i32
-    %c42 = vm.const.i32 42 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c27 = vm.const.i32 27
+    %c42 = vm.const.i32 42
 
     // These allocs shouldn't be CSE'd.
     %list0 = vm.list.alloc %c1 : (i32) -> !vm.list<i8>
@@ -94,8 +94,8 @@ vm.module @list_ops {
 
   vm.export @fail_uninitialized_access
   vm.func @fail_uninitialized_access() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<i32>
     vm.list.set.i32 %list, %c0, %c1 : (!vm.list<i32>, i32, i32)
     vm.return
@@ -103,7 +103,7 @@ vm.module @list_ops {
 
   vm.export @fail_out_of_bounds_read
   vm.func @fail_out_of_bounds_read() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<i32>
     vm.list.resize %list, %c1 : (!vm.list<i32>, i32)
     %v = vm.list.get.i32 %list, %c1 : (!vm.list<i32>, i32) -> i32
@@ -115,7 +115,7 @@ vm.module @list_ops {
 
   vm.export @fail_out_of_bounds_write
   vm.func @fail_out_of_bounds_write() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<i32>
     vm.list.resize %list, %c1 : (!vm.list<i32>, i32)
     vm.list.set.i32 %list, %c1, %c1 : (!vm.list<i32>, i32, i32)

--- a/iree/vm/test/list_ops_i64.mlir
+++ b/iree/vm/test/list_ops_i64.mlir
@@ -6,9 +6,9 @@ vm.module @list_ops_i64 {
 
   vm.export @test_i64
   vm.func @test_i64() {
-    %capacity = vm.const.i32 42 : i32
-    %index = vm.const.i32 41 : i32
-    %max_int_plus_1 = vm.const.i64 2147483648 : i64
+    %capacity = vm.const.i32 42
+    %index = vm.const.i32 41
+    %max_int_plus_1 = vm.const.i64 2147483648
     %list = vm.list.alloc %capacity : (i32) -> !vm.list<i64>
     %sz = vm.list.size %list : (!vm.list<i64>) -> i32
     vm.list.resize %list, %capacity : (!vm.list<i64>, i32)

--- a/iree/vm/test/list_variant_ops.mlir
+++ b/iree/vm/test/list_variant_ops.mlir
@@ -6,13 +6,13 @@ vm.module @list_variant_ops {
 
   vm.export @test_listception
   vm.func @test_listception() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
-    %c2 = vm.const.i32 2 : i32
-    %c3 = vm.const.i32 3 : i32
-    %c100 = vm.const.i32 100 : i32
-    %c101 = vm.const.i32 101 : i32
-    %c102 = vm.const.i32 102 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
+    %c2 = vm.const.i32 2
+    %c3 = vm.const.i32 3
+    %c100 = vm.const.i32 100
+    %c101 = vm.const.i32 101
+    %c102 = vm.const.i32 102
 
     // [100, 101, 102]
     %inner0 = vm.list.alloc %c3 : (i32) -> !vm.list<i32>
@@ -29,7 +29,7 @@ vm.module @list_variant_ops {
     vm.list.set.i32 %inner1, %c2, %c100 : (!vm.list<i32>, i32, i32)
 
     // [ [100, 101, 102], [102, 101, 100] ]
-    %capacity = vm.const.i32 8 : i32
+    %capacity = vm.const.i32 8
     %outer = vm.list.alloc %capacity : (i32) -> !vm.list<!vm.list<i32>>
     vm.list.resize %outer, %c2 : (!vm.list<!vm.list<i32>>, i32)
     vm.list.set.ref %outer, %c0, %inner0 : (!vm.list<!vm.list<i32>>, i32, !vm.list<i32>)
@@ -56,25 +56,25 @@ vm.module @list_variant_ops {
 
   vm.export @test_variant
   vm.func @test_variant() {
-    %capacity = vm.const.i32 42 : i32
+    %capacity = vm.const.i32 42
     %list = vm.list.alloc %capacity : (i32) -> !vm.list<?>
     vm.list.resize %list, %capacity : (!vm.list<?>, i32)
 
     // Access element 10 as an i32.
-    %c10 = vm.const.i32 10 : i32
-    %v10_i32 = vm.const.i32 1234 : i32
+    %c10 = vm.const.i32 10
+    %v10_i32 = vm.const.i32 1234
     vm.list.set.i32 %list, %c10, %v10_i32 : (!vm.list<?>, i32, i32)
     %e10_i32 = vm.list.get.i32 %list, %c10 : (!vm.list<?>, i32) -> i32
     vm.check.eq %e10_i32, %v10_i32 : i32
 
     // Access element 10 as an i64.
-    %v10_i64 = vm.const.i64 1234 : i64
+    %v10_i64 = vm.const.i64 1234
     vm.list.set.i64 %list, %c10, %v10_i64 : (!vm.list<?>, i32, i64)
     %e10_i64 = vm.list.get.i64 %list, %c10 : (!vm.list<?>, i32) -> i64
     vm.check.eq %e10_i64, %v10_i64 : i64
 
     // Access element 11 as a ref object.
-    %c11 = vm.const.i32 11 : i32
+    %c11 = vm.const.i32 11
     %v11_buf = vm.const.ref.rodata @byte_buffer : !vm.buffer
     vm.list.set.ref %list, %c11, %v11_buf : (!vm.list<?>, i32, !vm.buffer)
     %e11_buf = vm.list.get.ref %list, %c11 : (!vm.list<?>, i32) -> !vm.buffer
@@ -95,8 +95,8 @@ vm.module @list_variant_ops {
 
   vm.export @fail_uninitialized_access
   vm.func @fail_uninitialized_access() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
 
     %ref = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
@@ -107,7 +107,7 @@ vm.module @list_variant_ops {
 
   vm.export @fail_out_of_bounds_read
   vm.func @fail_out_of_bounds_read() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
 
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
     vm.list.resize %list, %c1 : (!vm.list<?>, i32)
@@ -119,8 +119,8 @@ vm.module @list_variant_ops {
 
   vm.export @fail_out_of_bounds_write
   vm.func @fail_out_of_bounds_write() {
-    %c0 = vm.const.i32 0 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c0 = vm.const.i32 0
+    %c1 = vm.const.i32 1
 
     %ref = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %list = vm.list.alloc %c1 : (i32) -> !vm.list<?>
@@ -132,14 +132,14 @@ vm.module @list_variant_ops {
 
   vm.export @fail_variant_slot_change
   vm.func @fail_variant_slot_change() {
-    %capacity = vm.const.i32 42 : i32
+    %capacity = vm.const.i32 42
     %list = vm.list.alloc %capacity : (i32) -> !vm.list<?>
     vm.list.resize %list, %capacity : (!vm.list<?>, i32)
 
-    %c10 = vm.const.i32 10 : i32
+    %c10 = vm.const.i32 10
 
     // Access element 10 as an i32.
-    %v10_i32 = vm.const.i32 1234 : i32
+    %v10_i32 = vm.const.i32 1234
     vm.list.set.i32 %list, %c10, %v10_i32 : (!vm.list<?>, i32, i32)
     %e10_i32 = vm.list.get.i32 %list, %c10 : (!vm.list<?>, i32) -> i32
     vm.check.eq %e10_i32, %v10_i32 : i32
@@ -154,7 +154,7 @@ vm.module @list_variant_ops {
     // TODO(benvanik): support type queries and/or make this silently return 0.
     %e10_any = vm.list.get.i32 %list, %c10 : (!vm.list<?>, i32) -> i32
     // -- FAILURE HERE --
-    %zero = vm.const.i32.zero : i32
+    %zero = vm.const.i32.zero
     vm.check.eq %e10_any, %zero : i32
 
     vm.return

--- a/iree/vm/test/shift_ops.mlir
+++ b/iree/vm/test/shift_ops.mlir
@@ -6,20 +6,20 @@ vm.module @shift_ops {
 
   vm.export @test_shl_i32
   vm.func @test_shl_i32() {
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     %c1dno = util.do_not_optimize(%c1) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %v = vm.shl.i32 %c1dno, %c2 : i32
-    %c4 = vm.const.i32 4 : i32
+    %c4 = vm.const.i32 4
     vm.check.eq %v, %c4, "1<<2=4" : i32
     vm.return
   }
 
   vm.export @test_shr_i32s
   vm.func @test_shr_i32s() {
-    %cn1 = vm.const.i32 -1 : i32
+    %cn1 = vm.const.i32 -1
     %cn1dno = util.do_not_optimize(%cn1) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %v = vm.shr.i32.s %cn1dno, %c2 : i32
     vm.check.eq %v, %cn1dno, "-1>>2=-1" : i32
     vm.return
@@ -27,11 +27,11 @@ vm.module @shift_ops {
 
   vm.export @test_shr_i32u
   vm.func @test_shr_i32u() {
-    %c4 = vm.const.i32 4 : i32
+    %c4 = vm.const.i32 4
     %c4dno = util.do_not_optimize(%c4) : i32
-    %c2 = vm.const.i32 2 : i32
+    %c2 = vm.const.i32 2
     %v = vm.shr.i32.u %c4dno, %c2 : i32
-    %c1 = vm.const.i32 1 : i32
+    %c1 = vm.const.i32 1
     vm.check.eq %v, %c1, "4>>2=1" : i32
     vm.return
   }

--- a/iree/vm/test/shift_ops_i64.mlir
+++ b/iree/vm/test/shift_ops_i64.mlir
@@ -6,33 +6,33 @@ vm.module @shift_ops_i64 {
 
   vm.export @test_shl_i64
   vm.func @test_shl_i64() {
-    %c1 = vm.const.i64 1 : i64
+    %c1 = vm.const.i64 1
     %c1dno = util.do_not_optimize(%c1) : i64
-    %shamt = vm.const.i32 2 : i32
+    %shamt = vm.const.i32 2
     %v = vm.shl.i64 %c1dno, %shamt : i64
-    %c4 = vm.const.i64 4 : i64
+    %c4 = vm.const.i64 4
     vm.check.eq %v, %c4, "1<<2=4" : i64
     vm.return
   }
 
   vm.export @test_shr_i64s
   vm.func @test_shr_i64s() {
-    %c1 = vm.const.i64 -1 : i64
+    %c1 = vm.const.i64 -1
     %c1dno = util.do_not_optimize(%c1) : i64
-    %shamt = vm.const.i32 2 : i32
+    %shamt = vm.const.i32 2
     %v = vm.shr.i64.s %c1dno, %shamt : i64
-    %cn1 = vm.const.i64 -1 : i64
+    %cn1 = vm.const.i64 -1
     vm.check.eq %v, %cn1, "-1>>2=-1" : i64
     vm.return
   }
 
   vm.export @test_shr_i64u
   vm.func @test_shr_i64u() {
-    %c4 = vm.const.i64 4 : i64
+    %c4 = vm.const.i64 4
     %c4dno = util.do_not_optimize(%c4) : i64
-    %shamt = vm.const.i32 2 : i32
+    %shamt = vm.const.i32 2
     %v = vm.shr.i64.u %c4dno, %shamt : i64
-    %c1 = vm.const.i64 1 : i64
+    %c1 = vm.const.i64 1
     vm.check.eq %v, %c1, "4>>2=1" : i64
     vm.return
   }


### PR DESCRIPTION
As part of this I noticed that integer ops were specced to handle
tensors of integeres as well as integers, but that that was used nowhere
in the codebase. Dropping that makes the type buildable and it can
therefore be omitted (consistent with float ops).
