### PR TITLE
Fix CODEOWNERS patterns for submodules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,9 @@
 /.gitmodules @GMNGeoffrey @ScottTodd @stellaraccident
 /third_party/ @GMNGeoffrey @ScottTodd @stellaraccident
 # Except for routinely-updated submodules
-/third_party/llvm-project/ @ghost
-/third_party/tensorflow/ @ghost
-/third_party/mlir-hlo/ @ghost
+/third_party/llvm-project @ghost
+/third_party/tensorflow @ghost
+/third_party/mlir-hlo @ghost
 
 # Bindings
 /bindings/python/ @stellaraccident


### PR DESCRIPTION
Git considers these files, not directories. Note that matches happen on
an entire path segment, so codeowners would still be set for a
hypothetical third_party/tensorflow_foo submodule.
