### PR TITLE
Update third_party/vulkan_memory_allocator to latest.

### DIFF
--- a/iree/hal/vulkan/vma_allocator.cc
+++ b/iree/hal/vulkan/vma_allocator.cc
@@ -84,7 +84,7 @@ static void VKAPI_PTR iree_hal_vulkan_vma_free_callback(
 iree_status_t iree_hal_vulkan_vma_allocator_create(
     VkInstance instance, VkPhysicalDevice physical_device,
     VkDeviceHandle* logical_device, iree_hal_device_t* device,
-    VmaRecordSettings record_settings, iree_hal_allocator_t** out_allocator) {
+    iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(physical_device);
   IREE_ASSERT_ARGUMENT(logical_device);
@@ -144,10 +144,8 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
   create_info.preferredLargeHeapBlockSize = 64 * 1024 * 1024;
   create_info.pAllocationCallbacks = logical_device->allocator();
   create_info.pDeviceMemoryCallbacks = &device_memory_callbacks;
-  create_info.frameInUseCount = 0;
   create_info.pHeapSizeLimit = NULL;
   create_info.pVulkanFunctions = &vulkan_fns;
-  create_info.pRecordSettings = &record_settings;
   VmaAllocator vma = VK_NULL_HANDLE;
   iree_status_t status = VK_RESULT_TO_STATUS(
       vmaCreateAllocator(&create_info, &vma), "vmaCreateAllocator");

--- a/iree/hal/vulkan/vma_allocator.h
+++ b/iree/hal/vulkan/vma_allocator.h
@@ -36,8 +36,7 @@ extern "C" {
 iree_status_t iree_hal_vulkan_vma_allocator_create(
     VkInstance instance, VkPhysicalDevice physical_device,
     iree::hal::vulkan::VkDeviceHandle* logical_device,
-    iree_hal_device_t* device, VmaRecordSettings record_settings,
-    iree_hal_allocator_t** out_allocator);
+    iree_hal_device_t* device, iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -598,11 +598,9 @@ static iree_status_t iree_hal_vulkan_device_create_internal(
 
   // Create the device memory allocator that will service all buffer
   // allocation requests.
-  VmaRecordSettings vma_record_settings;
-  memset(&vma_record_settings, 0, sizeof(vma_record_settings));
   iree_status_t status = iree_hal_vulkan_vma_allocator_create(
       instance, physical_device, logical_device, (iree_hal_device_t*)device,
-      vma_record_settings, &device->device_allocator);
+      &device->device_allocator);
 
   // Create command pools for each queue family. If we don't have a transfer
   // queue then we'll ignore that one and just use the dispatch pool.


### PR DESCRIPTION
VmaRecordSettings (and the whole Record&Replay feature, which we did not use, was deleted).