### PR TITLE
Starting rework of HAL allocator APIs.

### DIFF
--- a/bindings/python/iree/runtime/hal_test.py
+++ b/bindings/python/iree/runtime/hal_test.py
@@ -80,7 +80,7 @@ class DeviceHalTest(unittest.TestCase):
       self.assertIn("HOST_LOCAL", stats_str)
 
   def testQueryCompatibility(self):
-    compat = self.allocator.query_buffer_compatibility(
+    compat = self.allocator.query_compatibility(
         memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
         allowed_usage=iree.runtime.BufferUsage.CONSTANT,
         intended_usage=iree.runtime.BufferUsage.CONSTANT |

--- a/bindings/tflite/tensor.c
+++ b/bindings/tflite/tensor.c
@@ -136,12 +136,14 @@ iree_status_t _TfLiteTensorReallocateIfNeeded(
 
   // Allocate the underlying buffer for the tensor.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      iree_hal_allocator_allocate_buffer(
-          buffer_allocator,
-          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-          IREE_HAL_BUFFER_USAGE_ALL, allocation_size,
-          iree_const_byte_span_empty(), &tensor->buffer));
+      z0, iree_hal_allocator_allocate_buffer(
+              buffer_allocator,
+              (iree_hal_buffer_params_t){
+                  .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+                  .usage = IREE_HAL_BUFFER_USAGE_ALL,
+              },
+              allocation_size, iree_const_byte_span_empty(), &tensor->buffer));
 
   // Map the buffer memory immediately. The tflite API doesn't let us know if
   // this is a buffer the user will actually touch or some state buffer that is

--- a/iree/hal/allocator.c
+++ b/iree/hal/allocator.c
@@ -47,14 +47,15 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_format(
 
 IREE_HAL_API_RETAIN_RELEASE(allocator);
 
-IREE_API_EXPORT iree_allocator_t
-iree_hal_allocator_host_allocator(const iree_hal_allocator_t* allocator) {
+IREE_API_EXPORT iree_allocator_t iree_hal_allocator_host_allocator(
+    const iree_hal_allocator_t* IREE_RESTRICT allocator) {
   IREE_ASSERT_ARGUMENT(allocator);
   return _VTABLE_DISPATCH(allocator, host_allocator)(allocator);
 }
 
 IREE_API_EXPORT
-iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator) {
+iree_status_t iree_hal_allocator_trim(
+    iree_hal_allocator_t* IREE_RESTRICT allocator) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(allocator, trim)(allocator);
@@ -63,8 +64,8 @@ iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator) {
 }
 
 IREE_API_EXPORT void iree_hal_allocator_query_statistics(
-    iree_hal_allocator_t* allocator,
-    iree_hal_allocator_statistics_t* out_statistics) {
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_allocator_statistics_t* IREE_RESTRICT out_statistics) {
   IREE_ASSERT_ARGUMENT(allocator);
   memset(out_statistics, 0, sizeof(*out_statistics));
   IREE_STATISTICS({
@@ -73,7 +74,7 @@ IREE_API_EXPORT void iree_hal_allocator_query_statistics(
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
-    FILE* file, iree_hal_allocator_t* allocator) {
+    FILE* file, iree_hal_allocator_t* IREE_RESTRICT allocator) {
 #if IREE_STATISTICS_ENABLE
   iree_hal_allocator_statistics_t statistics;
   iree_hal_allocator_query_statistics(allocator, &statistics);
@@ -105,33 +106,33 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
 }
 
 IREE_API_EXPORT iree_hal_buffer_compatibility_t
-iree_hal_allocator_query_buffer_compatibility(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_buffer_usage_t intended_usage,
-    iree_device_size_t allocation_size) {
+iree_hal_allocator_query_compatibility(
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_device_size_t allocation_size) {
   IREE_ASSERT_ARGUMENT(allocator);
-  return _VTABLE_DISPATCH(allocator, query_buffer_compatibility)(
-      allocator, memory_type, allowed_usage, intended_usage, allocation_size);
+  iree_hal_buffer_params_canonicalize(&params);
+  return _VTABLE_DISPATCH(allocator, query_compatibility)(allocator, &params,
+                                                          allocation_size);
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage, iree_host_size_t allocation_size,
-    iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer) {
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_host_size_t allocation_size,
+    iree_const_byte_span_t initial_data,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, allocate_buffer)(
-      allocator, memory_type, allowed_usage, allocation_size, initial_data,
-      out_buffer);
+      allocator, &params, allocation_size, initial_data, out_buffer);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer) {
+    iree_hal_allocator_t* IREE_RESTRICT allocator, iree_hal_buffer_t* buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -140,44 +141,43 @@ IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_byte_span_t data,
     iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, wrap_buffer)(
-      allocator, memory_type, allowed_access, allowed_usage, data,
-      data_allocator, out_buffer);
+      allocator, &params, data, data_allocator, out_buffer);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_external_buffer_t* external_buffer,
-    iree_hal_buffer_t** out_buffer) {
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params,
+    iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(external_buffer);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_buffer_params_canonicalize(&params);
   iree_status_t status = _VTABLE_DISPATCH(allocator, import_buffer)(
-      allocator, memory_type, allowed_access, allowed_usage, external_buffer,
-      out_buffer);
+      allocator, &params, external_buffer, out_buffer);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_export_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_t* IREE_RESTRICT buffer,
     iree_hal_external_buffer_type_t requested_type,
     iree_hal_external_buffer_flags_t requested_flags,
-    iree_hal_external_buffer_t* out_external_buffer) {
+    iree_hal_external_buffer_t* IREE_RESTRICT out_external_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_ASSERT_ARGUMENT(out_external_buffer);

--- a/iree/hal/allocator.h
+++ b/iree/hal/allocator.h
@@ -22,6 +22,95 @@ extern "C" {
 // Types and Enums
 //===----------------------------------------------------------------------===//
 
+// A bitmap indicating logical device queue affinity.
+// Used to direct submissions to specific device queues or locate memory nearby
+// where it will be used. The meaning of the bits in the bitmap is
+// implementation-specific: a bit may represent a logical queue in an underlying
+// API such as a VkQueue or a physical queue such as a discrete virtual device.
+//
+// Bitwise operations can be performed on affinities; for example AND'ing two
+// affinities will produce the intersection and OR'ing will produce the union.
+// This enables just-in-time selection as a command buffer could be made
+// available to some set of queues when recorded and then AND'ed with an actual
+// set of queues to execute on during submission.
+typedef uint64_t iree_hal_queue_affinity_t;
+
+// Specifies that any queue may be selected.
+#define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
+
+// Parameters defining how a buffer should be allocated.
+//
+// Designed to be zero-initialized: any field with a 0 value will be assigned
+// a default as indicated in the field description.
+//
+// For ergonomics when used from C++ w/o named initializers the first field is
+// the most commonly used so that it can be initialized by location:
+//    some_fn(..., {IREE_HAL_BUFFER_USAGE_FOO}, ...)
+typedef struct iree_hal_buffer_params_t {
+  // Specifies the usage allowed by HAL APIs and aids in memory placement.
+  // Devices may have different memory types for different usage and require
+  // the intended usage to be declared upon allocation. It's always best to
+  // limit the allowed usage bits to precisely what the actual usage will be to
+  // avoid additional copies, synchronization, and expensive emulation.
+  //
+  // If 0 then the usage will be set as IREE_HAL_BUFFER_USAGE_ALL.
+  iree_hal_buffer_usage_t usage;
+
+  // Specifies the access allowed to the memory via the HAL APIs.
+  // For example, if the IREE_HAL_MEMORY_ACCESS_WRITE bit is not set then any
+  // API call that would write to the memory will fail (such as
+  // iree_hal_command_buffer_update_buffer). This does not limit any untrusted
+  // dispatch or external use of the buffer and should not be treated as a
+  // memory protection mechanism.
+  //
+  // If 0 then the access will be set as IREE_HAL_MEMORY_ACCESS_ALL.
+  iree_hal_memory_access_t access;
+
+  // Specifies the memory type properties used for selecting a memory space.
+  // This should often be IREE_HAL_MEMORY_TYPE_OPTIMAL to allow the allocator
+  // to place the allocation based on usage bits but can be specified if the
+  // exact memory type must be used for compatibility with external code.
+  //
+  // If 0 then the type will be set as IREE_HAL_MEMORY_TYPE_OPTIMAL.
+  iree_hal_memory_type_t type;
+
+  // Queue affinity bitmap indicating which queues may access this buffer.
+  // For NUMA devices this can be used to more tightly scope the allocation to
+  // particular device memory and provide better pool placement. When a device
+  // supports peering or replication the affinity bitmap will be used to choose
+  // which subdevices require configuration.
+  //
+  // If 0 then the buffer will be available on any queue as if
+  // IREE_HAL_QUEUE_AFFINITY_ANY was specified.
+  iree_hal_queue_affinity_t queue_affinity;
+
+  // Minimum alignment, in bytes, of the resulting allocation.
+  // The actual alignment may be any value greater-than-or-equal-to this value.
+  //
+  // If 0 then the alignment will be decided by the allocator based on optimal
+  // device parameters.
+  iree_device_size_t min_alignment;
+} iree_hal_buffer_params_t;
+
+// Canonicalizes |params| fields when zero initialization is used.
+static inline void iree_hal_buffer_params_canonicalize(
+    iree_hal_buffer_params_t* params) {
+  if (!params->usage) params->usage = IREE_HAL_BUFFER_USAGE_ALL;
+  if (!params->access) params->access = IREE_HAL_MEMORY_ACCESS_ALL;
+  if (!params->queue_affinity) {
+    params->queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
+  }
+}
+
+// Returns |params| with the given |usage| bits OR'ed in.
+static inline iree_hal_buffer_params_t iree_hal_buffer_params_with_usage(
+    const iree_hal_buffer_params_t params, iree_hal_buffer_usage_t usage) {
+  iree_hal_buffer_params_t result = params;
+  if (!result.usage) result.usage = IREE_HAL_BUFFER_USAGE_ALL;
+  result.usage |= usage;
+  return result;
+}
+
 // A bitfield indicating compatible behavior for buffers in an allocator.
 enum iree_hal_buffer_compatibility_bits_t {
   // Indicates (in the absence of other bits) the buffer is not compatible with
@@ -199,12 +288,13 @@ IREE_API_EXPORT void iree_hal_allocator_release(
     iree_hal_allocator_t* allocator);
 
 // Returns the host allocator used for allocating host objects.
-IREE_API_EXPORT iree_allocator_t
-iree_hal_allocator_host_allocator(const iree_hal_allocator_t* allocator);
+IREE_API_EXPORT iree_allocator_t iree_hal_allocator_host_allocator(
+    const iree_hal_allocator_t* IREE_RESTRICT allocator);
 
 // Trims cached/unused pooled buffers, if any.
 IREE_API_EXPORT
-iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator);
+iree_status_t iree_hal_allocator_trim(
+    iree_hal_allocator_t* IREE_RESTRICT allocator);
 
 // Queries the aggregate statistics from the allocator since creation.
 // Thread-safe; statistics are captured at the time the call is made.
@@ -212,13 +302,13 @@ iree_status_t iree_hal_allocator_trim(iree_hal_allocator_t* allocator);
 // NOTE: statistics may be compiled out in some configurations and this call
 // will become a memset(0).
 IREE_API_EXPORT void iree_hal_allocator_query_statistics(
-    iree_hal_allocator_t* allocator,
-    iree_hal_allocator_statistics_t* out_statistics);
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_allocator_statistics_t* IREE_RESTRICT out_statistics);
 
 // Prints the current allocation statistics of |allocator| to |file|.
 // No-op if statistics are not enabled (IREE_STATISTICS_ENABLE).
 IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
-    FILE* file, iree_hal_allocator_t* allocator);
+    FILE* file, iree_hal_allocator_t* IREE_RESTRICT allocator);
 
 // Returns a bitmask indicating what operations with buffers of the given type
 // are available on the allocator.
@@ -231,18 +321,14 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
 // be transferred externally into a buffer compatible with the device the
 // allocator services.
 IREE_API_EXPORT iree_hal_buffer_compatibility_t
-iree_hal_allocator_query_buffer_compatibility(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_buffer_usage_t intended_usage, iree_device_size_t allocation_size);
+iree_hal_allocator_query_compatibility(
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_device_size_t allocation_size);
 
 // Allocates a buffer from the allocator.
 // If |initial_data| is provided then the bytes will be copied into the device
 // buffer. To avoid the copy when constant data is used prefer
 // iree_hal_allocator_wrap_buffer when available.
-// Fails if the memory type requested for the given usage cannot be serviced.
-// Callers can use iree_hal_allocator_can_allocate to decide their memory use
-// strategy.
 //
 // The memory type of the buffer returned may differ from the requested value
 // if the device can provide more functionality; for example, if requesting
@@ -251,17 +337,18 @@ iree_hal_allocator_query_buffer_compatibility(
 // IREE_HAL_MEMORY_TYPE_HOST_CACHED. The only requirement is that the buffer
 // satisfy the required bits.
 //
-// Fails if it is not possible to allocate and satisfy all placements for the
-// requested |allowed_usage|.
 // |out_buffer| must be released by the caller.
+// Fails if the memory type requested for the given usage cannot be serviced.
+// Callers can use iree_hal_allocator_query_compatibility to decide their memory
+// use strategy.
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage, iree_host_size_t allocation_size,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_host_size_t allocation_size,
     iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer);
 
 // Wraps an existing host allocation in a buffer.
 //
-// iree_hal_allocator_query_buffer_compatibility can be used to query whether a
+// iree_hal_allocator_query_compatibility can be used to query whether a
 // buffer can be wrapped when using the given memory type and usage. A
 // compatibility result containing IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE
 // means the wrap may succeed however if the pointer/page range is not in a
@@ -271,12 +358,11 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
 // destroyed. iree_allocator_null() can be passed to indicate the buffer does
 // not own the data.
 //
-// Fails if the allocator cannot access host memory in this way.
 // |out_buffer| must be released by the caller.
+// Fails if the allocator cannot access host memory in this way.
 IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params, iree_byte_span_t data,
     iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer);
 
 // TODO(benvanik): iree_hal_allocator_query_external_buffer_compatibility to
@@ -291,14 +377,14 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_wrap_buffer(
 // iree_hal_buffer_t. The returned external buffer may only be usable with the
 // same driver/device.
 //
+// |out_buffer| must be released by the caller.
 // Fails with IREE_STATUS_UNAVAILABLE if the allocator cannot import the buffer
 // into the given memory type. This may be due to unavailable device/platform
 // capabilities or the memory type the external buffer was allocated with.
 IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage,
-    iree_hal_external_buffer_t* external_buffer,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_params_t params,
+    iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
     iree_hal_buffer_t** out_buffer);
 
 // Exports an allocator-owned |buffer| to an external buffer handle.
@@ -312,10 +398,11 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_import_buffer(
 // into the external type. This may be due to unavailable device/platform
 // capabilities or the memory type the buffer was allocated with.
 IREE_API_EXPORT iree_status_t iree_hal_allocator_export_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer,
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_t* IREE_RESTRICT buffer,
     iree_hal_external_buffer_type_t requested_type,
     iree_hal_external_buffer_flags_t requested_flags,
-    iree_hal_external_buffer_t* out_external_buffer);
+    iree_hal_external_buffer_t* IREE_RESTRICT out_external_buffer);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_heap_allocator_t
@@ -339,57 +426,60 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
 //===----------------------------------------------------------------------===//
 
 typedef struct iree_hal_allocator_vtable_t {
-  void(IREE_API_PTR* destroy)(iree_hal_allocator_t* allocator);
+  void(IREE_API_PTR* destroy)(iree_hal_allocator_t* IREE_RESTRICT allocator);
 
   iree_allocator_t(IREE_API_PTR* host_allocator)(
-      const iree_hal_allocator_t* allocator);
+      const iree_hal_allocator_t* IREE_RESTRICT allocator);
 
-  iree_status_t(IREE_API_PTR* trim)(iree_hal_allocator_t* allocator);
+  iree_status_t(IREE_API_PTR* trim)(
+      iree_hal_allocator_t* IREE_RESTRICT allocator);
 
   void(IREE_API_PTR* query_statistics)(
-      iree_hal_allocator_t* allocator,
-      iree_hal_allocator_statistics_t* out_statistics);
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      iree_hal_allocator_statistics_t* IREE_RESTRICT out_statistics);
 
-  iree_hal_buffer_compatibility_t(IREE_API_PTR* query_buffer_compatibility)(
-      iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-      iree_hal_buffer_usage_t allowed_usage,
-      iree_hal_buffer_usage_t intended_usage,
+  iree_hal_buffer_compatibility_t(IREE_API_PTR* query_compatibility)(
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      const iree_hal_buffer_params_t* IREE_RESTRICT params,
       iree_device_size_t allocation_size);
 
   iree_status_t(IREE_API_PTR* allocate_buffer)(
-      iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-      iree_hal_buffer_usage_t allowed_usage, iree_host_size_t allocation_size,
-      iree_const_byte_span_t initial_data, iree_hal_buffer_t** out_buffer);
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      const iree_hal_buffer_params_t* IREE_RESTRICT params,
+      iree_host_size_t allocation_size, iree_const_byte_span_t initial_data,
+      iree_hal_buffer_t** IREE_RESTRICT out_buffer);
 
-  void(IREE_API_PTR* deallocate_buffer)(iree_hal_allocator_t* allocator,
-                                        iree_hal_buffer_t* buffer);
+  void(IREE_API_PTR* deallocate_buffer)(
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      iree_hal_buffer_t* IREE_RESTRICT buffer);
 
   iree_status_t(IREE_API_PTR* wrap_buffer)(
-      iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-      iree_hal_memory_access_t allowed_access,
-      iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
-      iree_allocator_t data_allocator, iree_hal_buffer_t** out_buffer);
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      const iree_hal_buffer_params_t* IREE_RESTRICT params,
+      iree_byte_span_t data, iree_allocator_t data_allocator,
+      iree_hal_buffer_t** IREE_RESTRICT out_buffer);
 
   iree_status_t(IREE_API_PTR* import_buffer)(
-      iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
-      iree_hal_memory_access_t allowed_access,
-      iree_hal_buffer_usage_t allowed_usage,
-      iree_hal_external_buffer_t* external_buffer,
-      iree_hal_buffer_t** out_buffer);
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      const iree_hal_buffer_params_t* IREE_RESTRICT params,
+      iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
+      iree_hal_buffer_t** IREE_RESTRICT out_buffer);
 
   iree_status_t(IREE_API_PTR* export_buffer)(
-      iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer,
+      iree_hal_allocator_t* IREE_RESTRICT allocator,
+      iree_hal_buffer_t* IREE_RESTRICT buffer,
       iree_hal_external_buffer_type_t requested_type,
       iree_hal_external_buffer_flags_t requested_flags,
-      iree_hal_external_buffer_t* out_external_buffer);
+      iree_hal_external_buffer_t* IREE_RESTRICT out_external_buffer);
 } iree_hal_allocator_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_allocator_vtable_t);
 
 IREE_API_EXPORT void iree_hal_allocator_destroy(
-    iree_hal_allocator_t* allocator);
+    iree_hal_allocator_t* IREE_RESTRICT allocator);
 
 IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* buffer);
+    iree_hal_allocator_t* IREE_RESTRICT allocator,
+    iree_hal_buffer_t* IREE_RESTRICT buffer);
 
 #if IREE_STATISTICS_ENABLE
 

--- a/iree/hal/allocator_heap.c
+++ b/iree/hal/allocator_heap.c
@@ -33,6 +33,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(out_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
+  *out_allocator = NULL;
 
   iree_hal_heap_allocator_t* allocator = NULL;
   iree_host_size_t total_size =
@@ -57,7 +58,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_create_heap(
   }
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static void iree_hal_heap_allocator_destroy(

--- a/iree/hal/buffer.h
+++ b/iree/hal/buffer.h
@@ -566,16 +566,17 @@ static_assert(offsetof(iree_hal_buffer_vtable_t, recycle) == 0,
               "to recycle instead");
 
 struct iree_hal_buffer_t {
-  iree_hal_resource_t resource;
-
-  iree_allocator_t host_allocator;
-  iree_hal_allocator_t* device_allocator;
-
+  // Frequently accessed:
+  iree_hal_resource_t resource;  // must be at 0
   iree_hal_buffer_t* allocated_buffer;
   iree_device_size_t allocation_size;
   iree_device_size_t byte_offset;
   iree_device_size_t byte_length;
 
+  // Rarely accessed:
+  iree_allocator_t host_allocator;
+  iree_hal_allocator_t* device_allocator;
+  // TODO(benvanik): bit pack these; could be ~4 bytes vs 12.
   iree_hal_memory_type_t memory_type;
   iree_hal_memory_access_t allowed_access;
   iree_hal_buffer_usage_t allowed_usage;

--- a/iree/hal/buffer_view_util.h
+++ b/iree/hal/buffer_view_util.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/allocator.h"
 #include "iree/hal/buffer_view.h"
 
 #ifdef __cplusplus
@@ -60,8 +61,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_range(
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_allocate_buffer(
     iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
     iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage, iree_const_byte_span_t initial_data,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_params_t buffer_params, iree_const_byte_span_t initial_data,
     iree_hal_buffer_view_t** out_buffer_view);
 
 // Imports a host buffer using |allocator| and wraps it in a buffer view.
@@ -76,9 +77,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_allocate_buffer(
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_heap_buffer(
     iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
     iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
     iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view);
 
 // Tries to import a host buffer using |allocator| and wrap it in a buffer view.
@@ -86,7 +86,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_heap_buffer(
 // source data will be copied into it.
 //
 // This is equivalent to:
-//   if iree_hal_allocator_query_buffer_compatibility ok:
+//   if iree_hal_allocator_query_compatibility ok:
 //     1. iree_hal_allocator_wrap_buffer
 //     2. iree_hal_buffer_view_create
 //   else:
@@ -96,9 +96,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_heap_buffer(
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_wrap_or_clone_heap_buffer(
     iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
     iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, iree_hal_memory_type_t memory_type,
-    iree_hal_memory_access_t allowed_access,
-    iree_hal_buffer_usage_t allowed_usage, iree_byte_span_t data,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_params_t buffer_params, iree_byte_span_t data,
     iree_allocator_t data_allocator, iree_hal_buffer_view_t** out_buffer_view);
 
 typedef iree_status_t(IREE_API_PTR* iree_hal_buffer_view_generator_callback_t)(
@@ -129,8 +128,8 @@ typedef iree_status_t(IREE_API_PTR* iree_hal_buffer_view_generator_callback_t)(
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_generate_buffer(
     iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
     iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, iree_hal_memory_type_t memory_type,
-    iree_hal_buffer_usage_t allowed_usage,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_params_t buffer_params,
     iree_hal_buffer_view_generator_callback_t callback, void* user_data,
     iree_hal_buffer_view_t** out_buffer_view);
 

--- a/iree/hal/command_buffer.h
+++ b/iree/hal/command_buffer.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/allocator.h"
 #include "iree/hal/buffer.h"
 #include "iree/hal/descriptor_set.h"
 #include "iree/hal/descriptor_set_layout.h"
@@ -83,22 +84,6 @@ enum iree_hal_command_category_bits_t {
       IREE_HAL_COMMAND_CATEGORY_TRANSFER | IREE_HAL_COMMAND_CATEGORY_DISPATCH,
 };
 typedef uint32_t iree_hal_command_category_t;
-
-// A bitmask indicating affinity for a submission to use a particular set of
-// queues.
-//
-// Upon submission the queue is selected based on the flags set in
-// |command_categories| and the |queue_affinity|. As the number of available
-// queues can vary the |queue_affinity| is used to hash into the available
-// queues for the required categories. For example if 2 queues support transfer
-// commands and the affinity is 5 the resulting queue could be index hash(5)=1.
-// The affinity can thus be treated as just a way to indicate whether two
-// submissions must be placed on to the same queue. Note that the exact hashing
-// function is implementation dependent.
-typedef uint64_t iree_hal_queue_affinity_t;
-
-// Specifies that any queue may be selected.
-#define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
 
 // Bitfield specifying which execution stage a barrier should start/end at.
 //

--- a/iree/hal/command_buffer_validation.c
+++ b/iree/hal/command_buffer_validation.c
@@ -57,10 +57,12 @@ static iree_status_t iree_hal_command_buffer_validate_buffer_compatibility(
     iree_hal_buffer_compatibility_t required_compatibility,
     iree_hal_buffer_usage_t intended_usage) {
   iree_hal_buffer_compatibility_t allowed_compatibility =
-      iree_hal_allocator_query_buffer_compatibility(
+      iree_hal_allocator_query_compatibility(
           iree_hal_device_allocator(VALIDATION_STATE(command_buffer)->device),
-          iree_hal_buffer_memory_type(buffer),
-          iree_hal_buffer_allowed_usage(buffer), intended_usage,
+          (iree_hal_buffer_params_t){
+              .type = iree_hal_buffer_memory_type(buffer),
+              .usage = iree_hal_buffer_allowed_usage(buffer) & intended_usage,
+          },
           iree_hal_buffer_allocation_size(buffer));
   if (!iree_all_bits_set(allowed_compatibility, required_compatibility)) {
     // Buffer cannot be used on the queue for the given usage.

--- a/iree/hal/device.c
+++ b/iree/hal/device.c
@@ -92,9 +92,12 @@ static iree_status_t iree_hal_device_transfer_buffer(
   iree_hal_buffer_t* target_buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_allocator_allocate_buffer(
-              iree_hal_device_allocator(device), memory_type,
-              allowed_usage | IREE_HAL_BUFFER_USAGE_TRANSFER, allocation_size,
-              iree_const_byte_span_empty(), &target_buffer));
+              iree_hal_device_allocator(device),
+              (iree_hal_buffer_params_t){
+                  .type = memory_type,
+                  .usage = allowed_usage | IREE_HAL_BUFFER_USAGE_TRANSFER,
+              },
+              allocation_size, iree_const_byte_span_empty(), &target_buffer));
 
   // Perform the transfer and wait for it to complete.
   const iree_hal_transfer_command_t transfer_command = {

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -80,11 +80,13 @@ class CheckTest : public ::testing::Test {
       num_elements *= dim;
     }
     ASSERT_EQ(contents.size(), num_elements);
+    iree_hal_buffer_params_t params = {0};
+    params.type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_INT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(int32_t)),
         &*out_buffer_view));
@@ -98,11 +100,13 @@ class CheckTest : public ::testing::Test {
       num_elements *= dim;
     }
     ASSERT_EQ(contents.size(), num_elements);
+    iree_hal_buffer_params_t params = {0};
+    params.type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_16,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(uint16_t)),
         &*out_buffer_view));
@@ -116,11 +120,13 @@ class CheckTest : public ::testing::Test {
       num_elements *= dim;
     }
     ASSERT_EQ(contents.size(), num_elements);
+    iree_hal_buffer_params_t params = {0};
+    params.type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(float)),
         &*out_buffer_view));
@@ -134,11 +140,13 @@ class CheckTest : public ::testing::Test {
       num_elements *= dim;
     }
     ASSERT_EQ(contents.size(), num_elements);
+    iree_hal_buffer_params_t params = {0};
+    params.type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+    params.usage = IREE_HAL_BUFFER_USAGE_ALL;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
         allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_64,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(double)),
         &*out_buffer_view));

--- a/iree/modules/hal/module.c
+++ b/iree/modules/hal/module.c
@@ -252,10 +252,14 @@ IREE_VM_ABI_EXPORT(iree_hal_module_allocator_allocate,  //
   iree_hal_buffer_usage_t buffer_usage = (iree_hal_buffer_usage_t)args->i2;
   iree_vm_size_t allocation_size = (iree_vm_size_t)args->i3;
 
+  const iree_hal_buffer_params_t params = {
+      .type = memory_types,
+      .usage = buffer_usage,
+  };
   iree_hal_buffer_t* buffer = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-      allocator, memory_types, buffer_usage, allocation_size,
-      iree_const_byte_span_empty(), &buffer));
+      allocator, params, allocation_size, iree_const_byte_span_empty(),
+      &buffer));
   rets->r0 = iree_hal_buffer_move_ref(buffer);
   return iree_ok_status();
 }
@@ -320,13 +324,18 @@ IREE_VM_ABI_EXPORT(iree_hal_module_allocator_map_byte_buffer,  //
   // Try mapping - note that this may fail if the target device cannot map the
   // memory into the given type (for example, mapping a host buffer into
   // device-local memory is only going to work on unified memory systems).
+  const iree_hal_buffer_params_t params = {
+      .type = memory_types,
+      .usage = buffer_usage,
+      .access = allowed_access,
+  };
   iree_allocator_t buffer_deref_allocator = {
       .self = source,
       .ctl = iree_hal_module_map_data_ctl,
   };
   iree_hal_buffer_t* buffer = NULL;
   iree_status_t status = iree_hal_allocator_wrap_buffer(
-      allocator, memory_types, allowed_access, buffer_usage,
+      allocator, params,
       iree_make_byte_span(source->data.data + offset, length),
       buffer_deref_allocator, &buffer);
   if (iree_status_is_ok(status)) {
@@ -372,10 +381,14 @@ IREE_VM_ABI_EXPORT(iree_hal_module_allocator_wrap_byte_buffer,  //
         (offset + length - 1), buffer_length);
   }
 
+  const iree_hal_buffer_params_t params = {
+      .type = memory_types,
+      .usage = buffer_usage,
+  };
   iree_hal_buffer_t* buffer = NULL;
   IREE_RETURN_IF_ERROR(
       iree_hal_allocator_allocate_buffer(
-          allocator, memory_types, buffer_usage, length,
+          allocator, params, length,
           iree_make_const_byte_span(source->data.data + offset, length),
           &buffer),
       "failed to allocate buffer of length %d", length);

--- a/iree/runtime/demo/hello_world_explained.c
+++ b/iree/runtime/demo/hello_world_explained.c
@@ -200,12 +200,15 @@ static iree_status_t iree_runtime_demo_perform_mul(
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           // Encoding type:
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-          // Where to allocate (host or device):
-          IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          // What access to allow to this memory (this is .rodata so READ only):
-          IREE_HAL_MEMORY_ACCESS_READ,
-          // Intended usage of the buffer (transfers, dispatches, etc):
-          IREE_HAL_BUFFER_USAGE_ALL,
+          (iree_hal_buffer_params_t){
+              // Where to allocate (host or device):
+              .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+              // Access to allow to this memory (this is .rodata so READ only):
+              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              // Intended usage of the buffer (transfers, dispatches, etc):
+              .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          },
           // The actual heap buffer to wrap or clone and its allocator:
           iree_make_byte_span((void*)arg0_data, sizeof(arg0_data)),
           iree_allocator_null(),
@@ -232,8 +235,12 @@ static iree_status_t iree_runtime_demo_perform_mul(
           device_allocator, arg1_shape, IREE_ARRAYSIZE(arg1_shape),
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-          IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-          IREE_HAL_MEMORY_ACCESS_READ, IREE_HAL_BUFFER_USAGE_ALL,
+          (iree_hal_buffer_params_t){
+              .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              .usage = IREE_HAL_BUFFER_USAGE_ALL,
+          },
           iree_make_byte_span((void*)arg1_data, sizeof(arg1_data)),
           iree_allocator_null(), &arg1);
     }

--- a/iree/runtime/demo/hello_world_terse.c
+++ b/iree/runtime/demo/hello_world_terse.c
@@ -83,8 +83,12 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
       iree_runtime_session_device_allocator(session), arg0_shape,
       IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_MEMORY_ACCESS_READ, IREE_HAL_BUFFER_USAGE_ALL,
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+      },
       iree_make_byte_span((void*)arg0_data, sizeof(arg0_data)),
       iree_allocator_null(), &arg0));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(
@@ -103,8 +107,12 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
       iree_runtime_session_device_allocator(session), arg1_shape,
       IREE_ARRAYSIZE(arg1_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_MEMORY_ACCESS_READ, IREE_HAL_BUFFER_USAGE_ALL,
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .access = IREE_HAL_MEMORY_ACCESS_READ,
+          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+      },
       iree_make_byte_span((void*)arg1_data, sizeof(arg1_data)),
       iree_allocator_null(), &arg1));
   IREE_CHECK_OK(iree_hal_buffer_view_fprint(

--- a/iree/samples/custom_modules/custom_modules_test.cc
+++ b/iree/samples/custom_modules/custom_modules_test.cc
@@ -133,12 +133,15 @@ TEST_F(CustomModulesTest, PrintTensor) {
   static iree_hal_dim_t kShape[] = {2, 4};
   static float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
                                          4.0f, 5.0f, 6.0f, 7.0f};
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.usage = IREE_HAL_BUFFER_USAGE_ALL;
   iree_hal_buffer_view_t* buffer_view = nullptr;
   IREE_ASSERT_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_MEMORY_ACCESS_ALL, IREE_HAL_BUFFER_USAGE_ALL,
+      params,
       iree_make_byte_span((void*)kBufferContents, sizeof(kBufferContents)),
       iree_allocator_null(), &buffer_view));
 
@@ -178,12 +181,15 @@ TEST_F(CustomModulesTest, RoundTripTensor) {
   static iree_hal_dim_t kShape[] = {2, 4};
   static float kBufferContents[2 * 4] = {0.0f, 1.0f, 2.0f, 3.0f,
                                          4.0f, 5.0f, 6.0f, 7.0f};
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.usage = IREE_HAL_BUFFER_USAGE_ALL;
   iree_hal_buffer_view_t* buffer_view = nullptr;
   IREE_ASSERT_OK(iree_hal_buffer_view_wrap_or_clone_heap_buffer(
       hal_allocator_, kShape, IREE_ARRAYSIZE(kShape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_MEMORY_ACCESS_ALL, IREE_HAL_BUFFER_USAGE_ALL,
+      params,
       iree_make_byte_span((void*)kBufferContents, sizeof(kBufferContents)),
       iree_allocator_null(), &buffer_view));
 

--- a/iree/samples/dynamic_shapes/main.c
+++ b/iree/samples/dynamic_shapes/main.c
@@ -25,8 +25,11 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
         iree_runtime_session_device_allocator(session), arg0_shape,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
   }
@@ -71,8 +74,11 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
         iree_runtime_session_device_allocator(session), arg0_shape,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
   }
@@ -111,8 +117,11 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
         iree_runtime_session_device_allocator(session), arg0_shape,
         IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
   }

--- a/iree/samples/simple_embedding/simple_embedding.c
+++ b/iree/samples/simple_embedding/simple_embedding.c
@@ -82,16 +82,24 @@ iree_status_t Run() {
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
       iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
-          IREE_HAL_BUFFER_USAGE_MAPPING,
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING,
+      },
       iree_make_const_byte_span(kFloat4, sizeof(kFloat4)), &arg0_buffer_view));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
       iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
-          IREE_HAL_BUFFER_USAGE_MAPPING,
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING,
+      },
       iree_make_const_byte_span(kFloat2, sizeof(kFloat2)), &arg1_buffer_view));
 
   // Setup call inputs with our buffers.

--- a/iree/samples/variables_and_state/main.c
+++ b/iree/samples/variables_and_state/main.c
@@ -50,8 +50,11 @@ iree_status_t counter_set_value(iree_runtime_session_t* session,
         iree_runtime_session_device_allocator(session), /*shape=*/NULL,
         /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_const_byte_span((void*)arg0_data, sizeof(arg0_data)), &arg0);
   }
   if (iree_status_is_ok(status)) {
@@ -82,8 +85,11 @@ iree_status_t counter_add_to_value(iree_runtime_session_t* session, int x) {
         iree_runtime_session_device_allocator(session), /*shape=*/NULL,
         /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_const_byte_span((void*)arg0_data, sizeof(arg0_data)), &arg0);
   }
   if (iree_status_is_ok(status)) {

--- a/iree/tools/iree-e2e-matmul-test.c
+++ b/iree/tools/iree-e2e-matmul-test.c
@@ -478,8 +478,12 @@ static iree_status_t allocate_buffer_like(iree_hal_allocator_t* hal_allocator,
       iree_hal_buffer_view_shape_rank(src),
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_ALL, iree_const_byte_span_empty(), dst);
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+      },
+      iree_const_byte_span_empty(), dst);
 }
 
 // Performs a deep copy of |src| into |dst|. Takes care of allocating |dst|.
@@ -500,8 +504,12 @@ static iree_status_t copy_buffer(iree_hal_allocator_t* hal_allocator,
       iree_hal_buffer_view_shape_rank(src),
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_ALL, src_span, dst);
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+      },
+      src_span, dst);
 }
 
 static iree_status_t copy_list_of_buffer_views(

--- a/iree/tools/utils/image_util.c
+++ b/iree/tools/utils/image_util.c
@@ -138,8 +138,12 @@ iree_status_t iree_tools_utils_buffer_view_from_image(
     result = iree_hal_buffer_view_wrap_or_clone_heap_buffer(
         allocator, shape, shape_rank, element_type,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
-        IREE_HAL_MEMORY_ACCESS_READ, IREE_HAL_BUFFER_USAGE_ALL,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+            .access = IREE_HAL_MEMORY_ACCESS_READ,
+            .usage = IREE_HAL_BUFFER_USAGE_ALL,
+        },
         iree_make_byte_span((void*)pixel_data, element_byte * buffer_length),
         iree_allocator_null(), out_buffer_view);
   }
@@ -200,9 +204,13 @@ iree_status_t iree_tools_utils_buffer_view_from_image_rescaled(
   };
   iree_status_t status = iree_hal_buffer_view_generate_buffer(
       allocator, shape, shape_rank, element_type, encoding_type,
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
-          IREE_HAL_BUFFER_USAGE_MAPPING,
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                   IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING,
+      },
       iree_tools_utils_buffer_view_load_image_rescaled, &params,
       out_buffer_view);
 

--- a/iree/tools/utils/trace_replay.c
+++ b/iree/tools/utils/trace_replay.c
@@ -710,9 +710,12 @@ static iree_status_t iree_trace_replay_parse_hal_buffer(
   iree_hal_buffer_t* buffer = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
       iree_hal_device_allocator(replay->device),
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-      IREE_HAL_BUFFER_USAGE_ALL, allocation_size, iree_const_byte_span_empty(),
-      &buffer));
+      (iree_hal_buffer_params_t){
+          .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          .usage = IREE_HAL_BUFFER_USAGE_ALL,
+      },
+      allocation_size, iree_const_byte_span_empty(), &buffer));
 
   iree_vm_ref_t buffer_ref = iree_hal_buffer_move_ref(buffer);
   iree_status_t status = iree_vm_list_push_ref_move(target_list, &buffer_ref);
@@ -786,17 +789,25 @@ static iree_status_t iree_trace_replay_parse_hal_buffer_view(
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_generate_buffer(
         iree_hal_device_allocator(replay->device), shape, shape_rank,
         element_type, encoding_type,
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
-            IREE_HAL_BUFFER_USAGE_MAPPING,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                     IREE_HAL_BUFFER_USAGE_TRANSFER |
+                     IREE_HAL_BUFFER_USAGE_MAPPING,
+        },
         iree_trace_replay_generate_hal_buffer_callback, &params, &buffer_view));
   } else {
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
         iree_hal_device_allocator(replay->device), shape, shape_rank,
         element_type, encoding_type,
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-        IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER |
-            IREE_HAL_BUFFER_USAGE_MAPPING,
+        (iree_hal_buffer_params_t){
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                    IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+            .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+                     IREE_HAL_BUFFER_USAGE_TRANSFER |
+                     IREE_HAL_BUFFER_USAGE_MAPPING,
+        },
         iree_const_byte_span_empty(), &buffer_view));
   }
 


### PR DESCRIPTION
This is the first part of a larger set of changes that reworks how buffers are allocated by both simplifying what the user needs to provide and adding more expression to what is provided. Memory types will still exist but in almost all cases be specified as `OPTIMAL` when allocating buffers enabling the implementation to choose the types based on availability and underlying API requirements. There are still cases where one would need to specify them (creating importable/exportable buffers, interoping with buffers allocated externally, etc) but usage will be the primary discriminator.

As part of this the allocator methods now take a `iree_hal_buffer_params_t` struct containing the various flags and attributes required to perform an allocation, enabling us to associate location information by way of queue affinities and alignment requirements which are required for exportable buffers in some implementations and virtual memory management. The intent is that zero initialization will be fine (once `OPTIMAL` is in place) but today both type and usage are required.

Future changes will significantly rework `iree_hal_memory_type_t` and `iree_hal_buffer_usage_t` and add some queries that can be used by allocator shims to determine how usage interacts with memory types. This will require compiler changes as well in order to plumb through the required usage information from the HAL dialect ops.