### PR TITLE
Refactor VMToEmitC conversions

### DIFF
--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -31,7 +31,7 @@ namespace iree_compiler {
 namespace {
 
 // TODO(simon-camp/marbre): Use this function throughout the conversions.
-Optional<std::string> getCType(Type type, bool refAsPointer = true) {
+Optional<std::string> getCType(Type type) {
   if (auto iType = type.dyn_cast<IntegerType>()) {
     switch (iType.getWidth()) {
       case 32:
@@ -55,8 +55,7 @@ Optional<std::string> getCType(Type type, bool refAsPointer = true) {
   }
 
   if (type.isa<IREE::VM::RefType>()) {
-    return refAsPointer ? std::string("iree_vm_ref_t*")
-                        : std::string("iree_vm_ref_t");
+    return std::string("iree_vm_ref_t");
   }
 
   return None;
@@ -74,7 +73,7 @@ LogicalResult clearStruct(OpBuilder builder, Value structValue,
     return failure();
   }
 
-  Optional<std::string> cType = getCType(type, false);
+  Optional<std::string> cType = getCType(type);
   if (!cType.hasValue()) {
     return failure();
   }
@@ -161,7 +160,7 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   }
 
   for (auto &resultType : funcType.getResults()) {
-    Optional<std::string> cType = getCType(resultType, false);
+    Optional<std::string> cType = getCType(resultType);
     if (!cType.hasValue()) {
       return funcOp.emitError() << "unable to emit C type";
     }
@@ -1737,7 +1736,7 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       std::string structBody;
 
       for (auto pair : llvm::enumerate(types)) {
-        Optional<std::string> cType = getCType(pair.value(), false);
+        Optional<std::string> cType = getCType(pair.value());
         if (!cType.hasValue()) {
           funcOp.emitError() << "unable to map function argument type to "
                                 "c type in argument struct declaration.";
@@ -2011,7 +2010,7 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
             /*operands=*/ArrayRef<Value>{value});
         resultStruct.callArguments.push_back(memberPtr.getResult(0));
       } else {
-        auto cType = getCType(result.value(), false).getValue() + "*";
+        auto cType = getCType(result.value()).getValue() + "*";
         Type ptrType = emitc::OpaqueType::get(ctx, cType);
         std::string memberName = "res" + std::to_string(result.index());
         auto memberPtr = rewriter.create<emitc::CallOp>(
@@ -2221,7 +2220,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
     }
 
     for (auto &resultType : functionType.getResults()) {
-      Optional<std::string> cType = getCType(resultType, false);
+      Optional<std::string> cType = getCType(resultType);
       if (!cType.hasValue()) {
         emitError(loc) << "unable to emit C type";
         return failure();
@@ -2256,7 +2255,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
     // TODO(simon-camp): Test if neccesary
     Type dummyType = rewriter.getI32Type();
     for (Type type : types.size() > 0 ? types : ArrayRef<Type>(dummyType)) {
-      auto cType = getCType(type, /*refAsPointer=*/false);
+      auto cType = getCType(type);
 
       if (!cType.hasValue()) {
         emitError(loc) << "Unable to emit C type.";
@@ -2459,7 +2458,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
       BlockArgument arg = funcOp.getArgument(i + inputOffset);
       assert(!arg.getType().isa<IREE::VM::RefType>());
 
-      auto cType = getCType(inputType, /*refAsPointer=*/false);
+      auto cType = getCType(inputType);
 
       if (!cType.hasValue()) {
         emitError(loc) << "unable to build C type in argument packing for `"
@@ -2583,7 +2582,7 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
       BlockArgument arg = funcOp.getArgument(i + resultOffset);
       assert(!arg.getType().isa<IREE::VM::RefType>());
 
-      auto cType = getCType(resultType, /*refAsPointer=*/false);
+      auto cType = getCType(resultType);
 
       if (!cType.hasValue()) {
         emitError(loc) << "unable to build C type in result unpacking";
@@ -3049,7 +3048,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
             /*resultType=*/result.getType(),
             /*value=*/emitc::OpaqueAttr::get(ctx, ""));
 
-        Optional<std::string> cType = getCType(resultOp.getType(), false);
+        Optional<std::string> cType = getCType(resultOp.getType());
         if (!cType.hasValue()) {
           return op->emitError() << "unable to emit C type";
         }

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -166,8 +166,13 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
     }
     // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
     // parameter
-    std::string cPtrType = cType.getValue() + std::string("*");
-    Type type = emitc::OpaqueType::get(ctx, cPtrType);
+    std::string cPtrType = cType.getValue();
+    Type type;
+    if (resultType.isa<IREE::VM::RefType>()) {
+      type = emitc::OpaqueType::get(ctx, cPtrType + "*");
+    } else {
+      type = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
+    }
     inputTypes.push_back(type);
     outputTypes.push_back(type);
   }
@@ -1996,34 +2001,24 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
       assert(resultStruct.value.hasValue());
       auto value = resultStruct.value.getValue();
 
+      auto cType = getCType(result.value()).getValue();
+      Type ptrType;
       if (result.value().isa<IREE::VM::RefType>()) {
-        Type ptrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
-        std::string memberName = "res" + std::to_string(result.index());
-        auto memberPtr = rewriter.create<emitc::CallOp>(
-            /*location=*/loc,
-            /*type=*/ptrType,
-            /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ADDRESS"),
-            /*args=*/
-            ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                                 emitc::OpaqueAttr::get(ctx, memberName)}),
-            /*templateArgs=*/ArrayAttr{},
-            /*operands=*/ArrayRef<Value>{value});
-        resultStruct.callArguments.push_back(memberPtr.getResult(0));
+        ptrType = emitc::OpaqueType::get(ctx, "iree_vm_ref_t*");
       } else {
-        auto cType = getCType(result.value()).getValue() + "*";
-        Type ptrType = emitc::OpaqueType::get(ctx, cType);
-        std::string memberName = "res" + std::to_string(result.index());
-        auto memberPtr = rewriter.create<emitc::CallOp>(
-            /*location=*/loc,
-            /*type=*/ptrType,
-            /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ADDRESS"),
-            /*args=*/
-            ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                                 emitc::OpaqueAttr::get(ctx, memberName)}),
-            /*templateArgs=*/ArrayAttr{},
-            /*operands=*/ArrayRef<Value>{value});
-        resultStruct.callArguments.push_back(memberPtr.getResult(0));
+        ptrType = emitc::PointerType::get(emitc::OpaqueType::get(ctx, cType));
       }
+      std::string memberName = "res" + std::to_string(result.index());
+      auto memberPtr = rewriter.create<emitc::CallOp>(
+          /*location=*/loc,
+          /*type=*/ptrType,
+          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ADDRESS"),
+          /*args=*/
+          ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
+                               emitc::OpaqueAttr::get(ctx, memberName)}),
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ArrayRef<Value>{value});
+      resultStruct.callArguments.push_back(memberPtr.getResult(0));
     }
 
     return success();
@@ -2227,8 +2222,9 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
       }
       // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
       // parameter
-      std::string cPtrType = cType.getValue() + std::string("*");
-      Type type = emitc::OpaqueType::get(ctx, cPtrType);
+      std::string cPtrType = cType.getValue();
+      Type type =
+          emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType));
       types.push_back(type);
     }
 
@@ -3053,10 +3049,11 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
           return op->emitError() << "unable to emit C type";
         }
 
-        std::string cPtrType = cType.getValue() + std::string("*");
+        std::string cPtrType = cType.getValue();
         auto resultPtrOp = rewriter.create<emitc::ApplyOp>(
             /*location=*/loc,
-            /*type=*/emitc::OpaqueType::get(ctx, cPtrType),
+            /*type=*/
+            emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType)),
             /*applicableOperator=*/StringAttr::get(ctx, "&"),
             /*operand=*/resultOp.getResult());
 

--- a/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -74,40 +74,32 @@ LogicalResult clearStruct(OpBuilder builder, Value structValue,
     return failure();
   }
 
-  Optional<std::string> cType = getCType(type);
-
+  Optional<std::string> cType = getCType(type, false);
   if (!cType.hasValue()) {
     return failure();
   }
+  std::string cPtrType = cType.getValue();
 
   Value structPointerValue;
   Value sizeValue;
 
   if (isPointer) {
-    std::string pointerType = cType.getValue();
-    if (pointerType.back() != '*') {
-      return failure();
-    }
-
-    std::string nonPointerType = pointerType.substr(0, pointerType.size() - 1);
-
     auto size = builder.create<emitc::CallOp>(
         /*location=*/loc,
         /*type=*/builder.getI32Type(),
         /*callee=*/StringAttr::get(ctx, "sizeof"),
         /*args=*/
-        ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, nonPointerType)}),
+        ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, cPtrType)}),
         /*templateArgs=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{});
 
     structPointerValue = structValue;
     sizeValue = size.getResult(0);
   } else {
-    std::string cPtrType = cType.getValue() + "*";
-
     auto structPointer = builder.create<emitc::ApplyOp>(
         /*location=*/loc,
-        /*result=*/emitc::OpaqueType::get(ctx, cPtrType),
+        /*result=*/
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, cPtrType)),
         /*applicableOperator=*/StringAttr::get(ctx, "&"),
         /*operand=*/structValue);
 
@@ -169,18 +161,13 @@ LogicalResult convertFuncOp(IREE::VM::FuncOp funcOp,
   }
 
   for (auto &resultType : funcType.getResults()) {
-    Optional<std::string> cType = getCType(resultType);
+    Optional<std::string> cType = getCType(resultType, false);
     if (!cType.hasValue()) {
       return funcOp.emitError() << "unable to emit C type";
     }
-    std::string cPtrType;
     // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
     // parameter
-    if (resultType.isa<IREE::VM::RefType>()) {
-      cPtrType = cType.getValue();
-    } else {
-      cPtrType = cType.getValue() + std::string("*");
-    }
+    std::string cPtrType = cType.getValue() + std::string("*");
     Type type = emitc::OpaqueType::get(ctx, cPtrType);
     inputTypes.push_back(type);
     outputTypes.push_back(type);
@@ -2024,7 +2011,7 @@ class ExportOpConversion : public OpConversionPattern<IREE::VM::ExportOp> {
             /*operands=*/ArrayRef<Value>{value});
         resultStruct.callArguments.push_back(memberPtr.getResult(0));
       } else {
-        auto cType = getCType(result.value()).getValue() + "*";
+        auto cType = getCType(result.value(), false).getValue() + "*";
         Type ptrType = emitc::OpaqueType::get(ctx, cType);
         std::string memberName = "res" + std::to_string(result.index());
         auto memberPtr = rewriter.create<emitc::CallOp>(
@@ -2234,19 +2221,14 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
     }
 
     for (auto &resultType : functionType.getResults()) {
-      Optional<std::string> cType = getCType(resultType);
+      Optional<std::string> cType = getCType(resultType, false);
       if (!cType.hasValue()) {
         emitError(loc) << "unable to emit C type";
         return failure();
       }
-      std::string cPtrType;
       // We pass refs as iree_vm_ref_t* regardless of whether it is an in or out
       // parameter
-      if (resultType.isa<IREE::VM::RefType>()) {
-        cPtrType = cType.getValue();
-      } else {
-        cPtrType = cType.getValue() + std::string("*");
-      }
+      std::string cPtrType = cType.getValue() + std::string("*");
       Type type = emitc::OpaqueType::get(ctx, cPtrType);
       types.push_back(type);
     }
@@ -2520,14 +2502,15 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
             /*templateArgs=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{arg, refPtr});
       } else {
-        auto cPtrType = cType.getValue() + "*";
+        auto cPtrType = cType.getValue();
 
         // memcpy(uint8Ptr, &arg, size);
         Value argPtr = rewriter
                            .create<emitc::ApplyOp>(
                                /*location=*/loc,
                                /*result=*/
-                               emitc::OpaqueType::get(ctx, cPtrType),
+                               emitc::PointerType::get(
+                                   emitc::OpaqueType::get(ctx, cPtrType)),
                                /*applicableOperator=*/StringAttr::get(ctx, "&"),
                                /*operand=*/arg)
                            .getResult();
@@ -2642,8 +2625,6 @@ class ImportOpConversion : public OpConversionPattern<IREE::VM::ImportOp> {
             /*templateArgs=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{refPtr, arg});
       } else {
-        auto cPtrType = cType.getValue() + "*";
-
         // memcpy(arg, uint8Ptr, size);
         rewriter.create<emitc::CallOp>(
             /*location=*/loc,
@@ -3068,7 +3049,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
             /*resultType=*/result.getType(),
             /*value=*/emitc::OpaqueAttr::get(ctx, ""));
 
-        Optional<std::string> cType = getCType(resultOp.getType());
+        Optional<std::string> cType = getCType(resultOp.getType(), false);
         if (!cType.hasValue()) {
           return op->emitError() << "unable to emit C type";
         }


### PR DESCRIPTION
* Refactors usage of getCType and ptr type emission
* Refactors getCType()
* Refactors remaining non-ref types to use !emitc.ptr

The refactoring of `iree_vm_ref_t` pointers will be addressed
in a follow-up PR to #8382.