### PR TITLE
Add special case of mul(float(bool), float)

### DIFF
--- a/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -674,6 +674,82 @@ class ScatterRank0Value : public OpRewritePattern<mhlo::ScatterOp> {
   }
 };
 
+// Mhlo of non-finite values (e.g. NaN, inf) and 0.0 produce 0.0 for XLA. For
+// linalg we need to conver these to select operations.
+class MulCastOfBool : public OpRewritePattern<mhlo::MulOp> {
+ public:
+  using OpRewritePattern<mhlo::MulOp>::OpRewritePattern;
+
+  // Traverse upward past common operations to see if the value came from a
+  // boolean tensor.
+  static bool IsFromBool(Value val) {
+    while(true) {
+      Operation* op = val.getDefiningOp();
+      if (!op) return false;
+
+      if (auto convertOp = dyn_cast<mhlo::ConvertOp>(op)) {
+        auto inTy = convertOp.operand().getType().cast<ShapedType>();
+        if (inTy.getElementType().isInteger(1)) {
+          return true;
+        }
+        val = convertOp.operand();
+        continue;
+      }
+
+      if (isa<mhlo::DynamicBroadcastInDimOp>(op) ||
+          isa<mhlo::BroadcastInDimOp>(op) ||
+          isa<mhlo::BroadcastOp>(op)) {
+        val = op->getOperand(0);
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  LogicalResult matchAndRewrite(mhlo::MulOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultTy = op.getType().cast<ShapedType>();
+    if (!resultTy.getElementType().isa<FloatType>()) return failure();
+    Value lhs = op.lhs();
+    Value rhs = op.rhs();
+    bool lhsIsBool = IsFromBool(lhs);
+    bool rhsIsBool = IsFromBool(rhs);
+    int64_t resultRank = resultTy.getRank();
+
+    if (lhsIsBool == rhsIsBool) return failure();
+    if (rhsIsBool) std::swap(lhs, rhs);
+
+    Type eType = resultTy.getElementType();
+    ShapedType lhsTy = lhs.getType().cast<ShapedType>();
+    Value lhsBool = rewriter.create<mhlo::ConvertOp>(
+      op.getLoc(), lhsTy.clone(rewriter.getIntegerType(1)), lhs);
+    Value zero = rewriter.create<mhlo::ConstOp>(
+      op.getLoc(), DenseElementsAttr::get(
+        RankedTensorType::get({}, eType), rewriter.getZeroAttr(eType)));
+
+    auto lhsShape = rewriter.create<shape::ShapeOfOp>(
+      op.getLoc(), RankedTensorType::get({lhsTy.getRank()},
+      rewriter.getIndexType()), lhs);
+
+    auto broadcast = [&](Value value) -> Value {
+      auto valueTy = value.getType().cast<ShapedType>();
+      auto dimensions = llvm::to_vector<4>(
+          llvm::seq<int64_t>(resultRank - valueTy.getRank(), resultRank));
+      return rewriter.create<mhlo::DynamicBroadcastInDimOp>(
+          op.getLoc(), RankedTensorType::get(resultTy.getShape(),
+          valueTy.getElementType()), value, lhsShape,
+          rewriter.getI64TensorAttr(dimensions));
+    };
+
+    zero = broadcast(zero);
+
+    rewriter.replaceOpWithNewOp<mhlo::SelectOp>(
+      op, resultTy, lhsBool, rhs, zero);
+    return success();
+  }
+};
+
 // Generates Gaussian noise with uniform random generator based on Box-Muller
 // transform.
 class ExpandRngNormal : public OpRewritePattern<mhlo::RngNormalOp> {
@@ -861,7 +937,8 @@ struct MHLOToMHLOPreprocessingPass
     mhlo::PopulateGatherToTorchIndexSelectPatterns(context, &patterns);
     patterns
         .insert<ExtractReduceWindowOpPaddingAttributes,
-                AdjustDepthwiseFilterShape, ScatterRank0Value, ExpandRngNormal>(
+                AdjustDepthwiseFilterShape, ScatterRank0Value, ExpandRngNormal,
+                MulCastOfBool>(
             context);
 
     // dot_general canoncalization patterns.

--- a/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -43,6 +43,9 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   // and cfg compatible.
   passManager.addNestedPass<FuncOp>(createTopLevelSCFToCFGPass());
 
+  passManager.addNestedPass<FuncOp>(createMHLOToMHLOPreprocessingPass());
+  passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
+
   // Various shape functions may have been materialized in the `shape.shape_of`
   // style of treating shapes as tensors. We prefer to legalize these to
   // scalar ops as early as possible to avoid having them persist as tensor
@@ -54,8 +57,6 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   // We also don't handle calls well on the old codepath; until we remove the
   // use of the CFG we can continue inlining.
   passManager.addPass(mlir::createInlinerPass());
-
-  passManager.addNestedPass<FuncOp>(createMHLOToMHLOPreprocessingPass());
 
   // Legalize input types. We do this after flattening tuples so that we don't
   // have to deal with them.

--- a/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
@@ -342,7 +342,6 @@ func @scatter_rank0(%arg0: tensor<5x5xi32>, %arg1: tensor<2xi32>, %arg2: tensor<
 // -----
 
 func @mul_float_bool_cast(%arg0 : tensor<?xi1>, %arg1 : tensor<?xf32>) -> tensor<?xf32> {
-
   %0 = "mhlo.convert"(%arg0) : (tensor<?xi1>) -> tensor<?xf32>
   %1 = "mhlo.multiply"(%0, %arg1) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   return %1 : tensor<?xf32>
@@ -355,3 +354,28 @@ func @mul_float_bool_cast(%arg0 : tensor<?xi1>, %arg1 : tensor<?xf32>) -> tensor
 // CHECK: %[[SHP:.+]] = shape.shape_of %[[BTOF]] : tensor<?xf32> -> tensor<1xindex>
 // CHECK: %[[BROADCAST:.+]] = "mhlo.dynamic_broadcast_in_dim"(%[[ZERO]], %[[SHP]]) {broadcast_dimensions = dense<> : tensor<0xi64>}
 // CHECK: %[[SELECT:.+]] = "mhlo.select"(%[[FTOB]], %arg1, %[[BROADCAST]])
+
+// -----
+
+func @mul_float_bool_cast_broadcast(%arg0: tensor<5xi1>, %arg1: tensor<5x6xf32>) -> tensor<5x6xf32> {
+  %0 = "mhlo.convert"(%arg0) : (tensor<5xi1>) -> tensor<5xf32>
+  %1 = "mhlo.broadcast_in_dim"(%0) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<5xf32>) -> tensor<5x6xf32>
+  %2 = mhlo.multiply %1, %arg1 : tensor<5x6xf32>
+  return %2 : tensor<5x6xf32>
+}
+
+// CHECK-LABEL: @mul_float_bool_cast_broadcast
+// CHECK: mhlo.select
+
+// -----
+
+func @mul_float_bool_cast_dyn_broadcast(%arg0: tensor<?xi1>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %0 = "mhlo.convert"(%arg0) : (tensor<?xi1>) -> tensor<?xf32>
+    %1 = shape.shape_of %arg1 : tensor<?x?xf32> -> tensor<2xindex>
+    %2 = "mhlo.dynamic_broadcast_in_dim"(%0, %1) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+    %3 = mhlo.multiply %2, %arg1 : tensor<?x?xf32>
+    return %3 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @mul_float_bool_cast_dyn_broadcast
+// CHECK: mhlo.select

--- a/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
@@ -338,3 +338,20 @@ func @scatter_rank0(%arg0: tensor<5x5xi32>, %arg1: tensor<2xi32>, %arg2: tensor<
 // CHECK-DAG: %[[RE_U:.+]] = "mhlo.reshape"(%arg2) : (tensor<i32>) -> tensor<1xi32>
 // CHECK:     %[[SCATTER:.+]] = "mhlo.scatter"(%arg0, %[[RE_I]], %[[RE_U]])
 // CHECK:       "mhlo.return"(%arg4)
+
+// -----
+
+func @mul_float_bool_cast(%arg0 : tensor<?xi1>, %arg1 : tensor<?xf32>) -> tensor<?xf32> {
+
+  %0 = "mhlo.convert"(%arg0) : (tensor<?xi1>) -> tensor<?xf32>
+  %1 = "mhlo.multiply"(%0, %arg1) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+// CHECK-LABEL: @mul_float_bool_cast
+// CHECK: %[[ZERO:.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK: %[[BTOF:.+]] = "mhlo.convert"(%arg0) : (tensor<?xi1>) -> tensor<?xf32>
+// CHECK: %[[FTOB:.+]] = "mhlo.convert"(%[[BTOF]]) : (tensor<?xf32>) -> tensor<?xi1>
+// CHECK: %[[SHP:.+]] = shape.shape_of %[[BTOF]] : tensor<?xf32> -> tensor<1xindex>
+// CHECK: %[[BROADCAST:.+]] = "mhlo.dynamic_broadcast_in_dim"(%[[ZERO]], %[[SHP]]) {broadcast_dimensions = dense<> : tensor<0xi64>}
+// CHECK: %[[SELECT:.+]] = "mhlo.select"(%[[FTOB]], %arg1, %[[BROADCAST]])


### PR DESCRIPTION
Multiplication of cast from bool is a common method for conditional
subtraction. Unfortunately it is expect that mul(inf, 0.0) -> 0.0, which is
not conformant with the IEEE floating point standard.

Added a special case to search for this substitution and perform a select
instead. It won't catch all cases but it should help track them down.