### PR TITLE
Make lint script run clang-format against main

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -98,7 +98,7 @@ echo "***** clang-format *****"
 disable_update_ret
 if exists git-clang-format; then
   enable_update_ret
-  git-clang-format --style=file
+  git-clang-format --style=file main
   git diff --exit-code
 else
   enable_update_ret


### PR DESCRIPTION
Because this script first checks that there are no uncommitted changes,
this line was actually doing nothing as it was comparing against the
default HEAD.