### PR TITLE
Cleanup flow pipeline.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
@@ -113,6 +114,7 @@ struct ConvertToFlowBeforeDispatchFormation
                 LinalgTensorReshapeToFlowTensorReshape<tensor::ExpandShapeOp>>(
             context);
     populateTensorToFlowPatternsBeforeDispatchFormation(context, patterns);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
     IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(patterns, context);
 
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
@@ -137,6 +139,7 @@ struct ConvertToFlowAfterDispatchFormation
 
     patterns.insert<LinalgFillToFlowTensorSplat>(context);
     populateTensorToFlowPatternsAfterDispatchFormation(context, patterns);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
     IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(patterns, context);
 
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {

--- a/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
@@ -122,6 +123,7 @@ struct FusionOfTensorOpsPass
         linalg::LinalgElementwiseFusionOptions()
             .setControlFoldingReshapes(foldReshapeBetweenLinalgFn)
             .setControlElementwiseOpsFusionFn(controlFn));
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(fusionPatterns);
 
     if (failed(applyPatternsAndFoldGreedily(op->getRegions(),
                                             std::move(fusionPatterns)))) {
@@ -139,6 +141,7 @@ struct FusionOfTensorOpsPass
                                                       context);
     linalg::FillOp::getCanonicalizationPatterns(reshapeCanonicalizations,
                                                 context);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(fusionPatterns);
     if (failed(applyPatternsAndFoldGreedily(
             op->getRegions(), std::move(reshapeCanonicalizations)))) {
       return signalPassFailure();
@@ -154,6 +157,7 @@ struct FusionOfTensorOpsPass
     linalg::InitTensorOp::getCanonicalizationPatterns(pushReshapePatterns,
                                                       context);
     linalg::FillOp::getCanonicalizationPatterns(pushReshapePatterns, context);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(fusionPatterns);
     if (failed(applyPatternsAndFoldGreedily(op->getRegions(),
                                             std::move(pushReshapePatterns)))) {
       return signalPassFailure();


### PR DESCRIPTION
Reording the passes added before dispatch region formation to do
pass + canonicalization + cse. Also instead of using the pass to fold
`tensor.dim` operations use the patterns directly where `tensor.dim`
could be introduced. That might remove the `tensor.dim` operations to
begin with.