### PR TITLE
Add aliases to DeviceArray that are used by Colab notebooks.

### DIFF
--- a/bindings/python/iree/runtime/array_interop.py
+++ b/bindings/python/iree/runtime/array_interop.py
@@ -153,6 +153,10 @@ class DeviceArray(numpy.lib.mixins.NDArrayOperatorsMixin):
     host_ary = self.to_host()
     return host_ary.__iter__()
 
+  def __getitem__(self, index):
+    host_ary = self.to_host()
+    return host_ary.__getitem__(index)
+
   def __reduce__(self):
     # Since this is used for making deep copies and pickling, we map
     # separately from any interactive state. We just reduce to the actual

--- a/bindings/python/iree/runtime/array_interop.py
+++ b/bindings/python/iree/runtime/array_interop.py
@@ -149,6 +149,10 @@ class DeviceArray(numpy.lib.mixins.NDArrayOperatorsMixin):
     host_ary = self.to_host()
     return host_ary.reshape(*args)
 
+  def __iter__(self):
+    host_ary = self.to_host()
+    return host_ary.__iter__()
+
   def __reduce__(self):
     # Since this is used for making deep copies and pickling, we map
     # separately from any interactive state. We just reduce to the actual

--- a/bindings/python/iree/runtime/array_interop.py
+++ b/bindings/python/iree/runtime/array_interop.py
@@ -143,6 +143,12 @@ class DeviceArray(numpy.lib.mixins.NDArrayOperatorsMixin):
     host_ary = self.to_host()
     return host_ary.astype(dtype, casting=casting, copy=copy)
 
+  def reshape(self, *args):
+    # TODO(scotttodd): add a native impl with a new buffer_view of the same data
+    # TODO(scotttodd): return DeviceArray instead of host ndarray?
+    host_ary = self.to_host()
+    return host_ary.reshape(*args)
+
   def __reduce__(self):
     # Since this is used for making deep copies and pickling, we map
     # separately from any interactive state. We just reduce to the actual

--- a/bindings/python/iree/runtime/array_interop_test.py
+++ b/bindings/python/iree/runtime/array_interop_test.py
@@ -78,6 +78,14 @@ class DeviceHalTest(unittest.TestCase):
     f = np.isfinite(ary)
     self.assertTrue(f.all())
 
+  def testReshape(self):
+    init_ary = np.zeros([3, 4], dtype=np.float32) + 2
+    ary = iree.runtime.asdevicearray(self.device,
+                                     init_ary,
+                                     implicit_host_transfer=True)
+    reshaped = ary.reshape((4, 3))
+    self.assertEqual((4, 3), reshaped.shape)
+
   def testDeepcopy(self):
     init_ary = np.zeros([3, 4], dtype=np.float32) + 2
     orig_ary = iree.runtime.asdevicearray(self.device,

--- a/bindings/python/iree/runtime/array_interop_test.py
+++ b/bindings/python/iree/runtime/array_interop_test.py
@@ -87,6 +87,16 @@ class DeviceHalTest(unittest.TestCase):
     for index, value in enumerate(ary):
       self.assertEqual(index, value)
 
+  def testSubscriptable(self):
+    init_ary = np.array([0, 1, 2, 3, 4, 5])
+    ary = iree.runtime.asdevicearray(self.device,
+                                     init_ary,
+                                     implicit_host_transfer=True)
+
+    for index in range(0, 6):
+      value = ary[index]
+      self.assertEqual(index, value)
+
   def testReshape(self):
     init_ary = np.zeros([3, 4], dtype=np.float32) + 2
     ary = iree.runtime.asdevicearray(self.device,

--- a/bindings/python/iree/runtime/array_interop_test.py
+++ b/bindings/python/iree/runtime/array_interop_test.py
@@ -78,6 +78,15 @@ class DeviceHalTest(unittest.TestCase):
     f = np.isfinite(ary)
     self.assertTrue(f.all())
 
+  def testIteration(self):
+    init_ary = np.array([0, 1, 2, 3, 4, 5])
+    ary = iree.runtime.asdevicearray(self.device,
+                                     init_ary,
+                                     implicit_host_transfer=True)
+
+    for index, value in enumerate(ary):
+      self.assertEqual(index, value)
+
   def testReshape(self):
     init_ary = np.zeros([3, 4], dtype=np.float32) + 2
     ary = iree.runtime.asdevicearray(self.device,


### PR DESCRIPTION
Progress on https://github.com/google/iree/issues/8253 (I believe the notebooks will run correct again after we push a nightly release including these changes).