### PR TITLE
Turn on LLVM loop unrolling by default

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -381,7 +381,6 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-llvm-loop-unrolling=true"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER
@@ -410,7 +409,6 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-llvm-loop-unrolling=true"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER
@@ -439,7 +437,6 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   TRANSLATION_FLAGS
 #     ${ANDROID_CPU_TRANSLATION_FLAGS}
-#     "--iree-llvm-loop-unrolling=true"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   DRIVER
@@ -466,7 +463,6 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   TRANSLATION_FLAGS
 #     ${ANDROID_CPU_TRANSLATION_FLAGS}
-#     "--iree-llvm-loop-unrolling=true"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   DRIVER
@@ -493,7 +489,6 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   TRANSLATION_FLAGS
     ${ANDROID_CPU_TRANSLATION_FLAGS}
-    "--iree-llvm-loop-unrolling=true"
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -84,7 +84,7 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       "iree-llvm-loop-vectorization", llvm::cl::init(true),
       llvm::cl::desc("Enable LLVM loop vectorization opt"));
   static llvm::cl::opt<bool> llvmLoopUnrolling(
-      "iree-llvm-loop-unrolling", llvm::cl::init(false),
+      "iree-llvm-loop-unrolling", llvm::cl::init(true),
       llvm::cl::desc("Enable LLVM loop unrolling opt"));
   static llvm::cl::opt<bool> llvmSLPVectorization(
       "iree-llvm-slp-vectorization", llvm::cl::init(false),


### PR DESCRIPTION
The reasons to not do this by default have been lost to time and it
provides a sizable speedup on single-threaded benchmarks.