### PR TITLE
Update linalg_ext.sort op to require the dimension attribute.

### DIFF
--- a/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/integrations/tensorflow/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -149,18 +149,15 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     See https://www.tensorflow.org/xla/operation_semantics#sort.
   }];
 
-  // Define arguments and results like linalg.generic op. The attribute has the
-  // same definition as mhlo.sort::dimension. If the rank is greater than 1,
-  // the attribute must be set. If the rank is exacatly 1, the dimension is
-  // optional.
   let arguments = (ins Variadic<AnyType>:$inputs,
                        Variadic<AnyShaped>:$outputs,
-                       OptionalAttr<I64Attr>:$dimension
+                       I64Attr:$dimension
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    attr-dict (`dimension` `(` $dimension^ `)`)?
+    attr-dict
+    `dimension` `(` $dimension `)`
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
@@ -177,13 +174,6 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     }
     ArrayRef<int64_t> getOperandShape() {
       return getOperandType(0).getShape();
-    }
-    uint64_t getSortedDimension() {
-      uint64_t sortedDim = 0;
-      if (auto setSortedDim = dimension()) {
-        sortedDim = *setSortedDim;
-      }
-      return sortedDim;
     }
   }];
 }

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -436,8 +436,7 @@ SmallVector<unsigned> SortOp::getPartitionableLoops(
     unsigned maxNumParallelDims) {
   auto range = llvm::seq<unsigned>(0, getOperandRank());
   SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
-  partitionableLoops.erase(
-      std::next(partitionableLoops.begin(), dimension()));
+  partitionableLoops.erase(std::next(partitionableLoops.begin(), dimension()));
   if (partitionableLoops.size() > maxNumParallelDims) {
     partitionableLoops.erase(
         partitionableLoops.begin(),

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -369,18 +369,12 @@ static LogicalResult verifySortOp(SortOp op) {
   }
 
   int64_t rank = op.getOperandRank();
-  ArrayRef<int64_t> shape = op.getOperandShape();
-  if (rank > 1 && !op.dimensionAttr()) {
-    return op.emitOpError("dimension must be specified if rank > 1");
-  }
-  int dimension = 0;
-  if (op.dimensionAttr()) {
-    dimension = op.dimension().getValue();
-  }
-  if (dimension < 0 || dimension >= rank) {
+  int sortDim = op.dimension();
+  if (sortDim < 0 || sortDim >= rank) {
     return op.emitOpError("dimension must be within (0, ") << rank << "]";
   }
 
+  ArrayRef<int64_t> shape = op.getOperandShape();
   for (auto indexedOperand : llvm::enumerate(op.outputs())) {
     int index = indexedOperand.index();
     auto operandType = op.getOperandType(index);
@@ -419,7 +413,7 @@ SmallVector<StringRef> SortOp::getLoopIteratorTypes() {
   // All loops except the dimension to sort along are parallel.
   SmallVector<StringRef> iteratorTypes(getOperandRank(),
                                        getParallelIteratorTypeName());
-  iteratorTypes[getSortedDimension()] = getReductionIteratorTypeName();
+  iteratorTypes[dimension()] = getReductionIteratorTypeName();
   return iteratorTypes;
 }
 
@@ -443,7 +437,7 @@ SmallVector<unsigned> SortOp::getPartitionableLoops(
   auto range = llvm::seq<unsigned>(0, getOperandRank());
   SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
   partitionableLoops.erase(
-      std::next(partitionableLoops.begin(), getSortedDimension()));
+      std::next(partitionableLoops.begin(), dimension()));
   if (partitionableLoops.size() > maxNumParallelDims) {
     partitionableLoops.erase(
         partitionableLoops.begin(),
@@ -488,7 +482,7 @@ Operation *SortOp::getTiledImplementation(OpBuilder &builder,
 
 LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
-  auto sortDim = getSortedDimension();
+  auto sortDim = dimension();
   SmallVector<Value> indices, sortBlkArgs;
   indices.append(ivs.begin(), ivs.end());
   // Bubble sort innermost loop.

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -64,6 +64,7 @@ func @sort_2d(%arg0: memref<16x32xi32>) {
 
 func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
   iree_linalg_ext.sort
+    dimension(0)
     outs(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) {
   ^bb0(%arg2: f32, %arg3: f32, %arg4: i32, %arg5: i32):  // no predecessors
     %0 = arith.cmpf ogt, %arg2, %arg3 : f32

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -13,19 +13,6 @@ func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 // -----
 
-func @sort_without_dimension(%arg0: tensor<3x4xi32>) -> tensor<3x4xi32> {
-  // expected-error @+1 {{dimension must be specified if rank > 1}}
-  %0 = iree_linalg_ext.sort
-    outs(%arg0 : tensor<3x4xi32>) {
-  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
-    %1 = arith.cmpi sgt, %arg1, %arg2 : i32
-    iree_linalg_ext.yield %1 : i1
-  } -> tensor<3x4xi32>
-  return %0 : tensor<3x4xi32>
-}
-
-// -----
-
 func @sort_mismatch_rank(%arg0: tensor<?x?xi32>, %arg1: tensor<?xf32>)
     -> (tensor<?x?xi32>, tensor<?xf32>) {
   // expected-error @+1 {{expected operand 1 to be rank 2, same as other operands}}

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/roundtrip.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/roundtrip.mlir
@@ -2,10 +2,12 @@
 
 // CHECK-LABEL: func @sort_tensor
 // CHECK:         iree_linalg_ext.sort
+// CHECK-SAME:      dimension(0)
 // CHECK-SAME:      outs({{.*}})
 // CHECK:           iree_linalg_ext.yield
 func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   %0 = iree_linalg_ext.sort
+    dimension(0)
     outs(%arg0 : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
@@ -18,6 +20,7 @@ func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 // CHECK-LABEL: func @sort_memref
 // CHECK:         iree_linalg_ext.sort
+// CHECK-SAME:      dimension(0)
 // CHECK-SAME:      outs({{.*}})
 // CHECK:           iree_linalg_ext.yield
 func @sort_memref(%arg0: memref<128xi32>) {

--- a/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/integrations/tensorflow/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -242,6 +242,7 @@ func @scatter_repeated_indices_no_tiling(
 func @sort_1d(%arg0: tensor<?xi32>) -> tensor<?xi32> {
   %0 = iree_linalg_ext.sort
        {__internal_linalg_transform__ = "outer_reduce_input"}
+       dimension(0)
        outs(%arg0 : tensor<?xi32>) {
        ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -149,18 +149,15 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     See https://www.tensorflow.org/xla/operation_semantics#sort.
   }];
 
-  // Define arguments and results like linalg.generic op. The attribute has the
-  // same definition as mhlo.sort::dimension. If the rank is greater than 1,
-  // the attribute must be set. If the rank is exacatly 1, the dimension is
-  // optional.
   let arguments = (ins Variadic<AnyType>:$inputs,
                        Variadic<AnyShaped>:$outputs,
-                       OptionalAttr<I64Attr>:$dimension
+                       I64Attr:$dimension
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
-    attr-dict (`dimension` `(` $dimension^ `)`)?
+    attr-dict
+    `dimension` `(` $dimension `)`
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
     $region (`->` type($results)^)?
@@ -177,13 +174,6 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     }
     ArrayRef<int64_t> getOperandShape() {
       return getOperandType(0).getShape();
-    }
-    uint64_t getSortedDimension() {
-      uint64_t sortedDim = 0;
-      if (auto setSortedDim = dimension()) {
-        sortedDim = *setSortedDim;
-      }
-      return sortedDim;
     }
   }];
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -436,8 +436,7 @@ SmallVector<unsigned> SortOp::getPartitionableLoops(
     unsigned maxNumParallelDims) {
   auto range = llvm::seq<unsigned>(0, getOperandRank());
   SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
-  partitionableLoops.erase(
-      std::next(partitionableLoops.begin(), dimension()));
+  partitionableLoops.erase(std::next(partitionableLoops.begin(), dimension()));
   if (partitionableLoops.size() > maxNumParallelDims) {
     partitionableLoops.erase(
         partitionableLoops.begin(),

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -369,18 +369,12 @@ static LogicalResult verifySortOp(SortOp op) {
   }
 
   int64_t rank = op.getOperandRank();
-  ArrayRef<int64_t> shape = op.getOperandShape();
-  if (rank > 1 && !op.dimensionAttr()) {
-    return op.emitOpError("dimension must be specified if rank > 1");
-  }
-  int dimension = 0;
-  if (op.dimensionAttr()) {
-    dimension = op.dimension().getValue();
-  }
-  if (dimension < 0 || dimension >= rank) {
+  int sortDim = op.dimension();
+  if (sortDim < 0 || sortDim >= rank) {
     return op.emitOpError("dimension must be within (0, ") << rank << "]";
   }
 
+  ArrayRef<int64_t> shape = op.getOperandShape();
   for (auto indexedOperand : llvm::enumerate(op.outputs())) {
     int index = indexedOperand.index();
     auto operandType = op.getOperandType(index);
@@ -419,7 +413,7 @@ SmallVector<StringRef> SortOp::getLoopIteratorTypes() {
   // All loops except the dimension to sort along are parallel.
   SmallVector<StringRef> iteratorTypes(getOperandRank(),
                                        getParallelIteratorTypeName());
-  iteratorTypes[getSortedDimension()] = getReductionIteratorTypeName();
+  iteratorTypes[dimension()] = getReductionIteratorTypeName();
   return iteratorTypes;
 }
 
@@ -443,7 +437,7 @@ SmallVector<unsigned> SortOp::getPartitionableLoops(
   auto range = llvm::seq<unsigned>(0, getOperandRank());
   SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
   partitionableLoops.erase(
-      std::next(partitionableLoops.begin(), getSortedDimension()));
+      std::next(partitionableLoops.begin(), dimension()));
   if (partitionableLoops.size() > maxNumParallelDims) {
     partitionableLoops.erase(
         partitionableLoops.begin(),
@@ -488,7 +482,7 @@ Operation *SortOp::getTiledImplementation(OpBuilder &builder,
 
 LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange ivs) {
-  auto sortDim = getSortedDimension();
+  auto sortDim = dimension();
   SmallVector<Value> indices, sortBlkArgs;
   indices.append(ivs.begin(), ivs.end());
   // Bubble sort innermost loop.

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/convert_to_loops.mlir
@@ -64,6 +64,7 @@ func @sort_2d(%arg0: memref<16x32xi32>) {
 
 func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
   iree_linalg_ext.sort
+    dimension(0)
     outs(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) {
   ^bb0(%arg2: f32, %arg3: f32, %arg4: i32, %arg5: i32):  // no predecessors
     %0 = arith.cmpf ogt, %arg2, %arg3 : f32

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/invalid.mlir
@@ -13,19 +13,6 @@ func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 // -----
 
-func @sort_without_dimension(%arg0: tensor<3x4xi32>) -> tensor<3x4xi32> {
-  // expected-error @+1 {{dimension must be specified if rank > 1}}
-  %0 = iree_linalg_ext.sort
-    outs(%arg0 : tensor<3x4xi32>) {
-  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
-    %1 = arith.cmpi sgt, %arg1, %arg2 : i32
-    iree_linalg_ext.yield %1 : i1
-  } -> tensor<3x4xi32>
-  return %0 : tensor<3x4xi32>
-}
-
-// -----
-
 func @sort_mismatch_rank(%arg0: tensor<?x?xi32>, %arg1: tensor<?xf32>)
     -> (tensor<?x?xi32>, tensor<?xf32>) {
   // expected-error @+1 {{expected operand 1 to be rank 2, same as other operands}}

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/roundtrip.mlir
@@ -2,10 +2,12 @@
 
 // CHECK-LABEL: func @sort_tensor
 // CHECK:         iree_linalg_ext.sort
+// CHECK-SAME:      dimension(0)
 // CHECK-SAME:      outs({{.*}})
 // CHECK:           iree_linalg_ext.yield
 func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   %0 = iree_linalg_ext.sort
+    dimension(0)
     outs(%arg0 : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
@@ -18,6 +20,7 @@ func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 // CHECK-LABEL: func @sort_memref
 // CHECK:         iree_linalg_ext.sort
+// CHECK-SAME:      dimension(0)
 // CHECK-SAME:      outs({{.*}})
 // CHECK:           iree_linalg_ext.yield
 func @sort_memref(%arg0: memref<128xi32>) {

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/tiling.mlir
@@ -242,6 +242,7 @@ func @scatter_repeated_indices_no_tiling(
 func @sort_1d(%arg0: tensor<?xi32>) -> tensor<?xi32> {
   %0 = iree_linalg_ext.sort
        {__internal_linalg_transform__ = "outer_reduce_input"}
+       dimension(0)
        outs(%arg0 : tensor<?xi32>) {
        ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32


### PR DESCRIPTION
The attribute was not required when the rank of operand is one. Forcing
the op to require the attribute to have less confusion.