### PR TITLE
Add flag for enabling MMT4D path in iree-translate

### DIFF
--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -226,6 +226,7 @@ def iree_generated_trace_runner_test(
 
     tests = []
     processed_opt_flags = [flag.replace("#pass_options_variant#", "") for flag in opt_flags]
+    processsed_compiler_flags = [flag.replace("#pass_options_variant#", "") for flag in compiler_flags]
     for backend, driver in target_backends_and_drivers:
         suite_entry_name = "_".join([name, backend, driver])
         iree_single_backend_generated_trace_runner_test(
@@ -235,7 +236,7 @@ def iree_generated_trace_runner_test(
             driver = driver,
             target_backend = backend,
             generator_args = generator_args,
-            compiler_flags = compiler_flags,
+            compiler_flags = processsed_compiler_flags,
             runner_args = runner_args,
             opt_tool = opt_tool,
             opt_flags = processed_opt_flags,

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -440,6 +440,7 @@ function(iree_check_test_suite)
     foreach(_TARGET_CPU_FEATURES_LIST_ELEM IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       process_target_cpu_features("${_TARGET_CPU_FEATURES_LIST_ELEM}" _ENABLED _TARGET_CPU_FEATURES _TARGET_CPU_FEATURES_SUFFIX _TARGET_PASS_OPTIONS)
       string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_OPT_FLAGS "${_RULE_OPT_FLAGS}")
+      string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_COMPILER_FLAGS "${_RULE_COMPILER_FLAGS}")
       if (NOT _ENABLED)
         # The current entry is disabled on the target CPU architecture.
         continue()
@@ -454,7 +455,7 @@ function(iree_check_test_suite)
         DRIVER
           ${_DRIVER}
         COMPILER_FLAGS
-          ${_RULE_COMPILER_FLAGS}
+          ${_PROCESSED_COMPILER_FLAGS}
         RUNNER_ARGS
           ${_RULE_RUNNER_ARGS}
         LABELS

--- a/build_tools/cmake/iree_trace_runner_test.cmake
+++ b/build_tools/cmake/iree_trace_runner_test.cmake
@@ -344,6 +344,7 @@ function(iree_generated_trace_runner_test)
     foreach(_TARGET_CPU_FEATURES_LIST_ELEM IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
       process_target_cpu_features("${_TARGET_CPU_FEATURES_LIST_ELEM}" _ENABLED _TARGET_CPU_FEATURES _TARGET_CPU_FEATURES_SUFFIX _TARGET_PASS_OPTIONS)
       string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_OPT_FLAGS "${_RULE_OPT_FLAGS}")
+      string(REPLACE "#pass_options_variant#" "${_TARGET_PASS_OPTIONS}" _PROCESSED_COMPILER_FLAGS "${_RULE_COMPILER_FLAGS}")
       if (NOT _ENABLED)
         # The current entry is disabled on the target CPU architecture.
         continue()
@@ -362,7 +363,7 @@ function(iree_generated_trace_runner_test)
         DRIVER
           ${_DRIVER}
         COMPILER_FLAGS
-          ${_RULE_COMPILER_FLAGS}
+          ${_PROCESSED_COMPILER_FLAGS}
         RUNNER_ARGS
           ${_RULE_RUNNER_ARGS}
         LABELS

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
@@ -419,6 +419,8 @@ class ConvertLinalgMatmulToMmt4DPass final
     : public ConvertLinalgMatmulToMmt4DBase<ConvertLinalgMatmulToMmt4DPass> {
  public:
   ConvertLinalgMatmulToMmt4DPass() {}
+  explicit ConvertLinalgMatmulToMmt4DPass(CustomKernelsTargetInfo targetInfo)
+      : targetInfo(targetInfo) {}
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect>();
   }
@@ -461,6 +463,26 @@ class ConvertLinalgMatmulToMmt4DPass final
 
 std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass() {
   return std::make_unique<ConvertLinalgMatmulToMmt4DPass>();
+}
+
+std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+    CustomKernelsTargetInfo targetInfo) {
+  return std::make_unique<ConvertLinalgMatmulToMmt4DPass>(targetInfo);
+}
+
+std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+    StringRef options) {
+  auto pass = std::make_unique<ConvertLinalgMatmulToMmt4DPass>();
+  // Unfortunately, we have to throw away the parse error here. These methods
+  // can't return a LogicalResult. Even if we could extract the parsing out of
+  // this function and require passing in a targetInfo using the function above
+  // the place this is called tops out at a pass pipeline registration, which
+  // also can't report failure. So we'd need to go all the way to the top level
+  // and reinvent the option parsing as an llvm::cl::parser.
+  LogicalResult result = pass->initializeOptions(options);
+  assert(result.succeeded() && "parsing pass options failed");
+  (void)result;
+  return pass;
 }
 
 }  // namespace Flow

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp
@@ -461,17 +461,16 @@ class ConvertLinalgMatmulToMmt4DPass final
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass() {
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass() {
   return std::make_unique<ConvertLinalgMatmulToMmt4DPass>();
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(
     CustomKernelsTargetInfo targetInfo) {
   return std::make_unique<ConvertLinalgMatmulToMmt4DPass>(targetInfo);
 }
 
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
-    StringRef options) {
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(StringRef options) {
   auto pass = std::make_unique<ConvertLinalgMatmulToMmt4DPass>();
   // Unfortunately, we have to throw away the parse error here. These methods
   // can't return a LogicalResult. Even if we could extract the parsing out of

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -79,11 +79,10 @@ std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
 
 // Pass to convert a linalg.matmul into linalg.mmt4d given some target ISA
 // information currently passed as pass options.
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass();
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass();
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(
     CustomKernelsTargetInfo targetInfo);
-std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
-    StringRef options);
+std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(StringRef options);
 
 // Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Utils/CustomKernelsTargetInfo.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
@@ -79,6 +80,10 @@ std::unique_ptr<Pass> createPadTensorToSubTensorInsertPass();
 // Pass to convert a linalg.matmul into linalg.mmt4d given some target ISA
 // information currently passed as pass options.
 std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+    CustomKernelsTargetInfo targetInfo);
+std::unique_ptr<OperationPass<FuncOp>> createConvertLinalgMatmulToMmt4DPass(
+    StringRef options);
 
 // Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<Pass> createFusionOfTensorOpsPass();

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -105,7 +105,7 @@ def PadLinalgOps :
 }
 
 def ConvertLinalgMatmulToMmt4D :
-    Pass<"iree-flow-convert-linalg-matmul-to-mmt4d", "FuncOp"> {
+    Pass<"iree-flow-convert-linalg-matmul-to-mmt4d", ""> {
   let summary = "Convert linalg.matmul to linalg.mmt4d";
   let constructor = "mlir::iree_compiler::IREE::Flow::createConvertLinalgMatmulToMmt4DPass()";
   let options = [

--- a/iree/test/e2e/regression/BUILD
+++ b/iree/test/e2e/regression/BUILD
@@ -134,13 +134,13 @@ py_binary(
 # Test asm
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_small" % lhs_rhs_type,
+    compiler_flags = [
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=small",
-    ],
-    opt_flags = [
-        "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -155,13 +155,13 @@ py_binary(
 
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_large" % lhs_rhs_type,
+    compiler_flags = [
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=large",
-    ],
-    opt_flags = [
-        "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),
@@ -179,14 +179,14 @@ py_binary(
 # tests in ways that are orthogonal to problem sizes.
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_intrinsics_%s" % (lhs_rhs_type, size),
-    compiler_flags = ["--iree-codegen-mmt4d-use-intrinsics"],
+    compiler_flags = [
+        "--iree-codegen-mmt4d-use-intrinsics",
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
+    ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--shapes=%s" % size,
-    ],
-    opt_flags = [
-        "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#",
     ],
     target_backends_and_drivers = [
         ("dylib-llvm-aot", "dylib"),

--- a/iree/test/e2e/regression/CMakeLists.txt
+++ b/iree/test/e2e/regression/CMakeLists.txt
@@ -175,8 +175,8 @@ iree_generated_trace_runner_test(
     "dylib-llvm-aot"
   DRIVERS
     "dylib"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+  COMPILER_FLAGS
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -196,8 +196,8 @@ iree_generated_trace_runner_test(
     "dylib-llvm-aot"
   DRIVERS
     "dylib"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+  COMPILER_FLAGS
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )
@@ -216,8 +216,8 @@ iree_generated_trace_runner_test(
     "dylib-llvm-aot"
   DRIVERS
     "dylib"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+  COMPILER_FLAGS
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -237,8 +237,8 @@ iree_generated_trace_runner_test(
     "dylib-llvm-aot"
   DRIVERS
     "dylib"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+  COMPILER_FLAGS
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )
@@ -259,8 +259,7 @@ iree_generated_trace_runner_test(
     "dylib"
   COMPILER_FLAGS
     "--iree-codegen-mmt4d-use-intrinsics"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -282,8 +281,7 @@ iree_generated_trace_runner_test(
     "dylib"
   COMPILER_FLAGS
     "--iree-codegen-mmt4d-use-intrinsics"
-  OPT_FLAGS
-    "--iree-flow-convert-linalg-matmul-to-mmt4d=enable_generic_slow #pass_options_variant#"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )


### PR DESCRIPTION
Per discussion with Ben, this is a hack, but it's a contained hack
where the necessary target information is just given directly to this
pass. The necessity for this information is a blocker on enabling MMT4D
as currently constructed by default. This does make it much easier to
test and benchmark though. Notably, this flag is not exposed to users
at the Python level.